### PR TITLE
[languages] refactor code and add support for variable naming

### DIFF
--- a/language/stackless_bytecode/bytecode_to_boogie/output.bpl
+++ b/language/stackless_bytecode/bytecode_to_boogie/output.bpl
@@ -417,7 +417,6 @@ procedure {:inline 1} UpdateValueMax(srcPath: Path, srcValue: Value, dstPath: Pa
 }
 
 procedure TestArithmetic_add_two_number (c: CreationTime, addr_exists: [Address]bool, arg0: Value, arg1: Value) returns (addr_exists': [Address]bool, ret0: Value, ret1: Value)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int
@@ -470,7 +469,6 @@ ensures !abort_flag;
 
 }
 procedure TestArithmetic_multiple_ops (c: CreationTime, addr_exists: [Address]bool, arg0: Value, arg1: Value, arg2: Value) returns (addr_exists': [Address]bool, ret0: Value)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int
@@ -522,7 +520,6 @@ ensures !abort_flag;
 
 }
 procedure TestArithmetic_bool_ops (c: CreationTime, addr_exists: [Address]bool, arg0: Value, arg1: Value) returns (addr_exists': [Address]bool)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int
@@ -617,7 +614,6 @@ Label_23:
 
 }
 procedure TestArithmetic_arithmetic_ops (c: CreationTime, addr_exists: [Address]bool, arg0: Value, arg1: Value) returns (addr_exists': [Address]bool, ret0: Value, ret1: Value)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int
@@ -708,7 +704,6 @@ Label_19:
 
 }
 procedure TestArithmetic_overflow (c: CreationTime, addr_exists: [Address]bool) returns (addr_exists': [Address]bool)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int
@@ -747,7 +742,6 @@ ensures !abort_flag;
 
 }
 procedure TestArithmetic_underflow (c: CreationTime, addr_exists: [Address]bool) returns (addr_exists': [Address]bool)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int
@@ -786,7 +780,6 @@ ensures !abort_flag;
 
 }
 procedure TestArithmetic_div_by_zero (c: CreationTime, addr_exists: [Address]bool) returns (addr_exists': [Address]bool)
-ensures !abort_flag;
 {
     // declare local variables
     var t0: Value; // int


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As the title of this PR suggests, I
- Refactored translator code so that generation of different parts of the code now happen in different functions. For example, now there are separate `generate_function_sig` and `generate_function_body` for generating signature and body of a function. This is useful for specification generation which I'm also working on. 
- Added support for variable mapping. If argument names are provided in the form of `Option<Vec<String>>`, generated Boogie will refer to the actual names of the arguments instead of temporaries like `t1`. This is also useful for specification generation since specs are written on IR level and refer to actual variable names.
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```
cargo run FILENAME
```

## Related PRs

#434
#461 
#524 