### PR TITLE
Vote in timeout msg

### DIFF
--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -571,19 +571,18 @@ fn process_new_round_msg_test() {
 
     // As the static proposer processes the new round message it should learn about
     // block_0_quorum_cert at round 1.
-    block_on(
-        static_proposer
-            .event_processor
-            .process_timeout_msg(TimeoutMsg::new(
-                SyncInfo::new(
-                    block_0_quorum_cert,
-                    QuorumCert::certificate_for_genesis(),
-                    None,
-                ),
-                PacemakerTimeout::new(2, &non_proposer.signer),
-                &non_proposer.signer,
-            )),
-    );
+    block_on(static_proposer.event_processor.process_timeout_msg(
+        TimeoutMsg::new(
+            SyncInfo::new(
+                block_0_quorum_cert,
+                QuorumCert::certificate_for_genesis(),
+                None,
+            ),
+            PacemakerTimeout::new(2, &non_proposer.signer, None),
+            &non_proposer.signer,
+        ),
+        2,
+    ));
     assert_eq!(
         static_proposer
             .block_store
@@ -678,7 +677,8 @@ fn process_timeout_certificate_test() {
         node.block_store.signer(),
     );
     let block_skip_round_id = block_skip_round.id();
-    let tc = PacemakerTimeoutCertificate::new(1, vec![PacemakerTimeout::new(1, &node.signer)]);
+    let tc =
+        PacemakerTimeoutCertificate::new(1, vec![PacemakerTimeout::new(1, &node.signer, None)]);
     block_on(async move {
         node.event_processor
             .process_proposal(ProposalInfo::<TestPayload, Author> {

--- a/consensus/src/chained_bft/liveness/local_pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker_test.rs
@@ -88,7 +88,7 @@ fn test_timeout_certificate() {
         // accumulated into single timeout certificate
         for round in 1..rounds {
             let signer = &signers[round - 1];
-            let pacemaker_timeout = PacemakerTimeout::new(round as u64, signer);
+            let pacemaker_timeout = PacemakerTimeout::new(round as u64, signer, None);
             pm.process_remote_timeout(pacemaker_timeout).await;
         }
         // Then timeout quorum for previous round (1,2,3) generates new round event for round 2

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
@@ -23,13 +23,13 @@ fn test_basic() {
     let validator_signer2 = ValidatorSigner::random([1u8; 32]);
 
     // No timeout certificate generated on adding 2 timeouts from the same author
-    let timeout_signer1_round1 = PacemakerTimeout::new(1, &validator_signer1);
+    let timeout_signer1_round1 = PacemakerTimeout::new(1, &validator_signer1, None);
     assert_eq!(
         timeout_manager.update_received_timeout(timeout_signer1_round1),
         false
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
-    let timeout_signer1_round2 = PacemakerTimeout::new(2, &validator_signer1);
+    let timeout_signer1_round2 = PacemakerTimeout::new(2, &validator_signer1, None);
     assert_eq!(
         timeout_manager.update_received_timeout(timeout_signer1_round2),
         false
@@ -37,7 +37,7 @@ fn test_basic() {
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
 
     // Timeout certificate generated on adding a timeout from signer2
-    let timeout_signer2_round1 = PacemakerTimeout::new(1, &validator_signer2);
+    let timeout_signer2_round1 = PacemakerTimeout::new(1, &validator_signer2, None);
     assert_eq!(
         timeout_manager.update_received_timeout(timeout_signer2_round1),
         true
@@ -51,7 +51,7 @@ fn test_basic() {
     );
 
     // Timeout certificate increased when incrementing the round from signer 2
-    let timeout_signer2_round2 = PacemakerTimeout::new(2, &validator_signer2);
+    let timeout_signer2_round2 = PacemakerTimeout::new(2, &validator_signer2, None);
     assert_eq!(
         timeout_manager.update_received_timeout(timeout_signer2_round2),
         true
@@ -65,7 +65,7 @@ fn test_basic() {
     );
 
     // No timeout certificate generated since signer 1 is still on round 2
-    let timeout_signer2_round3 = PacemakerTimeout::new(3, &validator_signer2);
+    let timeout_signer2_round3 = PacemakerTimeout::new(3, &validator_signer2, None);
     assert_eq!(
         timeout_manager.update_received_timeout(timeout_signer2_round3),
         false
@@ -82,8 +82,8 @@ fn test_basic() {
     let received_timeout_certificate = PacemakerTimeoutCertificate::new(
         10,
         vec![
-            PacemakerTimeout::new(10, &validator_signer1),
-            PacemakerTimeout::new(11, &validator_signer2),
+            PacemakerTimeout::new(10, &validator_signer1, None),
+            PacemakerTimeout::new(11, &validator_signer2, None),
         ],
     );
     assert_eq!(
@@ -104,8 +104,8 @@ fn test_recovery_from_highest_timeout_certificate() {
     let validator_signer1 = ValidatorSigner::random([0u8; 32]);
     let validator_signer2 = ValidatorSigner::random([1u8; 32]);
 
-    let timeout1 = PacemakerTimeout::new(10, &validator_signer1);
-    let timeout2 = PacemakerTimeout::new(11, &validator_signer2);
+    let timeout1 = PacemakerTimeout::new(10, &validator_signer1, None);
+    let timeout2 = PacemakerTimeout::new(11, &validator_signer2, None);
     let tc = PacemakerTimeoutCertificate::new(10, vec![timeout1, timeout2]);
 
     let timeout_manager = PacemakerTimeoutManager::new(

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -62,6 +62,9 @@ pub static ref TIMEOUT_COUNT: IntCounter = OP_COUNTERS.counter("timeout_count");
 /// The timeout of the current round.
 pub static ref ROUND_TIMEOUT_MS: IntGauge = OP_COUNTERS.gauge("round_timeout_ms");
 
+/// Count the number of cases, in which the vote carried by a timeout message helps to form a QC
+pub static ref TIMEOUT_VOTES_FORM_QC_COUNT: IntCounter = OP_COUNTERS.counter("timeout_votes_form_qc_count");
+
 ////////////////////////
 // SYNCMANAGER COUNTERS
 ////////////////////////

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -37,6 +37,8 @@ message PacemakerTimeout {
   bytes author = 2;
   // Signature that this timeout was authored by owner
   bytes signature = 3;
+  // Optional vote for the given round
+  Vote vote = 4;
 }
 
 message TimeoutMsg {


### PR DESCRIPTION
[Consensus] Attach votes to timeout messages.
  
Summary:
In this diff we're extending timeout message to include an optional Vote field:
* the votes are cached in `EventProcessor` to include the last vote msg of a validator
* upon timeout the cached vote message is attached to the timeout message
* upon receiving timeout message, the votes are added to the block store and new QCs can be generated

This PR appears as two commits, but the first one belongs to another PR #367 (they're touching similar pieces of code, so it's now rebased on top of it). Please review the second commit only.

Test: added a unit test that verifies vote aggregation via timeout messages
Task: ref #371
