### PR TITLE
[crypto] Removes public key lengths from API + cleanup

### DIFF
--- a/crypto/legacy_crypto/src/hash.rs
+++ b/crypto/legacy_crypto/src/hash.rs
@@ -147,21 +147,6 @@ impl HashValue {
         HashValue { hash }
     }
 
-    /// Get the size of the hash.
-    pub fn len() -> usize {
-        HashValue::LENGTH
-    }
-
-    /// Get the last n bytes as a String.
-    pub fn last_n_bytes(&self, bytes: usize) -> String {
-        let mut string = String::from("HashValue(..");
-        for byte in &self.hash[(HashValue::LENGTH - bytes)..] {
-            string.push_str(&format!("{:02x}", byte));
-        }
-        string.push_str(")");
-        string
-    }
-
     // Intentionally not public.
     fn from_sha3(buffer: &[u8]) -> Self {
         let mut sha3 = Keccak::new_sha3_256();

--- a/crypto/nextgen_crypto/src/bls12381.rs
+++ b/crypto/nextgen_crypto/src/bls12381.rs
@@ -178,9 +178,6 @@ impl From<&BLS12381PrivateKey> for BLS12381PublicKey {
 // we get the ability to do `pubkey.validate(msg, signature)`
 impl PublicKey for BLS12381PublicKey {
     type PrivateKeyMaterial = BLS12381PrivateKey;
-    fn length() -> usize {
-        BLS12381_PUBLIC_KEY_LENGTH
-    }
 }
 
 impl VerifyingKey for BLS12381PublicKey {

--- a/crypto/nextgen_crypto/src/ed25519.rs
+++ b/crypto/nextgen_crypto/src/ed25519.rs
@@ -40,11 +40,11 @@ use serde::{de, export, ser};
 use std::fmt;
 
 /// The length of the Ed25519PrivateKey
-const ED25519_PRIVATE_KEY_LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+pub const ED25519_PRIVATE_KEY_LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
 /// The length of the Ed25519PublicKey
-const ED25519_PUBLIC_KEY_LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+pub const ED25519_PUBLIC_KEY_LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
 /// The length of the Ed25519Signature
-const ED25519_SIGNATURE_LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
+pub const ED25519_SIGNATURE_LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
 
 /// An Ed25519 private key
 #[derive(SilentDisplay, SilentDebug)]
@@ -232,9 +232,6 @@ impl From<&Ed25519PrivateKey> for Ed25519PublicKey {
 // We deduce PublicKey from this
 impl PublicKey for Ed25519PublicKey {
     type PrivateKeyMaterial = Ed25519PrivateKey;
-    fn length() -> usize {
-        ED25519_PUBLIC_KEY_LENGTH
-    }
 }
 
 impl std::hash::Hash for Ed25519PublicKey {

--- a/crypto/nextgen_crypto/src/traits.rs
+++ b/crypto/nextgen_crypto/src/traits.rs
@@ -144,9 +144,6 @@ pub trait PublicKey: Sized + Clone + Eq + Hash +
     /// We require public / private types to be coupled, i.e. their
     /// associated type is each other.
     type PrivateKeyMaterial: PrivateKey<PublicKeyMaterial = Self>;
-    /// The length of the [`PublicKey`]
-    fn length() -> usize;
-
 }
 
 /// A type family of public keys that are used for signing.

--- a/crypto/nextgen_crypto/src/unit_tests/cross_test.rs
+++ b/crypto/nextgen_crypto/src/unit_tests/cross_test.rs
@@ -81,10 +81,6 @@ impl ValidKey for PrivateK {
 
 impl PublicKey for PublicK {
     type PrivateKeyMaterial = PrivateK;
-    // TODO(fga): fix this!
-    fn length() -> usize {
-        std::cmp::max(BLS12381PublicKey::length(), Ed25519PublicKey::length())
-    }
 }
 
 impl TryFrom<&[u8]> for PublicK {

--- a/crypto/nextgen_crypto/src/x25519.rs
+++ b/crypto/nextgen_crypto/src/x25519.rs
@@ -268,18 +268,10 @@ impl Eq for X25519PublicKey {}
 
 impl PublicKey for X25519PublicKey {
     type PrivateKeyMaterial = X25519EphemeralPrivateKey;
-
-    fn length() -> usize {
-        X25519_PUBLIC_KEY_LENGTH
-    }
 }
 
 impl PublicKey for X25519StaticPublicKey {
     type PrivateKeyMaterial = X25519StaticPrivateKey;
-
-    fn length() -> usize {
-        X25519_PUBLIC_KEY_LENGTH
-    }
 }
 
 impl TryFrom<&[u8]> for X25519StaticPublicKey {

--- a/crypto/secret_service/src/crypto_wrappers.rs
+++ b/crypto/secret_service/src/crypto_wrappers.rs
@@ -101,10 +101,6 @@ impl ValidKey for GenericPrivateKey {
 
 impl PublicKey for GenericPublicKey {
     type PrivateKeyMaterial = GenericPrivateKey;
-
-    fn length() -> usize {
-        std::cmp::max(BLS12381PublicKey::length(), Ed25519PublicKey::length())
-    }
 }
 
 impl TryFrom<&[u8]> for GenericPublicKey {

--- a/storage/libradb/src/schema/validator/mod.rs
+++ b/storage/libradb/src/schema/validator/mod.rs
@@ -14,7 +14,7 @@ use crate::schema::{ensure_slice_len_eq, VALIDATOR_CF_NAME};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use core::convert::TryFrom;
 use failure::prelude::*;
-use nextgen_crypto::{ed25519::Ed25519PublicKey, PublicKey};
+use nextgen_crypto::ed25519::{Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
@@ -36,7 +36,7 @@ impl KeyCodec<ValidatorSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
         let public_key_serialized = self.public_key.to_bytes();
         let mut encoded_key =
-            Vec::with_capacity(size_of::<Version>() + Ed25519PublicKey::length() * size_of::<u8>());
+            Vec::with_capacity(size_of::<Version>() + ED25519_PUBLIC_KEY_LENGTH * size_of::<u8>());
         encoded_key.write_u64::<BigEndian>(self.version)?;
         encoded_key.write_all(&public_key_serialized)?;
         Ok(encoded_key)


### PR DESCRIPTION
*What this does*

Makes us rely on constants in the individual signing scheme's declarations for length information rather than on a (mostly unused) generic method.
Removes dead code.
(see individual commit messages)

*Why this is better*

Makes union types (in cross_test, secret_service) more regular.

*Why this is worse*
n/a

*Tests & TODO*
Technically augments code coverage (red diff)