### PR TITLE
[mempool] shared mempool: spawn separate task for each sync request

### DIFF
--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -10,9 +10,10 @@ use config::config::{MempoolConfig, NodeConfig};
 use failure::prelude::*;
 use futures::sync::mpsc::UnboundedSender;
 use futures_preview::{
+    channel::mpsc,
     compat::{Future01CompatExt, Stream01CompatExt},
-    future::{self, join_all},
-    FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt,
+    future::join_all,
+    FutureExt, SinkExt, Stream, StreamExt, TryFutureExt, TryStreamExt,
 };
 use logger::prelude::*;
 use network::{
@@ -29,7 +30,7 @@ use std::{
 };
 use storage_client::StorageRead;
 use tokio::{
-    runtime::{Builder, Runtime},
+    runtime::{Builder, Runtime, TaskExecutor},
     timer::Interval,
 };
 use types::{transaction::SignedTransaction, PeerId};
@@ -205,6 +206,7 @@ async fn process_incoming_transactions<V>(
     smp: SharedMempool<V>,
     peer_id: PeerId,
     transactions: Vec<SignedTransaction>,
+    mut completion_channel: mpsc::Sender<()>,
 ) where
     V: TransactionValidation,
 {
@@ -222,29 +224,34 @@ async fn process_incoming_transactions<V>(
     )
     .await;
 
-    let mut mempool = smp
-        .mempool
-        .lock()
-        .expect("[shared mempool] failed to acquire mempool lock");
+    {
+        let mut mempool = smp
+            .mempool
+            .lock()
+            .expect("[shared mempool] failed to acquire mempool lock");
 
-    for (idx, transaction) in transactions.into_iter().enumerate() {
-        if let Ok(None) = validations[idx] {
-            if let Ok((sequence_number, balance)) = account_states[idx] {
-                let gas_cost = transaction.max_gas_amount();
-                let insertion_result = mempool.add_txn(
-                    transaction,
-                    gas_cost,
-                    sequence_number,
-                    balance,
-                    TimelineState::NonQualified,
-                );
-                if insertion_result.code == MempoolAddTransactionStatusCode::Valid {
-                    OP_COUNTERS.inc(&format!("smp.transactions.success.{:?}", peer_id));
+        for (idx, transaction) in transactions.into_iter().enumerate() {
+            if let Ok(None) = validations[idx] {
+                if let Ok((sequence_number, balance)) = account_states[idx] {
+                    let gas_cost = transaction.max_gas_amount();
+                    let insertion_result = mempool.add_txn(
+                        transaction,
+                        gas_cost,
+                        sequence_number,
+                        balance,
+                        TimelineState::NonQualified,
+                    );
+                    if insertion_result.code == MempoolAddTransactionStatusCode::Valid {
+                        OP_COUNTERS.inc(&format!("smp.transactions.success.{:?}", peer_id));
+                    }
                 }
             }
         }
     }
     notify_subscribers(SharedMempoolNotification::NewTransactions, &smp.subscribers);
+    if let Err(e) = completion_channel.send(()).await {
+        error!("[smp] error in sync task completion {:?}", e);
+    }
 }
 
 /// This task handles [`SyncEvent`], which is periodically emitted for us to
@@ -277,92 +284,80 @@ where
 }
 
 /// This task handles inbound network events.
-async fn inbound_network_task<V>(smp: SharedMempool<V>, network_events: MempoolNetworkEvents)
-where
+async fn inbound_network_task<V>(
+    smp: SharedMempool<V>,
+    executor: TaskExecutor,
+    mut network_events: MempoolNetworkEvents,
+) where
     V: TransactionValidation,
 {
     let peer_info = smp.peer_info.clone();
     let subscribers = smp.subscribers.clone();
-    let max_inbound_syncs = smp.config.shared_mempool_max_concurrent_inbound_syncs;
+    let mut workers_available = smp.config.shared_mempool_max_concurrent_inbound_syncs;
+    let (sender, mut receiver) = mpsc::channel(workers_available);
 
-    // Handle the NewPeer/LostPeer events immediatedly, since they are not async
-    // and we don't want to buffer them or let them get reordered. The inbound
-    // direct-send messages are placed in a bounded FuturesUnordered queue and
-    // allowed to execute concurrently. The .buffer_unordered() also correctly
-    // handles back-pressure, so if mempool is slow the back-pressure will
-    // propagate down to network.
-    let f_inbound_network_task = network_events
-        .filter_map(move |network_event| {
-            trace!("SharedMempoolEvent::NetworkEvent::{:?}", network_event);
-            match network_event {
-                Ok(network_event) => match network_event {
-                    Event::NewPeer(peer_id) => {
-                        OP_COUNTERS.inc("smp.event.new_peer");
-                        new_peer(&peer_info, peer_id);
-                        notify_subscribers(
-                            SharedMempoolNotification::PeerStateChange,
-                            &subscribers,
-                        );
-                        future::ready(None)
-                    }
-                    Event::LostPeer(peer_id) => {
-                        OP_COUNTERS.inc("smp.event.lost_peer");
-                        lost_peer(&peer_info, peer_id);
-                        notify_subscribers(
-                            SharedMempoolNotification::PeerStateChange,
-                            &subscribers,
-                        );
-                        future::ready(None)
-                    }
-                    // Pass through messages to next combinator
-                    Event::Message((peer_id, msg)) => future::ready(Some((peer_id, msg))),
-                    _ => {
-                        security_log(SecurityEvent::InvalidNetworkEventMP)
-                            .error("UnexpectedNetworkEvent")
-                            .data(&network_event)
-                            .log();
-                        unreachable!("Unexpected network event")
-                    }
-                },
-                Err(e) => {
-                    security_log(SecurityEvent::InvalidNetworkEventMP)
-                        .error(&e)
-                        .log();
-                    future::ready(None)
+    while let Some(event) = network_events.next().await {
+        trace!("SharedMempoolEvent::NetworkEvent::{:?}", event);
+        match event {
+            Ok(network_event) => match network_event {
+                Event::NewPeer(peer_id) => {
+                    OP_COUNTERS.inc("smp.event.new_peer");
+                    new_peer(&peer_info, peer_id);
+                    notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
                 }
-            }
-        })
-        // Run max_inbound_syncs number of `process_incoming_transactions` concurrently
-        .for_each_concurrent(
-            max_inbound_syncs, /* limit */
-            move |(peer_id, mut msg)| {
-                OP_COUNTERS.inc("smp.event.message");
-                let transactions: Vec<_> = msg
-                    .take_transactions()
-                    .into_iter()
-                    .filter_map(|txn| match SignedTransaction::from_proto(txn) {
-                        Ok(t) => Some(t),
-                        Err(e) => {
-                            security_log(SecurityEvent::InvalidTransactionMP)
-                                .error(&e)
-                                .data(&msg)
-                                .log();
-                            None
-                        }
-                    })
-                    .collect();
-                OP_COUNTERS.inc_by(
-                    &format!("smp.transactions.received.{:?}", peer_id),
-                    transactions.len(),
-                );
-
-                process_incoming_transactions(smp.clone(), peer_id, transactions)
+                Event::LostPeer(peer_id) => {
+                    OP_COUNTERS.inc("smp.event.lost_peer");
+                    lost_peer(&peer_info, peer_id);
+                    notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
+                }
+                Event::Message((peer_id, mut msg)) => {
+                    if workers_available == 0 {
+                        receiver.next().await;
+                    } else {
+                        workers_available -= 1;
+                    }
+                    OP_COUNTERS.inc("smp.event.message");
+                    let transactions: Vec<_> = msg
+                        .take_transactions()
+                        .into_iter()
+                        .filter_map(|txn| match SignedTransaction::from_proto(txn) {
+                            Ok(t) => Some(t),
+                            Err(e) => {
+                                security_log(SecurityEvent::InvalidTransactionMP)
+                                    .error(&e)
+                                    .data(&msg)
+                                    .log();
+                                None
+                            }
+                        })
+                        .collect();
+                    OP_COUNTERS.inc_by(
+                        &format!("smp.transactions.received.{:?}", peer_id),
+                        transactions.len(),
+                    );
+                    let future = process_incoming_transactions(
+                        smp.clone(),
+                        peer_id,
+                        transactions,
+                        sender.clone(),
+                    );
+                    executor.spawn(future.boxed().unit_error().compat());
+                }
+                _ => {
+                    security_log(SecurityEvent::InvalidNetworkEventMP)
+                        .error("UnexpectedNetworkEvent")
+                        .data(&network_event)
+                        .log();
+                    unreachable!("Unexpected network event")
+                }
             },
-        );
-
-    // drive the inbound futures to completion
-    f_inbound_network_task.await;
-
+            Err(e) => {
+                security_log(SecurityEvent::InvalidNetworkEventMP)
+                    .error(&e)
+                    .log();
+            }
+        }
+    }
     crit!("SharedMempool inbound_network_task terminated");
 }
 
@@ -434,7 +429,7 @@ where
     );
 
     executor.spawn(
-        inbound_network_task(smp, network_events)
+        inbound_network_task(smp, executor.clone(), network_events)
             .boxed()
             .unit_error()
             .compat(),


### PR DESCRIPTION
right now SMP doesn't utilize multiple cores
this diff reverts to previous behavior when each sync request used to be a separate task
to prevent unbound concerns and potential OOMing semaphore is added
