### PR TITLE
[consensus] remove last_committed_round from safety_rules

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -494,7 +494,7 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
             let pacemaker = self.create_pacemaker(
                 executor.clone(),
                 self.storage.persistent_liveness_storage(),
-                safety_rules.read().unwrap().last_committed_round(),
+                block_store.root().round(),
                 block_store.highest_certified_block().round(),
                 highest_timeout_certificates,
                 time_service.clone(),

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -370,7 +370,7 @@ fn process_successful_proposal_test() {
         assert_eq!(pending_for_proposer[0].proposed_block_id(), proposal_id);
         assert_eq!(
             *node.storage.shared_storage.state.lock().unwrap(),
-            ConsensusState::new(1, 0, 0),
+            ConsensusState::new(1, 0),
         );
     });
 }
@@ -845,7 +845,7 @@ fn basic_restart_test() {
     node = node.restart(&mut playground, runtime.executor());
     assert_eq!(
         node.event_processor.consensus_state(),
-        ConsensusState::new(num_proposals, 0, 0,),
+        ConsensusState::new(num_proposals, 0),
     );
     for id in proposals {
         assert_eq!(node.block_store.block_exists(id), true);

--- a/consensus/src/chained_bft/liveness/local_pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker.rs
@@ -399,6 +399,14 @@ impl Pacemaker for LocalPacemaker {
         self.inner.read().unwrap().current_round
     }
 
+    fn highest_timeout_certificate(&self) -> Option<PacemakerTimeoutCertificate> {
+        let guard = self.inner.read().unwrap();
+        guard
+            .pacemaker_timeout_manager
+            .highest_timeout_certificate()
+            .cloned()
+    }
+
     fn process_certificates(
         &self,
         qc_round: Round,
@@ -428,18 +436,13 @@ impl Pacemaker for LocalPacemaker {
         async {}.boxed()
     }
 
-    fn update_highest_committed_round(&self, highest_committed_round: Round) {
+    fn update_highest_committed_round(&self, highest_committed_round: Round) -> bool {
         let mut guard = self.inner.write().unwrap();
         if guard.highest_committed_round < highest_committed_round {
             guard.highest_committed_round = highest_committed_round;
+            true
+        } else {
+            false
         }
-    }
-
-    fn highest_timeout_certificate(&self) -> Option<PacemakerTimeoutCertificate> {
-        let guard = self.inner.read().unwrap();
-        guard
-            .pacemaker_timeout_manager
-            .highest_timeout_certificate()
-            .cloned()
     }
 }

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -83,6 +83,6 @@ pub trait Pacemaker: Send + Sync {
         pacemaker_timeout: PacemakerTimeout,
     ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
 
-    /// Update the highest committed round
-    fn update_highest_committed_round(&self, highest_committed_round: Round);
+    /// Update the highest committed round and return if it's updated.
+    fn update_highest_committed_round(&self, highest_committed_round: Round) -> bool;
 }

--- a/consensus/src/chained_bft/safety/safety_rules_test.rs
+++ b/consensus/src/chained_bft/safety/safety_rules_test.rs
@@ -159,7 +159,6 @@ fn test_initial_state() {
     let safety_rules = SafetyRules::new(block_tree.clone(), ConsensusState::default());
     let state = safety_rules.consensus_state();
     assert_eq!(state.last_vote_round(), 0);
-    assert_eq!(state.last_committed_round(), block_tree.root().round());
     assert_eq!(state.preferred_block_round(), block_tree.root().round());
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Safety doesn't depend on last_committed_round, remove it for simplicity.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
