### PR TITLE
[consensus] Cleanup unused, untested helper methods in consensus

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -3,9 +3,7 @@
 
 use crate::{
     chained_bft::{
-        block_storage::{
-            block_tree::BlockTree, BlockReader, BlockTreeError, InsertError, VoteReceptionResult,
-        },
+        block_storage::{block_tree::BlockTree, BlockReader, InsertError, VoteReceptionResult},
         common::{Payload, Round},
         consensus_types::{block::Block, quorum_cert::QuorumCert},
         persistent_storage::PersistentStorage,
@@ -435,14 +433,6 @@ impl<T: Payload> BlockReader for BlockStore<T> {
             .read()
             .unwrap()
             .get_quorum_cert_for_block(block_id)
-    }
-
-    fn is_ancestor(
-        &self,
-        ancestor: &Block<Self::Payload>,
-        block: &Block<Self::Payload>,
-    ) -> Result<bool, BlockTreeError> {
-        self.inner.read().unwrap().is_ancestor(ancestor, block)
     }
 
     fn path_from_root(&self, block: Arc<Block<T>>) -> Option<Vec<Arc<Block<T>>>> {

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -172,25 +172,6 @@ where
         self.id_to_quorum_cert.get(&block_id).cloned()
     }
 
-    pub(super) fn is_ancestor(
-        &self,
-        ancestor: &Block<T>,
-        block: &Block<T>,
-    ) -> Result<bool, BlockTreeError> {
-        let mut current_block = block;
-        while current_block.round() >= ancestor.round() {
-            let parent_id = current_block.parent_id();
-            current_block = self
-                .id_to_block
-                .get(&parent_id)
-                .ok_or(BlockTreeError::BlockNotFound { id: parent_id })?;
-            if current_block.id() == ancestor.id() {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
     pub(super) fn insert_block(
         &mut self,
         block: Block<T>,
@@ -424,14 +405,6 @@ where
 
     pub(super) fn get_all_block_id(&self) -> Vec<HashValue> {
         self.id_to_block.keys().cloned().collect()
-    }
-
-    #[allow(dead_code)]
-    fn print_all_blocks(&self) {
-        println!("Printing all {} blocks", self.id_to_block.len());
-        for block in self.id_to_block.values() {
-            println!("{:?}", block);
-        }
     }
 }
 

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -168,15 +168,6 @@ pub trait BlockReader: Send + Sync {
 
     fn get_quorum_cert_for_block(&self, block_id: HashValue) -> Option<Arc<QuorumCert>>;
 
-    /// Returns true if a given "ancestor" block is an ancestor of a given "block".
-    /// Returns a failure if not all the blocks are present between the block's height and the
-    /// parent's height.
-    fn is_ancestor(
-        &self,
-        ancestor: &Block<Self::Payload>,
-        block: &Block<Self::Payload>,
-    ) -> Result<bool, BlockTreeError>;
-
     /// Returns all the blocks between the root and the given block, including the given block
     /// but excluding the root.
     /// In case a given block is not the successor of the root, return None.


### PR DESCRIPTION
*What this does*:

- remove `is_ancestor` from block storage,
- remove `print_all_blocks`.

*Why this is better*:

- no code or test is using this,

*Why this is worse*:

- it's not