### PR TITLE
[consensus][nit] use future::ready/ok/err

### DIFF
--- a/consensus/src/chained_bft/liveness/local_pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/local_pacemaker.rs
@@ -15,7 +15,7 @@ use crate::{
     util::time_service::{SendTask, TimeService},
 };
 use channel;
-use futures::{Future, FutureExt, SinkExt, StreamExt, TryFutureExt};
+use futures::{future, Future, FutureExt, SinkExt, StreamExt, TryFutureExt};
 use logger::prelude::*;
 use std::{
     cmp,
@@ -298,7 +298,7 @@ impl LocalPacemakerInner {
                 new_round,
                 Fg(Reset)
             );
-            return async {}.boxed();
+            return future::ready(()).boxed();
         }
         assert!(
             new_round > self.current_round,
@@ -421,7 +421,7 @@ impl Pacemaker for LocalPacemaker {
         if tc_round_updated || qc_round_updated {
             return guard.update_current_round();
         }
-        async {}.boxed()
+        future::ready(()).boxed()
     }
 
     /// The function is invoked upon receiving a remote timeout message from another validator.
@@ -436,6 +436,6 @@ impl Pacemaker for LocalPacemaker {
         {
             return guard.update_current_round();
         }
-        async {}.boxed()
+        future::ready(()).boxed()
     }
 }

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use failure::Result;
-use futures::{channel::mpsc, Future, FutureExt};
+use futures::{channel::mpsc, future, Future, FutureExt};
 use logger::prelude::*;
 use nextgen_crypto::ed25519::*;
 use state_synchronizer::SyncStatus;
@@ -35,15 +35,13 @@ impl StateComputer for MockStateComputer {
         _block_id: HashValue,
         _transactions: &Self::Payload,
     ) -> Pin<Box<dyn Future<Output = Result<StateComputeResult>> + Send>> {
-        async move {
-            Ok(StateComputeResult {
-                new_state_id: *ACCUMULATOR_PLACEHOLDER_HASH,
-                compute_status: vec![],
-                num_successful_txns: 0,
-                validators: None,
-            })
-        }
-            .boxed()
+        future::ok(StateComputeResult {
+            new_state_id: *ACCUMULATOR_PLACEHOLDER_HASH,
+            compute_status: vec![],
+            num_successful_txns: 0,
+            validators: None,
+        })
+        .boxed()
     }
 
     fn commit(
@@ -53,7 +51,7 @@ impl StateComputer for MockStateComputer {
         self.commit_callback
             .unbounded_send(commit)
             .expect("Fail to notify about commit.");
-        async { Ok(()) }.boxed()
+        future::ok(()).boxed()
     }
 
     fn sync_to(
@@ -69,7 +67,7 @@ impl StateComputer for MockStateComputer {
         self.commit_callback
             .unbounded_send(commit.ledger_info().clone())
             .expect("Fail to notify about sync");
-        async { Ok(SyncStatus::Finished) }.boxed()
+        future::ok(SyncStatus::Finished).boxed()
     }
 
     fn get_chunk(
@@ -78,6 +76,6 @@ impl StateComputer for MockStateComputer {
         _: u64,
         _: u64,
     ) -> Pin<Box<dyn Future<Output = Result<TransactionListWithProof>> + Send>> {
-        async move { Err(format_err!("not implemented")) }.boxed()
+        future::err(format_err!("not implemented")).boxed()
     }
 }

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -3,7 +3,7 @@
 
 use crate::state_replication::{StateComputeResult, TxnManager};
 use failure::Result;
-use futures::{channel::mpsc, Future, FutureExt, SinkExt};
+use futures::{channel::mpsc, future, Future, FutureExt, SinkExt};
 use std::{
     pin::Pin,
     sync::{
@@ -59,7 +59,7 @@ impl TxnManager for MockTransactionManager {
         let upper_bound = next_value + max_size as usize;
         let res = (next_value..upper_bound).collect();
         self.next_val.store(upper_bound, Ordering::SeqCst);
-        async move { Ok(res) }.boxed()
+        future::ok(res).boxed()
     }
 
     fn commit_txns<'a>(

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -12,7 +12,7 @@ use execution_proto::proto::{
     execution_grpc::ExecutionClient,
 };
 use failure::Result;
-use futures::{compat::Future01CompatExt, Future, FutureExt};
+use futures::{compat::Future01CompatExt, future, Future, FutureExt};
 use logger::prelude::*;
 use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProto, IntoProto};
@@ -113,7 +113,7 @@ impl StateComputer for ExecutionProxy {
                 }
                     .boxed()
             }
-            Err(e) => async move { Err(e.into()) }.boxed(),
+            Err(e) => future::err(e.into()).boxed(),
         }
     }
 
@@ -156,7 +156,7 @@ impl StateComputer for ExecutionProxy {
                 }
                     .boxed()
             }
-            Err(e) => async move { Err(e.into()) }.boxed(),
+            Err(e) => future::err(e.into()).boxed(),
         }
     }
 

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -6,7 +6,7 @@ use crate::{
     state_replication::{StateComputeResult, TxnManager},
 };
 use failure::Result;
-use futures::{compat::Future01CompatExt, Future, FutureExt};
+use futures::{compat::Future01CompatExt, future, Future, FutureExt};
 use logger::prelude::*;
 use mempool::proto::{
     mempool::{
@@ -70,7 +70,7 @@ impl MempoolProxy {
                 }
             }
                 .boxed(),
-            Err(e) => async move { Err(e.into()) }.boxed(),
+            Err(e) => future::err(e.into()).boxed(),
         }
     }
 }
@@ -120,7 +120,7 @@ impl TxnManager for MempoolProxy {
                 }
             }
                 .boxed(),
-            Err(e) => async move { Err(e.into()) }.boxed(),
+            Err(e) => future::err(e.into()).boxed(),
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It's more idiomatic to use the util functions than creating a closure when we don't need await.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
