### PR TITLE
[VM] Verify native struct

### DIFF
--- a/language/vm/src/views.rs
+++ b/language/vm/src/views.rs
@@ -192,6 +192,14 @@ impl<'a, T: ModuleAccess> StructHandleView<'a, T> {
         }
     }
 
+    pub fn kind(&self) -> &Kind {
+        &self.struct_handle.kind
+    }
+
+    pub fn type_parameter_constraints(&self) -> &Vec<Kind> {
+        &self.struct_handle.kind_constraints
+    }
+
     pub fn definition(&self) -> StructDefinitionView<'a, T> {
         unimplemented!("this requires linking")
     }
@@ -261,6 +269,21 @@ impl<'a, T: ModuleAccess> StructDefinitionView<'a, T> {
 
     pub fn is_resource(&self) -> bool {
         self.struct_handle_view.is_resource()
+    }
+
+    pub fn is_native(&self) -> bool {
+        match &self.struct_def.field_information {
+            StructFieldInformation::Native => true,
+            StructFieldInformation::Declared { .. } => false,
+        }
+    }
+
+    pub fn kind(&self) -> &Kind {
+        self.struct_handle_view.kind()
+    }
+
+    pub fn type_parameter_constraints(&self) -> &Vec<Kind> {
+        self.struct_handle_view.type_parameter_constraints()
     }
 
     pub fn fields(

--- a/language/vm/vm_runtime/vm_runtime_types/src/lib.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/lib.rs
@@ -13,4 +13,5 @@ mod proptest_types;
 
 pub mod loaded_data;
 pub mod native_functions;
+pub mod native_structs;
 pub mod value;

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use types::{account_address::AccountAddress, language_storage::ModuleId};
+use vm::file_format::{Kind, StructHandleIndex};
+
+/// Struct representing the expected definition for a native struct
+pub struct NativeStruct {
+    /// The expected kind of the struct/resource
+    pub expected_kind: Kind,
+    /// The expected kind constraints of the type parameters.
+    pub expected_type_parameters: Vec<Kind>,
+    /// The expected index for the struct
+    /// Helpful for ensuring proper typing of native functions
+    pub expected_index: StructHandleIndex,
+}
+
+/// Looks up the expected native struct definition from the module id (address and module) and
+/// function name where it was expected to be declared
+pub fn dispatch_native_struct(
+    module: &ModuleId,
+    struct_name: &str,
+) -> Option<&'static NativeStruct> {
+    NATIVE_STRUCT_MAP.get(module)?.get(struct_name)
+}
+
+macro_rules! add {
+    ($m:ident, $addr:expr, $module:expr, $name:expr, $kind: expr) => {{
+        add!($m, $addr, $module, $name, $kind, vec![])
+    }};
+    ($m:ident, $addr:expr, $module:expr, $name:expr, $kind: expr, $ty_kinds: expr) => {{
+        let addr = AccountAddress::from_hex_literal($addr).unwrap();
+        let id = ModuleId::new(addr, $module.into());
+        let struct_table = $m.entry(id).or_insert_with(HashMap::new);
+        let expected_index = StructHandleIndex(struct_table.len() as u16);
+
+        let s = NativeStruct {
+            expected_kind: $kind,
+            expected_type_parameters: $ty_kinds,
+            expected_index,
+        };
+        let old = struct_table.insert($name.into(), s);
+        assert!(old.is_none());
+    }};
+}
+
+type NativeStructMap = HashMap<ModuleId, HashMap<String, NativeStruct>>;
+
+lazy_static! {
+    static ref NATIVE_STRUCT_MAP: NativeStructMap = {
+        use Kind::*;
+        let mut m: NativeStructMap = HashMap::new();
+        add!(m, "0x0", "Vector", "T", Copyable);
+        m
+    };
+}

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_structs/mod.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_structs/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod dispatch;


### PR DESCRIPTION
## Motivation

- Added similar dispatch for native structs as exists for native functions
- Utilized the native struct dispatch for builiding the signature of native functions
- Added a check for verifying the linking of native structs
- Cannot yet test easily without IR support (coming shortly)

## Test Plan

cargo check; cargo test

Cannot test the core functionality yet

## Related PRs

Depends on #405 