### PR TITLE
[crypto] Support external transaction signer

### DIFF
--- a/client/libra_wallet/src/wallet_library.rs
+++ b/client/libra_wallet/src/wallet_library.rs
@@ -17,7 +17,7 @@ use crate::{
     key_factory::{ChildNumber, KeyFactory, Seed},
     mnemonic::Mnemonic,
 };
-use libra_crypto::hash::CryptoHash;
+pub use libra_crypto::hash::CryptoHash;
 use proto_conv::{FromProto, IntoProto};
 use protobuf::Message;
 use rand::{rngs::EntropyRng, Rng};

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -6,9 +6,17 @@
 //!
 //! Client (binary) is the CLI tool to interact with Libra validator.
 //! It supposes all public APIs.
-use nextgen_crypto::{ed25519::*, test_utils::KeyPair, traits::ValidKeyStringExt};
+pub use libra_wallet::wallet_library::CryptoHash;
+pub use nextgen_crypto::{ed25519::*, test_utils::KeyPair, traits::ValidKeyStringExt};
+pub use proto_conv::{FromProtoBytes, IntoProtoBytes};
 use serde::{Deserialize, Serialize};
-use types::account_address::AccountAddress;
+pub use types::{
+    account_address::AccountAddress,
+    transaction::{
+        Program, RawTransaction, RawTransactionBytes, TransactionArgument, TransactionPayload,
+    },
+};
+pub use vm_genesis;
 
 pub(crate) mod account_commands;
 /// Main instance of client holding corresponding information, e.g. account address.

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -24,3 +24,4 @@ libra_swarm = { path = "../libra_swarm", features = ["testing"]}
 logger = { path = "../common/logger" }
 config_builder = { path = "../config/config_builder" }
 tempfile = "3.1.0"
+nextgen_crypto = { path = "../crypto/nextgen_crypto" }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This enhancement separates the construction and the submission of a transfer transaction into 2 separate routines:

* `prepare_transfer_coins` - construct and return a transfer (unsigned) RawTransaction.
* `submit_signed_transaction` - construct and submit a signed transaction from an unsigned raw transaction, a signature, and the respective public key.

This is useful for plugging in an external transaction signer, e.g., a hardware wallet or a threshold signature scheme.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

### Signed CLA

Yes, Corporate CLA. Confirmed with Kostas and Eric.

## Test Plan

Added `test_external_transaction_signer` in testsuite/tests/libratest/smoke_test.rs. 

## Related PRs

https://github.com/libra/libra/pull/438
