### PR TITLE
[faucet] Only accept POST requests

### DIFF
--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -40,7 +40,7 @@ print(sys.version, platform.python_version())
 create_client()
 
 
-@application.route("/", methods=('GET', 'POST'))
+@application.route("/", methods=('POST',))
 def send_transaction():
     address = flask.request.args['address']
 


### PR DESCRIPTION
The client now sends these as POST.

## Test Plan

Ran validators and faucet locally, tested minting. Tested
with `curl` that GET returns 405.