### PR TITLE
[cli] dev section: polishing

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -426,10 +426,13 @@ impl ClientProxy {
     pub fn compile_program(&mut self, space_delim_strings: &[&str]) -> Result<String> {
         let address = self.get_account_address_from_parameter(space_delim_strings[1])?;
         let file_path = space_delim_strings[2];
-        let is_module = if space_delim_strings.len() > 3 {
-            parse_bool(space_delim_strings[3])?
-        } else {
-            false
+        let is_module = match space_delim_strings[3] {
+            "module" => true,
+            "script" => false,
+            _ => bail!(
+                "Invalid program type: {}. Available options: module, script",
+                space_delim_strings[3]
+            ),
         };
         let output_path = {
             if space_delim_strings.len() == 5 {
@@ -446,7 +449,7 @@ impl ClientProxy {
         };
         let mut tmp_source_file = NamedTempFile::new()?;
         let mut code = fs::read_to_string(file_path)?;
-        code = code.replace("{{default}}", &format!("0x{}", address));
+        code = code.replace("{{sender}}", &format!("0x{}", address));
         writeln!(tmp_source_file, "{}", code)?;
 
         let dependencies_file =

--- a/client/src/commands.rs
+++ b/client/src/commands.rs
@@ -54,16 +54,20 @@ pub fn is_address(data: &str) -> bool {
 
 /// Returns all the commands available, as well as the reverse index from the aliases to the
 /// commands.
-pub fn get_commands() -> (
+pub fn get_commands(
+    include_dev: bool,
+) -> (
     Vec<Arc<dyn Command>>,
     HashMap<&'static str, Arc<dyn Command>>,
 ) {
-    let commands: Vec<Arc<dyn Command>> = vec![
+    let mut commands: Vec<Arc<dyn Command>> = vec![
         Arc::new(AccountCommand {}),
         Arc::new(QueryCommand {}),
         Arc::new(TransferCommand {}),
-        Arc::new(DevCommand {}),
     ];
+    if include_dev {
+        commands.push(Arc::new(DevCommand {}));
+    }
     let mut alias_to_cmd = HashMap::new();
     for command in &commands {
         for alias in command.get_aliases() {

--- a/client/src/dev_commands.rs
+++ b/client/src/dev_commands.rs
@@ -31,13 +31,13 @@ impl Command for DevCommandCompile {
         vec!["compile", "c"]
     }
     fn get_params_help(&self) -> &'static str {
-        "<sender_account_address>|<sender_account_ref_id> <file_path> [is_module (default=false)] [output_file_path (compile into tmp file by default)]"
+        "<sender_account_address>|<sender_account_ref_id> <file_path> <module|script> [output_file_path (compile into tmp file by default)]"
     }
     fn get_description(&self) -> &'static str {
         "Compile move program"
     }
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
-        if params.len() < 3 || params.len() > 5 {
+        if params.len() < 4 || params.len() > 5 {
             println!("Invalid number of arguments for compilation");
             return;
         }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -52,10 +52,10 @@ struct Args {
 fn main() -> std::io::Result<()> {
     let _logger = set_default_global_logger(false /* async */, None);
     crash_handler::setup_panic_handler();
-
-    let (commands, alias_to_cmd) = get_commands();
-
     let args = Args::from_args();
+
+    let (commands, alias_to_cmd) = get_commands(args.faucet_account_file.is_some());
+
     let faucet_account_file = args.faucet_account_file.unwrap_or_else(|| "".to_string());
 
     let mut client_proxy = ClientProxy::new(

--- a/libra_swarm/src/client.rs
+++ b/libra_swarm/src/client.rs
@@ -154,7 +154,7 @@ impl InProcessTestClient {
         mnemonic_file_path: &str,
         validator_set_file: String,
     ) -> Self {
-        let (_, alias_to_cmd) = commands::get_commands();
+        let (_, alias_to_cmd) = commands::get_commands(true);
         Self {
             client: ClientProxy::new(
                 "localhost",


### PR DESCRIPTION
diffs adds following changes to developer flow:
* address preprocessor will use {{sender}} template instead of {{default}} to substitute sender address
* is_module compilation flag changed to explicit module|script choice
* dev section shouldn't be displayed during connection to production testnet. It will only be displayed if mint key is provided (e.g. developer owns given network)
