### PR TITLE
[client] use sequence_number is better

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -272,7 +272,7 @@ impl ClientProxy {
                     if chain_seq_number >= sequence_number {
                         println!(
                             "Transaction completed, found sequence number {}]",
-                            chain_seq_number
+                            sequence_number
                         );
                         break;
                     }


### PR DESCRIPTION
 
## Motivation

it's better to report `sequence_number` than `chain_seq_number`. because `chain_seq_number` is the latest sequence number ,and the `sequence_number` is the actual number when this transaction occurs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instrutions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
