### PR TITLE
Implement Accumulator::append_siblings

### DIFF
--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -10,8 +10,10 @@ edition = "2018"
 itertools = "0.8.0"
 
 crypto = { path = "../../crypto/legacy_crypto" }
+failure = { path = "../../common/failure_ext", package = "failure_ext" }
 types = { path = "../../types" }
 
 [dev-dependencies]
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
+proptest = "0.9.4"
+
 types = { path = "../../types", features = ["testing"] }

--- a/storage/scratchpad/src/accumulator/accumulator_test.rs
+++ b/storage/scratchpad/src/accumulator/accumulator_test.rs
@@ -6,42 +6,78 @@ use crypto::{
     hash::{CryptoHash, TestOnlyHash, TestOnlyHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
-use types::proof::TestAccumulatorInternalNode;
+use proptest::{collection::vec, prelude::*};
+use std::collections::HashMap;
+use types::proof::{
+    position::{FrozenSubtreeSiblingIterator, Position},
+    TestAccumulatorInternalNode,
+};
 
-// Computes the root hash of an accumulator with given leaves.
-fn compute_root_hash_naive(leaves: &[HashValue]) -> HashValue {
+fn compute_parent_hash(left_hash: HashValue, right_hash: HashValue) -> HashValue {
+    if left_hash == *ACCUMULATOR_PLACEHOLDER_HASH && right_hash == *ACCUMULATOR_PLACEHOLDER_HASH {
+        *ACCUMULATOR_PLACEHOLDER_HASH
+    } else {
+        TestAccumulatorInternalNode::new(left_hash, right_hash).hash()
+    }
+}
+
+/// Given a list of leaves, constructs the smallest accumulator that has all the leaves and
+/// computes the hash of every node in the tree.
+fn compute_hashes_for_all_positions(leaves: &[HashValue]) -> HashMap<Position, HashValue> {
     if leaves.is_empty() {
-        return *ACCUMULATOR_PLACEHOLDER_HASH;
+        return HashMap::new();
     }
 
-    let mut current_level = leaves.to_vec();
-    current_level.resize(
+    let mut current_leaves = leaves.to_vec();
+    current_leaves.resize(
         leaves.len().next_power_of_two(),
         *ACCUMULATOR_PLACEHOLDER_HASH,
     );
+    let mut position_to_hash = HashMap::new();
+    let mut current_level = 0;
 
-    while current_level.len() > 1 {
-        assert!(current_level.len().is_power_of_two());
+    while current_leaves.len() > 1 {
+        assert!(current_leaves.len().is_power_of_two());
 
-        let mut parent_level = vec![];
-        for (index, hash) in current_level.iter().enumerate().step_by(2) {
-            let left_hash = hash;
-            let right_hash = &current_level[index + 1];
-            let parent_hash = if *left_hash == *ACCUMULATOR_PLACEHOLDER_HASH
-                && *right_hash == *ACCUMULATOR_PLACEHOLDER_HASH
-            {
-                *ACCUMULATOR_PLACEHOLDER_HASH
-            } else {
-                TestAccumulatorInternalNode::new(*left_hash, *right_hash).hash()
-            };
-            parent_level.push(parent_hash);
+        let mut parent_leaves = vec![];
+        for (index, _hash) in current_leaves.iter().enumerate().step_by(2) {
+            let left_hash = current_leaves[index];
+            let right_hash = current_leaves[index + 1];
+            let parent_hash = compute_parent_hash(left_hash, right_hash);
+            parent_leaves.push(parent_hash);
+
+            let left_pos = Position::from_level_and_pos(current_level, index as u64);
+            let right_pos = Position::from_level_and_pos(current_level, index as u64 + 1);
+            assert_eq!(position_to_hash.insert(left_pos, left_hash), None);
+            assert_eq!(position_to_hash.insert(right_pos, right_hash), None);
         }
 
-        current_level = parent_level;
+        assert_eq!(current_leaves.len(), parent_leaves.len() << 1);
+        current_leaves = parent_leaves;
+        current_level += 1;
     }
 
-    assert_eq!(current_level.len(), 1);
-    current_level.remove(0)
+    assert_eq!(
+        position_to_hash.insert(
+            Position::from_level_and_pos(current_level, 0),
+            current_leaves[0],
+        ),
+        None,
+    );
+    position_to_hash
+}
+
+// Computes the root hash of an accumulator with given leaves.
+fn compute_root_hash_naive(leaves: &[HashValue]) -> HashValue {
+    let position_to_hash = compute_hashes_for_all_positions(leaves);
+    if position_to_hash.is_empty() {
+        return *ACCUMULATOR_PLACEHOLDER_HASH;
+    }
+
+    let rightmost_leaf_index = leaves.len() as u64 - 1;
+    *position_to_hash
+        .get(&Position::get_root_position(rightmost_leaf_index))
+        .expect("Root position should exist in the map.")
 }
 
 // Helper function to create a list of leaves.
@@ -68,5 +104,30 @@ fn test_accumulator_append() {
         assert_eq!(accumulator.root_hash(), expected_root_hash);
         assert_eq!(accumulator.num_leaves(), i as u64);
         accumulator = accumulator.append(vec![leaf]);
+    }
+}
+
+proptest! {
+    #[test]
+    fn test_accumulator_append_siblings(
+        hashes1 in vec(any::<HashValue>(), 1..100),
+        hashes2 in vec(any::<HashValue>(), 0..100),
+    ) {
+        // Construct an accumulator with hashes1.
+        let accumulator = Accumulator::<TestOnlyHasher>::default().append(hashes1.clone());
+
+        // Compute all the internal nodes in a bigger accumulator with combination of hashes1 and
+        // hashes2.
+        let mut all_hashes = hashes1.clone();
+        all_hashes.extend_from_slice(&hashes2);
+        let position_to_hash = compute_hashes_for_all_positions(&all_hashes);
+
+        let sibling_hashes: Vec<_> = FrozenSubtreeSiblingIterator::new(hashes1.len() as u64)
+            .filter_map(|pos| position_to_hash.get(&pos).cloned())
+            .collect();
+        prop_assert_eq!(
+            accumulator.append_siblings(&sibling_hashes).unwrap(),
+            compute_root_hash_naive(&all_hashes)
+        );
     }
 }

--- a/storage/scratchpad/src/accumulator/mod.rs
+++ b/storage/scratchpad/src/accumulator/mod.rs
@@ -17,8 +17,9 @@ use crypto::{
     hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
+use failure::prelude::*;
 use std::marker::PhantomData;
-use types::proof::{position::Position, treebits::NodeDirection, MerkleTreeInternalNode};
+use types::proof::MerkleTreeInternalNode;
 
 /// The Accumulator implementation.
 pub struct Accumulator<H> {
@@ -123,6 +124,129 @@ where
         }
     }
 
+    /// Computes what the root hash would become if the current accumulator is extended with a list
+    /// of new leaves. This is similar to [`append`](Accumulator::append) except that the new
+    /// leaves themselves are not known and they are represented by `siblings`, so we would not be
+    /// able to construct a new list of frozen subtrees, but would just compute the root hash of
+    /// the new accumulator. As an example, given the following accumulator that currently has 10
+    /// leaves, the frozen subtree roots and the siblings are annotated below. Note that in this
+    /// case `siblings[0]` represents two new leaves `A` and `B`, `siblings[1]` represents four new
+    /// leaves, and the last `siblings[2]` may represent 1~16 new leaves.
+    ///
+    /// ```text
+    ///                                                 new_root
+    ///                                                /        \
+    ///                                               /          \
+    ///                                       old_root            siblings[2]
+    ///                                      /        \
+    ///                                    /            \
+    ///                                  /                \
+    ///                                /                    \
+    ///                              /                        \
+    ///                            /                            \
+    ///                          /                                \
+    ///                        /                                    \
+    /// frozen_subtree_roots[0]                                      o
+    ///                    /   \                                    / \
+    ///                   /     \                                  /   \
+    ///                  o       o                                o     siblings[1]
+    ///                 / \     / \                              / \
+    ///                o   o   o   o      frozen_subtree_roots[1]   siblings[0]
+    ///               / \ / \ / \ / \                         / \           / \
+    ///               o o o o o o o o                         o o           A B
+    /// ```
+    pub fn append_siblings(&self, siblings: &[HashValue]) -> Result<HashValue> {
+        Self::append_siblings_impl(&self.frozen_subtree_roots, self.num_leaves, siblings)
+    }
+
+    fn append_siblings_impl(
+        frozen_subtree_roots: &[HashValue],
+        num_existing_leaves: u64,
+        siblings: &[HashValue],
+    ) -> Result<HashValue> {
+        if frozen_subtree_roots.is_empty() {
+            ensure!(
+                siblings.len() == 1,
+                "{} siblings are provided when only one is required.",
+                siblings.len(),
+            );
+            return Ok(siblings[0]);
+        }
+        if siblings.is_empty() {
+            ensure!(
+                frozen_subtree_roots.len() == 1,
+                "No siblings are provided when some are required to compute root hash."
+            );
+            return Ok(frozen_subtree_roots[0]);
+        }
+
+        Self::validate_siblings(num_existing_leaves, siblings)?;
+
+        let mut frozen_subtree_iter = frozen_subtree_roots.iter().rev().peekable();
+        let mut sibling_iter = siblings.iter().peekable();
+        let mut current_hash = *sibling_iter
+            .next()
+            .expect("Code would have returned if siblings is empty.");
+
+        // Using the above example, num_existing_leaves = 10 = 0b1010. We check each bit from right
+        // to left starting from the rightmost one bit. If a bit is 0, it means there is no
+        // existing frozen subtree on this level, so we combine current hash with a sibling.
+        // Otherwise we combine it with the corresponding frozen subtree.
+        let mut bitmap = num_existing_leaves >> num_existing_leaves.trailing_zeros();
+        while frozen_subtree_iter.peek().is_some() || sibling_iter.peek().is_some() {
+            current_hash = if bitmap & 1 == 0 {
+                MerkleTreeInternalNode::<H>::new(
+                    current_hash,
+                    *sibling_iter.next().expect("This sibling should exist."),
+                )
+            } else {
+                MerkleTreeInternalNode::<H>::new(
+                    *frozen_subtree_iter
+                        .next()
+                        .expect("This frozen subtree should exist."),
+                    current_hash,
+                )
+            }
+            .hash();
+            bitmap >>= 1;
+        }
+        assert_eq!(bitmap, 0);
+
+        Ok(current_hash)
+    }
+
+    /// Does some basic validation on the input siblings.
+    fn validate_siblings(num_existing_leaves: u64, siblings: &[HashValue]) -> Result<()> {
+        // `siblings` should start with 0 or more non-placeholder trees, followed by 0 or more
+        // placeholder ones.
+        for i in 1..siblings.len() {
+            if siblings[i] != *ACCUMULATOR_PLACEHOLDER_HASH {
+                ensure!(
+                    siblings[i - 1] != *ACCUMULATOR_PLACEHOLDER_HASH,
+                    "Placeholder sibling should not be followed by non-placeholder sibling.",
+                );
+            }
+        }
+
+        let max_num_siblings =
+            num_existing_leaves.count_zeros() - num_existing_leaves.trailing_zeros();
+        ensure!(
+            siblings.len() <= max_num_siblings as usize,
+            "Max number of siblings: {}. {} are provided.",
+            max_num_siblings,
+            siblings.len(),
+        );
+        let min_num_siblings = max_num_siblings - num_existing_leaves.leading_zeros();
+        ensure!(
+            siblings.len() >= min_num_siblings as usize,
+            "Min number of siblings: {}. {} are provided.",
+            min_num_siblings,
+            siblings.len(),
+        );
+
+        Ok(())
+    }
+
     /// Returns the root hash of the accumulator.
     pub fn root_hash(&self) -> HashValue {
         self.root_hash
@@ -135,42 +259,24 @@ where
             return *ACCUMULATOR_PLACEHOLDER_HASH;
         }
 
-        // First, start from the rightmost leaf position and move it to the rightmost frozen root.
-        let max_leaf_index = num_leaves - 1;
-        let mut current_position = Position::from_leaf_index(max_leaf_index);
-        // Move current position up until it reaches the corresponding frozen subtree root.
-        while current_position.get_parent().is_freezable(max_leaf_index) {
-            current_position = current_position.get_parent();
-        }
+        // Computing the root hash is equivalent to calling `append_siblings` with a list of
+        // placeholder siblings.
 
-        let mut roots = frozen_subtree_roots.iter().rev();
-        let mut current_hash = *roots
-            .next()
-            .expect("We have checked frozen_subtree_roots is not empty.");
+        // For any accumulator, if we add two children to every existing leaf, the positions of the
+        // frozen subtrees do no change, so the trailing zeros do not matter.
+        let num_leaves = num_leaves >> num_leaves.trailing_zeros();
+        // Because every time we combine two hashes to compute its parent, the tree can be made one
+        // level smaller. So the total number of hashes needed to compute the root hash is
+        // `num_levels`.
+        let num_levels = num_leaves.next_power_of_two().trailing_zeros() + 1;
+        let num_placeholders = num_levels as usize - frozen_subtree_roots.len();
 
-        // While current position is not root, find current sibling and compute parent hash.
-        let root_position = Position::get_root_position(max_leaf_index);
-        while current_position != root_position {
-            current_hash = match current_position.get_direction_for_self() {
-                NodeDirection::Left => {
-                    // If a frozen node is the left child of its parent, its sibling must be
-                    // a placeholder node.
-                    MerkleTreeInternalNode::<H>::new(current_hash, *ACCUMULATOR_PLACEHOLDER_HASH)
-                        .hash()
-                }
-                NodeDirection::Right => {
-                    // Otherwise the left sibling must have been frozen.
-                    MerkleTreeInternalNode::<H>::new(
-                        *roots.next().expect("Ran out of subtree roots."),
-                        current_hash,
-                    )
-                    .hash()
-                }
-            };
-            current_position = current_position.get_parent();
-        }
-
-        current_hash
+        Self::append_siblings_impl(
+            frozen_subtree_roots,
+            num_leaves,
+            &vec![*ACCUMULATOR_PLACEHOLDER_HASH; num_placeholders],
+        )
+        .expect("Computing root hash should succeed.")
     }
 
     /// Returns the total number of leaves in this accumulator.

--- a/types/src/proof/position.rs
+++ b/types/src/proof/position.rs
@@ -75,6 +75,11 @@ impl Position {
         treebits::level(self.0)
     }
 
+    // Compute the position given the level and the pos count on this level.
+    pub fn from_level_and_pos(level: u32, pos: u64) -> Self {
+        Self::from_inorder_index(treebits::node_from_level_and_pos(level, pos))
+    }
+
     // Given the position, return the leaf index counting from the left
     pub fn to_leaf_index(self) -> u64 {
         treebits::pos_counting_from_left(self.0)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This functionality will be used when we need to verify the proof showing
that two accumulators are consistent -- one of them can be obtained by
appending certain items to the other.

Here `append_siblings` will compute the new root hash of the accumulator
with newly appended items.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.
