### PR TITLE
[crypto] remove derive_deref dependency from crypto crate

### DIFF
--- a/crypto/legacy_crypto/Cargo.toml
+++ b/crypto/legacy_crypto/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 bincode = "1.1.1"
 bytes = "0.4.12"
 curve25519-dalek = "1.1.3"
-derive_deref = "1.1.0"
 ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
 hex = "0.3"
 lazy_static = "1.3.0"

--- a/crypto/legacy_crypto/src/x25519.rs
+++ b/crypto/legacy_crypto/src/x25519.rs
@@ -48,7 +48,6 @@
 use crate::{hkdf::Hkdf, utils::*};
 use core::fmt;
 use crypto_derive::{SilentDebug, SilentDisplay};
-use derive_deref::Deref;
 use failure::prelude::*;
 use proptest::{
     arbitrary::any,
@@ -61,17 +60,20 @@ use rand::{
 };
 use serde::{de, export, ser};
 use sha2::Sha256;
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    ops::Deref,
+};
 use x25519_dalek;
 
 /// An x25519 private key.
-#[derive(Deref, SilentDisplay, SilentDebug)]
+#[derive(SilentDisplay, SilentDebug)]
 pub struct X25519PrivateKey {
     value: x25519_dalek::StaticSecret,
 }
 
 /// An x25519 public key.
-#[derive(Copy, Clone, Deref)]
+#[derive(Copy, Clone)]
 pub struct X25519PublicKey {
     value: x25519_dalek::PublicKey,
 }
@@ -86,6 +88,14 @@ impl Clone for X25519PrivateKey {
         X25519PrivateKey {
             value: x25519_dalek::StaticSecret::from(bytes),
         }
+    }
+}
+
+impl Deref for X25519PrivateKey {
+    type Target = x25519_dalek::StaticSecret;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
     }
 }
 
@@ -140,6 +150,14 @@ impl Display for X25519PublicKey {
 impl Debug for X25519PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         X25519PublicKey::fmt(self, f)
+    }
+}
+
+impl Deref for X25519PublicKey {
+    type Target = x25519_dalek::PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
     }
 }
 

--- a/crypto/nextgen_crypto/Cargo.toml
+++ b/crypto/nextgen_crypto/Cargo.toml
@@ -11,7 +11,6 @@ bincode = "1.1.1"
 byteorder = "1.3.2"
 bytes = "0.4.12"
 curve25519-dalek = "1.1.3"
-derive_deref = "1.1.0"
 ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
 hex = "0.3"
 lazy_static = "1.3.0"

--- a/crypto/nextgen_crypto/src/bls12381.rs
+++ b/crypto/nextgen_crypto/src/bls12381.rs
@@ -35,7 +35,6 @@ use bincode::{deserialize, serialize};
 use core::convert::TryFrom;
 use crypto::hash::HashValue;
 use crypto_derive::{SilentDebug, SilentDisplay};
-use derive_deref::Deref;
 use failure::prelude::*;
 use pairing::{
     bls12_381::{Fr, FrRepr},
@@ -43,6 +42,7 @@ use pairing::{
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 use threshold_crypto;
 
 // type alias for this unwieldy type
@@ -50,15 +50,15 @@ type ThresholdBLSPrivateKey =
     threshold_crypto::serde_impl::SerdeSecret<threshold_crypto::SecretKey>;
 
 /// A BLS12-381 private key
-#[derive(Serialize, Deserialize, Deref, SilentDisplay, SilentDebug)]
+#[derive(Serialize, Deserialize, SilentDisplay, SilentDebug)]
 pub struct BLS12381PrivateKey(ThresholdBLSPrivateKey);
 
 /// A BLS12-381 public key
-#[derive(Clone, Hash, Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]
+#[derive(Clone, Hash, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct BLS12381PublicKey(threshold_crypto::PublicKey);
 
 /// A BLS12-381 signature
-#[derive(Clone, Hash, Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]
+#[derive(Clone, Hash, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct BLS12381Signature(threshold_crypto::Signature);
 
 impl BLS12381PublicKey {
@@ -163,6 +163,14 @@ impl Genesis for BLS12381PrivateKey {
     }
 }
 
+impl Deref for BLS12381PublicKey {
+    type Target = threshold_crypto::PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 //////////////////////
 // PublicKey Traits //
 //////////////////////
@@ -211,6 +219,14 @@ impl ValidKey for BLS12381PublicKey {
     }
 }
 
+impl Deref for BLS12381PrivateKey {
+    type Target = ThresholdBLSPrivateKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 //////////////////////
 // Signature Traits //
 //////////////////////
@@ -251,5 +267,13 @@ impl TryFrom<&[u8]> for BLS12381Signature {
         let sig = threshold_crypto::Signature::from_bytes(&tmp)
             .map_err(|_err| CryptoMaterialError::ValidationError)?;
         Ok(BLS12381Signature(sig))
+    }
+}
+
+impl Deref for BLS12381Signature {
+    type Target = threshold_crypto::Signature;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/crypto/nextgen_crypto/src/vrf/ecvrf.rs
+++ b/crypto/nextgen_crypto/src/vrf/ecvrf.rs
@@ -52,12 +52,12 @@ use curve25519_dalek::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar as ed25519_Scalar,
 };
-use derive_deref::Deref;
 use ed25519_dalek::{
     self, Digest, PublicKey as ed25519_PublicKey, SecretKey as ed25519_PrivateKey, Sha512,
 };
 use failure::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 const SUITE: u8 = 0x03;
 const ONE: u8 = 0x01;
@@ -70,11 +70,11 @@ pub const OUTPUT_LENGTH: usize = 64;
 pub const PROOF_LENGTH: usize = 80;
 
 /// An ECVRF private key
-#[derive(Serialize, Deserialize, Deref, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct VRFPrivateKey(ed25519_PrivateKey);
 
 /// An ECVRF public key
-#[derive(Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct VRFPublicKey(ed25519_PublicKey);
 
 /// A longer private key which is slightly optimized for proof generation.
@@ -131,6 +131,14 @@ impl TryFrom<&[u8]> for VRFPrivateKey {
         Ok(VRFPrivateKey(
             ed25519_PrivateKey::from_bytes(bytes).unwrap(),
         ))
+    }
+}
+
+impl Deref for VRFPrivateKey {
+    type Target = ed25519_PrivateKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -209,6 +217,14 @@ impl<'a> From<&'a VRFPrivateKey> for VRFPublicKey {
         let secret: &ed25519_PrivateKey = private_key;
         let public: ed25519_PublicKey = secret.into();
         VRFPublicKey(public)
+    }
+}
+
+impl Deref for VRFPublicKey {
+    type Target = ed25519_PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/crypto/nextgen_crypto/src/x25519.rs
+++ b/crypto/nextgen_crypto/src/x25519.rs
@@ -57,14 +57,12 @@
 //! ```
 
 use crate::traits::*;
-use core::ops::Deref;
 use crypto::hkdf::Hkdf;
 use crypto_derive::{SilentDebug, SilentDisplay};
-use derive_deref::Deref;
 use rand::{rngs::EntropyRng, RngCore};
 use serde::{de, export, ser};
 use sha2::Sha256;
-use std::{convert::TryFrom, fmt};
+use std::{convert::TryFrom, fmt, ops::Deref};
 use x25519_dalek;
 
 /// TODO: move traits to the right file (possibly traits.rs)
@@ -93,7 +91,7 @@ pub struct X25519PublicKey(x25519_dalek::PublicKey);
 
 /// An x25519 public key to match the X25519Static key type, which
 /// dereferences to an X2519PublicKey
-#[derive(Clone, Debug, Deref, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct X25519StaticPublicKey(X25519PublicKey);
 
 /// An x25519 shared key
@@ -242,6 +240,14 @@ impl<'a> From<&'a X25519ExchangeKey> for X25519PublicKey {
 impl<'a> From<&'a X25519StaticExchangeKey> for X25519StaticPublicKey {
     fn from(ephemeral: &'a X25519StaticExchangeKey) -> X25519StaticPublicKey {
         X25519StaticPublicKey(X25519PublicKey(x25519_dalek::PublicKey::from(&ephemeral.0)))
+    }
+}
+
+impl Deref for X25519StaticPublicKey {
+    type Target = X25519PublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/crypto/secret_service/Cargo.toml
+++ b/crypto/secret_service/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-derive_deref = "1.1.0"
 futures = "0.1.28"
 grpcio = "0.4.3"
 protobuf = "~2.7"

--- a/crypto/secret_service/src/crypto_wrappers.rs
+++ b/crypto/secret_service/src/crypto_wrappers.rs
@@ -7,7 +7,6 @@
 use core::convert::TryFrom;
 use crypto::hash::HashValue;
 use crypto_derive::SilentDebug;
-use derive_deref::Deref;
 use failure::prelude::*;
 use nextgen_crypto::{
     bls12381::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature},
@@ -15,10 +14,19 @@ use nextgen_crypto::{
     traits::*,
 };
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 /// KeyID value is a handler to the secret key and a simple wrapper around the hash value.
-#[derive(Clone, PartialEq, Eq, Hash, Deref)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyID(pub HashValue);
+
+impl Deref for KeyID {
+    type Target = HashValue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 ///////////////////////////////////////////////////////////////////
 // Declarations pulled from crypto/src/unit_tests/cross_test.rs  //


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This change removes `derive_deref` from the crypto crate, reducing dependent crates from 288 to 283.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests.