### PR TITLE
[benchmark] Implement per-account waiting mechanism.

### DIFF
--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -28,7 +28,7 @@ fn test_liveness(
             let tx_reqs = bm.gen_ring_txn_requests(accounts);
             repeated_tx_reqs.extend(tx_reqs.into_iter());
         }
-        bm.submit_and_wait_txn_committed(&repeated_tx_reqs);
+        bm.submit_and_wait_txn_committed(&repeated_tx_reqs, accounts);
     }
 }
 
@@ -53,7 +53,7 @@ pub(crate) fn measure_throughput(
             let tx_reqs = bm.gen_pairwise_txn_requests(accounts);
             repeated_tx_reqs.extend(tx_reqs.into_iter());
         }
-        let txn_throughput = bm.measure_txn_throughput(&repeated_tx_reqs);
+        let txn_throughput = bm.measure_txn_throughput(&repeated_tx_reqs, accounts);
         txn_throughput_seq.push(txn_throughput);
     }
     info!(


### PR DESCRIPTION
## Motivation
Implement the following wait TXNs mechanism: when an account's persisted sequence number on validator
equals its local sequence number manipulated in `Benchmarker`, all its TXNs are committed.
Therefore waiting for all TXNs is equivalent to waiting on all senders' sequence numbers to meet this condition.

Advantage over waiting on storage's committed_txns counter:
1. robustness: we can have test liveness from multiple `Benchenmarker`s, assuming mint operations from them are not overlapped.
2. finer granularity: we can extend easily to report per account throughput.

## Test Plan
* E2E test with `libra_swarm`. Normal case everything is fine. Notice we divided accounts into 4 chunks and wait:
```
./target/release/ruben -f faucet_for_ruben -s temp_config -n 40 -c 4
......
Dispatch a chunk of 400 requests to client.
Dispatch a chunk of 400 requests to client.
Dispatch a chunk of 400 requests to client.
Dispatch a chunk of 400 requests to client.
Submitted and accepted 1600 TXNs within 1656 ms, during which 425 already committed
Dispatch a chunk of 10 accounts to client.
Dispatch a chunk of 10 accounts to client.
Dispatch a chunk of 10 accounts to client.
Dispatch a chunk of 10 accounts to client.
Waited TXNs for 2895 ms
REQ throughput est = 1600 txns / 1656 ms = 966.18 rps.
TXN throughput est = 1600 txns / 4551 ms = 351.57 rps.
......
10 epoch(s) of TXN throughput = [(899.3816750983699, 375.4106053496011), (955.7945041816009, 381.49737720553173), (875.27352297593, 428.03638309256286), (966.1835748792271, 351.57108327840035), (1205.7272042200452, 329.2181069958848), (980.9932556713673, 376.02820211515865), (1074.5466756212222, 171.01325352714835), (1341.156747694887, 134.37473754934072), (1104.9723756906078, 337.2681281618887), (1203.9127163280662, 381.31553860819827)]
```

* After a Benchmarker finish minting its generated accounts, we can start a new Benchmarker that connects to the same `libra_swarm`.

* In the case of many submission failure (by making each account submit more than `capacity_per_user` TXN requests):
From a particular run: ruben generated 2560 TXNs, 144 of them are rejected by AC due to TooManyTransactions errors. For the 2416 acceptted TXNs, 1508 are finally committed in Libra. 1052 TXNs are not committed (144 not accepted and 908 accepted but not committed). See logs for details:
```
./target/release/ruben -f faucet_for_ruben -s temp_config -n 16 -c 1 -e 1 -r 10
......
Dispatch a chunk of 2560 requests to client
Dispatch a chunk of 16 accounts to client
Submitted txn failed: ErrorMessage { msg: "Request causes error on VM/mempool: SubmitTransactionResponse { ac_status: None, mempool_error: Some(MempoolAddTransactionStatus { code: TooManyTransactions, message: \"txns length: 100 capacity per user: 100\" }), vm_error: None, validator_id: [] }" }
------[in total 144 TooManyTransactions errors]------
Submitted and accepted 2416 TXNs within 3229 ms, during which 1026 already committed
Waited TXNs for 76174 ms
REQ throughput est = 2560 txns / 3229 ms = 792.82 rps.
TXN throughput est = 1508 txns / 79403 ms = 18.99 rps.
1 epoch(s) of TXN throughput = [(792.8151130380922, 18.99172575343501)]
```
