### PR TITLE
[language/functional tests] pass comments with no special meanings th…

### DIFF
--- a/language/compiler/ir_to_bytecode/src/parser.rs
+++ b/language/compiler/ir_to_bytecode/src/parser.rs
@@ -21,7 +21,7 @@ pub use ir_to_bytecode_syntax::ast;
 // comments for now. Will later on add in other comment types.
 fn strip_comments(string: &str) -> String {
     // Remove line comments
-    let line_comments = Regex::new(r"//.*(\r\n|\n|\r)").unwrap();
+    let line_comments = Regex::new(r"(?m)//.*$").unwrap();
     line_comments.replace_all(string, "$1").into_owned()
 }
 

--- a/language/functional_tests/src/checker.rs
+++ b/language/functional_tests/src/checker.rs
@@ -40,7 +40,17 @@ impl FromStr for Directive {
             // TODO: implement transaction directive
             unimplemented!();
         }
-        Ok(Directive::Check(s.to_string()))
+        if s.starts_with("check:")
+            || s.starts_with("sameln:")
+            || s.starts_with("nextln:")
+            || s.starts_with("unordered:")
+            || s.starts_with("not:")
+            || s.starts_with("regex:")
+        {
+            Ok(Directive::Check(s.to_string()))
+        } else {
+            Err(ErrorKind::Other("unrecognized directive".to_string()).into())
+        }
     }
 }
 

--- a/language/functional_tests/src/tests/checker_tests.rs
+++ b/language/functional_tests/src/tests/checker_tests.rs
@@ -10,6 +10,8 @@ use crate::{
 fn parse_directives() {
     for s in &[
         "abc",
+        "// not a directive",
+        "//",
         "// stage:   runtime  bad  ",
         "// stage: bad stage",
         "// stage: ",
@@ -21,6 +23,10 @@ fn parse_directives() {
         "// check: abc",
         "  // check: abc",
         "//not: foo",
+        "// sameln: abc",
+        "// nextln: abc",
+        "// unordered: abc",
+        "// regex: X=aaa",
         "// stage: parser",
         "// stage: compiler",
         "// stage: verifier",

--- a/language/functional_tests/src/tests/utils_tests.rs
+++ b/language/functional_tests/src/tests/utils_tests.rs
@@ -7,7 +7,7 @@ fn parse_input_no_transactions() {
 
 #[test]
 fn parse_input_no_transactions_with_config() {
-    parse_input("//! no-verify").unwrap_err();
+    parse_input("//! no-run: verifier").unwrap_err();
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
## Motivation
Functional tests used to pass comments it doesn't recognize to filecheck, which may get silently ignored if not a filecheck directive. This is less than ideal as it strips out all comments from the program being tested. This is different from the real world use case as the parser never gets the chance to handle a program with comments.

This PR adds a filter so that only comments with certain prefixes will be considered directives and unrecognized ones will be left intact. 

## Test Plan
cargo test