### PR TITLE
 [benchmark] Linear search Libra's max throughput

### DIFF
--- a/benchmark/src/bin/lisar.rs
+++ b/benchmark/src/bin/lisar.rs
@@ -1,0 +1,75 @@
+use benchmark::{
+    bin_utils::{
+        create_benchmarker_from_opt, linear_search_max_throughput, try_start_metrics_server,
+    },
+    ruben_opt::{RuBenOpt, TransactionPattern},
+    txn_generator::{LoadGenerator, PairwiseTransferTxnGenerator, RingTransferTxnGenerator},
+};
+use logger::{self, prelude::*};
+use std::ops::DerefMut;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "LiSar",
+    author = "Libra",
+    about = "LiSar (Li)near (S)e(ar)ch Maximum Throughput."
+)]
+pub struct LiSarOpt {
+    #[structopt(flatten)]
+    pub ruben_opt: RuBenOpt,
+    /// Upper bound value of submission rate for each client.
+    #[structopt(short = "u", long = "upper_bound", default_value = "100")]
+    pub upper_bound: u64,
+    /// Upper bound value of submission rate for each client.
+    #[structopt(short = "l", long = "lower_bound", default_value = "10")]
+    pub lower_bound: u64,
+    /// Increase step of submission rate for each client.
+    #[structopt(short = "i", long = "inc_step", default_value = "10")]
+    pub inc_step: u64,
+    /// How many times to repeat the same linear search. Each time with new accounts/TXNs.
+    #[structopt(short = "b", long = "num_searches", default_value = "10")]
+    pub num_searches: u64,
+}
+
+impl LiSarOpt {
+    pub fn new_from_args() -> Self {
+        let mut args = LiSarOpt::from_args();
+        args.ruben_opt.try_parse_validator_addresses();
+        if args.ruben_opt.num_clients == 0 {
+            args.ruben_opt.num_clients = args.ruben_opt.validator_addresses.len();
+        }
+        assert!(args.lower_bound > 0);
+        assert!(args.inc_step > 0);
+        assert!(args.lower_bound < args.upper_bound);
+        args
+    }
+}
+
+fn main() {
+    let _g = logger::set_default_global_logger(false, Some(256));
+    info!("LiSar: the utility to (Li)near (S)e(ar)ch maximum throughput");
+    let args = LiSarOpt::new_from_args();
+    info!("Parsed arguments: {:#?}", args);
+
+    try_start_metrics_server(&args.ruben_opt);
+    let mut bm = create_benchmarker_from_opt(&args.ruben_opt);
+    let mut faucet_account = bm.load_faucet_account(&args.ruben_opt.faucet_key_file_path);
+    let mut generator: Box<dyn LoadGenerator> = match args.ruben_opt.txn_pattern {
+        TransactionPattern::Ring => Box::new(RingTransferTxnGenerator::new()),
+        TransactionPattern::Pairwise => Box::new(PairwiseTransferTxnGenerator::new()),
+    };
+    for _ in 0..args.num_searches {
+        linear_search_max_throughput(
+            &mut bm,
+            generator.deref_mut(),
+            &mut faucet_account,
+            args.lower_bound,
+            args.upper_bound,
+            args.inc_step,
+            args.ruben_opt.num_accounts,
+            args.ruben_opt.num_rounds,
+            args.ruben_opt.num_epochs,
+        );
+    }
+}

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -36,6 +36,7 @@ fn main() {
     info!("RuBen: the utility to (Ru)n (Ben)chmarker");
     let args = RubenOpt::new_from_args();
     info!("Parsed arguments: {:#?}", args);
+
     try_start_metrics_server(&args);
     let mut bm = create_benchmarker_from_opt(&args);
     let mut faucet_account = bm.load_faucet_account(&args.faucet_key_file_path);

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -11,7 +11,9 @@ use client::AccountData;
 use grpcio::{ChannelBuilder, EnvBuilder};
 use logger::{self, prelude::*};
 use metrics::metric_server::start_server;
-use std::sync::Arc;
+use std::{sync::Arc, time};
+
+const COMMIT_RATIO_THRESHOLD: f64 = 0.7;
 
 /// Creates a client for AC with a unique user-agent.
 ///
@@ -64,6 +66,23 @@ pub fn try_start_metrics_server(args: &RubenOpt) {
     }
 }
 
+pub fn gen_and_mint_accounts<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    txn_generator: &mut T,
+    faucet_account: &mut AccountData,
+    num_accounts: u64,
+) -> Vec<AccountData> {
+    // Generate testing accounts.
+    let mut accounts: Vec<AccountData> = txn_generator.gen_accounts(num_accounts);
+    bm.register_accounts(&accounts);
+
+    // Submit setup/minting TXN requests.
+    let setup_requests = txn_generator.gen_setup_txn_requests(faucet_account, &mut accounts);
+    let mint_txns = convert_load_to_txn_requests(setup_requests);
+    bm.mint_accounts(&mint_txns, faucet_account);
+    accounts
+}
+
 /// Play given TXN pattern with Benchmarker for several epochs and measure burst throughput,
 /// e.g., the average committed txns per second. Since time is counted from submission
 /// until all TXNs are committed, this measurement is in a sense the user-side throughput.
@@ -77,24 +96,125 @@ pub fn measure_throughput<T: LoadGenerator + ?Sized>(
     num_epochs: u64,
 ) -> std::vec::Vec<(f64, f64)> {
     // Generate testing accounts.
-    let mut accounts: Vec<AccountData> = txn_generator.gen_accounts(num_accounts);
-    bm.register_accounts(&accounts);
-
-    // Submit setup/minting TXN requests.
-    let setup_requests = txn_generator.gen_setup_txn_requests(faucet_account, &mut accounts);
-    let mint_txns = convert_load_to_txn_requests(setup_requests);
-    bm.mint_accounts(&mint_txns, faucet_account);
+    let mut accounts = gen_and_mint_accounts(bm, txn_generator, faucet_account, num_accounts);
 
     // Submit TXN load and measure throughput.
     let mut txn_throughput_seq = vec![];
     for _ in 0..num_epochs {
         let repeated_tx_reqs = gen_repeated_txn_load(txn_generator, &mut accounts, num_rounds);
-        let txn_throughput = bm.measure_txn_throughput(&repeated_tx_reqs, &mut accounts);
-        txn_throughput_seq.push(txn_throughput);
+        let (_, _, request_throughput, txn_throughput) =
+            bm.measure_txn_throughput(&repeated_tx_reqs, &mut accounts, None);
+        txn_throughput_seq.push((request_throughput, txn_throughput));
     }
     info!(
         "{} epoch(s) of REQ/TXN throughput = {:?}",
         num_epochs, txn_throughput_seq
     );
     txn_throughput_seq
+}
+
+/// Run benchmarker at constant submission rate for several epochs. Use the averaged result
+/// to check if Libra network is able to absorb TXNs at the submission speed.
+fn run_benchmarker_at_const_rate<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    accounts: &mut [AccountData],
+    txn_generator: &mut T,
+    rate: u64,
+    num_accounts: u64,
+    num_rounds: u64,
+    num_epochs: u64,
+) -> (usize, usize, f64, f64) {
+    let (mut total_submitted, mut total_committed) = (0, 0);
+    let (mut avg_req_throughput, mut avg_txn_throughput) = (0.0f64, 0.0f64);
+    for _ in 0..num_epochs {
+        let mut txn_reqs = vec![];
+        let now = time::Instant::now();
+        for account_chunk in accounts.chunks_mut(num_accounts as usize) {
+            let txn_req_chunk = gen_repeated_txn_load(txn_generator, account_chunk, num_rounds);
+            txn_reqs.extend(txn_req_chunk.into_iter());
+        }
+        info!(
+            "Generate {} TXNs within {} ms",
+            txn_reqs.len(),
+            now.elapsed().as_millis()
+        );
+        let (_, num_committed, req_throughput, txn_throughput) =
+            bm.measure_txn_throughput(&txn_reqs, accounts, Some(rate));
+        total_submitted += txn_reqs.len();
+        total_committed += num_committed;
+        avg_req_throughput += req_throughput;
+        avg_txn_throughput += txn_throughput;
+    }
+    avg_req_throughput /= num_epochs as f64;
+    avg_txn_throughput /= num_epochs as f64;
+    (
+        total_submitted,
+        total_committed,
+        avg_req_throughput,
+        avg_txn_throughput,
+    )
+}
+
+/// Search the maximum throughput between range SEARCH_UPPER_BOUND * [1/10, 1].
+/// Also consider the runs that fails the check as sometimes request throughput is hard to meet.
+/// Return the request/TXN throughput pairs for success runs.
+pub fn linear_search_max_throughput<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    txn_generator: &mut T,
+    faucet_account: &mut AccountData,
+    lower_bound: u64,
+    upper_bound: u64,
+    inc_step: u64,
+    num_accounts: u64,
+    num_rounds: u64,
+    num_epochs: u64,
+) -> (f64, f64) {
+    let mut rate = lower_bound;
+    let mut max_result = (0.0f64, 0.0f64);
+    let mut growing_accounts = vec![];
+    while rate <= upper_bound {
+        let accounts = gen_and_mint_accounts(bm, txn_generator, faucet_account, num_accounts);
+        growing_accounts.extend(accounts.into_iter());
+        info!(
+            "Sending at constant rate {} TPS per client with {} accounts.",
+            rate,
+            growing_accounts.len()
+        );
+        let (num_submitted, num_committed, req_throughput, txn_throughput) =
+            run_benchmarker_at_const_rate(
+                bm,
+                &mut growing_accounts,
+                txn_generator,
+                rate,
+                num_accounts,
+                num_rounds,
+                num_epochs,
+            );
+        if max_result.1 < txn_throughput {
+            max_result.0 = req_throughput;
+            max_result.1 = txn_throughput;
+        }
+        info!(
+            "#submitted = {}, #committed = {}, Avg REQ/TXN throughput = {:.2}/{:.2}.",
+            num_submitted, num_committed, req_throughput, txn_throughput
+        );
+        let commit_ratio = num_committed as f64 / num_submitted as f64;
+        info!(
+            "Commit ratio at submit rate {} per client is {:.4}",
+            rate, commit_ratio
+        );
+        if commit_ratio < COMMIT_RATIO_THRESHOLD {
+            info!(
+                "Search ends ealier as commit ratio {:.4} < {:.2}",
+                commit_ratio, COMMIT_RATIO_THRESHOLD,
+            );
+            break;
+        }
+        rate += inc_step;
+    }
+    info!(
+        "Search result: max REQ/TXN throughput = {:?} TPS",
+        max_result
+    );
+    max_result
 }

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -370,9 +370,10 @@ impl Benchmarker {
         &mut self,
         txn_reqs: &[SubmitTransactionRequest],
         senders: &mut [AccountData],
-    ) -> (f64, f64) {
+        submit_rate: Option<u64>,
+    ) -> (usize, usize, f64, f64) {
         let (num_accepted, num_committed, submit_duration_ms, wait_duration_ms) =
-            self.submit_and_wait_txn_committed(txn_reqs, senders, None);
+            self.submit_and_wait_txn_committed(txn_reqs, senders, submit_rate);
         let request_throughput =
             Self::calculate_throughput(num_accepted, submit_duration_ms, "REQ");
         let running_duration_ms = submit_duration_ms + wait_duration_ms;
@@ -384,6 +385,11 @@ impl Benchmarker {
         OP_COUNTER.set("request_throughput", request_throughput as usize);
         OP_COUNTER.set("txn_throughput", txn_throughput as usize);
 
-        (request_throughput, txn_throughput)
+        (
+            num_accepted,
+            num_committed,
+            request_throughput,
+            txn_throughput,
+        )
     }
 }


### PR DESCRIPTION
### Summary:
Based on submitting TXN load at constant rates, search the maximum throughput, starting from `-l lower_bound`, ends at `-u upper_bound`, with `-i inc_step`. Whole search process can be repeated multiple times.

### Basic Test Plan
Test local `libra_swarm`'s max throughput.
```
./target/release/ruben -f faucet_for_ruben -s temp_config \
-g 1 -n 32 -c 4 -r 3 -e 1 -m localhost:45345 \
searchmaxthroughput -u 200 -i 5 -l 100
......
Search result: SUCCESS REQ/TXN = (557.430593358737, 402.9380902413431) TPS, \
FAIL REQ/TXN = (607.1146245059289, 280.13861024986323) TPS
```
![image](https://user-images.githubusercontent.com/1838298/62236559-2cc9fa00-b384-11e9-865a-57c0d7f434c3.png)

### Test Plan for Multiple Searches
To search multiple times, use `-s` option in `searchmaxthroughput`. The accounts/TXNs will be generated from scratch in each search. But Benchmarker is reused.
```
./target/release/ruben -f faucet_for_ruben -s temp_config \
-g 1 -n 32 -c 4 -r 3 -e 1 -m localhost:45345 \
searchmaxthroughput -u 200 -i 50 -l 100 -s 3
```

![image](https://user-images.githubusercontent.com/1838298/62247318-70c7f980-b39a-11e9-9738-b8df4af12cec.png)



### TODO:
* Wait #294 , re-push and maybe rebase after that.
* Merge with #357, linear search can use both ring and pairwise TXN generators.