### PR TITLE
[client] Fix bug in client minting

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -988,7 +988,7 @@ impl ClientProxy {
         }
         let sequence_number = raw_data.parse::<u64>()?;
         if is_blocking {
-            self.wait_for_transaction(AccountAddress::new([0; 32]), sequence_number);
+            self.wait_for_transaction(association_address(), sequence_number);
         }
         Ok(())
     }


### PR DESCRIPTION
# Motivation

Association address was modified in some previous PR, but the client is still listening to the old address.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Checked minting locally against testnet



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
