### PR TITLE
[proptest_helpers] add a remove method to repeat_vec

### DIFF
--- a/common/proptest_helpers/proptest-regressions/unit_tests/repeat_vec_tests.txt
+++ b/common/proptest_helpers/proptest-regressions/unit_tests/repeat_vec_tests.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc bed7b5b3625868c27a6c5c41149a5a33d499f9d8eb3c5c63345246135f4c4040 # shrinks to item_sizes = [], ok_queries = [Index(0)]
+cc 7b5ab398a2ae837e253aee9685848a8b3dc7402484173431621ff55cdda47e9f # shrinks to item_sizes = [], ops = [Get(Index(0))]

--- a/common/proptest_helpers/src/repeat_vec.rs
+++ b/common/proptest_helpers/src/repeat_vec.rs
@@ -3,6 +3,7 @@
 
 use crate::pick_slice_idxs;
 use proptest::sample::Index;
+use std::iter;
 
 /// An efficient representation of a vector with repeated elements inserted.
 ///
@@ -98,13 +99,110 @@ impl<T> RepeatVec<T> {
         }
     }
 
+    /// Removes the item specified by the given *logical* index, shifting all elements after it to
+    /// the left by updating start positions.
+    ///
+    /// Out of bounds indexes have no effect.
+    pub fn remove(&mut self, index: usize) {
+        self.remove_all(iter::once(index))
+    }
+
+    /// Removes the items specified by the given *logical* indexes, shifting all elements after them
+    /// to the left by updating start positions.
+    ///
+    /// Ignores any out of bounds indexes.
+    pub fn remove_all(&mut self, logical_indexes: impl IntoIterator<Item = usize>) {
+        let mut logical_indexes: Vec<_> = logical_indexes.into_iter().collect();
+        logical_indexes.sort();
+        logical_indexes.dedup();
+        self.remove_all_impl(logical_indexes)
+    }
+
+    fn remove_all_impl(&mut self, logical_indexes: Vec<usize>) {
+        // # Notes
+        //
+        // * This looks pretty long and complicated, mostly because the logic is complex enough to
+        //   require manual loops and iteration.
+        // * This is unavoidably linear time in the number of physical elements. One way to make the
+        //   constant factors smaller would be to implement a ChunkedRepeatVec<T>, which can be done
+        //   by wrapping a RepeatVec<RepeatVec<T>> plus some glue logic. The idea would be similar
+        //   to skip-lists. 2 levels should be enough, but 3 or more would work as well.
+
+        // Separate function to minimize the amount of monomorphized code.
+        let first = match logical_indexes.first() {
+            Some(first) => *first,
+            None => {
+                // No indexes to remove, nothing to do.
+                return;
+            }
+        };
+        if first >= self.len() {
+            // First index is out of bounds, nothing to do.
+            return;
+        }
+
+        let first_idx = match self.binary_search(first) {
+            Ok(exact_idx) => {
+                // Logical copy 0 of the element at this position.
+                exact_idx
+            }
+            Err(start_idx) => {
+                // This is the physical index after the logical item. Start reasoning from the
+                // previous index to match the Ok branch above.
+                start_idx - 1
+            }
+        };
+
+        // This serves two purposes -- it represents the number of elements to decrease by and
+        // the current position in indexes.
+        let mut decrease = 0;
+
+        let new_items = {
+            let mut items = self.items.drain(first_idx..).peekable();
+            let mut new_items = vec![];
+
+            while let Some((current_logical_idx_old, current_elem)) = items.next() {
+                let current_logical_idx_new = current_logical_idx_old - decrease;
+
+                let next_logical_idx_old = match items.peek() {
+                    Some(&(idx, _)) => idx,
+                    None => self.len,
+                };
+
+                // Remove all indexes until the next logical index or sorted_indexes runs out.
+                while let Some(remove_idx) = logical_indexes.get(decrease) {
+                    if *remove_idx < next_logical_idx_old {
+                        decrease += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                let next_logical_idx_new = next_logical_idx_old - decrease;
+                assert!(
+                    next_logical_idx_new >= current_logical_idx_new,
+                    "too many items removed from next"
+                );
+
+                // Drop zero-length items to maintain invariant.
+                if next_logical_idx_new > current_logical_idx_new {
+                    new_items.push((current_logical_idx_new, current_elem));
+                }
+            }
+            new_items
+        };
+
+        self.items.extend(new_items);
+        self.len -= decrease;
+    }
+
     /// Returns the item at location `at`. The return value is a reference to the stored item, plus
     /// the offset from the start (logically, which copy of the item is being returned).
     pub fn get(&self, at: usize) -> Option<(&T, usize)> {
         if at >= self.len {
             return None;
         }
-        match self.items.binary_search_by_key(&at, |(start, _)| *start) {
+        match self.binary_search(at) {
             Ok(exact_idx) => Some((&self.items[exact_idx].1, 0)),
             Err(start_idx) => {
                 // start_idx can never be 0 because usize starts from 0 and items[0].0 is always 0.
@@ -114,6 +212,12 @@ impl<T> RepeatVec<T> {
                 Some((&start_val.1, offset))
             }
         }
+    }
+
+    /// Picks out indexes uniformly randomly from this `RepeatVec`, using the provided
+    /// [`Index`](proptest::sample::Index) instances as sources of randomness.
+    pub fn pick_uniform_indexes(&self, indexes: &[impl AsRef<Index>]) -> Vec<usize> {
+        pick_slice_idxs(self.len(), indexes)
     }
 
     /// Picks out elements uniformly randomly from this `RepeatVec`, using the provided
@@ -126,6 +230,34 @@ impl<T> RepeatVec<T> {
                     .expect("indexes picked should always be in range")
             })
             .collect()
+    }
+
+    #[inline]
+    fn binary_search(&self, at: usize) -> Result<usize, usize> {
+        self.items.binary_search_by_key(&at, |(start, _)| *start)
+    }
+
+    /// Check and assert the internal invariants for this RepeatVec.
+    #[cfg(test)]
+    pub(crate) fn assert_invariants(&self) {
+        for window in self.items.windows(2) {
+            let (idx1, idx2) = match window {
+                [(idx1, _), (idx2, _)] => (*idx1, *idx2),
+                _ => panic!("wrong window size"),
+            };
+            assert!(idx1 < idx2, "no zero-length elements");
+        }
+        match self.items.last() {
+            Some(&(idx, _)) => {
+                assert!(
+                    idx < self.len,
+                    "length must be greater than last element's start"
+                );
+            }
+            None => {
+                assert_eq!(self.len, 0, "empty RepeatVec");
+            }
+        }
     }
 }
 

--- a/common/proptest_helpers/src/unit_tests/repeat_vec_tests.rs
+++ b/common/proptest_helpers/src/unit_tests/repeat_vec_tests.rs
@@ -2,12 +2,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::RepeatVec;
-use proptest::{collection::vec, prelude::*, sample::Index as PropIndex};
+use proptest::{
+    collection::vec, prelude::*, sample::Index as PropIndex, test_runner::TestCaseResult,
+};
+use proptest_derive::Arbitrary;
 use std::{
     collections::HashSet,
-    iter,
+    fmt, iter, mem,
     sync::atomic::{AtomicUsize, Ordering},
 };
+
+trait RepeatVecMethods<T>: fmt::Debug {
+    fn len(&self) -> usize;
+    fn extend(&mut self, item: T, size: usize);
+    fn remove(&mut self, logical_index: usize);
+    fn remove_all(&mut self, logical_indexes: impl IntoIterator<Item = usize>);
+    fn get(&self, at: usize) -> Option<(&T, usize)>;
+}
+
+impl<T> RepeatVecMethods<T> for RepeatVec<T>
+where
+    T: fmt::Debug,
+{
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn extend(&mut self, item: T, size: usize) {
+        self.extend(item, size)
+    }
+
+    fn remove(&mut self, logical_index: usize) {
+        self.remove(logical_index)
+    }
+
+    fn remove_all(&mut self, logical_indexes: impl IntoIterator<Item = usize>) {
+        self.remove_all(logical_indexes)
+    }
+
+    fn get(&self, at: usize) -> Option<(&T, usize)> {
+        self.get(at)
+    }
+}
 
 /// A naive implementation of `RepeatVec` that actually repeats its elements.
 #[derive(Clone, Debug, Default)]
@@ -19,15 +55,17 @@ impl<T> NaiveRepeatVec<T> {
     pub fn new() -> Self {
         Self { items: vec![] }
     }
+}
 
-    pub fn len(&self) -> usize {
+impl<T> RepeatVecMethods<T> for NaiveRepeatVec<T>
+where
+    T: Clone + fmt::Debug,
+{
+    fn len(&self) -> usize {
         self.items.len()
     }
 
-    pub fn extend(&mut self, item: T, size: usize)
-    where
-        T: Clone,
-    {
+    fn extend(&mut self, item: T, size: usize) {
         self.items.extend(
             iter::repeat(item)
                 .enumerate()
@@ -36,7 +74,45 @@ impl<T> NaiveRepeatVec<T> {
         );
     }
 
-    pub fn get(&self, at: usize) -> Option<(&T, usize)> {
+    fn remove(&mut self, logical_index: usize) {
+        self.remove_all(iter::once(logical_index))
+    }
+
+    fn remove_all(&mut self, logical_indexes: impl IntoIterator<Item = usize>) {
+        let mut logical_indexes: Vec<_> = logical_indexes.into_iter().collect();
+        logical_indexes.sort();
+        logical_indexes.dedup();
+
+        let new_items = {
+            let items = self.items.drain(0..);
+            let mut decrease = 0;
+            let mut current_index = 0;
+
+            items
+                .enumerate()
+                .filter_map(move |(idx, (item, offset))| {
+                    if offset == 0 {
+                        // Reset the decrease counter since this is a new item.
+                        decrease = 0;
+                    }
+                    if let Some(remove_idx) = logical_indexes.get(current_index) {
+                        if idx == *remove_idx {
+                            decrease += 1;
+                            current_index += 1;
+                            None
+                        } else {
+                            Some((item, offset - decrease))
+                        }
+                    } else {
+                        Some((item, offset - decrease))
+                    }
+                })
+                .collect()
+        };
+        mem::replace(&mut self.items, new_items);
+    }
+
+    fn get(&self, at: usize) -> Option<(&T, usize)> {
         // Unlike `RepeatVec`, this actually could return &(T, usize) because that's how data is
         // stored internally. But keeping the signature identical makes more sense.
         self.items.get(at).map(|(item, offset)| (item, *offset))
@@ -61,6 +137,74 @@ impl Counter {
     }
 }
 
+/// An operation on a RepeatVec.
+#[derive(Arbitrary, Clone, Debug)]
+#[proptest(params = "usize")]
+enum RepeatVecOp {
+    #[proptest(weight = 3)]
+    Get(PropIndex),
+    #[proptest(weight = 1)]
+    #[proptest(strategy = "(Counter::strategy(), 0..params).prop_map(RepeatVecOp::Extend)")]
+    Extend((Counter, usize)),
+    #[proptest(weight = 1)]
+    Remove(PropIndex),
+    #[proptest(weight = 1)]
+    #[proptest(strategy = "vec(any::<PropIndex>(), 0..params).prop_map(RepeatVecOp::RemoveAll)")]
+    RemoveAll(Vec<PropIndex>),
+}
+
+impl RepeatVecOp {
+    /// Strategy that only produces get operations.
+    fn get_strategy() -> impl Strategy<Value = Self> {
+        any::<PropIndex>().prop_map(RepeatVecOp::Get)
+    }
+}
+
+#[test]
+fn basic_ops() {
+    basic_ops_impl(RepeatVec::new());
+    basic_ops_impl(NaiveRepeatVec::new());
+}
+
+fn basic_ops_impl(repeat_vec: impl RepeatVecMethods<&'static str>) {
+    let mut repeat_vec = repeat_vec;
+
+    repeat_vec.extend("foo", 3);
+    repeat_vec.extend("bar", 4);
+    repeat_vec.extend("baz", 0);
+    assert_eq!(repeat_vec.len(), 7);
+
+    // Basic queries work.
+    assert_eq!(repeat_vec.get(0), Some((&"foo", 0)));
+    assert_eq!(repeat_vec.get(1), Some((&"foo", 1)));
+    assert_eq!(repeat_vec.get(2), Some((&"foo", 2)));
+    assert_eq!(repeat_vec.get(3), Some((&"bar", 0)));
+    assert_eq!(repeat_vec.get(4), Some((&"bar", 1)));
+    assert_eq!(repeat_vec.get(5), Some((&"bar", 2)));
+    assert_eq!(repeat_vec.get(6), Some((&"bar", 3)));
+    assert_eq!(repeat_vec.get(7), None);
+
+    // Removing an element shifts all further elements to the left.
+    repeat_vec.remove(1);
+    assert_eq!(repeat_vec.len(), 6);
+    assert_eq!(repeat_vec.get(0), Some((&"foo", 0)));
+    assert_eq!(repeat_vec.get(1), Some((&"foo", 1)));
+    assert_eq!(repeat_vec.get(2), Some((&"bar", 0)));
+    assert_eq!(repeat_vec.get(3), Some((&"bar", 1)));
+    assert_eq!(repeat_vec.get(4), Some((&"bar", 2)));
+    assert_eq!(repeat_vec.get(5), Some((&"bar", 3)));
+    assert_eq!(repeat_vec.get(6), None);
+
+    // Removing multiple elements shifts all other elements to the left. 6 and 7 are ignored as
+    // out of bounds. Removing 0 and 1 causes the entire surface to be dropped.
+    repeat_vec.remove_all(vec![0, 1, 3, 6, 7]);
+    assert_eq!(repeat_vec.len(), 3);
+    assert_eq!(repeat_vec.get(0), Some((&"bar", 0)));
+    assert_eq!(repeat_vec.get(1), Some((&"bar", 1)));
+    assert_eq!(repeat_vec.get(2), Some((&"bar", 2)));
+    assert_eq!(repeat_vec.get(3), None);
+}
+
 proptest! {
     // Counter uniqueness is not strictly necessary for RepeatVec, but it makes the tests less
     // forgiving.
@@ -72,31 +216,89 @@ proptest! {
     }
 
     #[test]
-    fn repeat_vec(
+    fn repeat_vec_gets(
         item_sizes in vec((Counter::strategy(), 0..1000usize), 0..100),
-        queries in vec(any::<PropIndex>(), 1..5000),
+        gets in vec(RepeatVecOp::get_strategy(), 1..5000),
     ) {
-        let mut test_vec = RepeatVec::new();
-        let mut naive_vec = NaiveRepeatVec::new();
+        repeat_vec_proptest_impl(item_sizes, gets)?;
+    }
 
-        for (item, size) in item_sizes {
-            test_vec.extend(item.clone(), size);
-            naive_vec.extend(item, size);
+    // Run remove ops with smaller numbers as removing is very expensive with the naive RepeatVec.
+    // The numbers here are tweaked to ensure a wide range of sizes from 0 to 256.
+    #[test]
+    fn repeat_vec_all_ops(
+        item_sizes in vec((Counter::strategy(), 0..16usize), 0..32),
+        ops in vec(any_with::<RepeatVecOp>(16), 1..64),
+    ) {
+        repeat_vec_proptest_impl(item_sizes, ops)?;
+    }
+}
+
+fn repeat_vec_proptest_impl(
+    item_sizes: Vec<(Counter, usize)>,
+    ops: Vec<RepeatVecOp>,
+) -> TestCaseResult {
+    let mut test_vec = RepeatVec::new();
+    let mut naive_vec = NaiveRepeatVec::new();
+
+    for (item, size) in item_sizes {
+        test_vec.extend(item.clone(), size);
+        naive_vec.extend(item, size);
+    }
+
+    prop_assert_eq!(test_vec.len(), naive_vec.len());
+
+    fn scaled_index(index: &PropIndex, len: usize) -> usize {
+        // Go roughly 10% beyond the end of the list to also check negative cases.
+        let scaled_len = len + (len / 10);
+        if scaled_len == 0 {
+            // The vector is empty -- return 0, which is beyond the end of the vector
+            // (but that's fine).
+            0
+        } else {
+            index.index(scaled_len)
+        }
+    }
+
+    for op in ops {
+        match op {
+            RepeatVecOp::Get(query) => {
+                // Go beyond the end of the list to also check negative cases.
+                let at = scaled_index(&query, test_vec.len());
+                let test_get = test_vec.get(at);
+                prop_assert_eq!(test_get, naive_vec.get(at));
+                if at >= test_vec.len() {
+                    prop_assert!(test_get.is_none());
+                } else {
+                    prop_assert!(test_get.is_some());
+                }
+            }
+            RepeatVecOp::Extend((counter, size)) => {
+                test_vec.extend(counter.clone(), size);
+                naive_vec.extend(counter.clone(), size);
+            }
+            RepeatVecOp::Remove(prop_index) => {
+                let logical_index = scaled_index(&prop_index, test_vec.len());
+                test_vec.remove(logical_index);
+                naive_vec.remove(logical_index);
+            }
+            RepeatVecOp::RemoveAll(prop_indexes) => {
+                let logical_indexes: Vec<_> = prop_indexes
+                    .into_iter()
+                    .map(|prop_index| {
+                        // Go beyond the end of the list to also check out of bounds cases.
+                        scaled_index(&prop_index, test_vec.len())
+                    })
+                    .collect();
+
+                test_vec.remove_all(logical_indexes.iter().copied());
+                naive_vec.remove_all(logical_indexes);
+            }
         }
 
         prop_assert_eq!(test_vec.len(), naive_vec.len());
-        let len = test_vec.len();
-
-        for query in queries {
-            // Go beyond the end of the list to also check negative cases.
-            let at = query.index(len + 5000);
-            let test_get = test_vec.get(at);
-            prop_assert_eq!(test_get, naive_vec.get(at));
-            if at >= len {
-                prop_assert!(test_get.is_none());
-            } else {
-                prop_assert!(test_get.is_some());
-            }
-        }
+        test_vec.assert_invariants();
     }
+
+    Ok(())
 }


### PR DESCRIPTION
This will be useful for proptesting account universes, such that the probability of an account being selected can be reduced as the account is picked.

Included are both example-based and property-based tests.