### PR TITLE
Fix erroneous links in Move docs

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -31,7 +31,7 @@ Libra Core components interact with the language component through the VM. Speci
 * You can find many small Move IR examples in the [tests](https://github.com/libra/libra/tree/master/language/functional_tests/tests/testsuite). The easiest way to experiment with Move IR is to create a new test in this directory and follow the instructions for running the tests.
 * Some more substantial examples can be found in the [standard library](https://github.com/libra/libra/tree/master/language/stdlib/modules). The two most notable ones are [LibraAccount.mvir](https://github.com/libra/libra/blob/master/language/stdlib/modules/libra_account.mvir), which implements accounts on the Libra blockchain, and [LibraCoin.mvir](https://github.com/libra/libra/blob/master/language/stdlib/modules/libra_coin.mvir), which implements Libra coin.
 * The four transaction scripts supported in the Libra testnet are also in the standard library directiory. They are [peer-to-peer transfer](https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/peer_to_peer_transfer.mvir), [account creation](https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/create_account.mvir), [minting new Libra](https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/mint.mvir) (will only work for an account with proper privileges), and [key rotation](https://github.com/libra/libra/blob/master/language/stdlib/transaction_scripts/rotate_authentication_key.mvir).
-* The most complete documentation of the Move IR syntax is the [grammar](https://github.com/libra/libra/blob/master/language/compiler/src/parser/mod.rs). You can also take a look at the [parser for the Move IR](https://github.com/libra/libra/blob/master/language/compiler/src/parser/syntax.lalrpop).
+* The most complete documentation of the Move IR syntax is the [grammar](https://github.com/libra/libra/blob/master/language/compiler/ir_to_bytecode/src/parser/mod.rs). You can also take a look at the [parser for the Move IR](https://github.com/libra/libra/blob/master/language/compiler/ir_to_bytecode/src/parser/syntax.lalrpop).
 * Check out the [IR compiler README](https://github.com/libra/libra/blob/master/language/compiler/README.md) for more details on writing Move IR code.
 
 ### Directory Organization
@@ -50,4 +50,3 @@ Libra Core components interact with the language component through the VM. Speci
     ├── vm_genesis     # The genesis state creation, and blockchain genesis writeset
     └── vm_runtime     # The bytecode interpreter
 ```
-

--- a/language/README.md
+++ b/language/README.md
@@ -16,7 +16,7 @@ The Move language directory consists of five parts:
 
 - The [bytecode verifier](https://github.com/libra/libra/tree/master/language/bytecode_verifier), which contains a static analysis tool for rejecting invalid Move bytecode. The virtual machine runs the bytecode verifier on any new Move code it encounters before executing it. The compiler runs the bytecode verifier on its output and surfaces the errors to the programmer.
 
-- The Move intermediate representation (IR) [compiler](https://github.com/libra/libra/tree/master/language/stdlib), which compiles human-readable program text into Move bytecode. *Warning: the IR compiler is a testing tool. It can generate invalid bytecode that will be rejected by the Move bytecode verifier. The IR syntax is a work in progress that will undergo significant changes.*
+- The Move intermediate representation (IR) [compiler](https://github.com/libra/libra/tree/master/language/compiler), which compiles human-readable program text into Move bytecode. *Warning: the IR compiler is a testing tool. It can generate invalid bytecode that will be rejected by the Move bytecode verifier. The IR syntax is a work in progress that will undergo significant changes.*
 
 - The [standard library](https://github.com/libra/libra/tree/master/language/stdlib), which contains the Move IR code for the core system modules such as `LibraAccount` and `LibraCoin`.
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix erroneous links in Move language documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

None.

## Related PRs

None.
