### PR TITLE
[crypto] Use nextgen-crypto signing across Libra

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,7 +26,6 @@ tempfile = "3.1.0"
 admission_control_proto = { version = "0.1.0", path = "../admission_control/admission_control_proto" }
 config = { path = "../config" }
 crash_handler = { path = "../common/crash_handler" }
-crypto = { path = "../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 libc = "0.2.60"

--- a/config/config_builder/Cargo.toml
+++ b/config/config_builder/Cargo.toml
@@ -16,7 +16,6 @@ tempfile = "3.1.0"
 toml = "0.4"
 
 config = { path = ".." }
-crypto = { path = "../../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 generate_keypair = { path = "../generate_keypair" }

--- a/config/generate_keypair/Cargo.toml
+++ b/config/generate_keypair/Cargo.toml
@@ -13,6 +13,5 @@ serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 tempdir = "0.3.7"
 
-crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 nextgen_crypto = { path = "../../crypto/nextgen_crypto/"}

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 bytecode_verifier = { path = "../bytecode_verifier" }
 canonical_serialization = { path = "../../common/canonical_serialization" }
-crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 compiler = { path = "../compiler" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }

--- a/language/e2e_tests/src/gas_costs.rs
+++ b/language/e2e_tests/src/gas_costs.rs
@@ -9,6 +9,7 @@ use crate::{
     executor::FakeExecutor,
 };
 use lazy_static::lazy_static;
+use nextgen_crypto::ed25519::compat;
 use types::{account_address::AccountAddress, transaction::SignedTransaction};
 
 /// The gas each transaction is configured to reserve. If the gas available in the account,
@@ -130,8 +131,8 @@ lazy_static! {
         let mut executor = FakeExecutor::from_genesis_file();
         let sender = AccountData::new(1_000_000, 10);
         executor.add_account_data(&sender);
-        let (_privkey, pubkey) = crypto::signing::generate_keypair();
-        let new_key_hash = AccountAddress::from(pubkey);
+        let (_privkey, pubkey) = compat::generate_keypair(None);
+        let new_key_hash = AccountAddress::from_public_key(&pubkey);
 
          let txn = rotate_key_txn(sender.account(), new_key_hash, 10);
          compute_gas_used(txn, &mut executor)

--- a/language/functional_tests/_old_move_ir_tests/src/tests/key_rotation.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/key_rotation.rs
@@ -40,8 +40,7 @@ main() {{
 fn can_send_transaction_with_new_key_after_rotation() {
     let mut test_env = TestEnvironment::default();
 
-    let (privkey, pubkey) =
-        crypto::signing::generate_keypair_for_testing(&mut test_env.accounts.randomness_source);
+    let (privkey, pubkey) = compat::generate_keypair(&mut test_env.accounts.randomness_source);
     let program = format!(
         "
 import 0x0.LibraAccount;
@@ -52,7 +51,7 @@ main() {{
 
   return;
 }}",
-        hex::encode(AccountAddress::from(pubkey))
+        hex::encode(AccountAddress::from_public_key(pubkey))
     );
 
     // rotate key

--- a/language/tools/cost_synthesis/Cargo.toml
+++ b/language/tools/cost_synthesis/Cargo.toml
@@ -20,7 +20,7 @@ vm_runtime = { path = "../../vm/vm_runtime" }
 vm_runtime_types = { path = "../../vm/vm_runtime/vm_runtime_types" }
 language_e2e_tests = { path = "../../e2e_tests" }
 vm_cache_map = { path = "../../vm/vm_runtime/vm_cache_map" }
-crypto = { path = "../../../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
 state_view = { path = "../../../storage/state_view" }
 structopt = "0.2.15"
 

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -15,6 +15,7 @@ proptest = "0.9"
 proptest-derive = "0.1.1"
 
 crypto = { path = "../../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 proptest_helpers = { path = "../../common/proptest_helpers" }
 types = { path = "../../types" }

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
-use crypto::{signing::generate_genesis_keypair, PublicKey};
+use nextgen_crypto::ed25519::{compat, Ed25519PublicKey};
 use types::{account_address::AccountAddress, transaction::SignedTransaction};
 
 pub struct TransactionMetadata {
     pub sender: AccountAddress,
-    pub public_key: PublicKey,
+    pub public_key: Ed25519PublicKey,
     pub sequence_number: u64,
     pub max_gas_amount: GasUnits<GasCarrier>,
     pub gas_unit_price: GasPrice<GasCarrier>,
@@ -38,7 +38,7 @@ impl TransactionMetadata {
         self.sender.to_owned()
     }
 
-    pub fn public_key(&self) -> &PublicKey {
+    pub fn public_key(&self) -> &Ed25519PublicKey {
         &self.public_key
     }
 
@@ -53,7 +53,7 @@ impl TransactionMetadata {
 
 impl Default for TransactionMetadata {
     fn default() -> Self {
-        let (_, public_key) = generate_genesis_keypair();
+        let (_, public_key) = compat::generate_genesis_keypair();
         TransactionMetadata {
             sender: AccountAddress::default(),
             public_key,

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -19,6 +19,7 @@ bytecode_verifier = { path = "../../bytecode_verifier" }
 canonical_serialization = { path = "../../../common/canonical_serialization" }
 config = { path = "../../../config" }
 crypto = { path = "../../../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 logger = { path = "../../../common/logger" }
 metrics = { path = "../../../common/metrics" }

--- a/language/vm/vm_runtime/src/txn_executor.rs
+++ b/language/vm/vm_runtime/src/txn_executor.rs
@@ -480,7 +480,7 @@ where
                 }
                 Bytecode::GetTxnPublicKey => {
                     self.execution_stack.push(Local::bytearray(ByteArray::new(
-                        self.txn_data.public_key().to_slice().to_vec(),
+                        self.txn_data.public_key().to_bytes().to_vec(),
                     )));
                 }
                 Bytecode::BorrowGlobal(idx, _) => {

--- a/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::{code_cache::module_cache::VMModuleCache, txn_executor::TransactionExecutor};
 use bytecode_verifier::{VerifiedModule, VerifiedScript};
+use nextgen_crypto::ed25519::compat;
 use std::collections::HashMap;
 use types::{access_path::AccessPath, account_address::AccountAddress, byte_array::ByteArray};
 use vm::{
@@ -710,7 +711,7 @@ fn test_transaction_info() {
     let entry_func = FunctionRef::new(&loaded_main, CompiledScript::MAIN_INDEX);
 
     let txn_info = {
-        let (_, public_key) = crypto::signing::generate_genesis_keypair();
+        let (_, public_key) = compat::generate_genesis_keypair();
         TransactionMetadata {
             sender: AccountAddress::default(),
             public_key,

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -12,7 +12,7 @@ itertools = "0.7.3"
 lazy_static = "1.2.0"
 num-derive = "0.2"
 num-traits = "0.2"
-rand = "0.4.2"
+rand = "0.6.5"
 strum = "0.15.0"
 strum_macros = "0.15.0"
 tempfile = "3.0.6"
@@ -20,11 +20,11 @@ tempfile = "3.0.6"
 accumulator = { path = "../accumulator" }
 canonical_serialization = { path = "../../common/canonical_serialization" }
 crypto = { path = "../../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 jellyfish_merkle = { path = "../jellyfish_merkle" }
 logger = { path = "../../common/logger" }
 metrics = { path = "../../common/metrics" }
-nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proptest = "0.9.2"
 proptest-derive = "0.1.2"
 rusty-fork = "0.2.1"

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -10,7 +10,7 @@ use proptest::{
     prelude::*,
     strategy::Union,
 };
-use rand::{Rng, StdRng};
+use rand::Rng;
 use std::collections::HashMap;
 use tempfile::tempdir;
 use types::{

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -6,12 +6,15 @@
 use crate::LibraDB;
 use crypto::{
     hash::{CryptoHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID},
-    signing::generate_keypair,
     HashValue,
 };
 use failure::Result;
 use lazy_static::lazy_static;
 use nextgen_crypto::ed25519::*;
+use rand::{
+    rngs::{OsRng, StdRng},
+    Rng, SeedableRng,
+};
 use std::collections::HashMap;
 use types::{
     account_address::AccountAddress,
@@ -26,8 +29,11 @@ fn gen_mock_genesis() -> (
     LedgerInfoWithSignatures<Ed25519Signature>,
     TransactionToCommit,
 ) {
-    let (privkey, pubkey) = generate_keypair();
-    let some_addr = AccountAddress::from(pubkey);
+    let mut seed_rng = OsRng::new().expect("can't access OsRng");
+    let seed_buf: [u8; 32] = seed_rng.gen();
+    let mut rng = StdRng::from_seed(seed_buf);
+    let (privkey, pubkey) = compat::generate_keypair(&mut rng);
+    let some_addr = AccountAddress::from_public_key(&pubkey);
     let raw_txn = RawTransaction::new(
         some_addr,
         /* sequence_number = */ 0,

--- a/storage/libradb/src/schema/validator/mod.rs
+++ b/storage/libradb/src/schema/validator/mod.rs
@@ -12,8 +12,9 @@
 
 use crate::schema::{ensure_slice_len_eq, VALIDATOR_CF_NAME};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use crypto::PublicKey;
+use core::convert::TryFrom;
 use failure::prelude::*;
+use nextgen_crypto::{ed25519::Ed25519PublicKey, PublicKey};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
@@ -28,14 +29,14 @@ pub struct Key {
     /// version at which epoch starts
     pub(crate) version: Version,
     /// public_key of validator
-    pub(crate) public_key: PublicKey,
+    pub(crate) public_key: Ed25519PublicKey,
 }
 
 impl KeyCodec<ValidatorSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
-        let public_key_serialized = self.public_key.to_slice();
+        let public_key_serialized = self.public_key.to_bytes();
         let mut encoded_key =
-            Vec::with_capacity(size_of::<Version>() + PublicKey::LENGTH * size_of::<u8>());
+            Vec::with_capacity(size_of::<Version>() + Ed25519PublicKey::length() * size_of::<u8>());
         encoded_key.write_u64::<BigEndian>(self.version)?;
         encoded_key.write_all(&public_key_serialized)?;
         Ok(encoded_key)
@@ -43,7 +44,7 @@ impl KeyCodec<ValidatorSchema> for Key {
 
     fn decode_key(data: &[u8]) -> Result<Self> {
         let version = (&data[..size_of::<u64>()]).read_u64::<BigEndian>()?;
-        let public_key = PublicKey::from_slice(&data[size_of::<u64>()..])?;
+        let public_key = Ed25519PublicKey::try_from(&data[size_of::<u64>()..])?;
         Ok(Key {
             version,
             public_key,

--- a/storage/libradb/src/schema/validator/test.rs
+++ b/storage/libradb/src/schema/validator/test.rs
@@ -2,14 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::signing::generate_keypair;
 use itertools::Itertools;
-use rand::{thread_rng, Rng};
+use nextgen_crypto::ed25519::compat;
+use rand::{
+    rngs::{OsRng, StdRng},
+    seq::SliceRandom,
+    thread_rng, Rng, SeedableRng,
+};
 use schemadb::schema::assert_encode_decode;
 use types::transaction::Version;
 
 fn row_with_arbitrary_validator(version: Version) -> (Key, ()) {
-    let (_private_key, public_key) = generate_keypair();
+    let mut seed_rng = OsRng::new().expect("can't access OsRng");
+    let seed_buf: [u8; 32] = seed_rng.gen();
+    let mut rng = StdRng::from_seed(seed_buf);
+    let (_private_key, public_key) = compat::generate_keypair(&mut rng);
     (
         Key {
             version,
@@ -28,7 +35,7 @@ fn test_encode_decode() {
 #[test]
 fn test_order() {
     let mut versions: Vec<u64> = (0..1024).collect();
-    thread_rng().shuffle(&mut versions);
+    versions.shuffle(&mut thread_rng());
 
     let encoded_sorted: Vec<Vec<u8>> = versions
         .into_iter()

--- a/storage/storage_service/Cargo.toml
+++ b/storage/storage_service/Cargo.toml
@@ -14,6 +14,7 @@ protobuf = "~2.7"
 canonical_serialization = { path = "../../common/canonical_serialization" }
 config = { path = "../../config" }
 crypto = { path = "../../crypto/legacy_crypto" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 debug_interface = { path = "../../common/debug_interface" }
 executable_helpers = { path = "../../common/executable_helpers" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
@@ -21,11 +22,11 @@ grpc_helpers = { path = "../../common/grpc_helpers" }
 libradb = { path = "../libradb" }
 logger = { path = "../../common/logger" }
 metrics = { path = "../../common/metrics" }
-nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 storage_client = { path = "../storage_client" }
 storage_proto = { path = "../storage_proto" }
 types = { path = "../../types" }
+rand = "0.6.5"
 
 [dev-dependencies]
 itertools = "0.8.0"


### PR DESCRIPTION
## Motivation

Removing the remaining usages of the legacy crypto signing API from the code base, most notably the functions in tests generating keypairs based on the old random generation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

existing
