### PR TITLE
gRPC Hackery

### DIFF
--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -26,7 +26,7 @@ use network::{
 };
 use nextgen_crypto::ed25519::*;
 use std::{
-    cmp::max,
+    cmp::min,
     convert::{TryFrom, TryInto},
     sync::Arc,
     thread,
@@ -58,7 +58,7 @@ fn setup_ac(config: &NodeConfig) -> (::grpcio::Server, AdmissionControlClient) {
     let env = Arc::new(
         EnvBuilder::new()
             .name_prefix("grpc-ac-")
-            .cq_count(unsafe { max(grpcio_sys::gpr_cpu_num_cores() as usize / 2, 2) })
+            .cq_count(unsafe { min(grpcio_sys::gpr_cpu_num_cores() as usize * 2, 32) })
             .build(),
     );
     let port = config.admission_control.admission_control_service_port;

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -11,6 +11,7 @@ futures = { version = "0.3.0-alpha.13", package = "futures-preview", features = 
 futures_01 = { version = "0.1.25", package = "futures" }
 grpcio = "0.4.4"
 protobuf = "~2.7"
+rand = "0.6.5"
 
 canonical_serialization = { path = "../../common/canonical_serialization" }
 crypto = { path = "../../crypto/legacy_crypto" }


### PR DESCRIPTION
## Motivation

This PR introduces a few small changes to improve our gRPC use.
The gRPC library we use (pingcap/grpc-rs) is a Rust wrapper around the C gRPC implementation. The C implementation is targeted towards a common use case of many clients -> few servers. There are specific optimizations there to support this use case, but they're not suitable for our in-process use case. 

Changes:
1) Increase the AdmissionControl executor pool size. This increases the availability of our system to clients. Mempool provides the queuing, and we can stop accepting requests when Mempool is full.
2) Change the clients generated by benchmarker to report different user-agents. We want the benchmarker to appear like many different clients, to utilize multiple AC threads, and this is how we achieve it.
3) Use the same approach for storage client, to prevent all internal components waiting on the same storage thread.
There are other ways to force-use more of the threads in the executor pool (e.g., aggressively limiting slots in completion queues), but storage client has a convenient wrapper, so using multiple clients under the hood is a reasonable solution in this case.

This is one step towards #422, and all the code/components here might change later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
y

## Test Plan

1. Circle CI testing
2. Tested locally:

Start `libra_swarm`
```
$ cargo build -p libra_swarm && target/debug/libra_swarm -n 1
Faucet account created in (loaded from) file "/tmp/keypair.aqHiOVHw5zvx/temp_faucet_keys"
Base directory containing logs and configs: Temporary(TempDir { path: "/tmp/.tmpZrVMQI" })
           To run the Libra CLI client in a separate process and connect to the local cluster of nodes you just spawned, use this command:
        cargo run --bin client -- -a localhost -p 36615 -s "/tmp/.tmpZrVMQI/trusted_peers.config.toml" -m "/tmp/keypair.aqHiOVHw5zvx/temp_faucet_keys"
CTRL-C to exit.
```

Start benchmarker
```
$ cargo build -p benchmark && target/debug/ruben -f /tmp/keypair.aqHiOVHw5zvx/temp_faucet_keys  -s /tmp/.tmpZrVMQI  -e 10 -c 32 -n 32
```

Observe that 
a) All gRPC AC threads are in use. We can send more benchmark requests without waiting in a single completion queue.
b) All storage server threads are in use.
c) This results in more stable and slightly faster execution times and overall throughput.

Related to #422