### PR TITLE
Libra swarm to take parameter topology instead of single number of validators

### DIFF
--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -70,7 +70,7 @@ mod tests {
             let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
                 generate_keypair::load_faucet_key_or_create_default(None);
             let swarm = LibraSwarm::launch_swarm(
-                4,      /* num_nodes */
+                vec![4],      /* topology */
                 true,   /* disable_logging */
                 faucet_account_keypair,
                 false,  /* tee_logs */

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -34,6 +34,9 @@ struct Args {
 fn main() {
     let args = Args::from_args();
     let num_nodes = args.num_nodes.unwrap_or(1);
+    // topology indicates the shape of the validator network
+    // ['num_nodes', 'num_full_nodes', 'num_full_node_children']
+    let topology = vec![num_nodes];
 
     let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(args.faucet_key_path);
@@ -44,7 +47,7 @@ fn main() {
     );
 
     let swarm = LibraSwarm::launch_swarm(
-        num_nodes,
+        topology,
         !args.enable_logging,
         faucet_account_keypair,
         false, /* tee_logs */

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -250,7 +250,7 @@ pub enum SwarmLaunchFailure {
 
 impl LibraSwarm {
     pub fn launch_swarm(
-        num_nodes: usize,
+        topology: Vec<usize>,
         disable_logging: bool,
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
@@ -261,7 +261,7 @@ impl LibraSwarm {
         for i in 0..num_launch_attempts {
             info!("Launch swarm attempt: {} of {}", i, num_launch_attempts);
             match Self::launch_swarm_attempt(
-                num_nodes,
+                &topology,
                 disable_logging,
                 faucet_account_keypair.clone(),
                 tee_logs,
@@ -278,7 +278,7 @@ impl LibraSwarm {
     }
 
     fn launch_swarm_attempt(
-        num_nodes: usize,
+        topology: &[usize],
         disable_logging: bool,
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
@@ -305,9 +305,15 @@ impl LibraSwarm {
                 .unwrap_or(&"config/data/configs/node.config.toml".to_string()),
         );
         let mut config_builder = SwarmConfigBuilder::new();
+
+        // topology indicates the shape of the validator network
+        // ['num_nodes', 'num_full_nodes', 'num_full_node_children']
+        // Currently does not handle full nodes, so only take the first element
+        let num_validator_nodes = topology[0];
+
         config_builder
             .with_ipv4()
-            .with_nodes(num_nodes)
+            .with_nodes(num_validator_nodes)
             .with_base(base)
             .with_output_dir(&dir)
             .with_faucet_keypair(faucet_account_keypair)

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -16,9 +16,10 @@ fn setup_env(
 
     let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(None);
+    let topology = vec![num_nodes];
 
     let swarm = LibraSwarm::launch_swarm(
-        num_nodes,
+        topology,
         false, /* disable_logging */
         faucet_account_keypair,
         true, /* tee_logs */

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -33,11 +33,12 @@ rusty_fork_test! {
         let (num_nodes, num_accounts, num_clients) = (4, 32, 4);
         let (num_rounds, num_epochs, stagger_ms) = (2, 4, 1);
         let submit_rate = 50;
+        let topology = vec![num_nodes];
 
         let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
             generate_keypair::load_faucet_key_or_create_default(None);
         let swarm = LibraSwarm::launch_swarm(
-            num_nodes,
+            topology,
             true,   /* disable_logging */
             faucet_account_keypair,
             false,  /* tee_logs */


### PR DESCRIPTION
## Motivation

Currently when launching Libraswarm, we can only configure the number of validator nodes to spin up. Once we have full nodes, we want to test having full nodes as part of Libra swarm. This diff changes the "num_nodes" param to "topology", which takes in a vector of sizes in this order: vec['num_nodes', 'num_full_nodes', 'num_full_node_children']. Passing in vec[2, 2, 1] will create 2 validators, each with 2 full nodes, and each full node will have 1 children full node. 

Currently it is in a vector form, but it will likely become a string that will be parsed later.

## Test Plan

cargo test ran successfully
