### PR TITLE
[storage][jellyfish_merkle][1/3] Define node_type in jellyfish merkle tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "mempool",
     "storage/accumulator",
     "storage/libradb",
+    "storage/jellyfish_merkle",
     "storage/schemadb",
     "storage/scratchpad",
     "storage/sparse_merkle",

--- a/storage/jellyfish_merkle/Cargo.toml
+++ b/storage/jellyfish_merkle/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "jellyfish_merkle"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+bincode = "1.1.1"
+num-derive = "0.2"
+num-traits = "0.2"
+proptest = "0.9.2"
+
+crypto = { path = "../../crypto/legacy_crypto" }
+failure = { path = "../../common/failure_ext", package = "failure_ext" }
+serde = { version = "1.0.89", features = ["derive"] }
+sparse_merkle = { path = "../sparse_merkle" }
+types = { path = "../../types" }
+
+[dev-dependencies]
+rand = "0.6.5"

--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+mod node_type;

--- a/storage/jellyfish_merkle/src/node_type/mod.rs
+++ b/storage/jellyfish_merkle/src/node_type/mod.rs
@@ -1,0 +1,506 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Node types of [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
+//!
+//! This module defines two types of Jellyfish Merkle tree nodes: [`InternalNode`]
+//! and [`LeafNode`] as building blocks of a 256-bit
+//! [`JellyfishMerkleTree`](crate::JellyfishMerkleTree). [`InternalNode`] represents a 4-level
+//! binary tree to optimize for IOPS: it compresses a tree with 31 nodes into one node with 16
+//! chidren at the lowest level. [`LeafNode`] stores the full key and the account blob data
+//! associated.
+
+#[cfg(test)]
+mod node_type_test;
+
+use bincode::{deserialize, serialize};
+use crypto::{
+    hash::{
+        CryptoHash, SparseMerkleInternalHasher, SparseMerkleLeafHasher,
+        SPARSE_MERKLE_PLACEHOLDER_HASH,
+    },
+    HashValue,
+};
+use failure::{Fail, Result};
+use num_derive::{FromPrimitive, ToPrimitive};
+use num_traits::cast::FromPrimitive;
+use serde::{Deserialize, Serialize};
+use sparse_merkle::nibble_path::NibblePath;
+use std::collections::hash_map::HashMap;
+use types::{
+    account_state_blob::AccountStateBlob,
+    proof::{SparseMerkleInternalNode, SparseMerkleLeafNode},
+    transaction::Version,
+};
+
+/// The unique key of each node.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NodeKey {
+    // The version at which the node is created.
+    version: Version,
+    // The nibble path this node represents in the tree.
+    nibble_path: NibblePath,
+}
+
+impl NodeKey {
+    /// Creates a new `NodeKey`.
+    pub fn new(version: Version, nibble_path: NibblePath) -> Self {
+        Self {
+            version,
+            nibble_path,
+        }
+    }
+
+    /// A shortcut to generate a node key consisting of a version and an empty nibble path.
+    pub fn new_empty_path(version: Version) -> Self {
+        Self::new(version, NibblePath::new(vec![]))
+    }
+
+    /// Gets the version.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Gets the nibble path.
+    pub fn nibble_path(&self) -> &NibblePath {
+        &self.nibble_path
+    }
+
+    /// Generates a child node_key based on this node key.
+    pub fn gen_child_node_key(&self, version: Version, n: u8) -> Self {
+        let mut node_nibble_path = self.nibble_path().clone();
+        node_nibble_path.push(n);
+        Self::new(version, node_nibble_path)
+    }
+}
+
+/// Each child of [`InternalNode`] encapsulates a nibble forking at this node.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Child {
+    // The hash value of this child node.
+    pub hash: HashValue,
+    // `version`, the `nibble_path` of the ['NodeKey`] of this [`InternalNode`] the child belongs
+    // to and the child's index constitute the [`NodeKey`] to uniquely identify this child node
+    // from the storage. Used by `[`NodeKey::gen_child_node_key`].
+    pub version: Version,
+    // Whether the child is a leaf node.
+    pub is_leaf: bool,
+}
+
+impl Child {
+    pub fn new(hash: HashValue, version: Version, is_leaf: bool) -> Self {
+        Self {
+            hash,
+            version,
+            is_leaf,
+        }
+    }
+}
+
+/// [`Children`] is just a collection of children belonging to a [`InternalNode`], indexed from 0 to
+/// 15, inclusive.
+pub(crate) type Children = HashMap<u8, Child>;
+
+/// Represents a 4-level subtree with 16 children at the bottom level. Theoretically, this reduces
+/// IOPS to query a tree by 4x since we compress 4 levels in a standard Merkle tree into 1 node.
+/// Though we choose the same internal node structure as that of Patricia Merkle tree, the root hash
+/// computation logic is similar to a 4-level sparse Merkle tree except for some customizations. See
+/// the `CryptoHash` trait implementation below for details.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InternalNode {
+    // Up to 16 children.
+    children: Children,
+}
+
+/// Represents an account.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LeafNode {
+    // The hashed account address associated with this leaf node.
+    account_key: HashValue,
+    // The hash of the account state blob.
+    blob_hash: HashValue,
+    // The account blob associated with `account_key`.
+    blob: AccountStateBlob,
+}
+
+#[repr(u8)]
+#[derive(FromPrimitive, ToPrimitive)]
+enum NodeTag {
+    Internal = 1,
+    Leaf = 2,
+}
+
+/// The explicit tag is used as a prefix in the encoded format of nodes to distinguish different
+/// node discrinminants.
+trait Tag {
+    const TAG: NodeTag;
+}
+
+impl Tag for InternalNode {
+    const TAG: NodeTag = NodeTag::Internal;
+}
+
+impl Tag for LeafNode {
+    const TAG: NodeTag = NodeTag::Leaf;
+}
+
+/// Computes the hash of internal node according to [`JellyfishTree`](crate::JellyfishTree)
+/// data structure in the logical view. `start` and `nibble_height` determine a subtree whose
+/// root hash we want to get. For an internal node with 16 children at the bottom level, we compute
+/// the root hash of it as if a full binary Merkle tree with 16 leaves as below:
+///
+/// ```text
+///   4 ->              +------ root hash ------+
+///                     |                       |
+///   3 ->        +---- # ----+           +---- # ----+
+///               |           |           |           |
+///   2 ->        #           #           #           #
+///             /   \       /   \       /   \       /   \
+///   1 ->     #     #     #     #     #     #     #     #
+///           / \   / \   / \   / \   / \   / \   / \   / \
+///   0 ->   0   1 2   3 4   5 6   7 8   9 A   B C   D E   F
+///   ^
+/// height
+/// ```
+///
+/// As illustrated above, at nibble height 0, `0..F` in hex denote 16 chidren hashes.  Each `#`
+/// means the hash of its two direct children, which will be used to generate the hash of its
+/// parent with the hash of its sibling. Finally, we can get the hash of this internal node.
+///
+/// However, if an internal node doesn't have all 16 chidren exist at height 0 but just a few of
+/// them, we have a modified hashing rule on top of what is stated above:
+/// 1. From top to bottom, a node will be replaced by a leaf child if the subtree rooted at this
+/// node has only one child at height 0 and it is a leaf child.
+/// 2. From top to bottom, a node will be replaced by the placeholder node if the subtree rooted at
+/// this node doesn't have any child at height 0. For example, if an internal node has 3 leaf
+/// children at index 0, 3, 8, respectively, and 1 internal node at index C, then the computation
+/// graph will be like:
+///
+/// ```text
+///   4 ->              +------ root hash ------+
+///                     |                       |
+///   3 ->        +---- # ----+           +---- # ----+
+///               |           |           |           |
+///   2 ->        #           @           8           #
+///             /   \                               /   \
+///   1 ->     0     3                             #     @
+///                                               / \
+///   0 ->                                       C   @
+///   ^
+/// height
+/// Note: @ denotes placeholder hash.
+/// ```
+impl CryptoHash for InternalNode {
+    // Unused hasher.
+    type Hasher = SparseMerkleInternalHasher;
+
+    fn hash(&self) -> HashValue {
+        self.merkle_hash(
+            0,  /* start index */
+            16, /* the number of leaves in the subtree of which we want the hash of root */
+            self.generate_bitmaps(),
+        )
+    }
+}
+
+/// Computes the hash of a [`LeafNode`].
+impl CryptoHash for LeafNode {
+    // Unused hasher.
+    type Hasher = SparseMerkleLeafHasher;
+
+    fn hash(&self) -> HashValue {
+        SparseMerkleLeafNode::new(self.account_key, self.blob_hash).hash()
+    }
+}
+
+/// The concrete node type of [`JellyfishMerkleTree`](crate::JellyfishMerkleTree).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Node {
+    /// A wrapper of [`InternalNode`].
+    Internal(InternalNode),
+    /// A wrapper of [`LeafNode`].
+    Leaf(LeafNode),
+}
+
+impl From<InternalNode> for Node {
+    fn from(node: InternalNode) -> Self {
+        Node::Internal(node)
+    }
+}
+
+impl From<LeafNode> for Node {
+    fn from(node: LeafNode) -> Self {
+        Node::Leaf(node)
+    }
+}
+
+impl InternalNode {
+    /// Creates a new Internal node.
+    pub fn new(children: Children) -> Self {
+        Self { children }
+    }
+
+    /// Sets the `n`-th child.
+    pub fn set_child(&mut self, n: u8, child: Child) {
+        assert!(n < 16);
+        self.children.insert(n, child);
+    }
+
+    /// Gets the `n`-th child.
+    pub fn child(&self, n: u8) -> Option<&Child> {
+        self.children.get(&n)
+    }
+
+    /// Return the total number of existing children.
+    pub fn num_children(&self) -> usize {
+        self.children.len()
+    }
+
+    /// Generates `existence_bitmap` and `leaf_bitmap` as a pair of `u16`s: child at index `i`
+    /// exists if `existence_bitmap[i]` is set; child at index `i` is leaf node if
+    /// `leaf_bitmap[i]` is set.
+    pub fn generate_bitmaps(&self) -> (u16, u16) {
+        let mut existence_bitmap = 0;
+        let mut leaf_bitmap = 0;
+        for (i, child) in self.children.iter() {
+            existence_bitmap |= 1u16 << i;
+            leaf_bitmap |= (child.is_leaf as u16) << i;
+        }
+        // `leaf_bitmap` must be a subset of `existence_bitmap`.
+        assert_eq!(existence_bitmap | leaf_bitmap, existence_bitmap);
+        (existence_bitmap, leaf_bitmap)
+    }
+
+    /// Given a range [start, start + width), returns the sub-bitmap of that range.
+    fn range_bitmaps(start: u8, width: u8, bitmaps: (u16, u16)) -> (u16, u16) {
+        assert!(start < 16 && width.count_ones() == 1 && start % width == 0);
+        // A range with `start == 8` and `width == 4` will generate a mask 0b0000111100000000.
+        let mask = if width == 16 {
+            0xffff
+        } else {
+            assert!(width <= 16);
+            (1 << width) - 1
+        } << start;
+        (bitmaps.0 & mask, bitmaps.1 & mask)
+    }
+
+    fn merkle_hash(
+        &self,
+        start: u8,
+        width: u8,
+        (existence_bitmap, leaf_bitmap): (u16, u16),
+    ) -> HashValue {
+        // Given a bit [start, 1 << nibble_height], return the value of that range.
+        let (range_existence_bitmap, range_leaf_bitmap) =
+            InternalNode::range_bitmaps(start, width, (existence_bitmap, leaf_bitmap));
+        if range_existence_bitmap == 0 {
+            // No child under this subtree
+            *SPARSE_MERKLE_PLACEHOLDER_HASH
+        } else if range_existence_bitmap.count_ones() == 1 && (range_leaf_bitmap != 0 || width == 1)
+        {
+            // Only 1 leaf child under this subtree or reach the lowest level
+            let only_child_index = range_existence_bitmap.trailing_zeros() as u8;
+            self.child(only_child_index)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Corrupted internal node: existence_bitmap indicates \
+                         the existence of a non-exist child at index {}",
+                        only_child_index
+                    )
+                })
+                .hash
+        } else {
+            let left_child = self.merkle_hash(start, width / 2, (existence_bitmap, leaf_bitmap));
+            let right_child = self.merkle_hash(
+                start + width / 2,
+                width / 2,
+                (existence_bitmap, leaf_bitmap),
+            );
+            SparseMerkleInternalNode::new(left_child, right_child).hash()
+        }
+    }
+
+    /// Gets the child and its corresponding siblings that are necessary to generate the proof for
+    /// the `n`-th child. If it is an existence proof, the returned child must be the `n`-th
+    /// child; otherwise, the returned child may be another child. See inline explanation for
+    /// details. When calling this function with n = 11 (node `b` in the following graph), the
+    /// range at each level is illustrated as a pair of square brackets:
+    ///
+    /// ```text
+    ///     4      [f   e   d   c   b   a   9   8   7   6   5   4   3   2   1   0] -> root level
+    ///            ---------------------------------------------------------------
+    ///     3      [f   e   d   c   b   a   9   8] [7   6   5   4   3   2   1   0] width = 8
+    ///                                  chs <--┘                        shs <--┘
+    ///     2      [f   e   d   c] [b   a   9   8] [7   6   5   4] [3   2   1   0] width = 4
+    ///                  shs <--┘               └--> chs
+    ///     1      [f   e] [d   c] [b   a] [9   8] [7   6] [5   4] [3   2] [1   0] width = 2
+    ///                          chs <--┘       └--> shs
+    ///     0      [f] [e] [d] [c] [b] [a] [9] [8] [7] [6] [5] [4] [3] [2] [1] [0] width = 1
+    ///     ^                chs <--┘   └--> shs
+    ///     |   MSB|<---------------------- uint 16 ---------------------------->|LSB
+    ///  height    chs: `child_half_start`         shs: `sibling_half_start`
+    /// ```
+    pub fn get_child_with_siblings(
+        &self,
+        node_key: &NodeKey,
+        n: u8,
+    ) -> (Option<NodeKey>, Vec<HashValue>) {
+        let mut siblings = vec![];
+        assert!(n < 16);
+        let (existence_bitmap, leaf_bitmap) = self.generate_bitmaps();
+
+        // Nibble height from 3 to 0.
+        for h in (0..4).rev() {
+            // Get the number of children of the internal node that each subtree at this height
+            // covers.
+            let width = 1 << h;
+            // Get the index of the first child belonging to the same subtree whose root, let's say
+            // `r` is at height `h` that the n-th child belongs to.
+            // Note:  `child_half_start` will be always equal to `n` at height 0.
+            let child_half_start = (0xff << h) & n;
+            // Get the index of the first child belonging to the subtree whose root is the sibling
+            // of `r` at height `h`.
+            let sibling_half_start = child_half_start ^ (1 << h);
+            // Compute the root hash of the subtree rooted at the sibling of `r`.
+            siblings.push(self.merkle_hash(
+                sibling_half_start,
+                width,
+                (existence_bitmap, leaf_bitmap),
+            ));
+
+            let (range_existence_bitmap, range_leaf_bitmap) = InternalNode::range_bitmaps(
+                child_half_start,
+                width,
+                (existence_bitmap, leaf_bitmap),
+            );
+
+            if range_existence_bitmap == 0 {
+                // No child in this range.
+                return (None, siblings);
+            } else if range_existence_bitmap.count_ones() == 1
+                && (range_leaf_bitmap.count_ones() == 1 || width == 1)
+            {
+                // Return the only 1 leaf child under this subtree or reach the lowest level
+                // Even this leaf child is not the n-th child, it should be returned instead of
+                // `None` because it's existence indirectly proves the n-th child doesn't exist.
+                // Please read proof format for details.
+                let only_child_index = range_existence_bitmap.trailing_zeros() as u8;
+                return (
+                    {
+                        let only_child_version = self
+                            .child(only_child_index)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "Corrupted internal node: child_bitmap indicates \
+                                     the existence of a non-exist child at index {}",
+                                    only_child_index
+                                )
+                            })
+                            .version;
+                        Some(node_key.gen_child_node_key(only_child_version, only_child_index))
+                    },
+                    siblings,
+                );
+            }
+        }
+        unreachable!("Impossible to get here without returning even at the lowest level.")
+    }
+}
+
+impl LeafNode {
+    /// Creates a new leaf node.
+    pub fn new(account_key: HashValue, blob: AccountStateBlob) -> Self {
+        let blob_hash = blob.hash();
+        Self {
+            account_key,
+            blob_hash,
+            blob,
+        }
+    }
+
+    /// Gets the account key, the hashed account address.
+    pub fn account_key(&self) -> HashValue {
+        self.account_key
+    }
+
+    /// Gets the hash of associated blob.
+    pub fn blob_hash(&self) -> HashValue {
+        self.blob_hash
+    }
+
+    /// Gets the associated blob itself.
+    pub fn blob(&self) -> &AccountStateBlob {
+        &self.blob
+    }
+}
+
+impl Node {
+    /// Creates the [`Internal`](Node::Internal) variant.
+    pub fn new_internal(children: HashMap<u8, Child>) -> Self {
+        Node::Internal(InternalNode::new(children))
+    }
+
+    /// Creates the [`Leaf`](Node::Leaf) variant.
+    pub fn new_leaf(account_key: HashValue, blob: AccountStateBlob) -> Self {
+        Node::Leaf(LeafNode::new(account_key, blob))
+    }
+
+    /// Returns `true` if the node is a leaf node.
+    pub fn is_leaf(&self) -> bool {
+        match self {
+            Node::Leaf(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Serializes to bytes for physical storage.
+    pub fn encode(&self) -> Result<Vec<u8>> {
+        let mut out = vec![];
+        match self {
+            Node::Internal(internal_node) => {
+                out.push(InternalNode::TAG as u8);
+                out.extend(serialize(&internal_node)?);
+            }
+            Node::Leaf(leaf_node) => {
+                out.push(LeafNode::TAG as u8);
+                out.extend(serialize(&leaf_node)?);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Computes the hash of nodes.
+    pub fn hash(&self) -> HashValue {
+        match self {
+            Node::Internal(internal_node) => internal_node.hash(),
+            Node::Leaf(leaf_node) => leaf_node.hash(),
+        }
+    }
+
+    /// Recovers from serialized bytes in physical storage.
+    pub fn decode(val: &[u8]) -> Result<Node> {
+        if val.is_empty() {
+            return Err(NodeDecodeError::EmptyInput.into());
+        }
+        let tag = val[0];
+        let node_tag = NodeTag::from_u8(tag);
+        match node_tag {
+            Some(NodeTag::Internal) => Ok(Node::Internal(deserialize(&val[1..])?)),
+            Some(NodeTag::Leaf) => Ok(Node::Leaf(deserialize(&val[1..])?)),
+            None => Err(NodeDecodeError::UnknownTag { unknown_tag: tag }.into()),
+        }
+    }
+}
+
+/// Error thrown when a [`Node`] fails to be deserialized out of a byte sequence stored in physical
+/// storage, via [`Node::decode`].
+#[derive(Debug, Fail, Eq, PartialEq)]
+pub enum NodeDecodeError {
+    /// Input is empty.
+    #[fail(display = "Missing tag due to empty input")]
+    EmptyInput,
+
+    /// The first byte of the input is not a known tag representing one of the variants.
+    #[fail(display = "lead tag byte is unknown: {}", unknown_tag)]
+    UnknownTag { unknown_tag: u8 },
+}

--- a/storage/jellyfish_merkle/src/node_type/node_type_test.rs
+++ b/storage/jellyfish_merkle/src/node_type/node_type_test.rs
@@ -1,0 +1,631 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
+};
+use proptest::prelude::*;
+use types::proof::{SparseMerkleInternalNode, SparseMerkleLeafNode};
+
+fn hash_internal(left: HashValue, right: HashValue) -> HashValue {
+    SparseMerkleInternalNode::new(left, right).hash()
+}
+
+fn hash_leaf(key: HashValue, value_hash: HashValue) -> HashValue {
+    SparseMerkleLeafNode::new(key, value_hash).hash()
+}
+
+// Generate a random node key with 63 nibbles.
+fn random_63nibbles_node_key() -> NodeKey {
+    let mut bytes = HashValue::random().to_vec();
+    *bytes.last_mut().unwrap() &= 0xf0;
+    NodeKey::new(0 /* version */, NibblePath::new_odd(bytes))
+}
+
+// Generate a pair of leaf node key and account key with a passed-in 63-nibble node key and the last
+// nibble to be appended.
+fn gen_leaf_keys(version: Version, nibble_path: &NibblePath, nibble: u8) -> (NodeKey, HashValue) {
+    assert!(nibble_path.num_nibbles() == 63);
+    let mut np = nibble_path.clone();
+    np.push(nibble);
+    let account_key = HashValue::from_slice(np.bytes()).unwrap();
+    (NodeKey::new(version, np), account_key)
+}
+
+#[test]
+fn test_encode_decode() {
+    let internal_node_key = random_63nibbles_node_key();
+
+    let leaf1_keys = gen_leaf_keys(0, internal_node_key.nibble_path(), 1);
+    let leaf1_node = Node::new_leaf(leaf1_keys.1, AccountStateBlob::from(vec![0x00]));
+    let leaf2_keys = gen_leaf_keys(0, internal_node_key.nibble_path(), 1);
+    let leaf2_node = Node::new_leaf(leaf2_keys.1, AccountStateBlob::from(vec![0x01]));
+
+    let mut children = Children::default();
+    children.insert(1, Child::new(leaf1_node.hash(), 0 /* version */, true));
+    children.insert(2, Child::new(leaf2_node.hash(), 0 /* version */, true));
+
+    let account_key = HashValue::random();
+    let nodes = vec![
+        Node::new_internal(children),
+        Node::new_leaf(account_key, AccountStateBlob::from(vec![0x02])),
+    ];
+    for n in &nodes {
+        let v = n.encode().unwrap();
+        assert_eq!(*n, Node::decode(&v).unwrap());
+    }
+    // Error cases
+    if let Err(e) = Node::decode(&[]) {
+        assert_eq!(
+            e.downcast::<NodeDecodeError>().unwrap(),
+            NodeDecodeError::EmptyInput
+        );
+    }
+    if let Err(e) = Node::decode(&[100]) {
+        assert_eq!(
+            e.downcast::<NodeDecodeError>().unwrap(),
+            NodeDecodeError::UnknownTag { unknown_tag: 100 }
+        );
+    }
+}
+
+#[test]
+fn test_leaf_hash() {
+    {
+        let address = HashValue::random();
+        let blob = AccountStateBlob::from(vec![0x02]);
+        let value_hash = blob.hash();
+        let hash = hash_leaf(address, value_hash);
+        let leaf_node = Node::new_leaf(address, blob);
+        assert_eq!(leaf_node.hash(), hash);
+    }
+}
+
+proptest! {
+    #[test]
+    fn two_leaves_test1(index1 in (0..8u8), index2 in (8..16u8)) {
+        let internal_node_key = random_63nibbles_node_key();
+        let mut internal_node = InternalNode::new(Children::default());
+
+        let leaf1_node_key = gen_leaf_keys(0 /* version */, internal_node_key.nibble_path(), index1).0;
+        let leaf2_node_key = gen_leaf_keys(1 /* version */, internal_node_key.nibble_path(), index2).0;
+        let hash1 = HashValue::random();
+        let hash2 = HashValue::random();
+
+        internal_node.set_child(index1, Child::new(hash1, 0 /* verison */, true));
+        internal_node.set_child(index2, Child::new(hash2, 1 /* verison */, true));
+        // Internal node will have a structure below
+        //
+        //              root
+        //              / \
+        //             /   \
+        //        leaf1     leaf2
+        //
+        let root_hash = hash_internal(hash1, hash2);
+        prop_assert_eq!(internal_node.hash(), root_hash);
+
+        for i in 0..8 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (Some(leaf1_node_key.clone()), vec![hash2])
+            );
+        }
+        for i in 8..16 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (Some(leaf2_node_key.clone()), vec![hash1])
+            );
+        }
+
+    }
+
+    #[test]
+    fn two_leaves_test2(index1 in (4..6u8), index2 in (6..8u8)) {
+        let internal_node_key = random_63nibbles_node_key();
+        let mut internal_node = InternalNode::new(Children::default());
+
+        let leaf1_node_key = gen_leaf_keys(0 /* version */, internal_node_key.nibble_path(), index1).0;
+        let leaf2_node_key = gen_leaf_keys(1 /* version */, internal_node_key.nibble_path(), index2).0;
+        let hash1 = HashValue::random();
+        let hash2 = HashValue::random();
+
+        internal_node.set_child(index1, Child::new(hash1, 0 /* verison */, true));
+        internal_node.set_child(index2, Child::new(hash2, 1 /* verison */, true));
+        // Internal node will have a structure below
+        //
+        //              root
+        //              /
+        //             /
+        //            x2
+        //             \
+        //              \
+        //               x1
+        //              / \
+        //             /   \
+        //        leaf1     leaf2
+
+        let hash_x1 = hash_internal(hash1, hash2);
+        let hash_x2 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x1);
+
+        let root_hash = hash_internal(hash_x2, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        assert_eq!(internal_node.hash(), root_hash);
+
+        for i in 0..4 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (None, vec![*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x1])
+            );
+        }
+
+        for i in 4..6 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    Some(leaf1_node_key.clone()),
+                    vec![
+                        *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                        *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                        hash2
+                    ]
+                )
+            );
+        }
+
+        for i in 6..8 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    Some(leaf2_node_key.clone()),
+                    vec![
+                        *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                        *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                        hash1
+                    ]
+                )
+            );
+        }
+
+        for i in 8..16 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (None, vec![hash_x2])
+            );
+        }
+
+    }
+
+    #[test]
+    fn three_leaves_test1(index1 in (0..4u8), index2 in (4..8u8), index3 in (8..16u8)) {
+        let internal_node_key = random_63nibbles_node_key();
+        let mut internal_node = InternalNode::new(Children::default());
+
+        let leaf1_node_key = gen_leaf_keys(0 /* version */, internal_node_key.nibble_path(), index1).0;
+        let leaf2_node_key = gen_leaf_keys(1 /* version */, internal_node_key.nibble_path(), index2).0;
+        let leaf3_node_key = gen_leaf_keys(2 /* version */, internal_node_key.nibble_path(), index3).0;
+
+        let hash1 = HashValue::random();
+        let hash2 = HashValue::random();
+        let hash3 = HashValue::random();
+
+        internal_node.set_child(index1, Child::new(hash1, 0 /* verison */, true));
+        internal_node.set_child(index2, Child::new(hash2, 1 /* verison */, true));
+        internal_node.set_child(index3, Child::new(hash3, 2 /* verison */, true));
+        // Internal node will have a structure below
+        //
+        //               root
+        //               / \
+        //              /   \
+        //             x     leaf3
+        //            / \
+        //           /   \
+        //      leaf1     leaf2
+
+        let hash_x = hash_internal(hash1, hash2);
+        let root_hash = hash_internal(hash_x, hash3);
+        prop_assert_eq!(internal_node.hash(), root_hash);
+
+        for i in 0..4 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (Some(leaf1_node_key.clone()),vec![hash3, hash2])
+            );
+        }
+
+        for i in 4..8 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (Some(leaf2_node_key.clone()),vec![hash3, hash1])
+            );
+        }
+
+        for i in 8..16 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (Some(leaf3_node_key.clone()),vec![hash_x])
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_nodes_test(index1 in (0..2u8), index2 in (8..16u8)) {
+        let internal_node_key = random_63nibbles_node_key();
+        let mut internal_node = InternalNode::new(Children::default());
+
+        let leaf1_node_key = gen_leaf_keys(0 /* version */, internal_node_key.nibble_path(), index1).0;
+        let internal2_node_key = gen_leaf_keys(1 /* version */, internal_node_key.nibble_path(), 2).0;
+        let internal3_node_key = gen_leaf_keys(2 /* version */, internal_node_key.nibble_path(), 7).0;
+        let leaf4_node_key = gen_leaf_keys(3 /* version */, internal_node_key.nibble_path(), index2).0;
+
+        let hash1 = HashValue::random();
+        let hash2 = HashValue::random();
+        let hash3 = HashValue::random();
+        let hash4 = HashValue::random();
+        internal_node.set_child(index1, Child::new(hash1, 0, true));
+        internal_node.set_child(2, Child::new(hash2, 1, false));
+        internal_node.set_child(7, Child::new(hash3, 2, false));
+        internal_node.set_child(index2, Child::new(hash4, 3, true));
+        // Internal node (B) will have a structure below
+        //
+        //                   B (root hash)
+        //                  / \
+        //                 /   \
+        //                x5    leaf4
+        //               / \
+        //              /   \
+        //             x2    x4
+        //            / \     \
+        //           /   \     \
+        //      leaf1    x1     x3
+        //               /       \
+        //              /         \
+        //          internal2      internal3
+        //
+        let hash_x1 = hash_internal(hash2, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let hash_x2 = hash_internal(hash1, hash_x1);
+        let hash_x3 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash3);
+        let hash_x4 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x3);
+        let hash_x5 = hash_internal(hash_x2, hash_x4);
+        let root_hash = hash_internal(hash_x5, hash4);
+        assert_eq!(internal_node.hash(), root_hash);
+
+        for i in 0..2 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    Some(leaf1_node_key.clone()),
+                    vec![hash4, hash_x4, hash_x1]
+                )
+            );
+        }
+
+        prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, 2),
+            (
+                Some(internal2_node_key),
+                vec![
+                    hash4,
+                    hash_x4,
+                    hash1,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                ]
+            )
+        );
+
+        prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, 3),
+
+            (
+                None,
+                vec![hash4, hash_x4, hash1, hash2,]
+            )
+        );
+
+        for i in 4..6 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    None,
+                    vec![hash4, hash_x2, hash_x3]
+                )
+            );
+        }
+
+        prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, 6),
+            (
+                None,
+                vec![
+                    hash4,
+                    hash_x2,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash3,
+                ]
+            )
+        );
+
+        prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, 7),
+            (
+                Some(internal3_node_key),
+                vec![
+                    hash4,
+                    hash_x2,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                ]
+            )
+        );
+
+        for i in 8..16 {
+            prop_assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (Some(leaf4_node_key.clone()), vec![hash_x5])
+            );
+        }
+    }
+}
+
+#[test]
+fn test_internal_hash_and_proof() {
+    // non-leaf case 1
+    {
+        let internal_node_key = random_63nibbles_node_key();
+        let mut internal_node = InternalNode::new(Children::default());
+
+        let index1 = 4;
+        let index2 = 15;
+        let hash1 = HashValue::random();
+        let hash2 = HashValue::random();
+        let child1_node_key = gen_leaf_keys(
+            0, /* version */
+            internal_node_key.nibble_path(),
+            index1,
+        )
+        .0;
+        let child2_node_key = gen_leaf_keys(
+            1, /* version */
+            internal_node_key.nibble_path(),
+            index2,
+        )
+        .0;
+        internal_node.set_child(index1, Child::new(hash1, 0 /* version */, false));
+        internal_node.set_child(index2, Child::new(hash2, 1 /* version */, false));
+        // Internal node (B) will have a structure below
+        //
+        //              root
+        //              / \
+        //             /   \
+        //            x3    x6
+        //             \     \
+        //              \     \
+        //              x2     x5
+        //              /       \
+        //             /         \
+        //            x1          x4
+        //           /             \
+        //          /               \
+        // non-leaf1             non-leaf2
+        //
+        let hash_x1 = hash_internal(hash1, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let hash_x2 = hash_internal(hash_x1, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let hash_x3 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x2);
+        let hash_x4 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash2);
+        let hash_x5 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x4);
+        let hash_x6 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x5);
+        let root_hash = hash_internal(hash_x3, hash_x6);
+        assert_eq!(internal_node.hash(), root_hash);
+
+        for i in 0..4 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (None, vec![hash_x6, hash_x2])
+            );
+        }
+
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, index1),
+            (
+                Some(child1_node_key.clone()),
+                vec![
+                    hash_x6,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH
+                ]
+            )
+        );
+
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, 5),
+            (
+                None,
+                vec![
+                    hash_x6,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash1
+                ]
+            )
+        );
+        for i in 6..8 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    None,
+                    vec![hash_x6, *SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x1]
+                )
+            );
+        }
+
+        for i in 8..12 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (None, vec![hash_x3, hash_x5])
+            );
+        }
+
+        for i in 12..14 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    None,
+                    vec![hash_x3, *SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x4]
+                )
+            );
+        }
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, 14),
+            (
+                None,
+                vec![
+                    hash_x3,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash2
+                ]
+            )
+        );
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, index2),
+            (
+                Some(child2_node_key.clone()),
+                vec![
+                    hash_x3,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH
+                ]
+            )
+        );
+    }
+
+    // non-leaf case 2
+    {
+        let internal_node_key = random_63nibbles_node_key();
+        let mut internal_node = InternalNode::new(Children::default());
+
+        let index1 = 0;
+        let index2 = 7;
+        let hash1 = HashValue::random();
+        let hash2 = HashValue::random();
+        let child1_node_key = gen_leaf_keys(
+            0, /* version */
+            internal_node_key.nibble_path(),
+            index1,
+        )
+        .0;
+        let child2_node_key = gen_leaf_keys(
+            1, /* version */
+            internal_node_key.nibble_path(),
+            index2,
+        )
+        .0;
+
+        internal_node.set_child(index1, Child::new(hash1, 0 /* version */, false));
+        internal_node.set_child(index2, Child::new(hash2, 1 /* version */, false));
+        // Internal node will have a structure below
+        //
+        //                     root
+        //                     /
+        //                    /
+        //                   x5
+        //                  / \
+        //                 /   \
+        //               x2     x4
+        //               /       \
+        //              /         \
+        //            x1           x3
+        //            /             \
+        //           /               \
+        //  non-leaf1                 non-leaf2
+
+        let hash_x1 = hash_internal(hash1, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let hash_x2 = hash_internal(hash_x1, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        let hash_x3 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash2);
+        let hash_x4 = hash_internal(*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x3);
+        let hash_x5 = hash_internal(hash_x2, hash_x4);
+        let root_hash = hash_internal(hash_x5, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        assert_eq!(internal_node.hash(), root_hash);
+
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, 0),
+            (
+                Some(child1_node_key.clone()),
+                vec![
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash_x4,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                ]
+            )
+        );
+
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, 1),
+            (
+                None,
+                vec![
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash_x4,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash1,
+                ]
+            )
+        );
+
+        for i in 2..4 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    None,
+                    vec![*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x4, hash_x1]
+                )
+            );
+        }
+
+        for i in 4..6 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (
+                    None,
+                    vec![*SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x2, hash_x3]
+                )
+            );
+        }
+
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, 6),
+            (
+                None,
+                vec![
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash_x2,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash2
+                ]
+            )
+        );
+
+        assert_eq!(
+            internal_node.get_child_with_siblings(&internal_node_key, 7),
+            (
+                Some(child2_node_key.clone()),
+                vec![
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    hash_x2,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                    *SPARSE_MERKLE_PLACEHOLDER_HASH,
+                ]
+            )
+        );
+
+        for i in 8..16 {
+            assert_eq!(
+                internal_node.get_child_with_siblings(&internal_node_key, i),
+                (None, vec![hash_x5])
+            );
+        }
+    }
+}

--- a/storage/sparse_merkle/src/lib.rs
+++ b/storage/sparse_merkle/src/lib.rs
@@ -21,7 +21,7 @@
 
 #[cfg(test)]
 mod mock_tree_store;
-mod nibble_path;
+pub mod nibble_path;
 mod node_serde;
 pub mod node_type;
 #[cfg(test)]

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -19,9 +19,10 @@ use failure::prelude::*;
 use proptest::{arbitrary::Arbitrary, prelude::*};
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom, fmt};
 
-#[derive(Clone, Eq, PartialEq, FromProto, IntoProto)]
+#[derive(Clone, Eq, PartialEq, FromProto, IntoProto, Serialize, Deserialize)]
 #[ProtoType(crate::proto::account_state_blob::AccountStateBlob)]
 pub struct AccountStateBlob {
     blob: Vec<u8>,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We are going to change curent sparse merkle tree to jellyfish merkle
tree, which is more efficent than current merkle in the aspects of IOPS,
compaction overhead and space. This diff will first introduce the data
structures of two kinds of nodes in the tree and corresponding unit tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs
