### PR TITLE
[ci] Checking for dependency growth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,32 @@ jobs:
             cargo install --force cargo-audit
             cargo generate-lockfile
             cargo audit
+  dependency_hello:
+    docker:
+      - image: circleci/python:3.6.4
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Dependency Growth Checker
+          # this include dev dependencies which can impact us as well
+          command: |
+            # install dependencies
+            sudo pip install toml
+            # new dependencies
+            NEW_RESULT=`pwd`"/new_dependencies"
+            python ./scripts/dependencies_growth.py | sort >> "$NEW_RESULT"
+            # old dependencies
+            OLD_RESULT=`pwd`"/old_dependencies"
+            git checkout master
+            python ./scripts/dependencies_growth.py | sort >> "$OLD_RESULT"
+            # diff
+            RES=`comm -1 -3 "$OLD_RESULT" "$NEW_RESULT" | wc -l`
+            if [ "$RES" -gt 0 ]; then
+              exit 1
+            else
+              exit 0
+            fi
   terraform:
     docker:
       - image: hashicorp/terraform
@@ -80,6 +106,7 @@ workflows:
     jobs:
       - build
       - terraform
+      - dependency_hello
 
   scheduled-workflow:
     triggers:

--- a/scripts/dependencies_growth.py
+++ b/scripts/dependencies_growth.py
@@ -1,0 +1,29 @@
+import toml
+
+dependency_keys = ["dependencies", "dev-dependencies", "build-dependencies"]
+
+
+def main():
+    # dependency list
+    dependencies = set()
+    # parse workspace
+    ff = open("Cargo.toml")
+    workspace = toml.loads(ff.read())
+    for member in workspace["workspace"]["members"]:
+        # each cargo.toml
+        ff = open(member + "/Cargo.toml")
+        crate = toml.loads(ff.read())
+        # dependencies
+        for dependency_type in dependency_keys:
+            if dependency_type in crate:
+                for dependency, options in crate[dependency_type].items():
+                    # ignore internal dependencies
+                    if "path" not in options:
+                        dependencies.add(dependency)
+    # print dependencies
+    for dependency in dependencies:
+        print(dependency)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**DO NOT ACCEPT THIS PR YET :D**

## Motivation

It would be great to check if a PR actually increases the number of (depth=0) dependencies.
This PR provides a script that will fail the `commit-workflow` of circle CI.

Effectively, this means that to merge a PR that increases the number of dependencies, one will have to consciously merge a PR that fails the circle CI.

Ideally I would like to provide a warning instead of a failure, but I'm not sure if this is possible.

It is called **dependency_hello** for obvious reasons

## Test Plan

I am testing this in this PR itself! 

Check https://circleci.com/gh/libra/libra/1192?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link 

Right now, it is part of the `commit-workflow`:

```
commit-workflow:
    jobs:
      - build
      - terraform
      - dependency_hello
```

What I need to understand is:

* does it affect the actual merge in our codebase? This would be bad as it is doing a `checkout master` at the ned.
* can it not block a pull request if it fails? This is only intended as a warning.