### PR TITLE
[consensus] ProcessProposalResult now contains a better signal for success

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -183,7 +183,7 @@ impl<T: Payload, P: ProposerInfo> ChainedBftSMR<T, P> {
         while let Some(proposal_info) = receiver.next().await {
             let guard = event_processor.read().compat().await.unwrap();
             match guard.process_proposal(proposal_info).await {
-                ProcessProposalResult::Done => (),
+                ProcessProposalResult::Done(_) => (),
                 // Spawn a new task that would start retrieving the missing
                 // blocks in the background.
                 ProcessProposalResult::NeedFetch(deadline, proposal) => executor.spawn(

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -39,10 +39,11 @@ use termion::color::*;
 use types::ledger_info::LedgerInfoWithSignatures;
 
 /// Result of initial proposal processing
-/// NeedFetch means separate task mast be spawned for fetching block
-/// Caller should call fetch_and_process_proposal in separate task when NeedFetch is returned
+/// - Done(true) indicates that the proposal was sent to the proposer election
+/// - NeedFetch means separate task mast be spawned for fetching block
+/// - Caller should call fetch_and_process_proposal in separate task when NeedFetch is returned
 pub enum ProcessProposalResult<T, P> {
-    Done,
+    Done(bool),
     NeedFetch(Instant, ProposalInfo<T, P>),
     NeedSync(Instant, ProposalInfo<T, P>),
 }
@@ -198,7 +199,7 @@ impl<T: Payload, P: ProposerInfo> EventProcessor<T, P> {
                 proposal.proposal.round(),
                 current_round
             );
-            return ProcessProposalResult::Done;
+            return ProcessProposalResult::Done(false);
         }
         if self
             .proposer_election
@@ -210,7 +211,7 @@ impl<T: Payload, P: ProposerInfo> EventProcessor<T, P> {
                 proposal.proposal.author(),
                 proposal.proposal
             );
-            return ProcessProposalResult::Done;
+            return ProcessProposalResult::Done(false);
         }
 
         let deadline = self.pacemaker.current_round_deadline();
@@ -223,7 +224,7 @@ impl<T: Payload, P: ProposerInfo> EventProcessor<T, P> {
             }
         } else {
             warn!("Highest ledger info {} has no committed block", proposal);
-            return ProcessProposalResult::Done;
+            return ProcessProposalResult::Done(false);
         }
 
         match self
@@ -235,7 +236,7 @@ impl<T: Payload, P: ProposerInfo> EventProcessor<T, P> {
             }
             NeedFetchResult::QCRoundBeforeRoot => {
                 warn!("Proposal {} has a highest quorum certificate with round older than root round {}", proposal, self.block_store.root().round());
-                return ProcessProposalResult::Done;
+                return ProcessProposalResult::Done(false);
             }
             NeedFetchResult::QCBlockExist => {
                 if let Err(e) = self
@@ -247,21 +248,23 @@ impl<T: Payload, P: ProposerInfo> EventProcessor<T, P> {
                         "Quorum certificate for proposal {} could not be inserted to the block store: {:?}",
                         proposal, e
                     );
-                    return ProcessProposalResult::Done;
+                    return ProcessProposalResult::Done(false);
                 }
             }
             NeedFetchResult::QCAlreadyExist => (),
         }
 
-        self.finish_proposal_processing(proposal).await;
-        ProcessProposalResult::Done
+        self.finish_proposal_processing(proposal).await
     }
 
     /// Finish proposal processing: note that multiple tasks can execute this function in parallel
     /// so be careful with the updates. The safest thing to do is to pass the proposal further
     /// to the proposal election.
     /// This function is invoked when all the dependencies for the given proposal are ready.
-    async fn finish_proposal_processing(&self, proposal: ProposalInfo<T, P>) {
+    async fn finish_proposal_processing(
+        &self,
+        proposal: ProposalInfo<T, P>,
+    ) -> ProcessProposalResult<T, P> {
         let qc = proposal.proposal.quorum_cert();
         self.pacemaker
             .process_certificates(
@@ -278,10 +281,11 @@ impl<T: Payload, P: ProposerInfo> EventProcessor<T, P> {
                 proposal.proposal.round(),
                 current_round
             );
-            return;
+            return ProcessProposalResult::Done(false);
         }
 
         self.proposer_election.process_proposal(proposal).await;
+        ProcessProposalResult::Done(true)
     }
 
     /// Fetches and completes processing proposal in dedicated task


### PR DESCRIPTION
# Motivation

When a validator receives a proposal, it is processed and a `ProcessProposalResult` enum is returned as a result. 
This enum either indicates that there is more work to be done to process the block, or that there is nothing to be done (the proposal was processed). 
In the latter case, the enum does not distinguish a failure to process the proposal versus a proposal fully validated and voted on.

The reason is that even though the proposal is then called `winning_proposal`, we still cannot fully know if we will eventually vote on the proposal as [there is more logic](https://github.com/libra/libra/blob/master/consensus/src/chained_bft/event_processor.rs#L468) that could still prevent the validator to vote on the proposal.

Yet, this PR adds a boolean inside the enum, with `true` indicating a proposal that was processed up until it was sent to `proposer_election`, and `false` indicating otherwise.

This change is useful for fuzzing (we need to know if we can call further functions on the proposal or if the validation has failed) and for further testing. 

## Test Plan

```
cargo test -p consensus --lib
```