### PR TITLE
[storage] Add pop() method and related tests to NibblePath

### DIFF
--- a/storage/sparse_merkle/src/nibble_path/mod.rs
+++ b/storage/sparse_merkle/src/nibble_path/mod.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 use crate::ROOT_NIBBLE_HEIGHT;
 use std::{fmt, iter::FromIterator};
 
-/// NibblePath defines a path in Merkle tree in the unit of nibble (4 bits)
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+/// NibblePath defines a path in Merkle tree in the unit of nibble (4 bits).
+#[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct NibblePath {
-    /// the underlying bytes that stores the path, 2 nibbles per byte. If the number of nibbles is
+    /// The underlying bytes that stores the path, 2 nibbles per byte. If the number of nibbles is
     /// odd, the second half of the last byte must be 0.
     bytes: Vec<u8>,
     /// Indicates the total number of nibbles in bytes. Either `bytes.len() * 2 - 1` or
@@ -22,7 +22,7 @@ pub struct NibblePath {
     num_nibbles: usize,
 }
 
-/// Support debug format by concatenating nibbles literally. For example, [0x12, 0xa0] with 3
+/// Supports debug format by concatenating nibbles literally. For example, [0x12, 0xa0] with 3
 /// nibbles will be printed as "12a".
 impl fmt::Debug for NibblePath {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -61,7 +61,7 @@ impl NibblePath {
         NibblePath { bytes, num_nibbles }
     }
 
-    /// Adds a nibble to the end of nibble path.
+    /// Adds a nibble to the end of the nibble path.
     pub fn push(&mut self, nibble: u8) {
         assert!(nibble < 16);
         assert!(ROOT_NIBBLE_HEIGHT > self.num_nibbles);
@@ -71,6 +71,23 @@ impl NibblePath {
             self.bytes[self.num_nibbles / 2] |= nibble;
         }
         self.num_nibbles += 1;
+    }
+
+    /// Pops a nibble from the end of the nibble path.
+    pub fn pop(&mut self) -> Option<u8> {
+        let poped_nibble = if self.num_nibbles % 2 == 0 {
+            self.bytes.last_mut().map(|last_byte| {
+                let nibble = *last_byte & 0x0f;
+                *last_byte &= 0xf0;
+                nibble
+            })
+        } else {
+            self.bytes.pop().map(|byte| byte >> 4)
+        };
+        if poped_nibble.is_some() {
+            self.num_nibbles -= 1;
+        }
+        poped_nibble
     }
 
     /// Get the i-th bit.

--- a/storage/sparse_merkle/src/nibble_path/nibble_path_test.rs
+++ b/storage/sparse_merkle/src/nibble_path/nibble_path_test.rs
@@ -202,6 +202,16 @@ proptest! {
     }
 
     #[test]
+    fn test_pop(mut nibble_path in arb_nibble_path()) {
+        let mut nibbles: Vec<u8> = nibble_path.nibbles().collect();
+        let nibble_from_nibbles = nibbles.pop();
+        let nibble_from_nibble_path = nibble_path.pop();
+        let nibble_path2 = nibbles.into_iter().collect();
+        prop_assert_eq!(nibble_path, nibble_path2);
+        prop_assert_eq!(nibble_from_nibbles, nibble_from_nibble_path);
+    }
+
+    #[test]
     fn test_nibble_iter_roundtrip(nibble_path in arb_nibble_path()) {
         let nibbles = nibble_path.nibbles();
         let nibble_path2 = nibbles.collect();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
1. Changed some structs' visibility for migrating to JellyfishMerkleTree temporarily.
2. Add a method pop(), which is useful in JellyfishMerkleTree. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test` in `sparse_merkle` crate

## Related PRs
