### PR TITLE
Compiler: Specified stdlib root path for Move

### DIFF
--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -34,6 +34,9 @@ struct Args {
     /// Path to the Move IR source to compile
     #[structopt(parse(from_os_str))]
     pub source_path: PathBuf,
+    /// Path to the Move stdlib root path
+    #[structopt(long = "stdlib-root")]
+    pub stdlib_root: Option<String>,
 }
 
 fn print_errors_and_exit(verification_errors: &[VerificationError]) -> ! {
@@ -67,6 +70,14 @@ fn main() {
     let args = Args::from_args();
 
     let address = AccountAddress::default();
+
+    match args.stdlib_root {
+        Some(path) => {
+            std::env::set_var("MOVE_STDLIB_ROOT", path);
+        }
+        None => {
+        }
+    }
 
     if !args.module_input {
         let source = fs::read_to_string(args.source_path).expect("Unable to read file");

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -21,11 +21,22 @@ pub fn do_compile_module<T: ModuleAccess>(
     compile_module(address, &parsed_module, dependencies).unwrap()
 }
 
+pub fn get_stdlib_root() -> PathBuf {
+    let mut stdlib_root: PathBuf;
+    if std::env::var("MOVE_STDLIB_ROOT").is_ok() {
+        stdlib_root = PathBuf::from(std::env::var("MOVE_STDLIB_ROOT").unwrap());
+    } else {
+        stdlib_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        stdlib_root.pop();
+        stdlib_root.push("stdlib");
+    }
+
+    return stdlib_root;
+}
+
 pub fn build_stdlib(address: &AccountAddress) -> Vec<VerifiedModule> {
     // TODO: Change source paths for stdlib when we have proper SDK packaging.
-    let mut stdlib_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    stdlib_root.pop();
-    stdlib_root.push("stdlib");
+    let stdlib_root = get_stdlib_root();
 
     let mut stdlib_modules = vec![];
     for e in [


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Compiler: Specified stdlib root path for Move.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

1. `cargo build --bin compiler`
2. run compiler on other computer
```
$ ./compiler ~/hello.mvir
thread 'main' panicked at 'Unable to read file: "/Volumes/backup/repos/libra/language/stdlib/modules/hash.mvir"', language/compiler/src/util.rs:18:29
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```
3. with this PR
```
$ ./compiler --stdlib-root ~/repos/bcx/libra/language/stdlib/ ~/hello.mvir
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
