### PR TITLE
[consensus] Make some block store functions non-async

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -74,7 +74,7 @@ fn test_block_store_create_block() {
         placeholder_ledger_info(),
         block_store.signer(),
     );
-    block_on(block_store.insert_vote_and_qc(vote_msg, 1));
+    block_store.insert_vote_and_qc(vote_msg, 1);
 
     let b1 = block_store.create_block(Arc::clone(&a1_ref), vec![2], 2, 2);
     assert_eq!(b1.parent_id(), a1_ref.id());
@@ -211,57 +211,57 @@ proptest! {
 fn test_block_store_prune() {
     let (blocks, block_store) = build_simple_tree();
     // Attempt to prune genesis block (should be no-op)
-    assert_eq!(block_on(block_store.prune_tree(blocks[0].id())).len(), 0);
+    assert_eq!(block_store.prune_tree(blocks[0].id()).len(), 0);
     assert_eq!(block_store.len(), 7);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
     assert_eq!(block_store.pruned_blocks_in_mem(), 0);
 
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block A1
-    assert_eq!(block_on(block_store.prune_tree(blocks[1].id())).len(), 4);
+    assert_eq!(block_store.prune_tree(blocks[1].id()).len(), 4);
     assert_eq!(block_store.len(), 3);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
     assert_eq!(block_store.pruned_blocks_in_mem(), 4);
 
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block A2
-    assert_eq!(block_on(block_store.prune_tree(blocks[2].id())).len(), 5);
+    assert_eq!(block_store.prune_tree(blocks[2].id()).len(), 5);
     assert_eq!(block_store.len(), 2);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
     assert_eq!(block_store.pruned_blocks_in_mem(), 5);
 
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block A3
-    assert_eq!(block_on(block_store.prune_tree(blocks[3].id())).len(), 6);
+    assert_eq!(block_store.prune_tree(blocks[3].id()).len(), 6);
     assert_eq!(block_store.len(), 1);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
 
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block B1
-    assert_eq!(block_on(block_store.prune_tree(blocks[4].id())).len(), 4);
+    assert_eq!(block_store.prune_tree(blocks[4].id()).len(), 4);
     assert_eq!(block_store.len(), 3);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
 
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block B2
-    assert_eq!(block_on(block_store.prune_tree(blocks[5].id())).len(), 6);
+    assert_eq!(block_store.prune_tree(blocks[5].id()).len(), 6);
     assert_eq!(block_store.len(), 1);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
 
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block C1
-    assert_eq!(block_on(block_store.prune_tree(blocks[6].id())).len(), 6);
+    assert_eq!(block_store.prune_tree(blocks[6].id()).len(), 6);
     assert_eq!(block_store.len(), 1);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
 
     // Prune the chain of Genesis -> B1 -> B2
     let (blocks, block_store) = build_simple_tree();
     // Prune up to block B1
-    assert_eq!(block_on(block_store.prune_tree(blocks[4].id())).len(), 4);
+    assert_eq!(block_store.prune_tree(blocks[4].id()).len(), 4);
     assert_eq!(block_store.len(), 3);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
     // Prune up to block B2
-    assert_eq!(block_on(block_store.prune_tree(blocks[5].id())).len(), 2);
+    assert_eq!(block_store.prune_tree(blocks[5].id()).len(), 2);
     assert_eq!(block_store.len(), 1);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
 }
@@ -283,7 +283,7 @@ fn test_block_tree_gc() {
     for (i, block) in added_blocks.iter().enumerate() {
         assert_eq!(block_store.len(), 100 - i);
         assert_eq!(block_store.pruned_blocks_in_mem(), min(i, 10));
-        block_on(block_store.prune_tree(block.id()));
+        block_store.prune_tree(block.id());
     }
 }
 
@@ -302,7 +302,7 @@ fn test_path_from_root() {
     );
     assert_eq!(block_store.path_from_root(genesis.clone()), Some(vec![]));
 
-    block_on(block_store.prune_tree(b2.id()));
+    block_store.prune_tree(b2.id());
 
     assert_eq!(
         block_store.path_from_root(b3.clone()),
@@ -351,13 +351,13 @@ fn test_insert_vote() {
             placeholder_ledger_info(),
             voter,
         );
-        let vote_res = block_on(block_store.insert_vote_and_qc(vote_msg.clone(), qc_size));
+        let vote_res = block_store.insert_vote_and_qc(vote_msg.clone(), qc_size);
 
         // first vote of an author is accepted
         assert_eq!(vote_res, VoteReceptionResult::VoteAdded(i));
         // filter out duplicates
         assert_eq!(
-            block_on(block_store.insert_vote_and_qc(vote_msg, qc_size)),
+            block_store.insert_vote_and_qc(vote_msg, qc_size),
             VoteReceptionResult::DuplicateVote,
         );
         // qc is still not there
@@ -378,7 +378,7 @@ fn test_insert_vote() {
         placeholder_ledger_info(),
         final_voter,
     );
-    match block_on(block_store.insert_vote_and_qc(vote_msg, qc_size)) {
+    match block_store.insert_vote_and_qc(vote_msg, qc_size) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
             assert_eq!(qc.certified_block_id(), block.id());
         }
@@ -437,7 +437,7 @@ fn test_need_fetch_for_qc() {
     let a1 = inserter.insert_block(genesis.as_ref(), 1);
     let a2 = inserter.insert_block(a1.as_ref(), 2);
     let a3 = inserter.insert_block(a2.as_ref(), 3);
-    block_on(block_tree.prune_tree(a2.id()));
+    block_tree.prune_tree(a2.id());
     let need_fetch_qc = placeholder_certificate_for_block(
         vec![block_tree.signer()],
         HashValue::zero(),
@@ -487,7 +487,7 @@ fn test_need_sync_for_qc() {
     let a1 = inserter.insert_block(genesis.as_ref(), 1);
     let a2 = inserter.insert_block(a1.as_ref(), 2);
     let a3 = inserter.insert_block(a2.as_ref(), 3);
-    block_on(block_tree.prune_tree(a3.id()));
+    block_tree.prune_tree(a3.id());
     let qc = placeholder_certificate_for_block(
         vec![block_tree.signer()],
         HashValue::zero(),

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -252,7 +252,6 @@ impl<T: Payload> EventProcessor<T> {
                 if let Err(e) = self
                     .block_store
                     .insert_single_quorum_cert(proposal.proposal.quorum_cert().clone())
-                    .await
                 {
                     warn!(
                         "Quorum certificate for proposal {} could not be inserted to the block store: {:?}",
@@ -705,7 +704,7 @@ impl<T: Payload> EventProcessor<T> {
         // TODO [Reconfiguration] Verify epoch of the vote message.
         // Add the vote and check whether it completes a new QC.
         if let VoteReceptionResult::NewQuorumCertificate(qc) =
-            self.block_store.insert_vote(vote, quorum_size).await
+            self.block_store.insert_vote(vote, quorum_size)
         {
             if self.block_store.need_fetch_for_quorum_cert(&qc) == NeedFetchResult::NeedFetch {
                 if let Err(e) = self
@@ -719,7 +718,6 @@ impl<T: Payload> EventProcessor<T> {
             } else if let Err(e) = self
                 .block_store
                 .insert_single_quorum_cert(qc.as_ref().clone())
-                .await
             {
                 error!("Error inserting qc {}: {:?}", qc, e);
                 return None;
@@ -795,7 +793,7 @@ impl<T: Payload> EventProcessor<T> {
         }
         counters::LAST_COMMITTED_ROUND.set(committed_block.round() as i64);
         debug!("{}Committed{} {}", Fg(Blue), Fg(Reset), *committed_block);
-        self.block_store.prune_tree(committed_block.id()).await;
+        self.block_store.prune_tree(committed_block.id());
     }
 
     /// Retrieve a n chained blocks from the block store starting from

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -299,7 +299,7 @@ fn basic_new_rank_event_test() {
             placeholder_ledger_info(),
             node.block_store.signer(),
         );
-        node.block_store.insert_vote_and_qc(vote_msg, 0).await;
+        node.block_store.insert_vote_and_qc(vote_msg, 0);
         node.event_processor
             .process_new_round_event(NewRoundEvent {
                 round: 2,
@@ -524,12 +524,10 @@ fn process_new_round_msg_test() {
         block_0.quorum_cert().certified_parent_block_id(),
         block_0.quorum_cert().certified_parent_block_round(),
     );
-    block_on(
-        non_proposer
-            .block_store
-            .insert_single_quorum_cert(block_0_quorum_cert.clone()),
-    )
-    .unwrap();
+    non_proposer
+        .block_store
+        .insert_single_quorum_cert(block_0_quorum_cert.clone())
+        .unwrap();
     assert_eq!(
         static_proposer
             .block_store

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -86,7 +86,7 @@ fn test_proposal_generation_parent() {
         placeholder_ledger_info(),
         block_store.signer(),
     );
-    block_on(block_store.insert_vote_and_qc(vote_msg_a1, 1));
+    block_store.insert_vote_and_qc(vote_msg_a1, 1);
     let a1_child_res =
         block_on(proposal_generator.generate_proposal(11, minute_from_now())).unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
@@ -108,7 +108,7 @@ fn test_proposal_generation_parent() {
         block_store.signer(),
     );
 
-    block_on(block_store.insert_vote_and_qc(vote_msg_b1, 1));
+    block_store.insert_vote_and_qc(vote_msg_b1, 1);
     let b1_child_res =
         block_on(proposal_generator.generate_proposal(12, minute_from_now())).unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
@@ -142,7 +142,7 @@ fn test_old_proposal_generation() {
         placeholder_ledger_info(),
         block_store.signer(),
     );
-    block_on(block_store.insert_vote_and_qc(vote_msg_a1, 1));
+    block_store.insert_vote_and_qc(vote_msg_a1, 1);
 
     let proposal_err = block_on(proposal_generator.generate_proposal(1, minute_from_now())).err();
     assert_eq!(

--- a/consensus/src/chained_bft/sync_manager.rs
+++ b/consensus/src/chained_bft/sync_manager.rs
@@ -174,10 +174,10 @@ where
         // insert the qc <- block pair
         while let Some(block) = pending.pop() {
             let block_qc = block.quorum_cert().clone();
-            self.block_store.insert_single_quorum_cert(block_qc).await?;
+            self.block_store.insert_single_quorum_cert(block_qc)?;
             self.block_store.execute_and_insert_block(block).await?;
         }
-        self.block_store.insert_single_quorum_cert(qc).await
+        self.block_store.insert_single_quorum_cert(qc)
     }
 
     /// Check the highest ledger info sent by peer to see if we're behind and start a fast


### PR DESCRIPTION
This is very mechanical diff - some block store functions are marked as `async` while they don't have any async code in them, this diff removes those `async` modifiers.
