### PR TITLE
[docker] Improve build cache usage

### DIFF
--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -13,7 +13,7 @@ COPY rust-toolchain /libra/rust-toolchain
 RUN rustup install $(cat rust-toolchain)
 
 COPY . /libra
-RUN cargo build --release -p client
+RUN cargo build --release -p libra_node -p client
 RUN strip target/release/client
 
 ### Production Image ###

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -15,7 +15,7 @@ COPY rust-toolchain /libra/rust-toolchain
 RUN rustup install $(cat rust-toolchain)
 
 COPY . /libra
-RUN cargo build -p client --release
+RUN cargo build --release -p libra_node -p client
 
 ### Production Image ###
 FROM debian:stretch

--- a/docker/validator/validator.Dockerfile
+++ b/docker/validator/validator.Dockerfile
@@ -15,7 +15,7 @@ COPY rust-toolchain /libra/rust-toolchain
 RUN rustup install $(cat rust-toolchain)
 
 COPY . /libra
-RUN cargo build --release -p libra_node
+RUN cargo build --release -p libra_node -p client
 
 ### Production Image ###
 FROM debian:stretch


### PR DESCRIPTION
Summary: Run the same build command (building both e2e and client) in
all docker images. This allows the docker cache from after the build to
be reused for all images, because all the rules up to this point are the
same. This will significantly speed up building all three images.

Test Plan: Built all three images; rust build was not repeated for the
second and third.