### PR TITLE
[Consensus] Process QCs not only from proposals

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -792,6 +792,6 @@ fn chain_with_nil_blocks() {
                 >= 4
         );
 
-        // TODO: extend this test once we update the rules for processing newly generated QCs
+        assert!(nodes[2].smr.block_store().unwrap().root().round() >= 1)
     });
 }

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -737,7 +737,7 @@ fn process_block_retrieval() {
         sync_info: SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
     };
     node.pacemaker
-        .process_certificates(proposal_info.proposal.round() - 1, None);
+        .process_certificates(proposal_info.proposal.round() - 1, None, None);
 
     block_on(async move {
         node.event_processor
@@ -834,7 +834,7 @@ fn basic_restart_test() {
             proposals_mut.push(proposal_id);
             node_mut
                 .pacemaker
-                .process_certificates(proposal_info.proposal.round() - 1, None);
+                .process_certificates(proposal_info.proposal.round() - 1, None, None);
             node_mut
                 .event_processor
                 .process_winning_proposal(proposal_info)

--- a/consensus/src/chained_bft/liveness/local_pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker_test.rs
@@ -107,8 +107,8 @@ fn test_basic_qc() {
         // Wait for the initial event for the first round.
         expect_qc(1, &mut new_round_events_receiver).await;
 
-        pm.process_certificates(2, None).await;
-        pm.process_certificates(3, None).await;
+        pm.process_certificates(2, None, None).await;
+        pm.process_certificates(3, None, None).await;
 
         expect_qc(3, &mut new_round_events_receiver).await;
         expect_qc(4, &mut new_round_events_receiver).await;

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -74,6 +74,7 @@ pub trait Pacemaker: Send + Sync {
     fn process_certificates(
         &self,
         qc_round: Round,
+        highest_committed_round: Option<Round>,
         timeout_certificate: Option<&PacemakerTimeoutCertificate>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -82,7 +83,4 @@ pub trait Pacemaker: Send + Sync {
         &self,
         pacemaker_timeout: PacemakerTimeout,
     ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
-
-    /// Update the highest committed round and return if it's updated.
-    fn update_highest_committed_round(&self, highest_committed_round: Round) -> bool;
 }


### PR DESCRIPTION
Summary:
A validator can receive QCs via multiple ways: proposals, timeout certificates, QCs that are aggregated by the validator itself.
We used to send these QCs to SafetyRules and process the corresponding commits only if the QC is received via proposal.
However, once we introduce the NIL block voting we want to be able to commit blocks via the QCs that are generated during the timeouts: in this change we're adding QC processing to some several other places.

Tests: Extended the NIL block voting test to verify that a commit happens upon timeout.
Task: ref #371
