### PR TITLE
[storage] change ledger_counter name related to jellyfish merkle

### DIFF
--- a/storage/libradb/src/ledger_counters/mod.rs
+++ b/storage/libradb/src/ledger_counters/mod.rs
@@ -20,11 +20,11 @@ use strum_macros::{AsRefStr, EnumIter};
 pub(crate) enum LedgerCounter {
     EventsCreated = 101,
 
-    StateBlobsCreated = 201,
-    StateBlobsRetired = 202,
+    NewStateLeaves = 201,
+    StaleStateLeaves = 202,
 
-    StateNodesCreated = 301,
-    StateNodesRetired = 302,
+    NewStateInternals = 301,
+    StaleStateInternals = 302,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/storage/libradb/src/ledger_counters/test.rs
+++ b/storage/libradb/src/ledger_counters/test.rs
@@ -4,24 +4,24 @@ use super::*;
 fn test_ledger_counters() {
     // Defaults to 0.
     let mut counters = LedgerCounters::new();
-    assert_eq!(counters.get(LedgerCounter::StateBlobsCreated), 0);
+    assert_eq!(counters.get(LedgerCounter::NewStateLeaves), 0);
 
     // Bump
     let mut bumps = LedgerCounterBumps::new();
     bumps
-        .bump(LedgerCounter::StateBlobsCreated, 1)
-        .bump(LedgerCounter::StateBlobsRetired, 1);
+        .bump(LedgerCounter::NewStateLeaves, 1)
+        .bump(LedgerCounter::StaleStateLeaves, 1);
     counters.bump(bumps);
-    assert_eq!(counters.get(LedgerCounter::StateBlobsCreated), 1);
-    assert_eq!(counters.get(LedgerCounter::StateBlobsRetired), 1);
+    assert_eq!(counters.get(LedgerCounter::NewStateLeaves), 1);
+    assert_eq!(counters.get(LedgerCounter::StaleStateLeaves), 1);
 
     // Bump again.
     let mut bumps = LedgerCounterBumps::new();
     bumps
         .bump(LedgerCounter::EventsCreated, 1)
-        .bump(LedgerCounter::StateBlobsCreated, 1);
+        .bump(LedgerCounter::NewStateLeaves, 1);
     counters.bump(bumps);
     assert_eq!(counters.get(LedgerCounter::EventsCreated), 1);
-    assert_eq!(counters.get(LedgerCounter::StateBlobsCreated), 2);
-    assert_eq!(counters.get(LedgerCounter::StateBlobsRetired), 1);
+    assert_eq!(counters.get(LedgerCounter::NewStateLeaves), 2);
+    assert_eq!(counters.get(LedgerCounter::StaleStateLeaves), 1);
 }

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -68,11 +68,11 @@ impl StateStore {
             JellyfishMerkleTree::new(self).put_blob_sets(blob_sets, first_version)?;
 
         cs.counter_bumps.bump(
-            LedgerCounter::StateNodesCreated,
+            LedgerCounter::NewStateInternals,
             tree_update_batch.node_batch.len(),
         );
         cs.counter_bumps.bump(
-            LedgerCounter::StateBlobsCreated,
+            LedgerCounter::NewStateLeaves,
             tree_update_batch.num_new_leaves,
         );
         tree_update_batch
@@ -82,11 +82,11 @@ impl StateStore {
             .collect::<Result<Vec<()>>>()?;
 
         cs.counter_bumps.bump(
-            LedgerCounter::StateNodesRetired,
+            LedgerCounter::StaleStateInternals,
             tree_update_batch.stale_node_index_batch.len(),
         );
         cs.counter_bumps.bump(
-            LedgerCounter::StateBlobsRetired,
+            LedgerCounter::StaleStateLeaves,
             tree_update_batch.num_stale_leaves,
         );
         tree_update_batch

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -15,12 +15,12 @@ fn put_account_state_set(
     store: &StateStore,
     account_state_set: Vec<(AccountAddress, AccountStateBlob)>,
     version: Version,
-    expected_nodes_created: usize,
-    expected_nodes_retired: usize,
-    expected_blobs_retired: usize,
+    expected_new_internals: usize,
+    expected_stale_internals: usize,
+    expected_stale_leaves: usize,
 ) -> HashValue {
     let mut cs = ChangeSet::new();
-    let blobs_created = account_state_set.len();
+    let expected_new_leaves = account_state_set.len();
     let root = store
         .put_account_state_sets(
             vec![account_state_set.into_iter().collect::<HashMap<_, _>>()],
@@ -30,20 +30,20 @@ fn put_account_state_set(
         .unwrap()[0];
     store.db.write_schemas(cs.batch).unwrap();
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::StateNodesCreated),
-        expected_nodes_created
+        cs.counter_bumps.get(LedgerCounter::NewStateInternals),
+        expected_new_internals
     );
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::StateNodesRetired),
-        expected_nodes_retired
+        cs.counter_bumps.get(LedgerCounter::StaleStateInternals),
+        expected_stale_internals
     );
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::StateBlobsCreated),
-        blobs_created
+        cs.counter_bumps.get(LedgerCounter::NewStateLeaves),
+        expected_new_leaves
     );
     assert_eq!(
-        cs.counter_bumps.get(LedgerCounter::StateBlobsRetired),
-        expected_blobs_retired
+        cs.counter_bumps.get(LedgerCounter::StaleStateLeaves),
+        expected_stale_leaves
     );
 
     root


### PR DESCRIPTION
## Motivation

I think we are gonna use `Bell` and `Tentacle` to replace `Internal` and `Leaf`. More PRs are coming.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Cargo test

## Related PRs

