### PR TITLE
[MoveIR] Added Native Structs to the IR

### DIFF
--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -489,8 +489,10 @@ StructDecl: StructDefinition = {
         for (field, type_) in data.into_iter() {
             fields.insert(field, type_);
         }
-        StructDefinition::new(kind, n, fields)
-    }
+        StructDefinition::move_declared(kind, n, fields)
+    },
+    <native: NativeTag> <kind: StructKind> <n: Name> ";" =>
+        StructDefinition::native(kind, n),
 }
 
 QualifiedModuleIdent: QualifiedModuleIdent = {

--- a/language/functional_tests/tests/testsuite/natives/non_existant_native_struct.mvir
+++ b/language/functional_tests/tests/testsuite/natives/non_existant_native_struct.mvir
@@ -1,0 +1,12 @@
+module M {
+    native struct T;
+    native resource T2;
+}
+
+// check: VerificationError
+// check: StructHandle
+// check: MissingDependency
+
+// check: VerificationError
+// check: StructHandle
+// check: MissingDependency

--- a/language/stdlib/modules/vector.mvir
+++ b/language/stdlib/modules/vector.mvir
@@ -2,7 +2,7 @@
 
 module Vector {
 
-  struct T{}
+  native struct T;
 
   native public length(v: &R#Self.T): u64;
 


### PR DESCRIPTION
## Motivation

- Added native struct syntax to the IR. It is a modifier followed by no fi\
elds
- Added native struct support to the compiler
- Added tests for both the syntax and missing dependencies

## Test Plan
- new test
- cargo  check; cargo test

## Related PRs

Depends on #405 and #413 
