### PR TITLE
WIP: [network] Add chain_id to discovery PeerInfo for domain separation

### DIFF
--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -52,6 +52,9 @@ pub enum NetworkErrorKind {
 
     #[fail(display = "Peer disconnected")]
     NotConnected,
+
+    #[fail(display = "Peer note has different discovery chain id")]
+    DifferentChainId,
 }
 
 impl Fail for NetworkError {

--- a/network/src/proto/network.proto
+++ b/network/src/proto/network.proto
@@ -7,12 +7,17 @@ package network;
 
 // A `PeerInfo` represents the network address(es) of a Peer at some epoch.
 message PeerInfo {
-  // Addresses this peer can be reached at.
-  // An address is a byte array in the
+  // Addresses this peer can be reached at. An address is a byte array in the
   // [multiaddr](https://multiformats.io/multiaddr/) format.
   repeated bytes addrs = 1;
   // Monotonically increasing incarnation number. This is usually a timestamp.
+  // The epoch number allows peers to issue new PeerInfo's and recipients to
+  // safely replace the old PeerInfo with the new one.
   uint64 epoch = 2;
+  // The chain_id of this peer. PeerInfo's are only valid if their chain_id is
+  // the same as your chain_id. The intention is to prevent PeerInfo's from
+  // e.g. mainnet and testnet from mixing accidentally.
+  uint32 chain_id = 3;
 }
 
 // A `Note` represents a signed PeerInfo. The signature should be of the peer

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -10,9 +10,10 @@ use memsocket::MemorySocket;
 use nextgen_crypto::{ed25519::Ed25519PrivateKey, *};
 use tokio::runtime::Runtime;
 
-fn get_random_seed() -> PeerInfo {
+fn get_random_seed(chain_id: ChainId) -> PeerInfo {
     let mut peer_info = PeerInfo::new();
     peer_info.set_epoch(1);
+    peer_info.set_chain_id(chain_id.into_inner());
     peer_info.mut_addrs().push(
         Multiaddr::from_str("/ip4/127.0.0.1/tcp/9090")
             .unwrap()
@@ -24,11 +25,11 @@ fn get_random_seed() -> PeerInfo {
 
 fn setup_discovery(
     rt: &mut Runtime,
+    chain_id: ChainId,
     peer_id: PeerId,
     address: Multiaddr,
-    seed_peer_id: PeerId,
-    seed_peer_info: PeerInfo,
     signer: Signer<Ed25519PrivateKey>,
+    seed_peers: HashMap<PeerId, PeerInfo>,
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
 ) -> (
     channel::Receiver<PeerManagerRequest<MemorySocket>>,
@@ -42,10 +43,11 @@ fn setup_discovery(
     let (ticker_tx, ticker_rx) = channel::new_test(0);
     let discovery = {
         Discovery::new(
+            chain_id,
             peer_id,
             vec![address],
             signer,
-            vec![(seed_peer_id, seed_peer_info)].into_iter().collect(),
+            seed_peers,
             trusted_peers,
             ticker_rx,
             PeerManagerRequestSender::new(peer_mgr_reqs_tx),
@@ -103,32 +105,68 @@ fn generate_network_pub_keys_and_signer(
     )
 }
 
+async fn send_discovery_msg(
+    peer_mgr_notifs_tx: &mut channel::Sender<PeerManagerNotification<MemorySocket>>,
+    dialer_peer_id: PeerId,
+    msg: DiscoveryMsg,
+) {
+    let (dialer_substream, listener_substream) = MemorySocket::new_pair();
+
+    // Notify discovery actor of inbound substream.
+    peer_mgr_notifs_tx
+        .send(PeerManagerNotification::NewInboundSubstream(
+            dialer_peer_id,
+            NegotiatedSubstream {
+                protocol: ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
+                substream: listener_substream,
+            },
+        ))
+        .await
+        .unwrap();
+
+    // Wrap dialer substream in a framed substream.
+    let mut dialer_substream =
+        Framed::new(dialer_substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
+
+    dialer_substream
+        .send(msg.write_to_bytes().unwrap().into())
+        .await
+        .unwrap();
+}
+
 #[test]
 // Test behavior on receipt of an inbound DiscoveryMsg.
 fn inbound() {
     ::logger::try_init_for_testing();
     let mut rt = Runtime::new().unwrap();
+    let chain_id = ChainId::testnet();
+
     // Setup self.
     let peer_id = PeerId::random();
     let address = Multiaddr::from_str("/ip4/127.0.0.1/tcp/9090").unwrap();
     let (self_pub_keys, self_signer) = generate_network_pub_keys_and_signer(peer_id);
+
     // Setup seed.
-    let mut seed_peer_info = get_random_seed();
+    let mut seed_peer_info = get_random_seed(chain_id);
     let seed_peer_id = PeerId::random();
     let (seed_pub_keys, seed_signer) = generate_network_pub_keys_and_signer(seed_peer_id);
+    let seed_peers = vec![(seed_peer_id, seed_peer_info.clone())]
+        .into_iter()
+        .collect();
     let trusted_peers = Arc::new(RwLock::new(
         vec![(seed_peer_id, seed_pub_keys), (peer_id, self_pub_keys)]
             .into_iter()
             .collect(),
     ));
+
     // Setup discovery.
     let (_, mut conn_mgr_reqs_rx, mut peer_mgr_notifs_tx, _) = setup_discovery(
         &mut rt,
+        chain_id,
         peer_id,
         address.clone(),
-        seed_peer_id,
-        seed_peer_info.clone(),
         self_signer,
+        seed_peers,
         trusted_peers.clone(),
     );
 
@@ -143,23 +181,6 @@ fn inbound() {
         )
         .await;
 
-        let (dialer_substream, listener_substream) = MemorySocket::new_pair();
-        // Notify discovery actor of inbound substream.
-
-        peer_mgr_notifs_tx
-            .send(PeerManagerNotification::NewInboundSubstream(
-                seed_peer_id,
-                NegotiatedSubstream {
-                    protocol: ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
-                    substream: listener_substream,
-                },
-            ))
-            .await
-            .unwrap();
-        // Wrap dialer substream in a framed substream.
-        let mut dialer_substream =
-            Framed::new(dialer_substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
-
         // Send DiscoveryMsg consisting of 2 notes to the discovery actor - one note for the
         // seed peer and one for another peer. The discovery actor should send addresses of the new
         // peer to the connectivity manager.
@@ -173,6 +194,7 @@ fn inbound() {
             .insert(peer_id_other, pub_keys_other);
         let note_other = {
             let mut peer_info = PeerInfo::new();
+            peer_info.set_chain_id(chain_id.into_inner());
             let addrs = peer_info.mut_addrs();
             addrs.clear();
             addrs.push(address_other.as_ref().into());
@@ -181,10 +203,8 @@ fn inbound() {
         let mut msg = DiscoveryMsg::new();
         msg.mut_notes().push(note_other.clone());
         msg.mut_notes().push(seed_note.clone());
-        dialer_substream
-            .send(msg.write_to_bytes().unwrap().into())
-            .await
-            .unwrap();
+
+        send_discovery_msg(&mut peer_mgr_notifs_tx, peer_id_other, msg).await;
 
         // Connectivity manager receives address of new peer.
         expect_address_update(&mut conn_mgr_reqs_rx, peer_id_other, address_other).await;
@@ -192,39 +212,24 @@ fn inbound() {
         // Connectivity manager receives a connect to the seed peer at the same address.
         expect_address_update(&mut conn_mgr_reqs_rx, seed_peer_id, seed_peer_address).await;
 
-        let (dialer_substream, listener_substream) = MemorySocket::new_pair();
-        // Notify discovery actor of inbound substream.
-
-        peer_mgr_notifs_tx
-            .send(PeerManagerNotification::NewInboundSubstream(
-                peer_id_other,
-                NegotiatedSubstream {
-                    protocol: ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
-                    substream: listener_substream,
-                },
-            ))
-            .await
-            .unwrap();
-        // Wrap dialer substream in a framed substream.
-        let mut dialer_substream =
-            Framed::new(dialer_substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
-        // Compose new msg.
-        let mut msg = DiscoveryMsg::new();
-        msg.mut_notes().push(note_other);
+        // Seed peer changes its address
         let new_seed_addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/8098").unwrap();
-        {
+        let seed_note = {
             seed_peer_info.set_epoch(3000);
+            seed_peer_info.set_chain_id(chain_id.into_inner());
             seed_peer_info.mut_addrs().clear();
             seed_peer_info
                 .mut_addrs()
                 .push(new_seed_addr.as_ref().into());
-            let seed_note = create_note(&seed_signer, seed_peer_id, seed_peer_info);
-            msg.mut_notes().push(seed_note);
-            dialer_substream
-                .send(msg.write_to_bytes().unwrap().into())
-                .await
-                .unwrap();
-        }
+            create_note(&seed_signer, seed_peer_id, seed_peer_info)
+        };
+
+        // Compose new msg
+        let mut msg = DiscoveryMsg::new();
+        msg.mut_notes().push(note_other);
+        msg.mut_notes().push(seed_note);
+
+        send_discovery_msg(&mut peer_mgr_notifs_tx, peer_id_other, msg).await;
 
         // Connectivity manager receives new address of seed peer.
         expect_address_update(&mut conn_mgr_reqs_rx, seed_peer_id, new_seed_addr).await;
@@ -238,28 +243,35 @@ fn inbound() {
 fn outbound() {
     ::logger::try_init_for_testing();
     let mut rt = Runtime::new().unwrap();
+    let chain_id = ChainId::testnet();
+
     // Setup self.
     let peer_id = PeerId::random();
     let address = Multiaddr::from_str("/ip4/127.0.0.1/tcp/9090").unwrap();
     let (self_pub_keys, self_signer) = generate_network_pub_keys_and_signer(peer_id);
+
     // Setup seed.
     let seed_peer_id = PeerId::random();
-    let seed_peer_info = get_random_seed();
+    let seed_peer_info = get_random_seed(chain_id);
     let (seed_pub_keys, _) = generate_network_pub_keys_and_signer(seed_peer_id);
+    let seed_peers = vec![(seed_peer_id, seed_peer_info.clone())]
+        .into_iter()
+        .collect();
     let trusted_peers = Arc::new(RwLock::new(
         vec![(seed_peer_id, seed_pub_keys), (peer_id, self_pub_keys)]
             .into_iter()
             .collect(),
     ));
+
     // Setup discovery.
     let (mut peer_mgr_reqs_rx, _conn_mgr_req_rx, mut peer_mgr_notifs_tx, mut ticker_tx) =
         setup_discovery(
             &mut rt,
+            chain_id,
             peer_id,
             address.clone(),
-            seed_peer_id,
-            seed_peer_info.clone(),
             self_signer,
+            seed_peers,
             trusted_peers.clone(),
         );
 
@@ -299,6 +311,76 @@ fn outbound() {
         assert_eq!(address, get_addrs(&msg.get_notes()[0])[0]);
     };
 
+    rt.block_on(f_peer_mgr.boxed().unit_error().compat())
+        .unwrap();
+}
+
+#[test]
+fn reject_different_chain_id() {
+    ::logger::try_init_for_testing();
+    let mut rt = Runtime::new().unwrap();
+    let chain_id_1 = ChainId::mainnet();
+    let chain_id_2 = ChainId::testnet();
+
+    // Setup self.
+    let peer_id = PeerId::random();
+    let address = Multiaddr::from_str("/ip4/127.0.0.1/tcp/9090").unwrap();
+    let (self_pub_keys, self_signer) = generate_network_pub_keys_and_signer(peer_id);
+
+    // Generate note for peer with chain_id = 1
+    let peer_id_1 = PeerId::random();
+    let (peer_pub_keys_1, peer_signer_1) = generate_network_pub_keys_and_signer(peer_id_1);
+    let peer_info_1 = get_random_seed(chain_id_1);
+    let addr_1 = Multiaddr::try_from(peer_info_1.get_addrs()[0].clone()).unwrap();
+    let note_1 = create_note(&peer_signer_1, peer_id_1, peer_info_1);
+
+    // Generate note for peer with chain_id = 2
+    let peer_id_2 = PeerId::random();
+    let (peer_pub_keys_2, peer_signer_2) = generate_network_pub_keys_and_signer(peer_id_2);
+    let peer_info_2 = get_random_seed(chain_id_2);
+    let note_2 = create_note(&peer_signer_2, peer_id_2, peer_info_2);
+
+    let seed_peers = HashMap::new();
+    let trusted_peers = Arc::new(RwLock::new(
+        vec![
+            (peer_id, self_pub_keys),
+            (peer_id_1, peer_pub_keys_1),
+            (peer_id_2, peer_pub_keys_2),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+
+    // Setup discovery.
+    let (_peer_mgr_reqs_rx, mut conn_mgr_reqs_rx, mut peer_mgr_notifs_tx, _ticker_tx) =
+        setup_discovery(
+            &mut rt,
+            chain_id_1,
+            peer_id,
+            address.clone(),
+            self_signer,
+            seed_peers,
+            trusted_peers.clone(),
+        );
+
+    // Fake connectivity manager and dialer.
+    let f_peer_mgr = async move {
+        // Send DiscoveryMsg consisting of 2 notes to the discovery actor -- one
+        // note with chain_id = 1 and another note with chain_id = 2. The Discovery
+        // actor should reject the message as there is a note with a different
+        // chain_id.
+        let mut msg = DiscoveryMsg::new();
+        msg.mut_notes().push(note_1.clone());
+        msg.mut_notes().push(note_2.clone());
+        send_discovery_msg(&mut peer_mgr_notifs_tx, peer_id_1, msg).await;
+
+        // However, a note with only chain_id = 1 should not be rejected.
+        let mut msg = DiscoveryMsg::new();
+        msg.mut_notes().push(note_1.clone());
+        send_discovery_msg(&mut peer_mgr_notifs_tx, peer_id_1, msg).await;
+
+        expect_address_update(&mut conn_mgr_reqs_rx, peer_id_1, addr_1).await;
+    };
     rt.block_on(f_peer_mgr.boxed().unit_error().compat())
         .unwrap();
 }

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -1,0 +1,49 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use failure::{self, format_err};
+use std::convert::TryFrom;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+/// Libra protocols should not be confused by other instances of the Libra
+/// protocol that may be running concurrently. For instance, discovery notes made
+/// on Libra testnet should not be valid on Libra mainnet. A ChainId allows us to
+/// provide domain separation between Libra instances.
+///
+/// Current mappings:
+///
+/// Libra mainnet <=> 1
+/// Libra testnet <=> 10
+pub struct ChainId(u32);
+
+impl ChainId {
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// The chain id for Libra mainnet.
+    pub const fn mainnet() -> Self {
+        Self(1)
+    }
+
+    /// The chain id for Libra testnet.
+    pub const fn testnet() -> Self {
+        Self(10)
+    }
+
+    pub fn into_inner(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for ChainId {
+    type Error = failure::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "mainnet" | "libra-mainnet" => Ok(Self::mainnet()),
+            "testnet" | "libra-testnet" => Ok(Self::testnet()),
+            s => Err(format_err!("Unknown chain id string: \"{}\"", s)),
+        }
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod account_address;
 pub mod account_config;
 pub mod account_state_blob;
 pub mod byte_array;
+pub mod chain_id;
 pub mod contract_event;
 pub mod get_with_proof;
 pub mod language_storage;


### PR DESCRIPTION
Discovery protocols that don't disambiguate between which specific
chain they're operating on can accidentally merge with other compatible
discovery instances. The intention with this change is to ensure that
at least mainnet and testnet discovery have proper domain separation.

Specifically, this change adds a new `chain_id` field to the discovery
`PeerInfo` protobuf struct. Discovery participants include their
currently configured `chain_id` when building and signing their own
`PeerInfo` note. Upon receiving another peer's `DiscoveryMsg`, we
reject the whole message if any `PeerInfo` has a different `chain_id`.

To be clear, this change is not particularly useful for the current
validator discovery since it's very unlikely two networks have the
exact same validator set. Instead, this will be useful for the upcoming
public full node and client p2p network discovery.

Future changes will need to integrate the `chain_id` into the current
configuration. Depending on the overall domain separation design, the
`chain_id` could be stored on-chain and used for tx domain separation.

## Test Plan

`RUST_BACKTRACE=1 cargo test -p network --lib discovery`
