### PR TITLE
[grafana] enable embedding Grafana dashboards (e.g., in iframes)

### DIFF
--- a/terraform/templates/prometheus.json
+++ b/terraform/templates/prometheus.json
@@ -57,7 +57,8 @@
         ],
         "environment": [
             {"name": "GF_AUTH_ANONYMOUS_ENABLED", "value": "true"},
-            {"name": "GF_AUTH_ANONYMOUS_ORG_ROLE", "value": "Editor"}
+            {"name": "GF_AUTH_ANONYMOUS_ORG_ROLE", "value": "Editor"},
+            {"name": "GF_SECURITY_ALLOW_EMBEDDING", "value": "true"}
         ]
     }
 ]


### PR DESCRIPTION
## Motivation
Enabled an option to embed Grafana graphs & widgets in other pages.
This is useful for dashboards/external dashboard displays.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
Tested locally by setting Grafana in an `iframe`
