### PR TITLE
[network] drop messages when message queue is full

### DIFF
--- a/common/channel/src/lib.rs
+++ b/common/channel/src/lib.rs
@@ -56,6 +56,16 @@ impl<T> Sink<T> for Sender<T> {
     }
 }
 
+impl<T> Sender<T> {
+    pub fn try_send(&mut self, msg: T) -> Result<(), mpsc::SendError> {
+        self.gauge.inc();
+        (*self).value.try_send(msg).map_err(|e| {
+            self.gauge.dec();
+            e.into_send_error()
+        })
+    }
+}
+
 impl<T> FusedStream for Receiver<T> {
     fn is_terminated(&self) -> bool {
         self.value.is_terminated()


### PR DESCRIPTION
## Motivation

Fix #328 that slow peers can block the whole network module from processing.
When the message queue for a specific peer is full, drop the messages on the floor, so that it doesn't block other peers. Because direct send protocol is a fire-and-forget service, there is no delivery guarantee, and no feedback needs to be propagate up.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

