### PR TITLE
Use `assert_eq` when possible

### DIFF
--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -75,7 +75,7 @@ where
             let mut hash = [0u8; SCRIPT_HASH_LENGTH];
             let decoded_hash =
                 hex::decode(s).expect("Unable to decode script hash from configuration file.");
-            assert!(decoded_hash.len() == SCRIPT_HASH_LENGTH);
+            assert_eq!(decoded_hash.len(), SCRIPT_HASH_LENGTH);
             hash.copy_from_slice(decoded_hash.as_slice());
             hash
         })

--- a/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/code_unit_tests.rs
+++ b/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/code_unit_tests.rs
@@ -8,14 +8,14 @@ use vm::{
 fn invalid_fallthrough_br_true() {
     let module = file_format::dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
     let errors = CodeUnitVerifier::verify(&module);
-    assert!(errors[0].err == VMStaticViolation::InvalidFallThrough);
+    assert_eq!(errors[0].err, VMStaticViolation::InvalidFallThrough);
 }
 
 #[test]
 fn invalid_fallthrough_br_false() {
     let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
     let errors = CodeUnitVerifier::verify(&module);
-    assert!(errors[0].err == VMStaticViolation::InvalidFallThrough);
+    assert_eq!(errors[0].err, VMStaticViolation::InvalidFallThrough);
 }
 
 // all non-branch instructions should trigger invalid fallthrough; just check one of them
@@ -23,7 +23,7 @@ fn invalid_fallthrough_br_false() {
 fn invalid_fallthrough_non_branch() {
     let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
     let errors = CodeUnitVerifier::verify(&module);
-    assert!(errors[0].err == VMStaticViolation::InvalidFallThrough);
+    assert_eq!(errors[0].err, VMStaticViolation::InvalidFallThrough);
 }
 
 #[test]

--- a/language/bytecode_verifier/src/control_flow_graph.rs
+++ b/language/bytecode_verifier/src/control_flow_graph.rs
@@ -188,7 +188,7 @@ impl ControlFlowGraph for VMControlFlowGraph {
             }
         }
 
-        assert!(entry == code.len() as CodeOffset);
+        assert_eq!(entry, code.len() as CodeOffset);
         cfg
     }
 }

--- a/language/compiler/ir_to_bytecode/src/compiler.rs
+++ b/language/compiler/ir_to_bytecode/src/compiler.rs
@@ -1084,14 +1084,14 @@ fn compile_module_impl<'a>(
     // Create an empty locals signature with index 0.
     // This is required by the current implementation of generics.
     let locals_empty_idx = compiler.make_locals_signature(&LocalsSignature(vec![]))?;
-    assert!(locals_empty_idx.0 == 0);
+    assert_eq!(locals_empty_idx.0, 0);
 
     // Create a module handle for the current module.
     // It is required this be first entry in the table.
     let addr_idx = compiler.make_address(&address)?;
     let name_idx = compiler.make_string(module.name.name_ref())?;
     let mh_idx = compiler.make_module_handle(addr_idx, name_idx)?;
-    assert!(mh_idx.0 == 0);
+    assert_eq!(mh_idx.0, 0);
 
     for import in &module.imports {
         compiler.import_module(
@@ -1172,14 +1172,14 @@ fn compile_program_impl(
     // Create an empty locals signature with index 0.
     // This is required by the current implementation of generics.
     let locals_empty_idx = compiler.make_locals_signature(&LocalsSignature(vec![]))?;
-    assert!(locals_empty_idx.0 == 0);
+    assert_eq!(locals_empty_idx.0, 0);
 
     // Create a module handle for the script.
     // It is required this be first entry in the table.
     let addr_idx = compiler.make_address(&address)?;
     let name_idx = compiler.make_string(SELF_MODULE_NAME)?;
     let mh_idx = compiler.make_module_handle(addr_idx, name_idx)?;
-    assert!(mh_idx.0 == 0);
+    assert_eq!(mh_idx.0, 0);
 
     for import in &program.script.imports {
         compiler.import_module(

--- a/language/compiler/src/unit_tests/cfg_tests.rs
+++ b/language/compiler/src/unit_tests/cfg_tests.rs
@@ -18,9 +18,9 @@ fn cfg_compile_script_ret() {
     let compiled_script = compiled_script_res.unwrap();
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     cfg.display();
-    assert!(cfg.blocks.len() == 1);
-    assert!(cfg.num_blocks() == 1);
-    assert!(cfg.reachable_from(0).len() == 1);
+    assert_eq!(cfg.blocks.len(), 1);
+    assert_eq!(cfg.num_blocks(), 1);
+    assert_eq!(cfg.reachable_from(0).len(), 1);
 }
 
 #[test]
@@ -43,9 +43,9 @@ fn cfg_compile_script_let() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 1);
-    assert!(cfg.num_blocks() == 1);
-    assert!(cfg.reachable_from(0).len() == 1);
+    assert_eq!(cfg.blocks.len(), 1);
+    assert_eq!(cfg.num_blocks(), 1);
+    assert_eq!(cfg.reachable_from(0).len(), 1);
 }
 
 #[test]
@@ -68,9 +68,9 @@ fn cfg_compile_if() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 3);
-    assert!(cfg.num_blocks() == 3);
-    assert!(cfg.reachable_from(0).len() == 3);
+    assert_eq!(cfg.blocks.len(), 3);
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(cfg.reachable_from(0).len(), 3);
 }
 
 #[test]
@@ -96,9 +96,9 @@ fn cfg_compile_if_else() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 4);
-    assert!(cfg.num_blocks() == 4);
-    assert!(cfg.reachable_from(0).len() == 4);
+    assert_eq!(cfg.blocks.len(), 4);
+    assert_eq!(cfg.num_blocks(), 4);
+    assert_eq!(cfg.reachable_from(0).len(), 4);
 }
 
 #[test]
@@ -122,9 +122,9 @@ fn cfg_compile_if_else_with_else_return() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 4);
-    assert!(cfg.num_blocks() == 4);
-    assert!(cfg.reachable_from(0).len() == 4);
+    assert_eq!(cfg.blocks.len(), 4);
+    assert_eq!(cfg.num_blocks(), 4);
+    assert_eq!(cfg.reachable_from(0).len(), 4);
 }
 
 #[test]
@@ -151,9 +151,9 @@ fn cfg_compile_nested_if() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 6);
-    assert!(cfg.num_blocks() == 6);
-    assert!(cfg.reachable_from(7).len() == 4);
+    assert_eq!(cfg.blocks.len(), 6);
+    assert_eq!(cfg.num_blocks(), 6);
+    assert_eq!(cfg.reachable_from(7).len(), 4);
 }
 
 #[test]
@@ -176,11 +176,11 @@ fn cfg_compile_if_else_with_if_return() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 3);
-    assert!(cfg.num_blocks() == 3);
-    assert!(cfg.reachable_from(0).len() == 3);
-    assert!(cfg.reachable_from(4).len() == 1);
-    assert!(cfg.reachable_from(5).len() == 1);
+    assert_eq!(cfg.blocks.len(), 3);
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(cfg.reachable_from(0).len(), 3);
+    assert_eq!(cfg.reachable_from(4).len(), 1);
+    assert_eq!(cfg.reachable_from(5).len(), 1);
 }
 
 #[test]
@@ -202,12 +202,12 @@ fn cfg_compile_if_else_with_two_returns() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 4);
-    assert!(cfg.num_blocks() == 4);
-    assert!(cfg.reachable_from(0).len() == 3);
-    assert!(cfg.reachable_from(4).len() == 1);
-    assert!(cfg.reachable_from(5).len() == 1);
-    assert!(cfg.reachable_from(6).len() == 1);
+    assert_eq!(cfg.blocks.len(), 4);
+    assert_eq!(cfg.num_blocks(), 4);
+    assert_eq!(cfg.reachable_from(0).len(), 3);
+    assert_eq!(cfg.reachable_from(4).len(), 1);
+    assert_eq!(cfg.reachable_from(5).len(), 1);
+    assert_eq!(cfg.reachable_from(6).len(), 1);
 }
 
 #[test]
@@ -231,9 +231,9 @@ fn cfg_compile_if_else_with_else_abort() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 4);
-    assert!(cfg.num_blocks() == 4);
-    assert!(cfg.reachable_from(0).len() == 4);
+    assert_eq!(cfg.blocks.len(), 4);
+    assert_eq!(cfg.num_blocks(), 4);
+    assert_eq!(cfg.reachable_from(0).len(), 4);
 }
 
 #[test]
@@ -256,11 +256,11 @@ fn cfg_compile_if_else_with_if_abort() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 3);
-    assert!(cfg.num_blocks() == 3);
-    assert!(cfg.reachable_from(0).len() == 3);
-    assert!(cfg.reachable_from(4).len() == 1);
-    assert!(cfg.reachable_from(6).len() == 1);
+    assert_eq!(cfg.blocks.len(), 3);
+    assert_eq!(cfg.num_blocks(), 3);
+    assert_eq!(cfg.reachable_from(0).len(), 3);
+    assert_eq!(cfg.reachable_from(4).len(), 1);
+    assert_eq!(cfg.reachable_from(6).len(), 1);
 }
 
 #[test]
@@ -282,10 +282,10 @@ fn cfg_compile_if_else_with_two_aborts() {
     let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
-    assert!(cfg.blocks.len() == 4);
-    assert!(cfg.num_blocks() == 4);
-    assert!(cfg.reachable_from(0).len() == 3);
-    assert!(cfg.reachable_from(4).len() == 1);
-    assert!(cfg.reachable_from(6).len() == 1);
-    assert!(cfg.reachable_from(8).len() == 1);
+    assert_eq!(cfg.blocks.len(), 4);
+    assert_eq!(cfg.num_blocks(), 4);
+    assert_eq!(cfg.reachable_from(0).len(), 3);
+    assert_eq!(cfg.reachable_from(4).len(), 1);
+    assert_eq!(cfg.reachable_from(6).len(), 1);
+    assert_eq!(cfg.reachable_from(8).len(), 1);
 }

--- a/language/compiler/src/unit_tests/expression_tests.rs
+++ b/language/compiler/src/unit_tests/expression_tests.rs
@@ -27,17 +27,17 @@ fn compile_script_expr_addition() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    assert!(compiled_script.main().code.max_stack_size == 2);
-    assert!(count_locals(&compiled_script) == 3);
-    assert!(compiled_script.main().code.code.len() == 9);
+    assert_eq!(compiled_script.main().code.max_stack_size, 2);
+    assert_eq!(count_locals(&compiled_script), 3);
+    assert_eq!(compiled_script.main().code.code.len(), 9);
     assert!(compiled_script.struct_handles().is_empty());
-    assert!(compiled_script.function_handles().len() == 1);
+    assert_eq!(compiled_script.function_handles().len(), 1);
     assert!(compiled_script.type_signatures().is_empty());
-    assert!(compiled_script.function_signatures().len() == 1); // method sig
-    assert!(compiled_script.locals_signatures().len() == 2); // local variables sig
-    assert!(compiled_script.module_handles().len() == 1); // the <SELF> module
-    assert!(compiled_script.string_pool().len() == 2); // the name of `main()` + the name of the "<SELF>" module
-    assert!(compiled_script.address_pool().len() == 1); // the empty address of <SELF> module
+    assert_eq!(compiled_script.function_signatures().len(), 1); // method sig
+    assert_eq!(compiled_script.locals_signatures().len(), 2); // local variables sig
+    assert_eq!(compiled_script.module_handles().len(), 1); // the <SELF> module
+    assert_eq!(compiled_script.string_pool().len(), 2); // the name of `main()` + the name of the "<SELF>" module
+    assert_eq!(compiled_script.address_pool().len(), 1); // the empty address of <SELF> module
 }
 
 #[test]
@@ -57,17 +57,17 @@ fn compile_script_expr_combined() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    assert!(compiled_script.main().code.max_stack_size == 3);
-    assert!(count_locals(&compiled_script) == 3);
-    assert!(compiled_script.main().code.code.len() == 13);
+    assert_eq!(compiled_script.main().code.max_stack_size, 3);
+    assert_eq!(count_locals(&compiled_script), 3);
+    assert_eq!(compiled_script.main().code.code.len(), 13);
     assert!(compiled_script.struct_handles().is_empty());
-    assert!(compiled_script.function_handles().len() == 1);
+    assert_eq!(compiled_script.function_handles().len(), 1);
     assert!(compiled_script.type_signatures().is_empty());
-    assert!(compiled_script.function_signatures().len() == 1); // method sig
-    assert!(compiled_script.locals_signatures().len() == 2); // local variables sig
-    assert!(compiled_script.module_handles().len() == 1); // the <SELF> module
-    assert!(compiled_script.string_pool().len() == 2); // the name of `main()` + the name of the "<SELF>" module
-    assert!(compiled_script.address_pool().len() == 1); // the empty address of <SELF> module
+    assert_eq!(compiled_script.function_signatures().len(), 1); // method sig
+    assert_eq!(compiled_script.locals_signatures().len(), 2); // local variables sig
+    assert_eq!(compiled_script.module_handles().len(), 1); // the <SELF> module
+    assert_eq!(compiled_script.string_pool().len(), 2); // the name of `main()` + the name of the "<SELF>" module
+    assert_eq!(compiled_script.address_pool().len(), 1); // the empty address of <SELF> module
 }
 
 #[test]
@@ -86,15 +86,15 @@ fn compile_script_borrow_local() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    assert!(count_locals(&compiled_script) == 2);
+    assert_eq!(count_locals(&compiled_script), 2);
     assert!(compiled_script.struct_handles().is_empty());
-    assert!(compiled_script.function_handles().len() == 1);
+    assert_eq!(compiled_script.function_handles().len(), 1);
     assert!(compiled_script.type_signatures().is_empty());
-    assert!(compiled_script.function_signatures().len() == 1); // method sig
-    assert!(compiled_script.locals_signatures().len() == 2); // local variables sig
-    assert!(compiled_script.module_handles().len() == 1); // the <SELF> module
-    assert!(compiled_script.string_pool().len() == 2); // the name of `main()` + the name of the "<SELF>" module
-    assert!(compiled_script.address_pool().len() == 1); // the empty address of <SELF> module
+    assert_eq!(compiled_script.function_signatures().len(), 1); // method sig
+    assert_eq!(compiled_script.locals_signatures().len(), 2); // local variables sig
+    assert_eq!(compiled_script.module_handles().len(), 1); // the <SELF> module
+    assert_eq!(compiled_script.string_pool().len(), 2); // the name of `main()` + the name of the "<SELF>" module
+    assert_eq!(compiled_script.address_pool().len(), 1); // the empty address of <SELF> module
 }
 
 #[test]
@@ -113,15 +113,15 @@ fn compile_script_borrow_local_mutable() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    assert!(count_locals(&compiled_script) == 2);
+    assert_eq!(count_locals(&compiled_script), 2);
     assert!(compiled_script.struct_handles().is_empty());
-    assert!(compiled_script.function_handles().len() == 1);
+    assert_eq!(compiled_script.function_handles().len(), 1);
     assert!(compiled_script.type_signatures().is_empty());
-    assert!(compiled_script.function_signatures().len() == 1); // method sig
-    assert!(compiled_script.locals_signatures().len() == 2); // local variables sig
-    assert!(compiled_script.module_handles().len() == 1); // the <SELF> module
-    assert!(compiled_script.string_pool().len() == 2); // the name of `main()` + the name of the "<SELF>" module
-    assert!(compiled_script.address_pool().len() == 1); // the empty address of <SELF> module
+    assert_eq!(compiled_script.function_signatures().len(), 1); // method sig
+    assert_eq!(compiled_script.locals_signatures().len(), 2); // local variables sig
+    assert_eq!(compiled_script.module_handles().len(), 1); // the <SELF> module
+    assert_eq!(compiled_script.string_pool().len(), 2); // the name of `main()` + the name of the "<SELF>" module
+    assert_eq!(compiled_script.address_pool().len(), 1); // the empty address of <SELF> module
 }
 
 #[test]
@@ -141,15 +141,15 @@ fn compile_script_borrow_reference() {
     );
     let compiled_script_res = compile_script_string_and_assert_error(&code, vec![]);
     let compiled_script = compiled_script_res.unwrap();
-    assert!(count_locals(&compiled_script) == 3);
+    assert_eq!(count_locals(&compiled_script), 3);
     assert!(compiled_script.struct_handles().is_empty());
-    assert!(compiled_script.function_handles().len() == 1);
+    assert_eq!(compiled_script.function_handles().len(), 1);
     assert!(compiled_script.type_signatures().is_empty());
-    assert!(compiled_script.function_signatures().len() == 1); // method sig
-    assert!(compiled_script.locals_signatures().len() == 2); // local variables sig
-    assert!(compiled_script.module_handles().len() == 1); // the <SELF> module
-    assert!(compiled_script.string_pool().len() == 2); // the name of `main()` + the name of the "<SELF>" module
-    assert!(compiled_script.address_pool().len() == 1); // the empty address of <SELF> module
+    assert_eq!(compiled_script.function_signatures().len(), 1); // method sig
+    assert_eq!(compiled_script.locals_signatures().len(), 2); // local variables sig
+    assert_eq!(compiled_script.module_handles().len(), 1); // the <SELF> module
+    assert_eq!(compiled_script.string_pool().len(), 2); // the name of `main()` + the name of the "<SELF>" module
+    assert_eq!(compiled_script.address_pool().len(), 1); // the empty address of <SELF> module
 }
 
 #[test]
@@ -181,7 +181,7 @@ module Test {
 }",
     );
     let compiled_module = compile_module_string(&code).unwrap();
-    assert!(compiled_module.struct_handles().len() == 1);
+    assert_eq!(compiled_module.struct_handles().len(), 1);
 }
 
 #[test]

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -151,7 +151,7 @@ fn run_transaction(
 fn run_serializer_round_trip(program: &CompiledProgram) -> Result<()> {
     let (script_blob, module_blobs) = serialize_program(program)?;
 
-    assert!(module_blobs.len() == program.modules.len());
+    assert_eq!(module_blobs.len(), program.modules.len());
 
     let script = CompiledScript::deserialize(&script_blob)?;
     if script != program.script {

--- a/language/functional_tests/src/tests/global_config_tests.rs
+++ b/language/functional_tests/src/tests/global_config_tests.rs
@@ -39,19 +39,19 @@ fn build_global_config_1() {
         //! account: bob, 2000, 10
     ").unwrap();
 
-    assert!(config.accounts.len() == 3);
+    assert_eq!(config.accounts.len(), 3);
     assert!(config.accounts.contains_key("default"));
     assert!(config.accounts.contains_key("alice"));
     let bob = config.accounts.get("bob").unwrap();
-    assert!(bob.balance() == 2000);
-    assert!(bob.sequence_number() == 10);
+    assert_eq!(bob.balance(), 2000);
+    assert_eq!(bob.sequence_number(), 10);
 }
 
 #[test]
 fn build_global_config_2() {
     let config = parse_and_build_config("").unwrap();
 
-    assert!(config.accounts.len() == 1);
+    assert_eq!(config.accounts.len(), 1);
     assert!(config.accounts.contains_key("default"));
 }
 
@@ -71,7 +71,7 @@ fn build_global_config_4() {
         //! account: default, 50,
     ").unwrap();
 
-    assert!(config.accounts.len() == 1);
+    assert_eq!(config.accounts.len(), 1);
     let default = config.accounts.get("default").unwrap();
-    assert!(default.balance() == 50);
+    assert_eq!(default.balance(), 50);
 }

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/dispatch.rs
@@ -87,7 +87,7 @@ fn tstruct(
     let native_struct = dispatch_native_struct(&id, function_name).unwrap();
     let idx = native_struct.expected_index;
     // TODO assert kinds match
-    assert!(args.len() == native_struct.expected_type_parameters.len());
+    assert_eq!(args.len(), native_struct.expected_type_parameters.len());
     SignatureToken::Struct(idx, args)
 }
 

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -390,7 +390,7 @@ where
         connection: TMuxer,
     ) {
         let peer_id = identity.peer_id();
-        assert!(self.own_peer_id != peer_id);
+        assert_ne!(self.own_peer_id, peer_id);
 
         let mut send_new_peer_notification = true;
 

--- a/network/src/protocols/peer_id_exchange.rs
+++ b/network/src/protocols/peer_id_exchange.rs
@@ -50,7 +50,7 @@ impl PeerIdExchange {
         // Now exchange your PeerIds
         let mut buf: Vec<u8> = self.0.into();
         let buf_len = buf.len();
-        assert!(buf_len == 32);
+        assert_eq!(buf_len, 32);
         let buf_len = buf_len as u8;
         buf.insert(0, buf_len);
 

--- a/storage/jellyfish_merkle/src/node_type/node_type_test.rs
+++ b/storage/jellyfish_merkle/src/node_type/node_type_test.rs
@@ -27,7 +27,7 @@ fn random_63nibbles_node_key() -> NodeKey {
 // Generate a pair of leaf node key and account key with a passed-in 63-nibble node key and the last
 // nibble to be appended.
 fn gen_leaf_keys(version: Version, nibble_path: &NibblePath, nibble: u8) -> (NodeKey, HashValue) {
-    assert!(nibble_path.num_nibbles() == 63);
+    assert_eq!(nibble_path.num_nibbles(), 63);
     let mut np = nibble_path.clone();
     np.push(nibble);
     let account_key = HashValue::from_slice(np.bytes()).unwrap();

--- a/storage/sparse_merkle/src/node_type/mod.rs
+++ b/storage/sparse_merkle/src/node_type/mod.rs
@@ -266,7 +266,7 @@ impl BranchNode {
             leaf_bitmap |= (v.1 as u16) << k;
         }
         // `leaf_bitmap` must be a subset of `child_bitmap`.
-        assert!(child_bitmap | leaf_bitmap == child_bitmap);
+        assert_eq!(child_bitmap | leaf_bitmap, child_bitmap);
         (child_bitmap, leaf_bitmap)
     }
 


### PR DESCRIPTION
##Motivation

We should prefer `assert_eq` when possible as it's more declarative and it allows for more detailed assertion failed messages.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

existing tests
