### PR TITLE
[storage][jellyfish][3/3] Jellyfish Sparse Merkle Tree implementation

### DIFF
--- a/storage/jellyfish_merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish_merkle/src/jellyfish_merkle_test.rs
@@ -1,0 +1,595 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crypto::HashValue;
+use mock_tree_store::MockTreeStore;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use types::proof::verify_sparse_merkle_element;
+
+fn update_nibble(original_key: &HashValue, n: usize, nibble: u8) -> HashValue {
+    assert!(nibble < 16);
+    let mut key = original_key.to_vec();
+    key[n / 2] = if n % 2 == 0 {
+        key[n / 2] & 0x0f | nibble << 4
+    } else {
+        key[n / 2] & 0xf0 | nibble
+    };
+    HashValue::from_slice(&key).unwrap()
+}
+
+#[test]
+fn test_insert_to_empty_tree() {
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+
+    // Tree is initially empty. Root is a null node. We'll insert a key-value pair which creates a
+    // leaf node.
+    let key = HashValue::random();
+    let value = AccountStateBlob::from(vec![1u8, 2u8, 3u8, 4u8]);
+
+    let (_new_root_hash, batch) = tree
+        .put_blob_set(vec![(key, value.clone())], 0 /* version */)
+        .unwrap();
+    assert!(batch.stale_node_index_batch.is_empty());
+    db.write_tree_update_batch(batch).unwrap();
+
+    assert_eq!(tree.get(key, Some(0)).unwrap().unwrap(), value);
+}
+
+#[test]
+fn test_insert_at_leaf_with_internal_created() {
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = AccountStateBlob::from(vec![1u8, 2u8]);
+
+    let (_root0_hash, batch) = tree
+        .put_blob_set(vec![(key1, value1.clone())], 0 /* version */)
+        .unwrap();
+
+    assert!(batch.stale_node_index_batch.is_empty());
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.get(key1, Some(0)).unwrap().unwrap(), value1);
+
+    // Insert at the previous leaf node. Should generate an internal node at the root.
+    // Change the 1st nibble to 15.
+    let key2 = update_nibble(&key1, 0, 15);
+    let value2 = AccountStateBlob::from(vec![3u8, 4u8]);
+
+    let (_root1_hash, batch) = tree
+        .put_blob_set(vec![(key2, value2.clone())], 1 /* version */)
+        .unwrap();
+    assert_eq!(batch.stale_node_index_batch.len(), 1);
+    db.write_tree_update_batch(batch).unwrap();
+
+    assert_eq!(tree.get(key1, Some(0)).unwrap().unwrap(), value1);
+    assert!(tree.get(key2, Some(0)).unwrap().is_none());
+    assert_eq!(tree.get(key2, Some(1)).unwrap().unwrap(), value2);
+
+    // get # of nodes
+    assert_eq!(db.num_nodes(), 4 /* 1 + 3 */);
+
+    let internal_node_key = NodeKey::new_empty_path(1);
+
+    let leaf1 = Node::new_leaf(key1, value1);
+    let leaf2 = Node::new_leaf(key2, value2);
+    let mut children = HashMap::new();
+    children.insert(
+        0,
+        Child::new(leaf1.hash(), 1 /* version */, true /* is_leaf */),
+    );
+    children.insert(
+        15,
+        Child::new(leaf2.hash(), 1 /* version */, true /* is_leaf */),
+    );
+    let internal = Node::new_internal(children);
+    assert_eq!(
+        db.get_node(&NodeKey::new_empty_path(0)).unwrap(),
+        leaf1.clone().into()
+    );
+    assert_eq!(
+        db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, 0 /* index */))
+            .unwrap(),
+        leaf1.into()
+    );
+    assert_eq!(
+        db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, 15 /* index */))
+            .unwrap(),
+        leaf2.into()
+    );
+    assert_eq!(db.get_node(&internal_node_key).unwrap(), internal.into());
+}
+
+#[test]
+fn test_insert_at_leaf_with_multiple_internals_created() {
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+
+    // 1. Insert the first leaf into empty tree
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = AccountStateBlob::from(vec![1u8, 2u8]);
+
+    let (_root0_hash, batch) = tree
+        .put_blob_set(vec![(key1, value1.clone())], 0 /* version */)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.get(key1, Some(0)).unwrap().unwrap(), value1);
+
+    // 2. Insert at the previous leaf node. Should generate a branch node at root.
+    // Change the 2nd nibble to 1.
+    let key2 = update_nibble(&key1, 1 /* nibble_index */, 1 /* nibble */);
+    let value2 = AccountStateBlob::from(vec![3u8, 4u8]);
+
+    let (_root1_hash, batch) = tree
+        .put_blob_set(vec![(key2, value2.clone())], 1 /* version */)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.get(key1, Some(0)).unwrap().unwrap(), value1);
+    assert!(tree.get(key2, Some(0)).unwrap().is_none());
+    assert_eq!(tree.get(key2, Some(1)).unwrap().unwrap(), value2);
+
+    assert_eq!(db.num_nodes(), 5);
+
+    let internal_node_key = NodeKey::new(1, NibblePath::new_odd(vec![0x00]));
+
+    let leaf1 = Node::new_leaf(key1, value1.clone());
+    let leaf2 = Node::new_leaf(key2, value2.clone());
+    let internal = {
+        let mut children = HashMap::new();
+        children.insert(
+            0,
+            Child::new(leaf1.hash(), 1 /* version */, true /* is_leaf */),
+        );
+        children.insert(
+            1,
+            Child::new(leaf2.hash(), 1 /* version */, true /* is_leaf */),
+        );
+        Node::new_internal(children)
+    };
+
+    let root_internal = {
+        let mut children = HashMap::new();
+        children.insert(
+            0,
+            Child::new(
+                internal.hash(),
+                1,     /* version */
+                false, /* is_leaf */
+            ),
+        );
+        Node::new_internal(children)
+    };
+
+    assert_eq!(
+        db.get_node(&NodeKey::new_empty_path(0)).unwrap(),
+        leaf1.clone().into()
+    );
+    assert_eq!(
+        db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, 0 /* index */),)
+            .unwrap(),
+        leaf1.clone().into()
+    );
+    assert_eq!(
+        db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, 1 /* index */),)
+            .unwrap(),
+        leaf2.clone().into()
+    );
+    assert_eq!(
+        db.get_node(&internal_node_key).unwrap(),
+        internal.clone().into()
+    );
+    assert_eq!(
+        db.get_node(&NodeKey::new_empty_path(1)).unwrap(),
+        root_internal.clone().into()
+    );
+
+    // 3. Update leaf2 with new value
+    let value2_update = AccountStateBlob::from(vec![5u8, 6u8]);
+    let (_root2_hash, batch) = tree
+        .put_blob_set(vec![(key2, value2_update.clone())], 2 /* version */)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert!(tree.get(key2, Some(0)).unwrap().is_none());
+    assert_eq!(tree.get(key2, Some(1)).unwrap().unwrap(), value2);
+    assert_eq!(tree.get(key2, Some(2)).unwrap().unwrap(), value2_update);
+
+    // Get # of nodes.
+    assert_eq!(db.num_nodes(), 8);
+
+    // Purge retired nodes.
+    db.purge_stale_nodes(1).unwrap();
+    assert_eq!(db.num_nodes(), 7);
+    db.purge_stale_nodes(2).unwrap();
+    assert_eq!(db.num_nodes(), 4);
+    assert_eq!(tree.get(key1, Some(2)).unwrap().unwrap(), value1);
+    assert_eq!(tree.get(key2, Some(2)).unwrap().unwrap(), value2_update);
+}
+
+#[test]
+fn test_batch_insertion() {
+    // ```text
+    //                             internal(root)
+    //                            /        \
+    //                       internal       2        <- nibble 0
+    //                      /   |   \
+    //              internal    3    4               <- nibble 1
+    //                 |
+    //              internal                         <- nibble 2
+    //              /      \
+    //        internal      6                        <- nibble 3
+    //           |
+    //        internal                               <- nibble 4
+    //        /      \
+    //       1        5                              <- nibble 5
+    //
+    // Total: 12 nodes
+    // ```
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = AccountStateBlob::from(vec![1u8]);
+
+    let key2 = update_nibble(&key1, 0, 2);
+    let value2 = AccountStateBlob::from(vec![2u8]);
+    let value2_update = AccountStateBlob::from(vec![22u8]);
+
+    let key3 = update_nibble(&key1, 1, 3);
+    let value3 = AccountStateBlob::from(vec![3u8]);
+
+    let key4 = update_nibble(&key1, 1, 4);
+    let value4 = AccountStateBlob::from(vec![4u8]);
+
+    let key5 = update_nibble(&key1, 5, 5);
+    let value5 = AccountStateBlob::from(vec![5u8]);
+
+    let key6 = update_nibble(&key1, 3, 6);
+    let value6 = AccountStateBlob::from(vec![6u8]);
+
+    let batches = vec![
+        vec![(key1, value1.clone())],
+        vec![(key2, value2.clone())],
+        vec![(key3, value3.clone())],
+        vec![(key4, value4.clone())],
+        vec![(key5, value5.clone())],
+        vec![(key6, value6.clone())],
+        vec![(key2, value2_update.clone())],
+    ];
+    let one_batch = batches.iter().flatten().cloned().collect::<Vec<_>>();
+
+    let mut to_verify = one_batch.clone();
+    // key2 was updated so we remove it.
+    to_verify.remove(1);
+    let verify_fn = |tree: &JellyfishMerkleTree<MockTreeStore>, version: Version| {
+        to_verify
+            .iter()
+            .for_each(|(k, v)| assert_eq!(tree.get(*k, Some(version)).unwrap().unwrap(), *v))
+    };
+
+    // Insert as one batch.
+    {
+        let db = MockTreeStore::default();
+        let tree = JellyfishMerkleTree::new(&db);
+
+        let (_root, batch) = tree.put_blob_set(one_batch, 0 /* version */).unwrap();
+        db.write_tree_update_batch(batch).unwrap();
+        verify_fn(&tree, 0);
+
+        // get # of nodes
+        assert_eq!(db.num_nodes(), 12);
+    }
+
+    // Insert in multiple batches.
+    {
+        let db = MockTreeStore::default();
+        let tree = JellyfishMerkleTree::new(&db);
+
+        let (_roots, batch) = tree.put_blob_sets(batches, 0 /* first_version */).unwrap();
+        db.write_tree_update_batch(batch).unwrap();
+        verify_fn(&tree, 6);
+
+        // get # of nodes
+        assert_eq!(db.num_nodes(), 26 /* 1 + 3 + 4 + 3 + 8 + 5 + 2 */);
+
+        // Purge retired nodes('p' means purged and 'a' means added).
+        // The initial state of the tree at version 0
+        // ```test
+        //   1(root)
+        // ```
+        db.purge_stale_nodes(1).unwrap();
+        // ```text
+        //   1 (p)           internal(a)
+        //           ->     /        \
+        //                 1(a)       2(a)
+        // add 3, prune 1
+        // ```
+        assert_eq!(db.num_nodes(), 25);
+        db.purge_stale_nodes(2).unwrap();
+        // ```text
+        //     internal(p)             internal(a)
+        //    /        \              /        \
+        //   1(p)       2   ->   internal(a)    2
+        //                       /       \
+        //                      1(a)      3(a)
+        // add 4, prune 2
+        // ```
+        assert_eq!(db.num_nodes(), 23);
+        db.purge_stale_nodes(3).unwrap();
+        // ```text
+        //         internal(p)                internal(a)
+        //        /        \                 /        \
+        //   internal(p)    2   ->     internal(a)     2
+        //   /       \                /   |   \
+        //  1         3              1    3    4(a)
+        // add 3, prune 2
+        // ```
+        assert_eq!(db.num_nodes(), 21);
+        db.purge_stale_nodes(4).unwrap();
+        // ```text
+        //            internal(p)                         internal(a)
+        //           /        \                          /        \
+        //     internal(p)     2                    internal(a)    2
+        //    /   |   \                            /   |   \
+        //   1(p) 3    4           ->      internal(a) 3    4
+        //                                     |
+        //                                 internal(a)
+        //                                     |
+        //                                 internal(a)
+        //                                     |
+        //                                 internal(a)
+        //                                 /      \
+        //                                1(a)     5(a)
+        // add 8, prune 3
+        // ```
+        assert_eq!(db.num_nodes(), 18);
+        db.purge_stale_nodes(5).unwrap();
+        // ```text
+        //                  internal(p)                             internal(a)
+        //                 /        \                              /        \
+        //            internal(p)    2                        internal(a)    2
+        //           /   |   \                               /   |   \
+        //   internal(p) 3    4                      internal(a) 3    4
+        //       |                                      |
+        //   internal(p)                 ->          internal(a)
+        //       |                                   /      \
+        //   internal                          internal      6(a)
+        //       |                                |
+        //   internal                          internal
+        //   /      \                          /      \
+        //  1        5                        1        5
+        // add 5, prune 4
+        // ```
+        assert_eq!(db.num_nodes(), 14);
+        db.purge_stale_nodes(6).unwrap();
+        // ```text
+        //                         internal(p)                               internal(a)
+        //                        /        \                                /        \
+        //                   internal       2(p)                       internal       2(a)
+        //                  /   |   \                                 /   |   \
+        //          internal    3    4                        internal    3    4
+        //             |                                         |
+        //          internal                      ->          internal
+        //          /      \                                  /      \
+        //    internal      6                           internal      6
+        //       |                                         |
+        //    internal                                  internal
+        //    /      \                                  /      \
+        //   1        5                                1        5
+        // add 2, prune 2
+        // ```
+        assert_eq!(db.num_nodes(), 12);
+        verify_fn(&tree, 6);
+    }
+}
+
+#[test]
+fn test_non_existence() {
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+    // ```text
+    //                     internal(root)
+    //                    /        \
+    //                internal      2
+    //                   |
+    //                internal
+    //                /      \
+    //               1        3
+    // Total: 7 nodes
+    // ```
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = AccountStateBlob::from(vec![1u8]);
+
+    let key2 = update_nibble(&key1, 0, 15);
+    let value2 = AccountStateBlob::from(vec![2u8]);
+
+    let key3 = update_nibble(&key1, 2, 3);
+    let value3 = AccountStateBlob::from(vec![3u8]);
+
+    let (root, batch) = tree
+        .put_blob_set(
+            vec![
+                (key1, value1.clone()),
+                (key2, value2.clone()),
+                (key3, value3.clone()),
+            ],
+            0, /* version */
+        )
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.get(key1, Some(0)).unwrap().unwrap(), value1);
+    assert_eq!(tree.get(key2, Some(0)).unwrap().unwrap(), value2);
+    assert_eq!(tree.get(key3, Some(0)).unwrap().unwrap(), value3);
+    // get # of nodes
+    assert_eq!(db.num_nodes(), 6);
+
+    // test non-existing nodes.
+    // 1. Non-existing node at root node
+    {
+        let non_existing_key = update_nibble(&key1, 0, 1);
+        let (value, proof) = tree.get_with_proof(non_existing_key, Some(0)).unwrap();
+        assert_eq!(value, None);
+        assert!(verify_sparse_merkle_element(root, non_existing_key, &None, &proof).is_ok());
+    }
+    // 2. Non-existing node at non-root internal node
+    {
+        let non_existing_key = update_nibble(&key1, 1, 15);
+        let (value, proof) = tree.get_with_proof(non_existing_key, Some(0)).unwrap();
+        assert_eq!(value, None);
+        assert!(verify_sparse_merkle_element(root, non_existing_key, &None, &proof).is_ok());
+    }
+    // 3. Non-existing node at leaf node
+    {
+        let non_existing_key = update_nibble(&key1, 2, 4);
+        let (value, proof) = tree.get_with_proof(non_existing_key, Some(0)).unwrap();
+        assert_eq!(value, None);
+        assert!(verify_sparse_merkle_element(root, non_existing_key, &None, &proof).is_ok());
+    }
+}
+
+#[test]
+fn test_put_blob_sets() {
+    let mut keys = vec![];
+    let mut values = vec![];;
+    for _i in 0..100 {
+        keys.push(HashValue::random());
+        values.push(AccountStateBlob::from(HashValue::random().to_vec()));
+    }
+
+    let mut root_hashes_one_by_one = vec![];
+    let mut batch_one_by_one = TreeUpdateBatch::default();
+    {
+        let mut iter = keys.clone().into_iter().zip(values.clone().into_iter());
+        let db = MockTreeStore::default();
+        let tree = JellyfishMerkleTree::new(&db);
+        for version in 0..10 {
+            let mut keyed_blob_set = vec![];
+            for _ in 0..10 {
+                keyed_blob_set.push(iter.next().unwrap());
+            }
+            let (root, batch) = tree
+                .put_blob_set(keyed_blob_set, version as Version)
+                .unwrap();
+            db.write_tree_update_batch(batch.clone()).unwrap();
+            root_hashes_one_by_one.push(root);
+            batch_one_by_one.node_batch.extend(batch.node_batch);
+            batch_one_by_one
+                .stale_node_index_batch
+                .extend(batch.stale_node_index_batch);
+        }
+    }
+    {
+        let mut iter = keys.into_iter().zip(values.into_iter());
+        let db = MockTreeStore::default();
+        let tree = JellyfishMerkleTree::new(&db);
+        let mut blob_sets = vec![];
+        for _ in 0..10 {
+            let mut keyed_blob_set = vec![];
+            for _ in 0..10 {
+                keyed_blob_set.push(iter.next().unwrap());
+            }
+            blob_sets.push(keyed_blob_set);
+        }
+        let (root_hashes, batch) = tree.put_blob_sets(blob_sets, 0 /* version */).unwrap();
+        assert_eq!(root_hashes, root_hashes_one_by_one);
+        assert_eq!(batch, batch_one_by_one);
+    }
+}
+
+fn many_keys_get_proof_and_verify_tree_root(seed: &[u8], num_keys: usize) {
+    assert!(seed.len() < 32);
+    let mut actual_seed = [0u8; 32];
+    actual_seed[..seed.len()].copy_from_slice(&seed);
+    let mut rng: StdRng = StdRng::from_seed(actual_seed);
+
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+
+    let mut kvs = vec![];
+    for _i in 0..num_keys {
+        let key = HashValue::random_with_rng(&mut rng);
+        let value = AccountStateBlob::from(HashValue::random_with_rng(&mut rng).to_vec());
+        kvs.push((key, value));
+    }
+
+    let (root, batch) = tree.put_blob_set(kvs.clone(), 0 /* version */).unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+
+    for (k, v) in &kvs {
+        let (value, proof) = tree.get_with_proof(*k, Some(0)).unwrap();
+        assert_eq!(value.unwrap(), *v);
+        assert!(verify_sparse_merkle_element(root, *k, &Some(v.clone()), &proof).is_ok());
+    }
+}
+
+#[test]
+fn test_1000_keys() {
+    let seed: &[_] = &[1, 2, 3, 4];
+    many_keys_get_proof_and_verify_tree_root(seed, 1000);
+}
+
+fn many_versions_get_proof_and_verify_tree_root(seed: &[u8], num_versions: usize) {
+    assert!(seed.len() < 32);
+    let mut actual_seed = [0u8; 32];
+    actual_seed[..seed.len()].copy_from_slice(&seed);
+    let mut rng: StdRng = StdRng::from_seed(actual_seed);
+
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+
+    let mut kvs = vec![];
+    let mut roots = vec![];
+
+    for _i in 0..num_versions {
+        let key = HashValue::random_with_rng(&mut rng);
+        let value = AccountStateBlob::from(HashValue::random_with_rng(&mut rng).to_vec());
+        let new_value = AccountStateBlob::from(HashValue::random_with_rng(&mut rng).to_vec());
+        kvs.push((key, value.clone(), new_value.clone()));
+    }
+
+    for (idx, kvs) in kvs.iter().enumerate() {
+        let (root, batch) = tree
+            .put_blob_set(vec![(kvs.0, kvs.1.clone())], idx as Version)
+            .unwrap();
+        roots.push(root);
+        db.write_tree_update_batch(batch).unwrap();
+    }
+
+    // Update value of all keys
+    for (idx, kvs) in kvs.iter().enumerate() {
+        let version = (num_versions + idx) as Version;
+        let (root, batch) = tree
+            .put_blob_set(vec![(kvs.0, kvs.2.clone())], version)
+            .unwrap();
+        roots.push(root);
+        db.write_tree_update_batch(batch).unwrap();
+    }
+
+    for (i, (k, v, _)) in kvs.iter().enumerate() {
+        let random_version = rng.gen_range(i, i + num_versions);
+        let (value, proof) = tree
+            .get_with_proof(*k, Some(random_version as Version))
+            .unwrap();
+        assert_eq!(value.unwrap(), *v);
+        assert!(
+            verify_sparse_merkle_element(roots[random_version], *k, &Some(v.clone()), &proof)
+                .is_ok()
+        );
+    }
+
+    for (i, (k, _, v)) in kvs.iter().enumerate() {
+        let random_version = rng.gen_range(i + num_versions, 2 * num_versions);
+        let (value, proof) = tree
+            .get_with_proof(*k, Some(random_version as Version))
+            .unwrap();
+        assert_eq!(value.unwrap(), *v);
+        assert!(
+            verify_sparse_merkle_element(roots[random_version], *k, &Some(v.clone()), &proof)
+                .is_ok()
+        );
+    }
+}
+
+#[test]
+fn test_1000_versions() {
+    let seed: &[_] = &[1, 2, 3, 4];
+    many_versions_get_proof_and_verify_tree_root(seed, 1000);
+}

--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -1,18 +1,23 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
+#[cfg(test)]
+mod jellyfish_merkle_test;
 #[cfg(test)]
 mod mock_tree_store;
 mod node_type;
 mod tree_cache;
 
-use crypto::HashValue;
+use crypto::{hash::CryptoHash, HashValue};
 use failure::prelude::*;
-use node_type::{Node, NodeKey};
+use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey};
+use sparse_merkle::nibble_path::{skip_common_prefix, NibbleIterator, NibblePath};
 use std::collections::{HashMap, HashSet};
-use types::transaction::Version;
+use tree_cache::TreeCache;
+use types::{
+    account_state_blob::AccountStateBlob, proof::definition::SparseMerkleProof,
+    transaction::Version,
+};
 
 /// The hardcoded maximum height of a [`JellyfishMerkleTree`] in nibbles.
 const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;
@@ -34,8 +39,9 @@ pub type StaleNodeIndexBatch = HashSet<StaleNodeIndex>;
 pub struct StaleNodeIndex {
     /// The version since when the node is overwritten and becomes stale.
     pub stale_since_version: Version,
-    /// The [`NodeKey`](node_type::NodeKey) identifying the node associated with this
+    /// The [`NodeKey`] identifying the node associated with this
     /// record.
+    /// [`NodeKey`]: node_type::NodeKey
     pub node_key: NodeKey,
 }
 
@@ -52,5 +58,399 @@ pub struct TreeUpdateBatch {
 impl From<TreeUpdateBatch> for (NodeBatch, StaleNodeIndexBatch) {
     fn from(batch: TreeUpdateBatch) -> Self {
         (batch.node_batch, batch.stale_node_index_batch)
+    }
+}
+
+/// The Jellyfish Merkle tree data structure. See [`crate`] for description.
+pub struct JellyfishMerkleTree<'a, R: 'a + TreeReader> {
+    reader: &'a R,
+}
+
+impl<'a, R> JellyfishMerkleTree<'a, R>
+where
+    R: 'a + TreeReader,
+{
+    /// Creates a `JellyfishMerkleTree` backed by the given [`TreeReader`].
+    pub fn new(reader: &'a R) -> Self {
+        Self { reader }
+    }
+
+    /// This is a convenient function that calls
+    /// [`put_blob_set`](JellyfishMerkleTree::put_blob_set) with a single `keyed_blob_set`.
+    pub fn put_blob_set(
+        &self,
+        blob_set: Vec<(HashValue, AccountStateBlob)>,
+        version: Version,
+    ) -> Result<(HashValue, TreeUpdateBatch)> {
+        let (mut root_hashes, tree_update_batch) = self.put_blob_sets(vec![blob_set], version)?;
+        let root_hash = root_hashes.pop().expect("root hash must exist");
+        assert!(
+            root_hashes.is_empty(),
+            "root_hashes can only have 1 root hash inside"
+        );
+        Ok((root_hash, tree_update_batch))
+    }
+
+    /// Returns the new nodes and account state blobs in a batch after applying `blob_set`. For
+    /// example, if after transaction `T_i` the committed state of tree in the persistent storage
+    /// looks like the following structure:
+    ///
+    /// ```text
+    ///              S_i
+    ///             /   \
+    ///            .     .
+    ///           .       .
+    ///          /         \
+    ///         o           x
+    ///        / \
+    ///       A   B
+    ///        storage (disk)
+    /// ```
+    ///
+    /// where `A` and `B` denote the states of two adjacent accounts, and `x` is a sibling subtree
+    /// of the path from root to A and B in the tree. Then a `blob_set` produced by the next
+    /// transaction `T_{i+1}` modifies other accounts `C` and `D` exist in the subtree under `x`, a
+    /// new partial tree will be constructed in memory and the structure will be:
+    ///
+    /// ```text
+    ///                 S_i      |      S_{i+1}
+    ///                /   \     |     /       \
+    ///               .     .    |    .         .
+    ///              .       .   |   .           .
+    ///             /         \  |  /             \
+    ///            /           x | /               x'
+    ///           o<-------------+-               / \
+    ///          / \             |               C   D
+    ///         A   B            |
+    ///           storage (disk) |    cache (memory)
+    /// ```
+    ///
+    /// With this design, we are able to query the global state in persistent storage and
+    /// generate the proposed tree delta based on a specific root hash and `blob_set`. For
+    /// example, if we want to execute another transaction `T_{i+1}'`, we can use the tree `S_i` in
+    /// storage and apply the `blob_set` of transaction `T_{i+1}`. Then if the storage commits
+    /// the returned batch, the state `S_{i+1}` is ready to be read from the tree by calling
+    /// [`get_with_proof`](JellyfishMerkleTree::get_with_proof). Anything inside the batch is not
+    /// reachable from public interfaces before being committed.
+    pub fn put_blob_sets(
+        &self,
+        blob_sets: Vec<Vec<(HashValue, AccountStateBlob)>>,
+        first_version: Version,
+    ) -> Result<(Vec<HashValue>, TreeUpdateBatch)> {
+        let mut tree_cache = TreeCache::new(self.reader, first_version);
+        for (idx, blob_set) in blob_sets.into_iter().enumerate() {
+            assert!(
+                !blob_set.is_empty(),
+                "Transactions that output empty write set should not be included.",
+            );
+            let version = first_version + idx as u64;
+            blob_set
+                .into_iter()
+                .map(|(key, blob)| Self::put(key, blob, version, &mut tree_cache))
+                .collect::<Result<_>>()?;
+            // Freezes the current cache to make all contents in the current cache immutable.
+            tree_cache.freeze();
+        }
+
+        Ok(tree_cache.into())
+    }
+
+    fn put(
+        key: HashValue,
+        blob: AccountStateBlob,
+        version: Version,
+        tree_cache: &mut TreeCache<R>,
+    ) -> Result<()> {
+        let nibble_path = NibblePath::new(key.to_vec());
+
+        // Get the root node. If this is the first operation, it would get the root node from the
+        // underlying db. Otherwise it most likely would come from `cache`.
+        let root_node_key = tree_cache.get_root_node_key();
+        let mut nibble_iter = nibble_path.nibbles();
+
+        // Start insertion from the root node.
+        let (new_root_node_key, _) = match root_node_key {
+            Some(root_node_key) => Self::insert_at(
+                root_node_key.clone(),
+                version,
+                &mut nibble_iter,
+                blob,
+                tree_cache,
+            )?,
+            None => Self::create_leaf_node(
+                NodeKey::new_empty_path(version),
+                &nibble_iter,
+                blob,
+                tree_cache,
+            )?,
+        };
+
+        tree_cache.set_root_node_key(Some(new_root_node_key));
+        Ok(())
+    }
+
+    /// Helper function for recursive insertion into the subtree that starts from the current
+    /// [`NodeKey`]. Returns the newly inserted node.
+    /// It is safe to use recursion here because the max depth is limited by the key length which
+    /// for this tree is the length of the hash of account addresses.
+    fn insert_at(
+        node_key: NodeKey,
+        version: Version,
+        nibble_iter: &mut NibbleIterator,
+        blob: AccountStateBlob,
+        tree_cache: &mut TreeCache<R>,
+    ) -> Result<(NodeKey, Node)> {
+        let node = tree_cache.get_node(&node_key)?;
+        match node {
+            Node::Internal(internal_node) => Self::insert_at_internal_node(
+                node_key,
+                internal_node,
+                version,
+                nibble_iter,
+                blob,
+                tree_cache,
+            ),
+            Node::Leaf(leaf_node) => Self::insert_at_leaf_node(
+                node_key,
+                leaf_node,
+                version,
+                nibble_iter,
+                blob,
+                tree_cache,
+            ),
+        }
+    }
+
+    /// Helper function for recursive insertion into the subtree that starts from the current
+    /// `internal_node`. Returns the newly inserted node with its [`NodeKey`].
+    fn insert_at_internal_node(
+        mut node_key: NodeKey,
+        mut internal_node: InternalNode,
+        version: Version,
+        nibble_iter: &mut NibbleIterator,
+        blob: AccountStateBlob,
+        tree_cache: &mut TreeCache<R>,
+    ) -> Result<(NodeKey, Node)> {
+        // We always delete the existing internal node here because it will not be referenced anyway
+        // since this version.
+        tree_cache.delete_node(&node_key);
+
+        // Find the next node to visit following the next nibble as index.
+        let child_index = nibble_iter.next().expect("Ran out of nibbles");
+
+        // Traverse downwards from this internal node recursively to get the `node_key` of the child
+        // node at `child_index`.
+        let (_, new_child_node) = match internal_node.child(child_index) {
+            Some(child) => {
+                let child_node_key = node_key.gen_child_node_key(child.version, child_index);
+                Self::insert_at(child_node_key, version, nibble_iter, blob, tree_cache)?
+            }
+            None => {
+                let new_child_node_key = node_key.gen_child_node_key(version, child_index);
+                Self::create_leaf_node(new_child_node_key, nibble_iter, blob, tree_cache)?
+            }
+        };
+
+        // Reuse the current `InternalNode` in memory to create a new internal node.
+        internal_node.set_child(
+            child_index,
+            Child::new(new_child_node.hash(), version, new_child_node.is_leaf()),
+        );
+
+        node_key.set_version(version);
+
+        // Cache this new internal node.
+        tree_cache.put_node(node_key.clone(), internal_node.clone().into())?;
+        Ok((node_key, internal_node.into()))
+    }
+
+    /// Helper function for recursive insertion into the subtree that starts from the
+    /// `existing_leaf_node`. Returns the newly inserted node with its [`NodeKey`].
+    fn insert_at_leaf_node(
+        mut node_key: NodeKey,
+        existing_leaf_node: LeafNode,
+        version: Version,
+        nibble_iter: &mut NibbleIterator,
+        blob: AccountStateBlob,
+        tree_cache: &mut TreeCache<R>,
+    ) -> Result<(NodeKey, Node)> {
+        // We are on a leaf node but trying to insert another node, so we may diverge.
+        // We always delete the existing leaf node here because it will not be referenced anyway
+        // since this version.
+        tree_cache.delete_node(&node_key);
+
+        // 1. Make sure that the existing leaf nibble_path has the same prefix as the already
+        // visited part of the nibble iter of the incoming key and advances the existing leaf
+        // nibble iterator by the length of that prefix.
+        let mut visited_nibble_iter = nibble_iter.visited_nibbles();
+        let existing_leaf_nibble_path = NibblePath::new(existing_leaf_node.account_key().to_vec());
+        let mut existing_leaf_nibble_iter = existing_leaf_nibble_path.nibbles();
+        skip_common_prefix(&mut visited_nibble_iter, &mut existing_leaf_nibble_iter);
+
+        // TODO(lightmark): Change this to corrupted error.
+        assert!(
+            visited_nibble_iter.is_finished(),
+            "Leaf nodes failed to share the same visited nibbles before index {}",
+            existing_leaf_nibble_iter.visited_nibbles().num_nibbles()
+        );
+
+        // 2. Determine the extra part of the common prefix that extends from the position where
+        // step 1 ends between this leaf node and the incoming key.
+        let mut existing_leaf_nibble_iter_below_internal =
+            existing_leaf_nibble_iter.remaining_nibbles();
+        let num_common_nibbles_below_internal =
+            skip_common_prefix(nibble_iter, &mut existing_leaf_nibble_iter_below_internal);
+        let mut common_nibble_path = nibble_iter.visited_nibbles().collect::<NibblePath>();
+
+        // 2.1. Both are finished. That means the incoming key already exists in the tree and we
+        // just need to update its value.
+        if nibble_iter.is_finished() {
+            assert!(existing_leaf_nibble_iter_below_internal.is_finished());
+            // The new leaf node will have the same nibble_path with a new version as node_key.
+            node_key.set_version(version);
+            // Create the new leaf node with the same address but new blob content.
+            return Ok(Self::create_leaf_node(
+                node_key,
+                nibble_iter,
+                blob,
+                tree_cache,
+            )?);
+        }
+
+        // 2.2. both are unfinished(They have keys with same length so it's impossible to have one
+        // finished and ther other not). This means the incoming key forks at some point between the
+        // position where step 1 ends and the last nibble, inclusive. Then create a seris of
+        // internal nodes the number of which equals to the length of the extra part of the
+        // common prefix in step 2, a new leaf node for the incoming key, and update the
+        // [`NodeKey`] of existing leaf node. We create new internal nodes in a bottom-up
+        // order.
+        let existing_leaf_index = existing_leaf_nibble_iter_below_internal
+            .next()
+            .expect("Ran out of nibbles");
+        let new_leaf_index = nibble_iter.next().expect("Ran out of nibbles");
+        assert_ne!(existing_leaf_index, new_leaf_index);
+
+        let mut children = Children::new();
+        children.insert(
+            existing_leaf_index,
+            Child::new(existing_leaf_node.hash(), version, true /* is_leaf */),
+        );
+        node_key = NodeKey::new(version, common_nibble_path.clone());
+        tree_cache.put_node(
+            node_key.gen_child_node_key(version, existing_leaf_index),
+            existing_leaf_node.into(),
+        )?;
+
+        let (_, new_leaf_node) = Self::create_leaf_node(
+            node_key.gen_child_node_key(version, new_leaf_index),
+            nibble_iter,
+            blob,
+            tree_cache,
+        )?;
+        children.insert(
+            new_leaf_index,
+            Child::new(new_leaf_node.hash(), version, true /* is_leaf */),
+        );
+
+        let internal_node = InternalNode::new(children);
+        let mut next_internal_node = internal_node.clone();
+        tree_cache.put_node(node_key.clone(), internal_node.into())?;
+
+        for _i in 0..num_common_nibbles_below_internal {
+            let nibble = common_nibble_path
+                .pop()
+                .expect("Common nibble_path below internal node ran out of nibble");
+            node_key = NodeKey::new(version, common_nibble_path.clone());
+            let mut children = Children::new();
+            children.insert(
+                nibble,
+                Child::new(next_internal_node.hash(), version, false /* is_leaf */),
+            );
+            let internal_node = InternalNode::new(children);
+            next_internal_node = internal_node.clone();
+            tree_cache.put_node(node_key.clone(), internal_node.into())?;
+        }
+
+        Ok((node_key, next_internal_node.into()))
+    }
+
+    /// Helper function for creating leaf nodes. Returns the newly created leaf node.
+    fn create_leaf_node(
+        node_key: NodeKey,
+        nibble_iter: &NibbleIterator,
+        blob: AccountStateBlob,
+        tree_cache: &mut TreeCache<R>,
+    ) -> Result<(NodeKey, Node)> {
+        // Get the underlying bytes of nibble_iter which must be a key, i.e., hashed account address
+        // with `HashValue::LENGTH` bytes.
+        let new_leaf_node = Node::new_leaf(
+            HashValue::from_slice(nibble_iter.get_nibble_path().bytes())
+                .expect("LeafNode must have full nibble path."),
+            blob,
+        );
+
+        tree_cache.put_node(node_key.clone(), new_leaf_node.clone())?;
+        Ok((node_key, new_leaf_node.into()))
+    }
+
+    /// Returns the account state blob (if applicable) and the corresponding merkle proof.
+    pub fn get_with_proof(
+        &self,
+        key: HashValue,
+        version: Option<Version>,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
+        // Empty tree just returns proof with no sibling hash.
+        let mut next_node_key = match version {
+            None => return Ok((None, SparseMerkleProof::new(None, vec![]))),
+            Some(version) => NodeKey::new_empty_path(version),
+        };
+        let mut siblings = vec![];
+        let nibble_path = NibblePath::new(key.to_vec());
+        let mut nibble_iter = nibble_path.nibbles();
+
+        // We limit the number of loops here deliberately to avoid potential cyclic graph bugs
+        // in the tree structure.
+        for _i in 0..ROOT_NIBBLE_HEIGHT {
+            let next_node = self.reader.get_node(&next_node_key)?;
+            match next_node {
+                Node::Internal(internal_node) => {
+                    let queried_child_index = match nibble_iter.next() {
+                        Some(nibble) => nibble,
+                        // Shouldn't happen
+                        None => bail!("ran out of nibbles"),
+                    };
+                    let (child_node_key, mut siblings_in_internal) =
+                        internal_node.get_child_with_siblings(&next_node_key, queried_child_index);
+                    siblings.append(&mut siblings_in_internal);
+                    next_node_key = match child_node_key {
+                        Some(node_key) => node_key,
+                        None => return Ok((None, SparseMerkleProof::new(None, siblings))),
+                    };
+                }
+                Node::Leaf(leaf_node) => {
+                    return Ok((
+                        if leaf_node.account_key() == key {
+                            Some(leaf_node.blob().clone())
+                        } else {
+                            None
+                        },
+                        SparseMerkleProof::new(
+                            Some((leaf_node.account_key(), leaf_node.blob_hash())),
+                            siblings,
+                        ),
+                    ));
+                }
+            }
+        }
+        bail!("Jellyfish Merkle tree has cyclic graph inside.");
+    }
+
+    #[cfg(test)]
+    pub fn get(
+        &self,
+        key: HashValue,
+        version: Option<Version>,
+    ) -> Result<Option<AccountStateBlob>> {
+        Ok(self.get_with_proof(key, version)?.0)
     }
 }

--- a/storage/jellyfish_merkle/src/mock_tree_store.rs
+++ b/storage/jellyfish_merkle/src/mock_tree_store.rs
@@ -72,7 +72,7 @@ impl MockTreeStore {
 
         for log in to_prune {
             let removed = wlocked.0.remove(&log.node_key).is_some();
-            ensure!(removed, "Retire log refers to non-existent record.");
+            ensure!(removed, "Stale node index refers to non-existent node.");
             wlocked.1.remove(&log);
         }
 

--- a/storage/jellyfish_merkle/src/node_type/mod.rs
+++ b/storage/jellyfish_merkle/src/node_type/mod.rs
@@ -72,6 +72,11 @@ impl NodeKey {
         node_nibble_path.push(n);
         Self::new(version, node_nibble_path)
     }
+
+    /// Sets the version to the given version.
+    pub fn set_version(&mut self, version: Version) {
+        self.version = version;
+    }
 }
 
 /// Each child of [`InternalNode`] encapsulates a nibble forking at this node.

--- a/storage/jellyfish_merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish_merkle/src/tree_cache/mod.rs
@@ -155,12 +155,9 @@ where
         }
     }
 
-    /// Gets the current root node.
-    pub fn get_root_node(&self) -> Result<Option<Node>> {
-        self.root_node_key
-            .as_ref()
-            .map(|node_key| self.get_node(node_key))
-            .transpose()
+    /// Gets the current root node key.
+    pub fn get_root_node_key(&self) -> &Option<NodeKey> {
+        &self.root_node_key
     }
 
     /// Set roots `node_key`.
@@ -188,9 +185,12 @@ where
     }
 
     /// Freezes all the contents in cache to be immutable and clear `node_cache`.
-    pub fn freeze(&mut self) -> Result<()> {
-        let root_hash = match self.get_root_node()? {
-            Some(node) => node.hash(),
+    pub fn freeze(&mut self) {
+        let root_hash = match self.get_root_node_key() {
+            Some(node_key) => self
+                .get_node(node_key)
+                .unwrap_or_else(|_| panic!("Root node with key {:?} must exist", node_key))
+                .hash(),
             None => *SPARSE_MERKLE_PLACEHOLDER_HASH,
         };
         self.frozen_cache.root_hashes.push(root_hash);
@@ -208,7 +208,6 @@ where
                     }),
             );
         self.next_version += 1;
-        Ok(())
     }
 }
 

--- a/storage/jellyfish_merkle/src/tree_cache/tree_cache_test.rs
+++ b/storage/jellyfish_merkle/src/tree_cache/tree_cache_test.rs
@@ -34,13 +34,13 @@ fn test_root_node() {
     let next_version = 0;
     let db = MockTreeStore::default();
     let mut cache = TreeCache::new(&db, next_version);
-    assert_eq!(cache.get_root_node().unwrap(), None);
+    assert_eq!(*cache.get_root_node_key(), None);
 
     let (node, node_key) = random_leaf_with_key(next_version);
     db.put_node(node_key.clone(), node.clone()).unwrap();
-    cache.set_root_node_key(Some(node_key));
+    cache.set_root_node_key(Some(node_key.clone()));
 
-    assert_eq!(cache.get_root_node().unwrap().unwrap(), node);
+    assert_eq!(*cache.get_root_node_key().as_ref().unwrap(), node_key);
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn test_freeze_with_delete() {
     let db = MockTreeStore::default();
     let mut cache = TreeCache::new(&db, next_version);
 
-    assert_eq!(cache.get_root_node().unwrap(), None);
+    assert_eq!(*cache.get_root_node_key(), None);
 
     let (node1, node1_key) = random_leaf_with_key(next_version);
     cache.put_node(node1_key.clone(), node1.clone()).unwrap();
@@ -57,12 +57,12 @@ fn test_freeze_with_delete() {
     cache.put_node(node2_key.clone(), node2.clone()).unwrap();
     assert_eq!(cache.get_node(&node1_key).unwrap(), node1);
     assert_eq!(cache.get_node(&node2_key).unwrap(), node2);
-    cache.freeze().unwrap();
+    cache.freeze();
     assert_eq!(cache.get_node(&node1_key).unwrap(), node1);
     assert_eq!(cache.get_node(&node2_key).unwrap(), node2);
 
     cache.delete_node(&node1_key);
-    cache.freeze().unwrap();
+    cache.freeze();
     let (_, update_batch) = cache.into();
     let (node_batch, retire_log_batch) = update_batch.into();
     assert_eq!(node_batch.len(), 2);

--- a/storage/sparse_merkle/src/nibble_path/mod.rs
+++ b/storage/sparse_merkle/src/nibble_path/mod.rs
@@ -130,7 +130,7 @@ impl NibblePath {
     }
 }
 
-pub(crate) trait Peekable: Iterator {
+pub trait Peekable: Iterator {
     /// Returns the `next()` value without advancing the iterator.
     fn peek(&self) -> Option<Self::Item>;
 }
@@ -255,7 +255,7 @@ impl<'a> NibbleIterator<'a> {
 
 /// Advance both iterators if their next nibbles are the same until either reaches the end or
 /// the find a mismatch. Return the number of matched nibbles.
-pub(crate) fn skip_common_prefix<'a, 'b, I1: 'a, I2: 'b>(x: &'a mut I1, y: &mut I2) -> usize
+pub fn skip_common_prefix<'a, 'b, I1: 'a, I2: 'b>(x: &'a mut I1, y: &mut I2) -> usize
 where
     I1: Iterator + Peekable,
     I2: Iterator + Peekable,


### PR DESCRIPTION
## Motivation

This is the main implementation and tests of JellyfishMerkleTree. Which is essentially is a sparse merkle tree as our current implementation but with a few major optimizations.
1. We use NodeKey(version | nibble path) as key to uniquely identify a node instead of hash. The prefix - version - will help reducing compaction overhead since each commit of nodes will not overlap with any preceding commit thanks to monotonically increasing version.
2. We remove the `Extension` node to simplify code. It can be proved that the number of extension nodes will decrease as time goes and tree gets denser, so we choose to get rid of it to make the code easier to understand and maintain.
3. Merge blob node with leaf node for now for simplicity.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test 

## Related PRs

#378 #427 
