### PR TITLE
[storage] use Ordering::Relaxed everywhere for Prunner::worker_progress

### DIFF
--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -96,7 +96,7 @@ impl Pruner {
             let end = Instant::now() + TIMEOUT;
 
             while Instant::now() < end {
-                if self.worker_progress.load(Ordering::Acquire) >= least_readable_version {
+                if self.worker_progress.load(Ordering::Relaxed) >= least_readable_version {
                     return Ok(());
                 }
                 sleep(Duration::from_millis(1));
@@ -167,7 +167,7 @@ impl Worker {
                     self.blocking_recv = num_pruned < Self::BATCH_SIZE;
 
                     // Log the progress.
-                    self.progress.store(last_seen_version, Ordering::Release);
+                    self.progress.store(last_seen_version, Ordering::Relaxed);
                     OP_COUNTER.set(
                         "pruner.least_readable_state_version",
                         last_seen_version as usize,


### PR DESCRIPTION



## Motivation
I used to `Release` the atomic in the worker thread and `Acquire` it in the main thread (for test only), and now have realized `Relaxed` is good enough in this case since the atomic itself is the only thing that's communicated across the threads, relative ordering of other memory accesses is irrelevant.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
existing coverage