### PR TITLE
[storage] delete stale node index in batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,7 +3816,9 @@ dependencies = [
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics 0.1.0",
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=ea24c53b8f2e1f8a1d22f739cb5db4681d2d21ff)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tools 0.1.0",
 ]
 

--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -332,14 +332,16 @@ pub fn prune_state(
     target_least_readable_version: Version,
     max_versions: usize,
 ) -> Result<Version> {
-    let index_by_version = StaleNodeIndicesByVersionIterator::new(
+    let indices = StaleNodeIndicesByVersionIterator::new(
         &db,
         least_readable_version,
         target_least_readable_version,
     )?
-    .take(max_versions)
-    .collect::<Result<Vec<_>>>()?;
-    let indices = index_by_version.into_iter().flatten().collect::<Vec<_>>();
+    .take(max_versions) // Iterator<Item = Result<Vec<StaleNodeIndex>>>
+    .collect::<Result<Vec<_>>>()? // now Vec<Vec<StaleNodeIndex>>
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
 
     if indices.is_empty() {
         Ok(least_readable_version)

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -18,4 +18,6 @@ rev = "ea24c53b8f2e1f8a1d22f739cb5db4681d2d21ff"
 
 [dev-dependencies]
 byteorder = "1.3.2"
+proptest = "0.9.4"
+tempfile = "3.1.0"
 tools = { path = "../../common/tools" }

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -3,6 +3,7 @@
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use failure::Result;
+use proptest::{collection::vec, prelude::*};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, Schema, ValueCodec},
@@ -151,6 +152,35 @@ fn test_schema_put_get() {
         db.get::<TestSchema2>(&TestField(4)).unwrap(),
         Some(TestField(5)),
     );
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_schema_range_delete(
+        ranges_to_delete in vec(
+            (0..100u32).prop_flat_map(|begin| (Just(begin), (begin..100u32))), 0..10)
+    ) {
+        let db = TestDB::new();
+        for i in 0..100u32 {
+            db.put::<TestSchema1>(&TestField(i), &TestField(i)).unwrap();
+        }
+        let mut should_exist = [true; 100];
+        for (begin, end) in ranges_to_delete {
+            db.range_delete::<TestSchema1, TestField>(&TestField(begin), &TestField(end)).unwrap();
+            for i in begin..end {
+                should_exist[i as usize] = false;
+            }
+        }
+
+        for (i, should_exist) in should_exist.iter().enumerate() {
+            assert_eq!(
+                db.get::<TestSchema1>(&TestField(i as u32)).unwrap().is_some(),
+                *should_exist,
+            )
+        }
+    }
 }
 
 fn collect_values<S: Schema>(db: &TestDB) -> Vec<(S::Key, S::Value)> {


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation


It's very wasteful to delete the stale node indice key by key, not only disk space wise, but also CPU when you scan through the key range deleted. (We've already observed seek_to_first() went slow as hell.)

This utilizes the range delete capability of RocksDB to do it more efficiently. But sending too many small range deletes can also be a (slightly different) performance concern. So this did some tricks to ensure large enough batches.

Note that because now index is not purged in time, each prune_state() call should seek to exact where last time we left, otherwise repeated deletion should occur frequently. I chose to always delete all nodes that become stale in the same version at once, so that the seek position can be passed in as a version instead of the whole index entry.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Will test on nightly env.
