### PR TITLE
process_proposal local channel send should not fail silently

### DIFF
--- a/consensus/src/chained_bft/liveness/local_pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker.rs
@@ -384,7 +384,7 @@ impl LocalPacemaker {
         let timeout_processing_res = { inner.write().unwrap().process_local_timeout(round) };
         if let Some(mut sender) = timeout_processing_res {
             if let Err(e) = sender.send(round).await {
-                warn!("Can't send pacemaker timeout message: {:?}", e)
+                panic!("Error in sending pacemaker timeout message to local channel, uanble to recover: {:?}", e);
             }
         }
     }

--- a/consensus/src/chained_bft/liveness/rotating_proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/rotating_proposer_election.rs
@@ -8,7 +8,6 @@ use crate::chained_bft::{
 };
 use channel;
 use futures::{Future, FutureExt, SinkExt};
-use logger::prelude::*;
 use std::pin::Pin;
 
 /// The rotating proposer maps a round to an author according to a round-robin rotation.
@@ -70,7 +69,7 @@ impl<T: Payload, P: ProposerInfo> ProposerElection<T, P> for RotatingProposer<T,
         let mut sender = self.winning_proposals_sender.clone();
         async move {
             if let Err(e) = sender.send(proposal).await {
-                debug!("Error in sending the winning proposal: {:?}", e);
+                panic!("Error in sending the winning proposal to local channel, unable to recover: {:?}", e);
             }
         }
             .boxed()


### PR DESCRIPTION
## Motivation

The winning_proposals_sender.send can fail silently and leave the pacemaker
in an unproductive state.  If this occurs, it would be better to panic and
restart and recover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unittests