### PR TITLE
[Proof] Make definition module private

### DIFF
--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -76,10 +76,7 @@ use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey};
 use proptest_derive::Arbitrary;
 use std::collections::{HashMap, HashSet};
 use tree_cache::TreeCache;
-use types::{
-    account_state_blob::AccountStateBlob, proof::definition::SparseMerkleProof,
-    transaction::Version,
-};
+use types::{account_state_blob::AccountStateBlob, proof::SparseMerkleProof, transaction::Version};
 
 /// The hardcoded maximum height of a [`JellyfishMerkleTree`] in nibbles.
 const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;

--- a/storage/storage_client/src/state_view.rs
+++ b/storage/storage_client/src/state_view.rs
@@ -15,7 +15,7 @@ use std::{
 use types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    proof::{definition::SparseMerkleProof, verify_sparse_merkle_element},
+    proof::{verify_sparse_merkle_element, SparseMerkleProof},
     transaction::Version,
 };
 

--- a/storage/storage_proto/src/lib.rs
+++ b/storage/storage_proto/src/lib.rs
@@ -37,7 +37,7 @@ use types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    proof::definition::SparseMerkleProof,
+    proof::SparseMerkleProof,
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
 

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -22,7 +22,7 @@ use types::{
     account_state_blob::AccountStateBlob,
     get_with_proof::{RequestItem, ResponseItem},
     ledger_info::LedgerInfoWithSignatures,
-    proof::definition::SparseMerkleProof,
+    proof::SparseMerkleProof,
     proto::{
         account_state_blob::AccountStateWithProof,
         get_with_proof::{

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod definition;
 pub mod position;
 #[cfg(any(test, feature = "testing"))]
 pub mod proptest_proof;
 
+mod definition;
 #[cfg(test)]
 #[path = "unit_tests/proof_test.rs"]
 mod proof_test;
@@ -28,7 +28,8 @@ use failure::prelude::*;
 use std::{collections::VecDeque, marker::PhantomData};
 
 pub use crate::proof::definition::{
-    AccountStateProof, AccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleProof,
+    AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, EventProof,
+    SignedTransactionProof, SparseMerkleProof,
 };
 
 /// Verifies that a `SignedTransaction` with hash value of `signed_transaction_hash`


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There is some minor inconsistency that some code uses `types::proof:xxx` but other code uses `types::proof::definition::xxx`. This change makes `definition` private.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.
