### PR TITLE
[Consensus] Vote for NIL blocks upon timeout

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -395,9 +395,16 @@ impl<T: Payload> BlockStore<T> {
         if parent.round() >= block.round() {
             return Err(InsertError::InvalidBlockRound);
         }
-        if self.enforce_increasing_timestamps && parent.timestamp_usecs() >= block.timestamp_usecs()
-        {
-            return Err(InsertError::NonIncreasingTimestamp);
+        if self.enforce_increasing_timestamps {
+            // NIL blocks are supposed to have timestamps equal to their parents. Proposed blocks
+            // must have increasing timestamps.
+            if block.is_nil_block() {
+                if block.timestamp_usecs() != parent.timestamp_usecs() {
+                    return Err(InsertError::InvalidNilBlockTimestamp);
+                }
+            } else if block.timestamp_usecs() <= parent.timestamp_usecs() {
+                return Err(InsertError::NonIncreasingTimestamp);
+            }
         }
         let parent_id = parent.id();
         match self.inner.read().unwrap().get_state_for_block(parent_id) {

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -66,8 +66,11 @@ pub enum InsertError {
     #[fail(display = "InvalidBlockRound")]
     InvalidBlockRound,
     /// The block's timestamp is not greater than that of the parent.
-    #[fail(display = "InvalidTiemstamp")]
+    #[fail(display = "InvalidTimestamp")]
     NonIncreasingTimestamp,
+    /// The NIL block's timestamp is not equal to that of the parent.
+    #[fail(display = "InvalidNilBlockTimestamp")]
+    InvalidNilBlockTimestamp,
     /// The block is not newer than the root of the tree.
     #[fail(display = "OldBlock")]
     OldBlock,

--- a/consensus/src/chained_bft/safety/safety_rules.rs
+++ b/consensus/src/chained_bft/safety/safety_rules.rs
@@ -62,7 +62,7 @@ impl VoteInfo {
     }
 
     pub fn parent_block_id(&self) -> HashValue {
-        self.proposal_id
+        self.parent_block_id
     }
 
     pub fn parent_block_round(&self) -> Round {


### PR DESCRIPTION
[Consensus] Vote for NIL blocks upon timeout

Summary:
In this PR we introduce a possibility to vote for an artificially generated NIL block in case the validator has not voted for anything in this round yet.
This way, the QC chains are not broken during the timeout rounds and things can get committed faster.
Note that today we check the newly received QCs when receiving proposals only, so we still don't have the commits upon timeout messages, will add it in the next commit.

Test:
* Added a test to the event processor.
* Extended the network playground to support "drop messages after X successful deliveries" and verified the HQC upon timeout messages with NIL blocks.

Task: ref #371
