### PR TITLE
[storage] add back one missing line in event_store

### DIFF
--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -114,6 +114,7 @@ impl EventStore {
                 // Queries tend to base on very recent ledger infos, so first try to linear search
                 // from the most recent end, for limited tries.
                 // TODO: Optimize: Physical store use reverse order.
+                let mut n_try_recent = 10;
                 #[cfg(any(test, feature = "testing"))]
                 let mut n_try_recent = 1;
                 while seq > 0 && n_try_recent > 0 {


### PR DESCRIPTION
## Motivation

#532 removed this line and consensus tests are broken.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo test -p consensus

## Related PRs

#532 
