### PR TITLE
fix dev_setup.sh fail if user install protoc higher than 3.6.0

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -121,12 +121,14 @@ fi
 if [[ -f /etc/debian_version ]]; then
 	PROTOC_VERSION=`protoc --version | cut -d" " -f2`
 	REQUIRED_PROTOC_VERSION="3.6.0"
+	set +e
 	PROTOC_VERSION_CHECK=`dpkg --compare-versions $REQUIRED_PROTOC_VERSION "gt" $PROTOC_VERSION`
 
 	if [ $? -eq "0" ]; then
 		echo "protoc version is too old. Update protoc to 3.6.0 or above. Abort"
 		exit 1
 	fi
+	set -e
 fi
 
 cat <<EOF


### PR DESCRIPTION
dpkg --compare-versions will return 1 if user install protoc version higher than 3.6.0
then exit the seutp flow

cancel set error before doing dpkg --compare-versions to fix the problem

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

fix an unexpected error when setup env (./scripts/dev_setup.sh)

### Have you read the [Contributing Guidelines on pull requests](../CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

run ./scritps/dev_setup.sh while protoc 3.6.1 installed

## Related PRs

NA
