### PR TITLE
[crypto] Fix LinkerError in native signature verification

### DIFF
--- a/language/functional_tests/tests/testsuite/natives/signature_ed25519.mvir
+++ b/language/functional_tests/tests/testsuite/natives/signature_ed25519.mvir
@@ -1,9 +1,9 @@
 import 0x0.Signature;
 
 main() {
-    let signature: bytearray;
-    let public_key: bytearray;
     let message: bytearray;
+    let public_key: bytearray;
+    let signature: bytearray;
 
     let output: bool;
     let expected_output: bool;
@@ -12,13 +12,10 @@ main() {
     public_key = b"7013b6ed7dde3cfb1251db1b04ae9cd7853470284085693590a75def645a926d";
     message = b"0000000000000000000000000000000000000000000000000000000000000000";
 
-    output = Signature.ed25519_verify(copy(signature), copy(public_key), copy(message));
+    output = Signature.ed25519_verify(move(signature), move(public_key), move(message));
     expected_output = true;
 
     assert(move(output) == move(expected_output), 42);
 
     return;
 }
-
-// check: LinkerError
-// TODO: fix it

--- a/language/functional_tests/tests/testsuite/natives/signature_ed25519_bad_msg.mvir
+++ b/language/functional_tests/tests/testsuite/natives/signature_ed25519_bad_msg.mvir
@@ -1,24 +1,22 @@
 import 0x0.Signature;
 
 main() {
-    let signature: bytearray;
-    let public_key: bytearray;
     let message: bytearray;
+    let public_key: bytearray;
+    let signature: bytearray;
 
     let output: bool;
     let expected_output: bool;
 
     signature = b"62d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
     public_key = b"7013b6ed7dde3cfb1251db1b04ae9cd7853470284085693590a75def645a926d";
-    message = b"0000000000000000000000000000000000000000000000000000000000000001";
+    // Alter the first byte of the message.
+    message = b"1000000000000000000000000000000000000000000000000000000000000000";
 
-    output = Signature.ed25519_verify(copy(signature), copy(public_key), copy(message));
+    output = Signature.ed25519_verify(move(signature), move(public_key), move(message));
     expected_output = false;
 
     assert(move(output) == move(expected_output), 42);
 
     return;
 }
-
-// check: LinkerError
-// TODO: fix it

--- a/language/functional_tests/tests/testsuite/natives/signature_ed25519_bad_pk.mvir
+++ b/language/functional_tests/tests/testsuite/natives/signature_ed25519_bad_pk.mvir
@@ -1,24 +1,22 @@
 import 0x0.Signature;
 
 main() {
-    let signature: bytearray;
-    let public_key: bytearray;
     let message: bytearray;
+    let public_key: bytearray;
+    let signature: bytearray;
 
     let output: bool;
     let expected_output: bool;
 
     signature = b"62d6be393b8ec77fb2c12ff44ca8b5bd8bba83b805171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
-    public_key = b"7013b6ed7dde3cfb1251db1b04ae9cd7853480284085693590a75def645a926d";
+    // Alter the last byte of the public key.
+    public_key = b"7013b6ed7dde3cfb1251db1b04ae9cd7853480284085693590a75def645a9260";
     message = b"0000000000000000000000000000000000000000000000000000000000000000";
 
-    output = Signature.ed25519_verify(copy(signature), copy(public_key), copy(message));
+    output = Signature.ed25519_verify(move(signature), move(public_key), move(message));
     expected_output = false;
 
     assert(move(output) == move(expected_output), 42);
 
     return;
 }
-
-// check: LinkerError
-// TODO: fix it

--- a/language/functional_tests/tests/testsuite/natives/signature_ed25519_bad_sig.mvir
+++ b/language/functional_tests/tests/testsuite/natives/signature_ed25519_bad_sig.mvir
@@ -1,24 +1,22 @@
 import 0x0.Signature;
 
 main() {
-    let signature: bytearray;
-    let public_key: bytearray;
     let message: bytearray;
+    let public_key: bytearray;
+    let signature: bytearray;
 
     let output: bool;
     let expected_output: bool;
 
-    signature = b"62d6be393b8ec77fb2c12ff44ca8b5bd8bba83b895171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
+    // Alter the first byte of the signature.
+    signature = b"02d6be393b8ec77fb2c12ff44ca8b5bd8bba83b895171bc99f0af3bdc619b20b8bd529452fe62dac022c80752af2af02fb610c20f01fb67a4d72789db2b8b703";
     public_key = b"7013b6ed7dde3cfb1251db1b04ae9cd7853470284085693590a75def645a926d";
     message = b"0000000000000000000000000000000000000000000000000000000000000000";
 
-    output = Signature.ed25519_verify(copy(signature), copy(public_key), copy(message));
+    output = Signature.ed25519_verify(move(signature), move(public_key), move(message));
     expected_output = false;
 
     assert(move(output) == move(expected_output), 42);
 
     return;
 }
-
-// check: LinkerError
-// TODO: fix it

--- a/language/stdlib/natives/src/signature.rs
+++ b/language/stdlib/natives/src/signature.rs
@@ -11,9 +11,10 @@ const ED25519_COST: u64 = 35;
 pub fn native_ed25519_signature_verification<T: StackAccessor>(
     mut accessor: T,
 ) -> Result<CostedReturnType> {
-    let signature = accessor.get_byte_array()?;
-    let pubkey = accessor.get_byte_array()?;
     let msg = accessor.get_byte_array()?;
+    let pubkey = accessor.get_byte_array()?;
+    let signature = accessor.get_byte_array()?;
+
 
     let native_cost = ED25519_COST * msg.len() as u64;
 

--- a/language/stdlib/natives/src/signature.rs
+++ b/language/stdlib/natives/src/signature.rs
@@ -15,7 +15,6 @@ pub fn native_ed25519_signature_verification<T: StackAccessor>(
     let pubkey = accessor.get_byte_array()?;
     let signature = accessor.get_byte_array()?;
 
-
     let native_cost = ED25519_COST * msg.len() as u64;
 
     let sig = ed25519::Ed25519Signature::try_from(signature.as_bytes())?;


### PR DESCRIPTION
## Motivation
Fixing native single signature verification as it used to parse the inputs in reverse order than expected. Also functional tests were silently failing, so the above fixed the LinkerError as well. 

## Test Plan
Fixes in the following functional tests:
```
signature_ed25519.mvir
signature_ed25519_bad_msg.mvir
signature_ed25519_bad_pk.mvir
signature_ed25519_bad_sig.mvir
```