### PR TITLE
Make Docker image build scripts directory-independent

### DIFF
--- a/docker/client/build.sh
+++ b/docker/client/build.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
 PROXY=""
 if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f docker/client/client.Dockerfile . --tag libra_client --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+docker build -f $DIR/client.Dockerfile $DIR/../.. --tag libra_client --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY

--- a/docker/mint/build.sh
+++ b/docker/mint/build.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
 PROXY=""
 if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f docker/mint/mint.Dockerfile . --tag libra_mint  --build-arg GIT_REV=$(git rev-parse HEAD) --build-arg GIT_UPSTREAM=$(git merge-base --fork-point origin/master) --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+docker build -f $DIR/mint.Dockerfile $DIR/../.. --tag libra_mint  --build-arg GIT_REV=$(git rev-parse HEAD) --build-arg GIT_UPSTREAM=$(git merge-base --fork-point origin/master) --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY

--- a/docker/validator/build.sh
+++ b/docker/validator/build.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
 PROXY=""
 if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f docker/validator/validator.Dockerfile . --tag libra_e2e --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+docker build -f $DIR/validator.Dockerfile $DIR/../.. --tag libra_e2e --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY


### PR DESCRIPTION
Previously the build scripts had to be executed from the root of the
repository. Now they can be called from anywhere.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

Fixes #179.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instrutions for verifying that your changes work.)

I didn't change any Rust code.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)

None.