### PR TITLE
Remove uses of unsafe from file_format_common

### DIFF
--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -170,26 +170,17 @@ pub fn write_u32_as_uleb128(binary: &mut Vec<u8>, value: u32) {
 
 /// Write a `u16` in Little Endian format.
 pub fn write_u16(binary: &mut Vec<u8>, value: u16) {
-    let bytes: [u8; 2] = unsafe { transmute(value.to_le()) };
-    for byte in &bytes {
-        binary.push(*byte);
-    }
+    binary.extend(&value.to_le_bytes());
 }
 
 /// Write a `u32` in Little Endian format.
 pub fn write_u32(binary: &mut Vec<u8>, value: u32) {
-    let bytes: [u8; 4] = unsafe { transmute(value.to_le()) };
-    for byte in &bytes {
-        binary.push(*byte);
-    }
+    binary.extend(&value.to_le_bytes());
 }
 
 /// Write a `u64` in Little Endian format.
 pub fn write_u64(binary: &mut Vec<u8>, value: u64) {
-    let bytes: [u8; 8] = unsafe { transmute(value.to_le()) };
-    for byte in &bytes {
-        binary.push(*byte);
-    }
+    binary.extend(&value.to_le_bytes());
 }
 
 /// Reads a `u16` in ULEB128 format from a `binary`.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Making the code safer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/master/CONTRIBUTING.md#pull-requests)?

Yes. Probably the shortest Contributing Guidelines I have seen, being two words long ("Not" and "Found"), I really like that. Although I cannot help but think it could have been shorter, but at the same time, there may be a reason for that I'm not understanding.

## Test Plan

None.

## Related PRs

None.
