### PR TITLE
[language] report join failures in type and memory safety analysis

### DIFF
--- a/language/functional_tests/tests/testsuite/commands/join_failure.mvir
+++ b/language/functional_tests/tests/testsuite/commands/join_failure.mvir
@@ -1,0 +1,14 @@
+main() {
+    let x: u64;
+    let y: &u64;
+
+    x = 7;
+    if (true) {
+        y = &x;
+    }
+
+    return;
+}
+
+// check: VerificationError
+// check: JoinFailure


### PR DESCRIPTION
## Motivation

If the bytecode verifier encounters a join failure, it should flag the module or script as unverified. It used to do this correctly, but a bug was introduced when switching over to the generic abstract interpreter. This diff fixes the bug by:
- Introducing an enum for `BlockPrecondition` that includes join failures 
- Changing the type/memory safety analysis to flag any join failures encountered during analysis.

In the future, we may want to get rid of the idea of a "join failure" altogether and report all errors at the instruction level instead.

## Test Plan

New functional test that exhibits a join failure.