### PR TITLE
[Consensus] Introduce SyncInfo struct for accumulating sync information

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -5,6 +5,7 @@ use crate::{
     chained_bft::{
         block_storage::{BlockReader, BlockStore},
         common::{Payload, Round},
+        consensus_types::timeout_msg::TimeoutMsg,
         event_processor::{EventProcessor, ProcessProposalResult},
         liveness::{
             local_pacemaker::{ExponentialTimeInterval, LocalPacemaker},
@@ -13,7 +14,6 @@ use crate::{
             proposal_generator::ProposalGenerator,
             proposer_election::{ProposalInfo, ProposerElection, ProposerInfo},
             rotating_proposer_election::RotatingProposer,
-            timeout_msg::TimeoutMsg,
         },
         network::{
             BlockRetrievalRequest, ChunkRetrievalRequest, ConsensusNetworkImpl, NetworkReceivers,

--- a/consensus/src/chained_bft/consensus_types/mod.rs
+++ b/consensus/src/chained_bft/consensus_types/mod.rs
@@ -3,3 +3,5 @@
 
 pub(crate) mod block;
 pub(crate) mod quorum_cert;
+pub(crate) mod sync_info;
+pub(crate) mod timeout_msg;

--- a/consensus/src/chained_bft/consensus_types/sync_info.rs
+++ b/consensus/src/chained_bft/consensus_types/sync_info.rs
@@ -1,0 +1,79 @@
+use crate::chained_bft::consensus_types::{
+    quorum_cert::QuorumCert, timeout_msg::PacemakerTimeoutCertificate,
+};
+use network;
+use proto_conv::{FromProto, IntoProto};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
+/// This struct describes basic synchronization metadata.
+pub struct SyncInfo {
+    /// Highest quorum certificate known to the peer.
+    highest_quorum_cert: QuorumCert,
+    /// Highest ledger info known to the peer.
+    highest_ledger_info: QuorumCert,
+    /// Optional highest timeout certificate if available.
+    highest_timeout_cert: Option<PacemakerTimeoutCertificate>,
+}
+
+impl SyncInfo {
+    pub fn new(
+        highest_quorum_cert: QuorumCert,
+        highest_ledger_info: QuorumCert,
+        highest_timeout_cert: Option<PacemakerTimeoutCertificate>,
+    ) -> Self {
+        Self {
+            highest_quorum_cert,
+            highest_ledger_info,
+            highest_timeout_cert,
+        }
+    }
+
+    /// Highest quorum certificate
+    pub fn highest_quorum_cert(&self) -> &QuorumCert {
+        &self.highest_quorum_cert
+    }
+
+    /// Highest ledger info
+    pub fn highest_ledger_info(&self) -> &QuorumCert {
+        &self.highest_ledger_info
+    }
+
+    /// Highest timeout certificate if available
+    #[allow(dead_code)]
+    pub fn highest_timeout_certificate(&self) -> Option<&PacemakerTimeoutCertificate> {
+        self.highest_timeout_cert.as_ref()
+    }
+}
+
+impl FromProto for SyncInfo {
+    type ProtoType = network::proto::SyncInfo;
+
+    fn from_proto(mut object: network::proto::SyncInfo) -> failure::Result<Self> {
+        let highest_quorum_cert = QuorumCert::from_proto(object.take_highest_quorum_cert())?;
+        let highest_ledger_info = QuorumCert::from_proto(object.take_highest_ledger_info())?;
+        let highest_timeout_cert = if let Some(tc) = object.highest_timeout_cert.into_option() {
+            Some(PacemakerTimeoutCertificate::from_proto(tc)?)
+        } else {
+            None
+        };
+        Ok(SyncInfo::new(
+            highest_quorum_cert,
+            highest_ledger_info,
+            highest_timeout_cert,
+        ))
+    }
+}
+impl IntoProto for SyncInfo {
+    type ProtoType = network::proto::SyncInfo;
+
+    fn into_proto(self) -> Self::ProtoType {
+        let mut proto = Self::ProtoType::new();
+        proto.set_highest_quorum_cert(self.highest_quorum_cert.into_proto());
+        proto.set_highest_ledger_info(self.highest_ledger_info.into_proto());
+        if let Some(tc) = self.highest_timeout_cert {
+            proto.set_highest_timeout_cert(tc.into_proto());
+        }
+        proto
+    }
+}

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -5,7 +5,12 @@ use crate::{
     chained_bft::{
         block_storage::{BlockReader, BlockStore},
         common::Author,
-        consensus_types::{block::Block, quorum_cert::QuorumCert},
+        consensus_types::{
+            block::Block,
+            quorum_cert::QuorumCert,
+            sync_info::SyncInfo,
+            timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate, TimeoutMsg},
+        },
         event_processor::EventProcessor,
         liveness::{
             local_pacemaker::{ExponentialTimeInterval, LocalPacemaker},
@@ -14,7 +19,6 @@ use crate::{
             proposal_generator::ProposalGenerator,
             proposer_election::{ProposalInfo, ProposerElection, ProposerInfo},
             rotating_proposer_election::RotatingProposer,
-            timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate, TimeoutMsg},
         },
         network::{
             BlockRetrievalRequest, BlockRetrievalResponse, ChunkRetrievalRequest,
@@ -575,8 +579,11 @@ fn process_new_round_msg_test() {
         static_proposer
             .event_processor
             .process_timeout_msg(TimeoutMsg::new(
-                block_0_quorum_cert,
-                QuorumCert::certificate_for_genesis(),
+                SyncInfo::new(
+                    block_0_quorum_cert,
+                    QuorumCert::certificate_for_genesis(),
+                    None,
+                ),
                 PacemakerTimeout::new(2, &non_proposer.signer),
                 &non_proposer.signer,
             )),

--- a/consensus/src/chained_bft/liveness/local_pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker.rs
@@ -4,10 +4,10 @@
 use crate::{
     chained_bft::{
         common::Round,
+        consensus_types::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
         liveness::{
             pacemaker::{NewRoundEvent, NewRoundReason, Pacemaker},
             pacemaker_timeout_manager::{HighestTimeoutCertificates, PacemakerTimeoutManager},
-            timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
         },
         persistent_storage::PersistentLivenessStorage,
     },

--- a/consensus/src/chained_bft/liveness/local_pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker_test.rs
@@ -3,11 +3,11 @@
 
 use crate::{
     chained_bft::{
+        consensus_types::timeout_msg::PacemakerTimeout,
         liveness::{
             local_pacemaker::{ExponentialTimeInterval, LocalPacemaker, PacemakerTimeInterval},
             pacemaker::{NewRoundEvent, NewRoundReason, Pacemaker},
             pacemaker_timeout_manager::HighestTimeoutCertificates,
-            timeout_msg::PacemakerTimeout,
         },
         persistent_storage::PersistentStorage,
         test_utils::{consensus_runtime, MockStorage, TestPayload},

--- a/consensus/src/chained_bft/liveness/mod.rs
+++ b/consensus/src/chained_bft/liveness/mod.rs
@@ -7,7 +7,6 @@ pub(crate) mod pacemaker_timeout_manager;
 pub(crate) mod proposal_generator;
 pub(crate) mod proposer_election;
 pub(crate) mod rotating_proposer_election;
-pub(crate) mod timeout_msg;
 
 #[cfg(test)]
 mod local_pacemaker_test;

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -3,7 +3,7 @@
 
 use crate::chained_bft::{
     common::Round,
-    liveness::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
+    consensus_types::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
 };
 use futures::Future;
 use std::{

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager.rs
@@ -3,7 +3,7 @@
 
 use crate::chained_bft::{
     common::Author,
-    liveness::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
+    consensus_types::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
     persistent_storage::PersistentLivenessStorage,
 };
 use logger::prelude::*;

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chained_bft::{
-    liveness::{
-        pacemaker_timeout_manager::{HighestTimeoutCertificates, PacemakerTimeoutManager},
-        timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
-    },
+    consensus_types::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate},
+    liveness::pacemaker_timeout_manager::{HighestTimeoutCertificates, PacemakerTimeoutManager},
     persistent_storage::PersistentStorage,
     test_utils::{MockStorage, TestPayload},
 };

--- a/consensus/src/chained_bft/liveness/proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/proposer_election.rs
@@ -3,8 +3,9 @@
 
 use crate::chained_bft::{
     common::{Author, Payload, Round},
-    consensus_types::{block::Block, quorum_cert::QuorumCert},
-    liveness::timeout_msg::PacemakerTimeoutCertificate,
+    consensus_types::{
+        block::Block, quorum_cert::QuorumCert, timeout_msg::PacemakerTimeoutCertificate,
+    },
 };
 use failure::prelude::*;
 use futures::Future;

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -5,11 +5,8 @@ use crate::{
     chained_bft::{
         block_storage::BlockRetrievalFailure,
         common::{Author, Payload},
-        consensus_types::{block::Block, quorum_cert::QuorumCert},
-        liveness::{
-            proposer_election::{ProposalInfo, ProposerInfo},
-            timeout_msg::TimeoutMsg,
-        },
+        consensus_types::{block::Block, quorum_cert::QuorumCert, timeout_msg::TimeoutMsg},
+        liveness::proposer_election::{ProposalInfo, ProposerInfo},
         safety::vote_msg::VoteMsg,
     },
     counters,

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -42,16 +42,21 @@ message PacemakerTimeout {
 }
 
 message TimeoutMsg {
-  // Highest quorum certificate known after a timeout ouf a round.
-  QuorumCert highest_quorum_cert = 1;
+  // Information about the highest QC, LedgerInfo, TimeoutCertificate, etc.
+  SyncInfo sync_info = 1;
   // Timeout
   PacemakerTimeout pacemaker_timeout = 2;
-  // Author of new round message
-  bytes author = 3;
   // Signature that this timeout was authored by owner
-  bytes signature = 4;
-  // The highest ledger info
-  QuorumCert highest_ledger_info = 5;
+  bytes signature = 3;
+}
+
+message SyncInfo {
+  // Highest quorum certificate
+  QuorumCert highest_quorum_cert = 1;
+  // Highest ledger info
+  QuorumCert highest_ledger_info = 2;
+  // Optional highest timeout certificate if available
+  PacemakerTimeoutCertificate highest_timeout_cert = 3;
 }
 
 message PacemakerTimeoutCertificate {

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -13,8 +13,8 @@ use types::proto::{ledger_info, transaction};
 pub use self::{
     consensus::{
         Block, BlockRetrievalStatus, ConsensusMsg, PacemakerTimeout, PacemakerTimeoutCertificate,
-        Proposal, QuorumCert, RequestBlock, RequestChunk, RespondBlock, RespondChunk, TimeoutMsg,
-        Vote,
+        Proposal, QuorumCert, RequestBlock, RequestChunk, RespondBlock, RespondChunk, SyncInfo,
+        TimeoutMsg, Vote,
     },
     mempool::MempoolSyncMsg,
     network::{DiscoveryMsg, IdentityMsg, Note, PeerInfo, Ping, Pong},


### PR DESCRIPTION
Summary:
This commit doesn't change anything in the logic: it's the first preparation for the changes required for being able to send the missing pieces of information upon receiving of outdated timeout messages.
Today sync info is scattered across several fields both in the `TimeoutMsg` and in `Proposal`. This commit introduces a new struct `SyncInfo`, which is going to be included in both `TimeoutMsg`, `Proposal`, and could be sent as a standalone message.

Test: existing unit test coverage

Issue: #311