### PR TITLE
[benchmark] Search max throughput by linearly increasing submission speed and TXN volume.

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -17,6 +17,7 @@ rand = "0.7.0"
 regex = "1.1.9"
 structopt = "0.2.15"
 tempdir = "0.3.7"
+num_cpus = "1.10.1"
 
 admission_control_proto = { path = "../admission_control/admission_control_proto" }
 client = { path = "../client" }

--- a/benchmark/src/bin/max_throughput.rs
+++ b/benchmark/src/bin/max_throughput.rs
@@ -2,66 +2,23 @@ use benchmark::{
     bin_utils::{
         create_benchmarker_from_opt, linear_search_max_throughput, try_start_metrics_server,
     },
+    cli_opt::SearchOpt,
     load_generator::PairwiseTransferTxnGenerator,
-    ruben_opt::RubenOpt,
 };
 use logger::{self, prelude::*};
-use structopt::StructOpt;
 
 /// During linear search, both submission rate and number of TXNs are increased.
 /// With 32 new accounts and 2 rounds, we add extra 2K TXNs as rate increases.
 const NUM_NEW_ACCOUNTS: u64 = 32;
 const NUM_REPEATED_ROUNDS: u64 = 2;
 
-/// CLI options for linear search max throughput.
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "max_throughput",
-    author = "Libra",
-    about = "Linear Search Maximum Throughput."
-)]
-pub struct SearchOpt {
-    // Some arguments from RubenOpt will be set to linear search's default values, including
-    // num_accounts, num_rounds, num_clients, txn_pattern.
-    #[structopt(flatten)]
-    pub ruben_opt: RubenOpt,
-    /// Upper bound value of submission rate for each client.
-    #[structopt(short = "u", long = "upper_bound", default_value = "8000")]
-    pub upper_bound: u64,
-    /// Lower bound value of submission rate for each client.
-    #[structopt(short = "l", long = "lower_bound", default_value = "10")]
-    pub lower_bound: u64,
-    /// Increase step of submission rate for each client.
-    #[structopt(short = "i", long = "inc_step", default_value = "10")]
-    pub inc_step: u64,
-    /// How many times to repeat the same linear search. Each time with new accounts/TXNs.
-    #[structopt(short = "b", long = "num_searches", default_value = "10")]
-    pub num_searches: u64,
-}
-
-impl SearchOpt {
-    pub fn new_from_args() -> Self {
-        let mut args = SearchOpt::from_args();
-        args.ruben_opt.try_parse_validator_addresses();
-        args.ruben_opt.num_clients = args.ruben_opt.validator_addresses.len() * num_cpus::get();
-        info!(
-            "Search max throughput with {} clients",
-            args.ruben_opt.num_clients
-        );
-        assert!(args.lower_bound > 0);
-        assert!(args.inc_step > 0);
-        assert!(args.lower_bound < args.upper_bound);
-        args
-    }
-}
-
 fn main() {
     let _g = logger::set_default_global_logger(false, Some(256));
     let args = SearchOpt::new_from_args();
     info!("Parsed and adjusted arguments: {:#?}", args);
-    try_start_metrics_server(&args.ruben_opt);
-    let mut bm = create_benchmarker_from_opt(&args.ruben_opt);
-    let mut faucet_account = bm.load_faucet_account(&args.ruben_opt.faucet_key_file_path);
+    try_start_metrics_server(&args.bench_opt);
+    let mut bm = create_benchmarker_from_opt(&args.bench_opt);
+    let mut faucet_account = bm.load_faucet_account(&args.bench_opt.faucet_key_file_path);
     let mut generator = PairwiseTransferTxnGenerator::new();
     for _ in 0..args.num_searches {
         linear_search_max_throughput(
@@ -73,7 +30,7 @@ fn main() {
             args.inc_step,
             NUM_NEW_ACCOUNTS,
             NUM_REPEATED_ROUNDS,
-            args.ruben_opt.num_epochs,
+            args.num_epochs,
         );
     }
 }

--- a/benchmark/src/bin/max_throughput.rs
+++ b/benchmark/src/bin/max_throughput.rs
@@ -1,0 +1,79 @@
+use benchmark::{
+    bin_utils::{
+        create_benchmarker_from_opt, linear_search_max_throughput, try_start_metrics_server,
+    },
+    load_generator::PairwiseTransferTxnGenerator,
+    ruben_opt::RubenOpt,
+};
+use logger::{self, prelude::*};
+use structopt::StructOpt;
+
+/// During linear search, both submission rate and number of TXNs are increased.
+/// With 32 new accounts and 2 rounds, we add extra 2K TXNs as rate increases.
+const NUM_NEW_ACCOUNTS: u64 = 32;
+const NUM_REPEATED_ROUNDS: u64 = 2;
+
+/// CLI options for linear search max throughput.
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "max_throughput",
+    author = "Libra",
+    about = "Linear Search Maximum Throughput."
+)]
+pub struct SearchOpt {
+    // Some arguments from RubenOpt will be set to linear search's default values, including
+    // num_accounts, num_rounds, num_clients, txn_pattern.
+    #[structopt(flatten)]
+    pub ruben_opt: RubenOpt,
+    /// Upper bound value of submission rate for each client.
+    #[structopt(short = "u", long = "upper_bound", default_value = "8000")]
+    pub upper_bound: u64,
+    /// Lower bound value of submission rate for each client.
+    #[structopt(short = "l", long = "lower_bound", default_value = "10")]
+    pub lower_bound: u64,
+    /// Increase step of submission rate for each client.
+    #[structopt(short = "i", long = "inc_step", default_value = "10")]
+    pub inc_step: u64,
+    /// How many times to repeat the same linear search. Each time with new accounts/TXNs.
+    #[structopt(short = "b", long = "num_searches", default_value = "10")]
+    pub num_searches: u64,
+}
+
+impl SearchOpt {
+    pub fn new_from_args() -> Self {
+        let mut args = SearchOpt::from_args();
+        args.ruben_opt.try_parse_validator_addresses();
+        args.ruben_opt.num_clients = args.ruben_opt.validator_addresses.len() * num_cpus::get();
+        info!(
+            "Search max throughput with {} clients",
+            args.ruben_opt.num_clients
+        );
+        assert!(args.lower_bound > 0);
+        assert!(args.inc_step > 0);
+        assert!(args.lower_bound < args.upper_bound);
+        args
+    }
+}
+
+fn main() {
+    let _g = logger::set_default_global_logger(false, Some(256));
+    let args = SearchOpt::new_from_args();
+    info!("Parsed and adjusted arguments: {:#?}", args);
+    try_start_metrics_server(&args.ruben_opt);
+    let mut bm = create_benchmarker_from_opt(&args.ruben_opt);
+    let mut faucet_account = bm.load_faucet_account(&args.ruben_opt.faucet_key_file_path);
+    let mut generator = PairwiseTransferTxnGenerator::new();
+    for _ in 0..args.num_searches {
+        linear_search_max_throughput(
+            &mut bm,
+            &mut generator,
+            &mut faucet_account,
+            args.lower_bound,
+            args.upper_bound,
+            args.inc_step,
+            NUM_NEW_ACCOUNTS,
+            NUM_REPEATED_ROUNDS,
+            args.ruben_opt.num_epochs,
+        );
+    }
+}

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -11,7 +11,9 @@ use client::AccountData;
 use grpcio::{ChannelBuilder, EnvBuilder};
 use logger::{self, prelude::*};
 use metrics::metric_server::start_server;
-use std::sync::Arc;
+use std::{sync::Arc, time};
+
+const COMMIT_RATIO_THRESHOLD: f64 = 0.7;
 
 /// Creates a client for AC with a unique user-agent.
 ///
@@ -64,10 +66,27 @@ pub fn try_start_metrics_server(args: &RubenOpt) {
     }
 }
 
-/// Play given TXNs with Benchmarker for several epochs and measure burst throughput,
+/// Generate a group of new accounts, and mint them using Benchmarker before returning them.
+pub fn gen_and_mint_accounts<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    generator: &mut T,
+    faucet_account: &mut AccountData,
+    num_accounts: u64,
+) -> Vec<AccountData> {
+    // Generate testing accounts.
+    let mut accounts: Vec<AccountData> = generator.gen_accounts(num_accounts);
+    bm.register_accounts(&accounts);
+    // Mint generated accounts
+    let setup_requests = generator.gen_setup_requests(faucet_account, &mut accounts);
+    bm.mint_accounts(&setup_requests, faucet_account);
+    accounts
+}
+
+/// Play given TXNs with Benchmarker for several epochs and measure throughput,
 /// e.g., the average committed txns per second. Since time is counted from submission
 /// until all TXNs are committed, this measurement is in a sense the user-side throughput.
 /// Each epoch plays the given TXN pattern sequence repeatedly for several rounds.
+/// Return list of summaries for all epochs.
 pub fn measure_throughput<T: LoadGenerator + ?Sized>(
     bm: &mut Benchmarker,
     generator: &mut T,
@@ -77,19 +96,21 @@ pub fn measure_throughput<T: LoadGenerator + ?Sized>(
     num_epochs: u64,
 ) -> std::vec::Vec<BenchSummary> {
     // Generate testing accounts.
-    let mut accounts: Vec<AccountData> = generator.gen_accounts(num_accounts);
-    bm.register_accounts(&accounts);
-
-    // Submit minting TXNs.
-    let mint_txns = generator.gen_setup_requests(faucet_account, &mut accounts);
-    bm.mint_accounts(&mint_txns, faucet_account);
-
-    // Submit testing TXNs and measure throughput.
+    let mut accounts = gen_and_mint_accounts(bm, generator, faucet_account, num_accounts);
+    let account_chunk_size = accounts.len();
     let mut results = vec![];
     let mut throughput_seq = vec![];
     for _ in 0..num_epochs {
-        let repeated_txn_reqs = gen_repeated_requests(generator, &mut accounts, num_rounds);
-        let result = bm.measure_txn_throughput(&repeated_txn_reqs, &mut accounts, None);
+        // Submit testing TXNs and measure throughput.
+        let result = run_benchmarker_at_const_rate(
+            bm,
+            &mut accounts,
+            generator,
+            None, /* submit_rate is included in bm */
+            account_chunk_size,
+            num_rounds,
+            1, /* record result epoch by epoch */
+        );
         throughput_seq.push((result.req_throughput(), result.txn_throughput()));
         results.push(result);
     }
@@ -98,4 +119,111 @@ pub fn measure_throughput<T: LoadGenerator + ?Sized>(
         num_epochs, throughput_seq,
     );
     results
+}
+
+/// Generate TXNs, submit them at constant submission rate, and measure TXN throughput.
+/// Run this process for several epochs.
+/// Aggregate each epoch's running result into a single BenchSummary and return it.
+fn run_benchmarker_at_const_rate<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    accounts: &mut [AccountData],
+    generator: &mut T,
+    rate: Option<u64>,
+    account_chunk_size: usize,
+    num_rounds: u64,
+    num_epochs: u64,
+) -> BenchSummary {
+    let (mut total_submitted, mut total_accepted, mut total_committed) = (0, 0, 0);
+    let (mut total_submit_duration, mut total_wait_duration) = (0, 0);
+    for _ in 0..num_epochs {
+        let mut txn_reqs = vec![];
+        let now = time::Instant::now();
+        // Generate new TXNs with only a chunk of accounts to avoid exceeding mempool limit.
+        for account_chunk in accounts.chunks_mut(account_chunk_size as usize) {
+            let txn_req_chunk = gen_repeated_requests(generator, account_chunk, num_rounds);
+            txn_reqs.extend(txn_req_chunk.into_iter());
+        }
+        info!(
+            "Generate {} TXNs within {} ms.",
+            txn_reqs.len(),
+            now.elapsed().as_millis()
+        );
+        let result = bm.measure_txn_throughput(&txn_reqs, accounts, rate);
+        total_submitted += txn_reqs.len();
+        total_accepted += result.num_accepted;
+        total_committed += result.num_committed;
+        total_submit_duration += result.submit_duration_ms;
+        total_wait_duration += result.wait_duration_ms;
+    }
+    BenchSummary {
+        num_submitted: total_submitted,
+        num_accepted: total_accepted,
+        num_committed: total_committed,
+        submit_duration_ms: total_submit_duration,
+        wait_duration_ms: total_wait_duration,
+    }
+}
+
+/// Search the maximum throughput by increasing submission rate from lower_bound to upper_bound.
+/// Search may end earilier if commit ratio < COMMIT_RATIO_THRESHOLD.
+/// Return the max observed TXN throughput, along with the request throughput.
+pub fn linear_search_max_throughput<T: LoadGenerator + ?Sized>(
+    bm: &mut Benchmarker,
+    generator: &mut T,
+    faucet_account: &mut AccountData,
+    lower_bound: u64,
+    upper_bound: u64,
+    inc_step: u64,
+    num_accounts: u64,
+    num_rounds: u64,
+    num_epochs: u64,
+) -> (f64, f64) {
+    let mut rate = lower_bound;
+    let mut max_result = (0.0f64, 0.0f64);
+    let mut growing_accounts = vec![];
+    while rate <= upper_bound {
+        let accounts = gen_and_mint_accounts(bm, generator, faucet_account, num_accounts);
+        growing_accounts.extend(accounts.into_iter());
+        info!(
+            "Sending at constant rate {} TPS per client with {} accounts.",
+            rate,
+            growing_accounts.len()
+        );
+        let result = run_benchmarker_at_const_rate(
+            bm,
+            &mut growing_accounts,
+            generator,
+            Some(rate),
+            num_accounts as usize,
+            num_rounds,
+            num_epochs,
+        );
+        let (req_throughput, txn_throughput) = (result.req_throughput(), result.txn_throughput());
+        let (num_submitted, num_committed) = (result.num_submitted, result.num_committed);
+        if max_result.1 < txn_throughput {
+            max_result = (req_throughput, txn_throughput);
+        }
+        info!(
+            "#submitted = {}, #committed = {}, avg REQ/TXN throughput = {:.2}/{:.2}.",
+            num_submitted, num_committed, req_throughput, txn_throughput
+        );
+        let commit_ratio = num_committed as f64 / num_submitted as f64;
+        info!(
+            "Commit ratio at submit rate {} per client is {:.4}.",
+            rate, commit_ratio
+        );
+        if commit_ratio < COMMIT_RATIO_THRESHOLD {
+            info!(
+                "Search ends ealier as commit ratio {:.4} < {:.2}.",
+                commit_ratio, COMMIT_RATIO_THRESHOLD,
+            );
+            break;
+        }
+        rate += inc_step;
+    }
+    info!(
+        "Search result: max REQ/TXN throughput = {:?} TPS.",
+        max_result
+    );
+    max_result
 }

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    cli_opt::BenchOpt,
     load_generator::{gen_repeated_requests, LoadGenerator},
-    ruben_opt::RubenOpt,
     BenchSummary, Benchmarker,
 };
 use admission_control_proto::proto::admission_control_grpc::AdmissionControlClient;
@@ -46,9 +46,10 @@ pub fn create_ac_clients(
     clients
 }
 
-pub fn create_benchmarker_from_opt(args: &RubenOpt) -> Benchmarker {
+pub fn create_benchmarker_from_opt(args: &BenchOpt) -> Benchmarker {
     // Create AdmissionControlClient instances.
     let clients = create_ac_clients(args.num_clients, &args.validator_addresses);
+
     let submit_rate = args.parse_submit_rate();
     // Ready to instantiate Benchmarker.
     Benchmarker::new(clients, args.stagger_range_ms, submit_rate)
@@ -57,7 +58,7 @@ pub fn create_benchmarker_from_opt(args: &RubenOpt) -> Benchmarker {
 /// Benchmarker is not a long-lived job, so starting a server and expecting it to be polled
 /// continuously is not ideal. Directly pushing metrics when benchmarker is running
 /// can be achieved by using Pushgateway.
-pub fn try_start_metrics_server(args: &RubenOpt) {
+pub fn try_start_metrics_server(args: &BenchOpt) {
     if let Some(metrics_server_address) = &args.metrics_server_address {
         let address = metrics_server_address.clone();
         std::thread::spawn(move || {

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -16,9 +16,9 @@ use std::{collections::HashMap, convert::TryInto, sync::Arc, thread, time};
 use types::{account_address::AccountAddress, account_config::association_address};
 
 pub mod bin_utils;
+pub mod cli_opt;
 pub mod grpc_helpers;
 pub mod load_generator;
-pub mod ruben_opt;
 pub mod submit_rate;
 
 use grpc_helpers::{

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -51,8 +51,8 @@ rusty_fork_test! {
         let mut faucet_account = bm.load_faucet_account(&faucet_key_file_path);
         let mut pairwise_generator = PairwiseTransferTxnGenerator::new();
         let results = measure_throughput(&mut bm, &mut pairwise_generator, &mut faucet_account, num_accounts, num_rounds, num_epochs);
-        let req_throughput_seq: Vec<_> = results.iter().map(|x| x.0).collect();
-        let txn_throughput_seq: Vec<_> = results.iter().map(|x| x.1).collect();
+        let req_throughput_seq: Vec<_> = results.iter().map(|x| x.req_throughput()).collect();
+        let txn_throughput_seq: Vec<_> = results.iter().map(|x| x.txn_throughput()).collect();
         calculate_avg_std(&req_throughput_seq, &"REQ_throughput");
         calculate_avg_std(&txn_throughput_seq, &"TXN_throughput");
     }

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -3,8 +3,8 @@
 
 use benchmark::{
     bin_utils::{create_ac_clients, measure_throughput},
+    cli_opt::parse_swarm_config_from_dir,
     load_generator::PairwiseTransferTxnGenerator,
-    ruben_opt::parse_swarm_config_from_dir,
     Benchmarker,
 };
 use libra_swarm::swarm::LibraSwarm;


### PR DESCRIPTION
### Summary
* By submitting TXNs at constant rates and keeping increasing the rate by `inc_step`, search the maximum throughput within `[lower_bound, upper_bound]`. Search can end earlier when commit to submit ratio is less than a predefined threshold.

* Transaction volume is increasing by adding more new accounts into the network during search.

* For each submission rate, average throughput value over several epochs are calculated and used in comparing. The maximum of these moving-window-average values is reported when search end.

### Test Plan
Search the max throughput of my own server. The shortest one takes around 30 mins
```
./target/release/lisar -f faucet_for_ruben -s temp_config \
-e 1 -m localhost:45345 -l 50 -i 5 -b 1
......
Commit ratio at submit rate 155 per client is 0.6416
Search ends ealier as commit ratio 0.6416 < 0.70
Search result: max REQ/TXN throughput = (504.4334975369458, 426.7778067205001) TPS
```
![image](https://user-images.githubusercontent.com/1838298/62725949-fc5d0e00-b9ca-11e9-959a-9b88302afcb5.png)


A longer one with moving window size = 3 and search twice, which takes around 2.5 hours:
```
./target/release/lisar -f faucet_for_ruben -s temp_config \
-e 3 -m localhost:45345 -l 50 -i 5 -b 2

......
Commit ratio at submit rate 150 per client is 0.6271
Search ends ealier as commit ratio 0.6271 < 0.70
Search result: max REQ/TXN throughput = (507.6917134985419, 431.2480353419556) TPS
.......
```
![image](https://user-images.githubusercontent.com/1838298/62726118-52ca4c80-b9cb-11e9-8ac7-10b71e117a7e.png)
