### PR TITLE
Replace "decentralized" with "distributed" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CircleCI](https://circleci.com/gh/libra/libra.svg?style=shield)](https://circleci.com/gh/libra/libra)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE.md)
 
-Libra Core implements a decentralized, programmable database which provides a financial infrastructure that can empower billions of people.
+Libra Core implements a distributed, programmable database which provides a financial infrastructure that can empower billions of people.
 
 ## Note to Developers
 * Libra Core is a prototype.


### PR DESCRIPTION
Libra achieves consensus using a fixed set of pre-approved validators who pay millions of dollars for the privilege. Since this is not decentralized, it seems best to replace the world "decentralized" with "distributed" in the readme.

"a distributed, programmable database" is a clearer description of what Libra actually is.