### PR TITLE
[network][state sync] Integrate state sync sender and event stream into network builder

### DIFF
--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -91,7 +91,7 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
     .collect();
 
     // Set up the listener network
-    let ((_, _), (_listener_sender, mut listener_events), listen_addr) =
+    let ((_, _), (_listener_sender, mut listener_events), _, listen_addr) =
         NetworkBuilder::new(runtime.executor(), listener_peer_id, listener_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
@@ -107,7 +107,7 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
             .build();
 
     // Set up the dialer network
-    let ((_, _), (mut dialer_sender, mut dialer_events), _) =
+    let ((_, _), (mut dialer_sender, mut dialer_events), _, _dialer_addr) =
         NetworkBuilder::new(runtime.executor(), dialer_peer_id, dialer_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
@@ -218,7 +218,7 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
     .collect();
 
     // Set up the listener network
-    let ((_, _), (_listener_sender, mut listener_events), listen_addr) =
+    let ((_, _), (_listener_sender, mut listener_events), _, listen_addr) =
         NetworkBuilder::new(runtime.executor(), listener_peer_id, listener_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
@@ -230,7 +230,7 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
             .build();
 
     // Set up the dialer network
-    let ((_, _), (dialer_sender, mut dialer_events), _) =
+    let ((_, _), (dialer_sender, mut dialer_events), _, _dialer_addr) =
         NetworkBuilder::new(runtime.executor(), dialer_peer_id, dialer_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -67,6 +67,9 @@ lazy_static::lazy_static! {
     /// Counter of pending network events to Consensus
     pub static ref PENDING_CONSENSUS_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_consensus_network_events");
 
+    /// Counter of pending network events to Consensus
+    pub static ref PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_state_sync_network_events");
+
     /// Counter of pending requests in Peer Manager
     pub static ref PENDING_PEER_MANAGER_REQUESTS: IntGauge = OP_COUNTERS.gauge("pending_peer_manager_requests");
 

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -40,6 +40,7 @@ fn test_network_builder() {
     let (
         (_mempool_network_sender, _mempool_network_events),
         (_consensus_network_sender, _consensus_network_events),
+        (_state_sync_network_sender, _state_sync_network_events),
         _listen_addr,
     ) = NetworkBuilder::new(runtime.executor(), peer_id, addr)
         .transport(TransportType::Memory)
@@ -110,7 +111,7 @@ fn test_mempool_sync() {
     .into_iter()
     .collect();
 
-    let ((_, mut listener_mp_net_events), _, listener_addr) =
+    let ((_, mut listener_mp_net_events), _, _, listener_addr) =
         NetworkBuilder::new(runtime.executor(), listener_peer_id, listener_addr)
             .signing_keys((listener_signing_private_key, listener_signing_public_key))
             .identity_keys((listener_identity_private_key, listener_identity_public_key))
@@ -124,7 +125,7 @@ fn test_mempool_sync() {
     // Set up the dialer network
     let dialer_addr: Multiaddr = "/memory/0".parse().unwrap();
 
-    let ((mut dialer_mp_net_sender, mut dialer_mp_net_events), _, _dialer_addr) =
+    let ((mut dialer_mp_net_sender, mut dialer_mp_net_events), _, _, _dialer_addr) =
         NetworkBuilder::new(runtime.executor(), dialer_peer_id, dialer_addr)
             .transport(TransportType::Memory)
             .signing_keys((dialer_signing_private_key, dialer_signing_public_key))
@@ -234,7 +235,7 @@ fn test_consensus_rpc() {
     .into_iter()
     .collect();
 
-    let (_, (_, mut listener_con_net_events), listener_addr) =
+    let (_, (_, mut listener_con_net_events), _, listener_addr) =
         NetworkBuilder::new(runtime.executor(), listener_peer_id, listener_addr)
             .signing_keys((listener_signing_private_key, listener_signing_public_key))
             .identity_keys((listener_identity_private_key, listener_identity_public_key))
@@ -248,7 +249,7 @@ fn test_consensus_rpc() {
     // Set up the dialer network
     let dialer_addr: Multiaddr = "/memory/0".parse().unwrap();
 
-    let (_, (mut dialer_con_net_sender, mut dialer_con_net_events), _dialer_addr) =
+    let (_, (mut dialer_con_net_sender, mut dialer_con_net_events), _, _dialer_addr) =
         NetworkBuilder::new(runtime.executor(), dialer_peer_id, dialer_addr)
             .transport(TransportType::Memory)
             .signing_keys((dialer_signing_private_key, dialer_signing_public_key))

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -146,7 +146,7 @@ impl SynchronizerEnv {
         .into_iter()
         .collect();
 
-        let (_, (sender_b, mut events_b), listener_addr) =
+        let (_, (sender_b, mut events_b), _, listener_addr) =
             NetworkBuilder::new(runtime.executor(), peers[1], addr.clone())
                 .signing_keys((b_signing_private_key, b_signing_public_key))
                 .identity_keys((b_identity_private_key, b_identity_public_key))


### PR DESCRIPTION
## Details
Dedicated network sender and network event stream for State Synchronizer will allow splitting State Synchronizer from Consensus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Related PRs
#512