### PR TITLE
[language] remove unused verification annotations from parser/AST

### DIFF
--- a/language/compiler/ir_to_bytecode/src/compiler.rs
+++ b/language/compiler/ir_to_bytecode/src/compiler.rs
@@ -1793,7 +1793,6 @@ impl<S: Scope + Sized> Compiler<S> {
                     stmt_info = self.compile_if_else(&if_else, code, function_frame)?;
                     debug!("{:?}", code);
                 }
-                Statement::VerifyStatement(_) | Statement::AssumeStatement(_) => continue,
                 Statement::EmptyStatement => continue,
             };
             cf_info = ControlFlowInfo::successor(cf_info, stmt_info);

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -163,12 +163,6 @@ pub enum FunctionVisibility {
     Internal,
 }
 
-#[derive(PartialEq, Debug, Clone)]
-pub enum FunctionAnnotation {
-    Requires(String),
-    Ensures(String),
-}
-
 /// The body of a Move function
 #[derive(PartialEq, Debug, Clone)]
 pub enum FunctionBody {
@@ -195,8 +189,6 @@ pub struct Function {
     /// This list of acquires grants the borrow checker the ability to statically verify the safety
     /// of references into global storage
     pub acquires: Vec<StructName>,
-    /// Annotations on the function
-    pub annotations: Vec<FunctionAnnotation>,
     /// The code for the procedure
     pub body: FunctionBody,
 }
@@ -356,8 +348,6 @@ pub enum Statement {
     WhileStatement(While),
     /// `loop { s }`
     LoopStatement(Loop),
-    VerifyStatement(String),
-    AssumeStatement(String),
     /// no-op that eases parsing in some places
     EmptyStatement,
 }
@@ -750,7 +740,6 @@ impl Function {
         formals: Vec<(Var, Type)>,
         return_type: Vec<Type>,
         acquires: Vec<StructName>,
-        annotations: Vec<FunctionAnnotation>,
         body: FunctionBody,
     ) -> Self {
         let signature = FunctionSignature::new(formals, return_type);
@@ -758,7 +747,6 @@ impl Function {
             visibility,
             signature,
             acquires,
-            annotations,
             body,
         }
     }
@@ -1239,8 +1227,6 @@ impl fmt::Display for Statement {
             Statement::IfElseStatement(if_else) => write!(f, "{}", if_else),
             Statement::WhileStatement(while_) => write!(f, "{}", while_),
             Statement::LoopStatement(loop_) => write!(f, "{}", loop_),
-            Statement::VerifyStatement(cond) => write!(f, "verify<{}>)", cond),
-            Statement::AssumeStatement(cond) => write!(f, "assume<{}>", cond),
             Statement::EmptyStatement => write!(f, "<empty statement>"),
         }
     }

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -4,7 +4,7 @@ use codespan::{ByteIndex, Span};
 
 use crate::ast::{ModuleDefinition, StructDefinition, Script, Program};
 use crate::ast::{
-    FunctionAnnotation, FunctionBody, FunctionVisibility, ImportDefinition, ModuleName,
+    FunctionBody, FunctionVisibility, ImportDefinition, ModuleName,
     Block, Cmd, CopyableVal, Spanned,
     Cmd_, Exp_, Exp, Var,  Var_, FunctionCall,
     FunctionName, Builtin, Statement, IfElse, While, Loop, Type, Field, Fields,
@@ -275,8 +275,6 @@ Statement : Statement = {
     <IfStatement>,
     <WhileStatement>,
     <LoopStatement>,
-    <VerifyStatement>,
-    <AssumeStatement>,
     ";" => Statement::EmptyStatement,
 }
 
@@ -310,17 +308,6 @@ VerifierCondition: String = {
     }
 }
 
-VerifyStatement: Statement = {
-    "verify" <cond: VerifierCondition> => {
-        Statement::VerifyStatement(cond)
-    }
-}
-
-AssumeStatement: Statement = {
-    "assume" <cond: VerifierCondition> => {
-        Statement::AssumeStatement(cond)
-    }
-}
 
 Statements : Vec<Statement> = {
     <Statement*>
@@ -364,11 +351,6 @@ Public: () = {
   "public" => ()
 }
 
-FunctionAnnotation: FunctionAnnotation = {
-  "requires" <cond: VerifierCondition> => FunctionAnnotation::Requires(cond.to_string()),
-  "ensures" <cond: VerifierCondition> => FunctionAnnotation::Ensures(cond.to_string()),
-}
-
 ReturnType: Vec<Type> = {
     ":" <t: Type> <v: ("*" <Type>)*> => {
         let mut v = v;
@@ -393,7 +375,6 @@ FunctionDecl : (FunctionName, Function) = {
 MoveFunctionDecl : (FunctionName, Function) = {
     <p: Public?> <n: Name> "(" <args: (ArgDecl)*> ")" <ret: ReturnType?>
     <acquires: AcquireList?>
-    <annotations: (FunctionAnnotation)*>
     <locals_body: FunctionBlock> => {
         let (locals, body) = locals_body;
         (FunctionName::new(n), Function::new(
@@ -401,7 +382,6 @@ MoveFunctionDecl : (FunctionName, Function) = {
             args,
             ret.unwrap_or(vec![]),
             acquires.unwrap_or_else(Vec::new),
-            annotations,
             FunctionBody::Move{locals: locals, code: body},
         ))
     }
@@ -416,7 +396,6 @@ NativeFunctionDecl: (FunctionName, Function) = {
             args,
             ret.unwrap_or(vec![]),
             acquires.unwrap_or_else(Vec::new),
-            vec![],
             FunctionBody::Native,
         ))
     }
@@ -456,7 +435,6 @@ pub Program : Program = {
                 vec![],
                 vec![],
                 vec![],
-                vec![],
                 FunctionBody::Move {
                     locals: vec![],
                     code: Block::new(vec![return_stmt]),
@@ -474,7 +452,6 @@ pub Script : Script = {
             Function::new(
                 FunctionVisibility::Public,
                 args,
-                vec![],
                 vec![],
                 vec![],
                 FunctionBody::Move{ locals: locals, code: body },


### PR DESCRIPTION
Summary:
- The parser and AST currently supports prototype verification constructs `requires <string>`, `ensures <string>`, `verify <string>` and `assume <string>`. These are not used by any tooling downstream.
- We decided that ordinary procedures (or perhaps a special native module) would be a better way to implement `verify`/`assume` because we can also have optional runtime checking.
- We will likely want `requires`/`ensures` in the IR in the future, but they will be implemented using something more structured than a string (e.g., so we can match formals to variables used in the IR).

Test Plan:
`cargo test`, there actually weren't any tests for this parser functionality.