### PR TITLE
[Consensus][small] Fix `wait_before_vote` function

### DIFF
--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -142,11 +142,13 @@ pub enum WaitingSuccess {
 }
 
 /// Error states for wait_if_possible
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Fail)]
 pub enum WaitingError {
     /// The waiting period exceeds the maximum allowed duration, returning immediately
+    #[fail(display = "MaxWaitExceeded")]
     MaxWaitExceeded,
     /// Waiting to ensure the current time exceeds min_duration_since_epoch failed
+    #[fail(display = "WaitFailed")]
     WaitFailed {
         current_duration_since_epoch: Duration,
         wait_duration: Duration,


### PR DESCRIPTION
Summary:
In one of the recent changes I accidentally dropped the check on whether the wait before vote has succeeded (happens in case a block timestamp is slightly ahead of validator's local clock).
Fixing it in this PR.

Tests: consensus existing unit tests