### PR TITLE
[Consensus] Send sync info to help lagging remote peers

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -36,6 +36,9 @@ pub enum SecurityEvent {
     /// Consensus received an invalid new round message
     InvalidConsensusRound,
 
+    /// Consensus received an invalid sync info message
+    InvalidSyncInfoMsg,
+
     /// A block being committed or executed is invalid
     InvalidBlock,
 

--- a/consensus/src/chained_bft/consensus_types/sync_info.rs
+++ b/consensus/src/chained_bft/consensus_types/sync_info.rs
@@ -2,9 +2,16 @@ use crate::chained_bft::consensus_types::{
     quorum_cert::QuorumCert, timeout_msg::PacemakerTimeoutCertificate,
 };
 use network;
+use nextgen_crypto::ed25519::*;
+
+use crate::chained_bft::{
+    consensus_types::timeout_msg::PacemakerTimeoutCertificateVerificationError,
+    safety::vote_msg::VoteMsgVerificationError,
+};
 use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use types::validator_verifier::ValidatorVerifier;
 
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 /// This struct describes basic synchronization metadata.
@@ -28,6 +35,27 @@ impl Display for SyncInfo {
             "HQC: {}, HLI: {}, HTC: {}",
             self.highest_quorum_cert, self.highest_ledger_info, htc_repr,
         )
+    }
+}
+
+#[derive(Debug, PartialEq, Fail)]
+/// Sync info verification error cases.
+pub enum SyncInfoVerificationError {
+    #[fail(display = "QuorumCertificateError: {}", _0)]
+    QuorumCertificateError(VoteMsgVerificationError),
+    #[fail(display = "TimeoutCertificateError: {}", _0)]
+    TimeoutCertificateError(PacemakerTimeoutCertificateVerificationError),
+}
+
+impl From<VoteMsgVerificationError> for SyncInfoVerificationError {
+    fn from(source: VoteMsgVerificationError) -> Self {
+        SyncInfoVerificationError::QuorumCertificateError(source)
+    }
+}
+
+impl From<PacemakerTimeoutCertificateVerificationError> for SyncInfoVerificationError {
+    fn from(source: PacemakerTimeoutCertificateVerificationError) -> Self {
+        SyncInfoVerificationError::TimeoutCertificateError(source)
     }
 }
 
@@ -55,9 +83,20 @@ impl SyncInfo {
     }
 
     /// Highest timeout certificate if available
-    #[allow(dead_code)]
     pub fn highest_timeout_certificate(&self) -> Option<&PacemakerTimeoutCertificate> {
         self.highest_timeout_cert.as_ref()
+    }
+
+    pub fn verify(
+        &self,
+        validator: &ValidatorVerifier<Ed25519PublicKey>,
+    ) -> Result<(), SyncInfoVerificationError> {
+        self.highest_quorum_cert.verify(validator)?;
+        self.highest_ledger_info.verify(validator)?;
+        if let Some(tc) = &self.highest_timeout_cert {
+            tc.verify(validator)?;
+        }
+        Ok(())
     }
 }
 

--- a/consensus/src/chained_bft/consensus_types/timeout_msg.rs
+++ b/consensus/src/chained_bft/consensus_types/timeout_msg.rs
@@ -270,13 +270,16 @@ pub struct PacemakerTimeoutCertificate {
 }
 
 /// PacemakerTimeoutCertificate verification errors.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Fail)]
 pub enum PacemakerTimeoutCertificateVerificationError {
     /// Number of signed timeouts is less then required quorum size
+    #[fail(display = "NoQuorum")]
     NoQuorum,
     /// Round in message does not match calculated rounds based on signed timeouts
+    #[fail(display = "RoundMismatch {}", expected)]
     RoundMismatch { expected: Round },
     /// The signature on one of timeouts doesn't pass verification
+    #[fail(display = "SigVerifyError for {}: {}", _0, _1)]
     SigVerifyError(Author, VerifyError),
 }
 

--- a/consensus/src/chained_bft/liveness/local_pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker.rs
@@ -434,4 +434,12 @@ impl Pacemaker for LocalPacemaker {
             guard.highest_committed_round = highest_committed_round;
         }
     }
+
+    fn highest_timeout_certificate(&self) -> Option<PacemakerTimeoutCertificate> {
+        let guard = self.inner.read().unwrap();
+        guard
+            .pacemaker_timeout_manager
+            .highest_timeout_certificate()
+            .cloned()
+    }
 }

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -64,6 +64,10 @@ pub trait Pacemaker: Send + Sync {
     /// Synchronous function to return the current round.
     fn current_round(&self) -> Round;
 
+    /// Return a optional reference to the highest timeout certificate (locally generated or
+    /// remotely received)
+    fn highest_timeout_certificate(&self) -> Option<PacemakerTimeoutCertificate>;
+
     /// Function to update current round based on received certificates.
     /// Both round of latest received QC and timeout certificates are taken into account.
     /// This function guarantees to update pacemaker state when promise that it returns is fulfilled

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -262,9 +262,14 @@ impl NetworkPlayground {
         msg_copy.1.has_vote()
     }
 
-    /// Returns true for new round messages only.
-    pub fn new_round_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
+    /// Returns true for timeout messages only.
+    pub fn timeout_msg_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
         msg_copy.1.has_timeout_msg()
+    }
+
+    /// Returns true for sync info messages only.
+    pub fn sync_info_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
+        msg_copy.1.has_sync_info()
     }
 
     fn is_message_dropped(&self, src: &Author, net_req: &NetworkRequest) -> bool {

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -81,6 +81,12 @@ pub static ref BLOCK_RETRIEVAL_DURATION_MS: Histogram = OP_COUNTERS.histogram("b
 /// Histogram of state sync duration.
 pub static ref STATE_SYNC_DURATION_MS: Histogram = OP_COUNTERS.histogram("state_sync_duration_ms");
 
+/// Counts the number of times the sync info message has been set since last restart.
+pub static ref SYNC_INFO_MSGS_SENT_COUNT: IntCounter = OP_COUNTERS.counter("sync_info_msg_sent_count");
+
+/// Counts the number of times the sync info message has been received since last restart.
+pub static ref SYNC_INFO_MSGS_RECEIVED_COUNT: IntCounter = OP_COUNTERS.counter("sync_info_msg_received_count");
+
 //////////////////////
 // RECONFIGURATION COUNTERS
 //////////////////////


### PR DESCRIPTION
Summary:
In this diff we add a proper handling of `SyncInfoMsg`. We're sending this message when detecting that a remote peer is lagging:
* the check is executed upon receiving either a timeout message or a proposal
* the lagging criterion is determined by the round of the message and a round of the carried HQC

Test: in addition to the existing test coverage added a unit test that verifies proper sync info when receiving a timeout message from a lagging peer.

Issue: #311 