### PR TITLE
[consensus] Remove unnecessary Arc wrapper on futures_locks::RwLock

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -48,7 +48,7 @@ use std::{
 };
 use tokio::runtime::{Runtime, TaskExecutor};
 
-type ConcurrentEventProcessor<T> = Arc<futures_locks::RwLock<EventProcessor<T>>>;
+type ConcurrentEventProcessor<T> = futures_locks::RwLock<EventProcessor<T>>;
 
 /// Consensus configuration derived from ConsensusConfig
 pub struct ChainedBftSMRConfig {
@@ -190,7 +190,7 @@ impl<T: Payload> ChainedBftSMR<T> {
                         let winning_proposals_sender = winning_proposals_sender.clone();
                         executor.spawn(
                             Self::sync_and_process_proposal(
-                                Arc::clone(&event_processor),
+                                futures_locks::RwLock::clone(&event_processor),
                                 proposal,
                                 winning_proposals_sender,
                             )
@@ -505,7 +505,7 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
             let (winning_proposals_sender, winning_proposals_receiver) =
                 channel::new(1_024, &counters::PENDING_WINNING_PROPOSALS);
             let proposer_election = self.create_proposer_election();
-            let event_processor = Arc::new(futures_locks::RwLock::new(EventProcessor::new(
+            let event_processor = futures_locks::RwLock::new(EventProcessor::new(
                 self.author,
                 Arc::clone(&block_store),
                 Arc::clone(&pacemaker),
@@ -518,7 +518,7 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
                 Arc::clone(&self.storage),
                 time_service.clone(),
                 true,
-            )));
+            ));
 
             self.start_event_processing(
                 event_processor,


### PR DESCRIPTION
future_locks::RwLock is already an Arc internally. This removes the extra,
unnecessary wrapper. See the docs at
https://docs.rs/futures-locks/0.3.3/futures_locks/struct.RwLock.html

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I discovered this while reviewing some code in another context.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

This should not change any functionality, only reduce memory size of the type. Standard tests should not notice.

## Related PRs

none