### PR TITLE
[language] report invalid fallthrough on bytecode vector ending in co…

### DIFF
--- a/language/bytecode_verifier/src/code_unit_verifier.rs
+++ b/language/bytecode_verifier/src/code_unit_verifier.rs
@@ -51,7 +51,7 @@ impl<'a> CodeUnitVerifier<'a> {
 
         // Check to make sure that the bytecode vector ends with a branching instruction.
         if let Some(bytecode) = code.last() {
-            if !bytecode.is_branch() {
+            if !bytecode.is_unconditional_branch() {
                 return vec![VMStaticViolation::InvalidFallThrough];
             }
         } else {

--- a/language/bytecode_verifier/tests/code_unit_tests.rs
+++ b/language/bytecode_verifier/tests/code_unit_tests.rs
@@ -1,0 +1,48 @@
+use bytecode_verifier::CodeUnitVerifier;
+use vm::{
+    errors::VMStaticViolation,
+    file_format::{self, Bytecode},
+};
+
+#[test]
+fn invalid_fallthrough_br_true() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert!(errors[0].err == VMStaticViolation::InvalidFallThrough);
+}
+
+#[test]
+fn invalid_fallthrough_br_false() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert!(errors[0].err == VMStaticViolation::InvalidFallThrough);
+}
+
+// all non-branch instructions should trigger invalid fallthrough; just check one of them
+#[test]
+fn invalid_fallthrough_non_branch() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert!(errors[0].err == VMStaticViolation::InvalidFallThrough);
+}
+
+#[test]
+fn valid_fallthrough_branch() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::Branch(0)]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert!(errors.is_empty());
+}
+
+#[test]
+fn valid_fallthrough_ret() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::Ret]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert!(errors.is_empty());
+}
+
+#[test]
+fn valid_fallthrough_abort() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdConst(7), Bytecode::Abort]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert!(errors.is_empty());
+}

--- a/language/functional_tests/tests/testsuite/commands/invalid_fallthrough1.mvir
+++ b/language/functional_tests/tests/testsuite/commands/invalid_fallthrough1.mvir
@@ -1,0 +1,5 @@
+main() {
+}
+
+// check: VerificationError
+// check: InvalidFallThrough

--- a/language/functional_tests/tests/testsuite/commands/invalid_fallthrough2.mvir
+++ b/language/functional_tests/tests/testsuite/commands/invalid_fallthrough2.mvir
@@ -1,0 +1,9 @@
+main() {
+  let x: u64;
+
+  return;
+  x = 7;
+}
+
+// check: VerificationError
+// check: InvalidFallThrough

--- a/language/functional_tests/tests/testsuite/commands/invalid_fallthrough3.mvir
+++ b/language/functional_tests/tests/testsuite/commands/invalid_fallthrough3.mvir
@@ -1,0 +1,13 @@
+main() {
+  let x: u64;
+
+  if (true) {
+    return;
+  } else {
+    return;
+  }
+  x = 7;
+}
+
+// check: VerificationError
+// check: InvalidFallThrough

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1423,3 +1423,48 @@ impl CompiledModule {
         })
     }
 }
+
+/// Return the simplest module that will pass the bounds checker
+pub fn empty_module() -> CompiledModuleMut {
+    CompiledModuleMut {
+        module_handles: vec![ModuleHandle {
+            address: AddressPoolIndex::new(0),
+            name: StringPoolIndex::new(0),
+        }],
+        address_pool: vec![AccountAddress::default()],
+        string_pool: vec![SELF_MODULE_NAME.to_string()],
+        function_defs: vec![],
+        struct_defs: vec![],
+        field_defs: vec![],
+        struct_handles: vec![],
+        function_handles: vec![],
+        type_signatures: vec![],
+        function_signatures: vec![],
+        locals_signatures: vec![LocalsSignature(vec![])],
+        byte_array_pool: vec![],
+    }
+}
+
+/// Create a dummy module to wrap the bytecode program in local@code
+pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
+    let mut module = empty_module();
+    let mut code_unit = CodeUnit::default();
+    code_unit.code = code;
+    let mut fun_def = FunctionDefinition::default();
+    fun_def.code = code_unit;
+
+    module.function_signatures.push(FunctionSignature {
+        arg_types: vec![],
+        return_types: vec![],
+        kind_constraints: vec![],
+    });
+    let fun_handle = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: StringPoolIndex(0),
+        signature: FunctionSignatureIndex(0),
+    };
+
+    module.function_handles.push(fun_handle);
+    module.function_defs.push(fun_def);
+    module.freeze().unwrap()
+}


### PR DESCRIPTION
…nditional branch

Previously, the bytecode verifier allowed conditional instructions`BrTrue` and `BrFalse` as the last instructions in the vector of bytecode. Control-flow can fall through the end of the vector if the branch is not taken.

This PR fixes the problem by ensuring that the last instruction is an unconditional branch (i.e., `Return`, `Abort`, or `Branch`).

## Test Plan

New unit tests that check ending in all of the different branching instructions + some new functional tests.
