### PR TITLE
[Proof] Stop using treebits module outside position

### DIFF
--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -104,9 +104,7 @@
 use crypto::hash::{CryptoHash, CryptoHasher, HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use failure::prelude::*;
 use std::marker::PhantomData;
-use types::proof::{
-    position::Position, treebits::NodeDirection, AccumulatorProof, MerkleTreeInternalNode,
-};
+use types::proof::{position::Position, AccumulatorProof, MerkleTreeInternalNode};
 
 /// Defines the interface between `MerkleAccumulator` and underlying storage.
 pub trait HashReader {
@@ -243,7 +241,7 @@ where
 
         // first node may be a right child, in that case pair it with its existing sibling
         let (first_pos, first_hash) = iter.peek().expect("Current level is empty");
-        if first_pos.get_direction_for_self() == NodeDirection::Right {
+        if !first_pos.is_left_child() {
             parent_level.push((
                 first_pos.get_parent(),
                 Self::hash_internal_node(self.reader.get(first_pos.get_sibling())?, *first_hash),

--- a/types/src/proof/position.rs
+++ b/types/src/proof/position.rs
@@ -65,9 +65,12 @@ impl Position {
         Self::from_inorder_index(treebits::right_child(self.0))
     }
 
-    // Note: if self is root, the direction will overflow (and will always be left)
-    pub fn get_direction_for_self(self) -> treebits::NodeDirection {
-        treebits::direction_from_parent(self.0)
+    /// Whether this position is a left child of its parent.
+    pub fn is_left_child(self) -> bool {
+        match treebits::direction_from_parent(self.0) {
+            treebits::NodeDirection::Left => true,
+            treebits::NodeDirection::Right => false,
+        }
     }
 
     // The level start from 0 counting from the leaf level

--- a/types/src/proof/unit_tests/position_test.rs
+++ b/types/src/proof/unit_tests/position_test.rs
@@ -1,10 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proof::{
-    position::*,
-    treebits::{pos_counting_from_left, NodeDirection},
-};
+use crate::proof::{position::*, treebits::pos_counting_from_left};
 
 /// Position is marked with in-order-traversal sequence.
 ///
@@ -95,63 +92,25 @@ fn test_position_get_next_sibling() {
 }
 
 #[test]
-fn test_position_get_direction() {
-    assert_eq!(
-        Position::from_inorder_index(5).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(6).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(2).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(11).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(13).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(14).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(10).get_direction_for_self(),
-        NodeDirection::Right
-    );
-    assert_eq!(
-        Position::from_inorder_index(1).get_direction_for_self(),
-        NodeDirection::Left
-    );
-    assert_eq!(
-        Position::from_inorder_index(0).get_direction_for_self(),
-        NodeDirection::Left
-    );
-    assert_eq!(
-        Position::from_inorder_index(3).get_direction_for_self(),
-        NodeDirection::Left
-    );
-    assert_eq!(
-        Position::from_inorder_index(8).get_direction_for_self(),
-        NodeDirection::Left
-    );
-    assert_eq!(
-        Position::from_inorder_index(12).get_direction_for_self(),
-        NodeDirection::Left
-    );
+fn test_position_is_left_child() {
+    assert!(!Position::from_inorder_index(5).is_left_child());
+    assert!(!Position::from_inorder_index(6).is_left_child());
+    assert!(!Position::from_inorder_index(2).is_left_child());
+    assert!(!Position::from_inorder_index(11).is_left_child());
+    assert!(!Position::from_inorder_index(13).is_left_child());
+    assert!(!Position::from_inorder_index(14).is_left_child());
+    assert!(!Position::from_inorder_index(10).is_left_child());
+
+    assert!(Position::from_inorder_index(1).is_left_child());
+    assert!(Position::from_inorder_index(0).is_left_child());
+    assert!(Position::from_inorder_index(3).is_left_child());
+    assert!(Position::from_inorder_index(8).is_left_child());
+    assert!(Position::from_inorder_index(12).is_left_child());
 }
 
 #[test]
-fn test_position_get_direction_from_root() {
-    assert_eq!(
-        Position::from_inorder_index(7).get_direction_for_self(),
-        NodeDirection::Left
-    );
+fn test_position_is_left_child_from_root() {
+    assert!(Position::from_inorder_index(7).is_left_child());
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Exposing both position and treebits modules is a bit confusing. This
change makes sure the codebase uses only position so we can change
treebits to be a private module inside position next.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.
