### PR TITLE
Introduce Throughput Test

### DIFF
--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -23,103 +23,13 @@
 ///
 /// By conforming to the LoadGenerator APIs,
 /// this flow is basically the same for different LoadGenerators/experiments.
-use admission_control_proto::proto::admission_control_grpc::AdmissionControlClient;
 use benchmark::{
+    bin_utils::{create_benchmarker_from_opt, measure_throughput, try_start_metrics_server},
     ruben_opt::{Opt, TransactionPattern},
-    txn_generator::{
-        convert_load_to_txn_requests, gen_repeated_txn_load, LoadGenerator,
-        PairwiseTransferTxnGenerator, RingTransferTxnGenerator,
-    },
-    Benchmarker,
+    txn_generator::{LoadGenerator, PairwiseTransferTxnGenerator, RingTransferTxnGenerator},
 };
-use client::AccountData;
-use grpcio::{ChannelBuilder, EnvBuilder};
 use logger::{self, prelude::*};
-use metrics::metric_server::start_server;
-use std::{ops::DerefMut, sync::Arc};
-
-/// Play given TXN pattern with Benchmarker for several epochs and measure burst throughput,
-/// e.g., the average committed txns per second. Since time is counted from submission
-/// until all TXNs are committed, this measurement is in a sense the user-side throughput.
-/// Each epoch plays the given TXN request pattern sequence repeatedly for several rounds.
-pub(crate) fn measure_throughput<T: LoadGenerator + ?Sized>(
-    bm: &mut Benchmarker,
-    txn_generator: &mut T,
-    faucet_account: &mut AccountData,
-    args: &Opt,
-) {
-    // Generate testing accounts.
-    let mut accounts: Vec<AccountData> = txn_generator.gen_accounts(args.num_accounts);
-    bm.register_accounts(&accounts);
-
-    // Submit setup/minting TXN requests.
-    let setup_requests = txn_generator.gen_setup_txn_requests(faucet_account, &mut accounts);
-    let mint_txns = convert_load_to_txn_requests(setup_requests);
-    bm.mint_accounts(&mint_txns, faucet_account);
-
-    // Submit TXN load and measure throughput.
-    let mut txn_throughput_seq = vec![];
-    for _ in 0..args.num_epochs {
-        let repeated_tx_reqs = gen_repeated_txn_load(txn_generator, &mut accounts, args.num_rounds);
-        let txn_throughput = bm.measure_txn_throughput(&repeated_tx_reqs, &mut accounts);
-        txn_throughput_seq.push(txn_throughput);
-    }
-    info!(
-        "{} epoch(s) of REQ/TXN throughput = {:?}",
-        args.num_epochs, txn_throughput_seq
-    );
-}
-
-/// Creates a client for AC with a unique user-agent.
-///
-/// In a benchmark environment, we want to emulate multiple concurrent
-/// clients, even though all of them originate from the same benchmarker
-/// process. We add a unique user-agent to bypass some of gRPC default
-/// optimization that group connections from the same source onto
-/// a single completion queue (making requests sequntial).
-///
-/// index: unique identifier for the channel, to uniquify clients
-fn create_ac_client(index: usize, conn_addr: &str) -> AdmissionControlClient {
-    let env_builder = Arc::new(EnvBuilder::new().name_prefix("ac-grpc-").build());
-    let ch = ChannelBuilder::new(env_builder)
-        .primary_user_agent(&format!("grpc/benchmark-client-{}", index))
-        .connect(&conn_addr);
-    AdmissionControlClient::new(ch)
-}
-
-/// Creat a vector of AdmissionControlClient and connect them to validators.
-fn create_ac_clients(
-    num_clients: usize,
-    validator_addresses: &[String],
-) -> Vec<AdmissionControlClient> {
-    let mut clients: Vec<AdmissionControlClient> = vec![];
-    for i in 0..num_clients {
-        let index = i % validator_addresses.len();
-        let client = create_ac_client(i, &validator_addresses[index]);
-        clients.push(client);
-    }
-    clients
-}
-
-pub(crate) fn create_benchmarker_from_opt(args: &Opt) -> Benchmarker {
-    // Create AdmissionControlClient instances.
-    let clients = create_ac_clients(args.num_clients, &args.validator_addresses);
-    let submit_rate = args.parse_submit_rate();
-    // Ready to instantiate Benchmarker.
-    Benchmarker::new(clients, args.stagger_range_ms, submit_rate)
-}
-
-/// Benchmarker is not a long-lived job, so starting a server and expecting it to be polled
-/// continuously is not ideal. Directly pushing metrics when benchmarker is running
-/// can be achieved by using Pushgateway.
-fn try_start_metrics_server(args: &Opt) {
-    if let Some(metrics_server_address) = &args.metrics_server_address {
-        let address = metrics_server_address.clone();
-        std::thread::spawn(move || {
-            start_server(address);
-        });
-    }
-}
+use std::ops::DerefMut;
 
 fn main() {
     let _g = logger::set_default_global_logger(false, Some(256));
@@ -133,7 +43,14 @@ fn main() {
         TransactionPattern::Ring => Box::new(RingTransferTxnGenerator::new()),
         TransactionPattern::Pairwise => Box::new(PairwiseTransferTxnGenerator::new()),
     };
-    measure_throughput(&mut bm, generator.deref_mut(), &mut faucet_account, &args);
+    measure_throughput(
+        &mut bm,
+        generator.deref_mut(),
+        &mut faucet_account,
+        args.num_accounts,
+        args.num_rounds,
+        args.num_epochs,
+    );
 }
 
 #[cfg(test)]
@@ -185,7 +102,9 @@ mod tests {
                 &mut bm,
                 &mut ring_generator,
                 &mut faucet_account,
-                &args
+                args.num_accounts,
+                args.num_rounds,
+                args.num_epochs,
             );
             let requested_txns = OP_COUNTER.counter("requested_txns").get();
             let created_txns = OP_COUNTER.counter("created_txns").get();

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -1,0 +1,99 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ruben_opt::Opt,
+    txn_generator::{convert_load_to_txn_requests, gen_repeated_txn_load, LoadGenerator},
+    Benchmarker,
+};
+use admission_control_proto::proto::admission_control_grpc::AdmissionControlClient;
+use client::AccountData;
+use grpcio::{ChannelBuilder, EnvBuilder};
+use logger::{self, prelude::*};
+use metrics::metric_server::start_server;
+use std::sync::Arc;
+
+/// Creates a client for AC with a unique user-agent.
+///
+/// In a benchmark environment, we want to emulate multiple concurrent
+/// clients, even though all of them originate from the same benchmarker
+/// process. We add a unique user-agent to bypass some of gRPC default
+/// optimization that group connections from the same source onto
+/// a single completion queue (making requests sequntial).
+///
+/// index: unique identifier for the channel, to uniquify clients
+fn create_ac_client(index: usize, conn_addr: &str) -> AdmissionControlClient {
+    let env_builder = Arc::new(EnvBuilder::new().name_prefix("ac-grpc-").build());
+    let ch = ChannelBuilder::new(env_builder)
+        .primary_user_agent(&format!("grpc/benchmark-client-{}", index))
+        .connect(&conn_addr);
+    AdmissionControlClient::new(ch)
+}
+
+/// Creat a vector of AdmissionControlClient and connect them to validators.
+fn create_ac_clients(
+    num_clients: usize,
+    validator_addresses: &[String],
+) -> Vec<AdmissionControlClient> {
+    let mut clients: Vec<AdmissionControlClient> = vec![];
+    for i in 0..num_clients {
+        let index = i % validator_addresses.len();
+        let client = create_ac_client(i, &validator_addresses[index]);
+        clients.push(client);
+    }
+    clients
+}
+
+pub fn create_benchmarker_from_opt(args: &Opt) -> Benchmarker {
+    // Create AdmissionControlClient instances.
+    let clients = create_ac_clients(args.num_clients, &args.validator_addresses);
+    let submit_rate = args.parse_submit_rate();
+    // Ready to instantiate Benchmarker.
+    Benchmarker::new(clients, args.stagger_range_ms, submit_rate)
+}
+
+/// Benchmarker is not a long-lived job, so starting a server and expecting it to be polled
+/// continuously is not ideal. Directly pushing metrics when benchmarker is running
+/// can be achieved by using Pushgateway.
+pub fn try_start_metrics_server(args: &Opt) {
+    if let Some(metrics_server_address) = &args.metrics_server_address {
+        let address = metrics_server_address.clone();
+        std::thread::spawn(move || {
+            start_server(address);
+        });
+    }
+}
+
+/// Play given TXN pattern with Benchmarker for several epochs and measure burst throughput,
+/// e.g., the average committed txns per second. Since time is counted from submission
+/// until all TXNs are committed, this measurement is in a sense the user-side throughput.
+/// Each epoch plays the given TXN request pattern sequence repeatedly for several rounds.
+pub fn measure_throughput<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    txn_generator: &mut T,
+    faucet_account: &mut AccountData,
+    num_accounts: u64,
+    num_rounds: u64,
+    num_epochs: u64,
+) {
+    // Generate testing accounts.
+    let mut accounts: Vec<AccountData> = txn_generator.gen_accounts(num_accounts);
+    bm.register_accounts(&accounts);
+
+    // Submit setup/minting TXN requests.
+    let setup_requests = txn_generator.gen_setup_txn_requests(faucet_account, &mut accounts);
+    let mint_txns = convert_load_to_txn_requests(setup_requests);
+    bm.mint_accounts(&mint_txns, faucet_account);
+
+    // Submit TXN load and measure throughput.
+    let mut txn_throughput_seq = vec![];
+    for _ in 0..num_epochs {
+        let repeated_tx_reqs = gen_repeated_txn_load(txn_generator, &mut accounts, num_rounds);
+        let txn_throughput = bm.measure_txn_throughput(&repeated_tx_reqs, &mut accounts);
+        txn_throughput_seq.push(txn_throughput);
+    }
+    info!(
+        "{} epoch(s) of REQ/TXN throughput = {:?}",
+        num_epochs, txn_throughput_seq
+    );
+}

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -31,7 +31,7 @@ fn create_ac_client(index: usize, conn_addr: &str) -> AdmissionControlClient {
 }
 
 /// Creat a vector of AdmissionControlClient and connect them to validators.
-fn create_ac_clients(
+pub fn create_ac_clients(
     num_clients: usize,
     validator_addresses: &[String],
 ) -> Vec<AdmissionControlClient> {
@@ -75,7 +75,7 @@ pub fn measure_throughput<T: LoadGenerator + ?Sized>(
     num_accounts: u64,
     num_rounds: u64,
     num_epochs: u64,
-) {
+) -> std::vec::Vec<(f64, f64)> {
     // Generate testing accounts.
     let mut accounts: Vec<AccountData> = txn_generator.gen_accounts(num_accounts);
     bm.register_accounts(&accounts);
@@ -96,4 +96,5 @@ pub fn measure_throughput<T: LoadGenerator + ?Sized>(
         "{} epoch(s) of REQ/TXN throughput = {:?}",
         num_epochs, txn_throughput_seq
     );
+    txn_throughput_seq
 }

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -17,6 +17,7 @@ use rand::Rng;
 use std::{collections::HashMap, convert::TryInto, sync::Arc, thread, time};
 use types::{account_address::AccountAddress, account_config::association_address};
 
+pub mod bin_utils;
 pub mod grpc_helpers;
 pub mod ruben_opt;
 pub mod submit_rate;

--- a/benchmark/src/ruben_opt.rs
+++ b/benchmark/src/ruben_opt.rs
@@ -113,7 +113,7 @@ fn parse_socket_address(address: &str, port: u16) -> String {
 
 /// Scan *.node.config.toml files under config_dir_name, parse them as node config
 /// and return libra_swarm's node addresses info as a vector.
-fn parse_swarm_config_from_dir(config_dir_name: &str) -> Result<Vec<String>> {
+pub fn parse_swarm_config_from_dir(config_dir_name: &str) -> Result<Vec<String>> {
     let mut validator_addresses: Vec<String> = Vec::new();
     let re = Regex::new(r"[[:alnum:]]{64}\.node\.config\.toml").expect("failed to build regex");
     let config_dir = PathBuf::from(config_dir_name);

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -8,12 +8,16 @@ edition = "2018"
 
 [dev-dependencies]
 lazy_static = "1.2.0"
+num = "0.2.0"
 num-traits = "0.2"
 rust_decimal = "1.0.1"
+statistical = "1"
+rusty-fork = "0.2.1"
 
 # In order to limit the potential waiting time for binaries to be built while
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
+benchmark = { path = "../benchmark" }
 cli = { path = "../client", package="client" }
 generate_keypair = { path = "../config/generate_keypair" }
 libra_swarm = { path = "../libra_swarm", features = ["testing"]}

--- a/testsuite/tests/libratest/main.rs
+++ b/testsuite/tests/libratest/main.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod smoke_test;
+mod throughput_test;

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -1,0 +1,58 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use benchmark::{
+    bin_utils::{create_ac_clients, measure_throughput},
+    ruben_opt::parse_swarm_config_from_dir,
+    txn_generator::PairwiseTransferTxnGenerator,
+    Benchmarker,
+};
+use libra_swarm::swarm::LibraSwarm;
+use num::traits::Float;
+use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
+use statistical::{mean, population_standard_deviation};
+use std::fmt::Display;
+
+fn calculate_avg_std<T: Float + Display>(sequence: &[T], name: &str) {
+    // Output json-formatted result.
+    println!(
+        "{{\"{}_mean\": {:.2}, \"{}_stdev\": {:.2}}}",
+        name,
+        mean(sequence),
+        name,
+        population_standard_deviation(sequence, None),
+    );
+}
+
+rusty_fork_test! {
+    #[test]
+    fn test_throughput() {
+        // Choose parameters that is able to run on not-too-powerful local machines,
+        // but still generates enough TXNs for testing (2K TXNs per epoch).
+        // At submit rate 50 TXNs per second per client, submission takes around 10 seconds.
+        let (num_nodes, num_accounts, num_clients) = (4, 32, 4);
+        let (num_rounds, num_epochs, stagger_ms) = (2, 4, 1);
+        let submit_rate = 50;
+
+        let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
+            generate_keypair::load_faucet_key_or_create_default(None);
+        let swarm = LibraSwarm::launch_swarm(
+            num_nodes,
+            true,   /* disable_logging */
+            faucet_account_keypair,
+            false,  /* tee_logs */
+            None,   /* config_dir */
+        );
+        let swarm_config_dir = String::from(swarm.dir.as_ref().unwrap().as_ref().to_str().unwrap());
+        let validator_addresses = parse_swarm_config_from_dir(&swarm_config_dir).unwrap();
+        let clients = create_ac_clients(num_clients, &validator_addresses);
+        let mut bm = Benchmarker::new(clients, stagger_ms, submit_rate);
+        let mut faucet_account = bm.load_faucet_account(&faucet_key_file_path);
+        let mut pairwise_generator = PairwiseTransferTxnGenerator::new();
+        let results = measure_throughput(&mut bm, &mut pairwise_generator, &mut faucet_account, num_accounts, num_rounds, num_epochs);
+        let req_throughput_seq: Vec<_> = results.iter().map(|x| x.0).collect();
+        let txn_throughput_seq: Vec<_> = results.iter().map(|x| x.1).collect();
+        calculate_avg_std(&req_throughput_seq, &"REQ_throughput");
+        calculate_avg_std(&txn_throughput_seq, &"TXN_throughput");
+    }
+}


### PR DESCRIPTION
## Motivation
The first step to run throughput measurement as regression test.
In future, CI could run throughput tests on both submitted PR and master, then compare the observed throughput.

## Summary
Commit 1. Move helpers out of ruben.rs to be shared.
Commit 2. Add the end-to-end throughput test with `libra_swarm` and `Benchmarker`. Request speed is set to **constant 200 TXNs per seconds**, so the expected throughput should be around 150~190 TPS.

## Test Plan
Run
```
cargo test --release -p testsuite test_throughput -- --nocapture
......
{"REQ_throughput_mean": 197.83, "REQ_throughput_stdev": 0.17}
{"TXN_throughput_mean": 173.62, "TXN_throughput_stdev": 2.28}
test throughput_test::test_throughput ... ok
```
Note output is print out in JSON format.