### PR TITLE
[storage] Pruner optimiaztion: seek to first unpruned record faster

### DIFF
--- a/storage/libradb/src/schema/retired_state_record/mod.rs
+++ b/storage/libradb/src/schema/retired_state_record/mod.rs
@@ -28,10 +28,11 @@ use failure::prelude::*;
 use num_traits::{FromPrimitive, ToPrimitive};
 use schemadb::{
     define_schema,
-    schema::{KeyCodec, ValueCodec},
+    schema::{KeyCodec, SeekKeyCodec, ValueCodec},
 };
 use sparse_merkle::{RetiredRecordType, RetiredStateRecord};
 use std::io::{Cursor, Write};
+use types::transaction::Version;
 
 define_schema!(
     RetiredStateRecordSchema,
@@ -84,6 +85,12 @@ impl ValueCodec<RetiredStateRecordSchema> for () {
     fn decode_value(data: &[u8]) -> Result<Self> {
         ensure_slice_len_eq(data, 0)?;
         Ok(())
+    }
+}
+
+impl SeekKeyCodec<RetiredStateRecordSchema> for Version {
+    fn encode_seek_key(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
     }
 }
 

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -58,7 +58,7 @@ fn prune_retired_records(
     expected_num_purged: usize,
 ) {
     let (num_purged, _last_seen_version) =
-        pruner::prune_state(Arc::clone(&store.db), least_readable_version, limit).unwrap();
+        pruner::prune_state(Arc::clone(&store.db), 0, least_readable_version, limit).unwrap();
     assert_eq!(num_purged, expected_num_purged);
 }
 


### PR DESCRIPTION

## Motivation

With records being deleted on the smaller version side of the retire record log, seeking to
the first not-yet-deleted one gets slower and slower. While we can have more sophisticated implementation for this FIFO type data structure, remembering the current version being processed between pruning sessions is a straightforward optimization.
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan
existing coverage

