### PR TITLE
[cluster_test] Support larger clusters and add debugging information

### DIFF
--- a/testsuite/cluster_test/src/cluster.rs
+++ b/testsuite/cluster_test/src/cluster.rs
@@ -10,46 +10,53 @@ pub struct Cluster {
 
 impl Cluster {
     pub fn discover(aws: &Aws) -> failure::Result<Self> {
-        let filters = vec![
-            Filter {
-                name: Some("tag:Workspace".into()),
-                values: Some(vec![aws.workplace().clone()]),
-            },
-            Filter {
-                name: Some("tag:Role".into()),
-                values: Some(vec!["validator".into()]),
-            },
-            Filter {
-                name: Some("instance-state-name".into()),
-                values: Some(vec!["running".into()]),
-            },
-        ];
-        let result = aws
-            .ec2()
-            .describe_instances(DescribeInstancesRequest {
-                filters: Some(filters),
-                max_results: Some(1000),
-                dry_run: None,
-                instance_ids: None,
-                next_token: None,
-            })
-            .sync()
-            .expect("Failed to describe aws instances");
         let mut instances = vec![];
-        for reservation in result.reservations.expect("no reservations") {
-            for aws_instance in reservation.instances.expect("no instances") {
-                let ip = aws_instance
-                    .private_ip_address
-                    .expect("Instance does not have private IP address");
-                let tags = aws_instance.tags.expect("Instance does not have tags");
-                let peer_id = tags
-                    .into_iter()
-                    .find(|tag| tag.key == Some("PeerId".into()))
-                    .expect("No peer id")
-                    .value
-                    .expect("PeerId tag has no value");
-                let short_hash = peer_id[..8].into();
-                instances.push(Instance::new(short_hash, ip));
+        let mut next_token = None;
+        loop {
+            let filters = vec![
+                Filter {
+                    name: Some("tag:Workspace".into()),
+                    values: Some(vec![aws.workplace().clone()]),
+                },
+                Filter {
+                    name: Some("tag:Role".into()),
+                    values: Some(vec!["validator".into()]),
+                },
+                Filter {
+                    name: Some("instance-state-name".into()),
+                    values: Some(vec!["running".into()]),
+                },
+            ];
+            let result = aws
+                .ec2()
+                .describe_instances(DescribeInstancesRequest {
+                    filters: Some(filters),
+                    max_results: Some(1000),
+                    dry_run: None,
+                    instance_ids: None,
+                    next_token,
+                })
+                .sync()
+                .expect("Failed to describe aws instances");
+            for reservation in result.reservations.expect("no reservations") {
+                for aws_instance in reservation.instances.expect("no instances") {
+                    let ip = aws_instance
+                        .private_ip_address
+                        .expect("Instance does not have private IP address");
+                    let tags = aws_instance.tags.expect("Instance does not have tags");
+                    let peer_id = tags
+                        .into_iter()
+                        .find(|tag| tag.key == Some("PeerId".into()))
+                        .expect("No peer id")
+                        .value
+                        .expect("PeerId tag has no value");
+                    let short_hash = peer_id[..8].into();
+                    instances.push(Instance::new(short_hash, ip));
+                }
+            }
+            next_token = result.next_token;
+            if next_token.is_none() {
+                break;
             }
         }
         ensure!(!instances.is_empty(), "instances.txt is empty");

--- a/testsuite/cluster_test/src/health/commit_check.rs
+++ b/testsuite/cluster_test/src/health/commit_check.rs
@@ -77,4 +77,8 @@ impl HealthCheck for CommitHistoryHealthCheck {
             }
         }
     }
+
+    fn name(&self) -> &'static str {
+        "commit_check"
+    }
 }

--- a/testsuite/cluster_test/src/lib.rs
+++ b/testsuite/cluster_test/src/lib.rs
@@ -4,3 +4,13 @@ pub mod effects;
 pub mod experiments;
 pub mod health;
 pub mod instance;
+
+pub mod util {
+    use std::time::{Duration, SystemTime};
+
+    pub fn unix_timestamp_now() -> Duration {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("now < UNIX_EPOCH")
+    }
+}


### PR DESCRIPTION
This change mostly add various debug information that helps to debug spurious failures in cluster_test.

- Measure and log how much time health check run takes when HEALTH_CHECK_DEBUG env is set
- Collect received timestamps on events from kinesis
- Measure number of pending messages between log tail thread and health check to see if one of threads is lagging behind

Also there are couple of improvements in logic in order to support larger clusters:
- Support for paging read of EC2 instances when discovering cluster
- Rework how log tail thread ramp up works - instead of waiting for fixed delay, we now wait (with timeout) until at least one event from each validator was received
- Protect from rare cases when kinesis events arrive out of order - we track last timestamp of event received from validator and ignore out-of-order events
