### PR TITLE
Continuous Fuzzing Integration with Fuzzit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,14 +115,25 @@ jobs:
           name: Terraform validate
           command: terraform validate
           working_directory: terraform/
-
+  fuzzit:
+    docker:
+      - image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/github_circleci:latest
+        aws_auth:
+          aws_access_key_id: $ECR_RO_ACCESS_KEY_ID
+          aws_secret_access_key: $ECR_RO_SECRET_ACCESS_KEY
+    resource_class: 2xlarge
+    steps:
+      - env_setup
+      - run:
+          name: Run Fuzzit Regression and Fuzzing
+          command: ./scripts/fuzzit.sh
 workflows:
   commit-workflow:
     jobs:
       - build
       - validate-config
       - terraform
-
+      - fuzzit
   scheduled-workflow:
     triggers:
       - schedule:
@@ -132,3 +143,4 @@ workflows:
               only: master
     jobs:
       - audit
+      - fuzzit

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ---
 
 [![CircleCI](https://circleci.com/gh/libra/libra.svg?style=shield)](https://circleci.com/gh/libra/libra)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=libray=master)](https://fuzzit.dev)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE.md)
 
 Libra Core implements a decentralized, programmable database which provides a financial infrastructure that can empower billions of people.

--- a/scripts/fuzzit.sh
+++ b/scripts/fuzzit.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+## Download Fuzzit CLI
+cd ./testsuite/libra_fuzzer
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.39/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# Build targets
+export FUZZIT_API_KEY=e27b764735b43b2f5d63a2285a03e109b3aca39096fc90f454c0bd96f65df859e659776a0da4028a774722b0d02e9f6a
+export PORTABLE=1
+export RUSTFLAGS="-Ctarget-feature=-avx512f"
+cargo install cargo-fuzz
+TARGETS=$(cargo run list --no-desc 2> /dev/null)
+for i in $TARGETS
+do
+	cargo run fuzz "${i}" -- -- -runs=1
+	# run fuzzing on push to master
+	TARGET_NAME=${i//_/-}
+	./fuzzit create target --skip-if-exists --public-corpus "${TARGET_NAME}"
+	./fuzzit create job -e FUZZ_TARGET="${i}" libra/${TARGET_NAME} ./fuzz/target/x86_64-unknown-linux-gnu/debug/fuzz_runner
+done

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -15,6 +15,7 @@ metrics = { path = "../../common/metrics" }
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"
 rev = "ea24c53b8f2e1f8a1d22f739cb5db4681d2d21ff"
+default-features = false
 
 [dev-dependencies]
 byteorder = "1.3.2"

--- a/testsuite/libra_fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets.rs
@@ -69,7 +69,7 @@ lazy_static! {
             Box::new(compiled_module::CompiledModuleTarget::default()),
             Box::new(signed_transaction::SignedTransactionTarget::default()),
             Box::new(vm_value::ValueTarget::default()),
-            Box::new(consensus_proposal::ConsensusProposal::default()),
+            //Box::new(consensus_proposal::ConsensusProposal::default()),
         ];
         targets.into_iter().map(|target| (target.name(), target)).collect()
     };


### PR DESCRIPTION
This commit introduce continuous fuzzing workflow with
the following additions:

1) on every new code pushed to master the fuzzers are built and
sent to Fuzzit servers where they are continuously run and alert
the relevant people if a new bug is found.
2) on every pull-request a quick regression test is run using
the corpus which is generated on Fuzzit. This will fail the CI
and prevent new or old bugs from being merged.

(as a side note fuzzit is free for oss)

