### PR TITLE
[crypto] apply nextgen_crypto x25519 across Libra

### DIFF
--- a/config/config_builder/src/util.rs
+++ b/config/config_builder/src/util.rs
@@ -26,7 +26,7 @@ pub fn gen_genesis_transaction<P: AsRef<Path>>(
                 AccountAddress::try_from(peer_id.clone()).expect("[config] invalid peer_id"),
                 peer.get_consensus_public().clone(),
                 peer.get_network_signing_public().clone(),
-                peer.get_network_identity_public(),
+                peer.get_network_identity_public().clone(),
             )
         })
         .collect();

--- a/consensus/src/state_synchronizer/sync_test.rs
+++ b/consensus/src/state_synchronizer/sync_test.rs
@@ -13,7 +13,7 @@ use crate::{
 use bytes::Bytes;
 use config::config::NodeConfig;
 use config_builder::util::get_test_config;
-use crypto::{x25519, HashValue};
+use crypto::HashValue;
 use failure::prelude::*;
 use futures::{
     executor::block_on,
@@ -30,7 +30,7 @@ use network::{
     },
     NetworkPublicKeys, ProtocolId,
 };
-use nextgen_crypto::{ed25519::*, test_utils::TEST_SEED, traits::Genesis, SigningKey};
+use nextgen_crypto::{ed25519::*, test_utils::TEST_SEED, traits::Genesis, x25519, SigningKey};
 use parity_multiaddr::Multiaddr;
 use proto_conv::IntoProto;
 use protobuf::Message;
@@ -78,22 +78,24 @@ impl SynchronizerEnv {
         let (a_signing_private_key, a_signing_public_key) = compat::generate_keypair(&mut rng);
         let (b_signing_private_key, b_signing_public_key) = compat::generate_keypair(&mut rng);
         // Setup identity public keys.
-        let (a_identity_private_key, a_identity_public_key) = x25519::generate_keypair();
-        let (b_identity_private_key, b_identity_public_key) = x25519::generate_keypair();
+        let (a_identity_private_key, a_identity_public_key) =
+            x25519::compat::generate_keypair(&mut rng);
+        let (b_identity_private_key, b_identity_public_key) =
+            x25519::compat::generate_keypair(&mut rng);
 
         let trusted_peers: HashMap<_, _> = vec![
             (
                 peers[0],
                 NetworkPublicKeys {
                     signing_public_key: a_signing_public_key.clone(),
-                    identity_public_key: a_identity_public_key,
+                    identity_public_key: a_identity_public_key.clone(),
                 },
             ),
             (
                 peers[1],
                 NetworkPublicKeys {
                     signing_public_key: b_signing_public_key.clone(),
-                    identity_public_key: b_identity_public_key,
+                    identity_public_key: b_identity_public_key.clone(),
                 },
             ),
         ]

--- a/crypto/nextgen_crypto/src/ed25519.rs
+++ b/crypto/nextgen_crypto/src/ed25519.rs
@@ -500,13 +500,12 @@ pub mod compat {
 
     #[cfg(any(test, feature = "testing"))]
     impl Arbitrary for Ed25519PublicKey {
+        type Parameters = ();
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             LazyJust::new(|| generate_keypair(None).1).boxed()
         }
         type Strategy = BoxedStrategy<Self>;
-        type Parameters = ();
     }
-
 }
 
 //////////////////////////////

--- a/crypto/nextgen_crypto/src/unit_tests/x25519_test.rs
+++ b/crypto/nextgen_crypto/src/unit_tests/x25519_test.rs
@@ -13,12 +13,12 @@ fn test_default_key_pair() {
     let public_key2: X25519StaticPublicKey;
     {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let private_key1 = X25519StaticExchangeKey::generate_for_testing(&mut rng);
+        let private_key1 = X25519StaticPrivateKey::generate_for_testing(&mut rng);
         public_key1 = (&private_key1).into();
     }
     {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let private_key2 = X25519StaticExchangeKey::generate_for_testing(&mut rng);
+        let private_key2 = X25519StaticPrivateKey::generate_for_testing(&mut rng);
         public_key2 = (&private_key2).into();
     }
     assert_eq!(public_key1, public_key2);
@@ -30,8 +30,8 @@ fn test_hkdf_key_pair() {
     let salt = None;
     let seed = [0u8; 32];
     let info = None;
-    let (_, public_key1) = X25519StaticExchangeKey::derive_keypair_from_seed(salt, &seed, info);
-    let (_, public_key2) = X25519StaticExchangeKey::derive_keypair_from_seed(salt, &seed, info);
+    let (_, public_key1) = X25519StaticPrivateKey::derive_keypair_from_seed(salt, &seed, info);
+    let (_, public_key2) = X25519StaticPrivateKey::derive_keypair_from_seed(salt, &seed, info);
     assert_eq!(public_key1, public_key2);
 
     // HKDF with salt and info.
@@ -39,8 +39,8 @@ fn test_hkdf_key_pair() {
     let salt = Some(&raw_bytes[0..4]);
     let seed = [3u8; 32];
     let info = Some(&raw_bytes[4..10]);
-    let (_, public_key1) = X25519StaticExchangeKey::derive_keypair_from_seed(salt, &seed, info);
-    let (_, public_key2) = X25519StaticExchangeKey::derive_keypair_from_seed(salt, &seed, info);
+    let (_, public_key1) = X25519StaticPrivateKey::derive_keypair_from_seed(salt, &seed, info);
+    let (_, public_key2) = X25519StaticPrivateKey::derive_keypair_from_seed(salt, &seed, info);
     assert_eq!(public_key1, public_key2);
 }
 
@@ -51,14 +51,14 @@ fn test_generate_key_pair_with_seed() {
     let seed = [5u8; 32]; // seed is denoted as IKM in HKDF RFC 5869.
     let info = &b"some app info"[..];
     let (_, public_key1) =
-        X25519StaticExchangeKey::generate_keypair_hybrid(Some(salt), &seed, Some(info));
+        X25519StaticPrivateKey::generate_keypair_hybrid(Some(salt), &seed, Some(info));
     let (_, public_key2) =
-        X25519StaticExchangeKey::generate_keypair_hybrid(Some(salt), &seed, Some(info));
+        X25519StaticPrivateKey::generate_keypair_hybrid(Some(salt), &seed, Some(info));
     assert_ne!(public_key1, public_key2);
 
     // Ensure that the deterministic generate_keypair_from_seed returns a completely different key.
     let (_, public_key3) =
-        X25519StaticExchangeKey::derive_keypair_from_seed(Some(salt), &seed, Some(info));
+        X25519StaticPrivateKey::derive_keypair_from_seed(Some(salt), &seed, Some(info));
     assert_ne!(public_key3, public_key1);
     assert_ne!(public_key3, public_key2);
 }
@@ -67,11 +67,11 @@ fn test_generate_key_pair_with_seed() {
 fn test_serialize_deserialize() {
     let seed: [u8; 32] = [0u8; 32];
     let mut rng: StdRng = SeedableRng::from_seed(seed);
-    let private_key = X25519StaticExchangeKey::generate_for_testing(&mut rng);
+    let private_key = X25519StaticPrivateKey::generate_for_testing(&mut rng);
     let public_key: X25519StaticPublicKey = (&private_key).into();
 
     let serialized = serialize(&private_key).unwrap();
-    let deserialized = deserialize::<X25519StaticExchangeKey>(&serialized).unwrap();
+    let deserialized = deserialize::<X25519StaticPrivateKey>(&serialized).unwrap();
 
     assert_eq!(public_key, (&deserialized).into());
 }

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -15,7 +15,6 @@ use criterion::{
     criterion_group, criterion_main, AxisScale, Bencher, Criterion, ParameterizedBenchmark,
     PlotConfiguration, Throughput,
 };
-use crypto::x25519;
 use futures::{
     channel::mpsc,
     compat::Future01CompatExt,
@@ -33,7 +32,7 @@ use network::{
     },
     NetworkPublicKeys, ProtocolId,
 };
-use nextgen_crypto::{ed25519::compat, test_utils::TEST_SEED};
+use nextgen_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
 use parity_multiaddr::Multiaddr;
 use protobuf::Message;
 use rand::{rngs::StdRng, SeedableRng};
@@ -62,12 +61,14 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let (dialer_signing_private_key, dialer_signing_public_key) =
         compat::generate_keypair(&mut rng);
-    let (dialer_identity_private_key, dialer_identity_public_key) = x25519::generate_keypair();
+    let (dialer_identity_private_key, dialer_identity_public_key) =
+        x25519::compat::generate_keypair(&mut rng);
 
     // Setup keys for listener.
     let (listener_signing_private_key, listener_signing_public_key) =
         compat::generate_keypair(&mut rng);
-    let (listener_identity_private_key, listener_identity_public_key) = x25519::generate_keypair();
+    let (listener_identity_private_key, listener_identity_public_key) =
+        x25519::compat::generate_keypair(&mut rng);
 
     // Setup trusted peers.
     let trusted_peers: HashMap<_, _> = vec![
@@ -75,14 +76,14 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
             dialer_peer_id,
             NetworkPublicKeys {
                 signing_public_key: dialer_signing_public_key.clone().into(),
-                identity_public_key: dialer_identity_public_key,
+                identity_public_key: dialer_identity_public_key.clone(),
             },
         ),
         (
             listener_peer_id,
             NetworkPublicKeys {
                 signing_public_key: listener_signing_public_key.clone().into(),
-                identity_public_key: listener_identity_public_key,
+                identity_public_key: listener_identity_public_key.clone(),
             },
         ),
     ]
@@ -188,12 +189,14 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let (dialer_signing_private_key, dialer_signing_public_key) =
         compat::generate_keypair(&mut rng);
-    let (dialer_identity_private_key, dialer_identity_public_key) = x25519::generate_keypair();
+    let (dialer_identity_private_key, dialer_identity_public_key) =
+        x25519::compat::generate_keypair(&mut rng);
 
     // Setup keys for listener.
     let (listener_signing_private_key, listener_signing_public_key) =
         compat::generate_keypair(&mut rng);
-    let (listener_identity_private_key, listener_identity_public_key) = x25519::generate_keypair();
+    let (listener_identity_private_key, listener_identity_public_key) =
+        x25519::compat::generate_keypair(&mut rng);
 
     // Setup trusted peers.
     let trusted_peers: HashMap<_, _> = vec![
@@ -201,14 +204,14 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
             dialer_peer_id,
             NetworkPublicKeys {
                 signing_public_key: dialer_signing_public_key.clone().into(),
-                identity_public_key: dialer_identity_public_key,
+                identity_public_key: dialer_identity_public_key.clone(),
             },
         ),
         (
             listener_peer_id,
             NetworkPublicKeys {
                 signing_public_key: listener_signing_public_key.clone().into(),
-                identity_public_key: listener_identity_public_key,
+                identity_public_key: listener_identity_public_key.clone(),
             },
         ),
     ]

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -11,6 +11,7 @@ futures = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 snow = { version = "0.5.2", features=["ring-accelerated"]}
 
 crypto = { path = "../../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 netcore = { path = "../netcore" }
 logger = { path = "../../common/logger" }
 

--- a/network/noise/src/lib.rs
+++ b/network/noise/src/lib.rs
@@ -10,18 +10,19 @@
 //!
 //! [noise]: http://noiseprotocol.org/
 
-use crypto::x25519::{X25519PrivateKey, X25519PublicKey};
 use futures::io::{AsyncRead, AsyncWrite};
 use netcore::{
     negotiate::{negotiate_inbound, negotiate_outbound_interactive},
     transport::ConnectionOrigin,
 };
+use nextgen_crypto::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
 use snow::{self, params::NoiseParams, Keypair};
 use std::io;
 
 mod socket;
 
 pub use self::socket::NoiseSocket;
+use nextgen_crypto::ValidKey;
 
 const NOISE_IX_25519_AESGCM_SHA256_PROTOCOL_NAME: &[u8] = b"/noise_ix_25519_aesgcm_sha256/1.0.0";
 const NOISE_IX_PARAMETER: &str = "Noise_IX_25519_AESGCM_SHA256";
@@ -35,11 +36,11 @@ pub struct NoiseConfig {
 
 impl NoiseConfig {
     /// Create a new NoiseConfig with the provided keypair
-    pub fn new(keypair: (X25519PrivateKey, X25519PublicKey)) -> Self {
+    pub fn new(keypair: (X25519StaticPrivateKey, X25519StaticPublicKey)) -> Self {
         let parameters: NoiseParams = NOISE_IX_PARAMETER.parse().expect("Invalid protocol name");
         let keypair = Keypair {
             private: keypair.0.to_bytes().to_vec(),
-            public: keypair.1.as_bytes().to_vec(),
+            public: keypair.1.to_bytes().to_vec(),
         };
         Self {
             keypair,

--- a/network/src/common.rs
+++ b/network/src/common.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ProtocolId;
-use crypto::x25519::X25519PublicKey;
-use nextgen_crypto::ed25519::*;
+use nextgen_crypto::{ed25519::*, x25519::X25519StaticPublicKey};
 use std::fmt;
 
 /// A Negotiated substream encapsulates a protocol and a substream for which that protocol has been
@@ -31,5 +30,5 @@ pub struct NetworkPublicKeys {
     /// This key can validate signed messages at the network layer.
     pub signing_public_key: Ed25519PublicKey,
     /// This key establishes a node's identity in the p2p network.
-    pub identity_public_key: X25519PublicKey,
+    pub identity_public_key: X25519StaticPublicKey,
 }

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -4,10 +4,10 @@
 use super::*;
 use crate::peer_manager::PeerManagerRequest;
 use core::str::FromStr;
-use crypto::x25519;
 use futures::{FutureExt, SinkExt, TryFutureExt};
 use memsocket::MemorySocket;
-use nextgen_crypto::ed25519::compat;
+use nextgen_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
+use rand::{rngs::StdRng, SeedableRng};
 use std::io;
 use tokio::runtime::Runtime;
 use tokio_retry::strategy::FixedInterval;
@@ -28,8 +28,9 @@ fn setup_conn_mgr(
     let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) = channel::new_test(0);
     let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(0);
     let (ticker_tx, ticker_rx) = channel::new_test(0);
-    let (_, signing_public_key) = compat::generate_keypair(None);
-    let (_, identity_public_key) = x25519::generate_keypair();
+    let mut rng = StdRng::from_seed(TEST_SEED);
+    let (_, signing_public_key) = compat::generate_keypair(&mut rng);
+    let (_, identity_public_key) = x25519::compat::generate_keypair(&mut rng);
     let conn_mgr = {
         ConnectivityManager::new(
             Arc::new(RwLock::new(
@@ -62,8 +63,9 @@ fn setup_conn_mgr(
 
 fn gen_peer() -> (PeerId, NetworkPublicKeys) {
     let peer_id = PeerId::random();
-    let (_, signing_public_key) = compat::generate_keypair(None);
-    let (_, identity_public_key) = x25519::generate_keypair();
+    let mut rng = StdRng::from_seed(TEST_SEED);
+    let (_, signing_public_key) = compat::generate_keypair(&mut rng);
+    let (_, identity_public_key) = x25519::compat::generate_keypair(&mut rng);
     (
         peer_id,
         NetworkPublicKeys {

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -4,10 +4,10 @@
 use super::*;
 use crate::{peer_manager::PeerManagerRequest, proto::DiscoveryMsg};
 use core::str::FromStr;
-use crypto::x25519;
 use futures::future::{FutureExt, TryFutureExt};
 use memsocket::MemorySocket;
-use nextgen_crypto::{ed25519::Ed25519PrivateKey, *};
+use nextgen_crypto::{ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, *};
+use rand::{rngs::StdRng, SeedableRng};
 use tokio::runtime::Runtime;
 
 fn get_random_seed() -> PeerInfo {
@@ -92,8 +92,9 @@ async fn expect_address_update(
 fn generate_network_pub_keys_and_signer(
     peer_id: PeerId,
 ) -> (NetworkPublicKeys, Signer<Ed25519PrivateKey>) {
-    let (signing_priv_key, _) = compat::generate_keypair(None);
-    let (_, identity_pub_key) = x25519::generate_keypair();
+    let mut rng = StdRng::from_seed(TEST_SEED);
+    let (signing_priv_key, _) = compat::generate_keypair(&mut rng);
+    let (_, identity_pub_key) = x25519::compat::generate_keypair(&mut rng);
     (
         NetworkPublicKeys {
             signing_public_key: signing_priv_key.public_key().clone().into(),

--- a/network/src/validator_network/consensus.rs
+++ b/network/src/validator_network/consensus.rs
@@ -190,7 +190,7 @@ impl ConsensusNetworkSender {
                         (
                             *keys.account_address(),
                             NetworkPublicKeys {
-                                identity_public_key: *keys.network_identity_public_key(),
+                                identity_public_key: keys.network_identity_public_key().clone(),
                                 signing_public_key: keys.network_signing_public_key().clone(),
                             },
                         )

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -25,10 +25,12 @@ use crate::{
     ProtocolId,
 };
 use channel;
-use crypto::x25519::{X25519PrivateKey, X25519PublicKey};
 use futures::{compat::Compat01As03, FutureExt, StreamExt, TryFutureExt};
 use netcore::{multiplexing::StreamMultiplexer, transport::boxed::BoxedTransport};
-use nextgen_crypto::ed25519::*;
+use nextgen_crypto::{
+    ed25519::*,
+    x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
+};
 use parity_multiaddr::Multiaddr;
 use std::{
     collections::HashMap,
@@ -98,7 +100,7 @@ pub struct NetworkBuilder {
     max_concurrent_network_notifs: u32,
     max_connection_delay_ms: u64,
     signing_keys: Option<(Ed25519PrivateKey, Ed25519PublicKey)>,
-    identity_keys: Option<(X25519PrivateKey, X25519PublicKey)>,
+    identity_keys: Option<(X25519StaticPrivateKey, X25519StaticPublicKey)>,
 }
 
 impl NetworkBuilder {
@@ -164,7 +166,10 @@ impl NetworkBuilder {
     }
 
     /// Set identity keys of local node.
-    pub fn identity_keys(&mut self, keys: (X25519PrivateKey, X25519PublicKey)) -> &mut Self {
+    pub fn identity_keys(
+        &mut self,
+        keys: (X25519StaticPrivateKey, X25519StaticPublicKey),
+    ) -> &mut Self {
         self.identity_keys = Some(keys);
         self
     }


### PR DESCRIPTION
## Motivation
Convert usages of `legacy_crypto::X25519PrivateKey` to `nextgen_crypto::x25519`.
The purpose of this task is to use the `nextgen_crypto API` (i.e. make the network identity key an x25519 key using the new crypto API) and convert the corresponding network code (which makes a few uses of it).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

existing
