### PR TITLE
Time historgram buckets

### DIFF
--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -14,7 +14,7 @@ mod service_metrics;
 pub use service_metrics::ServiceMetrics;
 
 mod op_counters;
-pub use op_counters::OpMetrics;
+pub use op_counters::{DurationHistogram, OpMetrics};
 
 #[cfg(test)]
 mod unit_tests;

--- a/common/metrics/src/op_counters.rs
+++ b/common/metrics/src/op_counters.rs
@@ -11,13 +11,35 @@ use prometheus::{
     IntGaugeVec, Opts,
 };
 
+use std::time::Duration;
+
+/// A small wrapper around Histogram to handle the special case
+/// of duration buckets.
+/// This Histogram will handle the correct granularty for logging
+/// time duration in a way that fits the used buckets.
+pub struct DurationHistogram {
+    histogram: Histogram,
+}
+
+impl DurationHistogram {
+    pub fn new(histogram: Histogram) -> DurationHistogram {
+        DurationHistogram { histogram }
+    }
+
+    pub fn observe_duration(&self, d: Duration) {
+        // Duration is full seconds + nanos elapsed from the presious full second
+        let v = d.as_secs() as f64 + f64::from(d.subsec_nanos()) / 1e9;
+        self.histogram.observe(v);
+    }
+}
+
 #[derive(Clone)]
 pub struct OpMetrics {
     module: String,
     counters: IntCounterVec,
     gauges: IntGaugeVec,
     peer_gauges: IntGaugeVec,
-    histograms: HistogramVec,
+    duration_histograms: HistogramVec,
 }
 
 impl OpMetrics {
@@ -46,7 +68,7 @@ impl OpMetrics {
                 &["op", "remote_peer_id"],
             )
             .unwrap(),
-            histograms: HistogramVec::new(
+            duration_histograms: HistogramVec::new(
                 HistogramOpts::new(
                     format!("{}_duration", name_str.clone()),
                     format!("Histogram values for {}", name_str),
@@ -81,7 +103,11 @@ impl OpMetrics {
 
     #[inline]
     pub fn histogram(&self, name: &str) -> Histogram {
-        self.histograms.with_label_values(&[name])
+        self.duration_histograms.with_label_values(&[name])
+    }
+
+    pub fn duration_histogram(&self, name: &str) -> DurationHistogram {
+        DurationHistogram::new(self.duration_histograms.with_label_values(&[name]))
     }
 
     #[inline]
@@ -115,11 +141,19 @@ impl OpMetrics {
 
     #[inline]
     pub fn observe(&self, op: &str, v: f64) {
-        self.histograms.with_label_values(&[op]).observe(v);
+        self.duration_histograms.with_label_values(&[op]).observe(v);
+    }
+
+    pub fn observe_duration(&self, op: &str, d: Duration) {
+        // Duration is full seconds + nanos elapsed from the presious full second
+        let v = d.as_secs() as f64 + f64::from(d.subsec_nanos()) / 1e9;
+        self.duration_histograms.with_label_values(&[op]).observe(v);
     }
 
     pub fn timer(&self, op: &str) -> HistogramTimer {
-        self.histograms.with_label_values(&[op]).start_timer()
+        self.duration_histograms
+            .with_label_values(&[op])
+            .start_timer()
     }
 }
 
@@ -129,7 +163,7 @@ impl Collector for OpMetrics {
         ms.extend(self.counters.desc());
         ms.extend(self.gauges.desc());
         ms.extend(self.peer_gauges.desc());
-        ms.extend(self.histograms.desc());
+        ms.extend(self.duration_histograms.desc());
         ms
     }
 
@@ -138,7 +172,7 @@ impl Collector for OpMetrics {
         ms.extend(self.counters.collect());
         ms.extend(self.gauges.collect());
         ms.extend(self.peer_gauges.collect());
-        ms.extend(self.histograms.collect());
+        ms.extend(self.duration_histograms.collect());
         ms
     }
 }

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -294,7 +294,7 @@ where
                 if let Some(time_to_qc) = duration_since_epoch()
                     .checked_sub(Duration::from_micros(block.timestamp_usecs()))
                 {
-                    counters::CREATION_TO_QC_MS.observe(time_to_qc.as_millis() as f64);
+                    counters::CREATION_TO_QC_S.observe_duration(time_to_qc);
                 }
             }
             return VoteReceptionResult::NewQuorumCertificate(Arc::new(quorum_cert));

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -475,7 +475,7 @@ impl<T: Payload> EventProcessor<T> {
         if let Some(time_to_receival) =
             duration_since_epoch().checked_sub(Duration::from_micros(proposal.timestamp_usecs()))
         {
-            counters::CREATION_TO_RECEIVAL_MS.observe(time_to_receival.as_millis() as f64);
+            counters::CREATION_TO_RECEIVAL_S.observe_duration(time_to_receival);
         }
 
         let proposal_round = proposal.round();
@@ -513,12 +513,11 @@ impl<T: Payload> EventProcessor<T> {
 
                     match waiting_success {
                         WaitingSuccess::WaitWasRequired { wait_duration, .. } => {
-                            counters::VOTE_SUCCESS_WAIT_MS
-                                .observe(wait_duration.as_millis() as f64);
+                            counters::VOTE_SUCCESS_WAIT_S.observe_duration(wait_duration);
                             counters::VOTE_WAIT_WAS_REQUIRED_COUNT.inc();
                         }
                         WaitingSuccess::NoWaitRequired { .. } => {
-                            counters::VOTE_SUCCESS_WAIT_MS.observe(0.0);
+                            counters::VOTE_SUCCESS_WAIT_S.observe_duration(Duration::new(0, 0));
                             counters::VOTE_NO_WAIT_REQUIRED_COUNT.inc();
                         }
                     }
@@ -530,7 +529,7 @@ impl<T: Payload> EventProcessor<T> {
                                     "Waiting until proposal block timestamp usecs {:?} would exceed the round duration {:?}, hence will not vote for this round",
                                     block_timestamp_us,
                                     current_round_deadline);
-                            counters::VOTE_FAILURE_WAIT_MS.observe(0.0);
+                            counters::VOTE_FAILURE_WAIT_S.observe_duration(Duration::new(0, 0));
                             counters::VOTE_MAX_WAIT_EXCEEDED_COUNT.inc();
                         }
                         WaitingError::WaitFailed {
@@ -542,8 +541,7 @@ impl<T: Payload> EventProcessor<T> {
                                     wait_duration,
                                     block_timestamp_us,
                                     current_duration_since_epoch);
-                            counters::VOTE_FAILURE_WAIT_MS
-                                .observe(wait_duration.as_millis() as f64);
+                            counters::VOTE_FAILURE_WAIT_S.observe_duration(wait_duration);
                             counters::VOTE_WAIT_FAILED_COUNT.inc();
                         }
                     };
@@ -732,7 +730,7 @@ impl<T: Payload> EventProcessor<T> {
             if let Some(time_to_commit) = duration_since_epoch()
                 .checked_sub(Duration::from_micros(committed.timestamp_usecs()))
             {
-                counters::CREATION_TO_COMMIT_MS.observe(time_to_commit.as_millis() as f64);
+                counters::CREATION_TO_COMMIT_S.observe_duration(time_to_commit);
             }
             let compute_result = self
                 .block_store

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -171,8 +171,7 @@ impl<T: Payload> ProposalGenerator<T> {
                                 current_duration_since_epoch,
                                 wait_duration,
                             } => {
-                                counters::PROPOSAL_SUCCESS_WAIT_MS
-                                    .observe(wait_duration.as_millis() as f64);
+                                counters::PROPOSAL_SUCCESS_WAIT_S.observe_duration(wait_duration);
                                 counters::PROPOSAL_WAIT_WAS_REQUIRED_COUNT.inc();
                                 current_duration_since_epoch
                             }
@@ -180,7 +179,8 @@ impl<T: Payload> ProposalGenerator<T> {
                                 current_duration_since_epoch,
                                 ..
                             } => {
-                                counters::PROPOSAL_SUCCESS_WAIT_MS.observe(0.0);
+                                counters::PROPOSAL_SUCCESS_WAIT_S
+                                    .observe_duration(Duration::new(0, 0));
                                 counters::PROPOSAL_NO_WAIT_REQUIRED_COUNT.inc();
                                 current_duration_since_epoch
                             }
@@ -193,7 +193,8 @@ impl<T: Payload> ProposalGenerator<T> {
                                     "Waiting until parent block timestamp usecs {:?} would exceed the round duration {:?}, hence will not create a proposal for this round",
                                     hqc_block.timestamp_usecs(),
                                     round_deadline);
-                                counters::PROPOSAL_FAILURE_WAIT_MS.observe(0.0);
+                                counters::PROPOSAL_FAILURE_WAIT_S
+                                    .observe_duration(Duration::new(0, 0));
                                 counters::PROPOSAL_MAX_WAIT_EXCEEDED_COUNT.inc();
                                 return Err(ProposalGenerationError::ExceedsMaxRoundDuration);
                             }
@@ -206,8 +207,7 @@ impl<T: Payload> ProposalGenerator<T> {
                                     wait_duration,
                                     hqc_block.timestamp_usecs(),
                                     current_duration_since_epoch);
-                                counters::PROPOSAL_FAILURE_WAIT_MS
-                                    .observe(wait_duration.as_millis() as f64);
+                                counters::PROPOSAL_FAILURE_WAIT_S.observe_duration(wait_duration);
                                 counters::PROPOSAL_WAIT_FAILED_COUNT.inc();
                                 return Err(ProposalGenerationError::CurrentTimeTooOld);
                             }

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -210,8 +210,7 @@ impl ConsensusNetworkImpl {
                 return Err(BlockRetrievalFailure::InvalidResponse);
             }
         }
-        counters::BLOCK_RETRIEVAL_DURATION_MS
-            .observe(pre_retrieval_instant.elapsed().as_millis() as f64);
+        counters::BLOCK_RETRIEVAL_DURATION_S.observe_duration(pre_retrieval_instant.elapsed());
         let response = BlockRetrievalResponse {
             status: res_block.get_status(),
             blocks,

--- a/consensus/src/chained_bft/sync_manager.rs
+++ b/consensus/src/chained_bft/sync_manager.rs
@@ -229,7 +229,7 @@ where
                 e
             ),
         };
-        counters::STATE_SYNC_DURATION_MS.observe(pre_sync_instance.elapsed().as_millis() as f64);
+        counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());
         let root = (
             blocks.pop().expect("should have 3-chain"),
             quorum_certs.last().expect("should have 3-chain").clone(),

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use metrics::OpMetrics;
+use metrics::{DurationHistogram, OpMetrics};
 use prometheus::{Histogram, IntCounter, IntGauge};
 
 lazy_static::lazy_static! {
@@ -75,10 +75,10 @@ pub static ref STATE_SYNC_COUNT: IntCounter = OP_COUNTERS.counter("state_sync_co
 pub static ref BLOCK_RETRIEVAL_COUNT: IntCounter = OP_COUNTERS.counter("block_retrieval_count");
 
 /// Histogram of block retrieval duration.
-pub static ref BLOCK_RETRIEVAL_DURATION_MS: Histogram = OP_COUNTERS.histogram("block_retrieval_duration_ms");
+pub static ref BLOCK_RETRIEVAL_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("block_retrieval_duration_s");
 
 /// Histogram of state sync duration.
-pub static ref STATE_SYNC_DURATION_MS: Histogram = OP_COUNTERS.histogram("state_sync_duration_ms");
+pub static ref STATE_SYNC_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("state_sync_duration_s");
 
 /// Counts the number of times the sync info message has been set since last restart.
 pub static ref SYNC_INFO_MSGS_SENT_COUNT: IntCounter = OP_COUNTERS.counter("sync_info_msg_sent_count");
@@ -108,31 +108,31 @@ pub static ref NUM_BLOCKS_IN_TREE: IntGauge = OP_COUNTERS.gauge("num_blocks_in_t
 // PERFORMANCE COUNTERS
 //////////////////////
 /// Histogram of execution time (ms) of non-empty blocks.
-pub static ref BLOCK_EXECUTION_DURATION_MS: Histogram = OP_COUNTERS.histogram("block_execution_duration_ms");
+pub static ref BLOCK_EXECUTION_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("block_execution_duration_s");
 
 /// Histogram of duration of a commit procedure (the time it takes for the execution / storage to
 /// commit a block once we decide to do so).
-pub static ref BLOCK_COMMIT_DURATION_MS: Histogram = OP_COUNTERS.histogram("block_commit_duration_ms");
+pub static ref BLOCK_COMMIT_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("block_commit_duration_s");
 
 /// Histogram for the number of txns per (committed) blocks.
 pub static ref NUM_TXNS_PER_BLOCK: Histogram = OP_COUNTERS.histogram("num_txns_per_block");
 
 /// Histogram of per-transaction execution time (ms) of non-empty blocks
 /// (calculated as the overall execution time of a block divided by the number of transactions).
-pub static ref TXN_EXECUTION_DURATION_MS: Histogram = OP_COUNTERS.histogram("txn_execution_duration_ms");
+pub static ref TXN_EXECUTION_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("txn_execution_duration_s");
 
 /// Histogram of execution time (ms) of empty blocks.
-pub static ref EMPTY_BLOCK_EXECUTION_DURATION_MS: Histogram = OP_COUNTERS.histogram("empty_block_execution_duration_ms");
+pub static ref EMPTY_BLOCK_EXECUTION_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("empty_block_execution_duration_s");
 
 /// Histogram of the time it takes for a block to get committed.
 /// Measured as the commit time minus block's timestamp.
-pub static ref CREATION_TO_COMMIT_MS: Histogram = OP_COUNTERS.histogram("creation_to_commit_ms");
+pub static ref CREATION_TO_COMMIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("creation_to_commit_s");
 
 /// Duration between block generation time until the moment it gathers full QC
-pub static ref CREATION_TO_QC_MS: Histogram = OP_COUNTERS.histogram("creation_to_qc_ms");
+pub static ref CREATION_TO_QC_S: DurationHistogram = OP_COUNTERS.duration_histogram("creation_to_qc_s");
 
 /// Duration between block generation time until the moment it is received and ready for execution.
-pub static ref CREATION_TO_RECEIVAL_MS: Histogram = OP_COUNTERS.histogram("creation_to_receival_ms");
+pub static ref CREATION_TO_RECEIVAL_S: DurationHistogram = OP_COUNTERS.duration_histogram("creation_to_receival_s");
 
 ////////////////////////////////////
 // PROPSOSAL/VOTE TIMESTAMP COUNTERS
@@ -150,10 +150,10 @@ pub static ref PROPOSAL_MAX_WAIT_EXCEEDED_COUNT: IntCounter = OP_COUNTERS.counte
 pub static ref PROPOSAL_WAIT_FAILED_COUNT: IntCounter = OP_COUNTERS.counter("proposal_wait_failed_count");
 
 /// Histogram of time waited for successfully proposing a proposal (both those that waited and didn't wait) after following timestamp rules
-pub static ref PROPOSAL_SUCCESS_WAIT_MS: Histogram = OP_COUNTERS.histogram("proposal_success_wait_ms");
+pub static ref PROPOSAL_SUCCESS_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("proposal_success_wait_s");
 
 /// Histogram of time waited for failing to propose a proposal (both those that waited and didn't wait) while trying to follow timestamp rules
-pub static ref PROPOSAL_FAILURE_WAIT_MS: Histogram = OP_COUNTERS.histogram("proposal_failure_wait_ms");
+pub static ref PROPOSAL_FAILURE_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("proposal_failure_wait_s");
 
 /// Count of the votes that passed the timestamp rules and did not have to wait
 pub static ref VOTE_NO_WAIT_REQUIRED_COUNT: IntCounter = OP_COUNTERS.counter("vote_no_wait_required_count");
@@ -169,10 +169,10 @@ pub static ref VOTE_WAIT_FAILED_COUNT: IntCounter = OP_COUNTERS.counter("vote_wa
 
 /// Histogram of time waited for successfully having the ability to vote (both those that waited and didn't wait) after following timestamp rules.
 /// A success only means that a replica has an opportunity to vote.  It may not vote if it doesn't pass the voting rules.
-pub static ref VOTE_SUCCESS_WAIT_MS: Histogram = OP_COUNTERS.histogram("vote_success_wait_ms");
+pub static ref VOTE_SUCCESS_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("vote_success_wait_s");
 
 /// Histogram of time waited for failing to have the ability to vote (both those that waited and didn't wait) while trying to follow timestamp rules
-pub static ref VOTE_FAILURE_WAIT_MS: Histogram = OP_COUNTERS.histogram("vote_failure_wait_ms");
+pub static ref VOTE_FAILURE_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("vote_failure_wait_s");
 
 ///////////////////
 // CHANNEL COUNTERS


### PR DESCRIPTION
## Motivation

This PR makes our histograms for time duration usable by matching the values we log to the buckets we use. This enables us viewing percentile values (p50, p99, etc) and not just averages for duration. 

It also adds a small helper struct to log `Duration` struct directly, so code that tries to use it doesn't have to deal with unit conversions.

### Administrativia
I'd want to squash it before merging

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
(y)

## Test Plan

I ran it locally and checked that new buckets look good, values are distributed to many buckets (and not just the last one as previously).

## Future Work

- [ ] This change will require updating the dashboards.
- [ ] Most of our histograms now are using the time buckets, but some of the data logged are lengths (of arrays, # of transactions, etc). Future work will be to separate it into different histograms with different buckets