### PR TITLE
[VM] Consider stack size change during bytecode generation

### DIFF
--- a/language/tools/cost_synthesis/src/module_generator.rs
+++ b/language/tools/cost_synthesis/src/module_generator.rs
@@ -133,8 +133,7 @@ impl ModuleBuilder {
                             ),
                             None => {
                                 // Random nonsense to pad this out. We won't look at this at all,
-                                // just non-empty is all that
-                                // matters.
+                                // just non-empty is all that matters.
                                 vec![Bytecode::Sub, Bytecode::Sub, Bytecode::Add, Bytecode::Ret]
                             }
                         }

--- a/language/tools/test_generation/Cargo.toml
+++ b/language/tools/test_generation/Cargo.toml
@@ -14,3 +14,6 @@ bytecode_verifier = { path = "../../bytecode_verifier" }
 cost_synthesis = { path = "../cost_synthesis" }
 types = { path = "../../../types" }
 vm = { path = "../../vm" }
+
+[dev-dependencies]
+types = { path = "../../../types", features = ["testing"] }

--- a/language/tools/test_generation/src/common.rs
+++ b/language/tools/test_generation/src/common.rs
@@ -1,0 +1,9 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// This defines how tolerant the generator will be about deviating from
+/// the starting stack height. The higher the tolerance, the more likely
+/// it is for invalid programs to be generated within a given target number
+/// of instructions.
+/// Default is 0.9 for generating 1000 instruction sequences.
+pub const MUTATION_TOLERANCE: f32 = 0.9;

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod abstract_state;
 pub mod bytecode_generator;
+pub mod common;
 pub mod summaries;
 pub mod transitions;
 
@@ -18,11 +19,13 @@ use vm::{
 };
 
 /// This function calls the Bytecode verifier to test it
-fn run_verifier(module: CompiledModule) {
+fn run_verifier(module: CompiledModule) -> u64 {
     match VerifiedModule::new(module) {
-        Ok(_) => {}
+        Ok(_) => 1,
         Err((_, errs)) => {
+            // error!("Module: {:#?}", module.clone());
             error!("Module verification failed: {:#?}", errs);
+            0
         }
     }
 }
@@ -37,8 +40,7 @@ pub fn generate_bytecode(
     target_min: usize,
     target_max: usize,
 ) -> Vec<Bytecode> {
-    let seed: [u8; 32] = [0; 32];
-    let mut bytecode_generator = BytecodeGenerator::new(seed);
+    let mut bytecode_generator = BytecodeGenerator::new(None);
     bytecode_generator.generate(arguments, signature, target_min, target_max)
 }
 
@@ -47,10 +49,17 @@ pub fn generate_bytecode(
 pub fn run_generation(iterations: usize) {
     env_logger::init();
 
+    let mut valid_programs: u64 = 0;
     for _ in 0..iterations {
         let module =
-            ModuleBuilder::new(1, Some(Box::new(generate_bytecode))).materialize_unverified();
-        debug!("Module: {:#?}", module);
-        run_verifier(module);
+            ModuleBuilder::new(2, Some(Box::new(generate_bytecode))).materialize_unverified();
+        valid_programs += run_verifier(module);
     }
+
+    info!(
+        "Total valid: {}, Total programs: {}, Percent valid: {:.2}",
+        valid_programs,
+        iterations,
+        (valid_programs as f64) / (iterations as f64) * 100.0
+    );
 }

--- a/language/tools/test_generation/src/main.rs
+++ b/language/tools/test_generation/src/main.rs
@@ -4,5 +4,5 @@
 use test_generation::run_generation;
 
 pub fn main() {
-    run_generation(1);
+    run_generation(1000);
 }

--- a/language/tools/test_generation/src/transitions.rs
+++ b/language/tools/test_generation/src/transitions.rs
@@ -13,6 +13,13 @@ pub fn stack_has(state: &AbstractState, index: usize, token: Option<SignatureTok
     }
 }
 
+pub fn stack_has_polymorphic_eq(state: &AbstractState, index1: usize, index2: usize) -> bool {
+    if stack_has(state, index2, None) {
+        return state.stack_peek(index1) == state.stack_peek(index2);
+    }
+    false
+}
+
 /// Pop from the top of the stack.
 pub fn stack_pop(state: &AbstractState) -> AbstractState {
     let mut state = state.clone();
@@ -86,6 +93,13 @@ pub fn stack_pop_local_insert(state: &AbstractState, index: u8) -> AbstractState
 macro_rules! state_stack_has {
     ($e1: expr, $e2: expr) => {
         Box::new(move |state| stack_has(state, $e1, $e2))
+    };
+}
+
+#[macro_export]
+macro_rules! state_stack_has_polymorphic_eq {
+    ($e1: expr, $e2: expr) => {
+        Box::new(move |state| stack_has_polymorphic_eq(state, $e1, $e2))
     };
 }
 

--- a/language/tools/test_generation/tests/bitwise_instructions.rs
+++ b/language/tools/test_generation/tests/bitwise_instructions.rs
@@ -29,3 +29,16 @@ fn bytecode_bitor() {
         "stack type postcondition not met"
     );
 }
+
+#[test]
+fn bytecode_xor() {
+    let mut state1 = AbstractState::new(&Vec::new());
+    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(SignatureToken::U64);
+    let state2 = common::run_instruction(Bytecode::Xor, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(SignatureToken::U64),
+        "stack type postcondition not met"
+    );
+}

--- a/language/tools/test_generation/tests/boolean_instructions.rs
+++ b/language/tools/test_generation/tests/boolean_instructions.rs
@@ -31,19 +31,6 @@ fn bytecode_or() {
 }
 
 #[test]
-fn bytecode_xor() {
-    let mut state1 = AbstractState::new(&Vec::new());
-    state1.stack_push(SignatureToken::Bool);
-    state1.stack_push(SignatureToken::Bool);
-    let state2 = common::run_instruction(Bytecode::Xor, state1);
-    assert_eq!(
-        state2.stack_peek(0),
-        Some(SignatureToken::Bool),
-        "stack type postcondition not met"
-    );
-}
-
-#[test]
 fn bytecode_not() {
     let mut state1 = AbstractState::new(&Vec::new());
     state1.stack_push(SignatureToken::Bool);


### PR DESCRIPTION
## Motivation

This PR makes it more likely that a valid bytecode sequence will be found during test generation.

Instructions can broadly be split into those that add to the stack and those that remove from the stack. This adds a probability measure to discourage adding to the stack when it its height is large, and encourage adding when the height is small. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested with tests in `tests/`

## Related PRs

N/A
