### PR TITLE
[docker][tiny] Remove unused debug interface option from benchmark script

### DIFF
--- a/docker/bench/bench_init.sh
+++ b/docker/bench/bench_init.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "$MINT_KEY" | base64 -d > /opt/libra/etc/mint.key
-/opt/libra/bin/ruben -a $AC_HOST -f /opt/libra/etc/mint.key -d $AC_DEBUG --metrics_server_address "0.0.0.0:14297" $@
+/opt/libra/bin/ruben -a $AC_HOST -f /opt/libra/etc/mint.key --metrics_server_address "0.0.0.0:14297" $@


### PR DESCRIPTION
## Motivation
Remove unused option in benchmark image entry script.
This option was required, but got removed from code and left as optional argument to make sure deployment scripts do not break after the code is committed.
Now it's time to cleanup.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
None. This argument is unused, and stayed there for flexibility in updating deploy scripts and code.

