### PR TITLE
[common,type] Add more CanonicalSerialiazation support

### DIFF
--- a/common/canonical_serialization/src/canonical_serialization_test.rs
+++ b/common/canonical_serialization/src/canonical_serialization_test.rs
@@ -340,3 +340,35 @@ fn test_deserialization_failure_cases() {
     deserializer = SimpleDeserializer::new(&bool_bytes);
     assert!(deserializer.clone().decode_bool().is_err());
 }
+
+#[test]
+fn test_tuples() {
+    let input: (u32, u32) = (123, 456);
+    let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+    serializer.encode_tuple2(&input).unwrap();
+    let serialized_bytes = serializer.get_output();
+
+    let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+    let output: Result<(u32, u32)> = deserializer.decode_tuple2();
+    assert!(output.is_ok());
+    assert_eq!(output.unwrap(), input);
+
+    let bad_output: Result<(u32, u32)> = deserializer.decode_tuple2();
+    assert!(bad_output.is_err());
+}
+
+#[test]
+fn test_nested_tuples() {
+    let input: Vec<(u32, u32)> = vec![(123, 456)];
+    let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+    serializer.encode_vec(&input).unwrap();
+    let serialized_bytes = serializer.get_output();
+
+    let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+    let output: Result<Vec<(u32, u32)>> = deserializer.decode_vec();
+    assert!(output.is_ok());
+    assert_eq!(output.unwrap(), input);
+
+    let bad_output: Result<(u32, u32)> = deserializer.decode_tuple2();
+    assert!(bad_output.is_err());
+}

--- a/common/canonical_serialization/src/canonical_serialization_test.rs
+++ b/common/canonical_serialization/src/canonical_serialization_test.rs
@@ -372,3 +372,15 @@ fn test_nested_tuples() {
     let bad_output: Result<(u32, u32)> = deserializer.decode_tuple2();
     assert!(bad_output.is_err());
 }
+
+#[test]
+fn test_strings() {
+    let input: &'static str = "Hello, World!";
+    let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+    serializer.encode_string(input).unwrap();
+    let serialized_bytes = serializer.get_output();
+
+    let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+    let output: Result<String> = deserializer.decode_string();
+    assert_eq!(output.unwrap(), input);
+}

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -38,6 +38,9 @@ use std::{collections::HashMap, convert::TryFrom, fmt, time::Duration};
 mod program;
 mod transaction_argument;
 
+#[cfg(test)]
+mod unit_tests;
+
 pub use program::{Program, TransactionArgument, SCRIPT_HASH_LENGTH};
 use protobuf::well_known_types::UInt64Value;
 use std::ops::Deref;

--- a/types/src/transaction/program.rs
+++ b/types/src/transaction/program.rs
@@ -146,6 +146,25 @@ impl IntoProto for Program {
     }
 }
 
+impl CanonicalSerialize for Program {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_vec(&self.code)?;
+        serializer.encode_vec(&self.args)?;
+        serializer.encode_vec(&self.modules)?;
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for Program {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
+        let code: Vec<u8> = deserializer.decode_vec()?;
+        let args: Vec<TransactionArgument> = deserializer.decode_vec()?;
+        let modules: Vec<Vec<u8>> = deserializer.decode_vec()?;
+
+        Ok(Program::new(code, modules, args))
+    }
+}
+
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionArgument {
     U64(u64),

--- a/types/src/transaction/unit_tests/mod.rs
+++ b/types/src/transaction/unit_tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod program_test;

--- a/types/src/transaction/unit_tests/program_test.rs
+++ b/types/src/transaction/unit_tests/program_test.rs
@@ -1,13 +1,24 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transaction::program::TransactionArgument;
+use crate::transaction::program::{Program, TransactionArgument};
 use canonical_serialization::{
     CanonicalDeserializer, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
 };
 use proptest::prelude::*;
 
 proptest! {
+    #[test]
+    fn program_round_trip_canonical_serialization(program in any::<Program>()) {
+        let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+        serializer.encode_struct(&program).unwrap();
+        let serialized_bytes = serializer.get_output();
+
+        let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+        let output: Program = deserializer.decode_struct().unwrap();
+        assert_eq!(program, output);
+    }
+
     #[test]
     fn transaction_arguments_round_trip_canonical_serialization(
         transaction_argument in any::<TransactionArgument>()

--- a/types/src/transaction/unit_tests/program_test.rs
+++ b/types/src/transaction/unit_tests/program_test.rs
@@ -1,0 +1,23 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction::program::TransactionArgument;
+use canonical_serialization::{
+    CanonicalDeserializer, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
+};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn transaction_arguments_round_trip_canonical_serialization(
+        transaction_argument in any::<TransactionArgument>()
+    ) {
+        let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+        serializer.encode_struct(&transaction_argument).unwrap();
+        let serialized_bytes = serializer.get_output();
+
+        let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+        let output: TransactionArgument = deserializer.decode_struct().unwrap();
+        assert_eq!(transaction_argument, output);
+    }
+}

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     account_address::AccountAddress,
-    transaction::{Program, RawTransaction, SignedTransaction},
+    transaction::{Program, RawTransaction, SignedTransaction, TransactionPayload},
+};
+use canonical_serialization::{
+    CanonicalDeserializer, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
 };
 use nextgen_crypto::ed25519::*;
 use proptest::prelude::*;
@@ -39,5 +42,27 @@ proptest! {
         let txn = raw_txn.sign(&sk1, pk1).unwrap();
         let signed_txn = txn.into_inner();
         assert!(signed_txn.check_signature().is_ok());
+    }
+
+    #[test]
+    fn transaction_payload_round_trip_canonical_serialization(txn_payload in any::<TransactionPayload>()) {
+        let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+        serializer.encode_struct(&txn_payload).unwrap();
+        let serialized_bytes = serializer.get_output();
+
+        let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+        let output: TransactionPayload = deserializer.decode_struct().unwrap();
+        assert_eq!(txn_payload, output);
+    }
+
+    #[test]
+    fn transaction_round_trip_canonical_serialization(raw_txn in any::<RawTransaction>()) {
+        let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+        serializer.encode_struct(&raw_txn).unwrap();
+        let serialized_bytes = serializer.get_output();
+
+        let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+        let output: RawTransaction = deserializer.decode_struct().unwrap();
+        assert_eq!(raw_txn, output);
     }
 }

--- a/types/src/unit_tests/write_set_test.rs
+++ b/types/src/unit_tests/write_set_test.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::write_set::WriteSet;
+use canonical_serialization::{
+    CanonicalDeserializer, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
+};
 use proptest::prelude::*;
 use proto_conv::test_helper::assert_protobuf_encode_decode;
 
@@ -9,5 +12,16 @@ proptest! {
     #[test]
     fn write_set_roundtrip(write_set in any::<WriteSet>()) {
         assert_protobuf_encode_decode(&write_set);
+    }
+
+    #[test]
+    fn write_set_roundtrip_canonical_serialization(write_set in any::<WriteSet>()) {
+        let mut serializer = SimpleSerializer::<Vec<u8>>::new();
+        serializer.encode_struct(&write_set).unwrap();
+        let serialized_bytes = serializer.get_output();
+
+        let mut deserializer = SimpleDeserializer::new(&serialized_bytes);
+        let output: WriteSet = deserializer.decode_struct().unwrap();
+        assert_eq!(write_set, output);
     }
 }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -5,6 +5,9 @@
 //! path it updates. For each access path, the VM can either give its new value or delete it.
 
 use crate::access_path::AccessPath;
+use canonical_serialization::{
+    CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
+};
 use failure::prelude::*;
 use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
@@ -38,6 +41,50 @@ impl std::fmt::Debug for WriteOp {
         match self {
             WriteOp::Value(value) => write!(f, "Value({})", String::from_utf8_lossy(value)),
             WriteOp::Deletion => write!(f, "Deletion"),
+        }
+    }
+}
+
+impl CanonicalSerialize for WriteOp {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        match self {
+            WriteOp::Deletion => serializer.encode_u32(WriteOpType::Deletion as u32)?,
+            WriteOp::Value(value) => {
+                serializer.encode_u32(WriteOpType::Value as u32)?;
+                serializer.encode_vec(value)?
+            }
+        };
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for WriteOp {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
+        let decoded_write_op_type = deserializer.decode_u32()?;
+        let write_op_type = WriteOpType::from_u32(decoded_write_op_type);
+        match write_op_type {
+            Some(WriteOpType::Deletion) => Ok(WriteOp::Deletion),
+            Some(WriteOpType::Value) => Ok(WriteOp::Value(deserializer.decode_vec()?)),
+            None => Err(format_err!(
+                "ParseError: Unable to decode WriteOpType, found {}",
+                decoded_write_op_type
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+enum WriteOpType {
+    Deletion = 0,
+    Value = 1,
+}
+
+impl WriteOpType {
+    fn from_u32(value: u32) -> Option<WriteOpType> {
+        match value {
+            0 => Some(WriteOpType::Deletion),
+            1 => Some(WriteOpType::Value),
+            _ => None,
         }
     }
 }
@@ -167,6 +214,20 @@ impl IntoProto for WriteSet {
         let mut proto_write_set = Self::ProtoType::new();
         proto_write_set.set_write_set(proto_write_ops);
         proto_write_set
+    }
+}
+
+impl CanonicalSerialize for WriteSet {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_vec(&self.0.write_set)?;
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for WriteSet {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
+        let write_set = deserializer.decode_vec::<(AccessPath, WriteOp)>()?;
+        WriteSetMut::new(write_set).freeze()
     }
 }
 


### PR DESCRIPTION
This tackles the serialization subtasks from refs #454
- CanonicalSerialization support for TransactionPayload(Program, WriteSet)
- WriteSet contains AccessPath, which already supports CS, and WriteOp, which needs it
- WriteOp consists of a vec and primitves
- Program contains vec, primitives, and TransactionArguments
- Transaction arguments are a type field (i32) and a primitive (string, byte u64)
- Add serialization unit tests