### PR TITLE
Fix comments in earmarked_libra.mvir

### DIFF
--- a/language/functional_tests/tests/testsuite/move_getting_started_examples/earmarked_libra.mvir
+++ b/language/functional_tests/tests/testsuite/move_getting_started_examples/earmarked_libra.mvir
@@ -19,7 +19,7 @@ module EarmarkedLibraCoin {
     let t: R#Self.T;
 
     // Construct or "pack" a new resource of type T. Only procedures of the
-    // `EarmarkedCoin` module can create an `EarmarkedCoin.T`.
+    // `EarmarkedLibraCoin` module can create an `EarmarkedLibraCoin.T`.
     t = T {
       coin: move(coin),
       recipient: move(recipient),
@@ -39,7 +39,7 @@ module EarmarkedLibraCoin {
     let sender: address;
 
     // Remove the earmarked coin resource published under `earmarked_coin_address`.
-    // If there is resource of type T published under the address, this will fail.
+    // If there is no resource of type T published under the address, this will fail.
     t = move_from<T>(move(earmarked_coin_address));
 
     t_ref = &t;


### PR DESCRIPTION
## Motivation

Fixing some inconsistencies in the comments

- Fix name of EarmarkedLibraCoin in comments
- Add missing word "no" in comments

### Have you read the [Contributing Guidelines on pull requests](../CONTRIBUTING.md#pull-requests)?

Yes

## Related PRs

As this example is part of the website, I've submitted a separate PR to update the comments on the website:

https://github.com/libra/website/pull/27
