### PR TITLE
[language] remove work_list and cfg from stackless bytecode generator

### DIFF
--- a/language/stackless_bytecode_generator/tests/stack_elim_tests.rs
+++ b/language/stackless_bytecode_generator/tests/stack_elim_tests.rs
@@ -247,16 +247,18 @@ fn transform_code_with_easy_branching() {
     let (actual_code, actual_types) = generate_code_from_string(code);
     let expected_code = vec![
         LdTrue(0),
-        BrFalse(10, 0),
-        Branch(3),
+        BrFalse(4, 0),
+        Branch(6),
+        Branch(5),
+        Branch(0),
+        Branch(0),
         LdFalse(1),
         Not(2, 1),
         Not(3, 2),
-        BrFalse(9, 3),
+        BrFalse(12, 3),
         LdConst(4, 42),
         Abort(4),
         Ret(vec![]),
-        Branch(0),
     ];
     let expected_types = vec![
         SignatureToken::Bool,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Get rid of unnecessary `work_list` and `cfg` from `StacklessBytecodeGenerator`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

`cargo test`


