### PR TITLE
[libra_fuzzer] add a way for a fuzz target to skip generation

### DIFF
--- a/testsuite/libra_fuzzer/README.md
+++ b/testsuite/libra_fuzzer/README.md
@@ -11,6 +11,9 @@ Install [`cargo-fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html) if not 
 
 ### Fuzzing a target
 
+First, switch to the directory this README is in: `cd
+testsuite/libra_fuzzer`.
+
 To list out known fuzz targets, run `cargo run list`.
 
 To be effective, fuzzing requires a corpus of existing inputs. This

--- a/testsuite/libra_fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets.rs
@@ -31,13 +31,19 @@ macro_rules! proto_fuzz_target {
                 concat!(stringify!($ty), " (protobuf)")
             }
 
-            fn generate(&self, gen: &mut ::proptest_helpers::ValueGenerator) -> Vec<u8> {
+            fn generate(
+                &self,
+                _idx: usize,
+                gen: &mut ::proptest_helpers::ValueGenerator,
+            ) -> Option<Vec<u8>> {
                 use proto_conv::IntoProtoBytes;
 
                 let value = gen.generate(::proptest::arbitrary::any::<$ty>());
-                value
-                    .into_proto_bytes()
-                    .expect("failed to convert to bytes")
+                Some(
+                    value
+                        .into_proto_bytes()
+                        .expect("failed to convert to bytes"),
+                )
             }
 
             fn fuzz(&self, data: &[u8]) {

--- a/testsuite/libra_fuzzer/src/fuzz_targets/compiled_module.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets/compiled_module.rs
@@ -18,13 +18,13 @@ impl FuzzTargetImpl for CompiledModuleTarget {
         "VM CompiledModule (custom deserializer)"
     }
 
-    fn generate(&self, gen: &mut ValueGenerator) -> Vec<u8> {
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
         let value = gen.generate(any_with::<CompiledModuleMut>(16));
         let mut out = vec![];
         value
             .serialize(&mut out)
             .expect("serialization should work");
-        out
+        Some(out)
     }
 
     fn fuzz(&self, data: &[u8]) {

--- a/testsuite/libra_fuzzer/src/fuzz_targets/vm_value.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets/vm_value.rs
@@ -21,7 +21,7 @@ impl FuzzTargetImpl for ValueTarget {
         "VM values + types (custom deserializer)"
     }
 
-    fn generate(&self, gen: &mut ValueGenerator) -> Vec<u8> {
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
         let value = gen.generate(Value::struct_strategy());
         let struct_def = value.to_struct_def_FOR_TESTING();
 
@@ -40,7 +40,7 @@ impl FuzzTargetImpl for ValueTarget {
             .expect("writing should work");
         blob.extend_from_slice(&struct_def_blob);
         blob.extend_from_slice(&value_blob);
-        blob
+        Some(blob)
     }
 
     fn fuzz(&self, data: &[u8]) {

--- a/testsuite/libra_fuzzer/src/lib.rs
+++ b/testsuite/libra_fuzzer/src/lib.rs
@@ -15,8 +15,11 @@ pub trait FuzzTargetImpl: Sync + Send + fmt::Debug {
     /// A description for this target.
     fn description(&self) -> &'static str;
 
-    /// Generate a new example for this target to store in the corpus.
-    fn generate(&self, gen: &mut ValueGenerator) -> Vec<u8>;
+    /// Generates a new example for this target to store in the corpus. `idx` is the current index
+    /// of the item being generated, starting from 0.
+    ///
+    /// Returns `Some(bytes)` if a value was generated, or `None` if no value can be generated.
+    fn generate(&self, idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>>;
 
     /// Fuzz the target with this data. The fuzzer tests for panics or OOMs with this method.
     fn fuzz(&self, data: &[u8]);

--- a/testsuite/libra_fuzzer/src/main.rs
+++ b/testsuite/libra_fuzzer/src/main.rs
@@ -113,9 +113,9 @@ fn main() {
             target,
         } => {
             let corpus_dir = corpus_dir.unwrap_or_else(|| default_corpus_dir(target).0);
-            commands::make_corpus(target, num_items, &corpus_dir, opt.debug)
+            let item_count = commands::make_corpus(target, num_items, &corpus_dir, opt.debug)
                 .expect("Failed to create corpus");
-            println!("Wrote {} items to corpus", num_items);
+            println!("Wrote {} items to corpus", item_count);
         }
         Command::Fuzz {
             corpus_dir,


### PR DESCRIPTION
Some fuzz targets will only be able to generate 1 corpus value or even none at all.

(Also tacked on a readme update)