### PR TITLE
[crypto] Changes `types::SignedTransaction` to use the nextgen crypto API

### DIFF
--- a/admission_control/admission_control_proto/Cargo.toml
+++ b/admission_control/admission_control_proto/Cargo.toml
@@ -18,5 +18,8 @@ mempool = { path = "../../mempool" }
 proto_conv = { path = "../../common/proto_conv" }
 types = { path = "../../types" }
 
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"]}
+
 [build-dependencies]
 build_helpers = { path = "../../common/build_helpers" }

--- a/admission_control/admission_control_service/Cargo.toml
+++ b/admission_control/admission_control_service/Cargo.toml
@@ -23,6 +23,7 @@ grpc_helpers = { path = "../../common/grpc_helpers" }
 logger = { path = "../../common/logger" }
 mempool = { path = "../../mempool" }
 metrics = { path = "../../common/metrics" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv" }
 storage_client = { path = "../../storage/storage_client" }
 types = { path = "../../types" }
@@ -30,7 +31,9 @@ vm_validator = { path = "../../vm_validator" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
+rand = "0.6.5"
 storage_service = { path = "../../storage/storage_service" }
+types = { path = "../../types", features = ["testing"] }
 
 [build-dependencies]
 build_helpers = { path = "../../common/build_helpers" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -28,7 +28,11 @@ libra_wallet = { path = "../client/libra_wallet" }
 libra_swarm = { path = "../libra_swarm" }
 logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 rusty-fork = "0.2.1"
 types = { path = "../types" }
 vm_genesis = { path = "../language/vm/vm_genesis" }
+
+[dev-dependencies]
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -36,3 +36,11 @@ metrics = { path = "../common/metrics" }
 proto_conv = { path = "../common/proto_conv" }
 types = { path = "../types" }
 vm_genesis = { path = "../language/vm/vm_genesis" }
+
+[dev-dependencies]
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"] }
+types = { path = "../types", features = ["testing"]}
+
+[features]
+default = []
+testing = ["types/testing", "nextgen_crypto/testing"]

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -17,12 +17,10 @@ serde = "1.0.96"
 tiny-keccak = "1.5.0"
 protobuf = "~2.7"
 sha3 = "0.8.2"
+types = { path = "../../types" }
 
 [dependencies.ed25519-dalek]
 version = "1.0.0-pre.1"
-
-[dependencies.types]
-path = "../../types"
 
 [dependencies.libra_crypto]
 path = "../../crypto/legacy_crypto"
@@ -37,3 +35,4 @@ package = "failure_ext"
 
 [dev-dependencies]
 tempfile = "3.1.0"
+types = { path = "../../types", features = ["testing"]}

--- a/common/executable_helpers/Cargo.toml
+++ b/common/executable_helpers/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 clap = "2.32.0"
 slog-scope = "4.0"
 
-config = { path = "../../config" }
+config = { path = "../../config", features = ["testing"]}
 crash_handler = { path = "../crash_handler" }
 logger =  { path = "../logger" }
 metrics = { path = "../metrics" }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -24,7 +24,8 @@ failure = { path = "../common/failure_ext", package = "failure_ext" }
 types = { path = "../types" }
 
 [dev-dependencies]
-nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"]}
+types = { path = "../types", features = ["testing"] }
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"] }
 
 [features]
 default = []

--- a/config/config_builder/Cargo.toml
+++ b/config/config_builder/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 bincode = "1.1.1"
 clap = "2.32"
 hex = "0.3.2"
+rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 tempfile = "3.1.0"
 toml = "0.4"
@@ -22,3 +23,6 @@ generate_keypair = { path = "../generate_keypair" }
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 types = { path = "../../types" }
 vm_genesis = { path = "../../language/vm/vm_genesis" }
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"]}

--- a/config/config_builder/src/util.rs
+++ b/config/config_builder/src/util.rs
@@ -5,16 +5,17 @@ use config::{
     config::{NodeConfig, NodeConfigHelpers},
     trusted_peers::{TrustedPeersConfig, TrustedPeersConfigHelpers},
 };
-use crypto::signing::{self, KeyPair};
 use failure::prelude::*;
+use nextgen_crypto::{ed25519::*, test_utils::KeyPair};
 use proto_conv::IntoProtoBytes;
+use rand::{Rng, SeedableRng};
 use std::{convert::TryFrom, fs::File, io::prelude::*, path::Path};
 use types::{account_address::AccountAddress, validator_public_keys::ValidatorPublicKeys};
 use vm_genesis::encode_genesis_transaction_with_validator;
 
 pub fn gen_genesis_transaction<P: AsRef<Path>>(
     path: P,
-    faucet_account_keypair: &KeyPair,
+    faucet_account_keypair: &KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
     trusted_peer_config: &TrustedPeersConfig,
 ) -> Result<()> {
     let validator_set = trusted_peer_config
@@ -30,8 +31,8 @@ pub fn gen_genesis_transaction<P: AsRef<Path>>(
         })
         .collect();
     let transaction = encode_genesis_transaction_with_validator(
-        faucet_account_keypair.private_key(),
-        faucet_account_keypair.public_key(),
+        &faucet_account_keypair.private_key,
+        faucet_account_keypair.public_key.clone(),
         validator_set,
     );
     let mut file = File::create(path)?;
@@ -40,11 +41,16 @@ pub fn gen_genesis_transaction<P: AsRef<Path>>(
 }
 
 /// Returns the config as well as the genesis keyapir
-pub fn get_test_config() -> (NodeConfig, KeyPair) {
+pub fn get_test_config() -> (NodeConfig, KeyPair<Ed25519PrivateKey, Ed25519PublicKey>) {
     // TODO: test config should be moved here instead of config crate
     let config = NodeConfigHelpers::get_single_node_test_config(true);
-    let (private_key, _) = signing::generate_keypair();
-    let keypair = KeyPair::new(private_key);
+    // Those configs should be different on every call. We bypass the
+    // costly StdRng initialization
+    let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
+    let seed_buf: [u8; 32] = seed_rng.gen();
+    let mut rng = rand::rngs::StdRng::from_seed(seed_buf);
+    let (private_key, _) = compat::generate_keypair(&mut rng);
+    let keypair = KeyPair::from(private_key);
 
     gen_genesis_transaction(
         &config.execution.genesis_file_location,

--- a/config/generate_keypair/Cargo.toml
+++ b/config/generate_keypair/Cargo.toml
@@ -15,3 +15,4 @@ tempdir = "0.3.7"
 
 crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto/"}

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -293,7 +293,7 @@ where
         if li_with_sig.signatures().contains_key(&author) {
             return VoteReceptionResult::DuplicateVote;
         }
-        li_with_sig.add_signature(author, vote_msg.signature().clone().into());
+        li_with_sig.add_signature(author, vote_msg.signature().clone());
 
         let num_votes = li_with_sig.signatures().len();
         if num_votes >= min_votes_for_qc {

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -128,7 +128,7 @@ impl ChainedBftProvider {
         let peers_with_nextgen_public_keys = peers_with_public_keys
             .clone()
             .into_iter()
-            .map(|(k, v)| (AccountAddress::clone(&k), v.into()))
+            .map(|(k, v)| (AccountAddress::clone(&k), v))
             .collect();
         let peers = Arc::new(
             peers_with_public_keys

--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -143,7 +143,7 @@ where
             timestamp_usecs: 0, // The beginning of UNIX TIME
             quorum_cert: genesis_quorum_cert,
             author: genesis_validator_signer.author(),
-            signature: signature.into(),
+            signature,
         }
     }
 

--- a/consensus/src/chained_bft/consensus_types/quorum_cert.rs
+++ b/consensus/src/chained_bft/consensus_types/quorum_cert.rs
@@ -150,7 +150,7 @@ impl QuorumCert {
             .sign_message(li.hash())
             .expect("Fail to sign genesis ledger info");
         let mut signatures = HashMap::new();
-        signatures.insert(signer.author(), signature.into());
+        signatures.insert(signer.author(), signature);
         QuorumCert::new(
             *GENESIS_BLOCK_ID,
             ExecutedState::state_for_genesis(),

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -14,7 +14,7 @@ use crate::{
     state_replication::ExecutedState,
 };
 use channel;
-use crypto::{signing::generate_keypair, HashValue};
+use crypto::HashValue;
 use futures::{channel::mpsc, executor::block_on, FutureExt, SinkExt, StreamExt, TryFutureExt};
 use network::{
     interface::{NetworkNotification, NetworkRequest},
@@ -471,7 +471,7 @@ fn test_rpc() {
     let mut chunk_retrieval = receiver_1.chunk_retrieval;
     let on_request_chunk = async move {
         while let Some(request) = chunk_retrieval.next().await {
-            let keypair = generate_keypair();
+            let keypair = compat::generate_keypair(None);
             let proto_txn =
                 get_test_signed_txn(AccountAddress::random(), 0, keypair.0, keypair.1, None);
             let txn = SignedTransaction::from_proto(proto_txn).unwrap();

--- a/consensus/src/chained_bft/safety/vote_msg.rs
+++ b/consensus/src/chained_bft/safety/vote_msg.rs
@@ -157,7 +157,7 @@ impl VoteMsg {
             grandparent_block_round,
             author,
             ledger_info: ledger_info_placeholder,
-            signature: li_sig.into(),
+            signature: li_sig,
         }
     }
 

--- a/consensus/src/state_synchronizer/mocks.rs
+++ b/consensus/src/state_synchronizer/mocks.rs
@@ -40,14 +40,14 @@ impl ExecutorProxyTrait for MockExecutorProxy {
 }
 
 pub fn gen_txn_list(sequence_number: u64) -> TransactionListWithProof {
-    let sender = AccountAddress::from(GENESIS_KEYPAIR.1);
+    let sender = AccountAddress::from_public_key(&GENESIS_KEYPAIR.1);
     let receiver = AccountAddress::new([0xff; 32]);
     let program = encode_transfer_program(&receiver, 1);
     let transaction = get_test_signed_txn(
         sender.into(),
         sequence_number,
         GENESIS_KEYPAIR.0.clone(),
-        GENESIS_KEYPAIR.1,
+        GENESIS_KEYPAIR.1.clone(),
         Some(program),
     );
 

--- a/crypto/nextgen_crypto/src/ed25519.rs
+++ b/crypto/nextgen_crypto/src/ed25519.rs
@@ -468,6 +468,10 @@ pub mod compat {
 
     use rand::{rngs::StdRng, SeedableRng};
     /// Generate an arbitrary key pair, with possible Rng input
+    ///
+    /// Warning: if you pass in None, this will not return distinct
+    /// results every time! Should you want to write non-deterministic
+    /// tests, look at config::config_builder::util::get_test_config
     pub fn generate_keypair<'a, T>(opt_rng: T) -> (Ed25519PrivateKey, Ed25519PublicKey)
     where
         T: Into<Option<&'a mut StdRng>> + Sized,

--- a/crypto/nextgen_crypto/src/test_utils.rs
+++ b/crypto/nextgen_crypto/src/test_utils.rs
@@ -5,13 +5,14 @@
 
 use crate::traits::Uniform;
 use bincode::serialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A deterministic seed for PRNGs related to keys
 pub const TEST_SEED: [u8; 32] = [0u8; 32];
 
 /// A keypair consisting of a private and public key
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyPair<S, P>
 where
     for<'a> P: From<&'a S>,

--- a/execution/execution_client/Cargo.toml
+++ b/execution/execution_client/Cargo.toml
@@ -13,3 +13,6 @@ execution_proto = { path = "../execution_proto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 types = { path = "../../types" }
 proto_conv = { path = "../../common/proto_conv" }
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/execution/execution_service/Cargo.toml
+++ b/execution/execution_service/Cargo.toml
@@ -20,3 +20,6 @@ proto_conv = { path = "../../common/proto_conv" }
 storage_client = { path = "../../storage/storage_client" }
 types = { path = "../../types" }
 vm_runtime = { path = "../../language/vm/vm_runtime" }
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/execution/execution_tests/Cargo.toml
+++ b/execution/execution_tests/Cargo.toml
@@ -21,9 +21,14 @@ execution_proto = { path = "../execution_proto" }
 execution_service = { path = "../execution_service" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../../common/grpc_helpers" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv" }
 storage_client = { path = "../../storage/storage_client" }
 storage_proto = { path = "../../storage/storage_proto" }
 storage_service = { path = "../../storage/storage_service" }
 types = { path = "../../types" }
 vm_genesis = { path = "../../language/vm/vm_genesis" }
+
+[dev-dependencies]
+rand = "0.6.5"
+nextgen_crypto = { path = "../../crypto/nextgen_crypto", features = ["testing"] }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -18,6 +18,7 @@ execution_proto = { path = "../execution_proto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 logger = { path = "../../common/logger" }
 metrics = { path = "../../common/metrics" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv" }
 scratchpad = { path = "../../storage/scratchpad" }
 state_view = { path = "../../storage/state_view" }
@@ -30,6 +31,8 @@ vm_genesis = { path = "../../language/vm/vm_genesis" }
 grpcio = "0.4.4"
 proptest = "0.9.2"
 rusty-fork = "0.2.1"
+
+types = { path = "../../types", features = ["testing"]}
 
 storage_proto = { path = "../../storage/storage_proto" }
 storage_service = { path = "../../storage/storage_service" }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -34,7 +34,7 @@ fn get_config() -> NodeConfig {
     let config = NodeConfigHelpers::get_single_node_test_config(true);
     // Write out the genesis blob to the correct location.
     // XXX Should this logic live in NodeConfigHelpers?
-    let genesis_txn = encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1);
+    let genesis_txn = encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1.clone());
     let mut file = File::create(&config.execution.genesis_file_location).unwrap();
     file.write_all(&genesis_txn.into_proto_bytes().unwrap())
         .unwrap();

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -5,7 +5,7 @@
 mod mock_vm_test;
 
 use config::config::VMConfig;
-use crypto::signing::generate_keypair;
+use nextgen_crypto::ed25519::compat;
 use state_view::StateView;
 use std::collections::HashMap;
 use types::{
@@ -267,7 +267,7 @@ fn encode_transaction(sender: AccountAddress, program: Program) -> SignedTransac
     let raw_transaction =
         RawTransaction::new(sender, 0, program, 0, 0, std::time::Duration::from_secs(0));
 
-    let (privkey, pubkey) = generate_keypair();
+    let (privkey, pubkey) = compat::generate_keypair(None);
     raw_transaction
         .sign(&privkey, pubkey)
         .expect("Failed to sign raw transaction.")

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -14,6 +14,9 @@ language_e2e_tests = { path = "../e2e_tests" }
 proptest_helpers = { path = "../../common/proptest_helpers" }
 types = { path = "../../types" }
 
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }
+
 [[bench]]
 name = "transactions"
 harness = false

--- a/language/bytecode_verifier/invalid_mutations/Cargo.toml
+++ b/language/bytecode_verifier/invalid_mutations/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 proptest = "0.9"
 proptest_helpers = { path = "../../../common/proptest_helpers" }
 vm = { path = "../../vm" }
+
+[dev-dependencies]
+vm = { path = "../../vm", features = ["testing"] }

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -16,3 +16,6 @@ vm = { path = "../vm" }
 log = "0.4.7"
 structopt = "0.2.15"
 serde_json = "1.0.40"
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/language/compiler/ir_to_bytecode/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/Cargo.toml
@@ -16,3 +16,6 @@ log = "0.4.7"
 codespan = "0.1.3"
 codespan-reporting = "0.1.4"
 regex = "1.1.9"
+
+[dev-dependencies]
+types = { path = "../../../types", features = ["testing"] }

--- a/language/compiler/ir_to_bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/syntax/Cargo.toml
@@ -15,5 +15,8 @@ lalrpop-util = "0.16.3"
 regex = "1.1.9"
 types = { path = "../../../../types" }
 
+[dev-dependencies]
+types = { path = "../../../../types", features = ["testing"] }
+
 [build-dependencies]
 lalrpop = "0.16.3"

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -14,6 +14,8 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 compiler = { path = "../compiler" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 lazy_static = "1.3.0"
+nextgen_crypto = { path = "../../crypto/nextgen_crypto"}
+rand = "0.6.5"
 state_view = { path = "../../storage/state_view" }
 types = { path = "../../types" }
 vm = { path = "../vm" }
@@ -30,3 +32,6 @@ vm_genesis = { path = "../vm/vm_genesis" }
 config =  { path = "../../config" }
 logger = { path = "../../common/logger" }
 stdlib = { path = "../stdlib" }
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/language/e2e_tests/src/account_universe.rs
+++ b/language/e2e_tests/src/account_universe.rs
@@ -27,8 +27,8 @@ use crate::{
     account::{Account, AccountData},
     gas_costs,
 };
-use crypto::{PrivateKey, PublicKey};
 use lazy_static::lazy_static;
+use nextgen_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use proptest::{prelude::*, strategy::Union};
 use std::fmt;
 use types::{
@@ -132,7 +132,7 @@ impl AccountCurrent {
     }
 
     /// Rotates the key in this account.
-    pub fn rotate_key(&mut self, privkey: PrivateKey, pubkey: PublicKey) {
+    pub fn rotate_key(&mut self, privkey: Ed25519PrivateKey, pubkey: Ed25519PublicKey) {
         self.initial_data.rotate_key(privkey, pubkey);
     }
 

--- a/language/e2e_tests/src/account_universe/rotate_key.rs
+++ b/language/e2e_tests/src/account_universe/rotate_key.rs
@@ -6,7 +6,7 @@ use crate::{
     common_transactions::rotate_key_txn,
     gas_costs,
 };
-use crypto::{utils::keypair_strategy, PrivateKey, PublicKey};
+use nextgen_crypto::ed25519::{compat::keypair_strategy, *};
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use proptest_helpers::Index;
@@ -22,14 +22,14 @@ use types::{
 pub struct RotateKeyGen {
     sender: Index,
     #[proptest(strategy = "keypair_strategy()")]
-    new_key: (PrivateKey, PublicKey),
+    new_key: (Ed25519PrivateKey, Ed25519PublicKey),
 }
 
 impl AUTransactionGen for RotateKeyGen {
     fn apply(&self, universe: &mut AccountUniverse) -> (SignedTransaction, TransactionStatus) {
         let sender = universe.pick(&self.sender).1;
 
-        let new_key_hash = AccountAddress::from(self.new_key.1);
+        let new_key_hash = AccountAddress::from_public_key(&self.new_key.1);
         let txn = rotate_key_txn(sender.account(), new_key_hash, sender.sequence_number);
 
         // This should work all the time except for if the balance is too low for gas.
@@ -37,7 +37,7 @@ impl AUTransactionGen for RotateKeyGen {
         let status = if enough_max_gas {
             sender.sequence_number += 1;
             sender.balance -= *gas_costs::ROTATE_KEY;
-            let (privkey, pubkey) = (self.new_key.0.clone(), self.new_key.1);
+            let (privkey, pubkey) = (self.new_key.0.clone(), self.new_key.1.clone());
             sender.rotate_key(privkey, pubkey);
 
             TransactionStatus::Keep(VMStatus::Execution(ExecutionStatus::Executed))

--- a/language/e2e_tests/src/tests/genesis.rs
+++ b/language/e2e_tests/src/tests/genesis.rs
@@ -3,7 +3,7 @@
 
 use crate::{assert_prologue_parity, executor::FakeExecutor};
 use assert_matches::assert_matches;
-use crypto::signing::KeyPair;
+use nextgen_crypto::ed25519::*;
 use types::{
     access_path::AccessPath,
     account_config,
@@ -20,12 +20,12 @@ fn invalid_genesis_write_set() {
     let write_op = (AccessPath::default(), WriteOp::Deletion);
     let write_set = WriteSetMut::new(vec![write_op]).freeze().unwrap();
     let address = account_config::association_address();
-    let keypair = KeyPair::new(::crypto::signing::generate_keypair().0);
+    let (private_key, public_key) = compat::generate_keypair(None);
     let signed_txn = transaction_test_helpers::get_write_set_txn(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        private_key,
+        public_key,
         Some(write_set),
     )
     .into_inner();

--- a/language/e2e_tests/src/tests/rotate_key.rs
+++ b/language/e2e_tests/src/tests/rotate_key.rs
@@ -6,6 +6,7 @@ use crate::{
     common_transactions::{create_account_txn, rotate_key_txn},
     executor::FakeExecutor,
 };
+use nextgen_crypto::ed25519::compat;
 use types::{
     account_address::AccountAddress,
     transaction::TransactionStatus,
@@ -20,8 +21,8 @@ fn rotate_key() {
     let mut sender = AccountData::new(1_000_000, 10);
     executor.add_account_data(&sender);
 
-    let (privkey, pubkey) = crypto::signing::generate_keypair();
-    let new_key_hash = AccountAddress::from(pubkey);
+    let (privkey, pubkey) = compat::generate_keypair(None);
+    let new_key_hash = AccountAddress::from_public_key(&pubkey);
     let txn = rotate_key_txn(sender.account(), new_key_hash, 10);
 
     // execute transaction

--- a/language/e2e_tests/src/tests/verify_txn.rs
+++ b/language/e2e_tests/src/tests/verify_txn.rs
@@ -12,7 +12,7 @@ use assert_matches::assert_matches;
 use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
 use config::config::{NodeConfigHelpers, VMPublishingOption};
-use crypto::signing::KeyPair;
+use nextgen_crypto::ed25519::*;
 use std::collections::HashSet;
 use tiny_keccak::Keccak;
 use types::{
@@ -34,13 +34,13 @@ fn verify_signature() {
     let sender = AccountData::new(900_000, 10);
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
-    let other_keypair = KeyPair::new(::crypto::signing::generate_keypair().0);
+    let (private_key, _public_key) = compat::generate_keypair(None);
     let program = encode_transfer_program(sender.address(), 100);
     let signed_txn = transaction_test_helpers::get_test_unchecked_txn(
         *sender.address(),
         0,
-        other_keypair.private_key().clone(),
-        sender.account().pubkey,
+        private_key,
+        sender.account().pubkey.clone(),
         Some(program),
     );
 
@@ -60,7 +60,7 @@ fn verify_rejected_write_set() {
         *sender.address(),
         0,
         sender.account().privkey.clone(),
-        sender.account().pubkey,
+        sender.account().pubkey.clone(),
         None,
     )
     .into_inner();

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -20,3 +20,6 @@ filecheck = "0.4.0"
 datatest = "0.3.5"
 lazy_static = "1.3.0"
 regex = "1.1.9"
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -131,7 +131,7 @@ fn run_transaction(
         1,
         Duration::from_secs(u64::max_value()),
     )
-    .sign(&account.privkey, account.pubkey)?
+    .sign(&account.privkey, account.pubkey.clone())?
     .into_inner();
 
     let mut outputs = exec.execute_block(vec![transaction]);

--- a/language/stackless_bytecode_generator/Cargo.toml
+++ b/language/stackless_bytecode_generator/Cargo.toml
@@ -15,3 +15,4 @@ ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 [dev-dependencies]
 # invalid_mutations = { path = "invalid_mutations" }
 proptest = "0.9"
+types = { path = "../../types", features = ["testing"]}

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -11,3 +11,6 @@ bytecode_verifier = { path = "../bytecode_verifier" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 types = { path = "../../types" }
 lazy_static = "1.3.0"
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/language/tools/cost_synthesis/Cargo.toml
+++ b/language/tools/cost_synthesis/Cargo.toml
@@ -24,5 +24,8 @@ crypto = { path = "../../../crypto/legacy_crypto" }
 state_view = { path = "../../../storage/state_view" }
 structopt = "0.2.15"
 
+[dev-dependencies]
+types = { path = "../../../types", features = ["testing"] }
+
 [features]
 default = ["vm_runtime/instruction_synthesis"]

--- a/language/tools/repl/Cargo.toml
+++ b/language/tools/repl/Cargo.toml
@@ -16,3 +16,6 @@ stdlib = { path = "../../stdlib" }
 types = { path = "../../../types" }
 vm_runtime = { path = "../../vm/vm_runtime" }
 hex = "0.3.2"
+
+[dev-dependencies]
+types = { path = "../../../types", features = ["testing"] }

--- a/language/transaction_builder/Cargo.toml
+++ b/language/transaction_builder/Cargo.toml
@@ -14,6 +14,9 @@ structopt = { version = "0.2.15", optional = true }
 serde_json = { version = "1.0.40", optional = true }
 proto_conv = { path = "../../common/proto_conv", optional = true }
 
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"]}
+
 [features]
 build-binary = ["structopt", "serde_json", "proto_conv"]
 

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -18,7 +18,7 @@ impl TransactionMetadata {
     pub fn new(txn: &SignedTransaction) -> Self {
         Self {
             sender: txn.sender(),
-            public_key: txn.public_key(),
+            public_key: txn.public_key().into(),
             sequence_number: txn.sequence_number(),
             max_gas_amount: GasUnits::new(txn.max_gas_amount()),
             gas_unit_price: GasPrice::new(txn.gas_unit_price()),

--- a/language/vm/vm_genesis/Cargo.toml
+++ b/language/vm/vm_genesis/Cargo.toml
@@ -11,6 +11,7 @@ config = { path = "../../../config" }
 crypto = { path = "../../../crypto/legacy_crypto" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
+nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
 stdlib = { path = "../../stdlib" }
 proto_conv = { path = "../../../common/proto_conv", features = ["derive"] }
 state_view = { path = "../../../storage/state_view" }
@@ -27,6 +28,7 @@ toml = "0.4"
 
 [dev-dependencies]
 canonical_serialization = { path = "../../../common/canonical_serialization" }
+nextgen_crypto = { path = "../../../crypto/nextgen_crypto", features = ["testing"]}
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
 proptest_helpers = { path = "../../../common/proptest_helpers" }

--- a/language/vm/vm_genesis/src/main.rs
+++ b/language/vm/vm_genesis/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     config.save_config(CONFIG_LOCATION);
 
     // Generate a genesis blob used for vm tests.
-    let genesis_txn = encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1);
+    let genesis_txn = encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1.clone());
     let mut file = File::create(GENESIS_LOCATION).unwrap();
     file.write_all(&genesis_txn.into_proto_bytes().unwrap())
         .unwrap();

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -38,3 +38,4 @@ vm_validator = { path = "../vm_validator" }
 
 [dev-dependencies]
 config_builder = { path = "../config/config_builder" }
+types = { path = "../types", features = ["testing"]}

--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -161,7 +161,7 @@ pub fn setup_network(
             (
                 peer_id,
                 NetworkPublicKeys {
-                    signing_public_key: signing_public_key.into(),
+                    signing_public_key,
                     identity_public_key,
                 },
             )

--- a/libra_swarm/Cargo.toml
+++ b/libra_swarm/Cargo.toml
@@ -22,4 +22,12 @@ debug_interface = { path = "../common/debug_interface" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }
 logger = { path = "../common/logger" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 tools = { path = "../common/tools" }
+
+[dev-dependencies]
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"]}
+
+[features]
+default = []
+testing = ["nextgen_crypto/testing", "client_lib/testing"]

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -7,10 +7,10 @@ use crate::{
 };
 use config::config::NodeConfig;
 use config_builder::swarm_config::{SwarmConfig, SwarmConfigBuilder};
-use crypto::signing::KeyPair;
 use debug_interface::NodeDebugClient;
 use failure::prelude::*;
 use logger::prelude::*;
+use nextgen_crypto::{ed25519::*, test_utils::KeyPair};
 use std::{
     collections::HashMap,
     env,
@@ -252,7 +252,7 @@ impl LibraSwarm {
     pub fn launch_swarm(
         num_nodes: usize,
         disable_logging: bool,
-        faucet_account_keypair: KeyPair,
+        faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
         config_dir: Option<String>,
     ) -> Self {
@@ -278,7 +278,7 @@ impl LibraSwarm {
     fn launch_swarm_attempt(
         num_nodes: usize,
         disable_logging: bool,
-        faucet_account_keypair: KeyPair,
+        faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
         config_dir: &Option<String>,
     ) -> std::result::Result<Self, SwarmLaunchFailure> {

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -25,6 +25,7 @@ grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 network = { path = "../network" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 storage_client = { path = "../storage/storage_client" }
 types = { path = "../types" }
@@ -34,8 +35,8 @@ vm_validator = { path = "../vm_validator" }
 rand = "0.6.5"
 tempfile = "3.1.0"
 channel = { path = "../common/channel" }
-
 storage_service = { path = "../storage/storage_service" }
+types = { path = "../types", features = ["testing"] }
 
 [build-dependencies]
 build_helpers = { path = "../common/build_helpers" }

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -6,9 +6,9 @@ use crate::{
     proto::shared::mempool_status::MempoolAddTransactionStatusCode,
 };
 use config::config::NodeConfigHelpers;
-use crypto::signing::generate_keypair_for_testing;
 use failure::prelude::*;
 use lazy_static::lazy_static;
+use nextgen_crypto::ed25519::*;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::HashSet, iter::FromIterator};
 use types::{
@@ -81,7 +81,7 @@ impl TestTransaction {
         let mut seed: [u8; 32] = [0u8; 32];
         seed[..4].copy_from_slice(&[1, 2, 3, 4]);
         let mut rng: StdRng = StdRng::from_seed(seed);
-        let (privkey, pubkey) = generate_keypair_for_testing(&mut rng);
+        let (privkey, pubkey) = compat::generate_keypair(&mut rng);
         raw_txn
             .sign(&privkey, pubkey)
             .expect("Failed to sign raw transaction.")

--- a/mempool/src/unit_tests/service_test.rs
+++ b/mempool/src/unit_tests/service_test.rs
@@ -11,9 +11,9 @@ use crate::{
     },
 };
 use config::config::NodeConfigHelpers;
-use crypto::signing::generate_keypair;
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder};
+use nextgen_crypto::ed25519::compat::generate_keypair;
 use proto_conv::FromProto;
 use std::{
     sync::{Arc, Mutex},
@@ -47,7 +47,7 @@ fn setup_mempool() -> (::grpcio::Server, MempoolClient) {
 fn create_add_transaction_request(expiration_time: u64) -> AddTransactionWithValidationRequest {
     let mut req = AddTransactionWithValidationRequest::new();
     let sender = AccountAddress::random();
-    let (private_key, public_key) = generate_keypair();
+    let (private_key, public_key) = generate_keypair(None);
 
     let transaction = get_test_signed_transaction(
         sender,

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -477,10 +477,7 @@ fn verify_signatures(
             .unwrap()
             .iter()
             .map(|(peer_id, network_public_keys)| {
-                (
-                    *peer_id,
-                    network_public_keys.signing_public_key.clone().into(),
-                )
+                (*peer_id, network_public_keys.signing_public_key.clone())
             })
             .collect(),
         1, /* quorum size */

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -15,3 +15,4 @@ types = { path = "../../types" }
 
 [dev-dependencies]
 rand = "0.6.5"
+types = { path = "../../types", features = ["testing"] }

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -36,7 +36,7 @@ fn gen_mock_genesis() -> (
         /* expiration_time = */ std::time::Duration::new(0, 0),
     );
     let signed_txn = raw_txn
-        .sign(&privkey, pubkey)
+        .sign(&privkey.into(), pubkey.into())
         .expect("Signing failed.")
         .into_inner();
     let signed_txn_hash = signed_txn.hash();

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -14,3 +14,4 @@ types = { path = "../../types" }
 
 [dev-dependencies]
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+types = { path = "../../types", features = ["testing"] }

--- a/storage/sparse_merkle/Cargo.toml
+++ b/storage/sparse_merkle/Cargo.toml
@@ -22,3 +22,5 @@ types = { path = "../../types" }
 proptest = "0.9"
 rand = "0.6.5"
 serde_test = "1.0.96"
+
+types = { path = "../../types", features = ["testing"]}

--- a/storage/state_view/Cargo.toml
+++ b/storage/state_view/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 [dependencies]
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 types = { path = "../../types" }
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"]}

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -21,3 +21,6 @@ scratchpad = { path = "../scratchpad" }
 state_view = { path = "../state_view" }
 storage_proto = { path = "../storage_proto" }
 types = { path = "../../types" }
+
+[dev-dependencies]
+types = { path = "../../types", features = ["testing"] }

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -243,7 +243,8 @@ fn get_mock_txn_data(
     let mut txns = vec![];
     let mut infos = vec![];
     for i in start_seq..=end_seq {
-        let signed_txn = get_test_signed_txn(address, i, priv_key.clone(), pub_key, None);
+        let signed_txn =
+            get_test_signed_txn(address, i, priv_key.clone().into(), pub_key.into(), None);
         txns.push(signed_txn);
 
         let info = get_transaction_info().into_proto();

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -16,6 +16,6 @@ rust_decimal = "1.0.1"
 # should have their crates listed as dev-dependencies.
 cli = { path = "../client", package="client" }
 generate_keypair = { path = "../config/generate_keypair" }
-libra_swarm = { path = "../libra_swarm" }
+libra_swarm = { path = "../libra_swarm", features = ["testing"]}
 logger = { path = "../common/logger" }
 tempfile = "3.1.0"

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -21,9 +21,9 @@ use crypto::{
         CryptoHash, TestOnlyHash, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH,
         GENESIS_BLOCK_ID, SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
-    signing::generate_keypair,
     HashValue,
 };
+use nextgen_crypto::ed25519::*;
 use proptest::{collection::vec, prelude::*};
 
 #[test]
@@ -355,9 +355,9 @@ fn test_verify_account_state_and_event() {
     let txn_info0_hash = b"hellohello".test_only_hash();
     let txn_info1_hash = b"worldworld".test_only_hash();
 
-    let (privkey, pubkey) = generate_keypair();
+    let (privkey, pubkey) = compat::generate_keypair(None);
     let txn2_hash = RawTransaction::new(
-        AccountAddress::from(pubkey),
+        AccountAddress::from_public_key(&pubkey),
         /* sequence_number = */ 0,
         Program::new(vec![], vec![], vec![]),
         /* max_gas_amount = */ 0,

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -14,7 +14,8 @@ use crate::{
     transaction_helpers::get_signed_transactions_digest,
     write_set::WriteSet,
 };
-use crypto::{hash::CryptoHash, signing::sign_message, PrivateKey, PublicKey};
+use crypto::hash::CryptoHash;
+use nextgen_crypto::{ed25519::*, traits::*};
 use proto_conv::{FromProto, IntoProto};
 use protobuf::Message;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -28,8 +29,8 @@ const MAX_GAS_PRICE: u64 = 1;
 pub fn get_test_signed_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: PrivateKey,
-    public_key: PublicKey,
+    private_key: Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
     program: Option<Program>,
     expiration_time: u64,
     gas_unit_price: u64,
@@ -45,12 +46,12 @@ pub fn get_test_signed_transaction(
 
     let bytes = raw_txn.write_to_bytes().unwrap();
     let hash = RawTransactionBytes(&bytes).hash();
-    let signature = sign_message(hash, &private_key).unwrap();
+    let signature = private_key.sign_message(&hash);
 
     let mut signed_txn = ProtoSignedTransaction::new();
     signed_txn.set_raw_txn_bytes(bytes);
-    signed_txn.set_sender_public_key(public_key.to_slice().to_vec());
-    signed_txn.set_sender_signature(signature.to_compact().to_vec());
+    signed_txn.set_sender_public_key(public_key.to_bytes().to_vec());
+    signed_txn.set_sender_signature(signature.to_bytes().to_vec());
     signed_txn
 }
 
@@ -58,8 +59,8 @@ pub fn get_test_signed_transaction(
 pub fn get_test_unchecked_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: PrivateKey,
-    public_key: PublicKey,
+    private_key: Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
     program: Option<Program>,
     expiration_time: u64,
     gas_unit_price: u64,
@@ -75,7 +76,7 @@ pub fn get_test_unchecked_transaction(
 
     let bytes = raw_txn.write_to_bytes().unwrap();
     let hash = RawTransactionBytes(&bytes).hash();
-    let signature = sign_message(hash, &private_key).unwrap();
+    let signature = private_key.sign_message(&hash);
 
     SignedTransaction::craft_signed_transaction_for_client(
         RawTransaction::from_proto(raw_txn).unwrap(),
@@ -89,8 +90,8 @@ pub fn get_test_unchecked_transaction(
 pub fn get_test_signed_txn(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: PrivateKey,
-    public_key: PublicKey,
+    private_key: Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
     program: Option<Program>,
 ) -> ProtoSignedTransaction {
     let expiration_time = SystemTime::now()
@@ -113,8 +114,8 @@ pub fn get_test_signed_txn(
 pub fn get_test_unchecked_txn(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: PrivateKey,
-    public_key: PublicKey,
+    private_key: Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
     program: Option<Program>,
 ) -> SignedTransaction {
     let expiration_time = SystemTime::now()
@@ -141,8 +142,8 @@ pub fn placeholder_script() -> Program {
 pub fn get_write_set_txn(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: PrivateKey,
-    public_key: PublicKey,
+    private_key: Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
     write_set: Option<WriteSet>,
 ) -> SignatureCheckedTransaction {
     let write_set = write_set.unwrap_or_default();
@@ -156,10 +157,10 @@ pub fn create_signed_transactions_block(
     sender: AccountAddress,
     starting_sequence_number: u64,
     num_transactions_in_block: u64,
-    priv_key: &PrivateKey,
-    pub_key: &PublicKey,
-    validator_priv_key: &PrivateKey,
-    validator_pub_key: &PublicKey,
+    priv_key: &Ed25519PrivateKey,
+    pub_key: &Ed25519PublicKey,
+    validator_priv_key: &Ed25519PrivateKey,
+    validator_pub_key: &Ed25519PublicKey,
 ) -> SignedTransactionsBlock {
     let mut signed_txns_block = SignedTransactionsBlock::new();
     for i in starting_sequence_number..(starting_sequence_number + num_transactions_in_block) {
@@ -168,15 +169,15 @@ pub fn create_signed_transactions_block(
             sender,
             i, /* seq_number */
             priv_key.clone(),
-            *pub_key,
+            pub_key.clone(),
             None,
         ));
     }
 
     let message = get_signed_transactions_digest(&signed_txns_block.transactions);
-    let signature = sign_message(message, &validator_priv_key).unwrap();
-    signed_txns_block.set_validator_signature(signature.to_compact().to_vec());
-    signed_txns_block.set_validator_public_key(validator_pub_key.to_slice().to_vec());
+    let signature = validator_priv_key.sign_message(&message);
+    signed_txns_block.set_validator_signature(signature.to_bytes().to_vec());
+    signed_txns_block.set_validator_public_key(validator_pub_key.to_bytes().to_vec());
 
     signed_txns_block
 }

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -25,9 +25,10 @@ use crypto::{
         CryptoHash, CryptoHasher, EventAccumulatorHasher, RawTransactionHasher,
         SignedTransactionHasher, TransactionInfoHasher,
     },
-    signing, HashValue, PrivateKey, PublicKey, Signature,
+    HashValue,
 };
 use failure::prelude::*;
+use nextgen_crypto::{ed25519::*, traits::*};
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto, IntoProtoBytes};
@@ -115,12 +116,12 @@ impl RawTransaction {
     /// For a transaction that has just been signed, its signature is expected to be valid.
     pub fn sign(
         self,
-        private_key: &PrivateKey,
-        public_key: PublicKey,
+        private_key: &Ed25519PrivateKey,
+        public_key: Ed25519PublicKey,
     ) -> Result<SignatureCheckedTransaction> {
         let raw_txn_bytes = self.clone().into_proto_bytes()?;
         let hash = RawTransactionBytes(&raw_txn_bytes).hash();
-        let signature = signing::sign_message(hash, private_key)?;
+        let signature = private_key.sign_message(&hash);
         Ok(SignatureCheckedTransaction(SignedTransaction {
             raw_txn: self,
             public_key,
@@ -248,10 +249,10 @@ pub struct SignedTransaction {
 
     /// Sender's public key. When checking the signature, we first need to check whether this key
     /// is indeed the pre-image of the pubkey hash stored under sender's account.
-    public_key: PublicKey,
+    public_key: Ed25519PublicKey,
 
     /// Signature of the transaction that correspond to the public key
-    signature: Signature,
+    signature: Ed25519Signature,
 
     // The original raw bytes from the protobuf are also stored here so that we use
     // these bytes when generating the canonical serialization of the SignedTransaction struct
@@ -309,8 +310,8 @@ impl fmt::Debug for SignedTransaction {
 impl SignedTransaction {
     pub fn craft_signed_transaction_for_client(
         raw_txn: RawTransaction,
-        public_key: PublicKey,
-        signature: Signature,
+        public_key: Ed25519PublicKey,
+        signature: Ed25519Signature,
     ) -> SignedTransaction {
         SignedTransaction {
             raw_txn: raw_txn.clone(),
@@ -321,12 +322,12 @@ impl SignedTransaction {
         }
     }
 
-    pub fn public_key(&self) -> PublicKey {
-        self.public_key
+    pub fn public_key(&self) -> Ed25519PublicKey {
+        self.public_key.clone()
     }
 
-    pub fn signature(&self) -> Signature {
-        self.signature
+    pub fn signature(&self) -> Ed25519Signature {
+        self.signature.clone()
     }
 
     pub fn sender(&self) -> AccountAddress {
@@ -365,7 +366,7 @@ impl SignedTransaction {
     /// the signature is valid.
     pub fn check_signature(self) -> Result<SignatureCheckedTransaction> {
         let hash = RawTransactionBytes(&self.raw_txn_bytes).hash();
-        signing::verify_signature(hash, &self.signature, &self.public_key)?;
+        self.public_key.verify_signature(&hash, &self.signature)?;
         Ok(SignatureCheckedTransaction(self))
     }
 
@@ -414,8 +415,8 @@ impl FromProto for SignedTransaction {
 
         let t = SignedTransaction {
             raw_txn: RawTransaction::from_proto(proto_raw_transaction)?,
-            public_key: PublicKey::from_slice(txn.get_sender_public_key())?,
-            signature: Signature::from_compact(txn.get_sender_signature())?,
+            public_key: Ed25519PublicKey::try_from(txn.get_sender_public_key())?,
+            signature: Ed25519Signature::try_from(txn.get_sender_signature())?,
             raw_txn_bytes: txn.raw_txn_bytes,
         };
 
@@ -431,8 +432,8 @@ impl IntoProto for SignedTransaction {
     fn into_proto(self) -> Self::ProtoType {
         let mut transaction = Self::ProtoType::new();
         transaction.set_raw_txn_bytes(self.raw_txn_bytes);
-        transaction.set_sender_public_key(self.public_key.to_slice().to_vec());
-        transaction.set_sender_signature(self.signature.to_compact().to_vec());
+        transaction.set_sender_public_key(self.public_key.to_bytes().to_vec());
+        transaction.set_sender_signature(self.signature.to_bytes().to_vec());
         transaction
     }
 }
@@ -554,8 +555,8 @@ impl CanonicalSerialize for SignedTransaction {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_variable_length_bytes(&self.raw_txn_bytes)?
-            .encode_variable_length_bytes(&self.public_key.to_slice())?
-            .encode_variable_length_bytes(&self.signature.to_compact())?;
+            .encode_variable_length_bytes(&self.public_key.to_bytes())?
+            .encode_variable_length_bytes(&self.signature.to_bytes())?;
         Ok(())
     }
 }
@@ -574,8 +575,8 @@ impl CanonicalDeserialize for SignedTransaction {
 
         Ok(SignedTransaction {
             raw_txn: RawTransaction::from_proto(proto_raw_transaction)?,
-            public_key: PublicKey::from_slice(&public_key_bytes)?,
-            signature: Signature::from_compact(&signature_bytes)?,
+            public_key: Ed25519PublicKey::try_from(&public_key_bytes[..]).unwrap(),
+            signature: Ed25519Signature::try_from(&signature_bytes[..]).unwrap(),
             raw_txn_bytes,
         })
     }

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -212,12 +212,8 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
 
     /// Returns a ordered list of account addresses from smallest to largest.
     pub fn get_ordered_account_addresses(&self) -> Vec<AccountAddress> {
-        let mut account_addresses: Vec<AccountAddress> = self
-            .author_to_public_keys
-            .keys()
-            .into_iter()
-            .cloned()
-            .collect();
+        let mut account_addresses: Vec<AccountAddress> =
+            self.author_to_public_keys.keys().cloned().collect();
         account_addresses.sort();
         account_addresses
     }

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.1.28"
 config = { path = "../config" }
 crypto = { path = "../crypto/legacy_crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 scratchpad = { path = "../storage/scratchpad" }
 state_view = { path = "../storage/state_view" }
@@ -22,10 +23,13 @@ vm_runtime = { path = "../language/vm/vm_runtime" }
 [dev-dependencies]
 grpcio = "0.4.4"
 assert_matches = "1.3.0"
+rand = "0.6.5"
 
 execution_proto = { path = "../execution/execution_proto" }
 execution_service = { path = "../execution/execution_service" }
 grpc_helpers = { path = "../common/grpc_helpers" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"] }
 storage_service = { path = "../storage/storage_service" }
+types = { path = "../types", features = ["testing"] }
 vm_genesis = { path = "../language/vm/vm_genesis" }
 config_builder = { path = "../config/config_builder" }

--- a/vm_validator/src/unit_tests/vm_validator_test.rs
+++ b/vm_validator/src/unit_tests/vm_validator_test.rs
@@ -5,13 +5,14 @@ use crate::vm_validator::{TransactionValidation, VMValidator};
 use assert_matches::assert_matches;
 use config::config::NodeConfig;
 use config_builder::util::get_test_config;
-use crypto::signing::KeyPair;
 use execution_proto::proto::execution_grpc;
 use execution_service::ExecutionService;
 use futures::future::Future;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
+use nextgen_crypto::ed25519::*;
 use proto_conv::FromProto;
+use rand::SeedableRng;
 use std::{sync::Arc, u64};
 use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::start_storage_service;
@@ -103,8 +104,8 @@ fn test_validate_transaction() {
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(program),
     );
     let ret = vm_validator
@@ -119,17 +120,17 @@ fn test_validate_invalid_signature() {
     let (config, keypair) = get_test_config();
     let vm_validator = TestValidator::new(&config);
 
-    let (other_private_key, _) = ::crypto::signing::generate_keypair();
+    let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
+    let (other_private_key, _) = compat::generate_keypair(&mut rng);
     // Submit with an account using an different private/public keypair
-    let other_keypair = KeyPair::new(other_private_key);
 
     let address = account_config::association_address();
     let program = encode_transfer_program(&address, 100);
     let signed_txn = transaction_test_helpers::get_test_unchecked_txn(
         address,
         0,
-        other_keypair.private_key().clone(),
-        keypair.public_key(),
+        other_private_key,
+        keypair.public_key,
         Some(program),
     );
     let ret = vm_validator
@@ -151,8 +152,8 @@ fn test_validate_known_script_too_large_args() {
     let txn = transaction_test_helpers::get_test_signed_transaction(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(Program::new(
             vec![42; MAX_TRANSACTION_SIZE_IN_BYTES],
             vec![],
@@ -179,8 +180,8 @@ fn test_validate_max_gas_units_above_max() {
     let txn = transaction_test_helpers::get_test_signed_transaction(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         None,
         0,
         0,              /* max gas price */
@@ -205,8 +206,8 @@ fn test_validate_max_gas_units_below_min() {
     let txn = transaction_test_helpers::get_test_signed_transaction(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         None,
         0,
         0,       /* max gas price */
@@ -231,8 +232,8 @@ fn test_validate_max_gas_price_above_bounds() {
     let txn = transaction_test_helpers::get_test_signed_transaction(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         None,
         0,
         u64::MAX, /* max gas price */
@@ -261,8 +262,8 @@ fn test_validate_max_gas_price_below_bounds() {
     let txn = transaction_test_helpers::get_test_signed_transaction(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(program),
         0,
         0, /* max gas price */
@@ -289,8 +290,8 @@ fn test_validate_unknown_script() {
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         None,
     );
     let ret = vm_validator
@@ -317,8 +318,8 @@ fn test_validate_module_publishing() {
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(program),
     );
     let ret = vm_validator
@@ -336,17 +337,17 @@ fn test_validate_invalid_auth_key() {
     let (config, _) = get_test_config();
     let vm_validator = TestValidator::new(&config);
 
-    let (other_private_key, _) = ::crypto::signing::generate_keypair();
+    let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
+    let (other_private_key, other_public_key) = compat::generate_keypair(&mut rng);
     // Submit with an account using an different private/public keypair
-    let other_keypair = KeyPair::new(other_private_key);
 
     let address = account_config::association_address();
     let program = encode_transfer_program(&address, 100);
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         address,
         0,
-        other_keypair.private_key().clone(),
-        other_keypair.public_key(),
+        other_private_key,
+        other_public_key,
         Some(program),
     );
     let ret = vm_validator
@@ -369,8 +370,8 @@ fn test_validate_balance_below_gas_fee() {
     let signed_txn = transaction_test_helpers::get_test_signed_transaction(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key.clone(),
+        keypair.public_key,
         Some(program),
         0,
         // Note that this will be dependent upon the max gas price and gas amounts that are set. So
@@ -401,8 +402,8 @@ fn test_validate_account_doesnt_exist() {
     let signed_txn = transaction_test_helpers::get_test_signed_transaction(
         random_account_addr,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(program),
         0,
         1, /* max gas price */
@@ -428,8 +429,8 @@ fn test_validate_sequence_number_too_new() {
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(program),
     );
     let ret = vm_validator
@@ -450,8 +451,8 @@ fn test_validate_invalid_arguments() {
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         Some(program),
     );
     let ret = vm_validator
@@ -475,8 +476,8 @@ fn test_validate_non_genesis_write_set() {
     let signed_txn = transaction_test_helpers::get_write_set_txn(
         address,
         0,
-        keypair.private_key().clone(),
-        keypair.public_key(),
+        keypair.private_key,
+        keypair.public_key,
         None,
     )
     .into_inner();

--- a/vm_validator/src/vm_validator.rs
+++ b/vm_validator/src/vm_validator.rs
@@ -76,8 +76,7 @@ impl TransactionValidation for VMValidator {
                     return Box::new(err(format_err!(
                         "Unexpected number of items ({}).",
                         items.len()
-                    )
-                    .into()));
+                    )));
                 }
 
                 match items.remove(0) {
@@ -97,7 +96,7 @@ impl TransactionValidation for VMValidator {
                     _ => panic!("Unexpected item in response."),
                 }
             }
-            Err(e) => Box::new(err(e.into())),
+            Err(e) => Box::new(err(e)),
         }
     }
 }


### PR DESCRIPTION
*This changes the following behavior:*
- Propagates the change onto the rest of the code base

*Why this is better*
- continues the nextgen_crypto API
- removes copies of private key material effected through copies of `Account`s
- makes tests deterministic, with exception of the functional_tests, where this diff outlines the dependency on `e2e_tests::Account::new()` returning different values (see #430)

*Why this is worse*
- breaking change to `Transaction` serialization format

*Future work*
- remove remaining instances of crypto::signing (just a few of them, exclusively in tests)
- switch the network identity key to the nextgen_crypto implementation of X25519

