### PR TITLE
[full_node] configuration: add role

### DIFF
--- a/admission_control/admission_control_service/src/admission_control_node.rs
+++ b/admission_control/admission_control_service/src/admission_control_node.rs
@@ -55,7 +55,7 @@ impl AdmissionControlNode {
 
         self.run_with_clients(
             Arc::clone(&client_env),
-            Arc::new(MempoolClient::new(mempool_channel)),
+            Some(Arc::new(MempoolClient::new(mempool_channel))),
             Some(Arc::new(StorageReadServiceClient::new(
                 Arc::clone(&client_env),
                 &self.node_config.storage.address,
@@ -70,7 +70,7 @@ impl AdmissionControlNode {
     pub fn run_with_clients<M: MempoolClientTrait + 'static>(
         &self,
         env: Arc<Environment>,
-        mp_client: Arc<M>,
+        mp_client: Option<Arc<M>>,
         storage_client: Option<Arc<StorageReadServiceClient>>,
     ) -> Result<()> {
         // create storage client if doesn't exist

--- a/admission_control/admission_control_service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission_control_service/src/unit_tests/admission_control_service_test.rs
@@ -29,7 +29,7 @@ use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 fn create_ac_service_for_ut() -> AdmissionControlService<LocalMockMempool, MockVMValidator> {
     AdmissionControlService::new(
-        Arc::new(LocalMockMempool::new()),
+        Some(Arc::new(LocalMockMempool::new())),
         Arc::new(MockStorageReadClient),
         Arc::new(MockVMValidator),
         false,

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -147,6 +147,7 @@ mod tests {
                 faucet_account_keypair,
                 false,  /* tee_logs */
                 None,   /* config_dir */
+                None,   /* template_path */
             );
             let mut args = Opt {
                 validator_addresses: Vec::new(),

--- a/config/config_builder/src/swarm_config.rs
+++ b/config/config_builder/src/swarm_config.rs
@@ -56,6 +56,7 @@ impl SwarmConfig {
 
             let base_config = BaseConfig::new(
                 node_id.clone(),
+                template.base.role.clone(),
                 KeyPairs::default(),
                 key_file_name.into(),
                 template.base.data_dir_path.clone(),

--- a/config/data/configs/full_node.config.toml
+++ b/config/data/configs/full_node.config.toml
@@ -1,0 +1,22 @@
+# Defaults are now set in config.rs
+
+[base]
+peer_keypairs_file = ""  # For direct validation of this file
+trusted_peers_file = ""  # For direct validation of this file
+role = "full_node"
+
+[network]
+seed_peers_file = ""  # For direct validation of this file
+
+[execution]
+genesis_file_location = "<USE_TEMP_DIR>"
+
+[vm_config]
+  [vm_config.publishing_options]
+  type = "Locked"
+  whitelist = [
+    "ae1b54220905fca36d046a6e093632ed1f219e0a35a4fd7ba82e6e0d515f0b8e",
+    "fb999f2d6f45efc9b991993e332f40760171de8a46db40ca93f1baff56842c44",
+    "6465374a3ecf6d1a3836bbab3bcd624244a0217530a601fa20de80d562f87d80",
+    "774b10985dd9bf17ddee899256942c1dc0ab2c1b07d99ec78f774651f01e04b8"
+  ]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -82,6 +82,7 @@ pub struct NodeConfig {
 #[serde(default)]
 pub struct BaseConfig {
     pub peer_id: String,
+    pub role: String,
     // peer_keypairs contains all the node's private keys,
     // it is filled later on from a different file
     #[serde(skip)]
@@ -114,6 +115,7 @@ impl Default for BaseConfig {
     fn default() -> BaseConfig {
         BaseConfig {
             peer_id: "".to_string(),
+            role: "validator".to_string(),
             peer_keypairs_file: PathBuf::from("peer_keypairs.config.toml"),
             peer_keypairs: KeyPairs::default(),
             data_dir_path: PathBuf::from("<USE_TEMP_DIR>"),
@@ -250,10 +252,17 @@ impl KeyPairs {
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum RoleType {
+    Validator,
+    FullNode,
+}
+
 impl BaseConfig {
     /// Constructs a new BaseConfig with an empty temp directory
     pub fn new(
         peer_id: String,
+        role: String,
         peer_keypairs: KeyPairs,
         peer_keypairs_file: PathBuf,
         data_dir_path: PathBuf,
@@ -270,6 +279,7 @@ impl BaseConfig {
     ) -> Self {
         BaseConfig {
             peer_id,
+            role,
             peer_keypairs,
             peer_keypairs_file,
             data_dir_path,
@@ -282,6 +292,14 @@ impl BaseConfig {
             node_async_log_chan_size,
         }
     }
+
+    pub fn get_role(&self) -> RoleType {
+        match self.role.as_str() {
+            "validator" => RoleType::Validator,
+            "full_node" => RoleType::FullNode,
+            &_ => unimplemented!("Invalid node role: {}", self.role),
+        }
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -289,6 +307,7 @@ impl Clone for BaseConfig {
     fn clone(&self) -> Self {
         Self {
             peer_id: self.peer_id.clone(),
+            role: self.role.clone(),
             peer_keypairs: self.peer_keypairs.clone(),
             peer_keypairs_file: self.peer_keypairs_file.clone(),
             data_dir_path: self.data_dir_path.clone(),

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
         faucet_account_keypair,
         false, /* tee_logs */
         args.config_dir.clone(),
+        None, /* template_path */
     );
 
     let config = &swarm.config.get_configs()[0].1;

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -255,6 +255,7 @@ impl LibraSwarm {
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
         config_dir: Option<String>,
+        template_path: Option<String>,
     ) -> Self {
         let num_launch_attempts = 5;
         for i in 0..num_launch_attempts {
@@ -265,6 +266,7 @@ impl LibraSwarm {
                 faucet_account_keypair.clone(),
                 tee_logs,
                 &config_dir,
+                &template_path,
             ) {
                 Ok(swarm) => {
                     return swarm;
@@ -281,6 +283,7 @@ impl LibraSwarm {
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
         config_dir: &Option<String>,
+        template_path: &Option<String>,
     ) -> std::result::Result<Self, SwarmLaunchFailure> {
         let dir = match config_dir {
             Some(dir_str) => {
@@ -296,7 +299,11 @@ impl LibraSwarm {
         let logs_dir_path = &dir.as_ref().join("logs");
         println!("Base directory containing logs and configs: {:?}", &dir);
         std::fs::create_dir(&logs_dir_path).unwrap();
-        let base = utils::workspace_root().join("config/data/configs/node.config.toml");
+        let base = utils::workspace_root().join(
+            template_path
+                .as_ref()
+                .unwrap_or(&"config/data/configs/node.config.toml".to_string()),
+        );
         let mut config_builder = SwarmConfigBuilder::new();
         config_builder
             .with_ipv4()


### PR DESCRIPTION
## Motivation
Diff adds role parameter to node's base config
Current options: Validator/FullNode
After this change `Validator` nodes will behave as usual
For FullNode type:
* Mempool is disabled
* Consensus is disabled
* p2p network is disabled
* AC doesn't have active connection to Mempool
* AC can only serve read queries

## Test Plan
added `test_full_node` to integration tests. So far it just checks that AC can serve reads, but no writes   
