### PR TITLE
[storage][jellyfish] fix building error

### DIFF
--- a/storage/jellyfish_merkle/Cargo.toml
+++ b/storage/jellyfish_merkle/Cargo.toml
@@ -20,3 +20,8 @@ types = { path = "../../types" }
 
 [dev-dependencies]
 rand = "0.6.5"
+types = { path = "../../types", features = ["testing"]}
+
+[features]
+default = []
+testing = ["types/testing"]


### PR DESCRIPTION
## Motivation

#429 introduces the new API and somehow we have to enable `testing` feature of `types` whenever we depend on it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Cargo test

## Related PRs

