### PR TITLE
[consensus] switch from concurrent event processor to sequential

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -9,7 +9,7 @@
 
 #![deny(missing_docs)]
 #![feature(async_await)]
-#![recursion_limit = "128"]
+#![recursion_limit = "512"]
 #[macro_use]
 extern crate failure;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Continued from https://github.com/libra/libra/pull/579, this PR we switch from multiple concurrent tasks to one single task polling new events.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
