### PR TITLE
[cluster_test] Health checks for cluster test

### DIFF
--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -15,3 +15,5 @@ flate2 = { version = "1.0", features = ["rust_backend"], default-features = fals
 serde_json = "1.0"
 regex = "1.1.9"
 clap = "2.32"
+termion = "1.5.3"
+itertools = "0.8.0"

--- a/testsuite/cluster_test/src/cluster.rs
+++ b/testsuite/cluster_test/src/cluster.rs
@@ -6,6 +6,7 @@ use std::{
     io::{BufRead, BufReader},
 };
 
+#[derive(Clone)]
 pub struct Cluster {
     instances: Vec<Instance>, // guaranteed non-empty
 }
@@ -16,7 +17,14 @@ impl Cluster {
         let f = BufReader::new(f);
         let mut instances = vec![];
         for line in f.lines() {
-            instances.push(Instance::new(line?));
+            let line = line?;
+            let split: Vec<&str> = line.split(':').collect();
+            ensure!(
+                split.len() == 2,
+                "instances.txt has incorrect line: {}",
+                line
+            );
+            instances.push(Instance::new(split[0].into(), split[1].into()));
         }
         ensure!(!instances.is_empty(), "instances.txt is empty");
         Ok(Self { instances })
@@ -25,5 +33,9 @@ impl Cluster {
     pub fn random_instance(&self) -> Instance {
         let mut rnd = rand::thread_rng();
         self.instances.choose(&mut rnd).unwrap().clone()
+    }
+
+    pub fn instances(&self) -> &Vec<Instance> {
+        &self.instances
     }
 }

--- a/testsuite/cluster_test/src/experiments/mod.rs
+++ b/testsuite/cluster_test/src/experiments/mod.rs
@@ -1,7 +1,9 @@
 mod reboot_random_validator;
 
 pub use reboot_random_validator::RebootRandomValidator;
+use std::{collections::HashSet, fmt::Display};
 
-pub trait Experiment {
+pub trait Experiment: Display {
+    fn affected_validators(&self) -> HashSet<String>;
     fn run(&self) -> failure::Result<()>;
 }

--- a/testsuite/cluster_test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster_test/src/experiments/reboot_random_validator.rs
@@ -5,7 +5,7 @@ use crate::{
     instance::Instance,
 };
 use failure;
-use std::{thread, time::Duration};
+use std::{collections::HashSet, fmt, thread, time::Duration};
 
 pub struct RebootRandomValidator {
     instance: Instance,
@@ -20,6 +20,12 @@ impl RebootRandomValidator {
 }
 
 impl Experiment for RebootRandomValidator {
+    fn affected_validators(&self) -> HashSet<String> {
+        let mut r = HashSet::new();
+        r.insert(self.instance.short_hash().clone());
+        r
+    }
+
     fn run(&self) -> failure::Result<()> {
         let reboot = Reboot::new(self.instance.clone());
         reboot.apply()?;
@@ -27,5 +33,11 @@ impl Experiment for RebootRandomValidator {
             thread::sleep(Duration::from_secs(5));
         }
         Ok(())
+    }
+}
+
+impl fmt::Display for RebootRandomValidator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Reboot {}", self.instance)
     }
 }

--- a/testsuite/cluster_test/src/health/commit_check.rs
+++ b/testsuite/cluster_test/src/health/commit_check.rs
@@ -1,0 +1,80 @@
+use crate::health::{Event, HealthCheck, HealthCheckContext, ValidatorEvent};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+
+/// Verifies that commit history produced by validators is 'lineariazble'
+/// This means that validators can be behind each other, but commits that they are producing
+/// do not contradict each other
+pub struct CommitHistoryHealthCheck {
+    round_to_commit: HashMap<u64, CommitAndValidators>,
+    latest_committed_round: HashMap<String, u64>,
+}
+
+struct CommitAndValidators {
+    pub hash: String,
+    pub validators: HashSet<String>,
+}
+
+impl CommitHistoryHealthCheck {
+    pub fn new() -> Self {
+        Self {
+            round_to_commit: HashMap::new(),
+            latest_committed_round: HashMap::new(),
+        }
+    }
+}
+
+impl HealthCheck for CommitHistoryHealthCheck {
+    fn on_event(&mut self, ve: &ValidatorEvent, ctx: &mut HealthCheckContext) {
+        let commit = if let Event::Commit(ref commit) = ve.event {
+            commit
+        } else {
+            return;
+        };
+        let round_to_commit = self.round_to_commit.entry(commit.round);
+        match round_to_commit {
+            Entry::Occupied(mut oe) => {
+                let commit_and_validators = oe.get_mut();
+                if commit_and_validators.hash != commit.commit {
+                    ctx.report_failure(
+                        ve.validator.clone(),
+                        format!(
+                            "produced contradicting commit {} at round {}, expected: {}",
+                            commit.commit, commit.round, commit_and_validators.hash
+                        ),
+                    );
+                } else {
+                    commit_and_validators
+                        .validators
+                        .insert(ve.validator.clone());
+                }
+            }
+            Entry::Vacant(va) => {
+                let mut validators = HashSet::new();
+                validators.insert(ve.validator.clone());
+                va.insert(CommitAndValidators {
+                    hash: commit.commit.clone(),
+                    validators,
+                });
+            }
+        }
+        let latest_committed_round = self.latest_committed_round.entry(ve.validator.clone());
+        match latest_committed_round {
+            Entry::Occupied(mut oe) => {
+                let previous_round = *oe.get();
+                if previous_round > commit.round {
+                    ctx.report_failure(
+                        ve.validator.clone(),
+                        format!(
+                            "committed round {} after committing {}",
+                            commit.round, previous_round
+                        ),
+                    );
+                }
+                oe.insert(commit.round);
+            }
+            Entry::Vacant(va) => {
+                va.insert(commit.round);
+            }
+        }
+    }
+}

--- a/testsuite/cluster_test/src/health/liveness_check.rs
+++ b/testsuite/cluster_test/src/health/liveness_check.rs
@@ -1,0 +1,61 @@
+use crate::{
+    cluster::Cluster,
+    health::{Event, HealthCheck, HealthCheckContext, ValidatorEvent},
+};
+use std::{collections::HashMap, time::Duration};
+
+pub struct LivenessHealthCheck {
+    last_committed: HashMap<String, LastCommitInfo>,
+}
+
+const MAX_BEHIND: Duration = Duration::from_secs(15);
+
+#[derive(Default)]
+struct LastCommitInfo {
+    _round: u64,
+    timestamp: Duration,
+}
+
+impl LivenessHealthCheck {
+    pub fn new(cluster: &Cluster) -> Self {
+        let mut last_committed = HashMap::new();
+        for instance in cluster.instances() {
+            last_committed.insert(instance.short_hash().clone(), LastCommitInfo::default());
+        }
+        Self { last_committed }
+    }
+}
+
+impl HealthCheck for LivenessHealthCheck {
+    fn on_event(&mut self, ve: &ValidatorEvent, ctx: &mut HealthCheckContext) {
+        match ve.event {
+            Event::Commit(ref commit) => {
+                self.last_committed.insert(
+                    ve.validator.clone(),
+                    LastCommitInfo {
+                        _round: commit.round,
+                        timestamp: ve.timestamp,
+                    },
+                );
+            }
+            Event::ConsensusStarted => {
+                ctx.report_failure(ve.validator.clone(), "validator restarted".into());
+            }
+        }
+    }
+
+    fn verify(&mut self, ctx: &mut HealthCheckContext) {
+        let min_timestamp = ctx.now - MAX_BEHIND;
+        for (validator, lci) in &self.last_committed {
+            if lci.timestamp < min_timestamp {
+                ctx.report_failure(
+                    validator.clone(),
+                    format!(
+                        "Last commit is {} ms behind",
+                        (min_timestamp - lci.timestamp).as_millis()
+                    ),
+                );
+            }
+        }
+    }
+}

--- a/testsuite/cluster_test/src/health/mod.rs
+++ b/testsuite/cluster_test/src/health/mod.rs
@@ -1,6 +1,18 @@
+mod commit_check;
+mod liveness_check;
 mod log_tail;
 
+use crate::cluster::Cluster;
+pub use commit_check::CommitHistoryHealthCheck;
+use itertools::Itertools;
+pub use liveness_check::LivenessHealthCheck;
 pub use log_tail::AwsLogTail;
+use std::{
+    collections::HashMap,
+    fmt,
+    time::{Duration, SystemTime},
+};
+use termion::color::*;
 
 #[derive(Clone, Debug)]
 pub struct Commit {
@@ -12,10 +24,122 @@ pub struct Commit {
 #[derive(Debug)]
 pub enum Event {
     Commit(Commit),
+    ConsensusStarted,
+}
+
+pub struct ValidatorEvent {
+    validator: String,
+    timestamp: Duration,
+    event: Event,
+}
+
+impl fmt::Debug for ValidatorEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} {} {:?}",
+            self.timestamp.as_millis(),
+            self.validator,
+            self.event
+        )
+    }
+}
+
+pub trait HealthCheck {
+    /// Verify specific event
+    fn on_event(&mut self, event: &ValidatorEvent, ctx: &mut HealthCheckContext);
+    /// Periodic verification (happens even if when no events produced)
+    fn verify(&mut self, _ctx: &mut HealthCheckContext) {}
+}
+
+pub struct HealthCheckRunner {
+    cluster: Cluster,
+    health_checks: Vec<Box<dyn HealthCheck>>,
+}
+
+impl HealthCheckRunner {
+    pub fn new(cluster: Cluster, health_checks: Vec<Box<dyn HealthCheck>>) -> Self {
+        Self {
+            cluster,
+            health_checks,
+        }
+    }
+
+    pub fn new_all(cluster: Cluster) -> Self {
+        let liveness_health_check = LivenessHealthCheck::new(&cluster);
+        Self::new(
+            cluster,
+            vec![
+                Box::new(CommitHistoryHealthCheck::new()),
+                Box::new(liveness_health_check),
+            ],
+        )
+    }
+
+    /// Returns list of failed validators
+    pub fn run(&mut self, events: &[ValidatorEvent]) -> Vec<String> {
+        let mut node_health = HashMap::new();
+        for instance in self.cluster.instances() {
+            node_health.insert(instance.short_hash().clone(), true);
+        }
+
+        let mut context = HealthCheckContext::new();
+        for health_check in self.health_checks.iter_mut() {
+            for event in events {
+                health_check.on_event(event, &mut context);
+            }
+            health_check.verify(&mut context);
+        }
+        for err in context.err_acc {
+            node_health.insert(err.validator.clone(), false);
+            println!("{:?}", err);
+        }
+
+        let mut failed = vec![];
+        for (i, (node, healthy)) in node_health.into_iter().sorted().enumerate() {
+            if healthy {
+                print!("{}* {}{}\t", Fg(Green), node, Fg(Reset));
+            } else {
+                print!("{}* {}{}\t", Fg(Red), node, Fg(Reset));
+                failed.push(node);
+            }
+            if i % 5 == 0 {
+                println!();
+            }
+        }
+        println!();
+
+        failed
+    }
+}
+
+pub struct HealthCheckContext {
+    now: Duration,
+    err_acc: Vec<HealthCheckError>,
 }
 
 #[derive(Debug)]
-pub struct ValidatorEvent {
-    validator: String,
-    event: Event,
+pub struct HealthCheckError {
+    pub validator: String,
+    pub message: String,
+}
+
+impl HealthCheckContext {
+    pub fn new() -> Self {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Now is behind UNIX_EPOCH");
+        Self {
+            now,
+            err_acc: vec![],
+        }
+    }
+
+    pub fn now(&self) -> Duration {
+        self.now
+    }
+
+    pub fn report_failure(&mut self, validator: String, message: String) {
+        self.err_acc.push(HealthCheckError { validator, message })
+    }
 }

--- a/testsuite/cluster_test/src/instance.rs
+++ b/testsuite/cluster_test/src/instance.rs
@@ -7,15 +7,13 @@ use std::{
 
 #[derive(Clone)]
 pub struct Instance {
+    short_hash: String,
     ip: String,
 }
 
 impl Instance {
-    pub fn new<I>(ip: I) -> Instance
-    where
-        I: Into<String>,
-    {
-        Instance { ip: ip.into() }
+    pub fn new(short_hash: String, ip: String) -> Instance {
+        Instance { short_hash, ip }
     }
 
     pub fn run_cmd<I, S>(&self, args: I) -> failure::Result<()>
@@ -45,10 +43,14 @@ impl Instance {
             Ok(exit_status) => exit_status.success(),
         }
     }
+
+    pub fn short_hash(&self) -> &String {
+        &self.short_hash
+    }
 }
 
 impl fmt::Display for Instance {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.ip)
+        write!(f, "{}({})", self.short_hash, self.ip)
     }
 }

--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -3,30 +3,124 @@ use cluster_test::{
     aws::Aws,
     cluster::Cluster,
     experiments::{Experiment, RebootRandomValidator},
-    health::AwsLogTail,
+    health::{AwsLogTail, HealthCheckRunner},
+};
+use std::{
+    collections::HashSet,
+    sync::mpsc::{self, TryRecvError},
+    thread,
+    time::{Duration, Instant},
 };
 
 pub fn main() {
     let matches = arg_matches();
+
+    let workplace = matches
+        .value_of(ARG_WORKPLACE)
+        .expect("workplace should be set");
+    let aws = Aws::new(workplace.into());
+    let logs = AwsLogTail::spawn_new(aws.clone()).expect("Failed to start aws log tail");
+    let cluster = Cluster::discover().expect("Failed to discover cluster");
+    println!("Waiting little bit before starting...");
+    thread::sleep(Duration::from_secs(10));
+    println!("Done");
+
     if matches.is_present(ARG_RUN) {
-        let cluster = Cluster::discover().expect("Failed to discover cluster");
+        let mut health_check_runner = HealthCheckRunner::new_all(cluster.clone());
+        let events = logs.recv_all();
+        if !health_check_runner.run(&events).is_empty() {
+            panic!("Some validators are unhealthy before experiment started");
+        }
+
         let experiment = RebootRandomValidator::new(&cluster);
-        experiment.run().expect("Failed to run experiment");
-        println!("Test complete");
+        println!("Starting experiment {}", experiment);
+        let mut affected_validators = experiment.affected_validators();
+        let (exp_result_sender, exp_result_recv) = mpsc::channel();
+        thread::spawn(move || {
+            let result = experiment.run();
+            exp_result_sender
+                .send(result)
+                .expect("Failed to send experiment result");
+        });
+        loop {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            // Receive all events that arrived to aws log tail within next 1 second
+            // This assumes so far that event propagation time is << 1s, this need to be refined
+            // in future to account for actual event propagation delay
+            let events = logs.recv_all_until_deadline(deadline);
+            let failed_validators = health_check_runner.run(&events);
+            for failed in failed_validators {
+                if !affected_validators.contains(&failed) {
+                    panic!(
+                        "Validator {} failed, not expected for this experiment",
+                        failed
+                    );
+                }
+            }
+            match exp_result_recv.try_recv() {
+                Ok(result) => {
+                    result.expect("Failed to run experiment");
+                    break;
+                }
+                Err(TryRecvError::Empty) => {
+                    // Experiment in progress, continue monitoring health
+                }
+                Err(TryRecvError::Disconnected) => {
+                    panic!("Experiment thread exited without returning result");
+                }
+            }
+        }
+
+        println!();
+        println!("**Experiment finished, waiting until all affected validators recover**");
+        println!();
+
+        loop {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            // Receive all events that arrived to aws log tail within next 1 second
+            // This assumes so far that event propagation time is << 1s, this need to be refined
+            // in future to account for actual event propagation delay
+            let events = logs.recv_all_until_deadline(deadline);
+            let failed_validators = health_check_runner.run(&events);
+            let mut still_affected_validator = HashSet::new();
+            for failed in failed_validators {
+                if !affected_validators.contains(&failed) {
+                    panic!(
+                        "Validator {} failed, not expected for this experiment",
+                        failed
+                    );
+                }
+                still_affected_validator.insert(failed);
+            }
+            if still_affected_validator.is_empty() {
+                break;
+            }
+            affected_validators = still_affected_validator;
+        }
+
+        println!("Experiment completed");
     }
     if matches.is_present(ARG_TAIL_LOGS) {
-        let workplace = matches
-            .value_of(ARG_WORKPLACE)
-            .expect("workplace should be set");
-        let aws = Aws::new(workplace.into());
-        let logs = AwsLogTail::spawn_new(aws.clone()).expect("Failed to start aws log tail");
         for log in logs.event_receiver {
             println!("{:?}", log);
+        }
+    } else if matches.is_present(HEALTH_CHECK) {
+        let mut health_check_runner = HealthCheckRunner::new_all(cluster.clone());
+        // Initial sleep to collect events
+        // Otherwise liveness check will fail because it did not yet receive events from validators
+        loop {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            // Receive all events that arrived to aws log tail within next 1 second
+            // This assumes so far that event propagation time is << 1s, this need to be refined
+            // in future to account for actual event propagation delay
+            let events = logs.recv_all_until_deadline(deadline);
+            health_check_runner.run(&events);
         }
     }
 }
 
 const ARG_TAIL_LOGS: &str = "tail-logs";
+const HEALTH_CHECK: &str = "health-check";
 const ARG_RUN: &str = "run";
 const ARG_WORKPLACE: &str = "workplace";
 
@@ -35,19 +129,21 @@ fn arg_matches() -> ArgMatches<'static> {
     let workplace = Arg::with_name(ARG_WORKPLACE)
         .long("--workplace")
         .short("-w")
-        .takes_value(true);
-    let tail_logs = Arg::with_name(ARG_TAIL_LOGS)
-        .long("--tail-logs")
-        .requires(ARG_WORKPLACE);
+        .takes_value(true)
+        .required(true);
+    let tail_logs = Arg::with_name(ARG_TAIL_LOGS).long("--tail-logs");
+    let health_check = Arg::with_name(HEALTH_CHECK)
+        .long("--health-check")
+        .conflicts_with(ARG_TAIL_LOGS);
     // This grouping means at least one action (tail logs, or run test, or both) is required
     let action_group = ArgGroup::with_name("action")
         .multiple(true)
-        .args(&[ARG_TAIL_LOGS, ARG_RUN])
+        .args(&[ARG_TAIL_LOGS, ARG_RUN, HEALTH_CHECK])
         .required(true);
 
     App::new("cluster_test")
         .author("Libra Association <opensource@libra.org>")
         .group(action_group)
-        .args(&[run, tail_logs, workplace])
+        .args(&[workplace, run, tail_logs, health_check])
         .get_matches()
 }


### PR DESCRIPTION
This diff introduces health checks for cluster test:
- Commit check verifies invariants on history of committed blocks:
 * Commit sequence is increasing for each validator
 * Validators commit same blocks on same rounds

- Liveness check verifies that system is still working
 * Commits are produced by validators, with upper bound on delay
 * Validators don't restart during test

Those checks are not ideal yet, but that's a start.
[for example commit check can be enforced to make sure sequence of commits is exactly same, versus weaker check that we have right now.]

When we run experiment, we verify, in parallel thread, that health checks are passed:
- Verify that cluster is healthy before experiment
- Verify that during experiment only affected validators don't pass health checks
- Verify that at some point after experiment all validators are healthy again
