### PR TITLE
[network] add timeout for inbound consensus/mempool events

### DIFF
--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 lazy_static = "1.3.0"
+logger = { path = "../logger" }
 metrics = { path = "../metrics" }
 
 [dev-dependencies]

--- a/common/channel/src/lib.rs
+++ b/common/channel/src/lib.rs
@@ -10,24 +10,55 @@ use futures::{
     stream::{FusedStream, Stream},
     task::{Context, Poll},
 };
+use logger::prelude::*;
 use metrics::IntGauge;
-use std::pin::Pin;
+use std::{
+    pin::Pin,
+    time::{Duration, Instant},
+};
 
 #[cfg(test)]
 mod test;
 
-/// Wrapper around a value with an `IntGauge`
-/// It is used to gauge the number of elements in a `mpsc::channel`
-#[derive(Clone)]
-pub struct WithGauge<T> {
-    gauge: IntGauge,
+const MAX_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Wrapper around a value with an entry timestamp
+/// It is used to measure the time waiting in the `mpsc::channel`.
+pub struct WithEntryTimestamp<T> {
+    entry_time: Instant,
     value: T,
 }
 
+impl<T> WithEntryTimestamp<T> {
+    fn new(value: T) -> Self {
+        Self {
+            entry_time: Instant::now(),
+            value,
+        }
+    }
+}
+
 /// Similar to `mpsc::Sender`, but with an `IntGauge`
-pub type Sender<T> = WithGauge<mpsc::Sender<T>>;
+pub struct Sender<T> {
+    inner: mpsc::Sender<WithEntryTimestamp<T>>,
+    gauge: IntGauge,
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Sender {
+            inner: self.inner.clone(),
+            gauge: self.gauge.clone(),
+        }
+    }
+}
+
 /// Similar to `mpsc::Receiver`, but with an `IntGauge`
-pub type Receiver<T> = WithGauge<mpsc::Receiver<T>>;
+pub struct Receiver<T> {
+    inner: mpsc::Receiver<WithEntryTimestamp<T>>,
+    gauge: IntGauge,
+    timeout: Duration,
+}
 
 /// `Sender` implements `Sink` in the same way as `mpsc::Sender`, but it increments the
 /// associated `IntGauge` when it sends a message successfully.
@@ -35,69 +66,102 @@ impl<T> Sink<T> for Sender<T> {
     type Error = mpsc::SendError;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        (*self).value.poll_ready(cx)
+        (*self).inner.poll_ready(cx)
     }
 
     fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::Error> {
         self.gauge.inc();
-        (*self).value.start_send(msg).map_err(|e| {
-            self.gauge.dec();
-            e
-        })?;
+        (*self)
+            .inner
+            .start_send(WithEntryTimestamp::new(msg))
+            .map_err(|e| {
+                self.gauge.dec();
+                e
+            })?;
         Ok(())
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.value).poll_flush(cx)
+        Pin::new(&mut self.inner).poll_flush(cx)
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.value).poll_close(cx)
+        Pin::new(&mut self.inner).poll_close(cx)
     }
 }
 
 impl<T> Sender<T> {
     pub fn try_send(&mut self, msg: T) -> Result<(), mpsc::SendError> {
         self.gauge.inc();
-        (*self).value.try_send(msg).map_err(|e| {
-            self.gauge.dec();
-            e.into_send_error()
-        })
+        (*self)
+            .inner
+            .try_send(WithEntryTimestamp::new(msg))
+            .map_err(|e| {
+                self.gauge.dec();
+                e.into_send_error()
+            })
     }
 }
 
 impl<T> FusedStream for Receiver<T> {
     fn is_terminated(&self) -> bool {
-        self.value.is_terminated()
+        self.inner.is_terminated()
     }
 }
 
 /// `Receiver` implements `Stream` in the same way as `mpsc::Stream`, but it decrements the
 /// associated `IntGauge` when it gets polled successfully.
-impl<T> Stream for Receiver<T> {
+impl<T> Stream for Receiver<T>
+where
+    T: std::fmt::Debug,
+{
     type Item = T;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        let poll = Pin::new(&mut self.value).poll_next(cx);
-        if let Poll::Ready(Some(_)) = poll {
-            self.gauge.dec();
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Ready(Some(msg)) => {
+                    self.gauge.dec();
+                    // If the message times out, it gets dropped
+                    if Instant::now().duration_since(msg.entry_time) > self.timeout {
+                        warn!("Message dropped due to timeout: {:?}", msg.value);
+                        continue;
+                    } else {
+                        return Poll::Ready(Some(msg.value));
+                    }
+                }
+                Poll::Ready(None) => {
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => {
+                    return Poll::Pending;
+                }
+            }
         }
-        poll
     }
 }
 
 /// Similar to `mpsc::channel`, `new` creates a pair of `Sender` and `Receiver`
 pub fn new<T>(size: usize, gauge: &IntGauge) -> (Sender<T>, Receiver<T>) {
+    new_with_timeout(size, gauge, MAX_TIMEOUT)
+}
+
+pub fn new_with_timeout<T>(
+    size: usize,
+    gauge: &IntGauge,
+    timeout: Duration,
+) -> (Sender<T>, Receiver<T>) {
     gauge.set(0);
     let (sender, receiver) = mpsc::channel(size);
     (
-        WithGauge {
+        Sender {
+            inner: sender,
             gauge: gauge.clone(),
-            value: sender,
         },
-        WithGauge {
+        Receiver {
+            inner: receiver,
             gauge: gauge.clone(),
-            value: receiver,
+            timeout,
         },
     )
 }
@@ -109,4 +173,8 @@ lazy_static::lazy_static! {
 
 pub fn new_test<T>(size: usize) -> (Sender<T>, Receiver<T>) {
     new(size, &TEST_COUNTER)
+}
+
+pub fn new_test_with_timeout<T>(size: usize, timeout: Duration) -> (Sender<T>, Receiver<T>) {
+    new_with_timeout(size, &TEST_COUNTER, timeout)
 }

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -75,6 +75,7 @@ impl<T: Payload> BlockRetrievalResponse<T> {
 
 /// BlockRetrievalRequest carries a block id for the requested block as well as the
 /// oneshot sender to deliver the response.
+#[derive(Debug)]
 pub struct BlockRetrievalRequest<T> {
     pub block_id: HashValue,
     pub num_blocks: u64,
@@ -83,6 +84,7 @@ pub struct BlockRetrievalRequest<T> {
 
 /// Represents a request to get up to batch_size transactions starting from start_version
 /// with the oneshot sender to deliver the response.
+#[derive(Debug)]
 pub struct ChunkRetrievalRequest {
     pub start_version: u64,
     pub target: QuorumCert,

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -79,7 +79,9 @@ async fn expect_disconnect_request<'a, TSubstream>(
     peer_id: PeerId,
     address: Multiaddr,
     result: Result<(), PeerManagerError>,
-) {
+) where
+    TSubstream: Debug,
+{
     let success = result.is_ok();
     match peer_mgr_reqs_rx.next().await.unwrap() {
         PeerManagerRequest::DisconnectPeer(p, error_tx) => {
@@ -105,7 +107,9 @@ async fn expect_dial_request<'a, TSubstream>(
     peer_id: PeerId,
     address: Multiaddr,
     result: Result<(), PeerManagerError>,
-) {
+) where
+    TSubstream: Debug,
+{
     let success = result.is_ok();
     match peer_mgr_reqs_rx.next().await.unwrap() {
         PeerManagerRequest::DialPeer(p, addr, error_tx) => {

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -492,6 +492,7 @@ where
     }
 }
 
+#[derive(Debug)]
 enum ConnectionHandlerRequest {
     DialPeer(
         PeerId,


### PR DESCRIPTION
## Motivation

In general, consensus/mempool would not like to process stale network messages. Specifically, one issue we've observed is that if one node gets stuck on processing consensus messages due to some issue, and then gets back to full speed after a while, stale messages get accumulated in the message queue. Consensus processes stale proposals slowly because it needs to request for missing blocks from other peers, and if the blocks are pretty old, they're pruned from consensus DB already.
The fix is to add a timeout for the messages waiting in queues. If the wait time exceeds the timeout, those messages will be simply dropped to save capacity for new messages.
More specifically, this PR does:
1. Add a timeout field in the Receiver of the channel wrapper, and drop the messages when pulling the receiver, if they exceed the timeout.
2. Set a timeout (which is configurable) for inbound consensus/mempool events. Other channels have a very big timeout which is no timeout effectively.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

added a test case for timeout in channel

