### PR TITLE
Add default action for the question dev_setup.sh asks

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -55,7 +55,7 @@ now with Ctrl-C.
 
 EOF
 
-printf "Proceed with installing necessary dependencies? (y) > "
+printf "Proceed with installing necessary dependencies? (y/N) > "
 read -e input
 if [[ "$input" != "y"* ]]; then
 	echo "Exiting..."


### PR DESCRIPTION
There is no real standard, but de-facto standard is to have the capital N and the small y in this case:
https://ux.stackexchange.com/questions/53640/default-values-for-text-based-confirmation-prompt

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](../CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instrutions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
