### PR TITLE
fix typo  from little endian to little-endian

### DIFF
--- a/common/canonical_serialization/src/lib.rs
+++ b/common/canonical_serialization/src/lib.rs
@@ -17,7 +17,7 @@
 //! rules are:
 //! (All unsigned integers are encoded in little-endian representation unless specified otherwise)
 //!
-//! 1. The encoding of an unsigned 64-bit integer is defined as its little endian representation
+//! 1. The encoding of an unsigned 64-bit integer is defined as its little-endian representation
 //!    in 8 bytes
 //!
 //! 2. The encoding of an item (byte array) is defined as:


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

fix typo error from  little endian to little-endian

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

N/A

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
