### PR TITLE
[client] do not panic on empty lines

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -94,7 +94,10 @@ fn main() -> std::io::Result<()> {
         match readline {
             Ok(line) => {
                 let params = parse_cmd(&line);
-                match alias_to_cmd.get(params[0]) {
+                if params.is_empty() {
+                    continue;
+                }
+                match alias_to_cmd.get(&params[0]) {
                     Some(cmd) => cmd.execute(&mut client_proxy, &params),
                     None => match params[0] {
                         "quit" | "q!" => break,


### PR DESCRIPTION
# Motivation
The client cli crashes if no commands were provided e.g., newline or whitespaces

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
Started client, clicked a few `<RET>` nothing crashed

```
$ target/debug/client -a ac.testnet.libra.org -p 80 -s scripts/cli/trusted_peers.config.toml
Connected to validator at: ac.testnet.libra.org:80
usage: <command> <args>

Use the following commands:

account | a
        Account operations
query | q
        Query operations
transfer | transferb | t | tb
        <sender_account_address>|<sender_account_ref_id> <receiver_account_address>|<receiver_account_ref_id> <number_of_coins> [gas_unit_price_in_micro_libras (default=0)] [max_gas_amount_in_micro_libras (default 100000)] Suffix 'b' is for blocking.
        Transfer coins (in libra) from account to another.
dev
        Local move development
help | h
        Prints this help
quit | q!
        Exit this client


Please, input commands:

libra%
libra%
libra% a c
>> Creating/retrieving next account from wallet
Created/retrieved account #0 address 39d0b57776cff2a1c00849192b78a99d258966bedff2a87ee4b41a67587da72a
libra% q   b   0
Balance is: 0.000000
libra% q  b 0
Balance is: 0.000000
libra%
libra%
libra%   q!
```