### PR TITLE
[ci] Enable sccache to speed up build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,27 +9,42 @@ commands:
           name: Version Information
           command: rustc --version; cargo --version; rustup --version
       - run:
-          name: Install Dependencies
-          command: |
-            sudo sh -c 'echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list'
-            sudo apt-get update
-            sudo apt-get install -y protobuf-compiler/stretch-backports cmake golang curl
-            sudo apt-get clean
-            sudo rm -r /var/lib/apt/lists/*
-            rustup component add clippy rustfmt
-      - run:
           name: Setup Env
           command: |
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> $BASH_ENV
             echo 'export IMAGE_NAME=myapp' >> $BASH_ENV
+            echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
+            echo 'export SCCACHE_CACHE_SIZE=2G' >> $BASH_ENV
+            echo 'export RUSTC_WRAPPER=sccache' >> $BASH_ENV
+            echo 'export CC="sccache cc"' >> $BASH_ENV
+            echo 'export CXX="sccache c++"' >> $BASH_ENV
+  restore_sccache_cache:
+    steps:
+      - restore_cache:
+          name: Restore sccache Cache
+          key: sccache-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+  save_sccache_cache:
+    steps:
+      - run:
+          name: Show sccache Stats
+          command: sccache -s
+      - save_cache:
+          name: Save sccache Cache
+          key: sccache-cache-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
 
 jobs:
   build:
     docker:
-      - image: circleci/rust:stretch
+      - image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/github_circleci:latest
+        aws_auth:
+          aws_access_key_id: $ECR_RO_ACCESS_KEY_ID
+          aws_secret_access_key: $ECR_RO_SECRET_ACCESS_KEY
     resource_class: 2xlarge
     steps:
       - env_setup
+      - restore_sccache_cache
       - run:
           name: Git Hooks and Checks
           command: ./scripts/git-checks.sh
@@ -48,6 +63,7 @@ jobs:
       - run:
           name: Run All End to End Tests
           command: RUST_BACKTRACE=1 cargo test --package testsuite
+      - save_sccache_cache
   audit:
     docker:
       - image: circleci/rust:stretch

--- a/docker/circleci/build.sh
+++ b/docker/circleci/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+PROXY=""
+if [ "$https_proxy" ]; then
+	PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+fi
+
+docker build -f $DIR/circleci.Dockerfile $DIR/../.. --tag github_circleci --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY

--- a/docker/circleci/circleci.Dockerfile
+++ b/docker/circleci/circleci.Dockerfile
@@ -1,0 +1,16 @@
+FROM circleci/rust:stretch
+
+RUN sudo sh -c 'echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list' && \
+        sudo apt-get update && \
+        sudo apt-get install -y protobuf-compiler/stretch-backports cmake golang curl && \
+        sudo apt-get clean && \
+        sudo rm -rf /var/lib/apt/lists/* && \
+        cargo install sccache
+
+RUN cd /tmp && \
+        git clone https://github.com/libra/libra && \
+        cd /tmp/libra && \
+        rustup component add clippy rustfmt && \
+        cargo fetch
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
This installs and uses sccache for builds. The resulting cache file is stored
between CircleCI runs using CicleCI's caching system. While not perfectly
cacheable yet, this saves about 30% of build time.

See blog post about this at https://medium.com/@edouard.oger/rust-caching-on-circleci-using-sccache-c996344f0115

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Builds times can always be faster.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Current build times are ~15-20m on CI. This should reduce builds to ~10-15m. You can check in the [CircleCI jobs page](https://circleci.com/gh/libra)

## Related PRs

none
