### PR TITLE
Libra swarm to take parameter topology instead of single number of validators

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -21,6 +21,7 @@ tempdir = "0.3.7"
 admission_control_proto = { path = "../admission_control/admission_control_proto" }
 client = { path = "../client" }
 config = { path = "../config" }
+config_builder = { path = "../config/config_builder" }
 crypto = { path = "../crypto/legacy_crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -66,6 +66,7 @@ mod tests {
         OP_COUNTER,
     };
     use client::AccountData;
+    use config_builder::swarm_config::LibraSwarmTopology;
     use libra_swarm::swarm::LibraSwarm;
     use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
     use std::ops::Range;
@@ -76,9 +77,10 @@ mod tests {
     fn start_swarm_and_setup_arguments() -> (LibraSwarm, RubenOpt, Option<TempDir>) {
         let (faucet_account_keypair, faucet_key_file_path, temp_dir) =
             generate_keypair::load_faucet_key_or_create_default(None);
+        let topology = LibraSwarmTopology::create_validator_network(4);
         let swarm = LibraSwarm::launch_swarm(
-            4,    /* num_nodes */
-            true, /* disable_logging */
+            topology, /* num_nodes */
+            true,     /* disable_logging */
             faucet_account_keypair,
             false, /* tee_logs */
             None,  /* config_dir */

--- a/config/config_builder/src/bin/libra-config.rs
+++ b/config/config_builder/src/bin/libra-config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{value_t, App, Arg};
-use config_builder::swarm_config::SwarmConfigBuilder;
+use config_builder::swarm_config::{LibraSwarmTopology, SwarmConfigBuilder};
 use std::convert::TryInto;
 
 const BASE_ARG: &str = "base";
@@ -74,9 +74,10 @@ fn main() {
     let (faucet_account_keypair, _faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(Some(faucet_account_file_path));
 
+    let topology = LibraSwarmTopology::create_validator_network(nodes_count);
     let mut config_builder = SwarmConfigBuilder::new();
     config_builder
-        .with_nodes(nodes_count)
+        .with_topology(topology)
         .with_base(base_path)
         .with_output_dir(output_dir)
         .with_faucet_keypair(faucet_account_keypair);

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use config_builder::swarm_config::LibraSwarmTopology;
 use libra_swarm::{client, swarm::LibraSwarm};
 use std::path::Path;
 use structopt::StructOpt;
@@ -34,6 +35,9 @@ struct Args {
 fn main() {
     let args = Args::from_args();
     let num_nodes = args.num_nodes.unwrap_or(1);
+    // topology indicates structure of the validator network
+    // e.g. num of validators, num of full nodes and their children
+    let topology = LibraSwarmTopology::create_validator_network(num_nodes);
 
     let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(args.faucet_key_path);
@@ -44,7 +48,7 @@ fn main() {
     );
 
     let swarm = LibraSwarm::launch_swarm(
-        num_nodes,
+        topology,
         !args.enable_logging,
         faucet_account_keypair,
         false, /* tee_logs */

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -6,7 +6,7 @@ use crate::{
     utils,
 };
 use config::config::NodeConfig;
-use config_builder::swarm_config::{SwarmConfig, SwarmConfigBuilder};
+use config_builder::swarm_config::{LibraSwarmTopology, SwarmConfig, SwarmConfigBuilder};
 use debug_interface::NodeDebugClient;
 use failure::prelude::*;
 use logger::prelude::*;
@@ -250,7 +250,7 @@ pub enum SwarmLaunchFailure {
 
 impl LibraSwarm {
     pub fn launch_swarm(
-        num_nodes: usize,
+        topology: LibraSwarmTopology,
         disable_logging: bool,
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
@@ -261,7 +261,7 @@ impl LibraSwarm {
         for i in 0..num_launch_attempts {
             info!("Launch swarm attempt: {} of {}", i, num_launch_attempts);
             match Self::launch_swarm_attempt(
-                num_nodes,
+                topology.clone(),
                 disable_logging,
                 faucet_account_keypair.clone(),
                 tee_logs,
@@ -278,7 +278,7 @@ impl LibraSwarm {
     }
 
     fn launch_swarm_attempt(
-        num_nodes: usize,
+        topology: LibraSwarmTopology,
         disable_logging: bool,
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         tee_logs: bool,
@@ -305,9 +305,10 @@ impl LibraSwarm {
                 .unwrap_or(&"config/data/configs/node.config.toml".to_string()),
         );
         let mut config_builder = SwarmConfigBuilder::new();
+
         config_builder
             .with_ipv4()
-            .with_nodes(num_nodes)
+            .with_topology(topology)
             .with_base(base)
             .with_output_dir(&dir)
             .with_faucet_keypair(faucet_account_keypair)

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -22,4 +22,5 @@ cli = { path = "../client", package="client" }
 generate_keypair = { path = "../config/generate_keypair" }
 libra_swarm = { path = "../libra_swarm", features = ["testing"]}
 logger = { path = "../common/logger" }
+config_builder = { path = "../config/config_builder" }
 tempfile = "3.1.0"

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused_mut)]
 use cli::client_proxy::ClientProxy;
+use config_builder::swarm_config::LibraSwarmTopology;
 use libra_swarm::{swarm::LibraSwarm, utils};
 use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
@@ -16,9 +17,10 @@ fn setup_env(
 
     let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(None);
+    let topology = LibraSwarmTopology::create_validator_network(num_nodes);
 
     let swarm = LibraSwarm::launch_swarm(
-        num_nodes,
+        topology,
         false, /* disable_logging */
         faucet_account_keypair,
         true, /* tee_logs */

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -7,6 +7,7 @@ use benchmark::{
     ruben_opt::parse_swarm_config_from_dir,
     Benchmarker,
 };
+use config_builder::swarm_config::LibraSwarmTopology;
 use libra_swarm::swarm::LibraSwarm;
 use num::traits::Float;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
@@ -33,11 +34,12 @@ rusty_fork_test! {
         let (num_nodes, num_accounts, num_clients) = (4, 32, 4);
         let (num_rounds, num_epochs, stagger_ms) = (2, 4, 1);
         let submit_rate = 50;
+        let topology = LibraSwarmTopology::create_validator_network(num_nodes);
 
         let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
             generate_keypair::load_faucet_key_or_create_default(None);
         let swarm = LibraSwarm::launch_swarm(
-            num_nodes,
+            topology,
             true,   /* disable_logging */
             faucet_account_keypair,
             false,  /* tee_logs */


### PR DESCRIPTION
## Motivation

Currently when launching Libraswarm, we can only configure the number of validator nodes to spin up. Once we have full nodes, we want to test having full nodes as part of Libra swarm. This diff changes the "num_nodes" param to a struct LibraSwarmTopology, which has a vector of sizes in this order: vec['num_nodes', 'num_full_nodes']. Passing in vec[2, 2] will create 2 validators, each with 2 full node.

Full node is in development, so launch_swarm only takes the first value (num_nodes).

## Test Plan

cargo test ran successfully

