### PR TITLE
[network] Create RPC util library for unary_rpc

### DIFF
--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -84,6 +84,7 @@ use types::PeerId;
 use unsigned_varint::codec::UviBytes;
 
 pub mod error;
+pub mod utils;
 
 #[cfg(test)]
 mod test;

--- a/network/src/protocols/rpc/utils.rs
+++ b/network/src/protocols/rpc/utils.rs
@@ -1,0 +1,38 @@
+use crate::{
+    interface::NetworkRequest,
+    protocols::rpc::{error::RpcError, OutboundRpcRequest},
+    ProtocolId,
+};
+use futures::{channel::oneshot, SinkExt};
+use protobuf::Message;
+use std::time::Duration;
+use types::PeerId;
+
+/// Send a unary rpc request to remote peer `recipient`. Handles serialization and deserialization
+/// of the message types, assuming that the request and response both have the same message type.
+///
+/// TODO: specify error cases
+pub async fn unary_rpc<T: Message>(
+    mut inner: channel::Sender<NetworkRequest>,
+    recipient: PeerId,
+    protocol: ProtocolId,
+    req_msg: T,
+    timeout: Duration,
+) -> Result<T, RpcError> {
+    // serialize request
+    let req_data = req_msg.write_to_bytes()?.into();
+
+    // ask network to fulfill rpc request
+    let (res_tx, res_rx) = oneshot::channel();
+    let req = OutboundRpcRequest {
+        protocol,
+        data: req_data,
+        res_tx,
+        timeout,
+    };
+    inner.send(NetworkRequest::SendRpc(recipient, req)).await?;
+    // wait for response and deserialize
+    let res_data = res_rx.await??;
+    let res_msg = ::protobuf::parse_from_bytes(res_data.as_ref())?;
+    Ok(res_msg)
+}


### PR DESCRIPTION

## Motivation

Any client needing to implement RPC would end up re-implement this logic. So good to centralize in a `util` library.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes