### PR TITLE
follow conventions for Cargo.toml files

### DIFF
--- a/common/build_helpers/Cargo.toml
+++ b/common/build_helpers/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 protoc-grpcio = "0.3.1"
 walkdir = "2.2.0"
 
-grpcio-client = {path = "../grpcio-client"}
+grpcio-client = { path = "../grpcio-client" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -24,11 +24,11 @@ failure = { path = "../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
-network = {path = "../network"}
+network = { path = "../network" }
 proto_conv = { path = "../common/proto_conv" }
 storage_client = { path = "../storage/storage_client" }
 types = { path = "../types" }
-vm_validator = {path = "../vm_validator"}
+vm_validator = { path = "../vm_validator" }
 
 [dev-dependencies]
 rand = "0.6.5"


### PR DESCRIPTION
Puts one space before and after the curly braces and make consistent with others dependencies.