### PR TITLE
[VM] Automated Move bytecode test generation tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "language/compiler/ir_to_bytecode/syntax",
     "language/e2e_tests",
     "language/tools/cost_synthesis",
+    "language/tools/test_generation",
     "language/tools/repl",
     "language/stackless_bytecode/bytecode_to_boogie",
     "language/stackless_bytecode/generator",

--- a/language/tools/cost_synthesis/src/common.rs
+++ b/language/tools/cost_synthesis/src/common.rs
@@ -20,6 +20,9 @@ pub const MAX_NUM_LOCALS: usize = 10;
 /// The maximum number of arguments to generated function definitions.
 pub const MAX_FUNCTION_CALL_SIZE: usize = 8;
 
+/// The maximum number of return types of generated function definitions.
+pub const MAX_RETURN_TYPES_LENGTH: usize = 4;
+
 /// The default index to use when we need to have a frame on the execution stack.
 ///
 /// We are always guaranteed to have at least one function definition in a generated module. We can
@@ -28,3 +31,9 @@ pub const DEFAULT_FUNCTION_IDX: TableIndex = 0;
 
 /// The type of the value stack.
 pub type Stack = Vec<Local>;
+
+/// The minimum number of instructions to generate for function bodies
+pub const MIN_BYTECODE_INSTRUCTIONS: usize = 10;
+
+/// The maximum number of instructions to generate for function bodies
+pub const MAX_BYTECODE_INSTRUCTIONS: usize = 20;

--- a/language/tools/test_generation/Cargo.toml
+++ b/language/tools/test_generation/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test_generation"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+rand = "0.6.5"
+log = "0.4"
+env_logger = "0.6"
+bytecode_verifier = { path = "../../bytecode_verifier" }
+cost_synthesis = { path = "../cost_synthesis" }
+types = { path = "../../../types" }
+vm = { path = "../../vm" }

--- a/language/tools/test_generation/src/abstract_state.rs
+++ b/language/tools/test_generation/src/abstract_state.rs
@@ -1,0 +1,101 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use vm::file_format::SignatureToken;
+
+/// The BorrowState denotes whether a local is `Available` or
+/// has been moved and is `Unavailable`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BorrowState {
+    Available,
+    Unavailable,
+}
+
+/// An AbstractState represents an abstract view of the execution of the
+/// Move VM. Rather than considering values of items on the stack or in
+/// the locals, we only consider their type, represented by a `SignatureToken`
+/// and their availibility, represented by the `BorrowState`.
+#[derive(Debug, Clone)]
+pub struct AbstractState {
+    /// A Vector of `SignatureToken`s representing the VM value stack
+    stack: Vec<SignatureToken>,
+
+    /// A HashMap mapping local indicies to `SignatureToken`s and `BorrowState`s
+    locals: HashMap<usize, (SignatureToken, BorrowState)>,
+}
+
+impl AbstractState {
+    /// Create a new AbstractState given a list of `SignatureTokens` that will be
+    /// the (available) locals that the state will have.
+    pub fn new(initial_locals: &[SignatureToken]) -> AbstractState {
+        AbstractState {
+            stack: Vec::new(),
+            locals: initial_locals
+                .iter()
+                .enumerate()
+                .map(|(i, token)| (i, (token.clone(), BorrowState::Available)))
+                .collect(),
+        }
+    }
+
+    /// Add a `SignatureToken` to the stack
+    pub fn stack_push(&mut self, item: SignatureToken) {
+        self.stack.push(item);
+    }
+
+    /// Remove a `SignatureToken` from the stack if it exists
+    pub fn stack_pop(&mut self) -> Option<SignatureToken> {
+        self.stack.pop()
+    }
+
+    /// Get the `SignatureToken` at index `index` on the stack if it exists.
+    /// Index 0 is the top of the stack.
+    pub fn stack_peek(&self, index: usize) -> Option<SignatureToken> {
+        if index < self.stack.len() {
+            Some(self.stack[self.stack.len() - 1 - index].clone())
+        } else {
+            None
+        }
+    }
+
+    /// Get the length of the stack.
+    pub fn stack_len(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Check whether a local is available. Defaults to false if no local is
+    /// present at index `i`.
+    pub fn local_available(&self, i: usize) -> bool {
+        if let Some((_, borrow_state)) = self.locals.get(&i) {
+            return *borrow_state == BorrowState::Available;
+        }
+        false
+    }
+
+    /// Get the local at index `i` if it exists
+    pub fn get_local(&self, i: usize) -> Option<&(SignatureToken, BorrowState)> {
+        self.locals.get(&i)
+    }
+
+    /// Get the local at index `i` and set it to `Unavailable`
+    pub fn move_local(&mut self, i: usize) -> Option<&(SignatureToken, BorrowState)> {
+        // TODO: Change to precondition once MIRAI is integrated
+        assert!(self.get_local(i).is_some(), "Failed to move local");
+        let (local, _) = self.get_local(i).unwrap().clone();
+        self.locals.insert(i, (local, BorrowState::Unavailable));
+        self.locals.get(&i)
+    }
+
+    /// Insert a local at index `i` as `Available`
+    pub fn insert_local(&mut self, i: usize, token: SignatureToken) {
+        // TODO: What should the behavior be if there is already a local at i?
+        self.locals
+            .insert(i, (token.clone(), BorrowState::Available));
+    }
+
+    /// TODO: Determine whether the current state is a final state
+    pub fn is_final(&self) -> bool {
+        self.stack.is_empty()
+    }
+}

--- a/language/tools/test_generation/src/bytecode_generator.rs
+++ b/language/tools/test_generation/src/bytecode_generator.rs
@@ -1,0 +1,188 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{abstract_state::AbstractState, summaries};
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use vm::file_format::{
+    AddressPoolIndex, Bytecode, FunctionSignature, SignatureToken, StringPoolIndex,
+};
+
+/// This type represents bytecode instructions that take a `u8`
+type U8ToBytecode = fn(u8) -> Bytecode;
+
+/// This type represents bytecode instructions that take a `u64`
+type U64ToBytecode = fn(u64) -> Bytecode;
+
+/// This type represents bytecode instructions that take a `StringPoolIndex`
+type StringPoolIndexToBytecode = fn(StringPoolIndex) -> Bytecode;
+
+/// This type represents bytecode instructions that take a `AddressPoolIndex`
+type AddressPoolIndexToBytecode = fn(AddressPoolIndex) -> Bytecode;
+
+/// There are three types of bytecode instructions
+#[derive(Debug, Clone)]
+enum BytecodeType {
+    /// Instructions that do not take an argument
+    NoArg(Bytecode),
+
+    /// Instructions that take a `u8`
+    U8(U8ToBytecode),
+
+    /// Instructions that take a `u64`
+    U64(U64ToBytecode),
+
+    /// Instructions that take a `StringPoolIndex`
+    StringPoolIndex(StringPoolIndexToBytecode),
+
+    /// Instructions that take an `AddressPoolIndex`
+    AddressPoolIndex(AddressPoolIndexToBytecode),
+}
+
+/// Generates a sequence of bytecode instructions.
+/// This generator has:
+/// - `instructions`: A list of bytecode instructions to use for generation
+/// - `rng`: A random number generator for uniform random choice of next instruction
+#[derive(Debug, Clone)]
+pub struct BytecodeGenerator {
+    instructions: Vec<BytecodeType>,
+    rng: StdRng,
+}
+
+impl BytecodeGenerator {
+    /// The `BytecodeGenerator` is instantiated with a seed to use with
+    /// its random number generator.
+    pub fn new(seed: [u8; 32]) -> Self {
+        let instructions: Vec<BytecodeType> = vec![
+            BytecodeType::NoArg(Bytecode::Pop),
+            BytecodeType::U64(Bytecode::LdConst),
+            BytecodeType::StringPoolIndex(Bytecode::LdStr),
+            BytecodeType::AddressPoolIndex(Bytecode::LdAddr),
+            BytecodeType::NoArg(Bytecode::LdTrue),
+            BytecodeType::NoArg(Bytecode::LdFalse),
+            BytecodeType::U8(Bytecode::CopyLoc),
+            BytecodeType::U8(Bytecode::MoveLoc),
+            BytecodeType::U8(Bytecode::StLoc),
+            BytecodeType::NoArg(Bytecode::Add),
+            BytecodeType::NoArg(Bytecode::Sub),
+            BytecodeType::NoArg(Bytecode::Mul),
+            BytecodeType::NoArg(Bytecode::Div),
+            BytecodeType::NoArg(Bytecode::Mod),
+            BytecodeType::NoArg(Bytecode::BitAnd),
+            BytecodeType::NoArg(Bytecode::BitOr),
+            BytecodeType::NoArg(Bytecode::Xor),
+            BytecodeType::NoArg(Bytecode::Or),
+            BytecodeType::NoArg(Bytecode::And),
+            BytecodeType::NoArg(Bytecode::Not),
+            BytecodeType::NoArg(Bytecode::Eq),
+            BytecodeType::NoArg(Bytecode::Neq),
+            BytecodeType::NoArg(Bytecode::Lt),
+            BytecodeType::NoArg(Bytecode::Gt),
+            BytecodeType::NoArg(Bytecode::Le),
+            BytecodeType::NoArg(Bytecode::Ge),
+            BytecodeType::NoArg(Bytecode::GetTxnGasUnitPrice),
+            BytecodeType::NoArg(Bytecode::GetTxnMaxGasUnits),
+            BytecodeType::NoArg(Bytecode::GetGasRemaining),
+            BytecodeType::NoArg(Bytecode::GetTxnSequenceNumber),
+        ];
+        let generator = StdRng::from_seed(seed);
+        Self {
+            instructions,
+            rng: generator,
+        }
+    }
+
+    /// Given an `AbstractState`, `state`, and a the number of locals the function has,
+    /// this function returns a list of instructions whose preconditions are satisfied for
+    /// the state.
+    fn candidate_instructions(&mut self, state: AbstractState, locals_len: usize) -> Vec<Bytecode> {
+        let mut matches: Vec<Bytecode> = Vec::new();
+        let instructions = &self.instructions;
+        for instruction in instructions.iter() {
+            let instruction: Bytecode = match instruction {
+                BytecodeType::NoArg(instruction) => instruction.clone(),
+                BytecodeType::U8(instruction) => {
+                    // Generate a random index into the locals
+                    let local_index: u8 = self.rng.gen_range(0, locals_len as u8);
+                    instruction(local_index)
+                }
+                BytecodeType::U64(instruction) => {
+                    // Generate a random u64 constant to load
+                    let value = self.rng.gen_range(0, u64::max_value());
+                    instruction(value)
+                }
+                BytecodeType::StringPoolIndex(instruction) => {
+                    // TODO: Determine correct index
+                    instruction(StringPoolIndex::new(0))
+                }
+                BytecodeType::AddressPoolIndex(instruction) => {
+                    // TODO: Determine correct index
+                    instruction(AddressPoolIndex::new(0))
+                }
+            };
+            let summary = summaries::instruction_summary(instruction.clone());
+            let unsatisfied_preconditions = summary
+                .preconditions
+                .iter()
+                .any(|precondition| !precondition(&state));
+            if !unsatisfied_preconditions {
+                matches.push(instruction);
+            }
+        }
+        matches
+    }
+
+    /// Transition an abstract state, `state` to the next state by applying all of the effects
+    /// of a particular bytecode instruction, `instruction`.
+    fn abstract_step(&self, state: AbstractState, instruction: Bytecode) -> AbstractState {
+        summaries::instruction_summary(instruction)
+            .effects
+            .iter()
+            .fold(state, |acc, effect| effect(&acc))
+    }
+
+    /// Return a sequence of bytecode instructions given a set of `locals` and a target return
+    /// `signature`. The sequence should contain at least `target_min` and at most `target_max`
+    /// instructions.
+    pub fn generate(
+        &mut self,
+        locals: &[SignatureToken],
+        signature: &FunctionSignature,
+        target_min: usize,
+        target_max: usize,
+    ) -> Vec<Bytecode> {
+        let mut bytecode: Vec<Bytecode> = Vec::new();
+        let mut state: AbstractState = AbstractState::new(locals);
+        loop {
+            debug!("Bytecode: [{:?}]", bytecode);
+            debug!("AbstractState: [{:?}]", state);
+            let candidates = self.candidate_instructions(state.clone(), locals.len());
+            debug!("Candidates: [{:?}]", candidates);
+            if candidates.is_empty() {
+                warn!("No candidates found for state: [{:?}]", state);
+                break;
+            }
+            let next_instruction_index = self.rng.gen_range(0, candidates.len());
+            let next_instruction = candidates[next_instruction_index].clone();
+            debug!("Next instr: {:?}", next_instruction);
+            state = self.abstract_step(state, next_instruction.clone());
+            debug!("New state: {:?}", state);
+            bytecode.push(next_instruction);
+            debug!("**********************");
+            if bytecode.len() >= target_min && state.is_final() || bytecode.len() >= target_max {
+                info!("Instructions generated: {}", bytecode.len());
+                break;
+            }
+        }
+        for return_type in signature.return_types.iter() {
+            match return_type {
+                SignatureToken::String => bytecode.push(Bytecode::LdStr(StringPoolIndex::new(0))),
+                SignatureToken::Address => {
+                    bytecode.push(Bytecode::LdAddr(AddressPoolIndex::new(0)))
+                }
+                _ => panic!("Unsupported return type!"),
+            }
+        }
+        bytecode.push(Bytecode::Ret);
+        bytecode
+    }
+}

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -1,0 +1,56 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod abstract_state;
+pub mod bytecode_generator;
+pub mod summaries;
+pub mod transitions;
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+use bytecode_generator::BytecodeGenerator;
+use bytecode_verifier::VerifiedModule;
+use cost_synthesis::module_generator::ModuleBuilder;
+use vm::{
+    file_format::{Bytecode, FunctionSignature, SignatureToken},
+    CompiledModule,
+};
+
+/// This function calls the Bytecode verifier to test it
+fn run_verifier(module: CompiledModule) {
+    match VerifiedModule::new(module) {
+        Ok(_) => {}
+        Err((_, errs)) => {
+            error!("Module verification failed: {:#?}", errs);
+        }
+    }
+}
+
+/// Generate a sequence of bytecode instructions such that
+/// - The arguments 'arguments' are used
+/// - The return type 'signature' is reached
+/// - The number of instructions generated is between 'target_min' and 'target_max'
+pub fn generate_bytecode(
+    arguments: &[SignatureToken],
+    signature: &FunctionSignature,
+    target_min: usize,
+    target_max: usize,
+) -> Vec<Bytecode> {
+    let seed: [u8; 32] = [0; 32];
+    let mut bytecode_generator = BytecodeGenerator::new(seed);
+    bytecode_generator.generate(arguments, signature, target_min, target_max)
+}
+
+/// Run generate_bytecode for 'iterations' iterations and test each generated module
+/// on the bytecode verifier.
+pub fn run_generation(iterations: usize) {
+    env_logger::init();
+
+    for _ in 0..iterations {
+        let module =
+            ModuleBuilder::new(1, Some(Box::new(generate_bytecode))).materialize_unverified();
+        debug!("Module: {:#?}", module);
+        run_verifier(module);
+    }
+}

--- a/language/tools/test_generation/src/main.rs
+++ b/language/tools/test_generation/src/main.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use test_generation::run_generation;
+
+pub fn main() {
+    run_generation(1);
+}

--- a/language/tools/test_generation/src/summaries.rs
+++ b/language/tools/test_generation/src/summaries.rs
@@ -1,0 +1,263 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    abstract_state::AbstractState, state_local_available, state_never, state_stack_has,
+    state_stack_pop, state_stack_pop_local_insert, state_stack_push, state_stack_push_local_borrow,
+    state_stack_push_local_copy, state_stack_push_local_move, transitions::*,
+};
+use vm::file_format::{Bytecode, SignatureToken};
+
+/// A `Precondition` is a boolean predicate on an `AbstractState`.
+type Precondition = dyn Fn(&AbstractState) -> bool;
+
+/// A `Effect` is a function that transforms on `AbstractState` to another
+type Effect = dyn Fn(&AbstractState) -> AbstractState;
+
+/// The `Summary` of a bytecode instruction contains a list of `Precondition`s
+/// and a list of `Effect`s.
+pub struct Summary {
+    pub preconditions: Vec<Box<Precondition>>,
+    pub effects: Vec<Box<Effect>>,
+}
+
+/// Return the `Summary` for a bytecode instruction, `instruction`
+pub fn instruction_summary(instruction: Bytecode) -> Summary {
+    match instruction {
+        Bytecode::Pop => Summary {
+            preconditions: vec![state_stack_has!(0, None)],
+            effects: vec![state_stack_pop!()],
+        },
+        Bytecode::LdConst(_) => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::U64)],
+        },
+        Bytecode::LdStr(_) => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::String)],
+        },
+        Bytecode::LdAddr(_) => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::Address)],
+        },
+        Bytecode::LdTrue => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::Bool)],
+        },
+        Bytecode::LdFalse => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::Bool)],
+        },
+        Bytecode::CopyLoc(i) => Summary {
+            preconditions: vec![state_local_available!(i)],
+            effects: vec![state_stack_push_local_copy!(i)],
+        },
+        Bytecode::MoveLoc(i) => Summary {
+            preconditions: vec![state_local_available!(i)],
+            effects: vec![state_stack_push_local_move!(i)],
+        },
+        Bytecode::StLoc(i) => Summary {
+            preconditions: vec![state_stack_has!(0, None), state_local_available!(i)],
+            effects: vec![state_stack_pop_local_insert!(i), state_stack_pop!()],
+        },
+        Bytecode::BorrowLoc(i) => Summary {
+            preconditions: vec![state_local_available!(i)],
+            effects: vec![state_stack_push_local_borrow!(i)],
+        },
+        Bytecode::Add => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::Sub => Summary {
+            preconditions: vec![
+                // TODO: op1 needs to be >= op2 (negative numbers not supported)
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::Mul => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::Div => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::Mod => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::BitAnd => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::BitOr => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::U64),
+            ],
+        },
+        Bytecode::Xor => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::Bool)),
+                state_stack_has!(1, Some(SignatureToken::Bool)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Or => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::Bool)),
+                state_stack_has!(1, Some(SignatureToken::Bool)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::And => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::Bool)),
+                state_stack_has!(1, Some(SignatureToken::Bool)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Not => Summary {
+            preconditions: vec![state_stack_has!(0, Some(SignatureToken::Bool))],
+            effects: vec![state_stack_pop!(), state_stack_push!(SignatureToken::Bool)],
+        },
+        Bytecode::Eq => Summary {
+            preconditions: vec![state_stack_has!(0, None), state_stack_has!(1, None)],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Neq => Summary {
+            preconditions: vec![state_stack_has!(0, None), state_stack_has!(1, None)],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Lt => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(0, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Gt => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Le => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::Ge => Summary {
+            preconditions: vec![
+                state_stack_has!(0, Some(SignatureToken::U64)),
+                state_stack_has!(1, Some(SignatureToken::U64)),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_stack_pop!(),
+                state_stack_push!(SignatureToken::Bool),
+            ],
+        },
+        Bytecode::GetTxnGasUnitPrice => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::U64)],
+        },
+        Bytecode::GetTxnMaxGasUnits => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::U64)],
+        },
+        Bytecode::GetGasRemaining => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::U64)],
+        },
+        Bytecode::GetTxnSequenceNumber => Summary {
+            preconditions: vec![],
+            effects: vec![state_stack_push!(SignatureToken::U64)],
+        },
+        _ => Summary {
+            preconditions: vec![state_never!()],
+            effects: vec![],
+        },
+    }
+}

--- a/language/tools/test_generation/src/transitions.rs
+++ b/language/tools/test_generation/src/transitions.rs
@@ -1,0 +1,161 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::abstract_state::AbstractState;
+use vm::file_format::SignatureToken;
+
+/// Determine whether the stack is at least of size `index`. If the optional `token` argument
+/// is some `SignatureToken`, check whether the type at `index` is that token.
+pub fn stack_has(state: &AbstractState, index: usize, token: Option<SignatureToken>) -> bool {
+    match token {
+        Some(token) => index < state.stack_len() && state.stack_peek(index) == Some(token),
+        None => index < state.stack_len(),
+    }
+}
+
+/// Pop from the top of the stack.
+pub fn stack_pop(state: &AbstractState) -> AbstractState {
+    let mut state = state.clone();
+    state.stack_pop();
+    state
+}
+
+/// Push to the top of the stack.
+pub fn stack_push(state: &AbstractState, token: SignatureToken) -> AbstractState {
+    let mut state = state.clone();
+    state.stack_push(token);
+    state
+}
+
+/// Check whether the local at `index` is available.
+pub fn local_available(state: &AbstractState, index: u8) -> bool {
+    state.local_available(index as usize)
+}
+
+/// Push a copy of the local at `index` to the stack.
+pub fn stack_push_local_copy(state: &AbstractState, index: u8) -> AbstractState {
+    // TODO: Change to precondition once MIRAI is integrated
+    assert!(
+        state.get_local(index as usize).is_some(),
+        "Failed to copy local to stack"
+    );
+    let (token, _) = state.get_local(index as usize).unwrap();
+    stack_push(state, token.clone())
+}
+
+/// Move a local at `index` to the stack.
+pub fn stack_push_local_move(state: &AbstractState, index: u8) -> AbstractState {
+    // TODO: Change to precondition once MIRAI is integrated
+    assert!(
+        state.get_local(index as usize).is_some(),
+        "Failed to move local to stack"
+    );
+    let mut state = state.clone();
+    let (token, _) = state.move_local(index as usize).unwrap().clone();
+    stack_push(&state, token)
+}
+
+/// Push a reference to the local at `index` to the stack.
+pub fn stack_push_local_borrow(state: &AbstractState, index: u8) -> AbstractState {
+    // TODO: Change to precondition once MIRAI is integrated
+    assert!(
+        state.get_local(index as usize).is_some(),
+        "Failed to borrow local to stack"
+    );
+    let state = state.clone();
+    let (token, _) = state.get_local(index as usize).unwrap().clone();
+    stack_push(&state, SignatureToken::MutableReference(Box::new(token)))
+}
+
+/// Pop an element from the stack and insert it into the locals at `index`
+pub fn stack_pop_local_insert(state: &AbstractState, index: u8) -> AbstractState {
+    // TODO: Change to precondition once MIRAI is integrated
+    assert!(
+        state.stack_peek(0).is_some(),
+        "Failed to insert local from stack"
+    );
+    let mut state = state.clone();
+    let token = state.stack_peek(0).unwrap();
+    state.insert_local(index as usize, token.clone());
+    state
+}
+
+/// Wrapper for enclosing the arguments of `stack_has` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_has {
+    ($e1: expr, $e2: expr) => {
+        Box::new(move |state| stack_has(state, $e1, $e2))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_pop` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_pop {
+    () => {
+        Box::new(move |state| stack_pop(state))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_push` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_push {
+    ($e: expr) => {
+        Box::new(move |state| stack_push(state, $e))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_push_local_copy` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_push_local_copy {
+    ($e: expr) => {
+        Box::new(move |state| stack_push_local_copy(state, $e))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_push_local_move` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_push_local_move {
+    ($e: expr) => {
+        Box::new(move |state| stack_push_local_move(state, $e))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_push_local_borrow` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_push_local_borrow {
+    ($e: expr) => {
+        Box::new(move |state| stack_push_local_borrow(state, $e))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_pop_local_insert` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_pop_local_insert {
+    ($e: expr) => {
+        Box::new(move |state| stack_pop_local_insert(state, $e))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `local_available` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_local_available {
+    ($e: expr) => {
+        Box::new(move |state| local_available(state, $e))
+    };
+}
+
+/// Predicate that is false for every state.
+#[macro_export]
+macro_rules! state_never {
+    () => {
+        Box::new(|_| (false))
+    };
+}

--- a/language/tools/test_generation/tests/arithmetic_instructions.rs
+++ b/language/tools/test_generation/tests/arithmetic_instructions.rs
@@ -1,0 +1,70 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_add() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Add, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_sub() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Sub, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_mul() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Mul, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_div() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Div, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_mod() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Mod, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}

--- a/language/tools/test_generation/tests/bitwise_instructions.rs
+++ b/language/tools/test_generation/tests/bitwise_instructions.rs
@@ -1,0 +1,31 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_bitand() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::BitAnd, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_bitor() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::BitAnd, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}

--- a/language/tools/test_generation/tests/boolean_instructions.rs
+++ b/language/tools/test_generation/tests/boolean_instructions.rs
@@ -1,0 +1,57 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_and() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(SignatureToken::Bool);
+    let state2 = common::run_instruction(Bytecode::And, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_or() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(SignatureToken::Bool);
+    let state2 = common::run_instruction(Bytecode::Or, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_xor() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(SignatureToken::Bool);
+    let state2 = common::run_instruction(Bytecode::Xor, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_not() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(SignatureToken::Bool);
+    let state2 = common::run_instruction(Bytecode::Not, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}

--- a/language/tools/test_generation/tests/common.rs
+++ b/language/tools/test_generation/tests/common.rs
@@ -1,0 +1,22 @@
+extern crate test_generation;
+use test_generation::{abstract_state::AbstractState, summaries::instruction_summary};
+use vm::file_format::Bytecode;
+
+pub fn run_instruction(instruction: Bytecode, initial_state: AbstractState) -> AbstractState {
+    let instruction_summary = instruction_summary(instruction);
+    let mut preconditions_satisfied = true;
+    for precondition in instruction_summary.preconditions.into_iter() {
+        if !precondition(&initial_state) {
+            preconditions_satisfied = false;
+        }
+    }
+    assert_eq!(
+        preconditions_satisfied, true,
+        "preconditions of instruction not satisfied"
+    );
+    let mut state2 = initial_state.clone();
+    for effect in instruction_summary.effects.into_iter() {
+        state2 = effect(&state2);
+    }
+    state2
+}

--- a/language/tools/test_generation/tests/comparison_instructions.rs
+++ b/language/tools/test_generation/tests/comparison_instructions.rs
@@ -1,0 +1,109 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_gt() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Gt, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_lt() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Lt, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_ge() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Ge, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_le() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Le, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_eq_u64() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Eq, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_eq_bool() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(SignatureToken::Bool);
+    let state2 = common::run_instruction(Bytecode::Eq, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_neq_u64() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Neq, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_neq_bool() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(SignatureToken::Bool);
+    let state2 = common::run_instruction(Bytecode::Neq, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}

--- a/language/tools/test_generation/tests/load_instructions.rs
+++ b/language/tools/test_generation/tests/load_instructions.rs
@@ -1,0 +1,60 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{AddressPoolIndex, Bytecode, SignatureToken, StringPoolIndex};
+
+mod common;
+
+#[test]
+fn bytecode_ldconst() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::LdConst(0), state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_ldtrue() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::LdTrue, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_ldfalse() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::LdFalse, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Bool),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_ldstr() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::LdStr(StringPoolIndex::new(0)), state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::String),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_ldaddr() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::LdAddr(AddressPoolIndex::new(0)), state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::Address),
+        "stack type postcondition not met"
+    );
+}

--- a/language/tools/test_generation/tests/local_instructions.rs
+++ b/language/tools/test_generation/tests/local_instructions.rs
@@ -1,0 +1,106 @@
+extern crate test_generation;
+use test_generation::abstract_state::{AbstractState, BorrowState};
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_copyloc() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.insert_local(0, SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::CopyLoc(0), state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+    assert_eq!(
+        state2.get_local(0),
+        Some(&(SignatureToken::U64, BorrowState::Available)),
+        "locals signature postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_copyloc_no_local() {
+    let state1 = AbstractState::new(&Vec::new());
+    common::run_instruction(Bytecode::CopyLoc(0), state1);
+}
+
+#[test]
+#[should_panic]
+fn bytecode_copyloc_local_unavailable() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.insert_local(0, SignatureToken::U64);
+    state1.move_local(0);
+    common::run_instruction(Bytecode::CopyLoc(0), state1);
+}
+
+#[test]
+fn bytecode_moveloc() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.insert_local(0, SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::MoveLoc(0), state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+    assert_eq!(
+        state2.get_local(0),
+        Some(&(SignatureToken::U64, BorrowState::Unavailable)),
+        "locals signature postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_moveloc_no_local() {
+    let state1 = AbstractState::new(&Vec::new());
+    common::run_instruction(Bytecode::MoveLoc(0), state1);
+}
+
+#[test]
+#[should_panic]
+fn bytecode_moveloc_local_unavailable() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.insert_local(0, SignatureToken::U64);
+    state1.move_local(0);
+    common::run_instruction(Bytecode::MoveLoc(0), state1);
+}
+
+#[test]
+fn bytecode_borrowloc() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.insert_local(0, SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::BorrowLoc(0), state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::MutableReference(Box::new(
+            SignatureToken::U64
+        ))),
+        "stack type postcondition not met"
+    );
+    assert_eq!(
+        state2.get_local(0),
+        Some(&(SignatureToken::U64, BorrowState::Available)),
+        "locals signature postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_borrowloc_no_local() {
+    let state1 = AbstractState::new(&Vec::new());
+    common::run_instruction(Bytecode::BorrowLoc(0), state1);
+}
+
+#[test]
+#[should_panic]
+fn bytecode_borrowloc_local_unavailable() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.insert_local(0, SignatureToken::U64);
+    state1.move_local(0);
+    common::run_instruction(Bytecode::BorrowLoc(0), state1);
+}

--- a/language/tools/test_generation/tests/special_instructions.rs
+++ b/language/tools/test_generation/tests/special_instructions.rs
@@ -1,0 +1,13 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_pop() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Pop, state1);
+    assert_eq!(state2.stack_len(), 0, "stack type postcondition not met");
+}

--- a/language/tools/test_generation/tests/transaction_instructions.rs
+++ b/language/tools/test_generation/tests/transaction_instructions.rs
@@ -1,0 +1,49 @@
+extern crate test_generation;
+use test_generation::abstract_state::AbstractState;
+use vm::file_format::{Bytecode, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_gettxngasunitprice() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::GetTxnGasUnitPrice, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_gettxnmaxgasunits() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::GetTxnMaxGasUnits, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_gettxnsequencenumber() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::GetTxnSequenceNumber, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_getgasremaining() {
+    let state1 = AbstractState::new(&Vec::new());
+    let state2 = common::run_instruction(Bytecode::GetGasRemaining, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}


### PR DESCRIPTION
## Motivation

Initial framework for automated generation of valid Move bytecode programs. These generated programs will be used as tests for the Move bytecode verifier and the Move VM transaction execution pipeline.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A set of tests have been added `tests/` folder and will be run when `cargo test` is executed.

## Related PRs

N/A
