### PR TITLE
[benchmark] Calculate avg/std TPS over epochs

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -12,8 +12,10 @@ futures = "0.1.28"
 grpcio = "0.4"
 itertools = "0.8.0"
 lazy_static = "1.2.0"
+num = "0.2.0"
 protobuf = "2.7"
 regex = "1.1.9"
+statistical = "1"
 structopt = "0.2.15"
 
 admission_control_proto = { path = "../admission_control/admission_control_proto" }


### PR DESCRIPTION
## Motivation

Calculate mean/standard deviation over multiple epochs to evaluate
request and TXN throughput, because such metrics have lower variance.

## Test Plan

Test with
```
$./target/release/ruben -f faucet_for_ruben -s temp_config -n 16 -c 4 -e 10
10 epoch(s) of REQ/TXN throughputs = [(891.98606271777, 196.771714066103), (1248.780487804878, 124.8780487804878), (1044.8979591836735, 164.73616473616474), (1103.448275862069, 158.90751086281813), (1163.6363636363637, 155.05754088431254), (1147.982062780269, 143.25685506435366), (1127.7533039647576, 150.32295948326484), (1137.7777777777778, 150.1466275659824), (1049.1803278688524, 174.62482946793997), (1142.857142857143, 145.45454545454547)]
REQ Throughput Mean = 1105.83 Stdev = 90.05
TXN Throughput Mean = 156.42 Stdev = 18.44
```

