### PR TITLE
[storage] assert the validity of an internal node at the creation

### DIFF
--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -233,7 +233,7 @@ where
     /// `internal_node`. Returns the newly inserted node with its [`NodeKey`].
     fn insert_at_internal_node(
         mut node_key: NodeKey,
-        mut internal_node: InternalNode,
+        internal_node: InternalNode,
         version: Version,
         nibble_iter: &mut NibbleIterator,
         blob: AccountStateBlob,
@@ -260,16 +260,18 @@ where
         };
 
         // Reuse the current `InternalNode` in memory to create a new internal node.
-        internal_node.set_child(
+        let mut children: Children = internal_node.into();
+        children.insert(
             child_index,
             Child::new(new_child_node.hash(), version, new_child_node.is_leaf()),
         );
+        let new_internal_node = InternalNode::new(children);
 
         node_key.set_version(version);
 
         // Cache this new internal node.
-        tree_cache.put_node(node_key.clone(), internal_node.clone().into())?;
-        Ok((node_key, internal_node.into()))
+        tree_cache.put_node(node_key.clone(), new_internal_node.clone().into())?;
+        Ok((node_key, new_internal_node.into()))
     }
 
     /// Helper function for recursive insertion into the subtree that starts from the

--- a/storage/jellyfish_merkle/src/node_type/mod.rs
+++ b/storage/jellyfish_merkle/src/node_type/mod.rs
@@ -256,6 +256,12 @@ impl From<InternalNode> for Node {
     }
 }
 
+impl From<InternalNode> for Children {
+    fn from(node: InternalNode) -> Self {
+        node.children
+    }
+}
+
 impl From<LeafNode> for Node {
     fn from(node: LeafNode) -> Self {
         Node::Leaf(node)
@@ -265,12 +271,19 @@ impl From<LeafNode> for Node {
 impl InternalNode {
     /// Creates a new Internal node.
     pub fn new(children: Children) -> Self {
+        // Assert the internal node must have >= 1 children. If it only has one chlid, it cannot be
+        // a leaf node. Otherwise the leaf node should be a child of this internal node's parent.
+        assert!(!children.is_empty());
+        if children.len() == 1 {
+            assert!(
+                !children
+                    .values()
+                    .next()
+                    .expect("Must have 1 element")
+                    .is_leaf
+            )
+        }
         Self { children }
-    }
-
-    /// Sets the `n`-th child.
-    pub fn set_child(&mut self, n: Nibble, child: Child) {
-        self.children.insert(n, child);
     }
 
     /// Gets the `n`-th child.


### PR DESCRIPTION
## Motivation

An internal node can only be valid if it has:
1. 1 child, must be non-leaf
2. 2+ children, any type

We enforce this rule in this PR to prevent any bug in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Cargo test

## Related PRs

