### PR TITLE
[storage] fix that any::<NibblePath>() always returns paths shorter t…

### DIFF
--- a/storage/sparse_merkle/src/nibble_path/mod.rs
+++ b/storage/sparse_merkle/src/nibble_path/mod.rs
@@ -53,7 +53,8 @@ impl Arbitrary for NibblePath {
 
 prop_compose! {
     fn arb_nibble_path()(
-        mut bytes in vec(any::<u8>(), 0..ROOT_NIBBLE_HEIGHT/2), is_odd in any::<bool>()
+        mut bytes in vec(any::<u8>(), 0..=ROOT_NIBBLE_HEIGHT/2),
+        is_odd in any::<bool>()
     ) -> NibblePath {
         if let Some(last_byte) = bytes.last_mut() {
             if is_odd {
@@ -62,6 +63,17 @@ prop_compose! {
             }
         }
         NibblePath::new(bytes)
+    }
+}
+
+prop_compose! {
+    pub fn arb_internal_nibble_path()(
+        nibble_path in arb_nibble_path().prop_filter(
+            "Filter out leaf paths.",
+            |p| p.num_nibbles() < ROOT_NIBBLE_HEIGHT,
+        )
+    ) -> NibblePath {
+        nibble_path
     }
 }
 

--- a/storage/sparse_merkle/src/nibble_path/nibble_path_test.rs
+++ b/storage/sparse_merkle/src/nibble_path/nibble_path_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nibble_path::{skip_common_prefix, NibblePath};
+use crate::nibble_path::{arb_internal_nibble_path, skip_common_prefix, NibblePath};
 use proptest::prelude::*;
 
 #[test]
@@ -167,7 +167,10 @@ prop_compose! {
 
 proptest! {
     #[test]
-    fn test_push(nibble_path in any::<NibblePath>(), nibble in (0..16u8)) {
+    fn test_push(
+        nibble_path in arb_internal_nibble_path(),
+        nibble in 0..16u8
+    ) {
         let mut new_nibble_path = nibble_path.clone();
         new_nibble_path.push(nibble);
         let mut nibbles: Vec<u8> = nibble_path.nibbles().collect();


### PR DESCRIPTION
…han 64


## Motivation

This is non-intuitive.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes


## Test Plan
existing coverage

