### PR TITLE
[work-in-progress] Charge additional gas for first-time global reads

### DIFF
--- a/language/vm/src/gas_schedule.rs
+++ b/language/vm/src/gas_schedule.rs
@@ -151,6 +151,10 @@ lazy_static! {
     /// TODO: Fill this in with a proper number once it's determined.
     pub static ref GLOBAL_MEMORY_PER_BYTE_WRITE_COST: GasUnits<GasCarrier> = GasUnits::new(8);
 
+    /// The cost per-byte read from storage.
+    /// TODO: Fill this in with a proper number once it's determined.
+    pub static ref GLOBAL_MEMORY_PER_BYTE_READ_COST: GasUnits<GasCarrier> = GasUnits::new(4);
+
     /// The maximum size representable by AbstractMemorySize
     pub static ref MAX_ABSTRACT_MEMORY_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize::new(std::u64::MAX);
 


### PR DESCRIPTION
A proposal on what would need to be changed if we want to charge according to the state of the VM internal cache. One issue with this is that this costing may be too intensional. 


Since globals are cached after the first read (i.e. `borrow_global`)
we don't charge for subsequent reads of that data within a transaction
since this will not actually be reading from global storage.

## Test Plan

Normal tests/CI
