### PR TITLE
EarmarkedLibraCoin: removed unused variables

### DIFF
--- a/language/functional_tests/tests/testsuite/move_getting_started_examples/earmarked_libra.mvir
+++ b/language/functional_tests/tests/testsuite/move_getting_started_examples/earmarked_libra.mvir
@@ -56,8 +56,6 @@ module EarmarkedLibraCoin {
   // Allow the creator of the earmarked coin to reclaim it.
   public claim_for_creator(): R#Self.T {
     let t: R#Self.T;
-    let coin: R#LibraCoin.T;
-    let recipient: address;
     let sender: address;
 
     sender = get_txn_sender();


### PR DESCRIPTION
Removed unused variables "coin" and "recipient" to improve readability.

## Motivation

EarmarkedLibraCoin is one of the examples featured at https://developers.libra.org/docs/move-overview, and therefore should be as polished as possible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

You can verify the changes with the automated test tool:
`cargo test -p functional_tests earmarked_libra.mvir`

## Related PRs

Documentation update at:
https://github.com/libra/website/pull/50
