### PR TITLE
[VM] Verify native functions

### DIFF
--- a/language/bytecode_verifier/Cargo.toml
+++ b/language/bytecode_verifier/Cargo.toml
@@ -13,6 +13,8 @@ petgraph = "0.4"
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 vm = { path = "../vm" }
 types = { path = "../../types" }
+vm_runtime_types = { path = "../vm/vm_runtime/vm_runtime_types" }
+
 
 [dev-dependencies]
 invalid_mutations = { path = "invalid_mutations" }

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use codespan::{ByteIndex, Span};
 
 use crate::ast::{ModuleDefinition, StructDefinition, Script, Program};
@@ -27,24 +26,8 @@ ByteArray: ByteArray = {
 };
 AccountAddress: AccountAddress = {
     < s: r"0[xX][0-9a-fA-F]+" > => {
-        let mut hex_string = String::from(&s[2..]);
-        if hex_string.len() % 2 != 0 {
-            hex_string.insert(0, '0');
-        }
-
-        let mut result = hex::decode(hex_string.as_str()).unwrap();
-        let len = result.len();
-        if len < 32 {
-            result.reverse();
-            for i in len..32 {
-                result.push(0);
-            }
-            result.reverse();
-        }
-
-        assert!(result.len() >= 32);
-        AccountAddress::try_from(&result[..])
-            .unwrap_or_else(|_| panic!("The address {:?} is of invalid length. Addresses are at most 32-bytes long", result))
+        AccountAddress::from_hex_literal(&s)
+            .unwrap_or_else(|_| panic!("The address {:?} is of invalid length. Addresses are at most 32-bytes long", s))
     }
 };
 

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -60,7 +60,7 @@ fn do_verify_module(module: CompiledModule, dependencies: &[VerifiedModule]) -> 
         Ok(module) => module,
         Err((_, errors)) => print_errors_and_exit(&errors),
     };
-    let (verified_module, errors) = verify_module_dependencies(verified_module, dependencies);
+    let errors = verify_module_dependencies(&verified_module, dependencies);
     if !errors.is_empty() {
         print_errors_and_exit(&errors);
     }

--- a/language/functional_tests/tests/testsuite/natives/clever_non_existant_native_function.mvir
+++ b/language/functional_tests/tests/testsuite/natives/clever_non_existant_native_function.mvir
@@ -1,0 +1,22 @@
+module Hash {
+    native public keccak256(data: bytearray): bytearray;
+    native public ripemd160(data: bytearray): bytearray;
+    native public sha2_256(data: bytearray): bytearray;
+    native public sha3_256(data: bytearray): bytearray;
+}
+
+// check: VerificationError
+// check: FunctionHandle
+// check: MissingDependency
+
+// check: VerificationError
+// check: FunctionHandle
+// check: MissingDependency
+
+// check: VerificationError
+// check: FunctionHandle
+// check: MissingDependency
+
+// check: VerificationError
+// check: FunctionHandle
+// check: MissingDependency

--- a/language/functional_tests/tests/testsuite/natives/non_existant_native_function.mvir
+++ b/language/functional_tests/tests/testsuite/natives/non_existant_native_function.mvir
@@ -1,0 +1,7 @@
+module No {
+    native public made_up(x: u64): u64;
+}
+
+// check: VerificationError
+// check: FunctionHandle
+// check: MissingDependency

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -35,8 +35,7 @@ pub fn build_stdlib(address: &AccountAddress) -> Vec<VerifiedModule> {
         let verified_module =
             VerifiedModule::new(compiled_module).expect("stdlib module failed to verify");
 
-        let (verified_module, verification_errors) =
-            verify_module_dependencies(verified_module, &stdlib_modules);
+        let verification_errors = verify_module_dependencies(&verified_module, &stdlib_modules);
         // Fail if the module doesn't verify
         for e in &verification_errors {
             println!("{:?}", e);

--- a/language/vm/src/views.rs
+++ b/language/vm/src/views.rs
@@ -148,6 +148,10 @@ impl<'a, T: ModuleAccess> ModuleView<'a, T> {
     pub fn struct_definition(&self, name: &'a str) -> Option<&StructDefinitionView<'a, T>> {
         self.name_to_struct_definition_view.get(name)
     }
+
+    pub fn id(&self) -> ModuleId {
+        self.module.self_id()
+    }
 }
 
 pub struct ModuleHandleView<'a, T> {

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -65,6 +65,26 @@ impl AccountAddress {
         keccak.finalize(&mut hash);
         AccountAddress::new(hash)
     }
+
+    pub fn from_hex_literal(literal: &str) -> Result<Self> {
+        let mut hex_string = String::from(&literal[2..]);
+        if hex_string.len() % 2 != 0 {
+            hex_string.insert(0, '0');
+        }
+
+        let mut result = hex::decode(hex_string.as_str())?;
+        let len = result.len();
+        if len < 32 {
+            result.reverse();
+            for _ in len..32 {
+                result.push(0);
+            }
+            result.reverse();
+        }
+
+        assert!(result.len() >= 32);
+        AccountAddress::try_from(result)
+    }
 }
 
 impl CryptoHash for AccountAddress {


### PR DESCRIPTION
## Motivation

- To prevent programmers from publishing code with fake native functions. The bytecode verifier will now check that 
  (a) the native function exists 
  (b) the native function has the signature expected by the VM runtime 
- Any other properties of the native function (such as it being public or not) will still be left up to the declaration of the native function in move code
- Found bug with natives where the address was not checked. Added that field to the dispatch map to fix this

## Test Plan

- Manually tested that the type checking works for native functions. Cannot yet mock out the std lib for functional tests, so this one off test will have to do for now
- Added tests for trying to add a fake native function 
- cargo test
