### PR TITLE
[benchmark] Configurable TXN pattern generation

### DIFF
--- a/benchmark/src/ruben_opt.rs
+++ b/benchmark/src/ruben_opt.rs
@@ -17,6 +17,14 @@ arg_enum! {
     }
 }
 
+arg_enum! {
+    #[derive(Debug)]
+    pub enum TransactionPattern {
+        Ring,
+        Pairwise,
+    }
+}
+
 /// CLI options for RuBen.
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -78,6 +86,15 @@ pub struct Opt {
     /// Number of epochs to measure the TXN throughput, each time with newly created Benchmarker.
     #[structopt(short = "e", long = "num_epochs", default_value = "10")]
     pub num_epochs: u64,
+    /// Supported TXN pattern in Benchmarker: `Ring` or `Pairwise`.
+    #[structopt(
+        short = "t",
+        long = "txn_pattern",
+        raw(possible_values = "&TransactionPattern::variants()"),
+        case_insensitive = true,
+        default_value = "Ring"
+    )]
+    pub txn_pattern: TransactionPattern,
     /// Supported application of Benchmarker: `TestLiveness` or `MeasureThroughput`.
     #[structopt(
         short = "x",


### PR DESCRIPTION
## Summary:
In the old code, `-x testliveness` can only use ring TXNs pattern and
`-x measurethroughput` can only use pairwise TXN pattern.
With added argument `--txn_pattern`, how to generate TXNs become independent config from user.


## Test Plan
Test `ruben` with new argument `-t` or `--transaction_pattern` for 64 accounts. Note the number of TXNs generated differs:
```
$./target/release/ruben -f faucet_for_ruben -s temp_config -n 64 -c 4 -e 1 -t ring
Submitted and accepted 64 TXNs within 32 ms, during which 0 already committed
Waited 64 TXNs committed for 1027 ms

$./target/release/ruben -f faucet_for_ruben -s temp_config -n 64 -c 4 -e 1 -t pairwise
Submitted and accepted 4096 TXNs within 2765 ms, during which 249 already committed
Waited 4096 TXNs committed for 13891 ms
```
