### PR TITLE
[language/e2e_tests] rename some account_universe default methods

### DIFF
--- a/language/e2e_tests/src/account_universe.rs
+++ b/language/e2e_tests/src/account_universe.rs
@@ -70,7 +70,7 @@ lazy_static! {
 /// Larger values will provide greater testing but will take longer to run and shrink. Release mode
 /// is recommended for values above 100.
 #[inline]
-pub(crate) fn num_accounts() -> usize {
+pub(crate) fn default_num_accounts() -> usize {
     *UNIVERSE_SIZE
 }
 
@@ -80,7 +80,7 @@ pub(crate) fn num_accounts() -> usize {
 /// Larger values will provide greater testing but will take longer to run and shrink. Release mode
 /// is recommended for values above 100.
 #[inline]
-pub(crate) fn num_transactions() -> usize {
+pub(crate) fn default_num_transactions() -> usize {
     *UNIVERSE_SIZE * 2
 }
 
@@ -152,9 +152,12 @@ impl AccountUniverseGen {
     pub fn success_strategy(min_accounts: usize) -> impl Strategy<Value = Self> {
         // Set the minimum balance to be 5x possible transfers out to handle potential gas cost
         // issues.
-        let min_balance = (100_000 * (num_transactions()) * 5) as u64;
+        let min_balance = (100_000 * (default_num_transactions()) * 5) as u64;
         let max_balance = min_balance * 10;
-        Self::strategy(min_accounts..num_accounts(), min_balance..max_balance)
+        Self::strategy(
+            min_accounts..default_num_accounts(),
+            min_balance..max_balance,
+        )
     }
 
     /// Returns an [`AccountUniverse`] with the initial state generated in this universe.

--- a/language/e2e_tests/src/tests/account_universe.rs
+++ b/language/e2e_tests/src/tests/account_universe.rs
@@ -8,8 +8,8 @@ mod rotate_key;
 use crate::{
     account::AccountResource,
     account_universe::{
-        log_balance_strategy, num_accounts, num_transactions, AUTransactionGen, AccountCurrent,
-        AccountPairGen, AccountUniverse, AccountUniverseGen, RotateKeyGen,
+        default_num_accounts, default_num_transactions, log_balance_strategy, AUTransactionGen,
+        AccountCurrent, AccountPairGen, AccountUniverse, AccountUniverseGen, RotateKeyGen,
     },
     executor::FakeExecutor,
 };
@@ -22,8 +22,8 @@ proptest! {
     /// Ensure that account pair generators return the correct indexes.
     #[test]
     fn account_pair_gen(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), 0u64..10000),
-        pairs in vec(any::<AccountPairGen>(), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(2..default_num_accounts(), 0u64..10000),
+        pairs in vec(any::<AccountPairGen>(), 0..default_num_transactions()),
     ) {
         let mut executor = FakeExecutor::from_genesis_file();
         let mut universe = universe.setup(&mut executor);
@@ -54,8 +54,11 @@ proptest! {
 
     #[test]
     fn all_transactions(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), log_balance_strategy(10_000_000)),
-        transactions in vec(all_transactions_strategy(1, 1_000_000), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            log_balance_strategy(10_000_000),
+        ),
+        transactions in vec(all_transactions_strategy(1, 1_000_000), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transactions)?;
     }

--- a/language/e2e_tests/src/tests/account_universe/create_account.rs
+++ b/language/e2e_tests/src/tests/account_universe/create_account.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     account_universe::{
-        log_balance_strategy, num_accounts, num_transactions, AUTransactionGen, AccountUniverseGen,
-        CreateAccountGen, CreateExistingAccountGen,
+        default_num_accounts, default_num_transactions, log_balance_strategy, AUTransactionGen,
+        AccountUniverseGen, CreateAccountGen, CreateExistingAccountGen,
     },
     gas_costs,
     tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
@@ -20,15 +20,15 @@ proptest! {
     #[test]
     fn create_account_gas_cost_stability(
         universe in AccountUniverseGen::success_strategy(1),
-        transfers in vec(any_with::<CreateAccountGen>((1, 10_000)), 0..num_transactions()),
+        transfers in vec(any_with::<CreateAccountGen>((1, 10_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_gas_cost_stability(universe, transfers, *gas_costs::CREATE_ACCOUNT)?;
     }
 
     #[test]
     fn create_account_high_balance(
-        universe in AccountUniverseGen::strategy(1..num_accounts(), 1_000_000u64..10_000_000),
-        transfers in vec(any_with::<CreateAccountGen>((1, 10_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(1..default_num_accounts(), 1_000_000u64..10_000_000),
+        transfers in vec(any_with::<CreateAccountGen>((1, 10_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -36,8 +36,8 @@ proptest! {
     /// Test with balances small enough to possibly trigger failures.
     #[test]
     fn create_account_low_balance(
-        universe in AccountUniverseGen::strategy(1..num_accounts(), 0u64..100_000),
-        transfers in vec(any_with::<CreateAccountGen>((1, 50_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(1..default_num_accounts(), 0u64..100_000),
+        transfers in vec(any_with::<CreateAccountGen>((1, 50_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -47,15 +47,24 @@ proptest! {
     #[test]
     fn create_existing_account_gas_cost_stability(
         universe in AccountUniverseGen::success_strategy(2),
-        transfers in vec(any_with::<CreateExistingAccountGen>((1, 10_000)), 0..num_transactions()),
+        transfers in vec(
+            any_with::<CreateExistingAccountGen>((1, 10_000)),
+            0..default_num_transactions(),
+        ),
     ) {
         run_and_assert_gas_cost_stability(universe, transfers, *gas_costs::CREATE_EXISTING_ACCOUNT)?;
     }
 
     #[test]
     fn create_existing_account(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), log_balance_strategy(10_000_000)),
-        transfers in vec(any_with::<CreateExistingAccountGen>((1, 1_000_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            log_balance_strategy(10_000_000),
+        ),
+        transfers in vec(
+            any_with::<CreateExistingAccountGen>((1, 1_000_000)),
+            0..default_num_transactions(),
+        ),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -64,8 +73,11 @@ proptest! {
     /// of balances.
     #[test]
     fn create_account_mixed(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), log_balance_strategy(10_000_000)),
-        transfers in vec(create_account_strategy(1, 1_000_000), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            log_balance_strategy(10_000_000),
+        ),
+        transfers in vec(create_account_strategy(1, 1_000_000), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }

--- a/language/e2e_tests/src/tests/account_universe/peer_to_peer.rs
+++ b/language/e2e_tests/src/tests/account_universe/peer_to_peer.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     account_universe::{
-        log_balance_strategy, num_accounts, num_transactions, AUTransactionGen, AccountUniverseGen,
-        P2PNewReceiverGen, P2PTransferGen,
+        default_num_accounts, default_num_transactions, log_balance_strategy, AUTransactionGen,
+        AccountUniverseGen, P2PNewReceiverGen, P2PTransferGen,
     },
     gas_costs,
     tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
@@ -20,15 +20,18 @@ proptest! {
     #[test]
     fn p2p_gas_cost_stability(
         universe in AccountUniverseGen::success_strategy(2),
-        transfers in vec(any_with::<P2PTransferGen>((1, 10_000)), 0..num_transactions()),
+        transfers in vec(any_with::<P2PTransferGen>((1, 10_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_gas_cost_stability(universe, transfers, *gas_costs::PEER_TO_PEER)?;
     }
 
     #[test]
     fn p2p_high_balance(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), 1_000_000u64..10_000_000),
-        transfers in vec(any_with::<P2PTransferGen>((1, 10_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            1_000_000u64..10_000_000,
+        ),
+        transfers in vec(any_with::<P2PTransferGen>((1, 10_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -36,8 +39,8 @@ proptest! {
     /// Test with balances small enough to possibly trigger failures.
     #[test]
     fn p2p_low_balance(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), 0u64..100_000),
-        transfers in vec(any_with::<P2PTransferGen>((1, 50_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(2..default_num_accounts(), 0u64..100_000),
+        transfers in vec(any_with::<P2PTransferGen>((1, 50_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -47,7 +50,7 @@ proptest! {
     #[test]
     fn p2p_new_receiver_gas_cost_stability(
         universe in AccountUniverseGen::success_strategy(1),
-        transfers in vec(any_with::<P2PNewReceiverGen>((1, 10_000)), 0..num_transactions()),
+        transfers in vec(any_with::<P2PNewReceiverGen>((1, 10_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_gas_cost_stability(
             universe,
@@ -59,8 +62,11 @@ proptest! {
     /// Test that p2p transfers can be done to new accounts.
     #[test]
     fn p2p_new_receiver_high_balance(
-        universe in AccountUniverseGen::strategy(1..num_accounts(), 1_000_000u64..10_000_000),
-        transfers in vec(any_with::<P2PNewReceiverGen>((1, 10_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            1..default_num_accounts(),
+            1_000_000u64..10_000_000,
+        ),
+        transfers in vec(any_with::<P2PNewReceiverGen>((1, 10_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -68,8 +74,8 @@ proptest! {
     /// Test with balances small enough to possibly trigger failures.
     #[test]
     fn p2p_new_receiver_low_balance(
-        universe in AccountUniverseGen::strategy(1..num_accounts(), 0u64..100_000),
-        transfers in vec(any_with::<P2PNewReceiverGen>((1, 50_000)), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(1..default_num_accounts(), 0u64..100_000),
+        transfers in vec(any_with::<P2PNewReceiverGen>((1, 50_000)), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
@@ -78,8 +84,11 @@ proptest! {
     /// variety of balances.
     #[test]
     fn p2p_mixed(
-        universe in AccountUniverseGen::strategy(2..num_accounts(), log_balance_strategy(10_000_000)),
-        transfers in vec(p2p_strategy(1, 1_000_000), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            2..default_num_accounts(),
+            log_balance_strategy(10_000_000),
+        ),
+        transfers in vec(p2p_strategy(1, 1_000_000), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, transfers)?;
     }

--- a/language/e2e_tests/src/tests/account_universe/rotate_key.rs
+++ b/language/e2e_tests/src/tests/account_universe/rotate_key.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account_universe::{num_accounts, num_transactions, AccountUniverseGen, RotateKeyGen},
+    account_universe::{
+        default_num_accounts, default_num_transactions, AccountUniverseGen, RotateKeyGen,
+    },
     gas_costs,
     tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
 };
@@ -15,23 +17,26 @@ proptest! {
     #[test]
     fn rotate_key_gas_cost_stability(
         universe in AccountUniverseGen::success_strategy(1),
-        key_rotations in vec(any::<RotateKeyGen>(), 0..num_transactions()),
+        key_rotations in vec(any::<RotateKeyGen>(), 0..default_num_transactions()),
     ) {
         run_and_assert_gas_cost_stability(universe, key_rotations, *gas_costs::ROTATE_KEY)?;
     }
 
     #[test]
     fn rotate_key_high_balance(
-        universe in AccountUniverseGen::strategy(1..num_accounts(), 1_000_000u64..10_000_000),
-        key_rotations in vec(any::<RotateKeyGen>(), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(
+            1..default_num_accounts(),
+            1_000_000u64..10_000_000,
+        ),
+        key_rotations in vec(any::<RotateKeyGen>(), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, key_rotations)?;
     }
 
     #[test]
     fn rotate_key_low_balance(
-        universe in AccountUniverseGen::strategy(1..num_accounts(), 0u64..100_000),
-        key_rotations in vec(any::<RotateKeyGen>(), 0..num_transactions()),
+        universe in AccountUniverseGen::strategy(1..default_num_accounts(), 0u64..100_000),
+        key_rotations in vec(any::<RotateKeyGen>(), 0..default_num_transactions()),
     ) {
         run_and_assert_universe(universe, key_rotations)?;
     }


### PR DESCRIPTION
Add a `default_` prefix to `num_accounts` and `num_transactions`.

I kept getting confused at what these meant.