### PR TITLE
Support external transaction signer

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -389,12 +389,13 @@ impl ClientProxy {
     ) -> Result<RawTransaction> {
         let program = vm_genesis::encode_transfer_program(&receiver_address, num_coins);
 
-        Ok(self.create_unsigned_transaction(
+        Ok(create_unsigned_txn(
             program,
             sender_address,
             sender_sequence_number,
-            max_gas_amount,
-            gas_unit_price,
+            max_gas_amount.unwrap_or(MAX_GAS_AMOUNT),
+            gas_unit_price.unwrap_or(GAS_UNIT_PRICE),
+            TX_EXPIRATION,
         ))
     }
 
@@ -1007,25 +1008,6 @@ impl ClientProxy {
         let mut req = SubmitTransactionRequest::new();
         req.set_signed_txn(signed_txn.into_proto());
         Ok(req)
-    }
-
-    /// Craft an unsigned transaction
-    pub fn create_unsigned_transaction(
-        &self,
-        program: Program,
-        sender_address: AccountAddress,
-        sender_sequence_number: u64,
-        max_gas_amount: Option<u64>,
-        gas_unit_price: Option<u64>,
-    ) -> RawTransaction {
-        create_unsigned_txn(
-            program,
-            sender_address,
-            sender_sequence_number,
-            max_gas_amount.unwrap_or(MAX_GAS_AMOUNT),
-            gas_unit_price.unwrap_or(GAS_UNIT_PRICE),
-            TX_EXPIRATION,
-        )
     }
 
     fn mut_account_from_parameter(&mut self, para: &str) -> Result<&mut AccountData> {

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -4,7 +4,7 @@
 use crate::{commands::*, grpc_client::GRPCClient, AccountData, AccountStatus};
 use admission_control_proto::proto::admission_control::SubmitTransactionRequest;
 use config::trusted_peers::TrustedPeersConfig;
-use crypto::signing::{KeyPair, Signature, PublicKey};
+use crypto::signing::{KeyPair, PublicKey, Signature};
 use failure::prelude::*;
 use futures::{future::Future, stream::Stream};
 use hyper;
@@ -41,7 +41,7 @@ use types::{
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::{ContractEvent, EventWithProof},
     transaction::{
-        parse_as_transaction_argument, Program, RawTransaction, SignedTransaction, Version
+        parse_as_transaction_argument, Program, RawTransaction, SignedTransaction, Version,
     },
     transaction_helpers::{create_signed_txn, create_unsigned_txn, TransactionSigner},
     validator_verifier::ValidatorVerifier,
@@ -464,8 +464,7 @@ impl ClientProxy {
             "Invalid number of arguments for transfer"
         );
 
-        let sender_address =
-            self.get_account_address_from_parameter(space_delim_strings[1])?;
+        let sender_address = self.get_account_address_from_parameter(space_delim_strings[1])?;
         let sender_sequence_number = space_delim_strings[2].parse::<u64>()?;
         let receiver_address = self.get_account_address_from_parameter(space_delim_strings[3])?;
 
@@ -564,7 +563,8 @@ impl ClientProxy {
         Ok(output_path)
     }
 
-    /// Submit a transaction to the network given raw bytes of the transaction, sender public key and signature
+    /// Submit a transaction to the network given raw bytes of the transaction, sender public key
+    /// and signature
     pub fn submit_signed_transaction(
         &mut self,
         space_delim_strings: &[&str],
@@ -578,7 +578,8 @@ impl ClientProxy {
         let signature_bytes = hex::decode(space_delim_strings[2])?;
         let signature = Signature::from_compact(signature_bytes.as_slice())?;
 
-        let signed_txn = SignedTransaction::craft_signed_transaction_for_client(raw_txn, public_key, signature);
+        let signed_txn =
+            SignedTransaction::craft_signed_transaction_for_client(raw_txn, public_key, signature);
 
         let mut req = SubmitTransactionRequest::new();
         let sender_address = signed_txn.sender();
@@ -591,7 +592,7 @@ impl ClientProxy {
 
         Ok(AddressAndSequence {
             account_address: AccountAddress::from(public_key),
-            sequence_number: sender_sequence
+            sequence_number: sender_sequence,
         })
     }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -8,7 +8,12 @@
 //! It supposes all public APIs.
 use crypto::signing::KeyPair;
 use serde::{Deserialize, Serialize};
-use types::account_address::AccountAddress;
+pub use types::account_address::AccountAddress;
+pub use types::transaction::{RawTransaction, RawTransactionBytes, TransactionArgument, Program};
+pub use proto_conv::{IntoProtoBytes, FromProtoBytes};
+pub use crypto::hash::CryptoHash;
+pub use crypto::signing::{Signature, PublicKey};
+pub use vm_genesis;
 
 pub(crate) mod account_commands;
 /// Main instance of client holding corresponding information, e.g. account address.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -7,12 +7,16 @@
 //! Client (binary) is the CLI tool to interact with Libra validator.
 //! It supposes all public APIs.
 use crypto::signing::KeyPair;
+pub use crypto::{
+    hash::CryptoHash,
+    signing::{PublicKey, Signature},
+};
+pub use proto_conv::{FromProtoBytes, IntoProtoBytes};
 use serde::{Deserialize, Serialize};
-pub use types::account_address::AccountAddress;
-pub use types::transaction::{RawTransaction, RawTransactionBytes, TransactionArgument, Program};
-pub use proto_conv::{IntoProtoBytes, FromProtoBytes};
-pub use crypto::hash::CryptoHash;
-pub use crypto::signing::{Signature, PublicKey};
+pub use types::{
+    account_address::AccountAddress,
+    transaction::{Program, RawTransaction, RawTransactionBytes, TransactionArgument},
+};
 pub use vm_genesis;
 
 pub(crate) mod account_commands;

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -21,4 +21,3 @@ logger = { path = "../common/logger" }
 tempfile = "3.1.0"
 crypto = { path = "../crypto/legacy_crypto" }
 rand = "0.6.5"
-hex = "0.3.2"

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -19,3 +19,6 @@ generate_keypair = { path = "../config/generate_keypair" }
 libra_swarm = { path = "../libra_swarm" }
 logger = { path = "../common/logger" }
 tempfile = "3.1.0"
+crypto = { path = "../crypto/legacy_crypto" }
+rand = "0.6.5"
+hex = "0.3.2"

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -13,7 +13,7 @@ use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
 use std::str::FromStr;
 use rand::{rngs::StdRng, SeedableRng};
-use crypto::signing::{PublicKey, PrivateKey, Signature, sign_message, generate_keypair_for_testing};
+use crypto::signing::{sign_message, generate_keypair_for_testing};
 use hex;
 
 fn setup_swarm_and_client_proxy(

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -2,19 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused_mut)]
 use cli::{
-    AccountAddress,
-    client_proxy::ClientProxy,
-    RawTransactionBytes,
-    IntoProtoBytes,
-    CryptoHash
+    client_proxy::ClientProxy, AccountAddress, CryptoHash, IntoProtoBytes, RawTransactionBytes,
 };
+use crypto::signing::{generate_keypair_for_testing, sign_message};
+use hex;
 use libra_swarm::swarm::LibraSwarm;
 use num_traits::cast::FromPrimitive;
+use rand::{rngs::StdRng, SeedableRng};
 use rust_decimal::Decimal;
 use std::str::FromStr;
-use rand::{rngs::StdRng, SeedableRng};
-use crypto::signing::{sign_message, generate_keypair_for_testing};
-use hex;
 
 fn setup_swarm_and_client_proxy(
     num_nodes: usize,
@@ -292,7 +288,7 @@ fn test_external_transaction_signer() {
             &sender_address,
             &format!("{}", sequence_number),
             &receiver_address,
-            &amount
+            &amount,
         ])
         .unwrap();
 
@@ -308,7 +304,7 @@ fn test_external_transaction_signer() {
         .submit_signed_transaction(&[
             &hex::encode(raw_bytes),
             &hex::encode(public_key.to_slice()),
-            &hex::encode(signature.to_compact().to_vec().as_slice())
+            &hex::encode(signature.to_compact().to_vec().as_slice()),
         ])
         .unwrap();
 
@@ -316,8 +312,5 @@ fn test_external_transaction_signer() {
         address_and_sequence.account_address.to_string(),
         sender_address
     );
-    assert_eq!(
-        address_and_sequence.sequence_number,
-        0
-    );
+    assert_eq!(address_and_sequence.sequence_number, 0);
 }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -268,8 +268,10 @@ fn test_external_transaction_signer() {
 
     // create address from public key
     let sender_address = AccountAddress::from(public_key);
-    let receiver_address = client_proxy.get_account_address_from_parameter(
-        "1bfb3b36384dabd29e38b4a0eafd9797b75141bb007cea7943f8a4714d3d784a")
+    let receiver_address = client_proxy
+        .get_account_address_from_parameter(
+            "1bfb3b36384dabd29e38b4a0eafd9797b75141bb007cea7943f8a4714d3d784a",
+        )
         .unwrap();
     let amount = ClientProxy::convert_to_micro_libras("1").unwrap();
 
@@ -289,8 +291,8 @@ fn test_external_transaction_signer() {
             sequence_number,
             receiver_address,
             amount,
-            None,  /* gas_unit_price */
-            None,  /* max_gas_amount */
+            None, /* gas_unit_price */
+            None, /* max_gas_amount */
         )
         .unwrap();
 
@@ -303,11 +305,7 @@ fn test_external_transaction_signer() {
 
     // submit the transaction
     let address_and_sequence = client_proxy
-        .submit_signed_transaction(
-            unsigned_txn,
-            public_key,
-            signature,
-        )
+        .submit_signed_transaction(unsigned_txn, public_key, signature)
         .unwrap();
 
     assert_eq!(

--- a/types/src/transaction_helpers.rs
+++ b/types/src/transaction_helpers.rs
@@ -64,7 +64,7 @@ pub fn create_signed_txn<T: TransactionSigner + ?Sized>(
         sender_sequence_number,
         max_gas_amount,
         gas_unit_price,
-        txn_expiration
+        txn_expiration,
     );
     signer.sign_txn(raw_txn)
 }

--- a/types/src/transaction_helpers.rs
+++ b/types/src/transaction_helpers.rs
@@ -26,6 +26,24 @@ pub fn get_signed_transactions_digest(signed_txns: &[ProtoSignedTransaction]) ->
     signatures.test_only_hash()
 }
 
+pub fn create_unsigned_txn(
+    program: Program,
+    sender_address: AccountAddress,
+    sender_sequence_number: u64,
+    max_gas_amount: u64,
+    gas_unit_price: u64,
+    txn_expiration: i64, // for compatibility with UTC's timestamp.
+) -> RawTransaction {
+    RawTransaction::new(
+        sender_address,
+        sender_sequence_number,
+        program,
+        max_gas_amount,
+        gas_unit_price,
+        std::time::Duration::new((Utc::now().timestamp() + txn_expiration) as u64, 0),
+    )
+}
+
 pub trait TransactionSigner {
     fn sign_txn(&self, raw_txn: RawTransaction) -> Result<SignedTransaction>;
 }
@@ -40,13 +58,13 @@ pub fn create_signed_txn<T: TransactionSigner + ?Sized>(
     gas_unit_price: u64,
     txn_expiration: i64, // for compatibility with UTC's timestamp.
 ) -> Result<SignedTransaction> {
-    let raw_txn = RawTransaction::new(
+    let raw_txn = create_unsigned_txn(
+        program,
         sender_address,
         sender_sequence_number,
-        program,
         max_gas_amount,
         gas_unit_price,
-        std::time::Duration::new((Utc::now().timestamp() + txn_expiration) as u64, 0),
+        txn_expiration
     );
     signer.sign_txn(raw_txn)
 }


### PR DESCRIPTION
This enhancement separates the construction and the submission of a transfer transaction into 2 separate routines:
- `prepare_transfer_coins` - construct and return a transfer (unsigned) `RawTransaction`.
- `submit_signed_transaction` - construct and submit a signed transaction from an unsigned raw transaction, a signature, and the respective public key.

This is useful for plugging in an external transaction signer, e.g., a hardware wallet or a threshold signature scheme.