### PR TITLE
[benchmark] Submit TXNs in constant rate.

### DIFF
--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -19,6 +19,7 @@ use types::{account_address::AccountAddress, account_config::association_address
 
 pub mod grpc_helpers;
 pub mod ruben_opt;
+pub mod submit_rate;
 pub mod txn_generator;
 
 use grpc_helpers::{
@@ -42,8 +43,9 @@ lazy_static! {
 /// Metrics reported include:
 /// * Counters related to:
 ///   * TXN generation: requested_txns, created_txns, sign_failed_txns;
-///   * Submission to AC and AC response: submit_txns.{ac_status_code},
-///     submit_txns.{mempool_status_code}, submit_txns.{vm_status}, submit_txns.{grpc_error};
+///   * Submission to AC and AC response: submit_txns (used to measure submission rate),
+///     submit_txns.{ac_status_code}, submit_txns.{mempool_status_code}, submit_txns.{vm_status},
+///     submit_txns.{grpc_error};
 ///   * Final status within epoch: committed_txns, timedout_txns;
 /// * Gauges: request_duration_ms, running_duration_ms, request_throughput, txns_throughput.
 pub struct Benchmarker {
@@ -54,11 +56,17 @@ pub struct Benchmarker {
     /// Persisted sequence numbers for generated accounts and faucet account
     /// BEFORE playing new round of TXNs.
     prev_sequence_numbers: HashMap<AccountAddress, u64>,
+    /// Submit TXNs with specified rate. Minting opearation always floods TXNs.
+    submit_rate: u64,
 }
 
 impl Benchmarker {
     /// Construct Benchmarker with a vector of AC clients and a NodeDebugClient.
-    pub fn new(clients: Vec<AdmissionControlClient>, stagger_range_ms: u16) -> Self {
+    pub fn new(
+        clients: Vec<AdmissionControlClient>,
+        stagger_range_ms: u16,
+        submit_rate: u64,
+    ) -> Self {
         if clients.is_empty() {
             panic!("failed to create benchmarker without any AdmissionControlClient");
         }
@@ -68,6 +76,7 @@ impl Benchmarker {
             clients: arc_clients,
             stagger_range_ms,
             prev_sequence_numbers,
+            submit_rate,
         }
     }
 
@@ -124,8 +133,11 @@ impl Benchmarker {
         // Disable client staggering for mint operations.
         let stagger_range_ms = self.stagger_range_ms;
         self.stagger_range_ms = 1;
-        let (num_accepted, num_committed, _, _) =
-            self.submit_and_wait_txn_committed(mint_requests, std::slice::from_mut(faucet_account));
+        let (num_accepted, num_committed, _, _) = self.submit_and_wait_txn_committed(
+            mint_requests,
+            std::slice::from_mut(faucet_account),
+            Some(std::u64::MAX), /* Flood minting TXNs. */
+        );
         self.stagger_range_ms = stagger_range_ms;
         // We stop immediately if any minting fails.
         if num_accepted != mint_requests.len() || num_accepted - num_committed > 0 {
@@ -154,7 +166,11 @@ impl Benchmarker {
 
     /// Send requests to AC async, wait for responses from AC.
     /// Return #accepted TXNs and submission duration.
-    pub fn submit_txns(&mut self, txn_reqs: &[SubmitTransactionRequest]) -> (usize, u128) {
+    pub fn submit_txns(
+        &mut self,
+        txn_reqs: &[SubmitTransactionRequest],
+        submit_rate: u64,
+    ) -> (usize, u128) {
         let txn_req_chunks = divide_items(txn_reqs, self.clients.len());
         let now = time::Instant::now();
         // Zip txn_req_chunks with clients: when first iter returns none,
@@ -172,11 +188,14 @@ impl Benchmarker {
                     move || -> (Vec<ProtoSubmitTransactionResponse>, u16) {
                         let delay_duration_ms = Self::stagger_client(stagger_range_ms);
                         info!(
-                            "Dispatch a chunk of {} requests to client and start to submit after staggered {} ms.",
+                            "Dispatch {} requests to client after staggered {} ms.",
                             local_chunk.len(),
                             delay_duration_ms,
                         );
-                        (submit_and_wait_txn_requests(&local_client, &local_chunk), delay_duration_ms)
+                        (
+                            submit_and_wait_txn_requests(&local_client, local_chunk, submit_rate),
+                            delay_duration_ms,
+                        )
                     },
                 )
             })
@@ -301,8 +320,10 @@ impl Benchmarker {
         &mut self,
         txn_reqs: &[SubmitTransactionRequest],
         senders: &mut [AccountData],
+        submit_rate: Option<u64>,
     ) -> (usize, usize, u128, u128) {
-        let (num_txns_accepted, submit_duration_ms) = self.submit_txns(txn_reqs);
+        let rate = submit_rate.unwrap_or(self.submit_rate);
+        let (num_txns_accepted, submit_duration_ms) = self.submit_txns(txn_reqs, rate);
         let (sync_sequence_numbers, wait_duration_ms) = self.wait_txns(senders);
         let (num_committed, _) = self.check_txn_results(senders, &sync_sequence_numbers);
         (
@@ -342,10 +363,10 @@ impl Benchmarker {
         txn_reqs: &[SubmitTransactionRequest],
         senders: &mut [AccountData],
     ) -> (f64, f64) {
-        let (_, num_committed, submit_duration_ms, wait_duration_ms) =
-            self.submit_and_wait_txn_committed(txn_reqs, senders);
+        let (num_accepted, num_committed, submit_duration_ms, wait_duration_ms) =
+            self.submit_and_wait_txn_committed(txn_reqs, senders, None);
         let request_throughput =
-            Self::calculate_throughput(txn_reqs.len(), submit_duration_ms, "REQ");
+            Self::calculate_throughput(num_accepted, submit_duration_ms, "REQ");
         let running_duration_ms = submit_duration_ms + wait_duration_ms;
         let txn_throughput = Self::calculate_throughput(num_committed, running_duration_ms, "TXN");
 

--- a/benchmark/src/ruben_opt.rs
+++ b/benchmark/src/ruben_opt.rs
@@ -82,6 +82,9 @@ pub struct Opt {
     /// Number of epochs to measure the TXN throughput, each time with newly created Benchmarker.
     #[structopt(short = "e", long = "num_epochs", default_value = "10")]
     pub num_epochs: u64,
+    /// Submit constant number of TXN requests per second; otherwise TXNs are flood to Libra.
+    #[structopt(short = "k", long = "submit_rate")]
+    pub submit_rate: Option<u64>,
     /// Choices of how to generate TXNs/load.
     #[structopt(
         short = "t",
@@ -165,6 +168,10 @@ impl Opt {
                 parse_swarm_config_from_dir(swarm_config_dir).expect("invalid arguments");
             self.validator_addresses = validator_addresses;
         }
+    }
+
+    pub fn parse_submit_rate(&self) -> u64 {
+        self.submit_rate.unwrap_or(std::u64::MAX)
     }
 }
 

--- a/benchmark/src/submit_rate.rs
+++ b/benchmark/src/submit_rate.rs
@@ -1,0 +1,116 @@
+use logger::prelude::*;
+use std::{thread, time, vec::IntoIter};
+
+/// Items are returned in the world of microseconds.
+const MICROSECONDS_IN_ONE_SECOND: u64 = 1_000_000;
+
+/// Utilize IntoIter to implement an iterator that returns constant number of items per second.
+/// That is, an item is returned to user after waiting some time duration.
+/// Return immediately (e.g. flood all available items) when rate is set to u64::MAX.
+#[derive(Debug, Clone)]
+pub struct ConstantRate<T> {
+    /// Number of items to return per second.
+    rate: u64,
+    /// Time duration to return 1 item.
+    interval_us: u64,
+    /// Between two calls to next(), user may perform operations on the item, consuming some time.
+    /// We calculate it as the duration between two last_call values and then exclude.
+    last_call: time::Instant,
+    /// Pointer to the items to be consumed.
+    into_iter: IntoIter<T>,
+}
+
+impl<T> ConstantRate<T> {
+    /// Init with rate, and the IntoIter of the vector to be consumed.
+    /// For simplicity we assume user calls next() right after new().
+    pub fn new(rate: u64, into_iter: IntoIter<T>) -> Self {
+        assert!(rate > 0);
+        let interval_us = MICROSECONDS_IN_ONE_SECOND / rate;
+        debug!("Return 1 item after {} us", interval_us);
+        ConstantRate {
+            rate,
+            interval_us,
+            last_call: time::Instant::now(),
+            into_iter,
+        }
+    }
+}
+
+impl<T> Iterator for ConstantRate<T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        let exclude_duration_us = self.last_call.elapsed().as_micros() as u64;
+        if self.interval_us > exclude_duration_us {
+            let rest = self.interval_us - exclude_duration_us;
+            debug!("Sleep {} us before return next item", rest);
+            thread::sleep(time::Duration::from_micros(rest as u64));
+        }
+        self.last_call = time::Instant::now();
+        self.into_iter.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::submit_rate::ConstantRate;
+    use std::{thread, time};
+
+    #[test]
+    fn test_submit_rate_empty_vec() {
+        let empty_vec: Vec<u32> = vec![];
+        let mut rate = ConstantRate::new(1, empty_vec.into_iter());
+        let item = rate.next();
+        assert_eq!(item.is_none(), true);
+    }
+
+    #[test]
+    fn test_submit_rate_flood_all() {
+        let vec = vec![1, 2, 3, 4, 5, 6, 7];
+        let flood = ConstantRate::new(std::u64::MAX, vec.into_iter());
+
+        let now = time::Instant::now();
+        for item in flood {
+            let elapsed = now.elapsed().as_micros();
+            println!("Ret {:?} after {:?} us", item, elapsed);
+        }
+        let elapsed = now.elapsed().as_micros();
+        // Loop should finish at an glimpse.
+        assert!(elapsed < 1000);
+    }
+
+    #[test]
+    fn test_submit_rate_contant_rate() {
+        let vec = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let const_rate = ConstantRate::new(2, vec.into_iter());
+
+        let mut now = time::Instant::now();
+        for item in const_rate {
+            let new_now = time::Instant::now();
+            let delta = new_now.duration_since(now).as_micros();
+            println!("Ret {:?} after {:?} us", item, delta);
+            // Interval between each call to next() should be roughly 0.5 second.
+            assert!(delta < 510_000);
+            assert!(delta > 490_000);
+            now = new_now;
+        }
+    }
+
+    #[test]
+    fn test_submit_rate_exclude_duration() {
+        let vec = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let const_rate = ConstantRate::new(2, vec.into_iter());
+
+        let mut now = time::Instant::now();
+        for item in const_rate {
+            let new_now = time::Instant::now();
+            let delta = new_now.duration_since(now).as_micros();
+            println!("Ret {:?} after {:?} us", item, delta);
+            // Interval between each call to next() should be roughly 0.5 second.
+            assert!(delta < 510_000);
+            assert!(delta > 490_000);
+            now = time::Instant::now();
+            // Use this sleep to emulate that user performed something on item.
+            thread::sleep(time::Duration::from_micros(10_000));
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Add the ability to control how each client sends TXNs to AC. User can use `-k X` argument to send TXNs to AC at the speed of `X` TXNs per second per client.

## Test Plan
Unittest in `submit_rate.rs`:
```
cargo test --release -p benchmark test_submit_rate -- --nocapture
```

E2E test:
For aggregated constant submission rate of 400 requests per second, run
```
./target/release/ruben -m localhost:45345 -f faucet_for_ruben -s temp_config \
-g 1 -n 64 -c 4 -e 3 -t pairwise
-k 100

3 epoch(s) of REQ/TXN throughput = [
(381.0941570524749, 220.07307113690092),
(392.5627755414989, 219.08429610611896),
(393.69473279507883, 350.0256366433088)
]
```
We have 4 clients, each sending at constant rate 100. Log shows that request throughput is roughly 390 requests/s. Figure shows Benchmarker is submitting at constant rate and AC's accepting matches submission rate.

![image](https://user-images.githubusercontent.com/1838298/62226631-54fb2e00-b36f-11e9-8a7f-267666f84cda.png)


Another case with much less speed (40 requests per second)
![image](https://user-images.githubusercontent.com/1838298/62227032-131eb780-b370-11e9-8f03-eacc20551a11.png)


