### PR TITLE
[VM] Restructure Kinds

### DIFF
--- a/language/bytecode_verifier/src/resources.rs
+++ b/language/bytecode_verifier/src/resources.rs
@@ -24,13 +24,13 @@ impl<'a> ResourceTransitiveChecker<'a> {
     pub fn verify(self) -> Vec<VerificationError> {
         let mut errors = vec![];
         for (idx, struct_def) in self.module_view.structs().enumerate() {
-            let def_is_resource = struct_def.is_resource();
-            if !def_is_resource {
+            if !struct_def.is_nominal_resource() {
                 match struct_def.fields() {
                     None => (),
                     Some(mut fields) => {
+                        // TODO must be rethought with generics
                         let any_resource_field =
-                            fields.any(|field| field.type_signature().is_resource());
+                            fields.any(|field| field.type_signature().contains_nominal_resource());
                         if any_resource_field {
                             errors.push(VerificationError {
                                 kind: IndexKind::StructDefinition,

--- a/language/bytecode_verifier/src/signature.rs
+++ b/language/bytecode_verifier/src/signature.rs
@@ -115,7 +115,7 @@ pub(crate) fn check_signature_refs(
 ) -> Option<VMStaticViolation> {
     let type_signature = view.type_signature();
     let token = type_signature.token();
-    let kind = token.kind();
+    let kind = token.signature_token_kind();
     match kind {
         SignatureTokenKind::Reference | SignatureTokenKind::MutableReference => Some(
             VMStaticViolation::InvalidFieldDefReference(token.as_inner().clone(), kind),
@@ -138,8 +138,8 @@ pub(crate) fn check_structure(token: &SignatureToken) -> Option<VMStaticViolatio
         if inner_token.is_reference() {
             return Some(VMStaticViolation::InvalidSignatureToken(
                 token.clone(),
-                token.kind(),
-                inner_token.kind(),
+                token.signature_token_kind(),
+                inner_token.signature_token_kind(),
             ));
         }
     }

--- a/language/bytecode_verifier/src/verifier.rs
+++ b/language/bytecode_verifier/src/verifier.rs
@@ -428,15 +428,16 @@ fn verify_native_structs(module_view: &ModuleView<VerifiedModule>) -> Vec<Verifi
             }),
             Some(vm_native_struct) => {
                 let declared_index = idx as u16;
-                let declared_kind = native_struct_definition_view.kind();
+                let declared_is_nominal_resource =
+                    native_struct_definition_view.is_nominal_resource();
                 let declared_type_parameters =
                     native_struct_definition_view.type_parameter_constraints();
 
                 let expected_index = vm_native_struct.expected_index.0;
-                let expected_kind = &vm_native_struct.expected_kind;
+                let expected_is_nominal_resource = vm_native_struct.expected_nominal_resource;
                 let expected_type_parameters = &vm_native_struct.expected_type_parameters;
                 if declared_index != expected_index
-                    || declared_kind != expected_kind
+                    || declared_is_nominal_resource != expected_is_nominal_resource
                     || declared_type_parameters != expected_type_parameters
                 {
                     errors.push(VerificationError {
@@ -485,7 +486,11 @@ fn verify_struct_kind(
         let owner_module = &dependency_map[&owner_module_id];
         let owner_module_view = ModuleView::new(*owner_module);
         if let Some(struct_definition_view) = owner_module_view.struct_definition(struct_name) {
-            if struct_handle_view.is_resource() != struct_definition_view.is_resource() {
+            if struct_handle_view.is_nominal_resource()
+                != struct_definition_view.is_nominal_resource()
+                || struct_handle_view.type_parameter_constraints()
+                    != struct_definition_view.type_parameter_constraints()
+            {
                 errors.push(VerificationError {
                     kind: IndexKind::StructHandle,
                     idx,

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -117,9 +117,9 @@ pub struct StructName(String);
 /// A Move struct
 #[derive(Clone, Debug, PartialEq)]
 pub struct StructDefinition {
-    /// The struct will have kind resource if `resource_kind` is true
-    /// and a value otherwise
-    pub resource_kind: bool,
+    /// The struct will have kind resource if `is_nominal_resource` is true
+    /// and will be dependent on it's type arguments otherwise
+    pub is_nominal_resource: bool,
     /// Human-readable name for the struct that also serves as a nominal type
     pub name: StructName,
     /// the fields each instance has
@@ -692,9 +692,9 @@ impl StructDefinition {
     /// types
     /// Does not verify the correctness of any internal properties, e.g. doesn't check that the
     /// fields do not have reference types
-    pub fn move_declared(resource_kind: bool, name: String, fields: Fields<Type>) -> Self {
+    pub fn move_declared(is_nominal_resource: bool, name: String, fields: Fields<Type>) -> Self {
         StructDefinition {
-            resource_kind,
+            is_nominal_resource,
             name: StructName::new(name),
             fields: StructDefinitionFields::Move { fields },
         }
@@ -703,9 +703,9 @@ impl StructDefinition {
     /// Creates a new StructDefinition from the resource kind (true if resource), the string
     /// representation of the name, and the user specified fields, a map from their names to their
     /// types
-    pub fn native(resource_kind: bool, name: String) -> Self {
+    pub fn native(is_nominal_resource: bool, name: String) -> Self {
         StructDefinition {
-            resource_kind,
+            is_nominal_resource,
             name: StructName::new(name),
             fields: StructDefinitionFields::Native,
         }

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -470,15 +470,15 @@ pub Script : Script = {
 }
 
 StructDecl: StructDefinition = {
-    <kind: StructKind> <n: Name> "{" <data: (FieldDecl)*> "}" => {
+    <is_nominal_resource: StructKind> <n: Name> "{" <data: (FieldDecl)*> "}" => {
         let mut fields = Fields::new();
         for (field, type_) in data.into_iter() {
             fields.insert(field, type_);
         }
-        StructDefinition::move_declared(kind, n, fields)
+        StructDefinition::move_declared(is_nominal_resource, n, fields)
     },
-    <native: NativeTag> <kind: StructKind> <n: Name> ";" =>
-        StructDefinition::native(kind, n),
+    <native: NativeTag> <is_nominal_resource: StructKind> <n: Name> ";" =>
+        StructDefinition::native(is_nominal_resource, n),
 }
 
 QualifiedModuleIdent: QualifiedModuleIdent = {

--- a/language/tools/cost_synthesis/src/global_state/account.rs
+++ b/language/tools/cost_synthesis/src/global_state/account.rs
@@ -56,8 +56,10 @@ impl Account {
             ret_vec.extend(mod_ref.struct_defs().iter().enumerate().filter_map(
                 |(struct_idx, struct_def)| {
                     // Determine if the struct definition is a resource
-                    let kind = mod_ref.struct_handle_at(struct_def.struct_handle).kind;
-                    if kind.is_resource() {
+                    let is_nominal_resource = mod_ref
+                        .struct_handle_at(struct_def.struct_handle)
+                        .is_nominal_resource;
+                    if is_nominal_resource {
                         // Generate the type for the struct
                         let typ = SignatureToken::Struct(struct_def.struct_handle, vec![]);
                         // Generate a value of that type

--- a/language/tools/cost_synthesis/src/module_generator.rs
+++ b/language/tools/cost_synthesis/src/module_generator.rs
@@ -17,7 +17,7 @@ use vm::{
     file_format::{
         AddressPoolIndex, Bytecode, CodeUnit, CompiledModule, CompiledModuleMut, FieldDefinition,
         FieldDefinitionIndex, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
-        FunctionSignature, FunctionSignatureIndex, Kind, LocalsSignature, LocalsSignatureIndex,
+        FunctionSignature, FunctionSignatureIndex, LocalsSignature, LocalsSignatureIndex,
         MemberCount, ModuleHandle, ModuleHandleIndex, SignatureToken, StringPoolIndex,
         StructDefinition, StructFieldInformation, StructHandle, StructHandleIndex, TableIndex,
         TypeSignature, TypeSignatureIndex,
@@ -215,12 +215,8 @@ impl ModuleBuilder {
             .map(|struct_idx| StructHandle {
                 module: ModuleHandleIndex::new(0),
                 name: StringPoolIndex::new((struct_idx + offset) as TableIndex),
-                kind: if self.gen.gen_bool(1.0 / 2.0) {
-                    Kind::Resource
-                } else {
-                    Kind::Copyable
-                },
-                kind_constraints: vec![],
+                is_nominal_resource: self.gen.gen_bool(1.0 / 2.0),
+                type_parameters: vec![],
             })
             .collect();
     }
@@ -266,7 +262,7 @@ impl ModuleBuilder {
                 let function_sig = FunctionSignature {
                     arg_types: args,
                     return_types,
-                    kind_constraints: vec![],
+                    type_parameters: vec![],
                 };
 
                 (locals, function_sig)

--- a/language/tools/cost_synthesis/src/stack_generator.rs
+++ b/language/tools/cost_synthesis/src/stack_generator.rs
@@ -287,11 +287,11 @@ where
             .iter()
             .enumerate()
             .filter_map(|(idx, struct_def)| {
-                let kind = self
+                let is_nominal_resource = self
                     .root_module
                     .struct_handle_at(struct_def.struct_handle)
-                    .kind;
-                if kind.is_resource() {
+                    .is_nominal_resource;
+                if is_nominal_resource {
                     Some(idx)
                 } else {
                     None

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -232,10 +232,15 @@ pub struct StructHandle {
     pub module: ModuleHandleIndex,
     /// The name of the type.
     pub name: StringPoolIndex,
-    /// The kind of the struct itself.
-    pub kind: Kind,
-    /// The kind constraints of the type parameters.
-    pub kind_constraints: Vec<Kind>,
+    /// There are two ways for a type to have the Kind resource
+    /// 1) If it has a type argument of resource
+    /// 2) If it was declared as a resource
+    /// These "declared" resources are referred to as *nominal resources*
+    ///
+    /// If `is_nominal_resource` is true, it is a *nominal resource*
+    pub is_nominal_resource: bool,
+    /// The type parameters (identified by their index into the vec) and their kind constraints
+    pub type_parameters: Vec<Kind>,
 }
 
 /// A `FunctionHandle` is a reference to a function. It is composed by a
@@ -342,7 +347,7 @@ impl FunctionDefinition {
     }
 }
 
-// Signature definitions.
+// Signature
 // A signature can be for a type (field, local) or for a function - return type: (arguments).
 // They both go into the signature table so there is a marker that tags the signature.
 // Signature usually don't carry a size and you have to read them to get to the end.
@@ -375,8 +380,8 @@ pub struct FunctionSignature {
         proptest(strategy = "vec(any::<SignatureToken>(), 0..=params)")
     )]
     pub arg_types: Vec<SignatureToken>,
-    /// The kind constraints of the type parameters.
-    pub kind_constraints: Vec<Kind>,
+    /// The type parameters (identified by their index into the vec) and their kind constraints
+    pub type_parameters: Vec<Kind>,
 }
 
 /// A `LocalsSignature` is the list of locals used by a function.
@@ -412,29 +417,25 @@ impl LocalsSignature {
 /// type parameter in the `FunctionSignature/Handle` and `StructHandle`.
 pub type TypeParameterIndex = u16;
 
-/// A `Kind` is the type of a type. It classifies types into categories with rules each category
-/// must follow.
+/// A `Kind` classifies types into sets with rules each set must follow.
 ///
-/// Currently there are two kinds in Move: `resource` and `copyable`.
+/// Currently there are three kinds in Move: `All`, `Resource` and `Unrestricted`.
 #[derive(Debug, Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 pub enum Kind {
-    /// `resource` types must follow move semantics and various resource safety rules.
+    /// Represents the super set of all types. The type might actually be a `Resource` or
+    /// `Unrestricted` A type might be in this set if it is not known to be a `Resource` or
+    /// `Unrestricted`
+    ///   - This occurs when there is a type parameter with this kind as a constraint
+    All,
+    /// `Resource` types must follow move semantics and various resource safety rules, namely:
+    /// - `Resource` values cannot be copied
+    /// - `Resource` values cannot be popped, i.e. they must be used
     Resource,
-    /// `copyable` types do not need to follow the said rules. Most notably they can be freely
-    /// copied & destroyed. A `copyable` can still be used as a `resource` and therefore it is
-    /// considered a sub-kind of the latter.
-    Copyable,
-}
-
-impl Kind {
-    /// Checks if the kind is resource.
-    pub fn is_resource(self) -> bool {
-        match self {
-            Kind::Resource => true,
-            Kind::Copyable => false,
-        }
-    }
+    /// `Unrestricted` types do not need to follow the `Resource` rules.
+    /// - `Unrestricted` values can be copied
+    /// - `Unrestricted` values can be popped
+    Unrestricted,
 }
 
 /// A `SignatureToken` is a type declaration for a location.
@@ -538,9 +539,9 @@ impl SignatureToken {
         }
     }
 
-    /// Returns the "kind" for the `SignatureToken`
+    /// Returns the "value kind" for the `SignatureToken`
     #[inline]
-    pub fn kind(&self) -> SignatureTokenKind {
+    pub fn signature_token_kind(&self) -> SignatureTokenKind {
         // TODO: SignatureTokenKind is out-dated. fix/update/remove SignatureTokenKind and see if
         // this function needs to be cleaned up
         use SignatureToken::*;
@@ -1552,7 +1553,7 @@ pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
     module.function_signatures.push(FunctionSignature {
         arg_types: vec![],
         return_types: vec![],
-        kind_constraints: vec![],
+        type_parameters: vec![],
     });
     let fun_handle = FunctionHandle {
         module: ModuleHandleIndex(0),

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -87,9 +87,19 @@ pub enum SerializedType {
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 #[derive(Clone, Copy, Debug)]
+pub enum SerializedNominalResourceFlag {
+    NOMINAL_RESOURCE        = 0x1,
+    NORMAL_STRUCT           = 0x2,
+}
+
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
 pub enum SerializedKind {
-    RESOURCE                = 0x1,
-    COPYABLE                = 0x2,
+    ALL                     = 0x1,
+    UNRESTRICTED            = 0x2,
+    RESOURCE                = 0x3,
 }
 
 #[rustfmt::skip]

--- a/language/vm/src/printers.rs
+++ b/language/vm/src/printers.rs
@@ -409,9 +409,10 @@ fn display_struct_handle<T: TableAccess>(
     write!(
         f,
         "{} ",
-        match struct_.kind {
-            Kind::Resource => "resource",
-            Kind::Copyable => "struct",
+        if struct_.is_nominal_resource {
+            "resource"
+        } else {
+            "struct"
         }
     )?;
     write!(f, "{}@", tables.get_string_at(struct_.name).unwrap())?;

--- a/language/vm/src/resolver.rs
+++ b/language/vm/src/resolver.rs
@@ -88,8 +88,8 @@ impl Resolver {
                         .string_map
                         .get(struct_name)
                         .ok_or(VMStaticViolation::TypeResolutionFailure)?,
-                    kind: struct_handle.kind,
-                    kind_constraints: struct_handle.kind_constraints.clone(),
+                    is_nominal_resource: struct_handle.is_nominal_resource,
+                    type_parameters: struct_handle.type_parameters.clone(),
                 };
                 Ok(SignatureToken::Struct(
                     *self
@@ -131,7 +131,7 @@ impl Resolver {
         Ok(FunctionSignature {
             return_types,
             arg_types,
-            kind_constraints: func_sig.kind_constraints.clone(),
+            type_parameters: func_sig.type_parameters.clone(),
         })
     }
 }

--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -261,12 +261,12 @@ fn serialize_module_handle(binary: &mut BinaryData, module_handle: &ModuleHandle
 /// A `StructHandle` gets serialized as follows:
 /// - `StructHandle.module` as a ULEB128 (index into the `ModuleHandle` table)
 /// - `StructHandle.name` as a ULEB128 (index into the `StringPool`)
-/// - `StructHandle.is_resource` as a 1 byte boolean (0 for false, 1 for true)
+/// - `StructHandle.is_nominal_resource` as a 1 byte boolean (0 for false, 1 for true)
 fn serialize_struct_handle(binary: &mut BinaryData, struct_handle: &StructHandle) -> Result<()> {
     write_u16_as_uleb128(binary, struct_handle.module.0)?;
     write_u16_as_uleb128(binary, struct_handle.name.0)?;
-    serialize_kind(binary, struct_handle.kind)?;
-    serialize_kinds(binary, &struct_handle.kind_constraints)
+    serialize_nominal_resource_flag(binary, struct_handle.is_nominal_resource)?;
+    serialize_kinds(binary, &struct_handle.type_parameters)
 }
 
 /// Serializes a `FunctionHandle`.
@@ -419,7 +419,7 @@ fn serialize_function_signature(
     binary.push(SignatureType::FUNCTION_SIGNATURE as u8)?;
     serialize_signature_tokens(binary, &signature.return_types)?;
     serialize_signature_tokens(binary, &signature.arg_types)?;
-    serialize_kinds(binary, &signature.kind_constraints)
+    serialize_kinds(binary, &signature.type_parameters)
 }
 
 /// Serializes a `LocalsSignature`.
@@ -481,10 +481,23 @@ fn serialize_signature_token(binary: &mut BinaryData, token: &SignatureToken) ->
     Ok(())
 }
 
+fn serialize_nominal_resource_flag(
+    binary: &mut BinaryData,
+    is_nominal_resource: bool,
+) -> Result<()> {
+    binary.push(if is_nominal_resource {
+        SerializedNominalResourceFlag::NOMINAL_RESOURCE
+    } else {
+        SerializedNominalResourceFlag::NORMAL_STRUCT
+    } as u8)?;
+    Ok(())
+}
+
 fn serialize_kind(binary: &mut BinaryData, kind: Kind) -> Result<()> {
     binary.push(match kind {
+        Kind::All => SerializedKind::ALL,
         Kind::Resource => SerializedKind::RESOURCE,
-        Kind::Copyable => SerializedKind::COPYABLE,
+        Kind::Unrestricted => SerializedKind::UNRESTRICTED,
     } as u8)?;
     Ok(())
 }

--- a/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
@@ -64,12 +64,12 @@ fn test_module(name: String) -> VerifiedModule {
             FunctionSignature {
                 return_types: vec![],
                 arg_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
             FunctionSignature {
                 return_types: vec![],
                 arg_types: vec![SignatureToken::U64],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ],
         locals_signatures: vec![LocalsSignature(vec![])],
@@ -126,12 +126,12 @@ fn test_script() -> VerifiedScript {
             FunctionSignature {
                 return_types: vec![],
                 arg_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
             FunctionSignature {
                 return_types: vec![],
                 arg_types: vec![SignatureToken::U64],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ],
         locals_signatures: vec![LocalsSignature(vec![])],
@@ -413,12 +413,12 @@ fn test_multi_level_cache_write_back() {
             FunctionSignature {
                 return_types: vec![],
                 arg_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
             FunctionSignature {
                 return_types: vec![],
                 arg_types: vec![SignatureToken::U64],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ],
         locals_signatures: vec![LocalsSignature(vec![])],

--- a/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
@@ -65,7 +65,7 @@ fn fake_script() -> VerifiedScript {
         function_signatures: vec![FunctionSignature {
             arg_types: vec![],
             return_types: vec![],
-            kind_constraints: vec![],
+            type_parameters: vec![],
         }],
         locals_signatures: vec![LocalsSignature(vec![])],
         string_pool: vec!["hello".to_string()],
@@ -608,7 +608,7 @@ fn test_call() {
             FunctionSignature {
                 arg_types: vec![],
                 return_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ),
         // () -> (), two locals
@@ -617,7 +617,7 @@ fn test_call() {
             FunctionSignature {
                 arg_types: vec![],
                 return_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ),
         // (Int, Int) -> (), two locals,
@@ -626,7 +626,7 @@ fn test_call() {
             FunctionSignature {
                 arg_types: vec![SignatureToken::U64, SignatureToken::U64],
                 return_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ),
         // (Int, Int) -> (), three locals,
@@ -639,7 +639,7 @@ fn test_call() {
             FunctionSignature {
                 arg_types: vec![SignatureToken::U64, SignatureToken::U64],
                 return_types: vec![],
-                kind_constraints: vec![],
+                type_parameters: vec![],
             },
         ),
     ]);

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/dispatch.rs
@@ -61,7 +61,7 @@ macro_rules! add {
         let expected_signature = FunctionSignature {
             return_types: $ret,
             arg_types: $args,
-            kind_constraints: $kinds,
+            type_parameters: $kinds,
         };
         let f = NativeFunction {
             dispatch: $dis,

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
@@ -7,8 +7,8 @@ use vm::file_format::{Kind, StructHandleIndex};
 
 /// Struct representing the expected definition for a native struct
 pub struct NativeStruct {
-    /// The expected kind of the struct/resource
-    pub expected_kind: Kind,
+    /// The expected boolean indicating if it is a nominal resource or not
+    pub expected_nominal_resource: bool,
     /// The expected kind constraints of the type parameters.
     pub expected_type_parameters: Vec<Kind>,
     /// The expected index for the struct
@@ -26,16 +26,16 @@ pub fn dispatch_native_struct(
 }
 
 macro_rules! add {
-    ($m:ident, $addr:expr, $module:expr, $name:expr, $kind: expr) => {{
-        add!($m, $addr, $module, $name, $kind, vec![])
+    ($m:ident, $addr:expr, $module:expr, $name:expr, $resource: expr) => {{
+        add!($m, $addr, $module, $name, $resource, vec![])
     }};
-    ($m:ident, $addr:expr, $module:expr, $name:expr, $kind: expr, $ty_kinds: expr) => {{
+    ($m:ident, $addr:expr, $module:expr, $name:expr, $resource: expr, $ty_kinds: expr) => {{
         let id = ModuleId::new($addr, $module.into());
         let struct_table = $m.entry(id).or_insert_with(HashMap::new);
         let expected_index = StructHandleIndex(struct_table.len() as u16);
 
         let s = NativeStruct {
-            expected_kind: $kind,
+            expected_nominal_resource: $resource,
             expected_type_parameters: $ty_kinds,
             expected_index,
         };
@@ -48,10 +48,9 @@ type NativeStructMap = HashMap<ModuleId, HashMap<String, NativeStruct>>;
 
 lazy_static! {
     static ref NATIVE_STRUCT_MAP: NativeStructMap = {
-        use Kind::*;
         let mut m: NativeStructMap = HashMap::new();
         let addr = account_config::core_code_address();
-        add!(m, addr, "Vector", "T", Copyable);
+        add!(m, addr, "Vector", "T", false);
         m
     };
 }


### PR DESCRIPTION
## Motivation

- Kinds are a in weird spot currently where Kind's are used for multiple purposes
- Struct Defintions no longer have a a kind. Instead they now have a `is_nominal_resource` flag. Only types should have kinds
  - Nominal resources are the "root" resources. At some point, a type NEEDS to be declared a resource (instead of just being inferred as a resource from it's type arguments)
- Types can now be in two kinds `Resource` or `Unrestricted`. There is a kind `All` to represent the union of the two, which is used when the type is existential
- I chose `Unrestrictred` over `Copyable` since they can also be popped and dereferenced and mutate. None of those things are conveyed via `Copyable`. I still think `T: copyable` is a good UX choice for the language, but it feels off for an internal name 
- I tried to refactor many spots to remove `is_resource` since with the addition of `All` it is not really what the call-site wants 
- `All` might also be called `Unknown`. Its a more accurate name for what cases it appears in, but less informative as far as it being the union of `Resource` and `Unrestricted` types

## Test Plan

cargo check; cargo test

Can't fully test without full generics 