### PR TITLE
[common, easy] Update crossbeam

### DIFF
--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
+arc-swap = "0.4.0-pre.1"
 backtrace = { version = "0.3.33", features = ["serialize-serde"] }
 chrono = "0.4.7"
-crossbeam = "^0.4.1"
 futures = "0.1.28"
 hyper = "0.12.33"
 itertools = "0.8.0"

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -34,7 +34,7 @@ use crate::{
     http_local_slog_drain::HttpLocalSlogDrain, http_log_client::HttpLogClient,
     kv_categorizer::ErrorCategorizer,
 };
-use crossbeam::atomic::ArcCell;
+use arc_swap::ArcSwap;
 use failure::prelude::*;
 use glog_format::GlogFormat;
 use lazy_static::lazy_static;
@@ -128,8 +128,8 @@ lazy_static! {
 }
 
 lazy_static! {
-    static ref GLOBAL_LOG_COLLECTOR: ArcCell<Logger> =
-        ArcCell::new(Arc::new(Logger::root(Discard, o!())));
+    static ref GLOBAL_LOG_COLLECTOR: ArcSwap<Logger> =
+        ArcSwap::from(Arc::new(Logger::root(Discard, o!())));
 }
 
 #[derive(Clone, Debug)]
@@ -144,7 +144,7 @@ pub enum LoggerType {
 pub fn set_global_log_collector(collector: LoggerType, is_async: bool, chan_size: Option<usize>) {
     // Log collector should be available at this time.
     let log_collector = get_log_collector(collector, is_async, chan_size).unwrap();
-    GLOBAL_LOG_COLLECTOR.set(Arc::new(log_collector));
+    GLOBAL_LOG_COLLECTOR.store(Arc::new(log_collector));
 }
 
 /// Create and setup default global logger following the env-logger conventions,
@@ -198,7 +198,7 @@ pub fn with_logger<F, R>(f: F) -> R
 where
     F: FnOnce(&Logger) -> R,
 {
-    f(&(*GLOBAL_LOG_COLLECTOR.get()))
+    f(&(*GLOBAL_LOG_COLLECTOR.load()))
 }
 
 /// Log a critical level message using current log collector

--- a/common/proptest_helpers/Cargo.toml
+++ b/common/proptest_helpers/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-crossbeam = "0.7.1"
+crossbeam = "0.7.2"
 proptest = "0.9.4"
 proptest-derive = "0.1.2"

--- a/language/vm/vm_runtime/vm_cache_map/Cargo.toml
+++ b/language/vm/vm_runtime/vm_cache_map/Cargo.toml
@@ -11,6 +11,6 @@ chashmap = "2.2.2"
 typed-arena = "1.4.1"
 
 [dev-dependencies]
-crossbeam = "0.7"
+crossbeam = "0.7.2"
 proptest = "0.9"
 rand = "0.6.5"


### PR DESCRIPTION
* This modifies the following behavior:
  - updates `crossbeam` in `proptest_helpers` & `vm_runtime` to 0.7.2 (which was [just released](https://github.com/crossbeam-rs/crossbeam/issues/401#issuecomment-514829720))
  - removes usage of `crossbeam` in `common::logger` as:
    + `ArcCell` was [removed](https://github.com/crossbeam-rs/crossbeam/pull/301) in more recent versions of crossbeam,
    + it was [spin-locking](https://github.com/crossbeam-rs/crossbeam/issues/160) anyway

* Why this is better
  - closes #279
  - [`arc-swap`](https://docs.rs/arc-swap/) is ([mostly](https://github.com/crossbeam-rs/crossbeam/issues/160#issuecomment-378281816)) lock-free

* Why this is worse
  - [`arc-swap`](https://github.com/vorner/arc-swap) is young

* Tests
  - `cargo audit` + CI