### PR TITLE
[cluster_test] Reboot multiple validators

### DIFF
--- a/testsuite/cluster_test/src/experiments/mod.rs
+++ b/testsuite/cluster_test/src/experiments/mod.rs
@@ -1,6 +1,6 @@
 mod reboot_random_validator;
 
-pub use reboot_random_validator::RebootRandomValidator;
+pub use reboot_random_validator::RebootRandomValidators;
 use std::{collections::HashSet, fmt::Display};
 
 pub trait Experiment: Display {

--- a/testsuite/cluster_test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster_test/src/experiments/reboot_random_validator.rs
@@ -5,39 +5,63 @@ use crate::{
     instance::Instance,
 };
 use failure;
+use rand::Rng;
 use std::{collections::HashSet, fmt, thread, time::Duration};
 
-pub struct RebootRandomValidator {
-    instance: Instance,
+pub struct RebootRandomValidators {
+    instances: Vec<Instance>,
 }
 
-impl RebootRandomValidator {
-    pub fn new(cluster: &Cluster) -> Self {
-        Self {
-            instance: cluster.random_instance(),
+impl RebootRandomValidators {
+    pub fn new(count: usize, cluster: &Cluster) -> Self {
+        if count > cluster.instances().len() {
+            panic!(
+                "Can not reboot {} validators in cluster with {} instances",
+                count,
+                cluster.instances().len()
+            );
         }
+        let mut instances = Vec::with_capacity(count);
+        let mut all_instances = cluster.instances().clone();
+        let mut rnd = rand::thread_rng();
+        for _i in 0..count {
+            let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));
+            instances.push(instance);
+        }
+
+        Self { instances }
     }
 }
 
-impl Experiment for RebootRandomValidator {
+impl Experiment for RebootRandomValidators {
     fn affected_validators(&self) -> HashSet<String> {
         let mut r = HashSet::new();
-        r.insert(self.instance.short_hash().clone());
+        for instance in self.instances.iter() {
+            r.insert(instance.short_hash().clone());
+        }
         r
     }
 
     fn run(&self) -> failure::Result<()> {
-        let reboot = Reboot::new(self.instance.clone());
-        reboot.apply()?;
-        while !reboot.is_complete() {
+        let mut reboots = vec![];
+        for instance in self.instances.iter() {
+            let reboot = Reboot::new(instance.clone());
+            reboot.apply()?;
+            reboots.push(reboot)
+        }
+        while reboots.iter().any(|r| !r.is_complete()) {
             thread::sleep(Duration::from_secs(5));
         }
         Ok(())
     }
 }
 
-impl fmt::Display for RebootRandomValidator {
+impl fmt::Display for RebootRandomValidators {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Reboot {}", self.instance)
+        write!(f, "Reboot [")?;
+        for instance in self.instances.iter() {
+            write!(f, "{}, ", instance)?;
+        }
+        write!(f, "]")
     }
 }

--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -2,7 +2,7 @@ use clap::{App, Arg, ArgGroup, ArgMatches};
 use cluster_test::{
     aws::Aws,
     cluster::Cluster,
-    experiments::{Experiment, RebootRandomValidator},
+    experiments::{Experiment, RebootRandomValidators},
     health::{AwsLogTail, HealthCheckRunner},
 };
 use std::{
@@ -14,7 +14,7 @@ use std::{
 };
 use termion::{color, style};
 
-const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 pub fn main() {
     let matches = arg_matches();
@@ -81,7 +81,7 @@ impl ClusterTestRunner {
             panic!("Some validators are unhealthy before experiment started");
         }
 
-        let experiment = RebootRandomValidator::new(&self.cluster);
+        let experiment = RebootRandomValidators::new(3, &self.cluster);
         println!(
             "{}Starting experiment {}{}{}{}",
             style::Bold,


### PR DESCRIPTION
Rename RebootRandomValidator -> RebootRandomValidators and support simultaneous multiple validators reboot as experiment.

This PR also contains retry for rare kinesis failures(as separate commit)