### PR TITLE
[consensus] merge process_winning_proposal and process_proposal and re-naming/organize

### DIFF
--- a/consensus/src/chained_bft/mod.rs
+++ b/consensus/src/chained_bft/mod.rs
@@ -20,8 +20,6 @@ mod sync_manager;
 #[cfg(test)]
 mod chained_bft_smr_test;
 #[cfg(test)]
-mod event_processor_test;
-#[cfg(test)]
 mod network_tests;
 #[cfg(test)]
 mod proto_test;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Continued from last PR https://github.com/libra/libra/pull/515, this PR merges how we process ProposalMsg into a single function and also rename process_proposal -> pre_process_proposal, process_winning_proposal -> process_proposed_block.

It also reorganized the impl struct so that private functions stay in a separate block.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
