### PR TITLE
[crypto] Switches LedgerInfo to nextgen_crypto

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -293,7 +293,7 @@ where
         if li_with_sig.signatures().contains_key(&author) {
             return VoteReceptionResult::DuplicateVote;
         }
-        li_with_sig.add_signature(author, vote_msg.signature().clone());
+        li_with_sig.add_signature(author, vote_msg.signature().clone().into());
 
         let num_votes = li_with_sig.signatures().len();
         if num_votes >= min_votes_for_qc {

--- a/consensus/src/chained_bft/safety/vote_msg.rs
+++ b/consensus/src/chained_bft/safety/vote_msg.rs
@@ -8,7 +8,7 @@ use crate::{
 use canonical_serialization::{CanonicalSerialize, CanonicalSerializer, SimpleSerializer};
 use crypto::{
     hash::{CryptoHash, CryptoHasher, VoteMsgHasher},
-    HashValue, Signature,
+    HashValue,
 };
 use failure::Result as ProtoResult;
 use network::proto::Vote as ProtoVote;
@@ -84,7 +84,7 @@ pub struct VoteMsg {
     /// LedgerInfo of a block that is going to be committed in case this vote gathers QC.
     ledger_info: LedgerInfo,
     /// Signature of the LedgerInfo
-    signature: Signature,
+    signature: Ed25519Signature,
 }
 
 impl Display for VoteMsg {
@@ -153,7 +153,7 @@ impl VoteMsg {
     }
 
     /// Return the signature of the vote
-    pub fn signature(&self) -> &Signature {
+    pub fn signature(&self) -> &Ed25519Signature {
         &self.signature
     }
 
@@ -206,7 +206,7 @@ impl IntoProto for VoteMsg {
         proto.set_round(self.round);
         proto.set_author(self.author.into());
         proto.set_ledger_info(self.ledger_info.into_proto());
-        proto.set_signature(self.signature.to_compact().as_ref().into());
+        proto.set_signature(self.signature.to_bytes().as_ref().into());
         proto
     }
 }
@@ -221,7 +221,7 @@ impl FromProto for VoteMsg {
         let round = object.get_round();
         let author = Author::try_from(object.take_author())?;
         let ledger_info = LedgerInfo::from_proto(object.take_ledger_info())?;
-        let signature = Signature::from_compact(object.get_signature())?;
+        let signature = Ed25519Signature::try_from(object.get_signature())?;
         Ok(VoteMsg {
             proposed_block_id,
             executed_state: ExecutedState { state_id, version },

--- a/consensus/src/state_synchronizer/sync_test.rs
+++ b/consensus/src/state_synchronizer/sync_test.rs
@@ -13,7 +13,7 @@ use crate::{
 use bytes::Bytes;
 use config::config::NodeConfig;
 use config_builder::util::get_test_config;
-use crypto::{signing, x25519, HashValue};
+use crypto::{x25519, HashValue};
 use failure::prelude::*;
 use futures::{
     executor::block_on,
@@ -30,7 +30,7 @@ use network::{
     },
     NetworkPublicKeys, ProtocolId,
 };
-use nextgen_crypto::{ed25519::compat, test_utils::TEST_SEED};
+use nextgen_crypto::{ed25519::*, test_utils::TEST_SEED, traits::Genesis, SigningKey};
 use parity_multiaddr::Multiaddr;
 use proto_conv::IntoProto;
 use protobuf::Message;
@@ -180,8 +180,8 @@ impl SynchronizerEnv {
             0,
         );
         let mut signatures = HashMap::new();
-        let private_key = signing::generate_genesis_keypair().0;
-        let signature = signing::sign_message(HashValue::zero(), &private_key).unwrap();
+        let private_key = Ed25519PrivateKey::genesis();
+        let signature = private_key.sign_message(&HashValue::zero());
         signatures.insert(self.peers[1], signature);
         QuorumCert::new(
             HashValue::zero(),

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -11,7 +11,7 @@ use crate::{
 use canonical_serialization::{CanonicalSerialize, CanonicalSerializer, SimpleSerializer};
 use crypto::{
     hash::{CryptoHash, CryptoHasher, LedgerInfoHasher},
-    HashValue, Signature,
+    HashValue,
 };
 use failure::prelude::*;
 use nextgen_crypto::ed25519::*;
@@ -20,6 +20,7 @@ use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    convert::TryFrom,
     fmt::{Display, Formatter},
 };
 
@@ -189,7 +190,7 @@ pub struct LedgerInfoWithSignatures {
     ledger_info: LedgerInfo,
     /// The validator is identified by its account address: in order to verify a signature
     /// one needs to retrieve the public key of the validator for the given epoch.
-    signatures: HashMap<AccountAddress, Signature>,
+    signatures: HashMap<AccountAddress, Ed25519Signature>,
 }
 
 impl Display for LedgerInfoWithSignatures {
@@ -199,7 +200,10 @@ impl Display for LedgerInfoWithSignatures {
 }
 
 impl LedgerInfoWithSignatures {
-    pub fn new(ledger_info: LedgerInfo, signatures: HashMap<AccountAddress, Signature>) -> Self {
+    pub fn new(
+        ledger_info: LedgerInfo,
+        signatures: HashMap<AccountAddress, Ed25519Signature>,
+    ) -> Self {
         LedgerInfoWithSignatures {
             ledger_info,
             signatures,
@@ -210,11 +214,11 @@ impl LedgerInfoWithSignatures {
         &self.ledger_info
     }
 
-    pub fn add_signature(&mut self, validator: AccountAddress, signature: Signature) {
+    pub fn add_signature(&mut self, validator: AccountAddress, signature: Ed25519Signature) {
         self.signatures.entry(validator).or_insert(signature);
     }
 
-    pub fn signatures(&self) -> &HashMap<AccountAddress, Signature> {
+    pub fn signatures(&self) -> &HashMap<AccountAddress, Ed25519Signature> {
         &self.signatures
     }
 
@@ -243,7 +247,8 @@ impl FromProto for LedgerInfoWithSignatures {
             .into_iter()
             .map(|proto| {
                 let validator_id = AccountAddress::from_proto(proto.get_validator_id().to_vec())?;
-                let signature = Signature::from_compact(proto.get_signature())?;
+                let signature_bytes: &[u8] = proto.get_signature();
+                let signature = Ed25519Signature::try_from(signature_bytes)?;
                 Ok((validator_id, signature))
             })
             .collect::<Result<HashMap<_, _>>>()?;
@@ -270,7 +275,7 @@ impl IntoProto for LedgerInfoWithSignatures {
             .for_each(|(validator_id, signature)| {
                 let mut validator_signature = crate::proto::ledger_info::ValidatorSignature::new();
                 validator_signature.set_validator_id(validator_id.into_proto());
-                validator_signature.set_signature(signature.to_compact().to_vec());
+                validator_signature.set_signature(signature.to_bytes().to_vec());
                 proto.mut_signatures().push(validator_signature)
             });
         proto


### PR DESCRIPTION
## This commit modifies the following behavior:
- Switches LedgerInfo to use Ed25519Signature

## Why this is better:
- Progress of conversion to the nextgen-crypto API
- this includes QuorumCertificate, VoteMsg, and transfers the whole of Consensus to nextgen

## Why this is worse:
- breaking change, as LedgerInfo (etc) are serialized

## Test:
- existing unit tests (type-only modifications)

## Follow-up:
- more conversion, esp. `transaction.rs`