### PR TITLE
[Executor] Initialize in-memory accumulator correctly after restart

### DIFF
--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -26,7 +26,7 @@ use storage_service::StorageService;
 use types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    transaction::SignedTransaction,
+    transaction::{SignedTransaction, TransactionListWithProof, Version},
 };
 use vm_genesis::{encode_genesis_transaction, GENESIS_KEYPAIR};
 
@@ -270,6 +270,68 @@ rusty_fork_test! {
     }
 }
 
+/// Generates a list of `TransactionListWithProof`s according to the given ranges.
+fn create_transaction_chunks(
+    chunk_ranges: Vec<std::ops::Range<Version>>,
+) -> (Vec<TransactionListWithProof>, LedgerInfoWithSignatures) {
+    assert_eq!(chunk_ranges.first().unwrap().start, 1);
+    for i in 1..chunk_ranges.len() {
+        let previous_range = &chunk_ranges[i - 1];
+        let range = &chunk_ranges[i];
+        assert!(previous_range.start <= previous_range.end);
+        assert!(range.start <= range.end);
+        assert!(range.start <= previous_range.end);
+        assert!(previous_range.end <= range.end);
+    }
+
+    // To obtain the batches of transactions, we first execute and save all these transactions in a
+    // separate DB. Then we call get_transactions to retrieve them.
+    let mut config = get_config();
+    let (storage_server, shutdown_receiver) = create_storage_server(&mut config);
+    let executor = create_executor(&config);
+
+    let mut txns = vec![];
+    for i in 1..chunk_ranges.last().unwrap().end {
+        let txn = encode_mint_transaction(gen_address(i), 100);
+        txns.push(txn);
+    }
+    let id = gen_block_id(1);
+
+    let response = block_on(executor.execute_block(txns.clone(), *GENESIS_BLOCK_ID, id))
+        .unwrap()
+        .unwrap();
+    let ledger_version = txns.len() as u64;
+    let ledger_info = gen_ledger_info(ledger_version, response.root_hash(), id, 1);
+    block_on(executor.commit_block(ledger_info.clone()))
+        .unwrap()
+        .unwrap();
+
+    let storage_client = StorageReadServiceClient::new(
+        Arc::new(EnvBuilder::new().build()),
+        "localhost",
+        config.storage.port,
+    );
+
+    let batches: Vec<_> = chunk_ranges
+        .into_iter()
+        .map(|range| {
+            storage_client
+                .get_transactions(
+                    range.start,
+                    range.end - range.start,
+                    ledger_version,
+                    false, /* fetch_events */
+                )
+                .unwrap()
+        })
+        .collect();
+
+    drop(storage_server);
+    shutdown_receiver.recv().unwrap();
+
+    (batches, ledger_info)
+}
+
 #[test]
 fn test_executor_execute_chunk() {
     let first_batch_size = 30;
@@ -277,64 +339,15 @@ fn test_executor_execute_chunk() {
     let third_batch_size = 20;
     let overlapping_size = 5;
 
-    // To obtain the two batches of transactions, we first execute and save these transactions in a
-    // separate DB. Then we call get_transactions to retrieve them.
-    let (first_batch, second_batch, third_batch, ledger_info) = {
-        let mut config = get_config();
-        let (storage_server, shutdown_receiver) = create_storage_server(&mut config);
-        let executor = create_executor(&config);
-
-        let mut txns = vec![];
-        for i in 0..first_batch_size + second_batch_size + third_batch_size - overlapping_size {
-            let txn = encode_mint_transaction(gen_address(i), 100);
-            txns.push(txn);
-        }
-        let id = gen_block_id(1);
-
-        let response = block_on(executor.execute_block(txns.clone(), *GENESIS_BLOCK_ID, id))
-            .unwrap()
-            .unwrap();
-        let ledger_version = txns.len() as u64;
-        let ledger_info = gen_ledger_info(ledger_version, response.root_hash(), id, 1);
-        block_on(executor.commit_block(ledger_info.clone()))
-            .unwrap()
-            .unwrap();
-
-        let storage_client = StorageReadServiceClient::new(
-            Arc::new(EnvBuilder::new().build()),
-            "localhost",
-            config.storage.port,
-        );
-        let first_batch = storage_client
-            .get_transactions(
-                /* start_version = */ 1,
-                first_batch_size,
-                ledger_version,
-                false, /* fetch_events */
-            )
-            .unwrap();
-        let second_batch = storage_client
-            .get_transactions(
-                /* start_version = */ first_batch_size + 1,
-                second_batch_size,
-                ledger_version,
-                false, /* fetch_events */
-            )
-            .unwrap();
-        let third_batch = storage_client
-            .get_transactions(
-                /* start_version = */
-                first_batch_size + second_batch_size + 1 - overlapping_size,
-                third_batch_size,
-                ledger_version,
-                false, /* fetch_events */
-            )
-            .unwrap();
-
-        drop(storage_server);
-        shutdown_receiver.recv().unwrap();
-
-        (first_batch, second_batch, third_batch, ledger_info)
+    let (chunks, ledger_info) = {
+        let first_batch_start = 1;
+        let second_batch_start = first_batch_start + first_batch_size;
+        let third_batch_start = second_batch_start + second_batch_size - overlapping_size;
+        create_transaction_chunks(vec![
+            first_batch_start..first_batch_start + first_batch_size,
+            second_batch_start..second_batch_start + second_batch_size,
+            third_batch_start..third_batch_start + third_batch_size,
+        ])
     };
 
     // Now we execute these two chunks of transactions.
@@ -348,7 +361,7 @@ fn test_executor_execute_chunk() {
     );
 
     // Execute the first chunk. After that we should still get the genesis ledger info from DB.
-    block_on(executor.execute_chunk(first_batch, ledger_info.clone()))
+    block_on(executor.execute_chunk(chunks[0].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
     let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
@@ -356,7 +369,7 @@ fn test_executor_execute_chunk() {
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
     // Execute the second chunk. After that we should still get the genesis ledger info from DB.
-    block_on(executor.execute_chunk(second_batch, ledger_info.clone()))
+    block_on(executor.execute_chunk(chunks[1].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
     let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
@@ -364,11 +377,65 @@ fn test_executor_execute_chunk() {
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
     // Execute the third chunk. After that we should get the new ledger info.
-    block_on(executor.execute_chunk(third_batch, ledger_info.clone()))
+    block_on(executor.execute_chunk(chunks[2].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
     let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
     assert_eq!(li, ledger_info);
+
+    drop(storage_server);
+    shutdown_receiver.recv().unwrap();
+}
+
+#[test]
+fn test_executor_execute_chunk_restart() {
+    let first_batch_size = 30;
+    let second_batch_size = 40;
+
+    let (chunks, ledger_info) = {
+        let first_batch_start = 1;
+        let second_batch_start = first_batch_start + first_batch_size;
+        create_transaction_chunks(vec![
+            first_batch_start..first_batch_start + first_batch_size,
+            second_batch_start..second_batch_start + second_batch_size,
+        ])
+    };
+
+    let mut config = get_config();
+    let (storage_server, shutdown_receiver) = create_storage_server(&mut config);
+
+    // First we simulate syncing the first chunk of transactions.
+    {
+        let executor = create_executor(&config);
+        let storage_client = StorageReadServiceClient::new(
+            Arc::new(EnvBuilder::new().build()),
+            "localhost",
+            config.storage.port,
+        );
+
+        block_on(executor.execute_chunk(chunks[0].clone(), ledger_info.clone()))
+            .unwrap()
+            .unwrap();
+        let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+        assert_eq!(li.ledger_info().version(), 0);
+        assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
+    }
+
+    // Then we restart executor and resume to the next chunk.
+    {
+        let executor = create_executor(&config);
+        let storage_client = StorageReadServiceClient::new(
+            Arc::new(EnvBuilder::new().build()),
+            "localhost",
+            config.storage.port,
+        );
+
+        block_on(executor.execute_chunk(chunks[1].clone(), ledger_info.clone()))
+            .unwrap()
+            .unwrap();
+        let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+        assert_eq!(li, ledger_info);
+    }
 
     drop(storage_server);
     shutdown_receiver.recv().unwrap();

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -76,7 +76,7 @@ where
                 (
                     info.account_state_root_hash,
                     info.ledger_frozen_subtree_hashes,
-                    ledger_info.version() + 1,
+                    info.latest_version + 1,
                     ledger_info.timestamp_usecs(),
                     ledger_info.consensus_block_id(),
                 )


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

If the node restarts in the middle of syncing, the latest version from
startup info might be larger than the version in the latest ledger info.
In this case we should initialize the in-memory accumulator using the
latest transaction version, not the version from latest ledger info.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a test that fails without the fix.

## Related PRs

None.
