### PR TITLE
[storage] increase storage gRPC receiving message length

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -432,6 +432,7 @@ pub struct StorageConfig {
     pub address: String,
     pub port: u16,
     pub dir: PathBuf,
+    pub grpc_max_receive_len: Option<i32>,
 }
 
 impl StorageConfig {
@@ -446,6 +447,7 @@ impl Default for StorageConfig {
             address: "localhost".to_string(),
             port: 30305,
             dir: PathBuf::from("libradb"),
+            grpc_max_receive_len: Some(100_000_000),
         }
     }
 }

--- a/execution/execution_tests/src/lib.rs
+++ b/execution/execution_tests/src/lib.rs
@@ -53,6 +53,7 @@ pub fn create_and_start_server(config: &NodeConfig) -> (ServerHandle, grpcio::Se
         Arc::clone(&client_env),
         &config.storage.address,
         config.storage.port,
+        None,
     ));
 
     let execution_service = create_execution(ExecutionService::new(

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -74,6 +74,7 @@ fn create_executor(config: &NodeConfig) -> Executor<MockVM> {
         Arc::clone(&client_env),
         "localhost",
         config.storage.port,
+        None,
     ));
     Executor::new(read_client, write_client, config)
 }

--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -110,6 +110,7 @@ fn setup_executor(config: &NodeConfig) -> ::grpcio::Server {
         Arc::clone(&client_env),
         &config.storage.address,
         config.storage.port,
+        config.storage.grpc_max_receive_len,
     ));
 
     let handle = ExecutionService::new(storage_read_client, storage_write_client, config);

--- a/storage/storage_client/src/lib.rs
+++ b/storage/storage_client/src/lib.rs
@@ -197,8 +197,17 @@ pub struct StorageWriteServiceClient {
 
 impl StorageWriteServiceClient {
     /// Constructs a `StorageWriteServiceClient` with given host and port.
-    pub fn new(env: Arc<Environment>, host: &str, port: u16) -> Self {
-        let channel = ChannelBuilder::new(env).connect(&format!("{}:{}", host, port));
+    pub fn new(
+        env: Arc<Environment>,
+        host: &str,
+        port: u16,
+        grpc_max_receive_len: Option<i32>,
+    ) -> Self {
+        let mut builder = ChannelBuilder::new(env);
+        if let Some(len) = grpc_max_receive_len {
+            builder = builder.max_receive_message_len(len);
+        }
+        let channel = builder.connect(&format!("{}:{}", host, port));
         let client = storage_grpc::StorageClient::new(channel);
         StorageWriteServiceClient { client }
     }

--- a/storage/storage_service/src/storage_service_test.rs
+++ b/storage/storage_service/src/storage_service_test.rs
@@ -44,6 +44,7 @@ fn start_test_storage_with_read_write_client(
         Arc::new(EnvBuilder::new().build()),
         &config.storage.address,
         config.storage.port,
+        None,
     );
     (tmp_dir, storage_server_handle, read_client, write_client)
 }

--- a/terraform/validator-sets/dev/node.config.toml
+++ b/terraform/validator-sets/dev/node.config.toml
@@ -35,6 +35,7 @@ address = "0.0.0.0"
 address = "localhost"
 port = 35647
 dir = "/opt/libra/data"
+grpc_max_receive_len = 100000000
 
 [network]
 seed_peers_file = "/opt/libra/etc/seed_peers.config.toml"

--- a/vm_validator/src/unit_tests/vm_validator_test.rs
+++ b/vm_validator/src/unit_tests/vm_validator_test.rs
@@ -44,6 +44,7 @@ impl TestValidator {
             Arc::clone(&client_env),
             &config.storage.address,
             config.storage.port,
+            None,
         ));
 
         let handle = ExecutionService::new(


### PR DESCRIPTION
When transactions are executed, these signed transactions along with
account states and events are passed to storage through a gRPC call.
Though the total size of the signed transactions is smaller than the 4MB
gRPC message length limit, the additional account states and events can
make the request exceeds the 4MB limit.
Given that the gRPC service between executor and storage is used within
a validator, I think it makes sense to increase the limit to 100MB.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested on benchmark cluster, get one node offline and online again, didn't observe the crash anymore during state sync
