### PR TITLE
[circleci] Validate Terraform configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> $BASH_ENV
             echo 'export IMAGE_NAME=myapp' >> $BASH_ENV
 
-jobs:  
+jobs:
   build:
     docker:
       - image: circleci/rust:stretch
@@ -60,11 +60,26 @@ jobs:
             cargo install --force cargo-audit
             cargo generate-lockfile
             cargo audit
+  terraform:
+    docker:
+      - image: hashicorp/terraform
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Terraform init
+          command: terraform init
+          working_directory: terraform/
+      - run:
+          name: Terraform validate
+          command: terraform validate
+          working_directory: terraform/
 
 workflows:
   commit-workflow:
     jobs:
       - build
+      - terraform
 
   scheduled-workflow:
     triggers:

--- a/terraform/faucet_variables.tf
+++ b/terraform/faucet_variables.tf
@@ -1,0 +1,14 @@
+variable "faucet_image_repo" {
+  description = "Docker image repository to use for faucet server"
+  default     = "docker.libra.org/faucet"
+}
+
+variable "faucet_log_level" {
+  description = "Log level for faucet to pass to gunicorn"
+  default     = "info"
+}
+
+variable "faucet_image_tag" {
+  description = "Docker image tag to use for faucet server"
+  default     = "latest"
+}


### PR DESCRIPTION
Summary: Add a job to run `terraform validate` to prevent blatant
breakages. Also restore missing faucet variables which broke TF.

Test Plan: https://circleci.com/gh/libra/libra/152