### PR TITLE
[easy] Fix Post 582

### DIFF
--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -20,6 +20,7 @@ canonical_serialization = { path = "../../common/canonical_serialization" }
 # List out modules with data structures being fuzzed here.
 types = { path = "../../types" }
 vm = { path = "../../language/vm" }
+vm_runtime = { path = "../../language/vm/vm_runtime"}
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types" }
 
 [dev-dependencies]


### PR DESCRIPTION
https://github.com/libra/libra/pull/582 breaks the fuzzer (spec. `libra_fuzzer/fuzz`). I [noticed the issue](https://github.com/libra/libra/pull/582#issuecomment-521506806) before merging, but my fat fingeers missed inserting the fix in the [new version of the PR](https://github.com/libra/libra/compare/8b5bc542505c6bf8d03f71c2080d1a556ed75236..dd3eb647b638ebee7b8e6205d66d558eb48e6900).

The fix is hereby attached.