### PR TITLE
[mempool] Only record local TXN's e2e latency.

### DIFF
--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -30,8 +30,8 @@ lazy_static! {
 
 #[derive(Clone)]
 pub struct TestTransaction {
-    address: usize,
-    sequence_number: u64,
+    pub(crate) address: usize,
+    pub(crate) sequence_number: u64,
     gas_price: u64,
 }
 
@@ -141,4 +141,11 @@ impl ConsensusMock {
             .collect();
         block
     }
+}
+
+pub(crate) fn exist_in_metrics_cache(mempool: &CoreMempool, txn: &SignedTransaction) -> bool {
+    mempool
+        .metrics_cache
+        .get(&(txn.sender(), txn.sequence_number()))
+        .is_some()
 }

--- a/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     core_mempool::{
-        unit_tests::common::{add_txn, add_txns_to_mempool, setup_mempool, TestTransaction},
+        unit_tests::common::{
+            add_txn, add_txns_to_mempool, exist_in_metrics_cache, setup_mempool, TestTransaction,
+        },
         CoreMempool, TimelineState,
     },
     proto::shared::mempool_status::MempoolAddTransactionStatusCode,
@@ -60,6 +62,18 @@ fn test_transaction_ordering() {
             vec![transaction.clone()]
         );
     }
+}
+
+#[test]
+fn test_metric_cache_add_local_txns() {
+    let (mut mempool, _) = setup_mempool();
+    let txns = add_txns_to_mempool(
+        &mut mempool,
+        vec![TestTransaction::new(0, 0, 1), TestTransaction::new(1, 0, 2)],
+    );
+    // Check txns' timestamps exist in metrics_cache.
+    assert_eq!(exist_in_metrics_cache(&mempool, &txns[0]), true);
+    assert_eq!(exist_in_metrics_cache(&mempool, &txns[1]), true);
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Current *e2e_latency* measured by mempool includes both *local* TXNs (from local AC) and *shared* TXNs (from shared mempool).
As a result, a TXN has `num_validators` e2e_latency values and the shared latency values will be less than, and noisy to, the one measured locally.

## Summary
When adding shared TXNs from mempool, `Mempool::add_txn()` simply ignores inserting it into the `metrics_cache`, so that there will be only local latency for a TXN.

## Test Plan:
Extended unittest.
E2E test with 4-node `libra_swarm`. On the left side, only 1 client is submitting TXNs to a fixed validator. On the other side, 4 clients have connected one-to-one to 4 validators and are submitting TXNs to corresponding connected validator.

![image](https://user-images.githubusercontent.com/1838298/61889016-8aa89e80-aeb9-11e9-81ad-fd1d4fdfcaaa.png)



Signed-off-by: Jiaqi Yan <yjq@calibra.com>
