### PR TITLE
[language] improve account parsing in functional tests

### DIFF
--- a/language/functional_tests/src/config/global.rs
+++ b/language/functional_tests/src/config/global.rs
@@ -36,7 +36,7 @@ impl FromStr for Entry {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let s1 = s.trim_start().trim_end();
+        let s1 = s.split_whitespace().collect::<String>();
         if !s1.starts_with("//!") {
             return Err(
                 ErrorKind::Other("global config entry must start with //!".to_string()).into(),

--- a/language/functional_tests/src/config/transaction.rs
+++ b/language/functional_tests/src/config/transaction.rs
@@ -38,7 +38,7 @@ impl FromStr for Entry {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let s = s.trim_start().trim_end();
+        let s = s.split_whitespace().collect::<String>();
         if !s.starts_with("//!") {
             return Err(
                 ErrorKind::Other("txn config entry must start with //!".to_string()).into(),

--- a/language/functional_tests/src/tests/global_config_tests.rs
+++ b/language/functional_tests/src/tests/global_config_tests.rs
@@ -8,19 +8,25 @@ use crate::{
 };
 
 #[test]
-fn parse_account() {
+fn parse_account_positive() {
     for s in &[
         "//! account: alice",
         "//!account: bob",
         "//! account: bob, 100",
         "//!account:alice,",
-        // TODO: The following should parse. Fix it.
-        // "//!   account :alice,1, 2",
+        "//!   account :alice,1, 2",
         "//! account: bob, 0, 0",
+        "//!    account : bob, 0, 0",
+        "//!    account     :bob,   0,  0",
+        "//!\naccount\n:bob,\n0,\n0",
+        "//!\taccount\t:bob,\t0,\t0",
     ] {
         s.parse::<Entry>().unwrap();
     }
+}
 
+#[test]
+fn parse_account_negative() {
     for s in &["//! account:", "//! account", "//! account: alice, 1, 2, 3"] {
         s.parse::<Entry>().unwrap_err();
     }

--- a/language/functional_tests/src/tests/transaction_config_tests.rs
+++ b/language/functional_tests/src/tests/transaction_config_tests.rs
@@ -21,6 +21,10 @@ fn parse_simple_positive() {
         "//! no-run: compiler, verifier, runtime",
         "//! sender: alice",
         "//! sender:foobar42",
+        "//! sender :alice",
+        "//! sender:foobar42",
+        "//! sender\t:\tfoobar42",
+        "//!\nsender\n:\nfoobar42",
     ] {
         s.parse::<Entry>().unwrap();
     }


### PR DESCRIPTION
##  Motivation

New contributor to the project and noticed at TODO in [global_config_tests.rs](https://github.com/libra/libra/blob/master/language/functional_tests/src/tests/global_config_tests.rs#L17):
```rust
#[test]
fn parse_account() {
    for s in &[
        "//! account: alice",
        "//!account: bob",
        "//! account: bob, 100",
        "//!account:alice,",
        // TODO: The following should parse. Fix it.
        // "//!   account :alice,1, 2",
        "//! account: bob, 0, 0",
    ] {
        s.parse::<Entry>().unwrap();
    }

    for s in &["//! account:", "//! account", "//! account: alice, 1, 2, 3"] {
        s.parse::<Entry>().unwrap_err();
    }
}
```
and am taking a stab are fixing this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
executing the following:
`cd language/functional_tests/`
`cargo test`