### PR TITLE
[benchmark] Remove debug_address option.

### DIFF
--- a/benchmark/src/cli_opt.rs
+++ b/benchmark/src/cli_opt.rs
@@ -70,9 +70,6 @@ pub struct RubenOpt {
     // Options for creating Benchmarker.
     #[structopt(flatten)]
     pub bench_opt: BenchOpt,
-    /// TODO: Discard this option. Debug interface address in the form of ip_address:port.
-    #[structopt(short = "d", long = "debug_address")]
-    pub debug_address: Option<String>,
     /// Number of accounts to create in Libra.
     #[structopt(short = "n", long = "num_accounts", default_value = "32")]
     pub num_accounts: u64,


### PR DESCRIPTION
### Summary
Final cleanup step to get rid of debug interface in benchmark.

### Test Plan:
Existing tests

```
$ ./target/release/ruben -f faucet_for_ruben -s temp_config -d localhost:9000
error: Found argument '-d' which wasn't expected, or isn't valid in this context
```

```
$ ./target/release/ruben -f faucet_for_ruben -s temp_config --debug_address localhost:9000
error: Found argument '--debug_address' which wasn't expected, or isn't valid in this context
```

Run `rg debug benchmark` and check no debug interface related code. 
