### PR TITLE
[execution] fix time spend in storage to save txns chart

### DIFF
--- a/terraform/templates/dashboards/execution.json
+++ b/terraform/templates/dashboards/execution.json
@@ -307,7 +307,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(executor_duration_sum{op='storage_save_transactions_time_us'}[1m]) / irate(executor_duration_count{op='storage_save_transactions_time_us'}[1m])",
+          "expr": "irate(executor_duration_sum{op='storage_save_transactions_time_s'}[1m]) / irate(executor_duration_count{op='storage_save_transactions_time_s'}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -333,7 +333,7 @@
       },
       "yaxes": [
         {
-          "format": "µs",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -355,7 +355,7 @@
       }
     }
   ],
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {


### PR DESCRIPTION
Update the time spend in storage to save txns chart as the counter
`block_execute_time_us` has been updated to `block_execute_time_s`


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated on the dashboard and exported from there.


