### PR TITLE
[easy] Removing cruft dependencies

### DIFF
--- a/admission_control/admission_control_proto/Cargo.toml
+++ b/admission_control/admission_control_proto/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1.28"
-futures03 = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 grpcio = "0.4.3"
 protobuf = "~2.7"
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -6,11 +6,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.4"
 clap = "2.33.0"
 futures = "0.1.28"
 grpcio = "0.4"
-itertools = "0.8.0"
 lazy_static = "1.2.0"
 protobuf = "~2.7"
 rand = "0.7.0"
@@ -23,7 +21,6 @@ admission_control_proto = { path = "../admission_control/admission_control_proto
 client = { path = "../client" }
 config = { path = "../config" }
 config_builder = { path = "../config/config_builder" }
-crypto = { path = "../crypto/legacy_crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }
 libra_wallet = { path = "../client/libra_wallet" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -28,7 +28,6 @@ config = { path = "../config" }
 crash_handler = { path = "../common/crash_handler" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
-libc = "0.2.61"
 libra_wallet = { path = "./libra_wallet" }
 logger =  { path = "../common/logger" }
 metrics = { path = "../common/metrics" }

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 rust-crypto = "0.2"
-log = "0.4.7"
 rand = "0.6.5"
 rand_core = "0.4.2"
 hex = "0.3"

--- a/common/tools/Cargo.toml
+++ b/common/tools/Cargo.toml
@@ -5,6 +5,3 @@ authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
 publish = false
 edition = "2018"
-
-[dependencies]
-futures = "0.1.28"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-clap = "2.32"
 get_if_addrs = "0.5.3"
 hex = "0.3.2"
 parity-multiaddr = "0.4.0"
@@ -15,8 +14,6 @@ rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 tempfile = "3.1.0"
 toml = "0.4"
-
-crypto = { path = "../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 logger = { path = "../common/logger" }

--- a/config/config_builder/Cargo.toml
+++ b/config/config_builder/Cargo.toml
@@ -7,13 +7,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.1"
 clap = "2.32"
 hex = "0.3.2"
 rand = "0.6.5"
-serde = { version = "1.0.96", features = ["derive"] }
-tempfile = "3.1.0"
-toml = "0.4"
 
 config = { path = ".." }
 nextgen_crypto = { path = "../../crypto/nextgen_crypto" }

--- a/config/generate_keypair/Cargo.toml
+++ b/config/generate_keypair/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 clap = { version = "2.32" }
-serde = { version = "1.0.96", features = ["derive"] }
-serde_json = "1.0.40"
 tempdir = "0.3.7"
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -31,7 +31,6 @@ crypto = { path = "../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 execution_proto = { path = "../execution/execution_proto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
-grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }
 mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
@@ -40,7 +39,6 @@ proto_conv = { path = "../common/proto_conv" }
 state_synchronizer = { path = "../state_synchronizer" }
 schemadb = { path = "../storage/schemadb" }
 storage_client = { path = "../storage/storage_client" }
-storage_proto = { path = "../storage/storage_proto" }
 tools = { path = "../common/tools" }
 types = { path = "../types" }
 

--- a/crypto/legacy_crypto/Cargo.toml
+++ b/crypto/legacy_crypto/Cargo.toml
@@ -9,25 +9,19 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 bytes = "0.4.12"
-curve25519-dalek = "1.2.3"
-ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
 hex = "0.3"
 lazy_static = "1.3.0"
-pairing = "0.14.2"
 proptest = "0.9.1"
 proptest-derive = "0.1.0"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
-threshold_crypto = "0.3"
 tiny-keccak = "1.5.0"
-x25519-dalek = "0.5.2"
 digest = "0.8.1"
 hmac = "0.7.1"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
-crypto-derive = { path = "./src/macros" }
 proto_conv = { path = "../../common/proto_conv" }
 
 [dev-dependencies]

--- a/crypto/nextgen_crypto/Cargo.toml
+++ b/crypto/nextgen_crypto/Cargo.toml
@@ -9,27 +9,20 @@ edition = "2018"
 [dependencies]
 bincode = "1.1.1"
 byteorder = "1.3.2"
-bytes = "0.4.12"
 curve25519-dalek = "1.2.3"
 ed25519-dalek = { version = "1.0.0-pre.1", features = ["serde"] }
 hex = "0.3"
-lazy_static = "1.3.0"
 pairing = "0.14.2"
 proptest = "0.9.1"
-proptest-derive = "0.1.0"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 threshold_crypto = "0.3"
-tiny-keccak = "1.5.0"
 x25519-dalek = "0.5.2"
-digest = "0.8.1"
 hmac = "0.7.1"
-sha3 = "0.8.2"
 sha2 = "0.8.0"
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 crypto-derive = { path = "../legacy_crypto/src/macros" }
-proto_conv = { path = "../../common/proto_conv" }
 crypto = { path = "../legacy_crypto" }
 
 [dev-dependencies]

--- a/execution/execution_service/Cargo.toml
+++ b/execution/execution_service/Cargo.toml
@@ -18,7 +18,6 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../../common/grpc_helpers" }
 proto_conv = { path = "../../common/proto_conv" }
 storage_client = { path = "../../storage/storage_client" }
-types = { path = "../../types" }
 vm_runtime = { path = "../../language/vm/vm_runtime" }
 
 [dev-dependencies]

--- a/execution/execution_tests/Cargo.toml
+++ b/execution/execution_tests/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 [dependencies]
 futures01 = { package = "futures", version = "0.1.26" }
 grpcio = "0.4.4"
-tempfile = "3.1.0"
 
 config = { path = "../../config" }
 config_builder = { path = "../../config/config_builder" }
@@ -24,7 +23,6 @@ grpc_helpers = { path = "../../common/grpc_helpers" }
 nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 proto_conv = { path = "../../common/proto_conv" }
 storage_client = { path = "../../storage/storage_client" }
-storage_proto = { path = "../../storage/storage_proto" }
 storage_service = { path = "../../storage/storage_service" }
 types = { path = "../../types" }
 vm_genesis = { path = "../../language/vm/vm_genesis" }

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -13,7 +13,6 @@ ir_to_bytecode = { path = "ir_to_bytecode" }
 stdlib = { path = "../stdlib" }
 types = { path = "../../types" }
 vm = { path = "../vm" }
-log = "0.4.7"
 structopt = "0.2.15"
 serde_json = "1.0.40"
 

--- a/language/compiler/ir_to_bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/syntax/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 
 [dependencies]
 codespan = "0.1.3"
-codespan-reporting = "0.1.4"
 hex = "0.3.2"
 lalrpop-util = "0.16.3"
 regex = "1.2.1"

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -11,7 +11,6 @@ bytecode_verifier = { path = "../bytecode_verifier" }
 canonical_serialization = { path = "../../common/canonical_serialization" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 compiler = { path = "../compiler" }
-ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 lazy_static = "1.3.0"
 nextgen_crypto = { path = "../../crypto/nextgen_crypto"}
 rand = "0.6.5"

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -15,7 +15,6 @@ bytecode_verifier = { path = "../bytecode_verifier" }
 language_e2e_tests = { path = "../e2e_tests" }
 config = { path = "../../config" }
 transaction_builder = { path = "../transaction_builder" }
-termcolor = "1.0.4"
 filecheck = "0.4.0"
 datatest = "0.3.5"
 lazy_static = "1.3.0"

--- a/language/stackless_bytecode/generator/Cargo.toml
+++ b/language/stackless_bytecode/generator/Cargo.toml
@@ -7,9 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytecode_verifier = { path = "../../bytecode_verifier" }
 vm = { path = "../../vm" }
-types = { path = "../../../types" }
 ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
 #
 [dev-dependencies]

--- a/language/tools/cost_synthesis/Cargo.toml
+++ b/language/tools/cost_synthesis/Cargo.toml
@@ -12,7 +12,6 @@ rand = "0.6.5"
 lazy_static = "1.3.0"
 
 bytecode_verifier = { path = "../../bytecode_verifier" }
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 stdlib = { path = "../../stdlib" }
 types = { path = "../../../types" }
 vm = { path = "../../vm" }
@@ -21,7 +20,6 @@ vm_runtime_types = { path = "../../vm/vm_runtime/vm_runtime_types" }
 language_e2e_tests = { path = "../../e2e_tests" }
 vm_cache_map = { path = "../../vm/vm_runtime/vm_cache_map" }
 nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
-state_view = { path = "../../../storage/state_view" }
 structopt = "0.2.15"
 
 [dev-dependencies]

--- a/language/tools/test_generation/Cargo.toml
+++ b/language/tools/test_generation/Cargo.toml
@@ -12,7 +12,6 @@ log = "0.4"
 env_logger = "0.6"
 bytecode_verifier = { path = "../../bytecode_verifier" }
 cost_synthesis = { path = "../cost_synthesis" }
-types = { path = "../../../types" }
 vm = { path = "../../vm" }
 
 [dev-dependencies]

--- a/language/transaction_builder/Cargo.toml
+++ b/language/transaction_builder/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 types = { path = "../../types" }
 vm = { path = "../vm" }
-hex = "0.3.2"
 structopt = { version = "0.2.15", optional = true }
 serde_json = { version = "1.0.40", optional = true }
 proto_conv = { path = "../../common/proto_conv", optional = true }

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -13,8 +13,6 @@ lazy_static = "1.3.0"
 mirai-annotations = "^1.2.2"
 proptest = "0.9"
 proptest-derive = "0.1.1"
-
-crypto = { path = "../../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 proptest_helpers = { path = "../../common/proptest_helpers" }

--- a/language/vm/vm_genesis/Cargo.toml
+++ b/language/vm/vm_genesis/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 config = { path = "../../../config" }
-crypto = { path = "../../../crypto/legacy_crypto" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
 nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
@@ -20,11 +19,9 @@ vm = { path = "../" }
 vm_cache_map = { path = "../vm_runtime/vm_cache_map" }
 vm_runtime = { path = "../vm_runtime" }
 vm_runtime_types = { path = "../vm_runtime/vm_runtime_types" }
-hex = "0.3.2"
 lazy_static = "1.3.0"
 rand = "0.6.5"
 tiny-keccak = "1.5.0"
-toml = "0.4"
 
 [dev-dependencies]
 canonical_serialization = { path = "../../../common/canonical_serialization" }

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bit-vec = "0.6.1"
 hex = "0.3.2"
 lazy_static = "1.3.0"
 proptest = "0.9"
@@ -18,9 +17,7 @@ tiny-keccak = "1.5.0"
 bytecode_verifier = { path = "../../bytecode_verifier" }
 canonical_serialization = { path = "../../../common/canonical_serialization" }
 config = { path = "../../../config" }
-crypto = { path = "../../../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../../../crypto/nextgen_crypto" }
-failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 logger = { path = "../../../common/logger" }
 metrics = { path = "../../../common/metrics" }
 state_view = { path = "../../../storage/state_view" }

--- a/language/vm/vm_runtime/vm_runtime_types/Cargo.toml
+++ b/language/vm/vm_runtime/vm_runtime_types/Cargo.toml
@@ -9,16 +9,12 @@ edition = "2018"
 [dependencies]
 bit-vec = "0.6.1"
 bitcoin_hashes = "0.3.0"
-hex = "0.3.2"
 lazy_static = "1.3.0"
 proptest = "0.9"
-rayon = "1.1"
-rental = "0.5.4"
 tiny-keccak = "1.5.0"
 
 types = { path = "../../../../types" }
 vm = { path = "../../" }
-vm_cache_map = { path = "../vm_cache_map" }
 canonical_serialization = { path = "../../../../common/canonical_serialization" }
 nextgen_crypto = { path = "../../../../crypto/nextgen_crypto" }
 failure = { path = "../../../../common/failure_ext", package = "failure_ext" }

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -17,7 +17,6 @@ admission_control_service = { path = "../admission_control/admission_control_ser
 config = { path = "../config" }
 consensus = { path = "../consensus" }
 crash_handler = { path = "../common/crash_handler" }
-crypto = { path = "../crypto/legacy_crypto" }
 debug_interface = { path = "../common/debug_interface" }
 logger = { path = "../common/logger" }
 executable_helpers = { path = "../common/executable_helpers" }
@@ -27,14 +26,11 @@ mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 execution_service = { path = "../execution/execution_service" }
-failure = { path = "../common/failure_ext", package = "failure_ext" }
 network = { path = "../network" }
-proto_conv = { path = "../common/proto_conv" }
 state_synchronizer = { path = "../state_synchronizer" }
 storage_client = { path = "../storage/storage_client" }
 storage_service = { path = "../storage/storage_service" }
 types = { path = "../types" }
-vm_genesis = { path = "../language/vm/vm_genesis" }
 vm_validator = { path = "../vm_validator" }
 
 [dev-dependencies]

--- a/libra_swarm/Cargo.toml
+++ b/libra_swarm/Cargo.toml
@@ -7,9 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.1"
 ctrlc = "3.1.3"
-grpcio = "0.4.3"
 lazy_static = "1.2.0"
 structopt = "0.2.15"
 tempfile = "3.1.0"
@@ -17,7 +15,6 @@ tempfile = "3.1.0"
 client_lib = { package = "client", path = "../client" }
 config = { path = "../config" }
 config_builder = { path = "../config/config_builder" }
-crypto = { path = "../crypto/legacy_crypto" }
 debug_interface = { path = "../common/debug_interface" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -20,7 +20,6 @@ ttl_cache = "0.4.2"
 
 bounded-executor = { path = "../common/bounded-executor" }
 config = { path = "../config" }
-crypto = { path = "../crypto/legacy_crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -9,8 +9,6 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview" }
 snow = { version = "0.5.2", features=["ring-accelerated"]}
-
-crypto = { path = "../../crypto/legacy_crypto" }
 nextgen_crypto = { path = "../../crypto/nextgen_crypto" }
 netcore = { path = "../netcore" }
 logger = { path = "../../common/logger" }

--- a/network/socket_bench_server/Cargo.toml
+++ b/network/socket_bench_server/Cargo.toml
@@ -11,11 +11,8 @@ bytes = "0.4.12"
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["async-await", "nightly", "io-compat", "compat"] }
 futures_01 = { version = "0.1.25", package = "futures" }
 parity-multiaddr = "0.4.0"
-structopt = "0.2.15"
 tokio = "0.1.22"
 unsigned-varint = { version = "0.2.2", features = ["codec"] }
-
-failure = { package = "failure_ext", path = "../../common/failure_ext" }
 logger = { path = "../../common/logger" }
 memsocket = { path = "../memsocket" }
 netcore = { path = "../netcore" }

--- a/state_synchronizer/Cargo.toml
+++ b/state_synchronizer/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["compat"] }
 grpcio = "0.4.3"
-grpcio-sys = "0.4.4"
 lazy_static = "1.3.0"
 protobuf = "~2.7"
 rand = "0.6.5"

--- a/storage/storage_client/Cargo.toml
+++ b/storage/storage_client/Cargo.toml
@@ -12,8 +12,6 @@ futures_01 = { version = "0.1.25", package = "futures" }
 grpcio = "0.4.4"
 protobuf = "~2.7"
 rand = "0.6.5"
-
-canonical_serialization = { path = "../../common/canonical_serialization" }
 crypto = { path = "../../crypto/legacy_crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 metrics = { path = "../../common/metrics" }

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -20,7 +20,6 @@ canonical_serialization = { path = "../../common/canonical_serialization" }
 # List out modules with data structures being fuzzed here.
 types = { path = "../../types" }
 vm = { path = "../../language/vm" }
-vm_runtime = { path = "../../language/vm/vm_runtime" }
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types" }
 
 [dev-dependencies]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -21,7 +21,6 @@ protobuf = "~2.7"
 radix_trie = "0.1.3"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
-serde_json = "1.0.40"
 tiny-keccak = "1.5.0"
 
 canonical_serialization = { path = "../common/canonical_serialization" }

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -10,9 +10,7 @@ edition = "2018"
 futures = "0.1.28"
 
 config = { path = "../config" }
-crypto = { path = "../crypto/legacy_crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
-nextgen_crypto = { path = "../crypto/nextgen_crypto" }
 proto_conv = { path = "../common/proto_conv" }
 scratchpad = { path = "../storage/scratchpad" }
 state_view = { path = "../storage/state_view" }


### PR DESCRIPTION
Dependency removal only:

Removing grpcio-sys from state_synchronizer

Removing grpc_helpers from consensus

Removing storage_proto from consensus

Removing crypto from vm_validator

Removing nextgen_crypto from vm_validator

Removing bincode from libra_swarm

Removing grpcio from libra_swarm

Removing crypto from libra_swarm

Removing bincode from config_builder

Removing serde from config_builder

Removing tempfile from config_builder

Removing toml from config_builder

Removing serde from generate_keypair

Removing serde_json from generate_keypair

Removing clap from config

Removing crypto from config

Removing crypto from noise

Removing structopt from socket_bench_server

Removing failure from socket_bench_server

Removing crypto from mempool

Removing vm_runtime from libra_fuzzer

Removing serde_json from types

Removing types from execution_service

Removing tempfile from execution_tests

Removing storage_proto from execution_tests

Removing termcolor from functional_tests

Removing codespan-reporting from syntax

Removing log from compiler

Removing hex from transaction_builder

Removing types from test_generation

Removing failure from cost_synthesis

Removing state_view from cost_synthesis

Removing bytecode_verifier from generator

Removing types from generator

Removing ir_to_bytecode from e2e_tests

Removing hex from vm_runtime_types

Removing rayon from vm_runtime_types

Removing rental from vm_runtime_types

Removing vm_cache_map from vm_runtime_types

Removing bit-vec from vm_runtime

Removing crypto from vm_runtime

Removing failure from vm_runtime

Removing crypto from vm_genesis

Removing hex from vm_genesis

Removing toml from vm_genesis

Removing crypto from vm

Removing bincode from benchmark

Removing itertools from benchmark

Removing crypto from benchmark

Removing futures from tools

Removing curve25519-dalek from legacy_crypto

Removing ed25519-dalek from legacy_crypto

Removing pairing from legacy_crypto

Removing threshold_crypto from legacy_crypto

Removing x25519-dalek from legacy_crypto

Removing crypto-derive from legacy_crypto

Removing bytes from nextgen_crypto

Removing lazy_static from nextgen_crypto

Removing proptest-derive from nextgen_crypto

Removing tiny-keccak from nextgen_crypto

Removing digest from nextgen_crypto

Removing sha3 from nextgen_crypto

Removing proto_conv from nextgen_crypto

Removing futures03 from admission_control_proto

Removing crypto from libra_node

Removing failure from libra_node

Removing proto_conv from libra_node

Removing vm_genesis from libra_node

Removing canonical_serialization from storage_client

Removing log from libra_wallet

Removing libc from client