### PR TITLE
Split out sccache environment as not all workflows use it.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,11 @@ commands:
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> $BASH_ENV
             echo 'export IMAGE_NAME=myapp' >> $BASH_ENV
             echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
+  sccache_setup:
+    steps:
+      - run:
+          name: Set Up sccache Environment
+          command: |
             echo 'export SCCACHE_CACHE_SIZE=2G' >> $BASH_ENV
             echo 'export RUSTC_WRAPPER=sccache' >> $BASH_ENV
             echo 'export CC="sccache cc"' >> $BASH_ENV
@@ -44,6 +49,7 @@ jobs:
     resource_class: 2xlarge
     steps:
       - env_setup
+      - sccache_setup
       - restore_sccache_cache
       - run:
           name: Git Hooks and Checks


### PR DESCRIPTION
This fixes the audit workflow, which is incorrectly trying to use sccache currently.

This was broken by #507, as it applied RUSTC_WRAPPER even on the audit workflow which did not have sccache installed, which caused failures like https://circleci.com/gh/libra/libra/2383.

## Motivation

Noticed audit workflow errors.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

If the normal CI workflows run successfully on this PR and still use caching, this should be good to go.