### PR TITLE
[network] Refactor NetworkBuilder to enable modularized construction

### DIFF
--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -18,10 +18,11 @@ config = { path = "../config" }
 consensus = { path = "../consensus" }
 crash_handler = { path = "../common/crash_handler" }
 debug_interface = { path = "../common/debug_interface" }
-logger = { path = "../common/logger" }
 executable_helpers = { path = "../common/executable_helpers" }
 execution_proto = { path = "../execution/execution_proto" }
+futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["async-await", "nightly", "io-compat", "compat"] }
 grpc_helpers = { path = "../common/grpc_helpers" }
+logger = { path = "../common/logger" }
 mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
 nextgen_crypto = { path = "../crypto/nextgen_crypto" }

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -91,23 +91,27 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
     .collect();
 
     // Set up the listener network
-    let ((_, _), (_listener_sender, mut listener_events), _, listen_addr) =
+    let (listen_addr, mut network_provider) =
         NetworkBuilder::new(runtime.executor(), listener_peer_id, listener_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
             .identity_keys((listener_identity_private_key, listener_identity_public_key))
             .signing_keys((listener_signing_private_key, listener_signing_public_key))
             .discovery_interval_ms(HOUR_IN_MS)
-            .consensus_protocols(vec![ProtocolId::from_static(
-                CONSENSUS_DIRECT_SEND_PROTOCOL,
-            )])
             .direct_send_protocols(vec![ProtocolId::from_static(
                 CONSENSUS_DIRECT_SEND_PROTOCOL,
             )])
             .build();
+    let (_listener_sender, mut listener_events) =
+        network_provider.add_consensus(vec![ProtocolId::from_static(
+            CONSENSUS_DIRECT_SEND_PROTOCOL,
+        )]);
+    runtime
+        .executor()
+        .spawn(network_provider.start().unit_error().compat());
 
     // Set up the dialer network
-    let ((_, _), (mut dialer_sender, mut dialer_events), _, _dialer_addr) =
+    let (_dialer_addr, mut network_provider) =
         NetworkBuilder::new(runtime.executor(), dialer_peer_id, dialer_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
@@ -120,13 +124,17 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
                     .collect(),
             )
             .discovery_interval_ms(HOUR_IN_MS)
-            .consensus_protocols(vec![ProtocolId::from_static(
-                CONSENSUS_DIRECT_SEND_PROTOCOL,
-            )])
             .direct_send_protocols(vec![ProtocolId::from_static(
                 CONSENSUS_DIRECT_SEND_PROTOCOL,
             )])
             .build();
+    let (mut dialer_sender, mut dialer_events) =
+        network_provider.add_consensus(vec![ProtocolId::from_static(
+            CONSENSUS_DIRECT_SEND_PROTOCOL,
+        )]);
+    runtime
+        .executor()
+        .spawn(network_provider.start().unit_error().compat());
 
     // Wait for establishing connection
     let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();
@@ -218,19 +226,23 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
     .collect();
 
     // Set up the listener network
-    let ((_, _), (_listener_sender, mut listener_events), _, listen_addr) =
+    let (listen_addr, mut network_provider) =
         NetworkBuilder::new(runtime.executor(), listener_peer_id, listener_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
             .identity_keys((listener_identity_private_key, listener_identity_public_key))
             .signing_keys((listener_signing_private_key, listener_signing_public_key))
             .discovery_interval_ms(HOUR_IN_MS)
-            .consensus_protocols(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)])
             .rpc_protocols(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)])
             .build();
+    let (_listener_sender, mut listener_events) =
+        network_provider.add_consensus(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)]);
+    runtime
+        .executor()
+        .spawn(network_provider.start().unit_error().compat());
 
     // Set up the dialer network
-    let ((_, _), (dialer_sender, mut dialer_events), _, _dialer_addr) =
+    let (_dialer_addr, mut network_provider) =
         NetworkBuilder::new(runtime.executor(), dialer_peer_id, dialer_addr)
             .transport(TransportType::TcpNoise)
             .trusted_peers(trusted_peers.clone())
@@ -243,9 +255,13 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
                     .collect(),
             )
             .discovery_interval_ms(HOUR_IN_MS)
-            .consensus_protocols(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)])
             .rpc_protocols(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)])
             .build();
+    let (dialer_sender, mut dialer_events) =
+        network_provider.add_consensus(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)]);
+    runtime
+        .executor()
+        .spawn(network_provider.start().unit_error().compat());
 
     // Wait for establishing connection
     let first_dialer_event = block_on(dialer_events.next()).unwrap().unwrap();

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -16,6 +16,7 @@ mod state_synchronizer;
 mod test;
 
 // Public re-exports
+pub use crate::interface::LibraNetworkProvider;
 pub use consensus::{
     ConsensusNetworkEvents, ConsensusNetworkSender, CONSENSUS_DIRECT_SEND_PROTOCOL,
     CONSENSUS_RPC_PROTOCOL,


### PR DESCRIPTION
## Motivation

`NetworkBuilder` currently constructs the consensus and mempool network handles by default. In the case of full nodes, if these handles are constructed but the corresponding modules are not initialized, we observe `panic!` in network code attempting to send events (such as `NewPeer`) to all upstream handlers.

With this PR, the goal is to modularize the construction of upstream handlers over the vanilla network stack. To accomplish this, we split construction of upstream senders and event handlers from `NetworkBuilder` and move it to `NetworkProvider`. Users now follow the following steps when setting up the network:

```
let (listen_addr, mut network_provider) = NetworkBuilder::new(...)
    .foo()
    .bar()
    .build();
let (upstream_sender, upstream_events) = network_provider.add_mempool([..mempool protocols..]);
// add other upstreams if needed
runtime.executor().spawn(network_provider.start().unit_error().compat();
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing test case coverage

## Related PRs
#537 #608 