### PR TITLE
[Storage] Cache latest ledger info in memory

### DIFF
--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+arc-swap = "0.4.2"
 byteorder = "1.3.2"
 itertools = "0.7.3"
 lazy_static = "1.2.0"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Right now we read latest ledger info from DB every time we need it, but deserializing the signatures seems expensive.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
