### PR TITLE
[Network] Fixed wrongly port assigned from old metrics port 14297 to new metrics port 9101

### DIFF
--- a/docker/bench/bench.Dockerfile
+++ b/docker/bench/bench.Dockerfile
@@ -27,7 +27,7 @@ COPY docker/bench/bench_init.sh /opt/libra/bin/
 RUN chmod +x /opt/libra/bin/bench_init.sh
 
 # Metrics
-EXPOSE 14297
+EXPOSE 9101
 
 # Define MINT_KEY, AC_HOST and AC_DEBUG environment variables when running
 ENTRYPOINT ["/opt/libra/bin/bench_init.sh"]

--- a/docker/bench/bench_init.sh
+++ b/docker/bench/bench_init.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 echo "$MINT_KEY" | base64 -d > /opt/libra/etc/mint.key
-/opt/libra/bin/ruben -a $AC_HOST -f /opt/libra/etc/mint.key --metrics_server_address "0.0.0.0:14297" $@
+
+/opt/libra/bin/ruben -a $AC_HOST -f /opt/libra/etc/mint.key --metrics_server_address "0.0.0.0:9101" $@


### PR DESCRIPTION
## Motivation

I'm currently following the docker for libra project and realized that bench docker was commit with older port number 14297 (metrics_server_port). 
Ref https://github.com/libra/libra/commit/283e17f5a687f003deb100674979598cec385a99
To avoid mistake in near future, I propose update port as the same.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes,

## Test Plan

Test Plan: Built docker images, ran locally. Deployed to my workspace.

## Related PRs
