### PR TITLE
[crypto] Converts the config module to use the nextgen_crypto API

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -17,7 +17,15 @@ tempfile = "3.1.0"
 toml = "0.4"
 
 crypto = { path = "../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 logger = { path = "../common/logger" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 types = { path = "../types" }
+
+[dev-dependencies]
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"]}
+
+[features]
+default = []
+testing = ["nextgen_crypto/testing", "types/testing"]

--- a/config/config_builder/src/swarm_config.rs
+++ b/config/config_builder/src/swarm_config.rs
@@ -4,7 +4,7 @@
 //! Convenience structs and functions for generating configuration for a swarm of libra nodes
 use crate::util::gen_genesis_transaction;
 use config::{
-    config::{KeyPairs, NodeConfig, NodeConfigHelpers, VMPublishingOption},
+    config::{BaseConfig, KeyPairs, NodeConfig, NodeConfigHelpers, VMPublishingOption},
     seed_peers::{SeedPeersConfig, SeedPeersConfigHelpers},
     trusted_peers::{TrustedPeersConfig, TrustedPeersConfigHelpers},
 };
@@ -32,9 +32,11 @@ impl SwarmConfig {
     ) -> Result<Self> {
         // Generate trusted peer configs + their private keys.
         template.base.data_dir_path = output_dir.into();
-        let (peers_private_keys, trusted_peers_config) =
+        let (mut peers_private_keys, trusted_peers_config) =
             TrustedPeersConfigHelpers::get_test_config(num_nodes, key_seed);
-        trusted_peers_config.save_config(&output_dir.join(&template.base.trusted_peers_file));
+        let trusted_peers_file = template.base.trusted_peers_file.clone();
+        let seed_peers_file = template.network.seed_peers_file.clone();
+        trusted_peers_config.save_config(&output_dir.join(&trusted_peers_file));
         let mut seed_peers_config = SeedPeersConfigHelpers::get_test_config_with_ipver(
             &trusted_peers_config,
             None,
@@ -50,11 +52,47 @@ impl SwarmConfig {
         let mut configs = Vec::new();
         // Generate configs for all nodes.
         for (node_id, addrs) in &seed_peers_config.seed_peers {
-            let mut config = template.clone();
+            let key_file_name = format!("{}.node.keys.toml", node_id.clone());
+
+            let base_config = BaseConfig::new(
+                node_id.clone(),
+                KeyPairs::default(),
+                key_file_name.into(),
+                template.base.data_dir_path.clone(),
+                trusted_peers_file.clone(),
+                template.base.trusted_peers.clone(),
+                template.base.node_sync_batch_size,
+                template.base.node_sync_retries,
+                template.base.node_sync_channel_buffer_size,
+                template.base.node_async_log_chan_size,
+            );
+            let mut config = NodeConfig {
+                base: base_config,
+                metrics: template.metrics.clone(),
+                execution: template.execution.clone(),
+                admission_control: template.admission_control.clone(),
+                debug_interface: template.debug_interface.clone(),
+                storage: template.storage.clone(),
+                network: template.network.clone(),
+                consensus: template.consensus.clone(),
+                mempool: template.mempool.clone(),
+                log_collector: template.log_collector.clone(),
+                vm_config: template.vm_config.clone(),
+                secret_service: template.secret_service.clone(),
+            };
+
             config.base.peer_id = node_id.clone();
             // serialize keypairs on independent {node}.node.keys.toml file
             // this is because the peer_keypairs field is skipped during (de)serialization
-            let private_keys = peers_private_keys.get(node_id.as_str()).unwrap();
+            let private_keys = peers_private_keys
+                .remove_entry(node_id.as_str())
+                .expect(
+                    &format!(
+                        "Seed peer {} not present in peer private keys, aborting",
+                        node_id.as_str()
+                    )[..],
+                )
+                .1;
             let peer_keypairs = KeyPairs::load(private_keys);
             let key_file_name = format!("{}.node.keys.toml", config.base.peer_id);
 
@@ -83,7 +121,7 @@ impl SwarmConfig {
                 .take(1)
                 .collect();
         }
-        seed_peers_config.save_config(&output_dir.join(&template.network.seed_peers_file));
+        seed_peers_config.save_config(&output_dir.join(&seed_peers_file));
         let configs = configs
             .into_iter()
             .map(|config| {
@@ -99,14 +137,8 @@ impl SwarmConfig {
 
         Ok(Self {
             configs,
-            seed_peers: (
-                output_dir.join(template.network.seed_peers_file),
-                seed_peers_config,
-            ),
-            trusted_peers: (
-                output_dir.join(template.base.trusted_peers_file),
-                trusted_peers_config,
-            ),
+            seed_peers: (output_dir.join(seed_peers_file), seed_peers_config),
+            trusted_peers: (output_dir.join(trusted_peers_file), trusted_peers_config),
         })
     }
 

--- a/config/config_builder/src/util.rs
+++ b/config/config_builder/src/util.rs
@@ -23,8 +23,8 @@ pub fn gen_genesis_transaction<P: AsRef<Path>>(
         .map(|(peer_id, peer)| {
             ValidatorPublicKeys::new(
                 AccountAddress::try_from(peer_id.clone()).expect("[config] invalid peer_id"),
-                peer.get_consensus_public().into(),
-                peer.get_network_signing_public().into(),
+                peer.get_consensus_public().clone(),
+                peer.get_network_signing_public().clone(),
                 peer.get_network_identity_public(),
             )
         })

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -11,11 +11,9 @@ use std::{
     string::ToString,
 };
 
-use crypto::{
-    signing,
-    x25519::{self, X25519PrivateKey, X25519PublicKey},
-};
+use crypto::x25519::{self, X25519PrivateKey, X25519PublicKey};
 use logger::LoggerType;
+use nextgen_crypto::ed25519::*;
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use toml;
@@ -28,7 +26,8 @@ use crate::{
     config::ConsensusProposerType::{FixedProposer, RotatingProposer},
     seed_peers::{SeedPeersConfig, SeedPeersConfigHelpers},
     trusted_peers::{
-        deserialize_key, serialize_key, TrustedPeerPrivateKeys, TrustedPeersConfig,
+        deserialize_key, deserialize_legacy_key, deserialize_opt_key, serialize_key,
+        serialize_legacy_key, serialize_opt_key, TrustedPeerPrivateKeys, TrustedPeersConfig,
         TrustedPeersConfigHelpers,
     },
     utils::get_available_port,
@@ -47,7 +46,8 @@ static CONFIG_TEMPLATE: &[u8] = include_bytes!("../data/configs/node.config.toml
 /// This is used to set up the nodes and configure various parameters.
 /// The config file is broken up into sections for each module
 /// so that only that module can be passed around
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
 pub struct NodeConfig {
     //TODO Add configuration for multiple chain's in a future diff
     pub base: BaseConfig,
@@ -99,42 +99,44 @@ pub struct BaseConfig {
 
 // KeyPairs is used to store all of a node's private keys.
 // It is filled via a config file at the moment.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
 pub struct KeyPairs {
+    #[serde(serialize_with = "serialize_opt_key")]
+    #[serde(deserialize_with = "deserialize_opt_key")]
+    network_signing_private_key: Option<Ed25519PrivateKey>,
     #[serde(serialize_with = "serialize_key")]
     #[serde(deserialize_with = "deserialize_key")]
-    network_signing_private_key: signing::PrivateKey,
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
-    network_signing_public_key: signing::PublicKey,
+    network_signing_public_key: Ed25519PublicKey,
 
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
+    #[serde(serialize_with = "serialize_legacy_key")]
+    #[serde(deserialize_with = "deserialize_legacy_key")]
     network_identity_private_key: X25519PrivateKey,
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
+    #[serde(serialize_with = "serialize_legacy_key")]
+    #[serde(deserialize_with = "deserialize_legacy_key")]
     network_identity_public_key: X25519PublicKey,
 
+    #[serde(serialize_with = "serialize_opt_key")]
+    #[serde(deserialize_with = "deserialize_opt_key")]
+    consensus_private_key: Option<Ed25519PrivateKey>,
     #[serde(serialize_with = "serialize_key")]
     #[serde(deserialize_with = "deserialize_key")]
-    consensus_private_key: signing::PrivateKey,
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
-    consensus_public_key: signing::PublicKey,
+    consensus_public_key: Ed25519PublicKey,
 }
 
 // required for serialization
 impl Default for KeyPairs {
     fn default() -> Self {
-        let (private_sig, public_sig) = signing::generate_keypair();
+        let (net_private_sig, net_public_sig) = compat::generate_keypair(None);
+        let (consensus_private_sig, consensus_public_sig) = compat::generate_keypair(None);
         let (private_kex, public_kex) = x25519::generate_keypair();
         Self {
-            network_signing_private_key: private_sig.clone(),
-            network_signing_public_key: public_sig,
-            network_identity_private_key: private_kex.clone(),
+            network_signing_private_key: Some(net_private_sig),
+            network_signing_public_key: net_public_sig,
+            network_identity_private_key: private_kex,
             network_identity_public_key: public_kex,
-            consensus_private_key: private_sig.clone(),
-            consensus_public_key: public_sig,
+            consensus_private_key: Some(consensus_private_sig),
+            consensus_public_key: consensus_public_sig,
         }
     }
 }
@@ -162,61 +164,96 @@ impl KeyPairs {
 
         file.write_all(&contents).expect("Error writing file");
     }
+
     // used in testing to fill the structure with test keypairs
-    pub fn load(private_keys: &TrustedPeerPrivateKeys) -> Self {
-        let network_signing_private_key = private_keys.get_network_signing_private();
+    pub fn load(private_keys: TrustedPeerPrivateKeys) -> Self {
+        let (network_signing_private_key, network_identity_private_key, consensus_private_key) =
+            private_keys.get_key_triplet();
         let network_signing_public_key = (&network_signing_private_key).into();
-        let network_identity_private_key = private_keys.get_network_identity_private();
         let network_identity_public_key = (&network_identity_private_key).into();
-        let consensus_private_key = private_keys.get_consensus_private();
         let consensus_public_key = (&consensus_private_key).into();
         Self {
-            network_signing_private_key,
+            network_signing_private_key: Some(network_signing_private_key),
             network_signing_public_key,
             network_identity_private_key,
             network_identity_public_key,
-            consensus_private_key,
+            consensus_private_key: Some(consensus_private_key),
             consensus_public_key,
         }
     }
     // getters for private keys
-    pub fn get_network_signing_private(&self) -> signing::PrivateKey {
-        self.network_signing_private_key.clone()
+    /// Beware, this destroys the private key from this NodeConfig
+    pub fn take_network_signing_private(&mut self) -> Option<Ed25519PrivateKey> {
+        std::mem::replace(&mut self.network_signing_private_key, None)
+    }
+    pub fn get_network_signing_private(&self) -> &Option<Ed25519PrivateKey> {
+        &self.network_signing_private_key
     }
     pub fn get_network_identity_private(&self) -> X25519PrivateKey {
         self.network_identity_private_key.clone()
     }
-    pub fn get_consensus_private(&self) -> signing::PrivateKey {
-        self.consensus_private_key.clone()
+    pub fn get_consensus_private(&self) -> &Option<Ed25519PrivateKey> {
+        &self.consensus_private_key
+    }
+
+    /// Beware, this destroys the private key from this NodeConfig
+    pub fn take_consensus_private(&mut self) -> Option<Ed25519PrivateKey> {
+        std::mem::replace(&mut self.consensus_private_key, None)
     }
     // getters for public keys
-    pub fn get_network_signing_public(&self) -> signing::PublicKey {
-        self.network_signing_public_key
+    pub fn get_network_signing_public(&self) -> &Ed25519PublicKey {
+        &self.network_signing_public_key
     }
     pub fn get_network_identity_public(&self) -> X25519PublicKey {
         self.network_identity_public_key
     }
-    pub fn get_consensus_public(&self) -> signing::PublicKey {
-        self.consensus_public_key
+    pub fn get_consensus_public(&self) -> &Ed25519PublicKey {
+        &self.consensus_public_key
     }
     // getters for keypairs
-    pub fn get_network_signing_keypair(&self) -> (signing::PrivateKey, signing::PublicKey) {
-        (
-            self.get_network_signing_private(),
-            self.get_network_signing_public(),
-        )
-    }
     pub fn get_network_identity_keypair(&self) -> (X25519PrivateKey, X25519PublicKey) {
         (
             self.get_network_identity_private(),
             self.get_network_identity_public(),
         )
     }
-    pub fn get_consensus_keypair(&self) -> (signing::PrivateKey, signing::PublicKey) {
-        (self.get_consensus_private(), self.get_consensus_public())
+}
+
+impl BaseConfig {
+    /// Constructs a new BaseConfig with an empty temp directory
+    pub fn new(
+        peer_id: String,
+        peer_keypairs: KeyPairs,
+        peer_keypairs_file: PathBuf,
+        data_dir_path: PathBuf,
+        trusted_peers_file: String,
+        trusted_peers: TrustedPeersConfig,
+
+        node_sync_batch_size: u64,
+
+        node_sync_retries: usize,
+
+        node_sync_channel_buffer_size: u64,
+
+        node_async_log_chan_size: usize,
+    ) -> Self {
+        BaseConfig {
+            peer_id,
+            peer_keypairs,
+            peer_keypairs_file,
+            data_dir_path,
+            temp_data_dir: None,
+            trusted_peers_file,
+            trusted_peers,
+            node_sync_batch_size,
+            node_sync_retries,
+            node_sync_channel_buffer_size,
+            node_async_log_chan_size,
+        }
     }
 }
 
+#[cfg(any(test, feature = "testing"))]
 impl Clone for BaseConfig {
     fn clone(&self) -> Self {
         Self {
@@ -522,12 +559,12 @@ impl NodeConfigHelpers {
             config.vm_config.publishing_options = vm_publishing_option;
         }
 
-        let (peers_private_keys, trusted_peers_test) =
+        let (mut peers_private_keys, trusted_peers_test) =
             TrustedPeersConfigHelpers::get_test_config(1, None);
         let peer_id = trusted_peers_test.peers.keys().collect::<Vec<_>>()[0];
         config.base.peer_id = peer_id.clone();
         // load node's keypairs
-        let private_keys = peers_private_keys.get(peer_id.as_str()).unwrap();
+        let private_keys = peers_private_keys.remove_entry(peer_id.as_str()).unwrap().1;
         config.base.peer_keypairs = KeyPairs::load(private_keys);
         config.base.trusted_peers = trusted_peers_test;
         config.network.seed_peers = SeedPeersConfigHelpers::get_test_config(

--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crypto::{
-    signing,
     utils::{encode_to_string, from_encoded_string},
     x25519::{self, X25519PrivateKey, X25519PublicKey},
+};
+use nextgen_crypto::{
+    ed25519::{compat, *},
+    traits::ValidKeyStringExt,
 };
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
@@ -25,46 +28,44 @@ mod trusted_peers_test;
 pub struct TrustedPeer {
     #[serde(serialize_with = "serialize_key")]
     #[serde(deserialize_with = "deserialize_key")]
-    network_signing_pubkey: signing::PublicKey,
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
+    network_signing_pubkey: Ed25519PublicKey,
+    #[serde(serialize_with = "serialize_legacy_key")]
+    #[serde(deserialize_with = "deserialize_legacy_key")]
     network_identity_pubkey: X25519PublicKey,
     #[serde(serialize_with = "serialize_key")]
     #[serde(deserialize_with = "deserialize_key")]
-    consensus_pubkey: signing::PublicKey,
+    consensus_pubkey: Ed25519PublicKey,
 }
 
 pub struct TrustedPeerPrivateKeys {
-    network_signing_private_key: signing::PrivateKey,
+    network_signing_private_key: Ed25519PrivateKey,
     network_identity_private_key: X25519PrivateKey,
-    consensus_private_key: signing::PrivateKey,
+    consensus_private_key: Ed25519PrivateKey,
 }
 
 impl TrustedPeerPrivateKeys {
-    pub fn get_network_signing_private(&self) -> signing::PrivateKey {
-        self.network_signing_private_key.clone()
-    }
-    pub fn get_network_identity_private(&self) -> X25519PrivateKey {
-        self.network_identity_private_key.clone()
-    }
-    pub fn get_consensus_private(&self) -> signing::PrivateKey {
-        self.consensus_private_key.clone()
+    pub fn get_key_triplet(self) -> (Ed25519PrivateKey, X25519PrivateKey, Ed25519PrivateKey) {
+        (
+            self.network_signing_private_key,
+            self.network_identity_private_key,
+            self.consensus_private_key,
+        )
     }
 }
 
 impl TrustedPeer {
-    pub fn get_network_signing_public(&self) -> signing::PublicKey {
-        self.network_signing_pubkey
+    pub fn get_network_signing_public(&self) -> &Ed25519PublicKey {
+        &self.network_signing_pubkey
     }
     pub fn get_network_identity_public(&self) -> X25519PublicKey {
         self.network_identity_pubkey
     }
-    pub fn get_consensus_public(&self) -> signing::PublicKey {
-        self.consensus_pubkey
+    pub fn get_consensus_public(&self) -> &Ed25519PublicKey {
+        &self.consensus_pubkey
     }
 }
 
-pub fn serialize_key<S, K>(key: &K, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize_legacy_key<S, K>(key: &K, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
     K: Serialize,
@@ -72,7 +73,31 @@ where
     serializer.serialize_str(&encode_to_string(key))
 }
 
-pub fn deserialize_key<'de, D, K>(deserializer: D) -> Result<K, D::Error>
+pub fn serialize_key<S, K>(key: &K, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    K: Serialize + ValidKeyStringExt,
+{
+    key.to_encoded_string()
+        .map_err(<S::Error as serde::ser::Error>::custom)
+        .and_then(|str| serializer.serialize_str(&str[..]))
+}
+
+pub fn serialize_opt_key<S, K>(opt_key: &Option<K>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    K: Serialize + ValidKeyStringExt,
+{
+    opt_key
+        .as_ref()
+        .map_or(Ok("".to_string()), |key| {
+            key.to_encoded_string()
+                .map_err(<S::Error as serde::ser::Error>::custom)
+        })
+        .and_then(|str| serializer.serialize_str(&str[..]))
+}
+
+pub fn deserialize_legacy_key<'de, D, K>(deserializer: D) -> Result<K, D::Error>
 where
     D: Deserializer<'de>,
     K: DeserializeOwned + 'static,
@@ -80,6 +105,29 @@ where
     let encoded_key: String = Deserialize::deserialize(deserializer)?;
 
     Ok(from_encoded_string(encoded_key))
+}
+
+pub fn deserialize_key<'de, D, K>(deserializer: D) -> Result<K, D::Error>
+where
+    D: Deserializer<'de>,
+    K: ValidKeyStringExt + DeserializeOwned + 'static,
+{
+    let encoded_key: String = Deserialize::deserialize(deserializer)?;
+
+    ValidKeyStringExt::from_encoded_string(&encoded_key)
+        .map_err(<D::Error as serde::de::Error>::custom)
+}
+
+pub fn deserialize_opt_key<'de, D, K>(deserializer: D) -> Result<Option<K>, D::Error>
+where
+    D: Deserializer<'de>,
+    K: ValidKeyStringExt + DeserializeOwned + 'static,
+{
+    let encoded_key: String = Deserialize::deserialize(deserializer)?;
+
+    ValidKeyStringExt::from_encoded_string(&encoded_key)
+        .map_err(<D::Error as serde::de::Error>::custom)
+        .map(Some)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -114,11 +162,11 @@ impl TrustedPeersConfig {
             .clone()
     }
 
-    pub fn get_consensus_keys(&self, peer_id: &str) -> signing::PublicKey {
+    pub fn get_consensus_keys(&self, peer_id: &str) -> Ed25519PublicKey {
         self.get_public_keys(peer_id).consensus_pubkey
     }
 
-    pub fn get_network_signing_keys(&self, peer_id: &str) -> signing::PublicKey {
+    pub fn get_network_signing_keys(&self, peer_id: &str) -> Ed25519PublicKey {
         self.get_public_keys(peer_id).network_signing_pubkey
     }
 
@@ -127,12 +175,12 @@ impl TrustedPeersConfig {
     }
 
     /// Returns a map of AccountAddress to its PublicKey for consensus.
-    pub fn get_trusted_consensus_peers(&self) -> HashMap<AccountAddress, signing::PublicKey> {
+    pub fn get_trusted_consensus_peers(&self) -> HashMap<AccountAddress, Ed25519PublicKey> {
         let mut res = HashMap::new();
         for (account, keys) in &self.peers {
             res.insert(
                 AccountAddress::try_from(account.clone()).expect("Failed to parse account addr"),
-                keys.consensus_pubkey,
+                keys.consensus_pubkey.clone(),
             );
         }
         res
@@ -143,14 +191,17 @@ impl TrustedPeersConfig {
     /// of the network.
     pub fn get_trusted_network_peers(
         &self,
-    ) -> HashMap<AccountAddress, (signing::PublicKey, X25519PublicKey)> {
+    ) -> HashMap<AccountAddress, (Ed25519PublicKey, X25519PublicKey)> {
         self.peers
             .iter()
             .map(|(account, keys)| {
                 (
                     AccountAddress::try_from(account.clone())
                         .expect("Failed to parse account addr"),
-                    (keys.network_signing_pubkey, keys.network_identity_pubkey),
+                    (
+                        keys.network_signing_pubkey.clone(),
+                        keys.network_identity_pubkey,
+                    ),
                 )
             })
             .collect()
@@ -189,16 +240,16 @@ impl TrustedPeersConfigHelpers {
 
         let mut fast_rng = StdRng::from_seed(seed);
         for _ in 0..number_of_peers {
-            let (private0, public0) = signing::generate_keypair_for_testing(&mut fast_rng);
+            let (private0, public0) = compat::generate_keypair(&mut fast_rng);
             let (private1, public1) = x25519::generate_keypair_for_testing(&mut fast_rng);
-            let (private2, public2) = signing::generate_keypair_for_testing(&mut fast_rng);
+            let (private2, public2) = compat::generate_keypair(&mut fast_rng);
             // save the public_key in peers hashmap
             let peer = TrustedPeer {
                 network_signing_pubkey: public0,
                 network_identity_pubkey: public1,
                 consensus_pubkey: public2,
             };
-            let peer_id = AccountAddress::from(peer.consensus_pubkey);
+            let peer_id = AccountAddress::from_public_key(&peer.consensus_pubkey);
             peers.insert(peer_id.to_string(), peer);
             // save the private keys in a different hashmap
             let private_keys = TrustedPeerPrivateKeys {

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -27,7 +27,7 @@ pub trait ConsensusProvider {
 
 /// Helper function to create a ConsensusProvider based on configuration
 pub fn make_consensus_provider(
-    node_config: &NodeConfig,
+    node_config: &mut NodeConfig,
     network_sender: ConsensusNetworkSender,
     network_receiver: ConsensusNetworkEvents,
 ) -> Box<dyn ConsensusProvider> {

--- a/crypto/secret_service/Cargo.toml
+++ b/crypto/secret_service/Cargo.toml
@@ -7,27 +7,26 @@ publish = false
 edition = "2018"
 
 [dependencies]
+derive_deref = "1.1.0"
 futures = "0.1.28"
 grpcio = "0.4.3"
 protobuf = "2.7"
-
-config = { path = "../../config" }
-grpc_helpers = { path = "../../common/grpc_helpers" }
-debug_interface = { path = "../../common/debug_interface" }
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
-executable_helpers = { path = "../../common/executable_helpers" }
-logger = { path = "../../common/logger" }
-
-nextgen_crypto = { path = "../nextgen_crypto" }
-crypto = { path = "../legacy_crypto" }
-# ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
-serde = { version = "1.0.96", features = ["derive"] }
 rand = "0.6.5"
 rand_chacha = "0.1.1"
+serde = { version = "1.0.96", features = ["derive"] }
 
-derive_deref = "1.1.0"
-
+config = { path = "../../config" }
+crypto = { path = "../legacy_crypto" }
 crypto-derive = { path = "../legacy_crypto/src/macros" }
+debug_interface = { path = "../../common/debug_interface" }
+executable_helpers = { path = "../../common/executable_helpers" }
+failure = { package = "failure_ext", path = "../../common/failure_ext" }
+grpc_helpers = { path = "../../common/grpc_helpers" }
+logger = { path = "../../common/logger" }
+nextgen_crypto = { path = "../nextgen_crypto" }
+
+[dev-dependencies]
+config = { path = "../../config", features = ["testing"]}
 
 [build-dependencies]
 build_helpers = { path = "../../common/build_helpers" }

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -25,6 +25,7 @@ execution_proto = { path = "../execution/execution_proto" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 execution_service = { path = "../execution/execution_service" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 network = { path = "../network" }

--- a/libra_node/src/main.rs
+++ b/libra_node/src/main.rs
@@ -29,11 +29,11 @@ fn register_signals(term: Arc<AtomicBool>) {
 }
 
 fn main() {
-    let (config, _logger, _args) = setup_executable(
+    let (mut config, _logger, _args) = setup_executable(
         "Libra single node".to_string(),
         vec![ARG_PEER_ID, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
     );
-    let (_ac_handle, _node_handle) = libra_node::main_node::setup_environment(&config);
+    let (_ac_handle, _node_handle) = libra_node::main_node::setup_environment(&mut config);
 
     let term = Arc::new(AtomicBool::new(false));
     register_signals(Arc::clone(&term));


### PR DESCRIPTION
## This diff modifies the following behavior:

- `config::KeyPairs` now contains `nextgen_crypto:ed5519::Ed25519PrivateKey` instances where `signing::PrivateKey` was used,
- `NodeConfig`, `BaseConfig` et al, only allow Clone under conditional compilations,
- The n copies of private key material per node (where n = # of peers) in `KeyPairs::load_config` are eliminated using the [mem::replace](https://github.com/rust-unofficial/patterns/blob/master/idioms/mem-replace.md) pattern
- elimination of `n` copies in `libra_swarm::LibraSwarm::add_node` through better mutability scoping
- The 2 copies of private key material per node (in `chained_bft_consensus_provider::initialize_setup` and `main_node::setup_network`) are eliminated through `mem::replace`.

## Why this is better:

- pursues the conversion to nextgen_crypto API
- the number of memory copies of private key material is brought down to one (the minimum)

## Why this is worse:

- the second access to the same owned private key from a `&mut NodeConfig` will panic

## Future (planned) work

- convert `LedgerInfo`, `QuorumCert` to use the nextgen crypto API
- use of X25519 keys should equally be converted to the nextgen crypto API, once the scheme is made available there

## Tests

Type modifications only. `cargo test -p libra_node -p libra_swarm`, 
