### PR TITLE
[types] Make LedgerInfoWithSignatures parametric in the Signature Scheme type

### DIFF
--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -138,7 +138,9 @@ impl GRPCClient {
     fn get_with_proof_async(
         &self,
         requested_items: Vec<RequestItem>,
-    ) -> Result<impl Future<Item = UpdateToLatestLedgerResponse, Error = failure::Error>> {
+    ) -> Result<
+        impl Future<Item = UpdateToLatestLedgerResponse<Ed25519Signature>, Error = failure::Error>,
+    > {
         let req = UpdateToLatestLedgerRequest::new(0, requested_items.clone());
         debug!("get_with_proof with request: {:?}", req);
         let proto_req = req.clone().into_proto();
@@ -176,8 +178,8 @@ impl GRPCClient {
     pub(crate) fn get_with_proof_sync(
         &self,
         requested_items: Vec<RequestItem>,
-    ) -> Result<UpdateToLatestLedgerResponse> {
-        let mut resp: Result<UpdateToLatestLedgerResponse> =
+    ) -> Result<UpdateToLatestLedgerResponse<Ed25519Signature>> {
+        let mut resp: Result<UpdateToLatestLedgerResponse<Ed25519Signature>> =
             self.get_with_proof_async(requested_items.clone())?.wait();
         let mut try_cnt = 0_u64;
 

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -15,6 +15,7 @@ use canonical_serialization::CanonicalSerialize;
 use crypto::HashValue;
 use logger::prelude::*;
 use mirai_annotations::checked_verify_eq;
+use nextgen_crypto::ed25519::*;
 use serde::Serialize;
 use std::{
     collections::{
@@ -61,7 +62,7 @@ pub struct BlockTree<T> {
     /// The vote digest is a hash that covers both the proposal id and the state id.
     /// Thus, the structure of `id_to_votes` is as follows:
     /// HashMap<proposed_block_id, HashMap<vote_digest, LedgerInfoWithSignatures>>
-    id_to_votes: HashMap<HashValue, HashMap<HashValue, LedgerInfoWithSignatures>>,
+    id_to_votes: HashMap<HashValue, HashMap<HashValue, LedgerInfoWithSignatures<Ed25519Signature>>>,
     /// Map of block id to its completed quorum certificate (2f + 1 votes)
     id_to_quorum_cert: HashMap<HashValue, Arc<QuorumCert>>,
     /// To keep the IDs of the elements that have been pruned from the tree but not cleaned up yet.

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -42,7 +42,7 @@ struct SMRNode {
     proposer: Vec<Author>,
     smr_id: usize,
     smr: ChainedBftSMR<TestPayload>,
-    commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures>,
+    commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures<Ed25519Signature>>,
     mempool: Arc<MockTransactionManager>,
     mempool_notif_receiver: mpsc::Receiver<usize>,
     storage: Arc<MockStorage<TestPayload>>,
@@ -97,7 +97,8 @@ impl SMRNode {
             storage.clone(),
             initial_data,
         );
-        let (commit_cb_sender, commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
+        let (commit_cb_sender, commit_cb_receiver) =
+            mpsc::unbounded::<LedgerInfoWithSignatures<Ed25519Signature>>();
         let mut mp = MockTransactionManager::new();
         let commit_receiver = mp.take_commit_receiver();
         let mempool = Arc::new(mp);
@@ -188,7 +189,10 @@ impl SMRNode {
     }
 }
 
-fn verify_finality_proof(node: &SMRNode, ledger_info_with_sig: &LedgerInfoWithSignatures) {
+fn verify_finality_proof(
+    node: &SMRNode,
+    ledger_info_with_sig: &LedgerInfoWithSignatures<Ed25519Signature>,
+) {
     let ledger_info_hash = ledger_info_with_sig.ledger_info().hash();
     for (author, signature) in ledger_info_with_sig.signatures() {
         assert_eq!(

--- a/consensus/src/chained_bft/consensus_types/quorum_cert.rs
+++ b/consensus/src/chained_bft/consensus_types/quorum_cert.rs
@@ -36,7 +36,7 @@ pub struct QuorumCert {
     /// The round of a certified block.
     certified_block_round: Round,
     /// The signed LedgerInfo of a committed block that carries the data about the certified block.
-    signed_ledger_info: LedgerInfoWithSignatures,
+    signed_ledger_info: LedgerInfoWithSignatures<Ed25519Signature>,
     /// The id of the parent block of the certified block
     certified_parent_block_id: HashValue,
     /// The round of the parent block of the certified block
@@ -63,7 +63,7 @@ impl QuorumCert {
         block_id: HashValue,
         state: ExecutedState,
         round: Round,
-        signed_ledger_info: LedgerInfoWithSignatures,
+        signed_ledger_info: LedgerInfoWithSignatures<Ed25519Signature>,
         certified_parent_block_id: HashValue,
         certified_parent_block_round: Round,
         certified_grandparent_block_id: HashValue,
@@ -93,7 +93,7 @@ impl QuorumCert {
         self.certified_block_round
     }
 
-    pub fn ledger_info(&self) -> &LedgerInfoWithSignatures {
+    pub fn ledger_info(&self) -> &LedgerInfoWithSignatures<Ed25519Signature> {
         &self.signed_ledger_info
     }
 

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -37,6 +37,7 @@ use crate::{
 };
 use logger::prelude::*;
 use network::proto::BlockRetrievalStatus;
+use nextgen_crypto::ed25519::*;
 use std::{
     sync::{Arc, RwLock},
     time::Duration,
@@ -753,7 +754,7 @@ impl<T: Payload> EventProcessor<T> {
     async fn process_commit(
         &self,
         committed_block: Arc<Block<T>>,
-        finality_proof: LedgerInfoWithSignatures,
+        finality_proof: LedgerInfoWithSignatures<Ed25519Signature>,
     ) {
         // Verify that the ledger info is indeed for the block we're planning to
         // commit.

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -71,7 +71,7 @@ struct NodeSetup {
     proposer_author: Author,
     peers: Arc<Vec<Author>>,
     pacemaker: Arc<dyn Pacemaker>,
-    commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures>,
+    commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures<Ed25519Signature>>,
 }
 
 impl NodeSetup {
@@ -80,7 +80,8 @@ impl NodeSetup {
         storage: Arc<dyn PersistentStorage<TestPayload>>,
         initial_data: RecoveryData<TestPayload>,
     ) -> Arc<BlockStore<TestPayload>> {
-        let (commit_cb_sender, _commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
+        let (commit_cb_sender, _commit_cb_receiver) =
+            mpsc::unbounded::<LedgerInfoWithSignatures<Ed25519Signature>>();
 
         Arc::new(block_on(BlockStore::new(
             storage,
@@ -201,7 +202,8 @@ impl NodeSetup {
             Self::create_pacemaker(executor.clone(), time_service.clone());
 
         let proposer_election = Self::create_proposer_election(proposer_author);
-        let (commit_cb_sender, commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
+        let (commit_cb_sender, commit_cb_receiver) =
+            mpsc::unbounded::<LedgerInfoWithSignatures<Ed25519Signature>>();
         let event_processor = EventProcessor::new(
             author,
             Arc::clone(&block_store),

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -9,17 +9,20 @@ use crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use failure::Result;
 use futures::{channel::mpsc, Future, FutureExt};
 use logger::prelude::*;
+use nextgen_crypto::ed25519::*;
 use state_synchronizer::SyncStatus;
 use std::pin::Pin;
 use termion::color::*;
 use types::{ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof};
 
 pub struct MockStateComputer {
-    commit_callback: mpsc::UnboundedSender<LedgerInfoWithSignatures>,
+    commit_callback: mpsc::UnboundedSender<LedgerInfoWithSignatures<Ed25519Signature>>,
 }
 
 impl MockStateComputer {
-    pub fn new(commit_callback: mpsc::UnboundedSender<LedgerInfoWithSignatures>) -> Self {
+    pub fn new(
+        commit_callback: mpsc::UnboundedSender<LedgerInfoWithSignatures<Ed25519Signature>>,
+    ) -> Self {
         MockStateComputer { commit_callback }
     }
 }
@@ -45,7 +48,7 @@ impl StateComputer for MockStateComputer {
 
     fn commit(
         &self,
-        commit: LedgerInfoWithSignatures,
+        commit: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         self.commit_callback
             .unbounded_send(commit)

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -41,7 +41,8 @@ pub fn build_empty_tree() -> Arc<BlockStore<Vec<usize>>> {
 pub fn build_empty_tree_with_custom_signing(
     my_signer: ValidatorSigner<Ed25519PrivateKey>,
 ) -> Arc<BlockStore<Vec<usize>>> {
-    let (commit_cb_sender, _commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
+    let (commit_cb_sender, _commit_cb_receiver) =
+        mpsc::unbounded::<LedgerInfoWithSignatures<Ed25519Signature>>();
     let (storage, initial_data) = EmptyStorage::start_for_testing();
     Arc::new(block_on(BlockStore::new(
         storage,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -14,6 +14,7 @@ use execution_proto::proto::{
 use failure::Result;
 use futures::{compat::Future01CompatExt, Future, FutureExt};
 use logger::prelude::*;
+use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProto, IntoProto};
 use state_synchronizer::{StateSyncClient, SyncStatus};
 use std::{pin::Pin, sync::Arc, time::Instant};
@@ -119,7 +120,7 @@ impl StateComputer for ExecutionProxy {
     /// Send a successful commit. A future is fulfilled when the state is finalized.
     fn commit(
         &self,
-        commit: LedgerInfoWithSignatures,
+        commit: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         let version = commit.ledger_info().version();
         counters::LAST_COMMITTED_VERSION.set(version as i64);

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -6,6 +6,7 @@ use canonical_serialization::{CanonicalSerialize, CanonicalSerializer};
 use crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use failure::Result;
 use futures::Future;
+use nextgen_crypto::ed25519::*;
 use serde::{Deserialize, Serialize};
 use state_synchronizer::SyncStatus;
 use std::{pin::Pin, sync::Arc};
@@ -109,7 +110,7 @@ pub trait StateComputer: Send + Sync {
     /// Send a successful commit. A future is fulfilled when the state is finalized.
     fn commit(
         &self,
-        commit: LedgerInfoWithSignatures,
+        commit: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 
     /// Synchronize to a commit that not present locally.

--- a/execution/execution_client/Cargo.toml
+++ b/execution/execution_client/Cargo.toml
@@ -11,6 +11,7 @@ grpcio = "0.4.4"
 
 execution_proto = { path = "../execution_proto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 types = { path = "../../types" }
 proto_conv = { path = "../../common/proto_conv" }
 

--- a/execution/execution_client/src/lib.rs
+++ b/execution/execution_client/src/lib.rs
@@ -7,6 +7,7 @@ use execution_proto::{
 };
 use failure::{bail, Result};
 use grpcio::{ChannelBuilder, Environment};
+use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProto, IntoProto};
 use std::sync::Arc;
 use types::ledger_info::LedgerInfoWithSignatures;
@@ -30,7 +31,10 @@ impl ExecutionClient {
         }
     }
 
-    pub fn commit_block(&self, ledger_info_with_sigs: LedgerInfoWithSignatures) -> Result<()> {
+    pub fn commit_block(
+        &self,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+    ) -> Result<()> {
         let proto_ledger_info = ledger_info_with_sigs.into_proto();
         let mut request = CommitBlockRequest::new();
         request.set_ledger_info_with_sigs(proto_ledger_info);

--- a/execution/execution_proto/Cargo.toml
+++ b/execution/execution_proto/Cargo.toml
@@ -15,6 +15,7 @@ protobuf = "~2.7"
 
 crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proptest_helpers = { path = "../../common/proptest_helpers" }
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 types = { path = "../../types" }

--- a/execution/execution_proto/src/lib.rs
+++ b/execution/execution_proto/src/lib.rs
@@ -10,6 +10,7 @@ mod protobuf_conversion_test;
 
 use crypto::HashValue;
 use failure::prelude::*;
+use nextgen_crypto::ed25519::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
@@ -151,7 +152,7 @@ impl IntoProto for ExecuteBlockResponse {
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 #[ProtoType(crate::proto::execution::CommitBlockRequest)]
 pub struct CommitBlockRequest {
-    pub ledger_info_with_sigs: LedgerInfoWithSignatures,
+    pub ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -192,7 +193,7 @@ impl IntoProto for CommitBlockResponse {
 #[ProtoType(crate::proto::execution::ExecuteChunkRequest)]
 pub struct ExecuteChunkRequest {
     pub txn_list_with_proof: TransactionListWithProof,
-    pub ledger_info_with_sigs: LedgerInfoWithSignatures,
+    pub ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]

--- a/execution/execution_tests/src/lib.rs
+++ b/execution/execution_tests/src/lib.rs
@@ -15,6 +15,7 @@ use execution_proto::proto::execution_grpc::create_execution;
 use execution_service::ExecutionService;
 use grpc_helpers::ServerHandle;
 use grpcio::{EnvBuilder, ServerBuilder};
+use nextgen_crypto::ed25519::*;
 use std::{collections::HashMap, sync::Arc};
 use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::start_storage_service;
@@ -28,7 +29,7 @@ pub fn gen_ledger_info_with_sigs(
     version: u64,
     root_hash: HashValue,
     commit_block_id: HashValue,
-) -> LedgerInfoWithSignatures {
+) -> LedgerInfoWithSignatures<Ed25519Signature> {
     let ledger_info = LedgerInfo::new(
         version,
         root_hash,

--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -16,6 +16,7 @@ use execution_proto::{CommitBlockResponse, ExecuteBlockResponse, ExecuteChunkRes
 use failure::prelude::*;
 use futures::channel::oneshot;
 use logger::prelude::*;
+use nextgen_crypto::ed25519::*;
 use scratchpad::{Accumulator, ProofRead, SparseMerkleTree};
 use std::{
     collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque},
@@ -280,7 +281,7 @@ where
     fn execute_and_commit_chunk(
         &mut self,
         txn_list_with_proof: TransactionListWithProof,
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> Result<()> {
         if ledger_info_with_sigs.ledger_info().timestamp_usecs() <= self.committed_timestamp_usecs {
             warn!(
@@ -425,7 +426,7 @@ where
     fn verify_chunk(
         &self,
         txn_list_with_proof: &TransactionListWithProof,
-        ledger_info_with_sigs: &LedgerInfoWithSignatures,
+        ledger_info_with_sigs: &LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> Result<(u64, Version)> {
         txn_list_with_proof.verify(
             ledger_info_with_sigs.ledger_info(),

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -11,6 +11,7 @@ use config::config::{NodeConfig, NodeConfigHelpers};
 use crypto::{hash::GENESIS_BLOCK_ID, HashValue};
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, ServerBuilder};
+use nextgen_crypto::ed25519::*;
 use proptest::prelude::*;
 use proto_conv::IntoProtoBytes;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
@@ -157,7 +158,7 @@ fn gen_ledger_info(
     root_hash: HashValue,
     commit_block_id: HashValue,
     timestamp_usecs: u64,
-) -> LedgerInfoWithSignatures {
+) -> LedgerInfoWithSignatures<Ed25519Signature> {
     let ledger_info = LedgerInfo::new(
         version,
         root_hash,

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -21,6 +21,7 @@ use failure::{format_err, Result};
 use futures::{channel::oneshot, executor::block_on};
 use lazy_static::lazy_static;
 use logger::prelude::*;
+use nextgen_crypto::ed25519::*;
 use std::{
     collections::HashMap,
     marker::PhantomData,
@@ -199,7 +200,7 @@ where
     /// Commits a block and all its ancestors.
     pub fn commit_block(
         &self,
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> oneshot::Receiver<Result<CommitBlockResponse>> {
         debug!(
             "Received request to commit block {:x}.",
@@ -231,7 +232,7 @@ where
     pub fn execute_chunk(
         &self,
         txn_list_with_proof: TransactionListWithProof,
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> oneshot::Receiver<Result<ExecuteChunkResponse>> {
         debug!(
             "Received request to execute chunk. Chunk size: {}. Target version: {}.",
@@ -287,12 +288,12 @@ enum Command {
         resp_sender: oneshot::Sender<Result<ExecuteBlockResponse>>,
     },
     CommitBlock {
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
         resp_sender: oneshot::Sender<Result<CommitBlockResponse>>,
     },
     ExecuteChunk {
         txn_list_with_proof: TransactionListWithProof,
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
         resp_sender: oneshot::Sender<Result<ExecuteChunkResponse>>,
     },
 }

--- a/execution/executor/src/transaction_block.rs
+++ b/execution/executor/src/transaction_block.rs
@@ -10,6 +10,7 @@ use execution_proto::{CommitBlockResponse, ExecuteBlockResponse};
 use failure::{format_err, Result};
 use futures::channel::oneshot;
 use logger::prelude::*;
+use nextgen_crypto::ed25519::*;
 use scratchpad::{Accumulator, SparseMerkleTree};
 use std::{
     collections::{HashMap, HashSet},
@@ -46,7 +47,7 @@ pub struct TransactionBlock {
 
     /// The signatures on this block. Not all committed blocks will have signatures, if multiple
     /// blocks are committed at once.
-    ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
+    ledger_info_with_sigs: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
 
     /// The response for `execute_block` request.
     execute_response: Option<ExecuteBlockResponse>,
@@ -92,7 +93,7 @@ impl TransactionBlock {
     }
 
     /// Returns the signatures on this block.
-    pub fn ledger_info_with_sigs(&self) -> &Option<LedgerInfoWithSignatures> {
+    pub fn ledger_info_with_sigs(&self) -> &Option<LedgerInfoWithSignatures<Ed25519Signature>> {
         &self.ledger_info_with_sigs
     }
 
@@ -186,7 +187,7 @@ impl TransactionBlock {
 
 impl Block for TransactionBlock {
     type Output = ProcessedVMOutput;
-    type Signature = LedgerInfoWithSignatures;
+    type Signature = LedgerInfoWithSignatures<Ed25519Signature>;
 
     fn is_committed(&self) -> bool {
         self.committed

--- a/state_synchronizer/Cargo.toml
+++ b/state_synchronizer/Cargo.toml
@@ -22,6 +22,7 @@ grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 network = { path = "../network" }
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 storage_client = { path = "../storage/storage_client" }
 types = { path = "../types" }

--- a/state_synchronizer/src/downloader.rs
+++ b/state_synchronizer/src/downloader.rs
@@ -6,6 +6,7 @@ use failure::prelude::*;
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use logger::prelude::*;
 use network::{proto::RequestChunk, validator_network::ConsensusNetworkSender};
+use nextgen_crypto::ed25519::*;
 use rand::{thread_rng, Rng};
 use std::time::Duration;
 use types::{ledger_info::LedgerInfoWithSignatures, proto::transaction::TransactionListWithProof};
@@ -15,7 +16,7 @@ use types::{ledger_info::LedgerInfoWithSignatures, proto::transaction::Transacti
 #[derive(Clone)]
 pub struct FetchChunkMsg {
     // target version that we want to fetch
-    pub target: LedgerInfoWithSignatures,
+    pub target: LedgerInfoWithSignatures<Ed25519Signature>,
     // version from which to start fetching (the offset version)
     pub start_version: u64,
 }

--- a/state_synchronizer/src/synchronizer.rs
+++ b/state_synchronizer/src/synchronizer.rs
@@ -15,6 +15,7 @@ use futures::{
 use grpcio::EnvBuilder;
 use logger::prelude::*;
 use network::validator_network::ConsensusNetworkSender;
+use nextgen_crypto::ed25519::*;
 use std::sync::Arc;
 use storage_client::{StorageRead, StorageReadServiceClient};
 use tokio::runtime::{Builder, Runtime};
@@ -91,7 +92,7 @@ impl StateSyncClient {
     /// Sync validator's state up to given `version`
     pub fn sync_to(
         &self,
-        target: LedgerInfoWithSignatures,
+        target: LedgerInfoWithSignatures<Ed25519Signature>,
     ) -> impl Future<Output = Result<SyncStatus>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -24,6 +24,7 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 jellyfish_merkle = { path = "../jellyfish_merkle" }
 logger = { path = "../../common/logger" }
 metrics = { path = "../../common/metrics" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proptest = "0.9.2"
 proptest-derive = "0.1.2"
 rusty-fork = "0.2.1"

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -18,10 +18,10 @@ prop_compose! {
 prop_compose! {
     fn arb_ledger_infos_with_sigs()(
         partial_ledger_infos_with_sigs in vec(
-            any_with::<LedgerInfoWithSignatures>((1..3).into()).no_shrink(), 1..100
+            any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((1..3).into()).no_shrink(), 1..100
         ),
         start_version in 0..10000u64,
-    ) -> Vec<LedgerInfoWithSignatures> {
+    ) -> Vec<LedgerInfoWithSignatures<Ed25519Signature>> {
         partial_ledger_infos_with_sigs
             .iter()
             .enumerate()

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -49,6 +49,7 @@ use itertools::{izip, zip_eq};
 use lazy_static::lazy_static;
 use logger::prelude::*;
 use metrics::OpMetrics;
+use nextgen_crypto::ed25519::*;
 use schemadb::{ColumnFamilyOptions, ColumnFamilyOptionsMap, DB, DEFAULT_CF_NAME};
 use std::{iter::Iterator, path::Path, sync::Arc, time::Instant};
 use storage_proto::ExecutorStartupInfo;
@@ -347,7 +348,7 @@ impl LibraDB {
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
-        ledger_info_with_sigs: &Option<LedgerInfoWithSignatures>,
+        ledger_info_with_sigs: &Option<LedgerInfoWithSignatures<Ed25519Signature>>,
     ) -> Result<()> {
         let num_txns = txns_to_commit.len() as u64;
         // ledger_info_with_sigs could be None if we are doing state synchronization. In this case
@@ -491,8 +492,8 @@ impl LibraDB {
         request_items: Vec<RequestItem>,
     ) -> Result<(
         Vec<ResponseItem>,
-        LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
     )> {
         error_if_too_many_requested(request_items.len() as u64, MAX_REQUEST_ITEMS)?;
 

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -7,13 +7,17 @@ use crate::{
     test_helper::arb_blocks_to_commit,
 };
 use crypto::hash::CryptoHash;
+use nextgen_crypto::ed25519::*;
 use proptest::prelude::*;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::collections::HashMap;
 use types::{contract_event::ContractEvent, ledger_info::LedgerInfo};
 
 fn test_save_blocks_impl(
-    input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
+    input: Vec<(
+        Vec<TransactionToCommit>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+    )>,
 ) -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let db = db_with_mock_genesis(&tmp_dir)?;
@@ -66,7 +70,10 @@ fn test_save_blocks_impl(
 }
 
 fn test_sync_transactions_impl(
-    input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
+    input: Vec<(
+        Vec<TransactionToCommit>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+    )>,
 ) -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let db = db_with_mock_genesis(&tmp_dir)?;
@@ -264,7 +271,7 @@ fn verify_committed_transactions(
     db: &LibraDB,
     txns_to_commit: &[TransactionToCommit],
     first_version: Version,
-    ledger_info_with_sigs: &LedgerInfoWithSignatures,
+    ledger_info_with_sigs: &LedgerInfoWithSignatures<Ed25519Signature>,
     is_latest: bool,
 ) -> Result<()> {
     let ledger_info = ledger_info_with_sigs.ledger_info();

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -11,6 +11,7 @@ use crypto::{
 };
 use failure::Result;
 use lazy_static::lazy_static;
+use nextgen_crypto::ed25519::*;
 use std::collections::HashMap;
 use types::{
     account_address::AccountAddress,
@@ -22,7 +23,7 @@ use types::{
 
 fn gen_mock_genesis() -> (
     TransactionInfo,
-    LedgerInfoWithSignatures,
+    LedgerInfoWithSignatures<Ed25519Signature>,
     TransactionToCommit,
 ) {
     let (privkey, pubkey) = generate_keypair();
@@ -89,7 +90,7 @@ lazy_static! {
     /// other mocked information including validator signatures.
     pub static ref GENESIS_INFO: (
         TransactionInfo,
-        LedgerInfoWithSignatures,
+        LedgerInfoWithSignatures<Ed25519Signature>,
         TransactionToCommit
     ) = gen_mock_genesis();
 }

--- a/storage/libradb/src/schema/ledger_info/mod.rs
+++ b/storage/libradb/src/schema/ledger_info/mod.rs
@@ -15,6 +15,7 @@
 use crate::schema::ensure_slice_len_eq;
 use byteorder::{BigEndian, ReadBytesExt};
 use failure::prelude::*;
+use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProtoBytes, IntoProtoBytes};
 use schemadb::{
     define_schema,
@@ -27,7 +28,7 @@ use types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 define_schema!(
     LedgerInfoSchema,
     Version,
-    LedgerInfoWithSignatures,
+    LedgerInfoWithSignatures<Ed25519Signature>,
     DEFAULT_CF_NAME
 );
 
@@ -42,7 +43,7 @@ impl KeyCodec<LedgerInfoSchema> for Version {
     }
 }
 
-impl ValueCodec<LedgerInfoSchema> for LedgerInfoWithSignatures {
+impl ValueCodec<LedgerInfoSchema> for LedgerInfoWithSignatures<Ed25519Signature> {
     fn encode_value(&self) -> Result<Vec<u8>> {
         self.clone().into_proto_bytes()
     }

--- a/storage/libradb/src/schema/ledger_info/test.rs
+++ b/storage/libradb/src/schema/ledger_info/test.rs
@@ -9,7 +9,7 @@ use types::ledger_info::LedgerInfoWithSignatures;
 proptest! {
     #[test]
     fn test_encode_decode(
-        ledger_info_with_sigs in any_with::<LedgerInfoWithSignatures>((1..10).into())
+        ledger_info_with_sigs in any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((1..10).into())
     ) {
         assert_encode_decode::<LedgerInfoSchema>(&0, &ledger_info_with_sigs);
     }

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -7,13 +7,19 @@ use super::*;
 use crate::mock_genesis::{db_with_mock_genesis, GENESIS_INFO};
 use crypto::hash::CryptoHash;
 use itertools::zip_eq;
+use nextgen_crypto::ed25519::*;
 use proptest::{collection::vec, prelude::*};
 use types::{ledger_info::LedgerInfo, proptest_types::arb_txn_to_commit_batch};
 
 fn to_blocks_to_commit(
     txns_to_commit_vec: Vec<Vec<TransactionToCommit>>,
-    partial_ledger_info_with_sigs_vec: Vec<LedgerInfoWithSignatures>,
-) -> Result<Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>> {
+    partial_ledger_info_with_sigs_vec: Vec<LedgerInfoWithSignatures<Ed25519Signature>>,
+) -> Result<
+    Vec<(
+        Vec<TransactionToCommit>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+    )>,
+> {
     // Use temporary LibraDB and STORE LEVEL APIs to calculate hashes on a per transaction basis.
     // Result is used to test the batch PUBLIC API for saving everything, i.e. `save_transactions()`
     let tmp_dir = tempfile::tempdir()?;
@@ -88,8 +94,12 @@ fn to_blocks_to_commit(
 ///
 /// It is used in tests for both transaction block committing during normal running and
 /// transaction syncing during start up.
-pub fn arb_blocks_to_commit(
-) -> impl Strategy<Value = Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>> {
+pub fn arb_blocks_to_commit() -> impl Strategy<
+    Value = Vec<(
+        Vec<TransactionToCommit>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+    )>,
+> {
     vec(0..3usize, 1..10usize)
         .prop_flat_map(|batch_sizes| {
             let total_txns = batch_sizes.iter().sum();
@@ -98,7 +108,7 @@ pub fn arb_blocks_to_commit(
                 Just(batch_sizes),
                 arb_txn_to_commit_batch(3, total_txns),
                 vec(
-                    any_with::<LedgerInfoWithSignatures>((1..3).into()),
+                    any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((1..3).into()),
                     total_batches,
                 ),
             )

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -17,6 +17,7 @@ canonical_serialization = { path = "../../common/canonical_serialization" }
 crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 metrics = { path = "../../common/metrics" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv" }
 scratchpad = { path = "../scratchpad" }
 state_view = { path = "../state_view" }

--- a/storage/storage_client/src/lib.rs
+++ b/storage/storage_client/src/lib.rs
@@ -15,6 +15,7 @@ use futures::{compat::Future01CompatExt, executor::block_on, prelude::*};
 use futures_01::future::Future as Future01;
 use grpcio::{ChannelBuilder, Environment};
 use metrics::counters::SVC_COUNTERS;
+use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProto, IntoProto};
 use protobuf::Message;
 use rand::Rng;
@@ -105,8 +106,8 @@ impl StorageRead for StorageReadServiceClient {
         requested_items: Vec<RequestItem>,
     ) -> Result<(
         Vec<ResponseItem>,
-        LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
     )> {
         block_on(self.update_to_latest_ledger_async(client_known_version, requested_items))
     }
@@ -120,8 +121,8 @@ impl StorageRead for StorageReadServiceClient {
             dyn Future<
                     Output = Result<(
                         Vec<ResponseItem>,
-                        LedgerInfoWithSignatures,
-                        Vec<ValidatorChangeEventWithProof>,
+                        LedgerInfoWithSignatures<Ed25519Signature>,
+                        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
                     )>,
                 > + Send,
         >,
@@ -248,7 +249,7 @@ impl StorageWrite for StorageWriteServiceClient {
         &self,
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
-        ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
+        ledger_info_with_sigs: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
     ) -> Result<()> {
         block_on(self.save_transactions_async(txns_to_commit, first_version, ledger_info_with_sigs))
     }
@@ -257,7 +258,7 @@ impl StorageWrite for StorageWriteServiceClient {
         &self,
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
-        ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
+        ledger_info_with_sigs: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         let req =
             SaveTransactionsRequest::new(txns_to_commit, first_version, ledger_info_with_sigs);
@@ -283,8 +284,8 @@ pub trait StorageRead: Send + Sync {
         request_items: Vec<RequestItem>,
     ) -> Result<(
         Vec<ResponseItem>,
-        LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
     )>;
 
     /// See [`LibraDB::update_to_latest_ledger`].
@@ -300,8 +301,8 @@ pub trait StorageRead: Send + Sync {
             dyn Future<
                     Output = Result<(
                         Vec<ResponseItem>,
-                        LedgerInfoWithSignatures,
-                        Vec<ValidatorChangeEventWithProof>,
+                        LedgerInfoWithSignatures<Ed25519Signature>,
+                        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
                     )>,
                 > + Send,
         >,
@@ -377,7 +378,7 @@ pub trait StorageWrite: Send + Sync {
         &self,
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
-        ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
+        ledger_info_with_sigs: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
     ) -> Result<()>;
 
     /// See [`LibraDB::save_transactions`].
@@ -387,7 +388,7 @@ pub trait StorageWrite: Send + Sync {
         &self,
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
-        ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
+        ledger_info_with_sigs: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 }
 

--- a/storage/storage_proto/Cargo.toml
+++ b/storage/storage_proto/Cargo.toml
@@ -15,6 +15,7 @@ protobuf = "~2.7"
 
 crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 types = { path = "../../types" }
 

--- a/storage/storage_proto/src/lib.rs
+++ b/storage/storage_proto/src/lib.rs
@@ -29,6 +29,7 @@ pub mod proto;
 
 use crypto::HashValue;
 use failure::prelude::*;
+use nextgen_crypto::ed25519::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
@@ -139,7 +140,7 @@ impl Into<(Option<AccountStateBlob>, SparseMerkleProof)>
 pub struct SaveTransactionsRequest {
     pub txns_to_commit: Vec<TransactionToCommit>,
     pub first_version: Version,
-    pub ledger_info_with_signatures: Option<LedgerInfoWithSignatures>,
+    pub ledger_info_with_signatures: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
 }
 
 impl SaveTransactionsRequest {
@@ -147,7 +148,7 @@ impl SaveTransactionsRequest {
     pub fn new(
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
-        ledger_info_with_signatures: Option<LedgerInfoWithSignatures>,
+        ledger_info_with_signatures: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
     ) -> Self {
         SaveTransactionsRequest {
             txns_to_commit,

--- a/storage/storage_service/Cargo.toml
+++ b/storage/storage_service/Cargo.toml
@@ -21,6 +21,7 @@ grpc_helpers = { path = "../../common/grpc_helpers" }
 libradb = { path = "../libradb" }
 logger = { path = "../../common/logger" }
 metrics = { path = "../../common/metrics" }
+nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 storage_client = { path = "../storage_client" }
 storage_proto = { path = "../storage_proto" }

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -7,6 +7,7 @@ use canonical_serialization::SimpleSerializer;
 use crypto::{signing::generate_keypair, HashValue};
 use failure::prelude::*;
 use futures::prelude::*;
+use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProto, IntoProto};
 use std::{collections::BTreeMap, pin::Pin};
 use storage_client::StorageRead;
@@ -48,8 +49,8 @@ impl StorageRead for MockStorageReadClient {
         request_items: Vec<RequestItem>,
     ) -> Result<(
         Vec<ResponseItem>,
-        LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        LedgerInfoWithSignatures<Ed25519Signature>,
+        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
     )> {
         let request = types::get_with_proof::UpdateToLatestLedgerRequest::new(
             client_known_version,
@@ -75,8 +76,8 @@ impl StorageRead for MockStorageReadClient {
             dyn Future<
                     Output = Result<(
                         Vec<ResponseItem>,
-                        LedgerInfoWithSignatures,
-                        Vec<ValidatorChangeEventWithProof>,
+                        LedgerInfoWithSignatures<Ed25519Signature>,
+                        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
                     )>,
                 > + Send,
         >,

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use crypto::hash::CryptoHash;
 use failure::prelude::*;
-use nextgen_crypto::ed25519::*;
+use nextgen_crypto::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
@@ -47,20 +47,50 @@ impl UpdateToLatestLedgerRequest {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
-#[ProtoType(crate::proto::get_with_proof::UpdateToLatestLedgerResponse)]
-pub struct UpdateToLatestLedgerResponse {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpdateToLatestLedgerResponse<Sig> {
     pub response_items: Vec<ResponseItem>,
-    pub ledger_info_with_sigs: LedgerInfoWithSignatures,
-    pub validator_change_events: Vec<ValidatorChangeEventWithProof>,
+    pub ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
+    pub validator_change_events: Vec<ValidatorChangeEventWithProof<Sig>>,
 }
 
-impl UpdateToLatestLedgerResponse {
+impl<Sig: Signature> IntoProto for UpdateToLatestLedgerResponse<Sig> {
+    type ProtoType = crate::proto::get_with_proof::UpdateToLatestLedgerResponse;
+
+    fn into_proto(self) -> Self::ProtoType {
+        let mut out = crate::proto::get_with_proof::UpdateToLatestLedgerResponse::new();
+        out.set_response_items(self.response_items.into_proto());
+        out.set_ledger_info_with_sigs(self.ledger_info_with_sigs.into_proto());
+        out.set_validator_change_events(self.validator_change_events.into_proto());
+        out
+    }
+}
+
+impl<Sig: Signature> FromProto for UpdateToLatestLedgerResponse<Sig> {
+    type ProtoType = crate::proto::get_with_proof::UpdateToLatestLedgerResponse;
+
+    fn from_proto(mut object: Self::ProtoType) -> failure::Result<Self> {
+        Ok(UpdateToLatestLedgerResponse {
+            response_items: <Vec<ResponseItem> as FromProto>::from_proto(
+                object.take_response_items(),
+            )?,
+            ledger_info_with_sigs: LedgerInfoWithSignatures::from_proto(
+                object.take_ledger_info_with_sigs(),
+            )?,
+            validator_change_events:
+                <Vec<ValidatorChangeEventWithProof<Sig>> as FromProto>::from_proto(
+                    object.take_validator_change_events(),
+                )?,
+        })
+    }
+}
+
+impl<Sig: Signature> UpdateToLatestLedgerResponse<Sig> {
     /// Constructor.
     pub fn new(
         response_items: Vec<ResponseItem>,
-        ledger_info_with_sigs: LedgerInfoWithSignatures,
-        validator_change_events: Vec<ValidatorChangeEventWithProof>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
+        validator_change_events: Vec<ValidatorChangeEventWithProof<Sig>>,
     ) -> Self {
         UpdateToLatestLedgerResponse {
             response_items,
@@ -76,7 +106,7 @@ impl UpdateToLatestLedgerResponse {
     /// verification.
     pub fn verify(
         &self,
-        validator_verifier: Arc<ValidatorVerifier<Ed25519PublicKey>>,
+        validator_verifier: Arc<ValidatorVerifier<Sig::VerifyingKeyMaterial>>,
         request: &UpdateToLatestLedgerRequest,
     ) -> Result<()> {
         verify_update_to_latest_ledger_response(
@@ -91,12 +121,12 @@ impl UpdateToLatestLedgerResponse {
 
 /// Verifies content of an [`UpdateToLatestLedgerResponse`] against the proofs it
 /// carries and the content of the corresponding [`UpdateToLatestLedgerRequest`]
-pub fn verify_update_to_latest_ledger_response(
-    validator_verifier: Arc<ValidatorVerifier<Ed25519PublicKey>>,
+pub fn verify_update_to_latest_ledger_response<Sig: Signature>(
+    validator_verifier: Arc<ValidatorVerifier<Sig::VerifyingKeyMaterial>>,
     req_client_known_version: u64,
     req_request_items: &[RequestItem],
     response_items: &[ResponseItem],
-    ledger_info_with_sigs: &LedgerInfoWithSignatures,
+    ledger_info_with_sigs: &LedgerInfoWithSignatures<Sig>,
 ) -> Result<()> {
     let (ledger_info, signatures) = (
         ledger_info_with_sigs.ledger_info(),

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -301,7 +301,7 @@ prop_compose! {
     }
 }
 
-impl Arbitrary for LedgerInfoWithSignatures {
+impl Arbitrary for LedgerInfoWithSignatures<Ed25519Signature> {
     type Parameters = SizeRange;
     type Strategy = BoxedStrategy<Self>;
 
@@ -327,15 +327,15 @@ impl Arbitrary for LedgerInfoWithSignatures {
 prop_compose! {
     fn arb_update_to_latest_ledger_response()(
         response_items in vec(any::<ResponseItem>(), 0..10),
-        ledger_info_with_sigs in any::<LedgerInfoWithSignatures>(),
-        validator_change_events in vec(any::<ValidatorChangeEventWithProof>(), 0..10),
-    ) -> UpdateToLatestLedgerResponse {
+        ledger_info_with_sigs in any::<LedgerInfoWithSignatures<Ed25519Signature>>(),
+        validator_change_events in vec(any::<ValidatorChangeEventWithProof<Ed25519Signature>>(), 0..10),
+    ) -> UpdateToLatestLedgerResponse<Ed25519Signature> {
         UpdateToLatestLedgerResponse::new(
             response_items, ledger_info_with_sigs, validator_change_events)
     }
 }
 
-impl Arbitrary for UpdateToLatestLedgerResponse {
+impl Arbitrary for UpdateToLatestLedgerResponse<Ed25519Signature> {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
 

--- a/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
+++ b/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     proto,
 };
+use nextgen_crypto::ed25519::*;
 use proptest::prelude::*;
 use proto_conv::{test_helper::assert_protobuf_encode_decode, FromProto};
 
@@ -34,7 +35,7 @@ proptest! {
 
     #[test]
     fn test_update_to_latest_ledger_response(
-        response in any::<UpdateToLatestLedgerResponse>()
+        response in any::<UpdateToLatestLedgerResponse<Ed25519Signature>>()
     ) {
         assert_protobuf_encode_decode(&response);
     }

--- a/types/src/unit_tests/ledger_info_proto_conversion_test.rs
+++ b/types/src/unit_tests/ledger_info_proto_conversion_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ledger_info::{LedgerInfo, LedgerInfoWithSignatures};
+use nextgen_crypto::ed25519::*;
 use proptest::prelude::*;
 use proto_conv::test_helper::assert_protobuf_encode_decode;
 
@@ -13,7 +14,7 @@ proptest! {
 
     #[test]
     fn test_ledger_info_with_signatures(
-        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures>((0..11).into())
+        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((0..11).into())
     ) {
         assert_protobuf_encode_decode(&ledger_info_with_signatures);
     }
@@ -25,7 +26,7 @@ proptest! {
     #[test]
     fn test_ledger_info_with_many_signatures(
         // 100 is the number we have in mind in real world, setting 200 to have a good chance of hitting it
-        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures>((0..200).into())
+        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((0..200).into())
     ) {
         assert_protobuf_encode_decode(&ledger_info_with_signatures);
     }

--- a/types/src/unit_tests/validator_change_proto_conversion_test.rs
+++ b/types/src/unit_tests/validator_change_proto_conversion_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::validator_change::ValidatorChangeEventWithProof;
+use nextgen_crypto::ed25519::*;
 use proptest::prelude::*;
 use proto_conv::test_helper::assert_protobuf_encode_decode;
 
@@ -10,7 +11,7 @@ proptest! {
 
     #[test]
     fn test_validator_change_event_with_proof_conversion(
-        change in any::<ValidatorChangeEventWithProof>()
+        change in any::<ValidatorChangeEventWithProof<Ed25519Signature>>()
     ) {
         assert_protobuf_encode_decode(&change);
     }

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -4,14 +4,62 @@
 #![allow(clippy::unit_arg)]
 
 use crate::{contract_event::EventWithProof, ledger_info::LedgerInfoWithSignatures};
-#[cfg(any(test, feature = "testing"))]
-use proptest_derive::Arbitrary;
+use nextgen_crypto::*;
 use proto_conv::{FromProto, IntoProto};
 
-#[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[ProtoType(crate::proto::validator_change::ValidatorChangeEventWithProof)]
-pub struct ValidatorChangeEventWithProof {
-    ledger_info_with_sigs: LedgerInfoWithSignatures,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidatorChangeEventWithProof<Sig> {
+    ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
     event_with_proof: EventWithProof,
+}
+
+impl<Sig: Signature> IntoProto for ValidatorChangeEventWithProof<Sig> {
+    type ProtoType = crate::proto::validator_change::ValidatorChangeEventWithProof;
+
+    fn into_proto(self) -> Self::ProtoType {
+        let mut out = crate::proto::validator_change::ValidatorChangeEventWithProof::new();
+        out.set_ledger_info_with_sigs(self.ledger_info_with_sigs.into_proto());
+        out.set_event_with_proof(self.event_with_proof.into_proto());
+        out
+    }
+}
+
+impl<Sig: Signature> FromProto for ValidatorChangeEventWithProof<Sig> {
+    type ProtoType = crate::proto::validator_change::ValidatorChangeEventWithProof;
+
+    fn from_proto(mut object: Self::ProtoType) -> failure::Result<Self> {
+        Ok(ValidatorChangeEventWithProof {
+            ledger_info_with_sigs: LedgerInfoWithSignatures::from_proto(
+                object.take_ledger_info_with_sigs(),
+            )?,
+            event_with_proof: EventWithProof::from_proto(object.take_event_with_proof())?,
+        })
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+use nextgen_crypto::ed25519::*;
+#[cfg(any(test, feature = "testing"))]
+use proptest::prelude::*;
+
+#[cfg(any(test, feature = "testing"))]
+prop_compose! {
+    fn arb_validator_change_event_with_proof()(
+        ledger_info_with_sigs in any::<LedgerInfoWithSignatures<Ed25519Signature>>(),
+        event_with_proof in any::<EventWithProof>(),
+    ) -> ValidatorChangeEventWithProof<Ed25519Signature> {
+        ValidatorChangeEventWithProof{
+            ledger_info_with_sigs, event_with_proof
+        }
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl Arbitrary for ValidatorChangeEventWithProof<Ed25519Signature> {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        arb_validator_change_event_with_proof().boxed()
+    }
 }


### PR DESCRIPTION
*This PR modifies the following behavior:*
- makes LedgerInfoWihSignatures parametric in the type of their signatures,
- only modifies types, and not actual behavior

*Why this is better:*
- necessary stepping stone in making consensus parametric in the type of signature used internally
  (aka crypto agility)

*Why this is worse:*
- people have to be aware of the used scheme (though nothing changes in how it's used)

*TODO*
- same change on consensus (WIP)

## Motivation

crypto agility
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Types-only change => covered in CI

