### PR TITLE
[storage] move codec for NodeKey from schema to jellyfish merkle

### DIFF
--- a/storage/jellyfish_merkle/Cargo.toml
+++ b/storage/jellyfish_merkle/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.1.1"
+byteorder = "1.3.2"
 num-derive = "0.2"
 num-traits = "0.2"
 proptest = "0.9.2"

--- a/storage/libradb/src/schema/jellyfish_merkle_node/mod.rs
+++ b/storage/libradb/src/schema/jellyfish_merkle_node/mod.rs
@@ -8,20 +8,13 @@
 //! |  node_key  | serialized_node |
 //! ```
 
-use crate::schema::{ensure_slice_len_gt, JELLYFISH_MERKLE_NODE_CF_NAME};
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use crate::schema::JELLYFISH_MERKLE_NODE_CF_NAME;
 use failure::prelude::*;
 use jellyfish_merkle::node_type::{Node, NodeKey};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
 };
-use sparse_merkle::nibble_path::NibblePath;
-use std::{
-    io::{Cursor, Write},
-    mem::size_of,
-};
-use types::transaction::Version;
 
 define_schema!(
     JellyfishMerkleNodeSchema,
@@ -32,28 +25,11 @@ define_schema!(
 
 impl KeyCodec<JellyfishMerkleNodeSchema> for NodeKey {
     fn encode_key(&self) -> Result<Vec<u8>> {
-        let mut encoded_key = vec![];
-        encoded_key.write_u64::<BigEndian>(self.version())?;
-        encoded_key.write_u8((self.nibble_path().num_nibbles() & 1) as u8)?;
-        encoded_key.write_all(self.nibble_path().bytes())?;
-        Ok(encoded_key)
+        self.encode()
     }
 
     fn decode_key(data: &[u8]) -> Result<Self> {
-        let version_size = size_of::<Version>();
-        let u8_size = size_of::<u8>();
-        ensure_slice_len_gt(data, version_size + u8_size - 1)?;
-
-        let mut reader = Cursor::new(data);
-        let version = reader.read_u64::<BigEndian>()?;
-        let is_odd = reader.read_u8()? == 1;
-        let nibble_bytes = data[version_size + u8_size..].to_vec();
-        let nibble_path = if is_odd {
-            NibblePath::new_odd(nibble_bytes)
-        } else {
-            NibblePath::new(nibble_bytes)
-        };
-        Ok(NodeKey::new(version, nibble_path))
+        Self::decode(data)
     }
 }
 
@@ -63,7 +39,7 @@ impl ValueCodec<JellyfishMerkleNodeSchema> for Node {
     }
 
     fn decode_value(data: &[u8]) -> Result<Self> {
-        Ok(Node::decode(&data[..])?)
+        Ok(Self::decode(&data[..])?)
     }
 }
 


### PR DESCRIPTION
## Motivation

We need to use it at different places but not only in schema.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

https://github.com/libra/libra/pull/424#discussion_r310820978
