### PR TITLE
Follow-up to #401 #356 #373

### DIFF
--- a/crypto/nextgen_crypto/src/ed25519.rs
+++ b/crypto/nextgen_crypto/src/ed25519.rs
@@ -394,6 +394,7 @@ pub mod compat {
     };
     #[cfg(any(test, feature = "testing"))]
     use proptest::strategy::LazyJust;
+    #[cfg(any(test, feature = "testing"))]
     use proptest::{prelude::*, strategy::Strategy};
 
     impl From<Ed25519PublicKey> for LegacyPublicKey {
@@ -480,6 +481,7 @@ pub mod compat {
     }
 
     /// Used to produce keypairs from a seed for testing purposes
+    #[cfg(any(test, feature = "testing"))]
     pub fn keypair_strategy() -> impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)> {
         // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
         // keypair to be generated, which appears to not be very useful.

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -35,4 +35,4 @@ vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types", fea
 
 [features]
 default = ["testing"]
-testing = ["types/testing", "vm/testing", "vm_runtime/testing"]
+testing = ["types/testing", "vm/testing", "vm_runtime/testing", "vm_runtime_types/testing"]


### PR DESCRIPTION
*What this changes*

- make `libra_fuzzer` call into the `"testing"` feature of `vm_runtime_types`
- mask a strategy introduced in #373 that could not be masked until #356 was introduced

*Test*

- to make sure this doesn't break, I ran `find ./ -iname Cargo.toml -execdir cargo check --all-targets \;` (but it costs CPU)
- another option is `cargo check --all-targets --bins -p libra-node -p libra_swarm -p libra_fuzzer` but it requires keeping in mind an up-to-date list of relevant binaries