### PR TITLE
Fix incorrect characters in cargo build command

### DIFF
--- a/language/compiler/README.md
+++ b/language/compiler/README.md
@@ -52,7 +52,7 @@ ARGS:
 
 To compile a `*.mvir` file:
 
-> cargo build -—bin compiler
+> cargo build --bin compiler
 
 * This will build the compiler+verifier binary.
 * The binary can be found at `libra/target/debug/compiler`.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix incorrect characters in cargo build command

## Test Plan

``` bash
cargo build --bin compiler
```
