### PR TITLE
[RFC][vm_runtime] Implement a substitution map in runtime to support generics

### DIFF
--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -112,6 +112,7 @@ mod gas_meter;
 mod move_vm;
 mod process_txn;
 mod runtime;
+mod substitution_map;
 
 pub mod code_cache;
 pub mod data_cache;

--- a/language/vm/vm_runtime/src/substitution_map.rs
+++ b/language/vm/vm_runtime/src/substitution_map.rs
@@ -1,0 +1,101 @@
+use vm::{
+    errors::VMInvariantViolation,
+    file_format::{SignatureToken, StructHandleIndex, TypeParameterIndex},
+};
+
+#[cfg(test)]
+#[path = "unit_tests/substitution_map_tests.rs"]
+mod substitution_map_tests;
+
+enum SignatureTokenRef<'a> {
+    /// Boolean, `true` or `false`.
+    Bool,
+    /// Unsigned integers, 64 bits length.
+    U64,
+    /// Strings, immutable, utf8 representation.
+    String,
+    /// ByteArray, variable size, immutable byte array.
+    ByteArray,
+    /// Address, a 32 bytes immutable type.
+    Address,
+    /// MOVE user type, resource or unrestricted
+    Struct(StructHandleIndex, Vec<SignatureTokenRef<'a>>),
+    /// Type parameter.
+    TypeParameter(&'a SignatureTokenRef<'a>),
+}
+
+pub struct SubstitutionMap<'a>(Vec<SignatureTokenRef<'a>>);
+
+impl<'a> SignatureTokenRef<'a> {}
+
+impl<'a> SignatureTokenRef<'a> {
+    pub fn materialize(&self) -> SignatureToken {
+        match self {
+            SignatureTokenRef::Bool => SignatureToken::Bool,
+            SignatureTokenRef::U64 => SignatureToken::U64,
+            SignatureTokenRef::String => SignatureToken::String,
+            SignatureTokenRef::ByteArray => SignatureToken::ByteArray,
+            SignatureTokenRef::Address => SignatureToken::Address,
+            SignatureTokenRef::Struct(idx, tok_vec) => {
+                SignatureToken::Struct(*idx, tok_vec.iter().map(|tok| tok.materialize()).collect())
+            }
+            SignatureTokenRef::TypeParameter(ty) => ty.materialize(),
+        }
+    }
+}
+
+impl<'a> SubstitutionMap<'a> {
+    pub fn new() -> Self {
+        SubstitutionMap(vec![])
+    }
+
+    fn new_signature(
+        &self,
+        tok: SignatureToken,
+    ) -> Result<SignatureTokenRef, VMInvariantViolation> {
+        Ok(match tok {
+            SignatureToken::Bool => SignatureTokenRef::Bool,
+            SignatureToken::U64 => SignatureTokenRef::U64,
+            SignatureToken::String => SignatureTokenRef::String,
+            SignatureToken::ByteArray => SignatureTokenRef::ByteArray,
+            SignatureToken::Address => SignatureTokenRef::Address,
+            SignatureToken::Struct(idx, tok_vec) => SignatureTokenRef::Struct(
+                idx,
+                tok_vec
+                    .into_iter()
+                    .map(|tok| self.new_signature(tok))
+                    .collect::<Result<Vec<SignatureTokenRef>, VMInvariantViolation>>()?,
+            ),
+            SignatureToken::Reference(_) | SignatureToken::MutableReference(_) => {
+                return Err(VMInvariantViolation::InternalTypeError)
+            }
+            SignatureToken::TypeParameter(idx) => SignatureTokenRef::TypeParameter(
+                self.0
+                    .get(idx as usize)
+                    .ok_or(VMInvariantViolation::InternalTypeError)?,
+            ),
+        })
+    }
+
+    pub fn subst(
+        &self,
+        toks: Vec<SignatureToken>,
+    ) -> Result<SubstitutionMap, VMInvariantViolation> {
+        Ok(SubstitutionMap(
+            toks.into_iter()
+                .map(|tok| self.new_signature(tok))
+                .collect::<Result<Vec<SignatureTokenRef>, VMInvariantViolation>>()?,
+        ))
+    }
+
+    pub fn materialize(
+        &self,
+        idx: TypeParameterIndex,
+    ) -> Result<SignatureToken, VMInvariantViolation> {
+        Ok(self
+            .0
+            .get(idx as usize)
+            .ok_or(VMInvariantViolation::InternalTypeError)?
+            .materialize())
+    }
+}

--- a/language/vm/vm_runtime/src/unit_tests/substitution_map_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/substitution_map_tests.rs
@@ -1,0 +1,34 @@
+use crate::substitution_map::SubstitutionMap;
+use vm::file_format::{SignatureToken, StructHandleIndex};
+
+#[test]
+fn test_substitution() {
+    let map = SubstitutionMap::new();
+    {
+        let map_1 = map
+            .subst(vec![SignatureToken::Address, SignatureToken::U64])
+            .unwrap();
+        {
+            let map_2 = map_1
+                .subst(vec![
+                    SignatureToken::TypeParameter(0),
+                    SignatureToken::Struct(
+                        StructHandleIndex::new(0),
+                        vec![
+                            SignatureToken::TypeParameter(0),
+                            SignatureToken::TypeParameter(1),
+                        ],
+                    ),
+                ])
+                .unwrap();
+            assert_eq!(map_2.materialize(0).unwrap(), SignatureToken::Address);
+            assert_eq!(
+                map_2.materialize(1).unwrap(),
+                SignatureToken::Struct(
+                    StructHandleIndex::new(0),
+                    vec![SignatureToken::Address, SignatureToken::U64]
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
In general the VM doesn't need to know about generic type parameters at runtime. The only exceptions are these global instructions (borrowGlobal, MoveFrom, MoveTo, Exists) as we need to know the exact struct layout to store them on chain. The current plan is that we are going to disallow top level struct to contain any type parameters to simplify the runtime implementation. i.e: We are going to store:
`Resource FooCoin{
    f: Foo<Coin>,
}`
not
`Resource FooCoin<T> {
    f: Foo<T>
}`
on chain.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a unit test. Will wait for the front end support for generics to perform the functional tests
