### PR TITLE
[language][MoveIR] remove unused get_height construct

### DIFF
--- a/language/compiler/ir_to_bytecode/src/compiler.rs
+++ b/language/compiler/ir_to_bytecode/src/compiler.rs
@@ -2378,7 +2378,6 @@ impl<S: Scope + Sized> Compiler<S> {
                         };
                         Ok(self.make_singleton_vec_deque(InferredType::Reference(inner_token)))
                     }
-                    _ => bail!("unsupported builtin function: {}", function),
                 }
             }
             FunctionCall::ModuleFunctionCall { module, name } => {

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -255,8 +255,6 @@ pub enum Builtin {
     /// Get the struct object (`StructName` resolved by current module) associated with the given
     /// address
     BorrowGlobal(StructName),
-    /// Returns the height of the current transaction.
-    GetHeight,
     /// Returns the price per gas unit the current transaction is willing to pay
     GetTxnGasUnitPrice,
     /// Returns the maximum units of gas the current transaction is willing to use
@@ -1140,7 +1138,6 @@ impl fmt::Display for Builtin {
             Builtin::Release => write!(f, "release"),
             Builtin::Exists(t) => write!(f, "exists<{}>", t),
             Builtin::BorrowGlobal(t) => write!(f, "borrow_global<{}>", t),
-            Builtin::GetHeight => write!(f, "get_height"),
             Builtin::GetTxnMaxGasUnits => write!(f, "get_txn_max_gas_units"),
             Builtin::GetTxnGasUnitPrice => write!(f, "get_txn_gas_unit_price"),
             Builtin::GetTxnPublicKey => write!(f, "get_txn_public_key"),

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -205,7 +205,6 @@ Builtin: Builtin = {
     "release" => Builtin::Release,
     "exists<" <t : StructName> ">" => Builtin::Exists(t),
     "borrow_global<" <t : StructName> ">" => Builtin::BorrowGlobal(t),
-    "get_height" => Builtin::GetHeight,
     "get_txn_gas_unit_price" => Builtin::GetTxnGasUnitPrice,
     "get_txn_max_gas_units" => Builtin::GetTxnMaxGasUnits,
     "get_txn_public_key" => Builtin::GetTxnPublicKey,


### PR DESCRIPTION
A bit more AST cleanup.