### PR TITLE
[crypto] Converts the config module to use the nextgen_crypto API

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -17,7 +17,15 @@ tempfile = "3.1.0"
 toml = "0.4"
 
 crypto = { path = "../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 logger = { path = "../common/logger" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 types = { path = "../types" }
+
+[dev-dependencies]
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"]}
+
+[features]
+default = []
+testing = ["nextgen_crypto/testing", "types/testing"]

--- a/config/config_builder/src/util.rs
+++ b/config/config_builder/src/util.rs
@@ -23,8 +23,8 @@ pub fn gen_genesis_transaction<P: AsRef<Path>>(
         .map(|(peer_id, peer)| {
             ValidatorPublicKeys::new(
                 AccountAddress::try_from(peer_id.clone()).expect("[config] invalid peer_id"),
-                peer.get_consensus_public().into(),
-                peer.get_network_signing_public().into(),
+                peer.get_consensus_public().clone(),
+                peer.get_network_signing_public().clone(),
                 peer.get_network_identity_public(),
             )
         })

--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crypto::{
-    signing,
     utils::{encode_to_string, from_encoded_string},
     x25519::{self, X25519PrivateKey, X25519PublicKey},
+};
+use nextgen_crypto::{
+    ed25519::{compat, *},
+    traits::ValidKeyStringExt,
 };
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
@@ -23,44 +26,42 @@ mod trusted_peers_test;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TrustedPeer {
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
-    network_signing_pubkey: signing::PublicKey,
+    #[serde(serialize_with = "serialize_nextgen_key")]
+    #[serde(deserialize_with = "deserialize_nextgen_key")]
+    network_signing_pubkey: Ed25519PublicKey,
     #[serde(serialize_with = "serialize_key")]
     #[serde(deserialize_with = "deserialize_key")]
     network_identity_pubkey: X25519PublicKey,
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
-    consensus_pubkey: signing::PublicKey,
+    #[serde(serialize_with = "serialize_nextgen_key")]
+    #[serde(deserialize_with = "deserialize_nextgen_key")]
+    consensus_pubkey: Ed25519PublicKey,
 }
 
 pub struct TrustedPeerPrivateKeys {
-    network_signing_private_key: signing::PrivateKey,
+    network_signing_private_key: Ed25519PrivateKey,
     network_identity_private_key: X25519PrivateKey,
-    consensus_private_key: signing::PrivateKey,
+    consensus_private_key: Ed25519PrivateKey,
 }
 
 impl TrustedPeerPrivateKeys {
-    pub fn get_network_signing_private(&self) -> signing::PrivateKey {
-        self.network_signing_private_key.clone()
-    }
-    pub fn get_network_identity_private(&self) -> X25519PrivateKey {
-        self.network_identity_private_key.clone()
-    }
-    pub fn get_consensus_private(&self) -> signing::PrivateKey {
-        self.consensus_private_key.clone()
+    pub fn get_key_triplet(self) -> (Ed25519PrivateKey, X25519PrivateKey, Ed25519PrivateKey) {
+        (
+            self.network_signing_private_key,
+            self.network_identity_private_key,
+            self.consensus_private_key,
+        )
     }
 }
 
 impl TrustedPeer {
-    pub fn get_network_signing_public(&self) -> signing::PublicKey {
-        self.network_signing_pubkey
+    pub fn get_network_signing_public(&self) -> &Ed25519PublicKey {
+        &self.network_signing_pubkey
     }
     pub fn get_network_identity_public(&self) -> X25519PublicKey {
         self.network_identity_pubkey
     }
-    pub fn get_consensus_public(&self) -> signing::PublicKey {
-        self.consensus_pubkey
+    pub fn get_consensus_public(&self) -> &Ed25519PublicKey {
+        &self.consensus_pubkey
     }
 }
 
@@ -72,6 +73,33 @@ where
     serializer.serialize_str(&encode_to_string(key))
 }
 
+pub fn serialize_nextgen_key<S, K>(key: &K, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    K: Serialize + ValidKeyStringExt,
+{
+    key.to_encoded_string()
+        .map_err(<S::Error as serde::ser::Error>::custom)
+        .and_then(|str| serializer.serialize_str(&str[..]))
+}
+
+pub fn serialize_nextgen_opt_key<S, K>(
+    opt_key: &Option<K>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    K: Serialize + ValidKeyStringExt,
+{
+    opt_key
+        .as_ref()
+        .map_or(Ok("".to_string()), |key| {
+            key.to_encoded_string()
+                .map_err(<S::Error as serde::ser::Error>::custom)
+        })
+        .and_then(|str| serializer.serialize_str(&str[..]))
+}
+
 pub fn deserialize_key<'de, D, K>(deserializer: D) -> Result<K, D::Error>
 where
     D: Deserializer<'de>,
@@ -80,6 +108,29 @@ where
     let encoded_key: String = Deserialize::deserialize(deserializer)?;
 
     Ok(from_encoded_string(encoded_key))
+}
+
+pub fn deserialize_nextgen_key<'de, D, K>(deserializer: D) -> Result<K, D::Error>
+where
+    D: Deserializer<'de>,
+    K: ValidKeyStringExt + DeserializeOwned + 'static,
+{
+    let encoded_key: String = Deserialize::deserialize(deserializer)?;
+
+    ValidKeyStringExt::from_encoded_string(&encoded_key)
+        .map_err(<D::Error as serde::de::Error>::custom)
+}
+
+pub fn deserialize_nextgen_opt_key<'de, D, K>(deserializer: D) -> Result<Option<K>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: ValidKeyStringExt + DeserializeOwned + 'static,
+{
+    let encoded_key: String = Deserialize::deserialize(deserializer)?;
+
+    ValidKeyStringExt::from_encoded_string(&encoded_key)
+        .map_err(<D::Error as serde::de::Error>::custom)
+        .map(Some)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -114,11 +165,11 @@ impl TrustedPeersConfig {
             .clone()
     }
 
-    pub fn get_consensus_keys(&self, peer_id: &str) -> signing::PublicKey {
+    pub fn get_consensus_keys(&self, peer_id: &str) -> Ed25519PublicKey {
         self.get_public_keys(peer_id).consensus_pubkey
     }
 
-    pub fn get_network_signing_keys(&self, peer_id: &str) -> signing::PublicKey {
+    pub fn get_network_signing_keys(&self, peer_id: &str) -> Ed25519PublicKey {
         self.get_public_keys(peer_id).network_signing_pubkey
     }
 
@@ -127,12 +178,12 @@ impl TrustedPeersConfig {
     }
 
     /// Returns a map of AccountAddress to its PublicKey for consensus.
-    pub fn get_trusted_consensus_peers(&self) -> HashMap<AccountAddress, signing::PublicKey> {
+    pub fn get_trusted_consensus_peers(&self) -> HashMap<AccountAddress, Ed25519PublicKey> {
         let mut res = HashMap::new();
         for (account, keys) in &self.peers {
             res.insert(
                 AccountAddress::try_from(account.clone()).expect("Failed to parse account addr"),
-                keys.consensus_pubkey,
+                keys.consensus_pubkey.clone(),
             );
         }
         res
@@ -143,14 +194,17 @@ impl TrustedPeersConfig {
     /// of the network.
     pub fn get_trusted_network_peers(
         &self,
-    ) -> HashMap<AccountAddress, (signing::PublicKey, X25519PublicKey)> {
+    ) -> HashMap<AccountAddress, (Ed25519PublicKey, X25519PublicKey)> {
         self.peers
             .iter()
             .map(|(account, keys)| {
                 (
                     AccountAddress::try_from(account.clone())
                         .expect("Failed to parse account addr"),
-                    (keys.network_signing_pubkey, keys.network_identity_pubkey),
+                    (
+                        keys.network_signing_pubkey.clone(),
+                        keys.network_identity_pubkey,
+                    ),
                 )
             })
             .collect()
@@ -189,16 +243,16 @@ impl TrustedPeersConfigHelpers {
 
         let mut fast_rng = StdRng::from_seed(seed);
         for _ in 0..number_of_peers {
-            let (private0, public0) = signing::generate_keypair_for_testing(&mut fast_rng);
+            let (private0, public0) = compat::generate_keypair(&mut fast_rng);
             let (private1, public1) = x25519::generate_keypair_for_testing(&mut fast_rng);
-            let (private2, public2) = signing::generate_keypair_for_testing(&mut fast_rng);
+            let (private2, public2) = compat::generate_keypair(&mut fast_rng);
             // save the public_key in peers hashmap
             let peer = TrustedPeer {
                 network_signing_pubkey: public0,
                 network_identity_pubkey: public1,
                 consensus_pubkey: public2,
             };
-            let peer_id = AccountAddress::from(peer.consensus_pubkey);
+            let peer_id = AccountAddress::from_public_key(&peer.consensus_pubkey);
             peers.insert(peer_id.to_string(), peer);
             // save the private keys in a different hashmap
             let private_keys = TrustedPeerPrivateKeys {

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -51,7 +51,7 @@ pub struct ChainedBftProvider {
 
 impl ChainedBftProvider {
     pub fn new(
-        node_config: &NodeConfig,
+        node_config: &mut NodeConfig,
         network_sender: ConsensusNetworkSender,
         network_events: ConsensusNetworkEvents,
         mempool_client: Arc<MempoolClient>,
@@ -109,15 +109,17 @@ impl ChainedBftProvider {
 
     /// Retrieve the initial "state" for consensus. This function is synchronous and returns after
     /// reading the local persistent store and retrieving the initial state from the executor.
-    fn initialize_setup(node_config: &NodeConfig) -> InitialSetup {
+    fn initialize_setup(node_config: &mut NodeConfig) -> InitialSetup {
         // Keeping the initial set of validators in a node config is embarrassing and we should
         // all feel bad about it.
         let peer_id_str = node_config.base.peer_id.clone();
         let author =
             AccountAddress::try_from(peer_id_str).expect("Failed to parse peer id of a validator");
-        let private_key = node_config.base.peer_keypairs.get_consensus_private();
-        let _public_key = node_config.base.peer_keypairs.get_consensus_public();
-        let signer = ValidatorSigner::new(author, private_key.into());
+        let private_key = node_config.base.peer_keypairs.consensus_private().expect(
+            "Failed to move a Consensus private key from a NodeConfig, key absent or already read",
+        );
+
+        let signer = ValidatorSigner::new(author, private_key);
         let peers_with_public_keys = node_config.base.trusted_peers.get_trusted_consensus_peers();
         let peers_with_nextgen_public_keys = peers_with_public_keys
             .clone()

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -27,7 +27,7 @@ pub trait ConsensusProvider {
 
 /// Helper function to create a ConsensusProvider based on configuration
 pub fn make_consensus_provider(
-    node_config: &NodeConfig,
+    node_config: &mut NodeConfig,
     network_sender: ConsensusNetworkSender,
     network_receiver: ConsensusNetworkEvents,
 ) -> Box<dyn ConsensusProvider> {

--- a/crypto/secret_service/Cargo.toml
+++ b/crypto/secret_service/Cargo.toml
@@ -7,27 +7,26 @@ publish = false
 edition = "2018"
 
 [dependencies]
+derive_deref = "1.1.0"
 futures = "0.1.28"
 grpcio = "0.4.3"
 protobuf = "2.7"
-
-config = { path = "../../config" }
-grpc_helpers = { path = "../../common/grpc_helpers" }
-debug_interface = { path = "../../common/debug_interface" }
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
-executable_helpers = { path = "../../common/executable_helpers" }
-logger = { path = "../../common/logger" }
-
-nextgen_crypto = { path = "../nextgen_crypto" }
-crypto = { path = "../legacy_crypto" }
-# ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
-serde = { version = "1.0.96", features = ["derive"] }
 rand = "0.6.5"
 rand_chacha = "0.1.1"
+serde = { version = "1.0.96", features = ["derive"] }
 
-derive_deref = "1.1.0"
-
+config = { path = "../../config" }
+crypto = { path = "../legacy_crypto" }
 crypto-derive = { path = "../legacy_crypto/src/macros" }
+debug_interface = { path = "../../common/debug_interface" }
+executable_helpers = { path = "../../common/executable_helpers" }
+failure = { package = "failure_ext", path = "../../common/failure_ext" }
+grpc_helpers = { path = "../../common/grpc_helpers" }
+logger = { path = "../../common/logger" }
+nextgen_crypto = { path = "../nextgen_crypto" }
+
+[dev-dependencies]
+config = { path = "../../config", features = ["testing"]}
 
 [build-dependencies]
 build_helpers = { path = "../../common/build_helpers" }

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -25,6 +25,7 @@ execution_proto = { path = "../execution/execution_proto" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 execution_service = { path = "../execution/execution_service" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 network = { path = "../network" }

--- a/libra_node/src/main.rs
+++ b/libra_node/src/main.rs
@@ -29,11 +29,11 @@ fn register_signals(term: Arc<AtomicBool>) {
 }
 
 fn main() {
-    let (config, _logger, _args) = setup_executable(
+    let (mut config, _logger, _args) = setup_executable(
         "Libra single node".to_string(),
         vec![ARG_PEER_ID, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
     );
-    let (_ac_handle, _node_handle) = libra_node::main_node::setup_environment(&config);
+    let (_ac_handle, _node_handle) = libra_node::main_node::setup_environment(&mut config);
 
     let term = Arc::new(AtomicBool::new(false));
     register_signals(Arc::clone(&term));

--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -24,6 +24,7 @@ use network::{
     },
     NetworkPublicKeys, ProtocolId,
 };
+use nextgen_crypto::ed25519::*;
 use std::{
     cmp::max,
     convert::{TryFrom, TryInto},
@@ -136,7 +137,7 @@ fn setup_debug_interface(config: &NodeConfig) -> ::grpcio::Server {
 }
 
 pub fn setup_network(
-    config: &NodeConfig,
+    config: &mut NodeConfig,
 ) -> (
     (MempoolNetworkSender, MempoolNetworkEvents),
     (ConsensusNetworkSender, ConsensusNetworkEvents),
@@ -173,8 +174,10 @@ pub fn setup_network(
         .into_iter()
         .map(|(peer_id, addrs)| (peer_id.try_into().expect("Invalid PeerId"), addrs))
         .collect();
-    let network_signing_keypair = config.base.peer_keypairs.get_network_signing_keypair();
-    let (private_key, public_key) = network_signing_keypair;
+    let network_signing_private = config.base.peer_keypairs.network_signing_private()
+        .expect("Failed to move network signing private key out of NodeConfig, key not set or moved already");
+
+    let network_signing_public: Ed25519PublicKey = (&network_signing_private).into();
     let network_identity_keypair = config.base.peer_keypairs.get_network_identity_keypair();
     let (
         (mempool_network_sender, mempool_network_events),
@@ -188,7 +191,7 @@ pub fn setup_network(
         })
         .advertised_address(advertised_addr)
         .seed_peers(seed_peers)
-        .signing_keys((private_key.into(), public_key.into()))
+        .signing_keys((network_signing_private, network_signing_public))
         .identity_keys(network_identity_keypair)
         .trusted_peers(trusted_peers)
         .discovery_interval_ms(config.network.discovery_interval_ms)
@@ -212,7 +215,7 @@ pub fn setup_network(
     )
 }
 
-pub fn setup_environment(node_config: &NodeConfig) -> (AdmissionControlClient, LibraHandle) {
+pub fn setup_environment(node_config: &mut NodeConfig) -> (AdmissionControlClient, LibraHandle) {
     crash_handler::setup_panic_handler();
 
     let mut instant = Instant::now();
@@ -234,7 +237,7 @@ pub fn setup_environment(node_config: &NodeConfig) -> (AdmissionControlClient, L
         (mempool_network_sender, mempool_network_events),
         (consensus_network_sender, consensus_network_events),
         network_runtime,
-    ) = setup_network(&node_config);
+    ) = setup_network(node_config);
     debug!("Network started in {} ms", instant.elapsed().as_millis());
 
     instant = Instant::now();
@@ -255,7 +258,7 @@ pub fn setup_environment(node_config: &NodeConfig) -> (AdmissionControlClient, L
 
     instant = Instant::now();
     let mut consensus_provider = make_consensus_provider(
-        &node_config,
+        node_config,
         consensus_network_sender,
         consensus_network_events,
     );


### PR DESCRIPTION
## This PR modifies the following behavior:
- `config::KeyPairs` now contains `nextgen_crypto:ed5519::Ed25519PrivateKey` instances where `signing::PrivateKey` was used,
- `NodeConfig`, `BaseConfig` et al, only allow Clone under conditional compilations,
- The n copies of private key material per node (where n = # of peers) in `KeyPairs::load_config` are eliminated using the [mem::replace](https://github.com/rust-unofficial/patterns/blob/master/idioms/mem-replace.md) pattern
- The 2 copies of private key material per node (in `chained_bft_consensus_provider::initialize_setup` and `main_node::setup_network`) are eliminated in the same way

## Why this is better:
- pursues the conversion to nextgen_crypto API
- the number of memory copies of private key material is brought down to one (the minimum) for all `nextgen` keys

## Why this is worse:
- the second access to the same owned private key from a `&mut NodeConfig` will panic

## Future (planned) work:
- convert `LedgerInfo`, `QuorumCert` to use the nextgen crypto API
- use of X25519 keys should equally be converted to the nextgen crypto API, once the scheme is made available there