### PR TITLE
update dev_setup.sh support native cURL

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -43,6 +43,7 @@ else
 	exit 1
 fi
 
+
 cat <<EOF
 Welcome to Libra!
 
@@ -62,6 +63,20 @@ if [[ "$input" != "y"* ]]; then
 	echo "Exiting..."
 	exit 0
 fi
+
+# Install cURL
+echo "Installing cURL......"
+if[[ "$OSTYPE" == "linux-gnu" ]]; then
+	if which yum &>/dev/null; then
+		yum install curl
+	elif which apt-get &>/dev/null; then
+		apt-get install curl
+	elif which pacman &>/dev/null; then
+		pacman -S curl
+	else
+		echo "Unable to find supported package manager (yum, apt-get, or pacman). Abort"
+		exit 1
+	fi
 
 # Install Rust
 echo "Installing Rust......"


### PR DESCRIPTION
# Motivation 

the Atual Script dev_setup.sh does not have the installation check done, if curl is installed.
fix exception for **dev_setup.sh** 

### the problem:

```
# Install Rust
echo "Installing Rust......"
if rustup --version &>/dev/null; then
	echo "Rust is already installed"
else
	**curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable**
	CARGO_ENV="$HOME/.cargo/env"
	source "$CARGO_ENV"
fi

```
[the line 71, not verified the curl is installed ](https://github.com/libra/libra/blob/master/scripts/dev_setup.sh#L71)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

y

## Test Plan

tested on 4.15.0-51-generic #55-Ubuntu ( ubuntu 16.06 ) 

## Related PRs
reported on fix website libra [DOCUMENTATION](https://github.com/libra/website/pull/46
)
