### PR TITLE
Remove a horrible regex from nextgen_crypto

### DIFF
--- a/crypto/nextgen_crypto/Cargo.toml
+++ b/crypto/nextgen_crypto/Cargo.toml
@@ -27,7 +27,6 @@ digest = "0.8.1"
 hmac = "0.7.1"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
-regex = "1.1.9"
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 crypto-derive = { path = "../legacy_crypto/src/macros" }

--- a/crypto/nextgen_crypto/src/slip0010.rs
+++ b/crypto/nextgen_crypto/src/slip0010.rs
@@ -13,7 +13,6 @@
 use byteorder::{BigEndian, ByteOrder};
 use ed25519_dalek::{PublicKey, SecretKey};
 use hmac::{Hmac, Mac};
-use regex::Regex;
 use sha2::Sha512;
 
 /// Extended private key that includes additional child_path and chain-code.
@@ -117,30 +116,21 @@ impl Slip0010 {
     }
     /// Match a valid path of the form "m/A/B.."; each sub-path after m is smaller than 2147483648.
     pub fn is_valid_path(path: &str) -> bool {
-        // match path where each node is [0..2147483647]
-        if !Regex::new(
-            r"^m(/([0-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8]
-[0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-8][0-9]{4}|9[0-8][0-9]{3}|99[0-8][0-9]{2}|999[0-8]
-[0-9]|9999[0-9]|[1-8][0-9]{5}|9[0-8][0-9]{4}|99[0-8][0-9]{3}|999[0-8][0-9]{2}|9999[0-8][0-9]|99999
-[0-9]|[1-8][0-9]{6}|9[0-8][0-9]{5}|99[0-8][0-9]{4}|999[0-8][0-9]{3}|9999[0-8][0-9]{2}|99999[0-8]
-[0-9]|999999[0-9]|[1-8][0-9]{7}|9[0-8][0-9]{6}|99[0-8][0-9]{5}|999[0-8][0-9]{4}|9999[0-8][0-9]{3}
-|99999[0-8][0-9]{2}|999999[0-8][0-9]|9999999[0-9]|[1-8][0-9]{8}|9[0-8][0-9]{7}|99[0-8][0-9]{6}|999
-[0-8][0-9]{5}|9999[0-8][0-9]{4}|99999[0-8][0-9]{3}|999999[0-8][0-9]{2}|9999999[0-8][0-9]|99999999
-[0-9]|1[0-9]{9}|20[0-9]{8}|21[0-3][0-9]{7}|214[0-6][0-9]{6}|2147[0-3][0-9]{5}|21474[0-7][0-9]{4}|
-214748[0-2][0-9]{3}|2147483[0-5][0-9]{2}|21474836[0-3][0-9]|214748364[0-7]))*$",
-        )
-        .unwrap() // The expression is valid, so this will never fail.
-        .is_match(path)
-        {
+        let mut segments = path.split('/');
+        if segments.next() != Some("m") {
             return false;
         }
-
-        let segments: Vec<&str> = path.split('/').collect();
-        segments
-            .iter()
-            .skip(1)
-            .map(|s| s.replace("'", ""))
-            .all(|s| s.parse::<u32>().is_ok())
+        segments.all(|s| {
+            if !s.starts_with('+') {
+                if let Ok(num) = s.parse::<u32>() {
+                    num < 2_147_483_648
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        })
     }
 
     /// Derive a key from a path and a seed.

--- a/crypto/nextgen_crypto/src/unit_tests/slip0010_test.rs
+++ b/crypto/nextgen_crypto/src/unit_tests/slip0010_test.rs
@@ -3,6 +3,17 @@
 
 use crate::slip0010::Slip0010;
 
+#[test]
+fn test_slip0010_valid_paths() {
+    assert!(Slip0010::is_valid_path("m/2147483647"));
+    assert!(!Slip0010::is_valid_path("m/2147483648"));
+    assert!(!Slip0010::is_valid_path("/m/0"));
+    assert!(!Slip0010::is_valid_path("m/0/"));
+    assert!(!Slip0010::is_valid_path("m/+5"));
+    assert!(Slip0010::is_valid_path("m"));
+    assert!(!Slip0010::is_valid_path("0"));
+}
+
 // Testing against SLIP-0010 test vectors.
 #[test]
 fn test_slip0010_vectors() {


### PR DESCRIPTION
## Motivation

Using a regex for checking numbers is not very optimal

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I added some tests for `is_valid_path`