### PR TITLE
[Proof] Introduce AccumulatorConsistencyProof

### DIFF
--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -241,6 +241,66 @@ impl IntoProto for SparseMerkleProof {
     }
 }
 
+/// A proof that can be used to show that two Merkle accumulators are consistent -- the big one can
+/// be obtained by appending certain leaves to the small one. For example, at some point in time a
+/// client knows that the root hash of the ledger at version 10 is `old_root` (it could be a
+/// waypoint). If a server wants to prove that the new ledger at version `N` is derived from the
+/// old ledger the client knows, it can show the frozen subtrees that form the small accumulator
+/// and the siblings that represent the new leaves. If the client can verify that the provided
+/// frozen subtrees match the old root hash and the new root hash can be obtained by combining the
+/// frozen subtrees with the siblings, it can be convinced that the two accumulators are
+/// consistent.
+///
+/// ```text
+///                                                  new_root (N = 17~32)
+///                                                 /        \
+///                                                /          \
+///                                   old_root (10)            siblings[2]
+///                                  /             \
+///                                /                 \
+///                              /                     \
+///                            /                         \
+///                          /                             \
+///                        /                                 \
+/// frozen_subtree_roots[0]                                   o
+///                    /   \                                 / \
+///                   /     \                               /   \
+///                  o       o                             o     siblings[1]
+///                 / \     / \                           / \
+///                o   o   o   o   frozen_subtree_roots[1]   siblings[0]
+///               / \ / \ / \ / \                      / \
+///               o o o o o o o o                      o o
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccumulatorConsistencyProof {
+    /// The root hashes of the frozen subtrees that form the small accumulator.
+    frozen_subtree_roots: Vec<HashValue>,
+
+    /// The siblings representing the newly appended leaves.
+    siblings: Vec<HashValue>,
+}
+
+impl AccumulatorConsistencyProof {
+    /// Constructs a new `AccumulatorConsistencyProof` using given `frozen_subtree_roots` and
+    /// `siblings`.
+    pub fn new(frozen_subtree_roots: Vec<HashValue>, siblings: Vec<HashValue>) -> Self {
+        Self {
+            frozen_subtree_roots,
+            siblings,
+        }
+    }
+
+    /// Returns the root hashes of the frozen subtrees.
+    pub fn frozen_subtree_roots(&self) -> &[HashValue] {
+        &self.frozen_subtree_roots
+    }
+
+    /// Returns the siblings.
+    pub fn siblings(&self) -> &[HashValue] {
+        &self.siblings
+    }
+}
+
 /// The complete proof used to authenticate a `SignedTransaction` object.  This structure consists
 /// of an `AccumulatorProof` from `LedgerInfo` to `TransactionInfo` the verifier needs to verify
 /// the correctness of the `TransactionInfo` object, and the `TransactionInfo` object that is


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This change introduces `AccumulatorConsistencyProof` that shows one accumulator can be obtained by appending leaves to the other accumulator.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Proof generation, verification and tests will be in another change.

## Related PRs

None.
