### PR TITLE
[benchmark] Suppress errors reported by counters.

### DIFF
--- a/benchmark/src/grpc_helpers.rs
+++ b/benchmark/src/grpc_helpers.rs
@@ -66,23 +66,23 @@ fn check_ac_response(resp: &ProtoSubmitTransactionResponse) -> bool {
             true
         } else {
             OP_COUNTER.inc(&format!("submit_txns.{:?}", status));
-            error!("Request rejected by AC: {:?}", resp);
+            debug!("Request rejected by AC: {:?}", resp);
             false
         }
     } else if resp.has_vm_status() {
         OP_COUNTER.inc(&format!("submit_txns.{:?}", resp.get_vm_status()));
-        error!("Request causes error on VM: {:?}", resp);
+        debug!("Request causes error on VM: {:?}", resp);
         false
     } else if resp.has_mempool_status() {
         OP_COUNTER.inc(&format!(
             "submit_txns.{:?}",
             resp.get_mempool_status().get_code()
         ));
-        error!("Request causes error on mempool: {:?}", resp);
+        debug!("Request causes error on mempool: {:?}", resp);
         false
     } else {
         OP_COUNTER.inc("submit_txns.Unknown");
-        error!("Request rejected by AC for unknown error: {:?}", resp);
+        debug!("Request rejected by AC for unknown error: {:?}", resp);
         false
     }
 }
@@ -122,7 +122,7 @@ pub fn submit_and_wait_txn_requests(
             }
             Err(e) => {
                 OP_COUNTER.inc(&format!("submit_txns.{:?}", e));
-                error!("Failed to receive gRPC response: {:?}", e);
+                debug!("Failed to receive gRPC response: {:?}", e);
                 None
             }
         })
@@ -185,7 +185,7 @@ pub fn get_account_states(
         .filter_map(|address| match get_account_state_async(client, *address) {
             Ok(future) => Some(future),
             Err(e) => {
-                error!("Failed to send account request: {:?}", e);
+                debug!("Failed to send account request: {:?}", e);
                 None
             }
         })
@@ -204,11 +204,11 @@ pub fn get_account_states(
                     states.insert(address, (sequence_number, status));
                 }
                 Err(e) => {
-                    error!("Invalid account response for {:?}: {:?}", address, e);
+                    debug!("Invalid account response for {:?}: {:?}", address, e);
                 }
             },
             Err(e) => {
-                error!("Failed to receive account response: {:?}", e);
+                debug!("Failed to receive account response: {:?}", e);
             }
         }
     }

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -188,7 +188,7 @@ impl Benchmarker {
                     // that are accepted by AC, and how long the client is delayed.
                     move || -> (Vec<ProtoSubmitTransactionResponse>, u16) {
                         let delay_duration_ms = Self::stagger_client(stagger_range_ms);
-                        info!(
+                        debug!(
                             "Dispatch {} requests to client after staggered {} ms.",
                             local_chunk.len(),
                             delay_duration_ms,
@@ -239,7 +239,7 @@ impl Benchmarker {
                     .map(|sender| (sender.address, sender.sequence_number))
                     .collect();
                 let local_client = Arc::clone(client);
-                info!(
+                debug!(
                     "Dispatch a chunk of {} accounts to client.",
                     local_chunk.len()
                 );
@@ -295,7 +295,11 @@ impl Benchmarker {
             assert!(sender.sequence_number >= *sync_sequence_number);
             assert!(*sync_sequence_number >= *prev_sequence_number);
             if sender.sequence_number > *sync_sequence_number {
-                error!("Account {:?} has uncommitted TXNs", sender.address);
+                error!(
+                    "Account {:?} has {} uncommitted TXNs",
+                    sender.address,
+                    sender.sequence_number - *sync_sequence_number
+                );
             }
             committed_txns += *sync_sequence_number - *prev_sequence_number;
             uncommitted_txns += sender.sequence_number - *sync_sequence_number;
@@ -342,7 +346,7 @@ impl Benchmarker {
     fn calculate_throughput(num_txns: usize, duration_ms: u128, prefix: &str) -> f64 {
         assert!(duration_ms > 0);
         let throughput = num_txns as f64 * 1000f64 / duration_ms as f64;
-        info!(
+        debug!(
             "{} throughput est = {} txns / {} ms = {:.2} rps.",
             prefix, num_txns, duration_ms, throughput,
         );


### PR DESCRIPTION
### Summary
One of many preparing steps for a new binary that linear search the max throughput.
Reduce the amount of print out error msgs if they have already caught by counters.

### Test Plan
Existing tests in benchmark package.
