### PR TITLE
[language/stdlib] remove kind annotations

### DIFF
--- a/language/stdlib/modules/libra_account.mvir
+++ b/language/stdlib/modules/libra_account.mvir
@@ -6,7 +6,7 @@ module LibraAccount {
     // Every Libra account has a LibraAccount.T resource
     resource T {
         // The coins stored in this account
-        balance: R#LibraCoin.T,
+        balance: LibraCoin.T,
         // The current authentication key.
         // This can be different than the key used to create the account
         authentication_key: bytearray,
@@ -51,8 +51,8 @@ module LibraAccount {
 
     // Creates a new LibraAccount.T
     // Invoked by the `create_account` builtin
-    make(auth_key: bytearray): R#Self.T {
-        let zero_balance: R#LibraCoin.T;
+    make(auth_key: bytearray): Self.T {
+        let zero_balance: LibraCoin.T;
         zero_balance = LibraCoin.zero();
         return T {
             balance: move(zero_balance),
@@ -65,13 +65,13 @@ module LibraAccount {
     }
 
     // Deposits the `to_deposit` coin into the `payee`'s account
-    public deposit(payee: address, to_deposit: R#LibraCoin.T) {
+    public deposit(payee: address, to_deposit: LibraCoin.T) {
         let deposit_value: u64;
-        let payee_account_ref: &mut R#Self.T;
+        let payee_account_ref: &mut Self.T;
         let sender: address;
-        let sender_account_ref: &mut R#Self.T;
-        let sent_event: V#Self.SentPaymentEvent;
-        let received_event: V#Self.ReceivedPaymentEvent;
+        let sender_account_ref: &mut Self.T;
+        let sent_event: Self.SentPaymentEvent;
+        let received_event: Self.ReceivedPaymentEvent;
 
         // Check that the `to_deposit` coin is non-zero
         deposit_value = LibraCoin.value(&to_deposit);
@@ -114,16 +114,16 @@ module LibraAccount {
     }
 
     // Helper to withdraw `amount` from the given `account` and return the resulting LibraCoin.T
-    withdraw_from_account(account: &mut R#Self.T, amount: u64): R#LibraCoin.T {
-        let to_withdraw: R#LibraCoin.T;
+    withdraw_from_account(account: &mut Self.T, amount: u64): LibraCoin.T {
+        let to_withdraw: LibraCoin.T;
 
         to_withdraw = LibraCoin.withdraw(&mut move(account).balance, copy(amount));
         return move(to_withdraw);
     }
 
     // Withdraw `amount` LibraCoin.T from the transaction sender's account
-    public withdraw_from_sender(amount: u64): R#LibraCoin.T {
-        let sender_account: &mut R#Self.T;
+    public withdraw_from_sender(amount: u64): LibraCoin.T {
+        let sender_account: &mut Self.T;
 
         sender_account = borrow_global<T>(get_txn_sender());
         if (*&copy(sender_account).delegated_withdrawal_capability) {
@@ -136,17 +136,17 @@ module LibraAccount {
     }
 
     // Withdraw `amount` LibraCoin.T from account under cap.account_address
-    public withdraw_with_capability(cap: &R#Self.WithdrawalCapability, amount: u64): R#LibraCoin.T {
-        let account: &mut R#Self.T;
+    public withdraw_with_capability(cap: &Self.WithdrawalCapability, amount: u64): LibraCoin.T {
+        let account: &mut Self.T;
 
         account = borrow_global<T>(*&move(cap).account_address);
         return Self.withdraw_from_account(move(account), move(amount));
     }
 
     // Return a unique capability granting permission to withdraw from the sender's account balance.
-    public extract_sender_withdrawal_capability(): R#Self.WithdrawalCapability {
+    public extract_sender_withdrawal_capability(): Self.WithdrawalCapability {
         let sender: address;
-        let sender_account: &mut R#Self.T;
+        let sender_account: &mut Self.T;
         let delegated_ref: &mut bool;
 
         sender = get_txn_sender();
@@ -162,9 +162,9 @@ module LibraAccount {
     }
 
     // Return the withdrawal capability to the account it originally came from
-    public restore_withdrawal_capability(cap: R#Self.WithdrawalCapability) {
+    public restore_withdrawal_capability(cap: Self.WithdrawalCapability) {
         let account_address: address;
-        let account: &mut R#Self.T;
+        let account: &mut Self.T;
 
         // Destroy the capability
         WithdrawalCapability { account_address } = move(cap);
@@ -181,7 +181,7 @@ module LibraAccount {
     // to the `payee` address
     // Creates the `payee` account if it does not exist
     public pay_from_sender(payee: address, amount: u64) {
-        let to_pay: R#LibraCoin.T;
+        let to_pay: LibraCoin.T;
         let payee_exists: bool;
         payee_exists = exists<T>(copy(payee));
         if (move(payee_exists)) {
@@ -197,7 +197,7 @@ module LibraAccount {
     // The new key will be used for signing future transactions
     public rotate_authentication_key(new_authentication_key: bytearray) {
         let sender: address;
-        let sender_account: &mut R#Self.T;
+        let sender_account: &mut Self.T;
         sender = get_txn_sender();
         sender_account = borrow_global<T>(move(sender));
         *(&mut move(sender_account).authentication_key) = move(new_authentication_key);
@@ -215,7 +215,7 @@ module LibraAccount {
     }
 
     // Helper to return u64 value of the `balance` field for given `account`
-    balance_for_account(account: &R#Self.T): u64 {
+    balance_for_account(account: &Self.T): u64 {
         let balance_value: u64;
         balance_value = LibraCoin.value(&move(account).balance);
         return move(balance_value);
@@ -223,8 +223,8 @@ module LibraAccount {
 
     // Return the current balance of the LibraCoin.T in LibraAccount.T at `addr`
     public balance(addr: address): u64 {
-        let payee_account: &mut R#Self.T;
-        let imm_payee_account: &R#Self.T;
+        let payee_account: &mut Self.T;
+        let imm_payee_account: &Self.T;
         let balance_amount: u64;
         payee_account = borrow_global<T>(move(addr));
         imm_payee_account = freeze(move(payee_account));
@@ -233,14 +233,14 @@ module LibraAccount {
     }
 
     // Helper to return the sequence number field for given `account`
-    sequence_number_for_account(account: &R#Self.T): u64 {
+    sequence_number_for_account(account: &Self.T): u64 {
         return *(&move(account).sequence_number);
     }
 
     // Return the current sequence number at `addr`
     public sequence_number(addr: address): u64 {
-        let account_ref: &mut R#Self.T;
-        let imm_ref: &R#Self.T;
+        let account_ref: &mut Self.T;
+        let imm_ref: &Self.T;
         let sequence_number_value: u64;
         account_ref = borrow_global<T>(move(addr));
         imm_ref = freeze(move(account_ref));
@@ -250,7 +250,7 @@ module LibraAccount {
 
     // Return true if the account at `addr` has delegated its withdrawal capability
     public delegated_withdrawal_capability(addr: address): bool {
-        let account_ref: &mut R#Self.T;
+        let account_ref: &mut Self.T;
 
         account_ref = borrow_global<T>(move(addr));
         return *&move(account_ref).delegated_withdrawal_capability;
@@ -271,8 +271,8 @@ module LibraAccount {
     prologue() {
         let transaction_sender: address;
         let transaction_sender_exists: bool;
-        let sender_account: &mut R#Self.T;
-        let imm_sender_account: &R#Self.T;
+        let sender_account: &mut Self.T;
+        let imm_sender_account: &Self.T;
         let sender_public_key: bytearray;
         let public_key_hash: bytearray;
         let gas_price: u64;
@@ -317,14 +317,14 @@ module LibraAccount {
     // It collects gas and bumps the sequence number
     epilogue() {
         let transaction_sender: address;
-        let sender_account: &mut R#Self.T;
-        let imm_sender_account: &R#Self.T;
+        let sender_account: &mut Self.T;
+        let imm_sender_account: &Self.T;
         let gas_price: u64;
         let gas_units_remaining: u64;
         let starting_gas_units: u64;
         let gas_fee_amount: u64;
         let balance_amount: u64;
-        let gas_fee: R#LibraCoin.T;
+        let gas_fee: LibraCoin.T;
         let transaction_sequence_number_value: u64;
 
         transaction_sender = get_txn_sender();

--- a/language/stdlib/modules/libra_coin.mvir
+++ b/language/stdlib/modules/libra_coin.mvir
@@ -17,9 +17,9 @@ module LibraCoin {
     // sender does not have a MintCapability.
     // Since only the Association account has a mint capability, this will only succeed if it is
     // invoked by a transaction sent by that account.
-    public mint_with_default_capability(amount: u64): R#Self.T {
-        let capability_ref: &mut R#Self.MintCapability;
-        let capability_immut_ref: &R#Self.MintCapability;
+    public mint_with_default_capability(amount: u64): Self.T {
+        let capability_ref: &mut Self.MintCapability;
+        let capability_immut_ref: &Self.MintCapability;
 
         capability_ref = borrow_global<MintCapability>(get_txn_sender());
         capability_immut_ref = freeze(move(capability_ref));
@@ -29,8 +29,8 @@ module LibraCoin {
     // Mint a new LibraCoin.T worth `value`. The caller must have a reference to a MintCapability.
     // Only the Association account can acquire such a reference, and it can do so only via
     // `borrow_sender_mint_capability`
-    public mint(value: u64, capability: &R#Self.MintCapability): R#Self.T {
-        let market_cap_ref: &mut R#Self.MarketCap;
+    public mint(value: u64, capability: &Self.MintCapability): Self.T {
+        let market_cap_ref: &mut Self.MarketCap;
         let market_cap_total_value: u64;
 
         release(move(capability));
@@ -50,9 +50,9 @@ module LibraCoin {
 
     // Temporary procedure that is called to burn off the collected gas fee
     // In the future this will be replaced by the actual mechanism for collecting gas
-    public TODO_REMOVE_burn_gas_fee(coin: R#Self.T) {
+    public TODO_REMOVE_burn_gas_fee(coin: Self.T) {
         let value: u64;
-        let market_cap_ref: &mut R#Self.MarketCap;
+        let market_cap_ref: &mut Self.MarketCap;
         let market_cap_total_value: u64;
 
         // destroy the coin
@@ -80,26 +80,26 @@ module LibraCoin {
 
     // Return the total value of all Libra in the system
     public market_cap(): u64 {
-        let market_cap_ref: &mut R#Self.MarketCap;
+        let market_cap_ref: &mut Self.MarketCap;
 
         market_cap_ref = borrow_global<MarketCap>(0xA550C18);
         return *&move(market_cap_ref).total_value;
     }
 
     // Create a new LibraCoin.T with a value of 0
-    public zero(): R#Self.T {
+    public zero(): Self.T {
         return T{value: 0};
     }
 
     // Public accessor for the value of a coin
-    public value(coin_ref: &R#Self.T): u64 {
+    public value(coin_ref: &Self.T): u64 {
         return *&move(coin_ref).value;
     }
 
     // Splits the given coin into two and returns them both
     // It leverages `Self.withdraw` for any verifications of the values
-    public split(coin: R#Self.T, amount: u64): R#Self.T * R#Self.T {
-        let other: R#Self.T;
+    public split(coin: Self.T, amount: u64): Self.T * Self.T {
+        let other: Self.T;
         other = Self.withdraw(&mut coin, move(amount));
         return move(coin), move(other);
     }
@@ -108,7 +108,7 @@ module LibraCoin {
     // The original coin will have value = original value - `amount`
     // The new coin will have a value = `amount`
     // Fails if the coins value is less than `amount`
-    public withdraw(coin_ref: &mut R#Self.T, amount: u64): R#Self.T {
+    public withdraw(coin_ref: &mut Self.T, amount: u64): Self.T {
         let value: u64;
 
         // Check that `amount` is less than the coin's value
@@ -121,7 +121,7 @@ module LibraCoin {
     }
 
     // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
-    public join(coin1: R#Self.T, coin2: R#Self.T): R#Self.T  {
+    public join(coin1: Self.T, coin2: Self.T): Self.T  {
         Self.deposit(&mut coin1, move(coin2));
         return move(coin1);
     }
@@ -129,7 +129,7 @@ module LibraCoin {
     // "Merges" the two coins
     // The coin passed in by reference will have a value equal to the sum of the two coins
     // The `check` coin is consumed in the process
-    public deposit(coin_ref: &mut R#Self.T, check: R#Self.T) {
+    public deposit(coin_ref: &mut Self.T, check: Self.T) {
         let value: u64;
         let check_value: u64;
 
@@ -143,7 +143,7 @@ module LibraCoin {
     // Fails if the value is non-zero
     // The amount of LibraCoin.T in the system is a tightly controlled property,
     // so you cannot "burn" any non-zero amount of LibraCoin.T
-    public destroy_zero(coin: R#Self.T) {
+    public destroy_zero(coin: Self.T) {
         let value: u64;
         T { value } = move(coin);
         assert(move(value) == 0, 11);

--- a/language/stdlib/modules/validator_set.mvir
+++ b/language/stdlib/modules/validator_set.mvir
@@ -6,16 +6,16 @@ module ValidatorSet {
         // TODO: Replace this with generic array once Move supports generic collections.
         array_size: u64,
         // Pubkey list. Since we don't have array for now, use hard coded fields instead.
-        key0: V#Self.ValidatorPublicKeys,
-        key1: V#Self.ValidatorPublicKeys,
-        key2: V#Self.ValidatorPublicKeys,
-        key3: V#Self.ValidatorPublicKeys,
-        key4: V#Self.ValidatorPublicKeys,
-        key5: V#Self.ValidatorPublicKeys,
-        key6: V#Self.ValidatorPublicKeys,
-        key7: V#Self.ValidatorPublicKeys,
-        key8: V#Self.ValidatorPublicKeys,
-        key9: V#Self.ValidatorPublicKeys,
+        key0: Self.ValidatorPublicKeys,
+        key1: Self.ValidatorPublicKeys,
+        key2: Self.ValidatorPublicKeys,
+        key3: Self.ValidatorPublicKeys,
+        key4: Self.ValidatorPublicKeys,
+        key5: Self.ValidatorPublicKeys,
+        key6: Self.ValidatorPublicKeys,
+        key7: Self.ValidatorPublicKeys,
+        key8: Self.ValidatorPublicKeys,
+        key9: Self.ValidatorPublicKeys,
     }
 
     struct ValidatorPublicKeys {
@@ -27,18 +27,18 @@ module ValidatorSet {
 
     publish_validator_set(
         size: u64,
-        key0: V#Self.ValidatorPublicKeys,
-        key1: V#Self.ValidatorPublicKeys,
-        key2: V#Self.ValidatorPublicKeys,
-        key3: V#Self.ValidatorPublicKeys,
-        key4: V#Self.ValidatorPublicKeys,
-        key5: V#Self.ValidatorPublicKeys,
-        key6: V#Self.ValidatorPublicKeys,
-        key7: V#Self.ValidatorPublicKeys,
-        key8: V#Self.ValidatorPublicKeys,
-        key9: V#Self.ValidatorPublicKeys
+        key0: Self.ValidatorPublicKeys,
+        key1: Self.ValidatorPublicKeys,
+        key2: Self.ValidatorPublicKeys,
+        key3: Self.ValidatorPublicKeys,
+        key4: Self.ValidatorPublicKeys,
+        key5: Self.ValidatorPublicKeys,
+        key6: Self.ValidatorPublicKeys,
+        key7: Self.ValidatorPublicKeys,
+        key8: Self.ValidatorPublicKeys,
+        key9: Self.ValidatorPublicKeys
     ) {
-        let set: R#Self.T;
+        let set: Self.T;
         // We only support at most 10 validator keys for now. Will get rid of of that
         assert(copy(size) <= 10, 42);
         set = T {
@@ -63,8 +63,8 @@ module ValidatorSet {
         consensus_public_key: bytearray,
         network_signing_public_key: bytearray,
         network_identity_public_key: bytearray
-    ): V#Self.ValidatorPublicKeys {
-        let key: V#Self.ValidatorPublicKeys;
+    ): Self.ValidatorPublicKeys {
+        let key: Self.ValidatorPublicKeys;
         key = ValidatorPublicKeys {
             account_address: move(account_address),
             consensus_public_key: move(consensus_public_key),

--- a/language/stdlib/modules/vector.mvir
+++ b/language/stdlib/modules/vector.mvir
@@ -4,9 +4,9 @@ module Vector {
 
   native struct T;
 
-  native public length(v: &R#Self.T): u64;
+  native public length(v: &Self.T): u64;
 
-  public is_empty(v: &R#Self.T): bool {
+  public is_empty(v: &Self.T): bool {
     return Self.length(move(v)) == 0;
   }
 


### PR DESCRIPTION
## Summary
Followup of #472. This removes the kind annotations in stdlib modules.

## Test Plan
cargo test