### PR TITLE
[language] bug fix in type checking of Eq and Neq

### DIFF
--- a/language/functional_tests/tests/testsuite/dereference_tests/deref_eq_bad.mvir
+++ b/language/functional_tests/tests/testsuite/dereference_tests/deref_eq_bad.mvir
@@ -1,0 +1,18 @@
+module M {
+    struct T {v : u64}
+
+    public new(v: u64): Self.T {
+        return T{v: move(v)};
+    }
+
+    public compare(t1: &mut Self.T, t2: &mut Self.T) : bool {
+        let b: bool;
+        let x_ref: &mut u64;
+        x_ref = &mut copy(t1).v;
+        b = move(t1) == move(t2);
+        return move(b);
+    }
+}
+
+// check: VerificationError
+// check: ReadRefExistsMutableBorrowError

--- a/language/functional_tests/tests/testsuite/dereference_tests/deref_eq_good.mvir
+++ b/language/functional_tests/tests/testsuite/dereference_tests/deref_eq_good.mvir
@@ -1,0 +1,20 @@
+module M {
+    struct T {v : u64}
+
+    public new(v: u64): Self.T {
+        return T{v: move(v)};
+    }
+
+    public compare1 (t1: &mut Self.T, t2: &mut Self.T) : bool {
+        return move(t1) == move(t2);
+    }
+
+    public compare2 (t1: &mut Self.T, t2: &mut Self.T) : bool {
+        let b: bool;
+        let x_ref: &u64;
+        x_ref = &copy(t1).v;
+        b = move(t1) == move(t2);
+        release(move(x_ref));
+        return move(b);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Eq and Neq can be applied to references.  The meaning is that
values obtained by dererencing are compared.  Therefore, checks
applied at ReadRef must be applied here also.  This diff adds
these extra checks.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests + two new tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
