### PR TITLE
Update README.md

### DIFF
--- a/language/compiler/README.md
+++ b/language/compiler/README.md
@@ -52,7 +52,7 @@ ARGS:
 
 To compile a `*.mvir` file:
 
-> cargo build -—bin compiler
+> cargo build --bin compiler
 
 * This will build the compiler+verifier binary.
 * The binary can be found at `libra/target/debug/compiler`.


### PR DESCRIPTION
`cargo build -—bin compiler`  (hyphen + [Em dash](https://www.compart.com/en/unicode/category/Pd))
Shows error: Found argument '-—' which wasn't expected, or isn't valid in this context.

`cargo build --bin compiler`  (hyphen + hyphen)
Solves this issue.