### PR TITLE
[Types] Fix warning

### DIFF
--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -16,6 +16,7 @@ use canonical_serialization::{
     CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
     SimpleDeserializer,
 };
+#[cfg(any(test, feature = "testing"))]
 use crypto::HashValue;
 use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

```
   Compiling types v0.1.0 (/Users/wqfish/github/libra/types)
warning: unused import: `crypto::HashValue`
  --> types/src/account_config.rs:19:5
   |
19 | use crypto::HashValue;
   |     ^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_imports)] on by default
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.