### PR TITLE
[crypto] Use sha3 instead of tiny-keccak

### DIFF
--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -7,16 +7,17 @@ publish = false
 edition = "2018"
 
 [dependencies]
-rust-crypto = "0.2"
 log = "0.4.7"
 rand = "0.6.5"
 rand_core = "0.4.0"
 hex = "0.3"
 byteorder = "1.3.2"
 serde = "1.0.96"
-tiny-keccak = "1.5.0"
 protobuf = "~2.7"
 sha3 = "0.8.2"
+sha2 = "0.8"
+pbkdf2 = { version = "0.3", default-features = false }
+hmac = "0.7"
 
 [dependencies.ed25519-dalek]
 version = "1.0.0-pre.1"

--- a/client/libra_wallet/src/mnemonic.rs
+++ b/client/libra_wallet/src/mnemonic.rs
@@ -6,11 +6,11 @@
 //!
 //! https://github.com/rust-bitcoin/rust-wallet/blob/master/wallet/src/mnemonic.rs
 use crate::error::*;
-use crypto::{digest::Digest, sha2::Sha256};
 #[cfg(test)]
 use rand::rngs::EntropyRng;
 #[cfg(test)]
 use rand_core::RngCore;
+use sha2::{Digest, Sha256};
 use std::{
     fs::{self, File},
     io::Write,
@@ -58,11 +58,7 @@ impl Mnemonic {
                 "Data for mnemonic should have a length divisible by 4".to_string(),
             ));
         }
-        let mut check = [0u8; 32];
-
-        let mut sha2 = Sha256::new();
-        sha2.input(data);
-        sha2.result(&mut check);
+        let check: [u8; 32] = Sha256::digest(data).into();
 
         let mut bits = vec![false; data.len() * 8 + data.len() / 4];
         for i in 0..data.len() {

--- a/crypto/legacy_crypto/Cargo.toml
+++ b/crypto/legacy_crypto/Cargo.toml
@@ -20,7 +20,6 @@ proptest-derive = "0.1.0"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 threshold_crypto = "0.3"
-tiny-keccak = "1.5.0"
 x25519-dalek = "0.5.2"
 digest = "0.8.1"
 hmac = "0.7.1"

--- a/crypto/legacy_crypto/README.md
+++ b/crypto/legacy_crypto/README.md
@@ -11,7 +11,7 @@ The crypto component hosts all the implementations of cryptographic primitives w
 
 Libra makes use of several cryptographic algorithms:
 
-* SHA-3 as the main hash function. It is standardized in [FIPS 202](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf). It is based on the [tiny_keccak](https://docs.rs/tiny-keccak/1.4.2/tiny_keccak/) library.
+* SHA-3 as the main hash function. It is standardized in [FIPS 202](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf). It is based on the [sha3](https://docs.rs/sha3/) library.
 * X25519 to perform key exchanges. It is used to secure communications between validators via the [Noise Protocol Framework](http://www.noiseprotocol.org/noise.html). It is based on the x25519-dalek library.
 * Ed25519 to perform signatures. It is used both for consensus signatures and for transaction signatures. EdDSA is planned to be added to the next revision of FIPS 186 as mentioned in [NIST SP 800-133 Rev. 1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-133r1-draft.pdf). It is based on the [ed25519-dalek](https://docs.rs/ed25519-dalek/1.0.0-pre.1/ed25519_dalek/) library with additional security checks (e.g., for malleability).
 * HKDF: HMAC-based Extract-and-Expand Key Derivation Function (HKDF) based on [RFC 5869](https://tools.ietf.org/html/rfc5869). It is used to generate keys from a salt (optional), seed, and application-info (optional).

--- a/crypto/nextgen_crypto/Cargo.toml
+++ b/crypto/nextgen_crypto/Cargo.toml
@@ -21,7 +21,6 @@ proptest-derive = "0.1.0"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 threshold_crypto = "0.3"
-tiny-keccak = "1.5.0"
 x25519-dalek = "0.5.2"
 digest = "0.8.1"
 hmac = "0.7.1"

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -24,7 +24,7 @@ assert_matches = "1.3.0"
 proptest_helpers = { path = "../../common/proptest_helpers" }
 protobuf = "~2.7"
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
-tiny-keccak = "1.5.0"
+sha3 = "0.8"
 vm_genesis = { path = "../vm/vm_genesis"}
 config =  { path = "../../config"}
 logger = { path = "../../common/logger" }

--- a/language/e2e_tests/src/tests/verify_txn.rs
+++ b/language/e2e_tests/src/tests/verify_txn.rs
@@ -13,8 +13,8 @@ use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
 use config::config::{NodeConfigHelpers, VMPublishingOption};
 use crypto::signing::KeyPair;
+use sha3::{Digest, Sha3_256};
 use std::collections::HashSet;
-use tiny_keccak::Keccak;
 use types::{
     account_address::AccountAddress,
     test_helpers::transaction_test_helpers,
@@ -77,21 +77,14 @@ fn verify_whitelist() {
     // Making sure the whitelist's hash matches the current compiled script. If this fails, please
     // try run `cargo run` under vm_genesis and update the vm_config in node.config.toml and in
     // config.rs in libra/config crate.
-    let programs: HashSet<_> = vec![
+    let programs: HashSet<[u8; SCRIPT_HASH_LENGTH]> = [
         PEER_TO_PEER.clone(),
         MINT.clone(),
         ROTATE_KEY.clone(),
         CREATE_ACCOUNT.clone(),
     ]
-    .into_iter()
-    .map(|s| {
-        let mut hash = [0u8; SCRIPT_HASH_LENGTH];
-        let mut keccak = Keccak::new_sha3_256();
-
-        keccak.update(&s);
-        keccak.finalize(&mut hash);
-        hash
-    })
+    .iter()
+    .map(|s| Sha3_256::digest(s).into())
     .collect();
 
     let config = NodeConfigHelpers::get_single_node_test_config(false);

--- a/language/stdlib/natives/Cargo.toml
+++ b/language/stdlib/natives/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 bitcoin_hashes = "0.3.0"
 nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
-tiny-keccak = "1.5.0"
+sha3 = "0.8"
 types = { path = "../../../types" }
 byteorder = "1.3.2"
 bit-vec = "0.6.1"

--- a/language/stdlib/natives/src/hash.rs
+++ b/language/stdlib/natives/src/hash.rs
@@ -3,25 +3,20 @@
 
 use crate::dispatch::{CostedReturnType, NativeReturnType, Result, StackAccessor};
 use bitcoin_hashes::{hash160, sha256, Hash};
+use sha3::{Digest, Keccak256, Sha3_256};
 use std::borrow::Borrow;
-use tiny_keccak::Keccak;
 use types::byte_array::ByteArray;
 
-const HASH_LENGTH: usize = 32;
 const KECCAK_COST: u64 = 30;
 const RIPEMD_COST: u64 = 35;
 const SHA2_COST: u64 = 30;
 const SHA3_COST: u64 = 30;
 
 pub fn native_keccak_256<T: StackAccessor>(mut accessor: T) -> Result<CostedReturnType> {
-    let mut hash = [0u8; HASH_LENGTH];
-    let mut keccak = Keccak::new_keccak256();
-
     let hash_arg = accessor.get_byte_array()?;
     let native_cost = KECCAK_COST * hash_arg.len() as u64;
 
-    keccak.update(hash_arg.as_bytes());
-    keccak.finalize(&mut hash);
+    let hash = Keccak256::digest(hash_arg.as_bytes());
 
     let native_return = NativeReturnType::ByteArray(ByteArray::new(hash.to_vec()));
     Ok(CostedReturnType::new(native_cost, native_return))
@@ -48,14 +43,10 @@ pub fn native_sha2_256<T: StackAccessor>(mut accessor: T) -> Result<CostedReturn
 }
 
 pub fn native_sha3_256<T: StackAccessor>(mut accessor: T) -> Result<CostedReturnType> {
-    let mut hash = [0u8; HASH_LENGTH];
-    let mut keccak = Keccak::new_sha3_256();
-
     let hash_arg = accessor.get_byte_array()?;
     let native_cost = SHA3_COST * hash_arg.len() as u64;
 
-    keccak.update(hash_arg.as_bytes());
-    keccak.finalize(&mut hash);
+    let hash = Sha3_256::digest(hash_arg.as_bytes());
 
     let native_return = NativeReturnType::ByteArray(ByteArray::new(hash.to_vec()));
     Ok(CostedReturnType::new(native_cost, native_return))

--- a/language/vm/vm_genesis/Cargo.toml
+++ b/language/vm/vm_genesis/Cargo.toml
@@ -21,7 +21,7 @@ vm_runtime = { path = "../vm_runtime" }
 hex = "0.3.2"
 lazy_static = "1.3.0"
 rand = "0.6.5"
-tiny-keccak = "1.5.0"
+sha3 = "0.8"
 toml = "0.4"
 
 [dev-dependencies]

--- a/language/vm/vm_genesis/src/lib.rs
+++ b/language/vm/vm_genesis/src/lib.rs
@@ -7,6 +7,7 @@ use failure::prelude::*;
 use ir_to_bytecode::{compiler::compile_program, parser::ast};
 use lazy_static::lazy_static;
 use rand::{rngs::StdRng, SeedableRng};
+use sha3::{Digest, Sha3_256};
 use state_view::StateView;
 use std::{collections::HashSet, iter::FromIterator, time::Duration};
 use stdlib::{
@@ -16,7 +17,6 @@ use stdlib::{
         ROTATE_AUTHENTICATION_KEY_TXN_BODY,
     },
 };
-use tiny_keccak::Keccak;
 use types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -256,14 +256,7 @@ pub fn allowing_script_hashes() -> Vec<[u8; SCRIPT_HASH_LENGTH]> {
         CREATE_ACCOUNT_TXN.clone(),
     ]
     .into_iter()
-    .map(|s| {
-        let mut hash = [0u8; SCRIPT_HASH_LENGTH];
-        let mut keccak = Keccak::new_sha3_256();
-
-        keccak.update(&s);
-        keccak.finalize(&mut hash);
-        hash
-    })
+    .map(|s| Sha3_256::digest(&s).into())
     .collect()
 }
 

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 rental = "0.5.4"
-tiny-keccak = "1.5.0"
+sha3 = "0.8"
 proptest = "0.9"
 rayon = "1.1"
 

--- a/language/vm/vm_runtime/src/code_cache/script_cache.rs
+++ b/language/vm/vm_runtime/src/code_cache/script_cache.rs
@@ -8,7 +8,7 @@ use crate::loaded_data::{
 };
 use bytecode_verifier::VerifiedScript;
 use logger::prelude::*;
-use tiny_keccak::Keccak;
+use sha3::{Digest, Sha3_256};
 use types::transaction::SCRIPT_HASH_LENGTH;
 use vm::{
     errors::{Location, VMErrorKind, VMResult, VMRuntimeError, VerificationStatus},
@@ -33,12 +33,7 @@ impl<'alloc> ScriptCache<'alloc> {
     /// Compiles, verifies, caches and resolves `raw_bytes` into a `FunctionRef` that can be
     /// executed.
     pub fn cache_script(&self, raw_bytes: &[u8]) -> VMResult<FunctionRef<'alloc>> {
-        let mut hash = [0u8; SCRIPT_HASH_LENGTH];
-        let mut keccak = Keccak::new_sha3_256();
-
-        keccak.update(raw_bytes);
-        keccak.finalize(&mut hash);
-
+        let hash: [u8; SCRIPT_HASH_LENGTH] = Sha3_256::digest(raw_bytes).into();
         // XXX We may want to put in some negative caching for scripts that fail verification.
         if let Some(f) = self.map.get(&hash) {
             trace!("[VM] Script cache hit");

--- a/language/vm/vm_runtime/src/process_txn/validate.rs
+++ b/language/vm/vm_runtime/src/process_txn/validate.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use config::config::VMPublishingOption;
 use logger::prelude::*;
-use tiny_keccak::Keccak;
+use sha3::{Digest, Sha3_256};
 use types::{
     transaction::{
         SignatureCheckedTransaction, TransactionPayload, MAX_TRANSACTION_SIZE_IN_BYTES,
@@ -29,10 +29,7 @@ pub fn is_allowed_script(publishing_option: &VMPublishingOption, program: &[u8])
     match publishing_option {
         VMPublishingOption::Open | VMPublishingOption::CustomScripts => true,
         VMPublishingOption::Locked(whitelist) => {
-            let mut hash = [0u8; SCRIPT_HASH_LENGTH];
-            let mut keccak = Keccak::new_sha3_256();
-            keccak.update(program);
-            keccak.finalize(&mut hash);
+            let hash: [u8; SCRIPT_HASH_LENGTH] = Sha3_256::digest(program).into();
             whitelist.contains(&hash)
         }
     }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -22,7 +22,7 @@ radix_trie = "0.1.3"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
-tiny-keccak = "1.5.0"
+sha3 = "0.8"
 
 canonical_serialization = { path = "../common/canonical_serialization"}
 crypto = { path = "../crypto/legacy_crypto" }

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -58,7 +58,6 @@ impl AccountAddress {
     pub fn from_public_key<PublicKey: VerifyingKey>(public_key: &PublicKey) -> Self {
         // TODO: using Sha3_256 directly instead of crypto::hash because we have to make sure we use
         // the same hash function that the Move transaction prologue is using.
-        // TODO: Sha3_256 is just a placeholder, make a principled choice for the hash function
         let hash = Sha3_256::digest(&public_key.to_bytes()).into();
         AccountAddress::new(hash)
     }

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -19,8 +19,8 @@ use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use rand::{rngs::OsRng, Rng};
 use serde::{Deserialize, Serialize};
+use sha3::{Digest, Sha3_256};
 use std::{convert::TryFrom, fmt, str::FromStr};
-use tiny_keccak::Keccak;
 
 pub const ADDRESS_LENGTH: usize = 32;
 
@@ -56,13 +56,10 @@ impl AccountAddress {
     }
 
     pub fn from_public_key<PublicKey: VerifyingKey>(public_key: &PublicKey) -> Self {
-        // TODO: using keccak directly instead of crypto::hash because we have to make sure we use
+        // TODO: using Sha3_256 directly instead of crypto::hash because we have to make sure we use
         // the same hash function that the Move transaction prologue is using.
-        // TODO: keccak is just a placeholder, make a principled choice for the hash function
-        let mut keccak = Keccak::new_sha3_256();
-        let mut hash = [0u8; ADDRESS_LENGTH];
-        keccak.update(&public_key.to_bytes());
-        keccak.finalize(&mut hash);
+        // TODO: Sha3_256 is just a placeholder, make a principled choice for the hash function
+        let hash = Sha3_256::digest(&public_key.to_bytes()).into();
         AccountAddress::new(hash)
     }
 }


### PR DESCRIPTION
## Motivation

This project already uses `sha3` crate and in some crates `sha3` and `tiny-keccak` are used simultaneously. I think for unification and to reduce a total amount of code which must be reviewed, it would be better to use a single SHA-3 implementation. Plus this change slightly reduces amount of code, also in future const generics will allow to remove most of annoying `hash.copy_from_slice(&Sha3_256::digest(v))` 3-liners and replace it with a simple `Sha3_256::digest(v)`. (Unfortunately `GenericArray` does not have a simple conversion into array of the same size)

UPD: With the following issue fixed, we can make code nicer without const generics: fizyk20/generic-array#78

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

No new functionality, so no new tests are needed.
