### PR TITLE
[Client]Fixed multiple whitespace error

### DIFF
--- a/client/src/commands.rs
+++ b/client/src/commands.rs
@@ -75,8 +75,7 @@ pub fn get_commands() -> (
 
 /// Parse a cmd string, the first element in the returned vector is the command to run
 pub fn parse_cmd(cmd_str: &str) -> Vec<&str> {
-    let input = &cmd_str[..];
-    input.trim().split(' ').map(str::trim).collect()
+    cmd_str.split_ascii_whitespace().collect()
 }
 
 /// Print the help message for all sub commands.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Parse cmd error when there are multi blank here, for example:
```
t    0 1 100
```
between "t" and "0", there are two blankspace here and caused parse error. error info:    
```
[ERROR] Failed to perform transaction: Unable to parse input for account_reference_id/account_address - please enter an Usize.  Input was: , error: ParseIntError { kind: Empty }
```

### Have you read the [Contributing Guidelines on pull requests]
Y
## Test Plan
execute "t  0 1 100" again.

## Related PRs


https://github.com/libra/libra/pull/323
