### PR TITLE
[dashboard] Overview: make "Total Accounts" panel accurate

### DIFF
--- a/terraform/templates/dashboards/analytics.json
+++ b/terraform/templates/dashboards/analytics.json
@@ -165,7 +165,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(executor{op='num_accounts'})",
+          "expr": "max(storage_gauge{op='state_blobs_created'}) - max(storage_gauge{op='state_blobs_retired'})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Num Accounts Created",

--- a/terraform/templates/dashboards/overview_dashboard.json
+++ b/terraform/templates/dashboards/overview_dashboard.json
@@ -188,7 +188,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(executor{op=\"num_accounts\"})",
+          "expr": "max(storage_gauge{op=\"state_blobs_created\"}) - max(storage_gauge{op=\"state_blobs_retired\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,

--- a/terraform/templates/dashboards/usage_stats.json
+++ b/terraform/templates/dashboards/usage_stats.json
@@ -80,7 +80,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(executor{op=\"num_accounts\"})",
+          "expr": "max(storage_gauge{op=\"state_blobs_created\"}) - max(storage_gauge{op=\"state_blobs_retired\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
By utilizing "state_blobs_created" and "state_blobs_retired" gauges in
storage module.


## Motivation

These counters are written as absolute values upon storage commit while the old one is bumpped by relative value when the executor executes a block (a restart and resync makes it inaccurrate).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan
query is verified to work in testnet prometheus:

http://prometheus.stable.aws.hlw3truzy4ls.com:9091/explore?left=%5B%22now-6h%22,%22now%22,%22Prometheus%22,%7B%22expr%22:%22max(storage_gauge%7Bop%3D%5C%22state_blobs_created%5C%22%7D)%20-%20max(storage_gauge%7Bop%3D%5C%22state_blobs_retired%5C%22%7D)%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D


## Related PRs

