### PR TITLE
[language] Add UInt64,Void to NativeReturnType

### DIFF
--- a/language/stdlib/natives/src/dispatch.rs
+++ b/language/stdlib/natives/src/dispatch.rs
@@ -11,6 +11,8 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub enum NativeReturnType {
     ByteArray(ByteArray),
     Bool(bool),
+    UInt64(u64),
+    Void,
 }
 
 pub struct CostedReturnType {

--- a/language/stdlib/natives/src/dispatch.rs
+++ b/language/stdlib/natives/src/dispatch.rs
@@ -38,6 +38,7 @@ pub trait StackAccessor {
     fn get_byte_array(&mut self) -> Result<ByteArray>;
     fn get_u64(&mut self) -> Result<u64>;
     fn get_address(&mut self) -> Result<AccountAddress>;
+    fn get_bool(&mut self) -> Result<bool>;
 }
 
 pub fn dispatch_native_call<T: StackAccessor>(

--- a/language/tools/cost_synthesis/src/natives.rs
+++ b/language/tools/cost_synthesis/src/natives.rs
@@ -67,4 +67,8 @@ impl StackAccessor for &mut StackAccessorMocker {
     fn get_address(&mut self) -> Result<AccountAddress> {
         unimplemented!("Come back later")
     }
+
+    fn get_bool(&mut self) -> Result<bool> {
+        unimplemented!("Come back later")
+    }
 }

--- a/language/vm/vm_runtime/src/execution_stack.rs
+++ b/language/vm/vm_runtime/src/execution_stack.rs
@@ -189,4 +189,15 @@ where
             None => Err(VMStaticViolation::TypeMismatch.into()),
         }
     }
+    
+    fn get_bool(&mut self) -> NativeResult<bool> {
+        match self.pop()?.value() {
+            Some(v) => match MutVal::try_own(v) {
+                Ok(Value::Bool(b)) => Ok(b),
+                Err(err) => Err(err.into()),
+                _ => Err(VMStaticViolation::TypeMismatch.into()),
+            },
+            None => Err(VMStaticViolation::TypeMismatch.into()),
+        }
+    }
 }

--- a/language/vm/vm_runtime/src/txn_executor.rs
+++ b/language/vm/vm_runtime/src/txn_executor.rs
@@ -270,6 +270,13 @@ where
                                 // Call stack is not reconstructed for a native call, so we just
                                 // proceed on to next instruction.
                             }
+                            NativeReturnType::UInt64(value) => {
+                                self.execution_stack.push(Local::u64(value));
+                                // Call stack is not reconstructed for a native call, so we just
+                                // proceed on to next instruction.
+                            }
+                            NativeReturnType::Void => {
+                            }
                         }
                     } else {
                         self.execution_stack.top_frame_mut()?.jump(pc);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Supporting return value of u64 and void type.

Update 
```
pub enum NativeReturnType {
    ByteArray(ByteArray),
    Bool(bool),
}
```
to
```
pub enum NativeReturnType {
    ByteArray(ByteArray),
    Bool(bool),
    UInt64(u64),
    Void,
}
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
