### PR TITLE
[language] Add command-line arguments to cost synthesis

### DIFF
--- a/language/tools/cost_synthesis/Cargo.toml
+++ b/language/tools/cost_synthesis/Cargo.toml
@@ -22,6 +22,7 @@ vm_cache_map = { path = "../../vm/vm_runtime/vm_cache_map" }
 move_ir_natives = { path = "../../stdlib/natives" }
 crypto = { path = "../../../crypto/legacy_crypto" }
 state_view = { path = "../../../storage/state_view" }
+structopt = "0.2.15"
 
 [features]
 default = ["vm_runtime/instruction_synthesis"]


### PR DESCRIPTION
The constants for determining stack size and number of iterations were
manually set variables within the main file. This commit makes these
settable from the command line using the `structopt` package. 

