### PR TITLE
[state sync] full node support

### DIFF
--- a/state_synchronizer/src/executor_proxy.rs
+++ b/state_synchronizer/src/executor_proxy.rs
@@ -1,0 +1,106 @@
+use crate::LedgerInfo;
+use config::config::NodeConfig;
+use execution_proto::proto::{
+    execution::{ExecuteChunkRequest, ExecuteChunkResponse},
+    execution_grpc::ExecutionClient,
+};
+use failure::prelude::*;
+use futures::{Future, FutureExt};
+use grpc_helpers::convert_grpc_response;
+use grpcio::{ChannelBuilder, EnvBuilder};
+use logger::prelude::*;
+use network::proto::GetChunkResponse;
+use nextgen_crypto::ed25519::*;
+use proto_conv::IntoProto;
+use std::{pin::Pin, sync::Arc};
+use storage_client::{StorageRead, StorageReadServiceClient};
+use types::ledger_info::LedgerInfoWithSignatures;
+
+/// Proxies interactions with execution and storage for state synchronization
+pub trait ExecutorProxyTrait: Sync + Send {
+    /// Return the latest known version
+    fn get_latest_ledger_info(&self) -> Pin<Box<dyn Future<Output = Result<LedgerInfo>> + Send>>;
+
+    /// Execute and commit a batch of transactions
+    fn execute_chunk(
+        &self,
+        request: ExecuteChunkRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ExecuteChunkResponse>> + Send>>;
+
+    /// Gets chunk of transactions
+    fn get_chunk(
+        &self,
+        known_version: u64,
+        limit: u64,
+        target: LedgerInfoWithSignatures<Ed25519Signature>,
+    ) -> Pin<Box<dyn Future<Output = Result<GetChunkResponse>> + Send>>;
+}
+
+pub(crate) struct ExecutorProxy {
+    storage_client: Arc<StorageReadServiceClient>,
+    execution_client: Arc<ExecutionClient>,
+}
+
+impl ExecutorProxy {
+    pub(crate) fn new(config: &NodeConfig) -> Self {
+        let connection_str = format!("localhost:{}", config.execution.port);
+        let env = Arc::new(EnvBuilder::new().name_prefix("grpc-coord-").build());
+        let execution_client = Arc::new(ExecutionClient::new(
+            ChannelBuilder::new(Arc::clone(&env)).connect(&connection_str),
+        ));
+        let storage_client = Arc::new(StorageReadServiceClient::new(
+            env,
+            &config.storage.address,
+            config.storage.port,
+        ));
+        Self {
+            storage_client,
+            execution_client,
+        }
+    }
+}
+
+impl ExecutorProxyTrait for ExecutorProxy {
+    fn get_latest_ledger_info(&self) -> Pin<Box<dyn Future<Output = Result<LedgerInfo>> + Send>> {
+        let client = Arc::clone(&self.storage_client);
+        async move { Ok(client.update_to_latest_ledger_async(0, vec![]).await?.1) }.boxed()
+    }
+
+    fn execute_chunk(
+        &self,
+        request: ExecuteChunkRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ExecuteChunkResponse>> + Send>> {
+        let client = Arc::clone(&self.execution_client);
+        convert_grpc_response(client.execute_chunk_async(&request)).boxed()
+    }
+
+    fn get_chunk(
+        &self,
+        known_version: u64,
+        limit: u64,
+        target: LedgerInfoWithSignatures<Ed25519Signature>,
+    ) -> Pin<Box<dyn Future<Output = Result<GetChunkResponse>> + Send>> {
+        let client = Arc::clone(&self.storage_client);
+        async move {
+            let transactions = client
+                .get_transactions_async(
+                    known_version + 1,
+                    limit,
+                    target.ledger_info().version(),
+                    false,
+                )
+                .await?;
+            if transactions.transaction_and_infos.is_empty() {
+                error!(
+                    "[state sync] can't get {} txns from version {}",
+                    limit, known_version
+                );
+            }
+            let mut resp = GetChunkResponse::new();
+            resp.set_ledger_info_with_sigs(target.into_proto());
+            resp.set_txn_list_with_proof(transactions.into_proto());
+            Ok(resp)
+        }
+            .boxed()
+    }
+}

--- a/state_synchronizer/src/lib.rs
+++ b/state_synchronizer/src/lib.rs
@@ -4,15 +4,18 @@
 //! Used for node restarts, network partitions, full node syncs
 #![feature(async_await)]
 #![recursion_limit = "1024"]
-use types::account_address::AccountAddress;
+use nextgen_crypto::ed25519::*;
+use types::{account_address::AccountAddress, ledger_info::LedgerInfoWithSignatures};
 
 pub use synchronizer::{StateSyncClient, StateSynchronizer};
 
 mod coordinator;
 mod counters;
+mod executor_proxy;
 mod synchronizer;
 
 type PeerId = AccountAddress;
+type LedgerInfo = LedgerInfoWithSignatures<Ed25519Signature>;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
adds support for normal full node workload
`autosync` parameter is added
In `autosync` mode, state synchronizer tries to fetch new data from upstream nodes even if no target version was set
notes:
* for Full Nodes peers will be discovered through networking stack. For Validator from relevant QC
* it's basic implementation. Works closer to rpc model than long polling. For latter we need request queue and async notification. Will be added in separate diff
* added API to state sync client to query/debug internal state. So far it includes known version only
* executor_proxy was moved to separate file

## Test Plan
`test_full_node` is added

