### PR TITLE
[language] add missing pieces to bytecode-to-boogie translator

### DIFF
--- a/language/stackless_bytecode/bytecode_to_boogie/Cargo.toml
+++ b/language/stackless_bytecode/bytecode_to_boogie/Cargo.toml
@@ -14,3 +14,4 @@ stackless_bytecode_generator = { path = "../generator"}
 
 [dev-dependencies]
 proptest = "0.9"
+types = { path = "../../../types", features = ["testing"]}

--- a/language/stackless_bytecode/bytecode_to_boogie/output.bpl
+++ b/language/stackless_bytecode/bytecode_to_boogie/output.bpl
@@ -2,6 +2,7 @@ type TypeName;
 type FieldName;
 type LocalName;
 type Address;
+type ByteArray;
 type String;
 type CreationTime = int;
 
@@ -18,6 +19,8 @@ type {:datatype} Value;
 function {:constructor} Boolean(b: bool): Value;
 function {:constructor} Integer(i: int): Value;
 function {:constructor} Address(a: Address): Value;
+function {:constructor} ByteArray(b: ByteArray): Value;
+function {:constructor} Str(a: String): Value;
 function {:constructor} Map(m: [Edge]Value): Value;
 
 const DefaultMap: [Edge]Value;
@@ -76,6 +79,7 @@ procedure {:inline 1} DeepUpdateGlobal(t: TypeName, src: Reference, dst: Resourc
 
 procedure {:inline 1} Exists(address: Value, rs: ResourceStore) returns (dst: Value)
 {
+    assert is#Address(address);
     dst := Boolean(domain#ResourceStore(rs)[a#Address(address)]);
 }
 
@@ -90,6 +94,7 @@ procedure {:inline 1} MoveToSender(rs: ResourceStore, v: Value) returns (rs': Re
 procedure {:inline 1} MoveFrom(address: Value, rs: ResourceStore) returns (dst: Value, rs': ResourceStore)
 {
     var a: Address;
+    assert is#Address(address);
     a := a#Address(address);
     assert domain#ResourceStore(rs)[a];
     dst := contents#ResourceStore(rs)[a];
@@ -114,8 +119,10 @@ procedure {:inline 1} BorrowLoc(c: CreationTime, l: LocalName, local: Value) ret
 procedure {:inline 1} BorrowField(src: Reference, f: FieldName) returns (dst: Reference)
 {
     if (is#GlobalReference(src)) {
+        assert is#Map(v#GlobalReference(src));
         dst := GlobalReference(a#GlobalReference(src), t#GlobalReference(src), Cons(p#GlobalReference(src), Field(f)), m#Map(v#GlobalReference(src))[Field(f)]);
     } else {
+        assert is#Map(v#LocalReference(src));
         dst := LocalReference(c#LocalReference(src), l#LocalReference(src), Cons(p#LocalReference(src), Field(f)), m#Map(v#LocalReference(src))[Field(f)]);
     }
 }
@@ -157,87 +164,130 @@ procedure {:inline 1} FreezeRef(src: Reference) returns (dest: Reference)
 
 procedure {:inline 1} Add(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) + i#Integer(src2));
 }
 
 procedure {:inline 1} Sub(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) - i#Integer(src2));
 }
 
 procedure {:inline 1} Mul(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) * i#Integer(src2));
 }
 
 procedure {:inline 1} Div(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) div i#Integer(src2));
 }
 
 procedure {:inline 1} Mod(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) mod i#Integer(src2));
 }
 
 procedure {:inline 1} Lt(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) < i#Integer(src2));
 }
 
 procedure {:inline 1} Gt(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) > i#Integer(src2));
 }
 
 procedure {:inline 1} Le(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) <= i#Integer(src2));
 }
 
 procedure {:inline 1} Ge(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) >= i#Integer(src2));
 }
 
 procedure {:inline 1} And(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) && b#Boolean(src2));
 }
 
 procedure {:inline 1} Or(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) || b#Boolean(src2));
 }
 
 procedure {:inline 1} Not(src: Value) returns (dst: Value)
 {
+    assert is#Boolean(src);
     dst := Boolean(!b#Boolean(src));
 }
 
 procedure {:inline 1} Eq_int(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) == i#Integer(src2));
 }
 
 procedure {:inline 1} Neq_int(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) != i#Integer(src2));
 }
 
 procedure {:inline 1} Eq_bool(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) == b#Boolean(src2));
 }
 
 procedure {:inline 1} Neq_bool(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) != b#Boolean(src2));
+}
+
+procedure {:inline 1} Eq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) == a#Address(src2));
+}
+
+procedure {:inline 1} Neq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) != a#Address(src2));
 }
 
 procedure {:inline 1} LdConst(val: int) returns (ret: Value)
 {
     ret := Integer(val);
+}
+
+procedure {:inline 1} LdAddr(val: Address) returns (ret: Value)
+{
+    ret := Address(val);
+}
+
+procedure {:inline 1} LdByteArray(val: ByteArray) returns (ret: Value)
+{
+    ret := ByteArray(val);
+}
+
+procedure {:inline 1} LdStr(val: String) returns (ret: Value)
+{
+    ret := Str(val);
 }
 
 procedure {:inline 1} LdTrue() returns (ret: Value)
@@ -250,6 +300,54 @@ procedure {:inline 1} LdFalse() returns (ret: Value)
     ret := Boolean(false);
 }
 
+// Transaction builtin instructions
+type {:datatype} Transaction;
+var txn: Transaction;
+function {:constructor} Transaction_cons(
+  gas_unit_price: int, max_gas_units: int, public_key: ByteArray,
+  sender: Address, sequence_number: int, gas_remaining: int) : Transaction;
+
+procedure {:inline 1} GetGasRemaining() returns (ret_gas_remaining: Value)
+{
+  ret_gas_remaining := Integer(gas_remaining#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSequenceNumber() returns (ret_sequence_number: Value)
+{
+  ret_sequence_number := Integer(sequence_number#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnPublicKey() returns (ret_public_key: Value)
+{
+  ret_public_key := ByteArray(public_key#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSenderAddress() returns (ret_sender: Value)
+{
+  ret_sender := Address(sender#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnMaxGasUnits() returns (ret_max_gas_units: Value)
+{
+  ret_max_gas_units := Integer(max_gas_units#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnGasUnitPrice() returns (ret_gas_unit_price: Value)
+{
+  ret_gas_unit_price := Integer(gas_unit_price#Transaction_cons(txn));
+}
+
+// Special instruction
+var Address_Exists: [Address]bool;
+procedure {:inline 1} CreateAccount(addr_val: Value)
+modifies Address_Exists;
+{
+  var addr: Address;
+  addr := a#Address(addr_val);
+  assert !Address_Exists[addr];
+  Address_Exists[addr] := true;
+}
+
 
 // everything below is auto generated
 
@@ -259,13 +357,35 @@ const unique Test3_T_g: FieldName;
 
 procedure {:inline 1} Pack_Test3_T(v0: Value, v1: Value) returns (v: Value)
 {
+    assert is#Integer(v0);
+    assert is#Integer(v1);
     v := Map(DefaultMap[Field(Test3_T_f) := v0][Field(Test3_T_g) := v1]);
 }
 
 procedure {:inline 1} Unpack_Test3_T(v: Value) returns (v0: Value, v1: Value)
 {
+    assert is#Map(v);
     v0 := m#Map(v)[Field(Test3_T_f)];
     v1 := m#Map(v)[Field(Test3_T_g)];
+}
+
+procedure {:inline 1} Eq_Test3_T(v1: Value, v2: Value) returns (res: Value)
+{
+    var b0: Value;
+    var b1: Value;
+    assert is#Map(v1) && is#Map(v2);
+    call b0 := Eq_int(m#Map(v1)[Field(Test3_T_f)], m#Map(v1)[Field(Test3_T_f)]);
+    call b1 := Eq_int(m#Map(v1)[Field(Test3_T_g)], m#Map(v1)[Field(Test3_T_g)]);
+    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
+}
+
+procedure {:inline 1} Neq_Test3_T(v1: Value, v2: Value) returns (res: Value)
+{
+    var res_val: Value;
+    var res_bool: bool;
+    assert is#Map(v1) && is#Map(v2);
+    call res_val := Eq_Test3_T(v1, v2);
+    res := Boolean(!b#Boolean(res_val));
 }
 
 const unique t0_LocalName: LocalName;
@@ -378,8 +498,10 @@ procedure {:inline 1} UpdateValueMax(srcPath: Path, srcValue: Value, dstPath: Pa
     }
 }
 
-procedure Test3_test3 (c: CreationTime, t0: Value, rs_Test3_T: ResourceStore) returns (rs_Test3_T': ResourceStore) {
+procedure Test3_test3 (c: CreationTime, arg0: Value, rs_Test3_T: ResourceStore) returns (rs_Test3_T': ResourceStore)
+{
     // declare local variables
+    var t0: Value; // bool
     var t1: Value; // Test3_T
     var t2: Reference; // Test3_T_ref
     var t3: Reference; // int_ref
@@ -430,9 +552,17 @@ procedure Test3_test3 (c: CreationTime, t0: Value, rs_Test3_T: ResourceStore) re
     var t48: Value; // bool
     var t49: Value; // int
 
-    // declare a new creation time for calls inside this functions;
+    // declare a new creation time for calls inside this function
     var c': CreationTime;
     assume c' > c;
+
+    // assume arguments are of correct types
+    assume is#Boolean(arg0);
+
+    // assign arguments to locals so they can be modified
+    t0 := arg0;
+
+    // assign ResourceStores to locals so they can be modified
     rs_Test3_T' := rs_Test3_T;
 
     // bytecode translation starts here
@@ -492,6 +622,7 @@ Label_15:
     call t25 := DeepUpdateReference(t18, t25);
     call t27 := DeepUpdateReference(t18, t27);
     call rs_Test3_T' := DeepUpdateGlobal(Test3_T, t18, rs_Test3_T');
+    call t0 := DeepUpdateLocal(c, t0_LocalName, t18, t0);
     call t1 := DeepUpdateLocal(c, t1_LocalName, t18, t1);
     call t6 := DeepUpdateLocal(c, t6_LocalName, t18, t6);
     call t7 := DeepUpdateLocal(c, t7_LocalName, t18, t7);
@@ -567,7 +698,7 @@ Label_15:
 
     call t34 := LdConst(42);
 
-    // abort not supported
+    assert false;
 
 Label_41:
     call t35 := CopyOrMoveValue(t7);
@@ -582,7 +713,7 @@ Label_41:
 
     call t39 := LdConst(42);
 
-    // abort not supported
+    assert false;
 
 Label_48:
     goto Label_63;
@@ -600,7 +731,7 @@ Label_49:
 
     call t44 := LdConst(42);
 
-    // abort not supported
+    assert false;
 
 Label_56:
     call t45 := CopyOrMoveValue(t7);
@@ -615,7 +746,7 @@ Label_56:
 
     call t49 := LdConst(42);
 
-    // abort not supported
+    assert false;
 
 Label_63:
     return;

--- a/language/stackless_bytecode/bytecode_to_boogie/src/bytecode_instrs.bpl
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/bytecode_instrs.bpl
@@ -2,6 +2,7 @@ type TypeName;
 type FieldName;
 type LocalName;
 type Address;
+type ByteArray;
 type String;
 type CreationTime = int;
 
@@ -18,6 +19,8 @@ type {:datatype} Value;
 function {:constructor} Boolean(b: bool): Value;
 function {:constructor} Integer(i: int): Value;
 function {:constructor} Address(a: Address): Value;
+function {:constructor} ByteArray(b: ByteArray): Value;
+function {:constructor} Str(a: String): Value;
 function {:constructor} Map(m: [Edge]Value): Value;
 
 const DefaultMap: [Edge]Value;
@@ -76,6 +79,7 @@ procedure {:inline 1} DeepUpdateGlobal(t: TypeName, src: Reference, dst: Resourc
 
 procedure {:inline 1} Exists(address: Value, rs: ResourceStore) returns (dst: Value)
 {
+    assert is#Address(address);
     dst := Boolean(domain#ResourceStore(rs)[a#Address(address)]);
 }
 
@@ -90,6 +94,7 @@ procedure {:inline 1} MoveToSender(rs: ResourceStore, v: Value) returns (rs': Re
 procedure {:inline 1} MoveFrom(address: Value, rs: ResourceStore) returns (dst: Value, rs': ResourceStore)
 {
     var a: Address;
+    assert is#Address(address);
     a := a#Address(address);
     assert domain#ResourceStore(rs)[a];
     dst := contents#ResourceStore(rs)[a];
@@ -114,8 +119,10 @@ procedure {:inline 1} BorrowLoc(c: CreationTime, l: LocalName, local: Value) ret
 procedure {:inline 1} BorrowField(src: Reference, f: FieldName) returns (dst: Reference)
 {
     if (is#GlobalReference(src)) {
+        assert is#Map(v#GlobalReference(src));
         dst := GlobalReference(a#GlobalReference(src), t#GlobalReference(src), Cons(p#GlobalReference(src), Field(f)), m#Map(v#GlobalReference(src))[Field(f)]);
     } else {
+        assert is#Map(v#LocalReference(src));
         dst := LocalReference(c#LocalReference(src), l#LocalReference(src), Cons(p#LocalReference(src), Field(f)), m#Map(v#LocalReference(src))[Field(f)]);
     }
 }
@@ -157,87 +164,130 @@ procedure {:inline 1} FreezeRef(src: Reference) returns (dest: Reference)
 
 procedure {:inline 1} Add(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) + i#Integer(src2));
 }
 
 procedure {:inline 1} Sub(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) - i#Integer(src2));
 }
 
 procedure {:inline 1} Mul(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) * i#Integer(src2));
 }
 
 procedure {:inline 1} Div(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) div i#Integer(src2));
 }
 
 procedure {:inline 1} Mod(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Integer(i#Integer(src1) mod i#Integer(src2));
 }
 
 procedure {:inline 1} Lt(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) < i#Integer(src2));
 }
 
 procedure {:inline 1} Gt(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) > i#Integer(src2));
 }
 
 procedure {:inline 1} Le(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) <= i#Integer(src2));
 }
 
 procedure {:inline 1} Ge(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) >= i#Integer(src2));
 }
 
 procedure {:inline 1} And(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) && b#Boolean(src2));
 }
 
 procedure {:inline 1} Or(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) || b#Boolean(src2));
 }
 
 procedure {:inline 1} Not(src: Value) returns (dst: Value)
 {
+    assert is#Boolean(src);
     dst := Boolean(!b#Boolean(src));
 }
 
 procedure {:inline 1} Eq_int(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) == i#Integer(src2));
 }
 
 procedure {:inline 1} Neq_int(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Integer(src1) && is#Integer(src2);
     dst := Boolean(i#Integer(src1) != i#Integer(src2));
 }
 
 procedure {:inline 1} Eq_bool(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) == b#Boolean(src2));
 }
 
 procedure {:inline 1} Neq_bool(src1: Value, src2: Value) returns (dst: Value)
 {
+    assert is#Boolean(src1) && is#Boolean(src2);
     dst := Boolean(b#Boolean(src1) != b#Boolean(src2));
+}
+
+procedure {:inline 1} Eq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) == a#Address(src2));
+}
+
+procedure {:inline 1} Neq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) != a#Address(src2));
 }
 
 procedure {:inline 1} LdConst(val: int) returns (ret: Value)
 {
     ret := Integer(val);
+}
+
+procedure {:inline 1} LdAddr(val: Address) returns (ret: Value)
+{
+    ret := Address(val);
+}
+
+procedure {:inline 1} LdByteArray(val: ByteArray) returns (ret: Value)
+{
+    ret := ByteArray(val);
+}
+
+procedure {:inline 1} LdStr(val: String) returns (ret: Value)
+{
+    ret := Str(val);
 }
 
 procedure {:inline 1} LdTrue() returns (ret: Value)
@@ -248,4 +298,52 @@ procedure {:inline 1} LdTrue() returns (ret: Value)
 procedure {:inline 1} LdFalse() returns (ret: Value)
 {
     ret := Boolean(false);
+}
+
+// Transaction builtin instructions
+type {:datatype} Transaction;
+var txn: Transaction;
+function {:constructor} Transaction_cons(
+  gas_unit_price: int, max_gas_units: int, public_key: ByteArray,
+  sender: Address, sequence_number: int, gas_remaining: int) : Transaction;
+
+procedure {:inline 1} GetGasRemaining() returns (ret_gas_remaining: Value)
+{
+  ret_gas_remaining := Integer(gas_remaining#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSequenceNumber() returns (ret_sequence_number: Value)
+{
+  ret_sequence_number := Integer(sequence_number#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnPublicKey() returns (ret_public_key: Value)
+{
+  ret_public_key := ByteArray(public_key#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSenderAddress() returns (ret_sender: Value)
+{
+  ret_sender := Address(sender#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnMaxGasUnits() returns (ret_max_gas_units: Value)
+{
+  ret_max_gas_units := Integer(max_gas_units#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnGasUnitPrice() returns (ret_gas_unit_price: Value)
+{
+  ret_gas_unit_price := Integer(gas_unit_price#Transaction_cons(txn));
+}
+
+// Special instruction
+var Address_Exists: [Address]bool;
+procedure {:inline 1} CreateAccount(addr_val: Value)
+modifies Address_Exists;
+{
+  var addr: Address;
+  addr := a#Address(addr_val);
+  assert !Address_Exists[addr];
+  Address_Exists[addr] := true;
 }

--- a/language/stackless_bytecode/bytecode_to_boogie/src/main.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/main.rs
@@ -13,8 +13,14 @@ use vm::file_format::CompiledModule;
 fn main() {
     let args: Vec<String> = env::args().collect();
     let file_name = &args[1];
-
     // read file and compile into compiled module
+
+    // TODO: option for loading bytecode?
+    // let mut f = File::open(file_name).unwrap();
+    // let mut buffer = Vec::new();
+    // let _ = f.read_to_end(&mut buffer);
+    // let loaded_module = CompiledModuleMut::deserialize_no_check_bounds(&buffer).unwrap();
+
     let code = fs::read_to_string(file_name).unwrap();
     let module = parse_module(&code).unwrap();
     let address = &AccountAddress::default();

--- a/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-arithmetic.mvir
+++ b/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-arithmetic.mvir
@@ -18,14 +18,15 @@ module TestArithmetic {
       let d: bool;
       c = (copy(a) > copy(b)) && (copy(a) >= copy(b));
       d = (copy(a) < copy(b)) || (copy(a) <= copy(b));
-      assert(!(move(c) != move(d)), 42);
+      assert((move(c) != move(d)), 42);
       return;
   }
 
 
 	public arithmetic_ops(a: u64, b: u64): u64 * u64 {
       let c: u64;
-      c = (copy(a) + move(b) - 1) * 2 / 3 % 4;
+      c = (6 + 4 - 1) * 2 / 3 % 4;
+			assert(copy(c) == 3, 42);
       return move(c), move(a);
   }
 }

--- a/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-func-call.mvir
+++ b/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-func-call.mvir
@@ -13,11 +13,12 @@ module TestFuncCall {
 		let x: u64;
 		let y: u64;
 		x = 3;
-		if (move(b)) {
+		if (copy(b)) {
 			y = Self.f(move(x));
 		} else {
 		    y = Self.g(move(x));
 		}
+		assert((copy(b) && (copy(y) == 4)) || (!copy(b) && (copy(y) == 5)), 42);
 		return move(y);
 	}
 }

--- a/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-reference.mvir
+++ b/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-reference.mvir
@@ -3,13 +3,21 @@ module TestReference {
         value: u64,
     }
 
-    public all_about_refs(a: &R#Self.T, b: &mut u64, c: &mut R#Self.T): u64 {
-        let value_ref: &u64;
-        let frozen_ref: &R#Self.T;
-        *move(b) = 0;
-        value_ref = &move(a).value;
-        frozen_ref = freeze(move(c));
-        release(move(frozen_ref));
-        return *move(value_ref);
+    public mut_b(b: &mut u64){
+        *move(b) = 10;
+        return;
+    }
+
+    public mut_ref() {
+        let b: u64;
+        let b_ref: &mut u64;
+
+        b = 20;
+        b_ref = &mut b;
+        // mutable reference passed into a function call
+        Self.mut_b(copy(b_ref));
+        b = *move(b_ref);
+        assert(move(b) == 10, 42);
+        return;
     }
 }

--- a/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-struct.mvir
+++ b/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test-struct.mvir
@@ -30,6 +30,7 @@ module TestStruct {
 		let b: bool;
 
 		b = exists<T>(copy(a));
+        assert(!copy(b), 42);
 		t_ref1 = borrow_global<T>(copy(a));
 		release(move(t_ref1));
 		t_ref2 = borrow_global<T>(copy(a));
@@ -38,19 +39,24 @@ module TestStruct {
 		return move(t_ref2), move(b);
     }
 
-	public nested_struct(a: address): R#Self.A
+	public nested_struct(a: address) : R#Self.B
 	{
 		let var_a: R#Self.A;
 		let var_b: R#Self.B;
+        let var_b_ref: &R#Self.B;
+        let b_val_ref: &u64;
+        let b_val: u64;
 
 		if (false) {
 			var_b = B { addr: copy(a), val: 1 };
 		} else {
 			var_b = B { addr: copy(a), val: 42 };
 		}
-
-		var_a = A { val: 2, b: move(var_b) };
-		return move(var_a);
+        var_b_ref = &var_b;
+        b_val_ref = &move(var_b_ref).val;
+        b_val = *move(b_val_ref);
+        assert(move(b_val) == 42, 42);
+		return move(var_b);
 	}
 
     public try_unpack(a: address): u64 {
@@ -59,6 +65,7 @@ module TestStruct {
         let aa: address;
         b = B { addr: copy(a), val: 42 };
         B { aa, v } = move(b);
+        assert(move(a) == move(aa), 0);
         return move(v);
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I added some of the missing pieces mentioned in my last PR(#434) and fixed some bugs. 

- Mutable references passed in as arguments to function calls are returned as well because they might have been updated in the callee.
- Deep update functions are called after function calls that take in mutable references as arguments.
- Type checking for arguments. For example, in logic operations like `And` we assert `is#Boolean(op1)` and `is#Boolean(op2)`. And in the main function which we want to verify, I added `assume is#TYPE_CONS(arg)`.
- Eq and Neq functions for structs.
- Instructions related to gas/transactions/account.
- Abort/assert.
- LdAddr, LdByteArray and LdStr.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```
cargo run FILE_NAME
```

## Included test cases and how to make them pass Boogie 

I added assert statements in some of the test cases and all of the test cases in `test_mvir/` behave expectedly. Specifically,

- `test-arithmetic.mvir`, `test-control-flow.mvir` and `test3.mvir` produce Boogie code that verify without any modification.
- `test-func-call.mvir` verifies after we inline functions `f` and `g`(adding `{:inline 1}` decorator to `TestFuncCall_f` and `TestFuncCall_g` in generated `output.bpl`).
- `test-reference.mvir` verifies after we inline function `mut_b`. Without inlining, somehow the SMT-LIB generated by Boogie will cause a seg fault in z3.
- `test-struct.mvir` verifies after we add the following pre conditions to function `module_builtins`:
```
requires domain#ResourceStore(rs_TestStruct_T)[a#Address(arg0)];
requires !domain#ResourceStore(rs_TestStruct_T)[a#Address(senderAddress)];
```
- `test-special-instr.mvir` does not verify because I don't know how to deal with special instructions like `CreateAccount`.

I will keep testing and fixing any bugs in the code.
## Related PR
https://github.com/libra/libra/pull/434
