### PR TITLE
[cluster_test] Fix cluster_test not working after re-creating workplace

### DIFF
--- a/testsuite/cluster_test/src/cluster.rs
+++ b/testsuite/cluster_test/src/cluster.rs
@@ -19,6 +19,10 @@ impl Cluster {
                 name: Some("tag:Role".into()),
                 values: Some(vec!["validator".into()]),
             },
+            Filter {
+                name: Some("instance-state-name".into()),
+                values: Some(vec!["running".into()]),
+            },
         ];
         let result = aws
             .ec2()

--- a/testsuite/cluster_test/src/instance.rs
+++ b/testsuite/cluster_test/src/instance.rs
@@ -22,7 +22,12 @@ impl Instance {
         S: AsRef<OsStr>,
     {
         let ssh_dest = format!("ec2-user@{}", self.ip);
-        let ssh_args = vec!["-i", "/libra_rsa", ssh_dest.as_str()];
+        let ssh_args = vec![
+            "-i",
+            "/libra_rsa",
+            "-oStrictHostKeyChecking=no",
+            ssh_dest.as_str(),
+        ];
         let mut ssh_cmd = Command::new("ssh");
         ssh_cmd.args(ssh_args).args(args).stderr(Stdio::null());
         let status = ssh_cmd.status()?;


### PR DESCRIPTION
Cluster test in previous version was not able to handle re-creation of workplace.
This change fixes two problems
- In discovery we should only account for running instances
  * When re-creating workplace, we have bunch of terminated instances that confused discovery
- Disable StrictHostKeyChecking when connecting to validators via ssh
  * Otherwise host key change breaks cluster_test
  * Since we are in private VPC this should be pretty safe
