### PR TITLE
[functional tests] add option 'no-stdlib'

### DIFF
--- a/language/functional_tests/tests/testsuite/examples/no_stdlib.mvir
+++ b/language/functional_tests/tests/testsuite/examples/no_stdlib.mvir
@@ -1,0 +1,10 @@
+//! no-stdlib
+
+import 0x0.LibraCoin;
+
+main() {
+}
+
+// check: can\'t find module
+// check: LibraCoin
+// check: in dependency list


### PR DESCRIPTION
## Summary
Feature requested by @tnowacki. This adds an option "no-stdlib" to functional tests. When this option is present, standard library modules (LibraCoin etc.) will not be included in the genesis block and hence not available to transactions in the test.

## Test Plan
CI
