### PR TITLE
[language] Strengthen borrow checker

### DIFF
--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad0.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad0.mvir
@@ -1,0 +1,16 @@
+module A {
+    resource T{v: u64}
+
+    public A0() {
+        let sender: address;
+        let t_ref: &mut R#Self.T;
+        sender = get_txn_sender();
+        t_ref = borrow_global<T>(copy(sender));
+        t_ref = borrow_global<T>(move(sender));
+        release(move(t_ref));
+        return;
+    }
+}
+
+// check: VerificationError
+// check: GlobalReferenceError

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad1.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad1.mvir
@@ -1,0 +1,16 @@
+module A {
+    resource T{v: u64}
+
+    public A0(addr: address) {
+        let x: &mut R#Self.T;
+        let y: &mut R#Self.T;
+        x = borrow_global<T>(get_txn_sender());
+        y = borrow_global<T>(move(addr));
+        release(move(x));
+        release(move(y));
+        return;
+    }
+}
+
+// check: VerificationError
+// check: GlobalReferenceError

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad2.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad2.mvir
@@ -1,0 +1,17 @@
+module A {
+    resource T{v: u64}
+
+    public A2() {
+        let sender: address;
+        let t: R#Self.T;
+        let t_ref: &mut R#Self.T;
+        sender = get_txn_sender();
+        t_ref = borrow_global<T>(copy(sender));
+        t = move_from<T>(move(sender));
+        release(move(t_ref));
+        return;
+    }
+}
+
+// check: VerificationError
+// check: GlobalReferenceError

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad4.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad4.mvir
@@ -1,0 +1,12 @@
+module A {
+    resource T{v: u64}
+
+    public A4() {
+        let t_ref: &mut R#Self.T;
+        t_ref = borrow_global<T>(get_txn_sender());
+        return;
+    }
+}
+
+// check: VerificationError
+// check: RetUnsafeToDestroyError

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad5.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad5.mvir
@@ -1,0 +1,14 @@
+module A {
+    resource T{v: u64}
+
+    public A5(b: bool) {
+        let t_ref: &mut R#Self.T;
+        if (move(b)) {
+            t_ref = borrow_global<T>(get_txn_sender());
+        }
+        return;
+    }
+}
+
+// check: VerificationError
+// check: JoinFailure

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_good.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_good.mvir
@@ -1,0 +1,63 @@
+module A {
+    resource T{v: u64}
+    resource U{v: u64}
+
+    public A0() {
+        let sender: address;
+        let t_ref: &mut R#Self.T;
+        sender = get_txn_sender();
+        t_ref = borrow_global<T>(copy(sender));
+        release(move(t_ref));
+        t_ref = borrow_global<T>(copy(sender));
+        release(move(t_ref));
+        return;
+    }
+
+    public A1() {
+        let sender: address;
+        let t_ref: &mut R#Self.T;
+        let u_ref: &mut R#Self.U;
+        sender = get_txn_sender();
+        t_ref = borrow_global<T>(copy(sender));
+        u_ref = borrow_global<U>(copy(sender));
+        release(move(t_ref));
+        release(move(u_ref));
+        return;
+    }
+
+    public A2(b: bool) {
+        let sender: address;
+        let t_ref: &mut R#Self.T;
+        sender = get_txn_sender();
+        if (move(b)) {
+            t_ref = borrow_global<T>(copy(sender));
+        } else {
+            t_ref = borrow_global<T>(copy(sender));
+        }
+        release(move(t_ref));
+        return;
+    }
+
+    public A3(b: bool) {
+        let sender: address;
+        let t_ref: &mut R#Self.T;
+        sender = get_txn_sender();
+        if (move(b)) {
+            t_ref = borrow_global<T>(copy(sender));
+            release(move(t_ref));
+        }
+        return;
+    }
+
+    public A4(b: bool) {
+        let sender: address;
+        let x: R#Self.T;
+        let y: &mut R#Self.T;
+        sender = get_txn_sender();
+        x = move_from<T>(copy(sender));
+        y = borrow_global<T>(move(sender));
+        release(move(y));
+        move_to_sender<T>(move(x));
+        return;
+    }
+}

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -279,6 +279,9 @@ pub enum VMStaticViolation {
     #[fail(display = "Unable to verify Exists at offset {}", _0)]
     ExistsResourceTypeMismatchError(usize),
 
+    #[fail(display = "Unable to verify Exists at offset {}", _0)]
+    ExistsNoResourceError(usize),
+
     #[fail(display = "Unable to verify BorrowGlobal at offset {}", _0)]
     BorrowGlobalTypeMismatchError(usize),
 
@@ -299,6 +302,9 @@ pub enum VMStaticViolation {
 
     #[fail(display = "Unable to verify MoveToSender at offset {}", _0)]
     CreateAccountTypeMismatchError(usize),
+
+    #[fail(display = "Illegal global operation at offset {}", _0)]
+    GlobalReferenceError(usize),
 }
 
 #[derive(Clone, Debug, Eq, Fail, Ord, PartialEq, PartialOrd)]
@@ -686,6 +692,9 @@ impl From<&VerificationError> for VMVerificationError {
             VMStaticViolation::ExistsResourceTypeMismatchError(_) => {
                 VMVerificationError::ExistsResourceTypeMismatchError(message)
             }
+            VMStaticViolation::ExistsNoResourceError(_) => {
+                VMVerificationError::ExistsNoResourceError(message)
+            }
             VMStaticViolation::BorrowGlobalTypeMismatchError(_) => {
                 VMVerificationError::BorrowGlobalTypeMismatchError(message)
             }
@@ -706,6 +715,9 @@ impl From<&VerificationError> for VMVerificationError {
             }
             VMStaticViolation::CreateAccountTypeMismatchError(_) => {
                 VMVerificationError::CreateAccountTypeMismatchError(message)
+            }
+            VMStaticViolation::GlobalReferenceError(_) => {
+                VMVerificationError::GlobalReferenceError(message)
             }
         }
     }

--- a/types/src/proto/vm_errors.proto
+++ b/types/src/proto/vm_errors.proto
@@ -160,17 +160,19 @@ enum VMVerificationErrorKind {
     BooleanOpTypeMismatchError = 57;
     EqualityOpTypeMismatchError = 58;
     ExistsResourceTypeMismatchError = 59;
-    BorrowGlobalTypeMismatchError = 60;
-    BorrowGlobalNoResourceError = 61;
-    MoveFromTypeMismatchError = 62;
-    MoveFromNoResourceError = 63;
-    MoveToSenderTypeMismatchError = 64;
-    MoveToSenderNoResourceError = 65;
-    CreateAccountTypeMismatchError = 66;
+    ExistsNoResourceError = 60;
+    BorrowGlobalTypeMismatchError = 61;
+    BorrowGlobalNoResourceError = 62;
+    MoveFromTypeMismatchError = 63;
+    MoveFromNoResourceError = 64;
+    MoveToSenderTypeMismatchError = 65;
+    MoveToSenderNoResourceError = 66;
+    CreateAccountTypeMismatchError = 67;
+    GlobalReferenceError = 68;
     // The self address of a module the transaction is publishing is not the sender address
-    ModuleAddressDoesNotMatchSender = 67;
+    ModuleAddressDoesNotMatchSender = 69;
     // The module does not have any module handles. Each module or script must have at least one module handle.
-    NoModuleHandles = 68;
+    NoModuleHandles = 70;
 }
 
 // These are errors that the VM might raise if a violation of internal

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -101,6 +101,7 @@ pub enum VMVerificationError {
     BooleanOpTypeMismatchError(String),
     EqualityOpTypeMismatchError(String),
     ExistsResourceTypeMismatchError(String),
+    ExistsNoResourceError(String),
     BorrowGlobalTypeMismatchError(String),
     BorrowGlobalNoResourceError(String),
     MoveFromTypeMismatchError(String),
@@ -108,6 +109,7 @@ pub enum VMVerificationError {
     MoveToSenderTypeMismatchError(String),
     MoveToSenderNoResourceError(String),
     CreateAccountTypeMismatchError(String),
+    GlobalReferenceError(String),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -542,6 +544,9 @@ impl IntoProto for VMVerificationError {
             VMVerificationError::ExistsResourceTypeMismatchError(message) => {
                 (ProtoKind::ExistsResourceTypeMismatchError, message)
             }
+            VMVerificationError::ExistsNoResourceError(message) => {
+                (ProtoKind::ExistsNoResourceError, message)
+            }
             VMVerificationError::BorrowGlobalTypeMismatchError(message) => {
                 (ProtoKind::BorrowGlobalTypeMismatchError, message)
             }
@@ -562,6 +567,9 @@ impl IntoProto for VMVerificationError {
             }
             VMVerificationError::CreateAccountTypeMismatchError(message) => {
                 (ProtoKind::CreateAccountTypeMismatchError, message)
+            }
+            VMVerificationError::GlobalReferenceError(message) => {
+                (ProtoKind::GlobalReferenceError, message)
             }
         }
     }
@@ -722,6 +730,9 @@ impl FromProto for VMVerificationError {
             ProtoKind::ExistsResourceTypeMismatchError => Ok(
                 VMVerificationError::ExistsResourceTypeMismatchError(message),
             ),
+            ProtoKind::ExistsNoResourceError => {
+                Ok(VMVerificationError::ExistsNoResourceError(message))
+            }
             ProtoKind::BorrowGlobalTypeMismatchError => {
                 Ok(VMVerificationError::BorrowGlobalTypeMismatchError(message))
             }
@@ -742,6 +753,9 @@ impl FromProto for VMVerificationError {
             }
             ProtoKind::CreateAccountTypeMismatchError => {
                 Ok(VMVerificationError::CreateAccountTypeMismatchError(message))
+            }
+            ProtoKind::GlobalReferenceError => {
+                Ok(VMVerificationError::GlobalReferenceError(message))
             }
             ProtoKind::UnknownVerificationError => {
                 bail_err!(DecodingError::UnknownVerificationErrorEncountered)


### PR DESCRIPTION
This commit enforces that only references that are borrowed from input reference parameters
are returned by a procedure. This goal is achieved by tracking references derived from
global values (those obtained by borrow_global) for each resource type in a module.  At procedure
return, all of these references (and borrows from them) are checked to be released.

As a side effect of this enhancement, we can now also check when borrow_global<T>, exists<T>,
move_from<T>, and move_to_sender<T> are done there are no existing borrows on resource type T.
This is the first step towards elimination of dynamic reference counting on global references 
from the runtime.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I want to strengthen the borrow checker so that dynamic reference counting on global references may be eliminated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests and two new tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
