### PR TITLE
[terraform] Fix startup race condition breaking trusted_peers

### DIFF
--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -117,7 +117,7 @@ resource "aws_instance" "validator" {
     aws_subnet.testnet.*.id,
     count.index % length(data.aws_availability_zones.available.names),
   )
-  depends_on                  = [aws_main_route_table_association.testnet]
+  depends_on                  = [aws_main_route_table_association.testnet, aws_iam_role_policy_attachment.ecs_extra]
   vpc_security_group_ids      = [aws_security_group.validator.id]
   associate_public_ip_address = local.instance_public_ip
   key_name                    = aws_key_pair.libra.key_name


### PR DESCRIPTION
Validator instances can startup before the policy allowing access to
trusted_peers in S3 is installed.