### PR TITLE
[config] Set BaseConfig and VMConfig defaults in code

### DIFF
--- a/config/data/configs/node.config.toml
+++ b/config/data/configs/node.config.toml
@@ -1,19 +1,11 @@
-[base]
-peer_id = ''
-peer_keypairs_file = ''
-data_dir_path = '<USE_TEMP_DIR>'
-trusted_peers_file = ''
-node_sync_batch_size = 1000
-node_sync_retries = 3
-node_sync_channel_buffer_size = 10
-node_async_log_chan_size = 256
+# Defaults are now set in config.rs
 
 [vm_config]
   [vm_config.publishing_options]
   type = "Locked"
   whitelist = [
-      "ae1b54220905fca36d046a6e093632ed1f219e0a35a4fd7ba82e6e0d515f0b8e",
-      "fb999f2d6f45efc9b991993e332f40760171de8a46db40ca93f1baff56842c44",
-      "6465374a3ecf6d1a3836bbab3bcd624244a0217530a601fa20de80d562f87d80",
-      "774b10985dd9bf17ddee899256942c1dc0ab2c1b07d99ec78f774651f01e04b8"
+    "ae1b54220905fca36d046a6e093632ed1f219e0a35a4fd7ba82e6e0d515f0b8e",
+    "fb999f2d6f45efc9b991993e332f40760171de8a46db40ca93f1baff56842c44",
+    "6465374a3ecf6d1a3836bbab3bcd624244a0217530a601fa20de80d562f87d80",
+    "774b10985dd9bf17ddee899256942c1dc0ab2c1b07d99ec78f774651f01e04b8"
   ]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -50,6 +50,7 @@ static CONFIG_TEMPLATE: &[u8] = include_bytes!("../data/configs/node.config.toml
 #[cfg_attr(any(test, feature = "testing"), derive(Clone))]
 pub struct NodeConfig {
     //TODO Add configuration for multiple chain's in a future diff
+    #[serde(default)]
     pub base: BaseConfig,
     #[serde(default)]
     pub metrics: MetricsConfig,
@@ -70,6 +71,7 @@ pub struct NodeConfig {
     pub mempool: MempoolConfig,
     #[serde(default)]
     pub log_collector: LoggerConfig,
+    #[serde(default)]
     pub vm_config: VMConfig,
 
     #[serde(default)]
@@ -77,6 +79,7 @@ pub struct NodeConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct BaseConfig {
     pub peer_id: String,
     // peer_keypairs contains all the node's private keys,
@@ -105,6 +108,24 @@ pub struct BaseConfig {
 
     // chan_size of slog async drain for node logging.
     pub node_async_log_chan_size: usize,
+}
+
+impl Default for BaseConfig {
+    fn default() -> BaseConfig {
+        BaseConfig {
+            peer_id: "".to_string(),
+            peer_keypairs_file: PathBuf::from(""),
+            peer_keypairs: KeyPairs::default(),
+            data_dir_path: PathBuf::from("<USE_TEMP_DIR>"),
+            temp_data_dir: None,
+            trusted_peers_file: "".to_string(),
+            trusted_peers: TrustedPeersConfig::default(),
+            node_sync_batch_size: 1000,
+            node_sync_retries: 3,
+            node_sync_channel_buffer_size: 10,
+            node_async_log_chan_size: 256,
+        }
+    }
 }
 
 // KeyPairs is used to store all of a node's private keys.
@@ -767,8 +788,17 @@ impl NodeConfigHelpers {
 /// Holds the VM configuration, currently this is only the publishing options for scripts and
 /// modules, but in the future this may need to be expanded to hold more information.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct VMConfig {
     pub publishing_options: VMPublishingOption,
+}
+
+impl Default for VMConfig {
+    fn default() -> VMConfig {
+        VMConfig {
+            publishing_options: VMPublishingOption::Open,
+        }
+    }
 }
 
 /// Defines and holds the publishing policies for the VM. There are three possible configurations:


### PR DESCRIPTION
Sets remaining defaults in code instead of the config file. This sets
the default VMPublishingOption to "Open", but keeps it as "Locked" in
the default config file.

Test Plan: Ran libra_swarm