### PR TITLE
[language][MoveIR] Added Parsing and Compiler Support for Acquires List

### DIFF
--- a/language/compiler/ir_to_bytecode/src/compiler.rs
+++ b/language/compiler/ir_to_bytecode/src/compiler.rs
@@ -1634,12 +1634,16 @@ impl<S: Scope + Sized> Compiler<S> {
             FunctionBody::Move { .. } => 0,
             FunctionBody::Native => CodeUnit::NATIVE,
         };
+        let mut acquires_global_resources = vec![];
+        for name in function.acquires.iter() {
+            let (_is_resource, def_idx) = self.scope.get_struct_def(name.name_ref())?;
+            acquires_global_resources.push(def_idx)
+        }
 
         let func_def = FunctionDefinition {
             function: fh_idx,
             flags,
-            // TODO needs to be parsed and added to the IR
-            acquires_global_resources: vec![],
+            acquires_global_resources,
             code: CodeUnit::default(), // TODO: eliminate usage of default
         };
 

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -190,6 +190,11 @@ pub struct Function {
     pub visibility: FunctionVisibility,
     /// The type signature
     pub signature: FunctionSignature,
+    /// List of nominal resources (declared in this module) that the procedure might access
+    /// Either through: BorrowGlobal, MoveFrom, or transitively through another procedure
+    /// This list of acquires grants the borrow checker the ability to statically verify the safety
+    /// of references into global storage
+    pub acquires: Vec<StructName>,
     /// Annotations on the function
     pub annotations: Vec<FunctionAnnotation>,
     /// The code for the procedure
@@ -746,6 +751,7 @@ impl Function {
         visibility: FunctionVisibility,
         formals: Vec<(Var, Type)>,
         return_type: Vec<Type>,
+        acquires: Vec<StructName>,
         annotations: Vec<FunctionAnnotation>,
         body: FunctionBody,
     ) -> Self {
@@ -753,6 +759,7 @@ impl Function {
         Function {
             visibility,
             signature,
+            acquires,
             annotations,
             body,
         }

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -377,6 +377,14 @@ ReturnType: Vec<Type> = {
     }
 }
 
+AcquireList: Vec<StructName> = {
+    "acquires" <s: StructName> <al: ("*" <StructName>)*> => {
+        let mut al = al;
+        al.insert(0, s);
+        al
+    }
+}
+
 FunctionDecl : (FunctionName, Function) = {
   <f: MoveFunctionDecl> => (f.0, f.1),
   <f: NativeFunctionDecl> => (f.0, f.1),
@@ -384,6 +392,7 @@ FunctionDecl : (FunctionName, Function) = {
 
 MoveFunctionDecl : (FunctionName, Function) = {
     <p: Public?> <n: Name> "(" <args: (ArgDecl)*> ")" <ret: ReturnType?>
+    <acquires: AcquireList?>
     <annotations: (FunctionAnnotation)*>
     <locals_body: FunctionBlock> => {
         let (locals, body) = locals_body;
@@ -391,6 +400,7 @@ MoveFunctionDecl : (FunctionName, Function) = {
             if p.is_some() { FunctionVisibility::Public } else { FunctionVisibility::Internal },
             args,
             ret.unwrap_or(vec![]),
+            acquires.unwrap_or_else(Vec::new),
             annotations,
             FunctionBody::Move{locals: locals, code: body},
         ))
@@ -398,11 +408,14 @@ MoveFunctionDecl : (FunctionName, Function) = {
 }
 
 NativeFunctionDecl: (FunctionName, Function) = {
-    <nat: NativeTag> <p: Public?> <n: Name> "(" <args: (ArgDecl)*> ")" <ret: ReturnType?> ";" => {
+    <nat: NativeTag> <p: Public?> <n: Name> "(" <args: (ArgDecl)*> ")" <ret: ReturnType?>
+        <acquires: AcquireList?>
+        ";" => {
         (FunctionName::new(n), Function::new(
             if p.is_some() { FunctionVisibility::Public } else { FunctionVisibility::Internal },
             args,
             ret.unwrap_or(vec![]),
+            acquires.unwrap_or_else(Vec::new),
             vec![],
             FunctionBody::Native,
         ))
@@ -443,6 +456,7 @@ pub Program : Program = {
                 vec![],
                 vec![],
                 vec![],
+                vec![],
                 FunctionBody::Move {
                     locals: vec![],
                     code: Block::new(vec![return_stmt]),
@@ -460,6 +474,7 @@ pub Script : Script = {
             Function::new(
                 FunctionVisibility::Public,
                 args,
+                vec![],
                 vec![],
                 vec![],
                 FunctionBody::Move{ locals: locals, code: body },


### PR DESCRIPTION
## Motivation

- Added Acquires list to Move IR AST
- It is parsed after the return type before the body of the function
- It is passed onto the bytecode, but not yet verified
- Not yet added to core contracts or tests, thats the next PR

## Test Plan

cargo check; cargo test

## Related PRs

Continuation of #575 