### PR TITLE
[network] Fix panic when opening too many substreams

### DIFF
--- a/network/netcore/src/multiplexing/yamux.rs
+++ b/network/netcore/src/multiplexing/yamux.rs
@@ -106,7 +106,7 @@ where
             Ok(Some(substream)) => Ok(Compat01As03::new(substream)),
             Ok(None) => Err(io::Error::new(
                 io::ErrorKind::Other,
-                "Unable to open substream",
+                "Unable to open substream; underlying connection is dead",
             )),
             Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
         };

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -111,10 +111,10 @@ impl<TSubstream> PeerManagerRequestSender<TSubstream> {
         let (oneshot_tx, oneshot_rx) = oneshot::channel();
         let request = PeerManagerRequest::OpenSubstream(peer_id, protocol, oneshot_tx);
         self.inner.send(request).await.unwrap();
-        // TODO(philiphayes): If this error changes, also change rpc errors to
-        // handle appropriate cases.
         oneshot_rx
             .await
+            // The open_substream request can get dropped/canceled if the peer
+            // connection is in the process of shutting down.
             .map_err(|_| PeerManagerError::NotConnected(peer_id))?
     }
 }

--- a/network/src/protocols/rpc/error.rs
+++ b/network/src/protocols/rpc/error.rs
@@ -60,7 +60,8 @@ impl From<PeerManagerError> for RpcError {
     fn from(err: PeerManagerError) -> Self {
         match err {
             PeerManagerError::NotConnected(peer_id) => RpcError::NotConnected(peer_id),
-            _ => unreachable!("open_substream only returns NotConnected errors"),
+            PeerManagerError::IoError(err) => RpcError::IoError(err),
+            _ => unreachable!("open_substream only returns NotConnected or IoError"),
         }
     }
 }


### PR DESCRIPTION
Our yamux implementation can actually error when opening a substream,
specifically when we hit the configured `max_num_streams` limit. This
also means the implementation doesn't provide backpressure when opening
substreams, which will have to be solved eventually.

This change now converts `PeerManagerError::IoError` into
`RpcError::IoError` so we don't panic on an unrecognized error case
when the `PeerManager` returns `Err` on `open_substream`.