### PR TITLE
[mempool+network] Add and use BoundedExecutor to spawn tasks with backpressure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "common/debug_interface",
     "common/executable_helpers",
     "common/failure_ext",
+    "common/futures-semaphore",
     "common/grpcio-client",
     "common/jemalloc",
     "common/logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "benchmark",
     "client",
     "client/libra_wallet",
+    "common/bounded-executor",
     "common/canonical_serialization",
     "common/crash_handler",
     "common/debug_interface",

--- a/common/bounded-executor/Cargo.toml
+++ b/common/bounded-executor/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bounded-executor"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+futures-semaphore = { path = "../futures-semaphore" }
+futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["async-await", "nightly", "compat"] }
+tokio = "0.1.22"

--- a/common/bounded-executor/src/lib.rs
+++ b/common/bounded-executor/src/lib.rs
@@ -1,0 +1,105 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A bounded tokio [`TaskExecutor`]. Only a bounded number of tasks can run
+//! concurrently when spawned through this executor, defined by the initial
+//! `capacity`.
+
+#![feature(async_await)]
+
+use futures::future::{Future, FutureExt, TryFutureExt};
+use futures_semaphore::Semaphore;
+use tokio::runtime::TaskExecutor;
+
+#[derive(Clone, Debug)]
+pub struct BoundedExecutor {
+    semaphore: Semaphore,
+    executor: TaskExecutor,
+}
+
+/// Returned by [`BoundedExecutor::try_spawn`] if it is at capacity.
+pub enum SpawnError {
+    AtCapacity,
+}
+
+impl BoundedExecutor {
+    /// Create a new `BoundedExecutor` from an existing tokio [`TaskExecutor`]
+    /// with a maximum concurrent task capacity of `capacity`.
+    pub fn new(capacity: usize, executor: TaskExecutor) -> Self {
+        let semaphore = Semaphore::new(capacity);
+        Self {
+            semaphore,
+            executor,
+        }
+    }
+
+    /// Spawn a [`Future`] on the `BoundedExecutor`. This function is async and
+    /// will block if the executor is at capacity.
+    pub async fn spawn<F>(&self, f: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let spawn_permit = self.semaphore.acquire().await;
+        let f = f.map(move |_| drop(spawn_permit));
+        self.executor.spawn(f.boxed().unit_error().compat());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures::{compat::Future01CompatExt, executor::block_on, future::Future};
+    use std::{
+        sync::atomic::{AtomicU32, Ordering},
+        time::{Duration, Instant},
+    };
+    use tokio::{runtime::Runtime, timer::Delay};
+
+    fn yield_task() -> impl Future<Output = ()> {
+        Delay::new(Instant::now() + Duration::from_millis(1))
+            .compat()
+            .map(|_| ())
+    }
+
+    // spawn NUM_TASKS futures on a BoundedExecutor, ensuring that no more than
+    // MAX_WORKERS ever enter the critical section.
+    #[test]
+    fn concurrent_bounded_executor() {
+        const MAX_WORKERS: u32 = 20;
+        const NUM_TASKS: u32 = 1000;
+        static WORKERS: AtomicU32 = AtomicU32::new(0);
+        static COMPLETED_TASKS: AtomicU32 = AtomicU32::new(0);
+
+        let rt = Runtime::new().unwrap();
+        let executor = rt.executor();
+        let executor = BoundedExecutor::new(MAX_WORKERS as usize, executor);
+
+        for _ in 0..NUM_TASKS {
+            block_on(executor.spawn(async move {
+                // acquired permit, there should only ever be MAX_WORKERS in this
+                // critical section
+
+                let prev_workers = WORKERS.fetch_add(1, Ordering::SeqCst);
+                assert!(prev_workers < MAX_WORKERS);
+
+                // yield back to the tokio scheduler
+                yield_task().await;
+
+                let prev_workers = WORKERS.fetch_sub(1, Ordering::SeqCst);
+                assert!(prev_workers > 0 && prev_workers <= MAX_WORKERS);
+
+                COMPLETED_TASKS.fetch_add(1, Ordering::Relaxed);
+            }));
+        }
+
+        // spin until completed
+        loop {
+            let completed = COMPLETED_TASKS.load(Ordering::Relaxed);
+            if completed == NUM_TASKS {
+                break;
+            } else {
+                ::std::sync::atomic::spin_loop_hint();
+            }
+        }
+    }
+}

--- a/common/futures-semaphore/Cargo.toml
+++ b/common/futures-semaphore/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "futures-semaphore"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+futures01 = { version = "0.1.26", package = "futures" }
+futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["async-await", "nightly", "compat"] }
+tokio-sync = "0.1.6"
+
+[dev-dependencies]
+tokio = "0.1.22"

--- a/common/futures-semaphore/src/lib.rs
+++ b/common/futures-semaphore/src/lib.rs
@@ -1,0 +1,251 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! `Semaphore` holds a set of permits. Permits are used to synchronize access
+//! to a shared resource. Before accessing the shared resource, callers must
+//! acquire a permit from the semaphore. Once the permit is acquired, the caller
+//! then enters the critical section. When the caller is finished, they drop the
+//! permit to release it back to the semaphore.
+//!
+//! `Semaphore` is futures-aware. Acquiring a [`Permit`] is an async function,
+//! which will yield to the futures executor if no permits are available and be
+//! woken up when one becomes available.
+//!
+//! In contrast, acquiring a permit from a [`std::sync::Mutex`] +
+//! [`std::sync::Condvar`] style semaphore will block the entire OS thread, which
+//! could potentially deadlock the futures runtime if enough tasks are waiting on
+//! the semaphore.
+
+#![feature(async_await)]
+
+use futures01::{future::Future as Future01, Async as Async01, Poll as Poll01};
+use futures03::compat::Future01CompatExt;
+use std::sync::Arc;
+use tokio_sync::semaphore::{AcquireError, Permit as TokioPermit, Semaphore as TokioSemaphore};
+
+/// The wrapped tokio_sync [`Semaphore`](TokioSemaphore) and total permit capacity.
+#[derive(Debug)]
+struct Inner {
+    semaphore: TokioSemaphore,
+    capacity: usize,
+}
+
+/// A futures-aware semaphore.
+#[derive(Clone, Debug)]
+pub struct Semaphore {
+    inner: Arc<Inner>,
+}
+
+/// A permit acquired from a semaphore, allowing access to a shared resource.
+/// Dropping a `Permit` will release it back to the semaphore.
+#[derive(Debug)]
+pub struct Permit {
+    inner: Arc<Inner>,
+    permit: TokioPermit,
+}
+
+impl Semaphore {
+    /// Create a new semaphore with `capacity` number of available permits.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                semaphore: TokioSemaphore::new(capacity),
+                capacity,
+            }),
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity
+    }
+
+    pub fn available_permits(&self) -> usize {
+        self.inner.semaphore.available_permits()
+    }
+
+    pub fn is_idle(&self) -> bool {
+        self.available_permits() == self.capacity()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.available_permits() == 0
+    }
+
+    /// Acquire an available permit from the semaphore, blocking until none are
+    /// available.
+    pub async fn acquire(&self) -> Permit {
+        let permit = Permit {
+            inner: Arc::clone(&self.inner),
+            permit: TokioPermit::new(),
+        };
+
+        PermitFuture01::new(permit)
+            .compat()
+            .await
+            // The TokioSemaphore is not dropped yet and our wrapper never calls
+            // .close(), so the TokioSemaphore can never be closed unless all
+            // references, including this &self, have been dropped.
+            .expect("TokioSemaphore is never closed")
+    }
+
+    /// Try to acquire an available permit from the semaphore. If no permits are
+    /// available, return `None`.
+    pub fn try_acquire(&self) -> Option<Permit> {
+        let mut permit = TokioPermit::new();
+        match permit.try_acquire(&self.inner.semaphore) {
+            Ok(()) => Some(Permit {
+                inner: Arc::clone(&self.inner),
+                permit,
+            }),
+            Err(err) => {
+                // The TokioSemaphore is not dropped yet and our wrapper never
+                // calls .close(), so the TokioSemaphore can never be closed
+                // unless all references, including this &self, have been
+                // dropped.
+                assert!(!err.is_closed());
+                assert!(err.is_no_permits());
+                None
+            }
+        }
+    }
+}
+
+impl Permit {
+    fn release(&mut self) {
+        self.permit.release(&self.inner.semaphore);
+    }
+}
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+struct PermitFuture01 {
+    permit: Option<Permit>,
+}
+
+impl PermitFuture01 {
+    fn new(permit: Permit) -> Self {
+        Self {
+            permit: Some(permit),
+        }
+    }
+}
+
+impl Future01 for PermitFuture01 {
+    type Item = Permit;
+    type Error = AcquireError;
+
+    fn poll(&mut self) -> Poll01<Self::Item, Self::Error> {
+        let mut permit = self.permit.take().unwrap();
+
+        match permit.permit.poll_acquire(&permit.inner.semaphore) {
+            Ok(Async01::Ready(())) => Ok(Async01::Ready(permit)),
+            Ok(Async01::NotReady) => {
+                self.permit = Some(permit);
+                Ok(Async01::NotReady)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures03::{
+        executor::block_on,
+        future::{Future, FutureExt, TryFutureExt},
+    };
+    use std::{
+        sync::atomic::{AtomicU32, Ordering},
+        time::{Duration, Instant},
+    };
+    use tokio::{runtime::Runtime, timer::Delay};
+
+    #[test]
+    fn basic_functionality_semaphore() {
+        let s = Semaphore::new(3);
+
+        assert!(s.is_idle());
+
+        let _p1 = block_on(s.acquire());
+        let p2 = block_on(s.acquire());
+        let p3 = block_on(s.acquire());
+
+        assert!(s.is_full());
+        assert!(s.try_acquire().is_none());
+
+        drop(p2);
+
+        assert!(!s.is_full());
+        assert!(!s.is_idle());
+
+        let _p4 = block_on(s.acquire());
+
+        assert!(s.is_full());
+        assert!(s.try_acquire().is_none());
+
+        drop(p3);
+
+        assert!(!s.is_full());
+        assert!(!s.is_idle());
+
+        assert!(s.try_acquire().is_some());
+    }
+
+    fn yield_task() -> impl Future<Output = ()> {
+        Delay::new(Instant::now() + Duration::from_millis(1))
+            .compat()
+            .map(|_| ())
+    }
+
+    // spawn NUM_TASKS futures that acquire a common semaphore, ensuring that no
+    // more than MAX_WORKERS ever enter the critical section.
+    #[test]
+    fn concurrent_semaphore() {
+        const MAX_WORKERS: u32 = 20;
+        const NUM_TASKS: u32 = 1000;
+        static WORKERS: AtomicU32 = AtomicU32::new(0);
+        static COMPLETED_TASKS: AtomicU32 = AtomicU32::new(0);
+        let semaphore = Semaphore::new(MAX_WORKERS as usize);
+
+        let mut rt = Runtime::new().unwrap();
+
+        for _ in 0..NUM_TASKS {
+            let semaphore = semaphore.clone();
+            let f = async move {
+                let _permit = semaphore.acquire().await;
+
+                // acquired permit, there should only ever be MAX_WORKERS in this
+                // critical section
+
+                let prev_workers = WORKERS.fetch_add(1, Ordering::SeqCst);
+                assert!(prev_workers < MAX_WORKERS);
+
+                // yield back to the tokio scheduler
+                yield_task().await;
+
+                let prev_workers = WORKERS.fetch_sub(1, Ordering::SeqCst);
+                assert!(prev_workers > 0 && prev_workers <= MAX_WORKERS);
+
+                COMPLETED_TASKS.fetch_add(1, Ordering::Relaxed);
+
+                // drop _permit and release access
+            };
+            rt.spawn(f.boxed().unit_error().compat());
+        }
+
+        // spin until completed
+        loop {
+            let completed = COMPLETED_TASKS.load(Ordering::Relaxed);
+            if completed == NUM_TASKS {
+                break;
+            } else {
+                ::std::sync::atomic::spin_loop_hint();
+            }
+        }
+    }
+}

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -18,6 +18,7 @@ protobuf = "~2.7"
 tokio = "0.1.22"
 ttl_cache = "0.4.2"
 
+bounded-executor = { path = "../common/bounded-executor" }
 config = { path = "../config" }
 crypto = { path = "../crypto/legacy_crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,6 +20,7 @@ tokio-timer = "0.2.10"
 tokio-retry = "0.2.0"
 unsigned-varint = { version = "0.2.2", features = ["codec"] }
 
+bounded-executor = { path = "../common/bounded-executor" }
 channel = { path = "../common/channel" }
 crypto = { path = "../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -618,6 +618,7 @@ fn rpc_protocol() {
     let dialer_peer_mgr_reqs_tx = PeerManagerRequestSender::new(dialer_peer_mgr_reqs_tx);
     let (rpc_handler_tx, _) = channel::new_test(8);
     let dialer_rpc = Rpc::new(
+        rt.executor(),
         dialer_rpc_rx,
         dialer_peer_mgr_notifs_rx,
         dialer_peer_mgr_reqs_tx,
@@ -668,6 +669,7 @@ fn rpc_protocol() {
     let listener_peer_mgr_reqs_tx = PeerManagerRequestSender::new(listener_peer_mgr_reqs_tx);
     let (listener_rpc_notifs_tx, mut listener_rpc_notifs_rx) = channel::new_test(8);
     let listener_rpc = Rpc::new(
+        rt.executor(),
         listener_rpc_reqs_rx,
         listener_peer_mgr_notifs_rx,
         listener_peer_mgr_reqs_tx,

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -492,6 +492,7 @@ impl NetworkBuilder {
 
         // Initialize and start RPC actor.
         let rpc = Rpc::new(
+            self.executor.clone(),
             rpc_reqs_rx,
             pm_rpc_notifs_rx,
             PeerManagerRequestSender::new(pm_reqs_tx.clone()),


### PR DESCRIPTION
In the beginning, we used to `executor.spawn(_)` tasks without limit, but this provided no backpressure and would eventually crash to OOM. Next we used `stream.buffer_unordered(limit)` for task-level concurrency with backpressure, but it is not actually task parallel. Now, with the newly implemented `BoundedExecutor`, you can `executor.spawn(_).await` to get task-level parallelism+concurrency with still providing backpressure, since `BoundedExecutor` only allows a user-defined number of tasks to be executing at any point in time.

Then, we use `BoundedExecutor` in both shared_mempool and rpc protocol.