### PR TITLE
[benchmark] Adjust RuBen's StructOpt

### DIFF
--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -25,7 +25,7 @@
 /// this flow is basically the same for different LoadGenerators/experiments.
 use benchmark::{
     bin_utils::{create_benchmarker_from_opt, measure_throughput, try_start_metrics_server},
-    ruben_opt::{Opt, TransactionPattern},
+    ruben_opt::{RubenOpt, TransactionPattern},
     txn_generator::{LoadGenerator, PairwiseTransferTxnGenerator, RingTransferTxnGenerator},
 };
 use logger::{self, prelude::*};
@@ -34,7 +34,7 @@ use std::ops::DerefMut;
 fn main() {
     let _g = logger::set_default_global_logger(false, Some(256));
     info!("RuBen: the utility to (Ru)n (Ben)chmarker");
-    let args = Opt::new_from_args();
+    let args = RubenOpt::new_from_args();
     info!("Parsed arguments: {:#?}", args);
     try_start_metrics_server(&args);
     let mut bm = create_benchmarker_from_opt(&args);
@@ -57,7 +57,7 @@ fn main() {
 mod tests {
     use crate::{create_benchmarker_from_opt, measure_throughput};
     use benchmark::{
-        ruben_opt::{Opt, TransactionPattern},
+        ruben_opt::{RubenOpt, TransactionPattern},
         txn_generator::RingTransferTxnGenerator,
         OP_COUNTER,
     };
@@ -77,7 +77,7 @@ mod tests {
                 None,   /* config_dir */
                 None,   /* template_path */
             );
-            let mut args = Opt {
+            let mut args = RubenOpt {
                 validator_addresses: Vec::new(),
                 debug_address: None,
                 swarm_config_dir: Some(String::from(
@@ -87,7 +87,6 @@ mod tests {
                 metrics_server_address: None,
                 faucet_key_file_path,
                 num_accounts: 4,
-                free_lunch: 10_000_000,
                 num_clients: 4,
                 stagger_range_ms: 1,
                 num_rounds: 4,

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ruben_opt::Opt,
+    ruben_opt::RubenOpt,
     txn_generator::{convert_load_to_txn_requests, gen_repeated_txn_load, LoadGenerator},
     Benchmarker,
 };
@@ -44,7 +44,7 @@ pub fn create_ac_clients(
     clients
 }
 
-pub fn create_benchmarker_from_opt(args: &Opt) -> Benchmarker {
+pub fn create_benchmarker_from_opt(args: &RubenOpt) -> Benchmarker {
     // Create AdmissionControlClient instances.
     let clients = create_ac_clients(args.num_clients, &args.validator_addresses);
     let submit_rate = args.parse_submit_rate();
@@ -55,7 +55,7 @@ pub fn create_benchmarker_from_opt(args: &Opt) -> Benchmarker {
 /// Benchmarker is not a long-lived job, so starting a server and expecting it to be polled
 /// continuously is not ideal. Directly pushing metrics when benchmarker is running
 /// can be achieved by using Pushgateway.
-pub fn try_start_metrics_server(args: &Opt) {
+pub fn try_start_metrics_server(args: &RubenOpt) {
     if let Some(metrics_server_address) = &args.metrics_server_address {
         let address = metrics_server_address.clone();
         std::thread::spawn(move || {

--- a/benchmark/src/ruben_opt.rs
+++ b/benchmark/src/ruben_opt.rs
@@ -24,7 +24,7 @@ arg_enum! {
     author = "Libra",
     about = "RuBen (Ru)ns The Libra (Ben)chmarker For You."
 )]
-pub struct Opt {
+pub struct RubenOpt {
     /// Validator address list separated by whitespace: `ip_address:port ip_address:port ...`.
     /// It is required unless (and hence conflict with) swarm_config_dir is present.
     #[structopt(
@@ -56,9 +56,6 @@ pub struct Opt {
     /// Number of accounts to create in Libra.
     #[structopt(short = "n", long = "num_accounts", default_value = "32")]
     pub num_accounts: u64,
-    /// Free lunch amount to accounts.
-    #[structopt(short = "l", long = "free_lunch", default_value = "1000000")]
-    pub free_lunch: u64,
     /// Number of AC clients.
     /// If not specified or equals 0, it will be set to validator_addresses.len().
     #[structopt(short = "c", long = "num_clients", default_value = "0")]
@@ -142,9 +139,9 @@ pub fn parse_swarm_config_from_dir(config_dir_name: &str) -> Result<Vec<String>>
     Ok(validator_addresses)
 }
 
-impl Opt {
+impl RubenOpt {
     pub fn new_from_args() -> Self {
-        let mut args = Opt::from_args();
+        let mut args = RubenOpt::from_args();
         args.try_parse_validator_addresses();
         if args.num_clients == 0 {
             args.num_clients = args.validator_addresses.len();


### PR DESCRIPTION
### Summary:
One of many preparing steps for a new binary that linear search the max throughput.
* Rename Opt to RuBenOpt. The future new binary will reuse all the arguments in RuBenOpt.
* Remove free lunch as it is never used.

### Test Plan:
Existing tests related to Benchmark package.
