### PR TITLE
[VM] Audit potential vector overflows

### DIFF
--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -14,6 +14,7 @@ proptest = "0.9"
 rayon = "1.1"
 rental = "0.5.4"
 tiny-keccak = "1.5.0"
+mirai-annotations = "1.2.2"
 
 bytecode_verifier = { path = "../../bytecode_verifier" }
 canonical_serialization = { path = "../../../common/canonical_serialization" }
@@ -45,3 +46,4 @@ vm = { path = "../", features = ["testing"]}
 default = []
 instruction_synthesis = []
 testing = ["types/testing"]
+mirai-contracts = []

--- a/language/vm/vm_runtime/src/block_processor.rs
+++ b/language/vm/vm_runtime/src/block_processor.rs
@@ -84,6 +84,10 @@ pub fn execute_block<'alloc>(
         };
         report_execution_status(output.status());
         data_cache.push_write_set(&output.write_set());
+
+        // `result` is initally empty, a single element is pushed per loop iteration and
+        // the number of iterations is bound to the max size of `signature_verified_block`
+        assume!(result.len() < usize::max_value());
         result.push(output);
     }
     trace!("[VM] Execute block finished");

--- a/language/vm/vm_runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm_runtime/src/code_cache/module_cache.rs
@@ -294,6 +294,7 @@ impl<'alloc> VMModuleCache<'alloc> {
                     fields,
                 } => {
                     let mut field_types = vec![];
+
                     for field in module.field_def_range(*field_count, *fields) {
                         let ty = try_runtime!(self.resolve_signature_token_with_fetcher(
                             module,
@@ -302,6 +303,11 @@ impl<'alloc> VMModuleCache<'alloc> {
                             fetcher
                         ));
                         if let Some(t) = ty {
+                            // `field_types` is initally empty, a single element is pushed per loop
+                            // iteration and the number of iterations is bound to the max size of
+                            // `module.field_def_range()`
+                            // MIRAI cannot currently check this bound in terms of `field_count`.
+                            assume!(field_types.len() < usize::max_value());
                             field_types.push(t);
                         } else {
                             return Ok(Ok(None));

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -104,6 +104,8 @@ extern crate vm;
 extern crate lazy_static;
 #[macro_use]
 extern crate rental;
+#[macro_use]
+extern crate mirai_annotations;
 
 mod block_processor;
 mod counters;

--- a/language/vm/vm_runtime/src/process_txn/execute.rs
+++ b/language/vm/vm_runtime/src/process_txn/execute.rs
@@ -60,6 +60,7 @@ where
 
             // Add modules to the cache and prepare for publishing.
             let mut publish_modules = vec![];
+
             for (module, raw_bytes) in modules.into_iter().zip(module_bytes) {
                 let module_id = module.self_id();
 
@@ -96,6 +97,11 @@ where
                 }
 
                 txn_executor.module_cache().cache_module(module);
+
+                // `publish_modules` is initally empty, a single element is pushed per loop
+                // iteration and the number of iterations is bound to the max size
+                // of `modules`
+                assume!(publish_modules.len() < usize::max_value());
                 publish_modules.push((module_id, raw_bytes));
             }
 

--- a/language/vm/vm_runtime/src/process_txn/validate.rs
+++ b/language/vm/vm_runtime/src/process_txn/validate.rs
@@ -104,6 +104,10 @@ where
                     ));
                 }
 
+                // Check is performed on `txn.raw_txn_bytes_len()` which is the same as
+                // `raw_bytes_len`
+                assume!(raw_bytes_len.get() <= MAX_TRANSACTION_SIZE_IN_BYTES as u64);
+
                 // The submitted max gas units that the transaction can consume is greater than the
                 // maximum number of gas units bound that we have set for any
                 // transaction.

--- a/language/vm/vm_runtime/src/process_txn/verify.rs
+++ b/language/vm/vm_runtime/src/process_txn/verify.rs
@@ -160,6 +160,7 @@ fn static_verify_modules(
     let modules_len = modules.len();
 
     let mut modules_out = vec![];
+
     for (module_idx, module) in modules.into_iter().enumerate() {
         // Make sure the module's self address matches the transaction sender. The self address is
         // where the module will actually be published. If we did not check this, the sender could
@@ -182,10 +183,15 @@ fn static_verify_modules(
         };
 
         if let Some(error) = self_error {
+            // Verification should stop before we generate enough errors to overflow
+            assume!(errors.len() < usize::max_value());
             errors.push(error);
         }
 
         if errors.is_empty() {
+            // `modules_out` is initally empty, a single element is pushed per loop iteration and
+            // the number of iterations is bound to the max size of `modules``
+            assume!(modules_out.len() < usize::max_value());
             modules_out.push(module.expect("empty errors => module should verify"));
         } else {
             statuses.push(Box::new(errors.into_iter().map(move |error| {


### PR DESCRIPTION
## Motivation

This commit addresses potential vector overflows in the VM runtime. These overflows are addressed by two methods:
- Showing that the overflow will not actually occur.
- Using Rust's checked add to detect the presence of an overflow and raise an appropriate error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Passes existing tests. To reproduce the analysis performed by MIRAI, please run `RUSTC_WRAPPER=mirai MIRAI_LOG=warn cargo build --features "mirai-contracts"` from the VM directory.

## Related PRs

#503
