### PR TITLE
[Proof] Change Accumulator::new to return Result

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -103,10 +103,13 @@ where
             command_receiver,
             committed_timestamp_usecs,
             committed_state_tree: Rc::new(SparseMerkleTree::new(previous_state_root_hash)),
-            committed_transaction_accumulator: Rc::new(Accumulator::new(
-                previous_frozen_subtrees_in_accumulator,
-                previous_num_leaves_in_accumulator,
-            )),
+            committed_transaction_accumulator: Rc::new(
+                Accumulator::new(
+                    previous_frozen_subtrees_in_accumulator,
+                    previous_num_leaves_in_accumulator,
+                )
+                .expect("The startup info read from storage should be valid."),
+            ),
             block_tree: BlockTree::new(last_committed_block_id),
             blocks_to_store: VecDeque::new(),
             storage_read_client,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To verify accumulator consistency proof, we will need to construct the small accumulator using the frozen subtree roots in the proof. Since the proof may not be valid, we change `Accumulator::new` to return a `Result`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.
