### PR TITLE
[language] Add check for coverage of instructions in gas schedule

### DIFF
--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -984,6 +984,11 @@ pub enum Bytecode {
     GetTxnPublicKey,
 }
 
+/// The number of bytecode instructions.
+/// This is necessary for checking that all instructions are covered since Rust
+/// does not provide a way of determining the number of variants of an enum.
+pub const NUMBER_OF_BYTECODE_INSTRUCTIONS: usize = 53;
+
 impl ::std::fmt::Debug for Bytecode {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         match self {


### PR DESCRIPTION
## Motivation

Currently there are no checks that ensure that every bytecode instruction is included in the `CostTable`.

This diff adds a check that will be run in debug builds to ensure that exactly `53` instructions (without duplicates) are present in the `memory_table` and `compute_table`.

This check is run during invocation of `cargo test` and thus can prevent a situation where a new instruction is added to the bytecode but is not added to the `CostTable`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing via `cargo test`. Ensured that the `debug_assert` fails on values other than `53`.

## Related PRs

N/A
