### PR TITLE
[consensus][fix] send highest timeout certificate with TimeoutMsg

### DIFF
--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -489,7 +489,7 @@ impl<T: Payload> EventProcessor<T> {
             SyncInfo::new(
                 self.block_store.highest_quorum_cert().as_ref().clone(),
                 self.block_store.highest_ledger_info().as_ref().clone(),
-                None,
+                self.pacemaker.highest_timeout_certificate(),
             ),
             PacemakerTimeout::new(round, self.block_store.signer(), vote_msg_with_timeout),
             self.block_store.signer(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This field is missing before and could help peer to jump to correct round faster.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
