### PR TITLE
[VM] Use account_config::core_code_address() in natives

### DIFF
--- a/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use types::{account_address::AccountAddress, language_storage::ModuleId};
+use types::{account_config, language_storage::ModuleId};
 use vm::file_format::{Kind, StructHandleIndex};
 
 /// Struct representing the expected definition for a native struct
@@ -30,8 +30,7 @@ macro_rules! add {
         add!($m, $addr, $module, $name, $kind, vec![])
     }};
     ($m:ident, $addr:expr, $module:expr, $name:expr, $kind: expr, $ty_kinds: expr) => {{
-        let addr = AccountAddress::from_hex_literal($addr).unwrap();
-        let id = ModuleId::new(addr, $module.into());
+        let id = ModuleId::new($addr, $module.into());
         let struct_table = $m.entry(id).or_insert_with(HashMap::new);
         let expected_index = StructHandleIndex(struct_table.len() as u16);
 
@@ -51,7 +50,8 @@ lazy_static! {
     static ref NATIVE_STRUCT_MAP: NativeStructMap = {
         use Kind::*;
         let mut m: NativeStructMap = HashMap::new();
-        add!(m, "0x0", "Vector", "T", Copyable);
+        let addr = account_config::core_code_address();
+        add!(m, addr, "Vector", "T", Copyable);
         m
     };
 }


### PR DESCRIPTION
## Motivation

- Small change to use account_config::core_code_address() isntead of a 0x0 for native function/struct address

## Test Plan

cargo check
cargo test

