### PR TITLE
Changing "0x00" to more commonly used "0x0" when importing (Move IR style issue)

### DIFF
--- a/language/stdlib/modules/libra_account.mvir
+++ b/language/stdlib/modules/libra_account.mvir
@@ -1,7 +1,7 @@
 // The module for the account resource that governs every Libra account
 module LibraAccount {
     import 0x0.LibraCoin;
-    import 0x00.Hash;
+    import 0x0.Hash;
 
     // Every Libra account has a LibraLibraAccount.T resource
     resource T {


### PR DESCRIPTION
Changing "import 0x00.Hash" to "import 0x0.Hash" which seems to conform better to the style used everywhere else (such as in Move IR files in language/functional_tests/tests/testsuite/natives/)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This commit unifies coding style in Move IR files.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The import I used is used word-to-word in other Move IR files in language/functional_tests/tests/testsuite/natives/.

## Related PRs

There are no related PRs
