### PR TITLE
[consensus] remove concurrent proposal processing

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -6,7 +6,7 @@ use crate::{
         block_storage::{BlockReader, BlockStore},
         common::{Payload, Round},
         consensus_types::{proposal_msg::ProposalMsg, timeout_msg::TimeoutMsg},
-        event_processor::{EventProcessor, ProcessProposalResult},
+        event_processor::EventProcessor,
         liveness::{
             local_pacemaker::{ExponentialTimeInterval, LocalPacemaker},
             pacemaker::{NewRoundEvent, Pacemaker},
@@ -34,7 +34,10 @@ use futures::{
 use nextgen_crypto::ed25519::*;
 use types::validator_signer::ValidatorSigner;
 
-use crate::chained_bft::{common::Author, consensus_types::sync_info::SyncInfo};
+use crate::chained_bft::{
+    common::Author,
+    consensus_types::{block::Block, sync_info::SyncInfo},
+};
 use config::config::ConsensusConfig;
 use futures::sink::SinkExt;
 use logger::prelude::*;
@@ -170,33 +173,14 @@ impl<T: Payload> ChainedBftSMR<T> {
     }
 
     async fn process_proposals(
-        executor: TaskExecutor,
         mut receiver: channel::Receiver<ProposalMsg<T>>,
         event_processor: ConcurrentEventProcessor<T>,
-        mut winning_proposals_sender: channel::Sender<ProposalMsg<T>>,
+        mut winning_proposals_sender: channel::Sender<Block<T>>,
     ) {
         while let Some(proposal_info) = receiver.next().await {
             let winning_proposal = {
-                let guard = event_processor.read().compat().await.unwrap();
-                match guard.process_proposal(proposal_info).await {
-                    ProcessProposalResult::Done(winning_proposal) => winning_proposal,
-                    // Spawn a new task that would start state synchronization
-                    // in the background.
-                    ProcessProposalResult::NeedSync(proposal) => {
-                        let winning_proposals_sender = winning_proposals_sender.clone();
-                        executor.spawn(
-                            Self::sync_and_process_proposal(
-                                futures_locks::RwLock::clone(&event_processor),
-                                proposal,
-                                winning_proposals_sender,
-                            )
-                            .boxed()
-                            .unit_error()
-                            .compat(),
-                        );
-                        None
-                    }
-                }
+                let mut guard = event_processor.write().compat().await.unwrap();
+                guard.process_proposal(proposal_info).await
             };
             if let Some(winning_proposal) = winning_proposal {
                 if let Err(e) = winning_proposals_sender.send(winning_proposal).await {
@@ -206,24 +190,8 @@ impl<T: Payload> ChainedBftSMR<T> {
         }
     }
 
-    async fn sync_and_process_proposal(
-        event_processor: ConcurrentEventProcessor<T>,
-        proposal: ProposalMsg<T>,
-        mut winning_proposals_sender: channel::Sender<ProposalMsg<T>>,
-    ) {
-        let winning_proposal = {
-            let mut guard = event_processor.write().compat().await.unwrap();
-            guard.sync_and_process_proposal(proposal).await
-        };
-        if let Some(winning_proposal) = winning_proposal {
-            if let Err(e) = winning_proposals_sender.send(winning_proposal).await {
-                warn!("Failed to send winning proposal: {:?}", e);
-            }
-        }
-    }
-
     async fn process_winning_proposals(
-        mut receiver: channel::Receiver<ProposalMsg<T>>,
+        mut receiver: channel::Receiver<Block<T>>,
         event_processor: ConcurrentEventProcessor<T>,
     ) {
         while let Some(proposal_info) = receiver.next().await {
@@ -299,10 +267,10 @@ impl<T: Payload> ChainedBftSMR<T> {
         event_processor: ConcurrentEventProcessor<T>,
         executor: TaskExecutor,
         new_round_events_receiver: channel::Receiver<NewRoundEvent>,
-        winning_proposals_receiver: channel::Receiver<ProposalMsg<T>>,
+        winning_proposals_receiver: channel::Receiver<Block<T>>,
         network_receivers: NetworkReceivers<T>,
         pacemaker_timeout_sender_rx: channel::Receiver<Round>,
-        winning_proposals_sender: channel::Sender<ProposalMsg<T>>,
+        winning_proposals_sender: channel::Sender<Block<T>>,
     ) {
         executor.spawn(
             Self::process_new_round_events(new_round_events_receiver, event_processor.clone())
@@ -313,7 +281,6 @@ impl<T: Payload> ChainedBftSMR<T> {
 
         executor.spawn(
             Self::process_proposals(
-                executor.clone(),
                 network_receivers.proposals,
                 event_processor.clone(),
                 winning_proposals_sender,

--- a/consensus/src/chained_bft/consensus_types/sync_info.rs
+++ b/consensus/src/chained_bft/consensus_types/sync_info.rs
@@ -5,7 +5,7 @@ use network;
 use nextgen_crypto::ed25519::*;
 
 use crate::chained_bft::{
-    consensus_types::timeout_msg::PacemakerTimeoutCertificateVerificationError,
+    common::Round, consensus_types::timeout_msg::PacemakerTimeoutCertificateVerificationError,
     safety::vote_msg::VoteMsgVerificationError,
 };
 use proto_conv::{FromProto, IntoProto};
@@ -32,8 +32,11 @@ impl Display for SyncInfo {
         };
         write!(
             f,
-            "HQC: {}, HLI: {}, HTC: {}",
-            self.highest_quorum_cert, self.highest_ledger_info, htc_repr,
+            "SyncInfo[round: {}, HQC: {}, HLI: {}, HTC: {}]",
+            self.highest_round(),
+            self.highest_quorum_cert,
+            self.highest_ledger_info,
+            htc_repr,
         )
     }
 }
@@ -85,6 +88,22 @@ impl SyncInfo {
     /// Highest timeout certificate if available
     pub fn highest_timeout_certificate(&self) -> Option<&PacemakerTimeoutCertificate> {
         self.highest_timeout_cert.as_ref()
+    }
+
+    pub fn hqc_round(&self) -> Round {
+        self.highest_quorum_cert.certified_block_round()
+    }
+
+    pub fn htc_round(&self) -> Round {
+        match self.highest_timeout_certificate() {
+            Some(tc) => tc.round(),
+            None => 0,
+        }
+    }
+
+    /// The highest round the SyncInfo carries.
+    pub fn highest_round(&self) -> Round {
+        std::cmp::max(self.hqc_round(), self.htc_round())
     }
 
     pub fn verify(

--- a/consensus/src/chained_bft/liveness/proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/proposer_election.rs
@@ -3,7 +3,7 @@
 
 use crate::chained_bft::{
     common::{Author, Round},
-    consensus_types::proposal_msg::ProposalMsg,
+    consensus_types::block::Block,
 };
 
 /// ProposerElection incorporates the logic of choosing a leader among multiple candidates.
@@ -22,5 +22,5 @@ pub trait ProposerElection<T> {
     /// Notify proposer election about a new proposal. The function doesn't return any information:
     /// proposer election is going to notify the client about the chosen proposal via a dedicated
     /// channel (to be passed in constructor).
-    fn process_proposal(&self, proposal: ProposalMsg<T>) -> Option<ProposalMsg<T>>;
+    fn process_proposal(&self, proposal: Block<T>) -> Option<Block<T>>;
 }

--- a/consensus/src/chained_bft/liveness/rotating_proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/rotating_proposer_election.rs
@@ -3,7 +3,7 @@
 
 use crate::chained_bft::{
     common::{Author, Payload, Round},
-    consensus_types::proposal_msg::ProposalMsg,
+    consensus_types::block::Block,
     liveness::proposer_election::ProposerElection,
 };
 
@@ -46,11 +46,11 @@ impl<T: Payload> ProposerElection<T> for RotatingProposer {
         vec![self.get_proposer(round)]
     }
 
-    fn process_proposal(&self, proposal: ProposalMsg<T>) -> Option<ProposalMsg<T>> {
+    fn process_proposal(&self, proposal: Block<T>) -> Option<Block<T>> {
         // This is a simple rotating proposer, the proposal is processed in the context of the
         // caller task, no synchronization required because there is no mutable state.
-        let round_author = self.get_proposer(proposal.proposal.round());
-        if round_author != proposal.proposer() {
+        let round_author = self.get_proposer(proposal.round());
+        if Some(round_author) != proposal.author() {
             None
         } else {
             Some(proposal)

--- a/consensus/src/chained_bft/liveness/rotating_proposer_test.rs
+++ b/consensus/src/chained_bft/liveness/rotating_proposer_test.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chained_bft::{
-    consensus_types::{
-        block::Block, proposal_msg::ProposalMsg, quorum_cert::QuorumCert, sync_info::SyncInfo,
-    },
+    consensus_types::{block::Block, quorum_cert::QuorumCert},
     liveness::{proposer_election::ProposerElection, rotating_proposer_election::RotatingProposer},
 };
 use nextgen_crypto::ed25519::*;
@@ -27,39 +25,30 @@ fn test_rotating_proposer() {
     let genesis_block = Block::make_genesis_block();
     let quorum_cert = QuorumCert::certificate_for_genesis();
 
-    let good_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            1,
-            1,
-            1,
-            quorum_cert.clone(),
-            &another_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
-    let bad_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            2,
-            1,
-            2,
-            quorum_cert.clone(),
-            &chosen_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
-    let next_good_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            3,
-            2,
-            3,
-            quorum_cert.clone(),
-            &chosen_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
+    let good_proposal = Block::make_block(
+        &genesis_block,
+        1,
+        1,
+        1,
+        quorum_cert.clone(),
+        &another_validator_signer,
+    );
+    let bad_proposal = Block::make_block(
+        &genesis_block,
+        2,
+        1,
+        2,
+        quorum_cert.clone(),
+        &chosen_validator_signer,
+    );
+    let next_good_proposal = Block::make_block(
+        &genesis_block,
+        3,
+        2,
+        3,
+        quorum_cert.clone(),
+        &chosen_validator_signer,
+    );
     assert_eq!(
         pe.process_proposal(good_proposal.clone()),
         Some(good_proposal)
@@ -96,39 +85,30 @@ fn test_rotating_proposer_with_three_contiguous_rounds() {
     let genesis_block = Block::make_genesis_block();
     let quorum_cert = QuorumCert::certificate_for_genesis();
 
-    let good_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            1,
-            1,
-            1,
-            quorum_cert.clone(),
-            &chosen_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
-    let bad_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            2,
-            1,
-            2,
-            quorum_cert.clone(),
-            &another_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
-    let next_good_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            3,
-            2,
-            3,
-            quorum_cert.clone(),
-            &chosen_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
+    let good_proposal = Block::make_block(
+        &genesis_block,
+        1,
+        1,
+        1,
+        quorum_cert.clone(),
+        &chosen_validator_signer,
+    );
+    let bad_proposal = Block::make_block(
+        &genesis_block,
+        2,
+        1,
+        2,
+        quorum_cert.clone(),
+        &another_validator_signer,
+    );
+    let next_good_proposal = Block::make_block(
+        &genesis_block,
+        3,
+        2,
+        3,
+        quorum_cert.clone(),
+        &chosen_validator_signer,
+    );
     assert_eq!(
         pe.process_proposal(good_proposal.clone()),
         Some(good_proposal)
@@ -162,39 +142,30 @@ fn test_fixed_proposer() {
     let genesis_block = Block::make_genesis_block();
     let quorum_cert = QuorumCert::certificate_for_genesis();
 
-    let good_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            1,
-            1,
-            1,
-            quorum_cert.clone(),
-            &chosen_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
-    let bad_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            2,
-            1,
-            2,
-            quorum_cert.clone(),
-            &another_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
-    let next_good_proposal = ProposalMsg {
-        proposal: Block::make_block(
-            &genesis_block,
-            2,
-            2,
-            3,
-            quorum_cert.clone(),
-            &chosen_validator_signer,
-        ),
-        sync_info: SyncInfo::new(quorum_cert.clone(), quorum_cert.clone(), None),
-    };
+    let good_proposal = Block::make_block(
+        &genesis_block,
+        1,
+        1,
+        1,
+        quorum_cert.clone(),
+        &chosen_validator_signer,
+    );
+    let bad_proposal = Block::make_block(
+        &genesis_block,
+        2,
+        1,
+        2,
+        quorum_cert.clone(),
+        &another_validator_signer,
+    );
+    let next_good_proposal = Block::make_block(
+        &genesis_block,
+        2,
+        2,
+        3,
+        quorum_cert.clone(),
+        &chosen_validator_signer,
+    );
     assert_eq!(
         pe.process_proposal(good_proposal.clone()),
         Some(good_proposal)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We think the current design is over-complicated because of the concurrent message processing. It results in error-prone and hard-to-debug/understand code.

And the nature of hotstuff protocol is sequential progressing(propose -> vote -> QC and propose), we think a simpler solution might work too.

This is the first PR to switch to sequential processing by removing concurrent proposals.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
