### PR TITLE
[cluster_test] Improve liveness check

### DIFF
--- a/testsuite/cluster_test/src/effects/reboot.rs
+++ b/testsuite/cluster_test/src/effects/reboot.rs
@@ -20,29 +20,21 @@ impl Effect for Reboot {
     }
 
     fn is_complete(&self) -> bool {
-        if self.instance.check_ac_port() {
-            match self
-                .instance
-                .run_cmd(vec!["! cat /dev/shm/cluster_test_reboot"])
-            {
-                Ok(..) => {
-                    println!("Rebooting {} complete", self.instance);
-                    true
-                }
-                Err(..) => {
-                    println!(
-                        "Rebooting {} in progress - did not reboot yet",
-                        self.instance
-                    );
-                    false
-                }
+        match self
+            .instance
+            .run_cmd(vec!["! cat /dev/shm/cluster_test_reboot"])
+        {
+            Ok(..) => {
+                println!("Rebooting {} complete", self.instance);
+                true
             }
-        } else {
-            println!(
-                "Rebooting {} in progress - waiting for connection",
-                self.instance
-            );
-            false
+            Err(..) => {
+                println!(
+                    "Rebooting {} in progress - did not reboot yet",
+                    self.instance
+                );
+                false
+            }
         }
     }
 }

--- a/testsuite/cluster_test/src/health/liveness_check.rs
+++ b/testsuite/cluster_test/src/health/liveness_check.rs
@@ -8,7 +8,7 @@ pub struct LivenessHealthCheck {
     last_committed: HashMap<String, LastCommitInfo>,
 }
 
-const MAX_BEHIND: Duration = Duration::from_secs(20);
+const MAX_BEHIND: Duration = Duration::from_secs(60);
 
 #[derive(Default)]
 struct LastCommitInfo {
@@ -63,6 +63,11 @@ impl HealthCheck for LivenessHealthCheck {
                 );
             }
         }
+    }
+
+    fn invalidate(&mut self, validator: &str) {
+        self.last_committed
+            .insert(validator.into(), LastCommitInfo::default());
     }
 
     fn name(&self) -> &'static str {

--- a/testsuite/cluster_test/src/health/mod.rs
+++ b/testsuite/cluster_test/src/health/mod.rs
@@ -53,6 +53,9 @@ pub trait HealthCheck {
     fn on_event(&mut self, event: &ValidatorEvent, ctx: &mut HealthCheckContext);
     /// Periodic verification (happens even if when no events produced)
     fn verify(&mut self, _ctx: &mut HealthCheckContext) {}
+    /// Optionally marks validator as failed, requiring waiting for at least one event from it to
+    /// mark it as healthy again
+    fn invalidate(&mut self, _validator: &str) {}
 
     fn name(&self) -> &'static str;
 }
@@ -130,6 +133,12 @@ impl HealthCheckRunner {
         println!();
 
         failed
+    }
+
+    pub fn invalidate(&mut self, validator: &str) {
+        for hc in self.health_checks.iter_mut() {
+            hc.invalidate(validator);
+        }
     }
 }
 

--- a/testsuite/cluster_test/src/instance.rs
+++ b/testsuite/cluster_test/src/instance.rs
@@ -39,16 +39,6 @@ impl Instance {
         Ok(())
     }
 
-    pub fn check_ac_port(&self) -> bool {
-        let mut cmd = Command::new("nc");
-        cmd.args(vec!["-w", "1", "-z", self.ip.as_str(), "8000"]);
-        let status = cmd.status();
-        match status {
-            Err(..) => false,
-            Ok(exit_status) => exit_status.success(),
-        }
-    }
-
     pub fn short_hash(&self) -> &String {
         &self.short_hash
     }

--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -140,6 +140,10 @@ impl ClusterTestRunner {
             style::Reset
         );
 
+        for validator in affected_validators.iter() {
+            self.health_check_runner.invalidate(validator);
+        }
+
         loop {
             if Instant::now() > experiment_deadline {
                 panic!("Cluster did not become healthy in time");


### PR DESCRIPTION
liveness check is still too flacky and can't be used for continuous testing.

This change improves it by increasing tolerance for commit delay.

One caveat of increased tolerance is that test passes before node even recovers from reboot, because liveness check sees commit that happened before reboot adn accepts it (reboot takes less then new accepted commit delay).

This is fixed with new `HealthCheck::invalidate` method. For liveness health check it removes information about last seen commit, making check fail for validator. This allows us to wait until validator comes back after reboot before completing experiment.

This change also removes dependency on ac port number:

Reboot effect now completes once instance starting reboot.
Previously it would wait until reboot is completed by checking ac port.
This required having ac port hardcoded in cluster test
Now we simply rely on health check to wait until node finishes reboot
