### PR TITLE
Fix LICENSE Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Read our [Contributing guide](https://developers.libra.org/docs/community/contri
 * [Storage](https://developers.libra.org/docs/crates/storage)
 * [Virtual Machine](https://developers.libra.org/docs/crates/vm)
 
-
 ## Community
 
 * Join us on the [Libra Discourse](https://community.libra.org).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <hr/>
 
 [![CircleCI](https://circleci.com/gh/libra/libra.svg?style=shield)](https://circleci.com/gh/libra/libra)
-[![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE.md)
+[![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
 
 Libra Core implements a decentralized, programmable database which provides a financial infrastructure that can empower billions of people.
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The previous link lead to a 404 page, because the license file is `LICENSE` not `LICENSE.md`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes. I have not yet signed the CLA, but I will.

## Test Plan

N/A

## Related PRs

None
