### PR TITLE
[Proof] Make treebits a private module inside position

### DIFF
--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -5,13 +5,10 @@ pub mod definition;
 pub mod position;
 #[cfg(any(test, feature = "testing"))]
 pub mod proptest_proof;
-pub mod treebits;
 
 #[cfg(test)]
 #[path = "unit_tests/proof_test.rs"]
 mod proof_test;
-#[cfg(test)]
-mod unit_tests;
 
 use crate::{
     account_state_blob::AccountStateBlob,

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -24,7 +24,9 @@
 //! Note2: The level of tree counts from leaf level, start from 0
 //! Note3: The leaf index starting from left-most leaf, starts from 0
 
-use super::treebits;
+#[cfg(test)]
+mod position_test;
+mod treebits;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Position(u64);

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proof::{position::*, treebits::pos_counting_from_left};
+use crate::proof::position::{treebits::pos_counting_from_left, *};
 
 /// Position is marked with in-order-traversal sequence.
 ///

--- a/types/src/proof/position/treebits/mod.rs
+++ b/types/src/proof/position/treebits/mod.rs
@@ -15,6 +15,10 @@
 //!
 //! This module can answer questions like "what is the level of 5"
 //! (`level(5)=1`), "what is the right child of 3" `right_child(3)=5`
+
+#[cfg(test)]
+mod treebits_test;
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum NodeDirection {
     Left,
@@ -126,7 +130,8 @@ pub fn smear_ones_for_u64(v: u64) -> u64 {
 ///
 /// But expanding the series this can be computed non-recursively
 /// sum 2^n, n=1 to x = 2^(x+1) - 2
-pub fn children_from_level(level: u32) -> u64 {
+#[cfg(test)]
+fn children_from_level(level: u32) -> u64 {
     (1u64 << (level + 1)) - 2
 }
 

--- a/types/src/proof/position/treebits/treebits_test.rs
+++ b/types/src/proof/position/treebits/treebits_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proof::treebits::*;
+use super::*;
 
 fn slow_nodes_to_left_of(node: u64) -> u64 {
     let ret_add = if node == right_child(parent(node)) {

--- a/types/src/proof/unit_tests/mod.rs
+++ b/types/src/proof/unit_tests/mod.rs
@@ -1,5 +1,0 @@
-// Copyright (c) The Libra Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-mod position_test;
-mod treebits_test;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Exposing both `position` and `treebits` modules seems a bit confusing. Instead make `treebits` a private module inside `position`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.
