### PR TITLE
[cluster_test] Discovery for cluster test

### DIFF
--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -11,6 +11,7 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 rand = "0.6.5"
 rusoto_core = "0.40.0"
 rusoto_kinesis = "0.40.0"
+rusoto_ec2 = "0.40.0"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 serde_json = "1.0"
 regex = "1.1.9"

--- a/testsuite/cluster_test/src/aws.rs
+++ b/testsuite/cluster_test/src/aws.rs
@@ -1,10 +1,12 @@
 use rusoto_core::Region;
+use rusoto_ec2::Ec2Client;
 use rusoto_kinesis::KinesisClient;
 
 #[derive(Clone)]
 pub struct Aws {
     workplace: String,
     kc: KinesisClient,
+    ec2: Ec2Client,
 }
 
 impl Aws {
@@ -12,11 +14,16 @@ impl Aws {
         Self {
             workplace,
             kc: KinesisClient::new(Region::UsWest2),
+            ec2: Ec2Client::new(Region::UsWest2),
         }
     }
 
     pub fn kc(&self) -> &KinesisClient {
         &self.kc
+    }
+
+    pub fn ec2(&self) -> &Ec2Client {
+        &self.ec2
     }
 
     pub fn workplace(&self) -> &String {

--- a/testsuite/cluster_test/src/cluster.rs
+++ b/testsuite/cluster_test/src/cluster.rs
@@ -1,10 +1,7 @@
-use crate::instance::Instance;
+use crate::{aws::Aws, instance::Instance};
 use failure::{self, prelude::*};
 use rand::prelude::*;
-use std::{
-    fs::File,
-    io::{BufRead, BufReader},
-};
+use rusoto_ec2::{DescribeInstancesRequest, Ec2, Filter};
 
 #[derive(Clone)]
 pub struct Cluster {
@@ -12,19 +9,44 @@ pub struct Cluster {
 }
 
 impl Cluster {
-    pub fn discover() -> failure::Result<Self> {
-        let f = File::open("instances.txt")?;
-        let f = BufReader::new(f);
+    pub fn discover(aws: &Aws) -> failure::Result<Self> {
+        let filters = vec![
+            Filter {
+                name: Some("tag:Workspace".into()),
+                values: Some(vec![aws.workplace().clone()]),
+            },
+            Filter {
+                name: Some("tag:Role".into()),
+                values: Some(vec!["validator".into()]),
+            },
+        ];
+        let result = aws
+            .ec2()
+            .describe_instances(DescribeInstancesRequest {
+                filters: Some(filters),
+                max_results: Some(1000),
+                dry_run: None,
+                instance_ids: None,
+                next_token: None,
+            })
+            .sync()
+            .expect("Failed to describe aws instances");
         let mut instances = vec![];
-        for line in f.lines() {
-            let line = line?;
-            let split: Vec<&str> = line.split(':').collect();
-            ensure!(
-                split.len() == 2,
-                "instances.txt has incorrect line: {}",
-                line
-            );
-            instances.push(Instance::new(split[0].into(), split[1].into()));
+        for reservation in result.reservations.expect("no reservations") {
+            for aws_instance in reservation.instances.expect("no instances") {
+                let ip = aws_instance
+                    .private_ip_address
+                    .expect("Instance does not have private IP address");
+                let tags = aws_instance.tags.expect("Instance does not have tags");
+                let peer_id = tags
+                    .into_iter()
+                    .find(|tag| tag.key == Some("PeerId".into()))
+                    .expect("No peer id")
+                    .value
+                    .expect("PeerId tag has no value");
+                let short_hash = peer_id[..8].into();
+                instances.push(Instance::new(short_hash, ip));
+            }
         }
         ensure!(!instances.is_empty(), "instances.txt is empty");
         Ok(Self { instances })

--- a/testsuite/cluster_test/src/health/mod.rs
+++ b/testsuite/cluster_test/src/health/mod.rs
@@ -103,7 +103,7 @@ impl HealthCheckRunner {
                 print!("{}* {}{}\t", Fg(Red), node, Fg(Reset));
                 failed.push(node);
             }
-            if i % 5 == 0 {
+            if (i + 1) % 5 == 0 {
                 println!();
             }
         }

--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -7,6 +7,7 @@ use cluster_test::{
 };
 use std::{
     collections::HashSet,
+    env,
     sync::mpsc::{self, TryRecvError},
     thread,
     time::{Duration, Instant},
@@ -17,24 +18,64 @@ const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 pub fn main() {
     let matches = arg_matches();
-
-    let workplace = matches
-        .value_of(ARG_WORKPLACE)
-        .expect("workplace should be set");
-    let aws = Aws::new(workplace.into());
-    let logs = AwsLogTail::spawn_new(aws.clone()).expect("Failed to start aws log tail");
-    println!("Aws log thread started");
-    let cluster = Cluster::discover(&aws).expect("Failed to discover cluster");
-    println!("Discovered {} peers", cluster.instances().len());
+    let mut runner = ClusterTestRunner::setup(&matches);
 
     if matches.is_present(ARG_RUN) {
-        let mut health_check_runner = HealthCheckRunner::new_all(cluster.clone());
-        let events = logs.recv_all();
-        if !health_check_runner.run(&events).is_empty() {
+        runner.run_experiments_in_loop();
+    } else if matches.is_present(ARG_RUN_ONCE) {
+        runner.run_single_experiment();
+    } else if matches.is_present(ARG_TAIL_LOGS) {
+        runner.tail_logs();
+    } else if matches.is_present(ARG_HEALTH_CHECK) {
+        runner.run_health_check();
+    }
+}
+
+struct ClusterTestRunner {
+    logs: AwsLogTail,
+    cluster: Cluster,
+    health_check_runner: HealthCheckRunner,
+}
+
+impl ClusterTestRunner {
+    /// Discovers cluster, setup log, etc
+    pub fn setup(matches: &ArgMatches) -> Self {
+        let workplace = matches
+            .value_of(ARG_WORKPLACE)
+            .expect("workplace should be set");
+        let aws = Aws::new(workplace.into());
+        let logs = AwsLogTail::spawn_new(aws.clone()).expect("Failed to start aws log tail");
+        println!("Aws log thread started");
+        let cluster = Cluster::discover(&aws).expect("Failed to discover cluster");
+        println!("Discovered {} peers", cluster.instances().len());
+        let health_check_runner = HealthCheckRunner::new_all(cluster.clone());
+        Self {
+            logs,
+            cluster,
+            health_check_runner,
+        }
+    }
+
+    /// Run experiments every EXPERIMENT_INTERVAL seconds until fails
+    pub fn run_experiments_in_loop(&mut self) {
+        let experiment_interval_sec = match env::var("EXPERIMENT_INTERVAL") {
+            Ok(s) => s.parse().expect("EXPERIMENT_INTERVAL env is not a number"),
+            Err(..) => 15,
+        };
+        let experiment_interval = Duration::from_secs(experiment_interval_sec);
+        loop {
+            self.run_single_experiment();
+            thread::sleep(experiment_interval);
+        }
+    }
+
+    pub fn run_single_experiment(&mut self) {
+        let events = self.logs.recv_all();
+        if !self.health_check_runner.run(&events).is_empty() {
             panic!("Some validators are unhealthy before experiment started");
         }
 
-        let experiment = RebootRandomValidator::new(&cluster);
+        let experiment = RebootRandomValidator::new(&self.cluster);
         println!(
             "{}Starting experiment {}{}{}{}",
             style::Bold,
@@ -63,8 +104,8 @@ pub fn main() {
             // Receive all events that arrived to aws log tail within next 1 second
             // This assumes so far that event propagation time is << 1s, this need to be refined
             // in future to account for actual event propagation delay
-            let events = logs.recv_all_until_deadline(deadline);
-            let failed_validators = health_check_runner.run(&events);
+            let events = self.logs.recv_all_until_deadline(deadline);
+            let failed_validators = self.health_check_runner.run(&events);
             for failed in failed_validators {
                 if !affected_validators.contains(&failed) {
                     panic!(
@@ -101,8 +142,8 @@ pub fn main() {
             // Receive all events that arrived to aws log tail within next 1 second
             // This assumes so far that event propagation time is << 1s, this need to be refined
             // in future to account for actual event propagation delay
-            let events = logs.recv_all_until_deadline(deadline);
-            let failed_validators = health_check_runner.run(&events);
+            let events = self.logs.recv_all_until_deadline(deadline);
+            let failed_validators = self.health_check_runner.run(&events);
             let mut still_affected_validator = HashSet::new();
             for failed in failed_validators {
                 if !affected_validators.contains(&failed) {
@@ -120,48 +161,50 @@ pub fn main() {
 
         println!("Experiment completed");
     }
-    if matches.is_present(ARG_TAIL_LOGS) {
-        for log in logs.event_receiver {
-            println!("{:?}", log);
-        }
-    } else if matches.is_present(HEALTH_CHECK) {
-        let mut health_check_runner = HealthCheckRunner::new_all(cluster.clone());
+
+    fn run_health_check(&mut self) {
         loop {
             let deadline = Instant::now() + Duration::from_secs(1);
             // Receive all events that arrived to aws log tail within next 1 second
             // This assumes so far that event propagation time is << 1s, this need to be refined
             // in future to account for actual event propagation delay
-            let events = logs.recv_all_until_deadline(deadline);
-            health_check_runner.run(&events);
+            let events = self.logs.recv_all_until_deadline(deadline);
+            self.health_check_runner.run(&events);
+        }
+    }
+
+    fn tail_logs(self) {
+        for log in self.logs.event_receiver {
+            println!("{:?}", log);
         }
     }
 }
 
-const ARG_TAIL_LOGS: &str = "tail-logs";
-const HEALTH_CHECK: &str = "health-check";
-const ARG_RUN: &str = "run";
 const ARG_WORKPLACE: &str = "workplace";
+// Actions:
+const ARG_TAIL_LOGS: &str = "tail-logs";
+const ARG_HEALTH_CHECK: &str = "health-check";
+const ARG_RUN: &str = "run";
+const ARG_RUN_ONCE: &str = "run-once";
 
 fn arg_matches() -> ArgMatches<'static> {
     let run = Arg::with_name(ARG_RUN).long("--run");
+    let run_once = Arg::with_name(ARG_RUN_ONCE).long("--run-once");
     let workplace = Arg::with_name(ARG_WORKPLACE)
         .long("--workplace")
         .short("-w")
         .takes_value(true)
         .required(true);
     let tail_logs = Arg::with_name(ARG_TAIL_LOGS).long("--tail-logs");
-    let health_check = Arg::with_name(HEALTH_CHECK)
-        .long("--health-check")
-        .conflicts_with(ARG_TAIL_LOGS);
-    // This grouping means at least one action (tail logs, or run test, or both) is required
+    let health_check = Arg::with_name(ARG_HEALTH_CHECK).long("--health-check");
+    // This grouping requires one and only one action (tail logs, run test, etc)
     let action_group = ArgGroup::with_name("action")
-        .multiple(true)
-        .args(&[ARG_TAIL_LOGS, ARG_RUN, HEALTH_CHECK])
+        .args(&[ARG_TAIL_LOGS, ARG_RUN, ARG_RUN_ONCE, ARG_HEALTH_CHECK])
         .required(true);
 
     App::new("cluster_test")
         .author("Libra Association <opensource@libra.org>")
         .group(action_group)
-        .args(&[workplace, run, tail_logs, health_check])
+        .args(&[workplace, run, run_once, tail_logs, health_check])
         .get_matches()
 }


### PR DESCRIPTION
Instead of reading instances.txt cluster test now queries instances from AWS.

This PR also have couple of nits:
* Instead of waiting for 10 seconds during startup, we query logs from past and wait for AWS thread startup
* More colors in output :)
* Health check runs less frequently, once every 5 seconds
* Experiment deadline - if experiment does not complete in 2 minutes it's considered failed
