### PR TITLE
[storage] pruner

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -20,6 +20,7 @@ mod change_set;
 mod event_store;
 mod ledger_counters;
 mod ledger_store;
+mod pruner;
 mod state_store;
 mod system_store;
 mod transaction_store;
@@ -33,6 +34,7 @@ use crate::{
     event_store::EventStore,
     ledger_counters::LedgerCounters,
     ledger_store::LedgerStore,
+    pruner::Pruner,
     schema::*,
     state_store::StateStore,
     system_store::SystemStore,
@@ -91,9 +93,13 @@ pub struct LibraDB {
     event_store: EventStore,
     #[allow(dead_code)]
     system_store: SystemStore,
+    pruner: Pruner,
 }
 
 impl LibraDB {
+    /// Config parameter for the pruner.
+    const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = 1_000_000;
+
     /// This creates an empty LibraDB instance on disk or opens one if it already exists.
     pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
         let cf_opts_map: ColumnFamilyOptionsMap = [
@@ -140,6 +146,7 @@ impl LibraDB {
             state_store: StateStore::new(Arc::clone(&db)),
             transaction_store: TransactionStore::new(Arc::clone(&db)),
             system_store: SystemStore::new(Arc::clone(&db)),
+            pruner: Pruner::new(Arc::clone(&db), Self::NUM_HISTORICAL_VERSIONS_TO_KEEP),
         }
     }
 
@@ -394,7 +401,7 @@ impl LibraDB {
         self.commit(sealed_cs)?;
 
         // Only increment counter if commit succeeds and there are at least one transaction written
-        // to the storage.
+        // to the storage. That's also when we'd inform the pruner thread to work.
         if num_txns > 0 {
             let last_version = first_version + num_txns - 1;
             OP_COUNTER.inc_by("committed_txns", num_txns as usize);
@@ -402,6 +409,8 @@ impl LibraDB {
             counters
                 .expect("Counters should be bumped with transactions being saved.")
                 .bump_op_counters();
+
+            self.pruner.wake(last_version);
         }
 
         Ok(())

--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -1,0 +1,265 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides `Pruner` which manages a thread pruning old data in the background and is
+//! meant to be triggered by other threads as they commit new data to the DB.
+
+use crate::{
+    schema::{
+        retired_state_record::RetiredStateRecordSchema, state_merkle_node::StateMerkleNodeSchema,
+    },
+    OP_COUNTER,
+};
+use failure::prelude::*;
+use logger::prelude::*;
+use schemadb::{ReadOptions, SchemaBatch, DB};
+use sparse_merkle::RetiredRecordType;
+use std::{
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Arc, Mutex,
+    },
+    thread::JoinHandle,
+};
+use types::transaction::Version;
+
+use failure::_core::sync::atomic::Ordering;
+use std::sync::atomic::AtomicU64;
+#[cfg(test)]
+use std::thread::sleep;
+#[cfg(test)]
+use std::time::{Duration, Instant};
+
+/// The `Pruner` is meant to be part of a `LibraDB` instance and runs in the background to prune old
+/// data.
+///
+/// It creates a worker thread on construction and joins it on destruction. When destructed, it
+/// quits the worker thread eagerly without waiting for all pending work to be done.
+pub(crate) struct Pruner {
+    /// Other than the latest version, how many historical versions to keep being readable. For
+    /// example, this being 0 means keep only the latest version.
+    num_historical_versions_to_keep: u64,
+    /// The worker thread handle, created upon Pruner instance construction and joined upon its
+    /// destruction. It only becomes `None` after joined in `drop()`.
+    worker_thread: Option<JoinHandle<()>>,
+    /// The sender side of the channel talking to the worker thread.
+    command_sender: Mutex<Sender<Command>>,
+    /// (For tests) A way for the worker thread to inform the `Pruner` the pruning progress. If it
+    /// sets this atomic value to `V`, all versions before `V` can no longer be accessed.
+    #[allow(dead_code)]
+    worker_progress: Arc<AtomicU64>,
+}
+
+impl Pruner {
+    /// Creates a worker thread that waits on a channel for pruning commands.
+    pub fn new(db: Arc<DB>, num_historical_versions_to_keep: u64) -> Self {
+        let (command_sender, command_receiver) = channel();
+        let worker_progress = Arc::new(AtomicU64::new(0));
+        let worker_progress_clone = Arc::clone(&worker_progress);
+
+        let worker_thread = std::thread::Builder::new()
+            .name("libradb_pruner".into())
+            .spawn(move || Worker::new(db, command_receiver, worker_progress_clone).work_loop())
+            .expect("Creating pruner thread should succeed.");
+
+        Self {
+            num_historical_versions_to_keep,
+            worker_thread: Some(worker_thread),
+            command_sender: Mutex::new(command_sender),
+            worker_progress,
+        }
+    }
+
+    /// Sends pruning command to the worker thread when necessary.
+    pub fn wake(&self, latest_version: Version) {
+        if latest_version > self.num_historical_versions_to_keep {
+            let least_readable_version = latest_version - self.num_historical_versions_to_keep;
+            self.command_sender
+                .lock()
+                .expect("command_sender to pruner thread should lock.")
+                .send(Command::Prune {
+                    least_readable_version,
+                })
+                .expect("Receiver should not destruct prematurely.");
+        }
+    }
+
+    /// (For tests only.) Notifies the worker thread and waits for it to finish its job by polling
+    /// an internal counter.
+    #[cfg(test)]
+    pub fn wake_and_wait(&self, latest_version: Version) -> Result<()> {
+        self.wake(latest_version);
+
+        if latest_version > self.num_historical_versions_to_keep {
+            let least_readable_version = latest_version - self.num_historical_versions_to_keep;
+            const TIMEOUT: Duration = Duration::from_millis(100);
+            let end = Instant::now() + TIMEOUT;
+
+            while Instant::now() < end {
+                if self.worker_progress.load(Ordering::Acquire) >= least_readable_version {
+                    return Ok(());
+                }
+                sleep(Duration::from_millis(1));
+            }
+            bail!("Timeout waiting for pruner worker.");
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Pruner {
+    fn drop(&mut self) {
+        self.command_sender
+            .lock()
+            .expect("Locking command_sender should not fail.")
+            .send(Command::Quit)
+            .expect("Receiver should not destruct.");
+        self.worker_thread
+            .take()
+            .expect("Worker thread must exist.")
+            .join()
+            .expect("Worker thread should join peacefully.");
+    }
+}
+
+enum Command {
+    Quit,
+    Prune { least_readable_version: Version },
+}
+
+struct Worker {
+    db: Arc<DB>,
+    command_receiver: Receiver<Command>,
+    least_readable_version: Version,
+    /// (For tests) a way for the worker thread to inform the `Pruner` the pruning progress. If we
+    /// set this atomic value to `V`, all versions before `V` can no longer be accessed.
+    progress: Arc<AtomicU64>,
+    /// indicates if there's NOT any pending work to do currently, to hint
+    /// `Self::receive_commands()` to `recv()` blocking-ly.
+    blocking_recv: bool,
+}
+
+impl Worker {
+    const BATCH_SIZE: usize = 1024;
+
+    fn new(db: Arc<DB>, command_receiver: Receiver<Command>, progress: Arc<AtomicU64>) -> Self {
+        Self {
+            db,
+            command_receiver,
+            progress,
+            least_readable_version: 0,
+            blocking_recv: true,
+        }
+    }
+
+    fn work_loop(mut self) {
+        while self.receive_commands() {
+            // Process a reasonably small batch of work before trying to receive commands again,
+            // in case `Command::Quit` is received (that's when we should quit.)
+            match prune_state(
+                Arc::clone(&self.db),
+                self.least_readable_version,
+                Self::BATCH_SIZE,
+            ) {
+                Ok((num_pruned, last_seen_version)) => {
+                    // Make next recv() blocking if all done.
+                    self.blocking_recv = num_pruned < Self::BATCH_SIZE;
+
+                    // Log the progress.
+                    self.progress.store(last_seen_version, Ordering::Release);
+                    OP_COUNTER.set(
+                        "pruner.least_readable_state_version",
+                        last_seen_version as usize,
+                    );
+                }
+                Err(e) => {
+                    crit!("Error purging db records. {:?}", e);
+                    // On error, stop retrying vigorously by making next recv() blocking.
+                    self.blocking_recv = true;
+                }
+            }
+        }
+    }
+
+    /// Tries to receive all pending commands, blocking waits for the next command if no work needs
+    /// to be done, otherwise quits with `true` to allow the outer loop to do some work before
+    /// getting back here.
+    ///
+    /// Returns `false` if `Command::Quit` is received, to break the outer loop and let
+    /// `work_loop()` return.
+    fn receive_commands(&mut self) -> bool {
+        loop {
+            let command = if self.blocking_recv {
+                // Worker has nothing to do, blocking wait for the next command.
+                self.command_receiver
+                    .recv()
+                    .expect("Sender should not destruct prematurely.")
+            } else {
+                // Worker has pending work to do, non-blocking recv.
+                match self.command_receiver.try_recv() {
+                    Ok(command) => command,
+                    // Channel has drained, yield control to the outer loop.
+                    Err(_) => return true,
+                }
+            };
+
+            match command {
+                // On `Command::Quit` inform the outer loop to quit by returning `false`.
+                Command::Quit => return false,
+                Command::Prune {
+                    least_readable_version,
+                } => {
+                    if least_readable_version > self.least_readable_version {
+                        self.least_readable_version = least_readable_version;
+                        // Switch to non-blocking to allow some work to be done after the
+                        // channel has drained.
+                        self.blocking_recv = false;
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub fn prune_state(
+    db: Arc<DB>,
+    least_readable_version: Version,
+    limit: usize,
+) -> Result<(usize, Version)> {
+    let mut batch = SchemaBatch::new();
+    let mut num_purged = 0;
+    let mut iter = db.iter::<RetiredStateRecordSchema>(ReadOptions::default())?;
+    iter.seek_to_first();
+
+    // Collect records to purge, as many as `limit`.
+    let mut iter = iter.take(limit);
+    let mut last_seen_version = 0;
+    while let Some((record, _)) = iter.next().transpose()? {
+        // Only records that have retired before or at version `least_readable_version` can be
+        // pruned in order to keep that version still readable after pruning.
+        if record.version_retired > least_readable_version {
+            break;
+        }
+        last_seen_version = record.version_retired;
+        match record.record_type {
+            RetiredRecordType::Node => {
+                batch.delete::<StateMerkleNodeSchema>(&record.hash)?;
+            }
+            RetiredRecordType::Blob => {
+                // TODO: prune state blobs after its key has `version_created` as a prefix.
+            }
+        }
+        batch.delete::<RetiredStateRecordSchema>(&record)?;
+        num_purged += 1;
+    }
+
+    // Persist.
+    if num_purged > 0 {
+        db.write_schemas(batch)?;
+    }
+
+    Ok((num_purged, last_seen_version))
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/libradb/src/pruner/test.rs
+++ b/storage/libradb/src/pruner/test.rs
@@ -1,0 +1,173 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::{change_set::ChangeSet, state_store::StateStore, LibraDB};
+use crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
+use std::collections::HashMap;
+use tempfile::tempdir;
+use types::{
+    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_state_blob::AccountStateBlob,
+};
+
+fn put_account_state_set(
+    db: &DB,
+    state_store: &StateStore,
+    account_state_set: Vec<(AccountAddress, AccountStateBlob)>,
+    version: Version,
+    root_hash: HashValue,
+) -> HashValue {
+    let mut cs = ChangeSet::new();
+    let root = state_store
+        .put_account_state_sets(
+            vec![account_state_set.into_iter().collect::<HashMap<_, _>>()],
+            version,
+            root_hash,
+            &mut cs,
+        )
+        .unwrap()[0];
+    db.write_schemas(cs.batch).unwrap();
+
+    root
+}
+
+fn verify_state_in_store(
+    state_store: &StateStore,
+    address: AccountAddress,
+    expected_value: Option<&AccountStateBlob>,
+    root: HashValue,
+) {
+    let (value, _proof) = state_store
+        .get_account_state_with_proof_by_state_root(address, root)
+        .unwrap();
+    assert_eq!(value.as_ref(), expected_value);
+}
+
+#[test]
+fn test_pruner() {
+    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let value0 = AccountStateBlob::from(vec![0x01]);
+    let value1 = AccountStateBlob::from(vec![0x02]);
+    let value2 = AccountStateBlob::from(vec![0x03]);
+    let root_default = *SPARSE_MERKLE_PLACEHOLDER_HASH;
+
+    let tmp_dir = tempdir().unwrap();
+    let db = LibraDB::new(&tmp_dir).db;
+    let state_store = &StateStore::new(Arc::clone(&db));
+    let pruner = Pruner::new(
+        Arc::clone(&db),
+        0, /* num_historical_versions_to_keep */
+    );
+
+    let root0 = put_account_state_set(
+        &db,
+        state_store,
+        vec![(address, value0.clone())],
+        0, /* version */
+        root_default,
+    );
+    let root1 = put_account_state_set(
+        &db,
+        state_store,
+        vec![(address, value1.clone())],
+        1, /* version */
+        root0,
+    );
+    let root2 = put_account_state_set(
+        &db,
+        state_store,
+        vec![(address, value2.clone())],
+        2, /* version */
+        root1,
+    );
+
+    // Purge till version=0.
+    {
+        pruner.wake_and_wait(0 /* latest_version */).unwrap();
+        verify_state_in_store(state_store, address, Some(&value0), root0);
+        verify_state_in_store(state_store, address, Some(&value1), root1);
+        verify_state_in_store(state_store, address, Some(&value2), root2);
+    }
+    // Purge till version=1.
+    {
+        pruner.wake_and_wait(1 /* latest_version */).unwrap();
+        // root0 is gone.
+        assert!(state_store
+            .get_account_state_with_proof_by_state_root(address, root0)
+            .is_err());
+        // root1 is still there.
+        verify_state_in_store(state_store, address, Some(&value1), root1);
+        verify_state_in_store(state_store, address, Some(&value2), root2);
+    }
+    // Purge till version=2.
+    {
+        pruner.wake_and_wait(2 /* latest_version */).unwrap();
+        // root1 is gone.
+        assert!(state_store
+            .get_account_state_with_proof_by_state_root(address, root1)
+            .is_err());
+        // root2 is still there.
+        verify_state_in_store(state_store, address, Some(&value2), root2);
+    }
+}
+
+#[test]
+fn test_worker_quit_eagerly() {
+    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let value0 = AccountStateBlob::from(vec![0x01]);
+    let value1 = AccountStateBlob::from(vec![0x02]);
+    let value2 = AccountStateBlob::from(vec![0x03]);
+    let root_default = *SPARSE_MERKLE_PLACEHOLDER_HASH;
+
+    let tmp_dir = tempdir().unwrap();
+    let db = LibraDB::new(&tmp_dir).db;
+    let state_store = &StateStore::new(Arc::clone(&db));
+
+    let root0 = put_account_state_set(
+        &db,
+        state_store,
+        vec![(address, value0.clone())],
+        0, /* version */
+        root_default,
+    );
+    let root1 = put_account_state_set(
+        &db,
+        state_store,
+        vec![(address, value1.clone())],
+        1, /* version */
+        root0,
+    );
+    let root2 = put_account_state_set(
+        &db,
+        state_store,
+        vec![(address, value2.clone())],
+        2, /* version */
+        root1,
+    );
+
+    {
+        let (command_sender, command_receiver) = channel();
+        let worker = Worker::new(
+            Arc::clone(&db),
+            command_receiver,
+            Arc::new(AtomicU64::new(0)), /* progress */
+        );
+        command_sender
+            .send(Command::Prune {
+                least_readable_version: 1,
+            })
+            .unwrap();
+        command_sender
+            .send(Command::Prune {
+                least_readable_version: 2,
+            })
+            .unwrap();
+        command_sender.send(Command::Quit).unwrap();
+        // Worker quits immediately although `Command::Quit` is not the first command sent.
+        worker.work_loop();
+        verify_state_in_store(state_store, address, Some(&value0), root0);
+        verify_state_in_store(state_store, address, Some(&value1), root1);
+        verify_state_in_store(state_store, address, Some(&value2), root2);
+    }
+}


### PR DESCRIPTION

## Motivation

Based on previous work that added and started maintaining the state retire records, this introduces a background thread to recollect db space. The length of history to keep is currently a constant, which needs to be converted to a config once we are clear about different behavior to expect on different types of nodes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Unit tests.


