### PR TITLE
[benchamrk] Let AC clients submit TXNs with slight time difference.

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -13,6 +13,7 @@ grpcio = "0.4"
 itertools = "0.8.0"
 lazy_static = "1.2.0"
 protobuf = "2.7"
+rand = "0.7.0"
 regex = "1.1.9"
 structopt = "0.2.15"
 

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -92,7 +92,7 @@ pub(crate) fn create_benchmarker_from_opt(args: &Opt) -> Benchmarker {
             .expect("failed to parse debug_address"),
     );
     // Ready to instantiate Benchmarker.
-    Benchmarker::new(clients, debug_client)
+    Benchmarker::new(clients, debug_client, args.stagger_range_ms)
 }
 
 /// Benchmarker is not a long-lived job, so starting a server and expecting it to be polled
@@ -162,6 +162,7 @@ mod tests {
                 num_accounts: 4,
                 free_lunch: 10_000_000,
                 num_clients: 4,
+                stagger_range_ms: 1,
                 num_rounds: 4,
                 num_epochs: 2,
                 executable: Executable::MeasureThroughput,

--- a/benchmark/src/grpc_helpers.rs
+++ b/benchmark/src/grpc_helpers.rs
@@ -83,7 +83,7 @@ fn check_ac_response(resp: &ProtoSubmitTransactionResponse) -> bool {
 }
 
 /// Send TXN requests to AC async, wait for and check the responses from AC.
-/// Return only the responses of accepted TXN requests.
+/// Return the responses of only accepted TXN requests.
 /// Ignore but count both gRPC-failed submissions and AC-rejected TXNs.
 pub fn submit_and_wait_txn_requests(
     client: &AdmissionControlClient,

--- a/benchmark/src/ruben_opt.rs
+++ b/benchmark/src/ruben_opt.rs
@@ -72,6 +72,10 @@ pub struct Opt {
     /// If not specified or equals 0, it will be set to validator_addresses.len().
     #[structopt(short = "c", long = "num_clients", default_value = "0")]
     pub num_clients: usize,
+    /// Randomly distribute the clients to start sending requests over the stagger_range_ms time.
+    /// A value of 1 ms effectively means starting all clients at once.
+    #[structopt(short = "g", long = "stagger_range_ms", default_value = "64")]
+    pub stagger_range_ms: u16,
     /// Number of repetition to attempt, in one epoch, to increase overal number of sent TXNs.
     #[structopt(short = "r", long = "num_rounds", default_value = "1")]
     pub num_rounds: u64,


### PR DESCRIPTION
## Motivation

With some randomly injected sleep, TXN submissions from multiple AC clients will be smoothed a bit.
User can control the upper bound of sleep duration by specifying `-g` or `--stagger_range_ms`.
The larger the value, the slower the request rate since TXNs are much spreading out.
Staggering is disabled for mint operations.

## Test Plan

E2E test with two different `stagger_range_ms` cases
Case 1. no stagger at all
```
./target/release/ruben -f faucet_for_ruben -s temp_config -n 32 -c 64 -g 1
......
Dispatch a chunk of 16 requests to client and start to submit after staggered 0 ms.
Dispatch a chunk of 16 requests to client and start to submit after staggered 0 ms.
......
10 epoch(s) of TXN throughput = [(972.4596391263058, 311.5302707636142), (1057.8512396694214, 307.8773301262778), (870.0084961767204, 336.8421052631579), (761.3382899628252, 330.74935400516796), (1160.9977324263039, 255.55278263039682), (796.2674961119751, 308.43373493975906), (1027.0812437311936, 342.0173680694723), (825.1410153102337, 371.41820819731595), (1071.1297071129707, 316.3422922459067), (942.0423183072677, 355.9263121306917)]
```

Case 2. at maximum 1600 ms delay
```
./target/release/ruben -f faucet_for_ruben -s temp_config -n 32 -c 64 -g 1600
......
Dispatch a chunk of 16 requests to client and start to submit after staggered 937 ms.
Dispatch a chunk of 16 requests to client and start to submit after staggered 951 ms.
......
10 epoch(s) of TXN throughput = [(558.0381471389646, 270.47015319598523), (578.8581119276428, 297.5879104911363), (575.9280089988752, 199.14430182808246), (581.1577752553916, 238.9174055062996), (615.3846153846154, 287.64044943820227), (616.1251504211793, 290.49645390070924), (557.430593358737, 271.90653212958046), (574.3129556926528, 282.40485383342525), (599.8828353837141, 291.73789173789174), (632.4891908585547, 292.23744292237444)]
```

Notice the request throughput drops significantly. TXN throughput's also dropped.
We can see the submissions are smoothed at AC site. The following figure visualizes accepted #TXNs of *0ms-stagger case* vs *1600ms-stagger case*:

![image](https://user-images.githubusercontent.com/1838298/61675678-1fd74780-acae-11e9-80eb-5204492edb4c.png)

