### PR TITLE
[Consensus][small] Nil block timestamp

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -395,16 +395,9 @@ impl<T: Payload> BlockStore<T> {
         if parent.round() >= block.round() {
             return Err(InsertError::InvalidBlockRound);
         }
-        if self.enforce_increasing_timestamps {
-            // NIL blocks are supposed to have timestamps equal to their parents. Proposed blocks
-            // must have increasing timestamps.
-            if block.is_nil_block() {
-                if block.timestamp_usecs() != parent.timestamp_usecs() {
-                    return Err(InsertError::InvalidNilBlockTimestamp);
-                }
-            } else if block.timestamp_usecs() <= parent.timestamp_usecs() {
-                return Err(InsertError::NonIncreasingTimestamp);
-            }
+        if self.enforce_increasing_timestamps && block.timestamp_usecs() <= parent.timestamp_usecs()
+        {
+            return Err(InsertError::NonIncreasingTimestamp);
         }
         let parent_id = parent.id();
         match self.inner.read().unwrap().get_state_for_block(parent_id) {

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -68,9 +68,6 @@ pub enum InsertError {
     /// The block's timestamp is not greater than that of the parent.
     #[fail(display = "InvalidTimestamp")]
     NonIncreasingTimestamp,
-    /// The NIL block's timestamp is not equal to that of the parent.
-    #[fail(display = "InvalidNilBlockTimestamp")]
-    InvalidNilBlockTimestamp,
     /// The block is not newer than the root of the tree.
     #[fail(display = "OldBlock")]
     OldBlock,

--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -245,9 +245,11 @@ where
 
         let payload = T::default();
         // We want all the NIL blocks to agree on the timestamps even though they're generated
-        // independently by different validators, hence we're using the timestamp of a parent.
-        let timestamp_usecs = parent_block.timestamp_usecs;
-
+        // independently by different validators, hence we're using the timestamp of a parent + 1.
+        // The reason for artificially adding 1 usec is to support execution state synchronization,
+        // which doesn't have any other way of determining the order of ledger infos rather than
+        // comparing their timestamps.
+        let timestamp_usecs = parent_block.timestamp_usecs + 1;
         let block_serializer = BlockSerializer {
             parent_id: parent_block.id(),
             payload: &payload,

--- a/consensus/src/chained_bft/consensus_types/block_test.rs
+++ b/consensus/src/chained_bft/consensus_types/block_test.rs
@@ -207,7 +207,10 @@ fn test_nil_block() {
         genesis_block.id()
     );
     assert_eq!(nil_block.round(), 1);
-    assert_eq!(nil_block.timestamp_usecs(), genesis_block.timestamp_usecs());
+    assert_eq!(
+        nil_block.timestamp_usecs(),
+        genesis_block.timestamp_usecs() + 1
+    );
     assert_eq!(nil_block.is_nil_block(), true);
     assert!(nil_block.author().is_none());
 


### PR DESCRIPTION
Summary: We used to have nil block timestamps equal to their parents timestamps. However, execution uses LedgerInfo timestamps for verifying that the state synchronization requests are moving the system forward.
There are several alternative options we could take: 1) remove the check from execution, 2) add a round field to LedgerInfo, and 3) have NIL blocks incrementing timestamps.
The simplest one for now is to just have a NIL block timestamp = parent timestamp + 1 us

Tests: unit tests

Issue: ref #371