### PR TITLE
fix typo in Fuzzer Readme

### DIFF
--- a/testsuite/libra_fuzzer/README.md
+++ b/testsuite/libra_fuzzer/README.md
@@ -40,7 +40,7 @@ artifact to the test suite, copy it to a file inside
 `artifacts/<target>/`.
 
 `cargo test` will now test the deserializer against the new artifact.
-The test will likely fail at first; use.
+The test will likely fail at first use.
 
 Note that `cargo test` runs each test in a separate process by default
 to isolate failures and memory usage; if you're attaching a debugger and


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There is an extraneous semicolon typo that should be removed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

N/A

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)

N/A
