### PR TITLE
[mempool] Check only gas price is updated when we allow increase in gas price to speed up a transaction

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -166,8 +166,15 @@ impl TransactionStore {
         if let Some(txns) = self.transactions.get_mut(&txn.get_sender()) {
             if let Some(current_version) = txns.get_mut(&txn.get_sequence_number()) {
                 is_update = true;
-                // TODO: do we need to ensure the rest of content hasn't changed
-                if txn.get_gas_price() <= current_version.get_gas_price() {
+                if current_version.txn.max_gas_amount() == txn.txn.max_gas_amount()
+                    && current_version.txn.payload() == txn.txn.payload()
+                    && current_version.txn.expiration_time() == txn.txn.expiration_time()
+                    && current_version.get_gas_price() < txn.get_gas_price()
+                {
+                    self.priority_index.remove(&current_version);
+                    current_version.txn = txn.txn.clone();
+                    self.priority_index.insert(&current_version);
+                } else {
                     status = MempoolAddTransactionStatus::new(
                         MempoolAddTransactionStatusCode::InvalidUpdate,
                         format!(
@@ -176,10 +183,6 @@ impl TransactionStore {
                             current_version.get_gas_price(),
                         ),
                     );
-                } else {
-                    self.priority_index.remove(&current_version);
-                    current_version.txn = txn.txn.clone();
-                    self.priority_index.insert(&current_version);
                 }
             }
         }

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -108,9 +108,12 @@ pub(crate) fn add_txns_to_mempool(
 }
 
 pub(crate) fn add_txn(pool: &mut CoreMempool, transaction: TestTransaction) -> Result<()> {
-    let txn = transaction.make_signed_transaction();
+    add_signed_txn(pool, transaction.make_signed_transaction())
+}
+
+pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransaction) -> Result<()> {
     match pool
-        .add_txn(txn.clone(), 0, 0, 1000, TimelineState::NotReady)
+        .add_txn(transaction, 0, 0, 1000, TimelineState::NotReady)
         .code
     {
         MempoolAddTransactionStatusCode::Valid => Ok(()),

--- a/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
@@ -4,7 +4,8 @@
 use crate::{
     core_mempool::{
         unit_tests::common::{
-            add_txn, add_txns_to_mempool, exist_in_metrics_cache, setup_mempool, TestTransaction,
+            add_signed_txn, add_txn, add_txns_to_mempool, exist_in_metrics_cache, setup_mempool,
+            TestTransaction,
         },
         CoreMempool, TimelineState,
     },
@@ -91,6 +92,27 @@ fn test_update_transaction_in_mempool() {
         vec![fixed_txns[0].clone()]
     );
     assert_eq!(consensus.get_block(&mut mempool, 1), vec![txns[1].clone()]);
+}
+
+#[test]
+fn test_update_invalid_transaction_in_mempool() {
+    let (mut mempool, mut consensus) = setup_mempool();
+    let txns = add_txns_to_mempool(
+        &mut mempool,
+        vec![TestTransaction::new(0, 0, 1), TestTransaction::new(1, 0, 2)],
+    );
+    let updated_txn = TestTransaction::make_signed_transaction_with_max_gas_amount(
+        &TestTransaction::new(0, 0, 5),
+        200,
+    );
+    let _added_tnx = add_signed_txn(&mut mempool, updated_txn);
+
+    // since both gas price and mas gas amount were updated, the ordering should not have changed.
+    // the second transaction with gas price 2 should come first
+    assert_eq!(consensus.get_block(&mut mempool, 1), vec![txns[1].clone()]);
+    let next_tnx = consensus.get_block(&mut mempool, 1);
+    assert_eq!(next_tnx, vec![txns[0].clone()]);
+    assert_eq!(next_tnx[0].gas_unit_price(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

We allow increases in gas price to speed up a transaction if needed. When updating, we need to make sure other values such as max gas amount, payload and expiration time have not been changed as well. Adding checks for consistency on those fields.

## Test Plan

Added unit test in core_mempool_test.rs
