### PR TITLE
[storage] set max receive message len on gRPC storage server

### DIFF
--- a/storage/storage_service/src/lib.rs
+++ b/storage/storage_service/src/lib.rs
@@ -39,6 +39,7 @@ pub fn start_storage_service(config: &NodeConfig) -> ServerHandle {
         config.storage.address.clone(),
         config.storage.port,
         "storage",
+        config.storage.grpc_max_receive_len,
         move || {
             shutdown_receiver
                 .recv()


### PR DESCRIPTION
PR #403 set max receive message len on the gRPC client of the storage
channel. It turns out the gRPC server side needs to be configured as
well to make it work.

## Test Plan
Tested locally with a simple gRPC client/server project, will double check on benchmark cluster.

## Related PRs
#403 