### PR TITLE
[Proof] Get accumulator consistency proof from storage and implement verification

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -17,7 +17,7 @@ use execution_proto::{CommitBlockResponse, ExecuteBlockResponse, ExecuteChunkRes
 use failure::prelude::*;
 use futures::channel::oneshot;
 use logger::prelude::*;
-use scratchpad::{Accumulator, ProofRead, SparseMerkleTree};
+use scratchpad::{ProofRead, SparseMerkleTree};
 use std::{
     collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque},
     convert::TryFrom,
@@ -30,7 +30,7 @@ use types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfoWithSignatures,
-    proof::SparseMerkleProof,
+    proof::{accumulator::Accumulator, SparseMerkleProof},
     transaction::{
         SignedTransaction, TransactionInfo, TransactionListWithProof, TransactionOutput,
         TransactionPayload, TransactionStatus, TransactionToCommit, Version,

--- a/execution/executor/src/transaction_block.rs
+++ b/execution/executor/src/transaction_block.rs
@@ -11,7 +11,7 @@ use execution_proto::{CommitBlockResponse, ExecuteBlockResponse};
 use failure::{format_err, Result};
 use futures::channel::oneshot;
 use logger::prelude::*;
-use scratchpad::{Accumulator, SparseMerkleTree};
+use scratchpad::SparseMerkleTree;
 use std::{
     collections::{HashMap, HashSet},
     rc::Rc,
@@ -21,6 +21,7 @@ use types::{
     account_state_blob::AccountStateBlob,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
+    proof::accumulator::Accumulator,
     transaction::{SignedTransaction, TransactionStatus},
 };
 

--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -104,7 +104,10 @@
 use crypto::hash::{CryptoHash, CryptoHasher, HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use failure::prelude::*;
 use std::marker::PhantomData;
-use types::proof::{position::Position, AccumulatorProof, MerkleTreeInternalNode};
+use types::proof::{
+    position::{FrozenSubTreeIterator, FrozenSubtreeSiblingIterator, Position},
+    AccumulatorConsistencyProof, AccumulatorProof, MerkleTreeInternalNode,
+};
 
 /// Defines the interface between `MerkleAccumulator` and underlying storage.
 pub trait HashReader {
@@ -144,6 +147,19 @@ where
     /// See [`types::proof::AccumulatorProof`] for proof format.
     pub fn get_proof(reader: &R, num_leaves: u64, leaf_index: u64) -> Result<AccumulatorProof> {
         MerkleAccumulatorView::<R, H>::new(reader, num_leaves).get_proof(leaf_index)
+    }
+
+    /// Gets a proof that this accumulator is consistent with another accumulator that has
+    /// `sub_acc_leaves` leaves. `sub_acc_leaves` must not be greater than `full_acc_leaves`.
+    ///
+    /// See [`types::proof::AccumulatorConsistencyProof`] for proof format.
+    pub fn get_consistency_proof(
+        reader: &R,
+        full_acc_leaves: u64,
+        sub_acc_leaves: u64,
+    ) -> Result<AccumulatorConsistencyProof> {
+        MerkleAccumulatorView::<R, H>::new(reader, full_acc_leaves)
+            .get_consistency_proof(sub_acc_leaves)
     }
 }
 
@@ -315,6 +331,38 @@ where
             .collect();
 
         Ok(AccumulatorProof::new(siblings))
+    }
+
+    /// Implementation for public interface `MerkleAccumulator::get_consistency_proof`.
+    fn get_consistency_proof(&self, sub_acc_leaves: u64) -> Result<AccumulatorConsistencyProof> {
+        ensure!(
+            sub_acc_leaves <= self.num_leaves,
+            "The other accumulator is bigger than this one. self.num_leaves: {}. \
+             sub_acc_leaves: {}.",
+            self.num_leaves,
+            sub_acc_leaves,
+        );
+
+        // If the other accumulator is empty. Nothing is needed for the proof since any accumulator
+        // is consistent with an empty one.
+        if sub_acc_leaves == 0 {
+            return Ok(AccumulatorConsistencyProof::new(vec![], vec![]));
+        }
+
+        let frozen_subtree_roots = FrozenSubTreeIterator::new(sub_acc_leaves)
+            .map(|p| self.get_hash(p))
+            .collect::<Result<Vec<_>>>()?;
+
+        let root_level = Position::get_root_position(self.num_leaves - 1).get_level();
+        let siblings = FrozenSubtreeSiblingIterator::new(sub_acc_leaves)
+            .take_while(|p| p.get_level() < root_level)
+            .map(|p| self.get_hash(p))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(AccumulatorConsistencyProof::new(
+            frozen_subtree_roots,
+            siblings,
+        ))
     }
 }
 

--- a/storage/scratchpad/src/lib.rs
+++ b/storage/scratchpad/src/lib.rs
@@ -3,10 +3,6 @@
 
 //! This crate provides in-memory representation of Libra core data structures used by the executor.
 
-mod accumulator;
 mod sparse_merkle;
 
-pub use crate::{
-    accumulator::Accumulator,
-    sparse_merkle::{AccountState, ProofRead, SparseMerkleTree},
-};
+pub use crate::sparse_merkle::{AccountState, ProofRead, SparseMerkleTree};

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Accumulator;
+use crate::proof::{
+    position::{FrozenSubtreeSiblingIterator, Position},
+    TestAccumulatorInternalNode,
+};
 use crypto::{
     hash::{CryptoHash, TestOnlyHash, TestOnlyHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
 use proptest::{collection::vec, prelude::*};
 use std::collections::HashMap;
-use types::proof::{
-    position::{FrozenSubtreeSiblingIterator, Position},
-    TestAccumulatorInternalNode,
-};
 
 fn compute_parent_hash(left_hash: HashValue, right_hash: HashValue) -> HashValue {
     if left_hash == *ACCUMULATOR_PLACEHOLDER_HASH && right_hash == *ACCUMULATOR_PLACEHOLDER_HASH {

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -13,13 +13,13 @@
 #[cfg(test)]
 mod accumulator_test;
 
+use crate::proof::MerkleTreeInternalNode;
 use crypto::{
     hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
 use failure::prelude::*;
 use std::marker::PhantomData;
-use types::proof::MerkleTreeInternalNode;
 
 /// The Accumulator implementation.
 pub struct Accumulator<H> {

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod accumulator;
 pub mod position;
 #[cfg(any(test, feature = "testing"))]
 pub mod proptest_proof;
@@ -28,8 +29,8 @@ use failure::prelude::*;
 use std::{collections::VecDeque, marker::PhantomData};
 
 pub use crate::proof::definition::{
-    AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, EventProof,
-    SignedTransactionProof, SparseMerkleProof,
+    AccountStateProof, AccumulatorConsistencyProof, AccumulatorConsistencyVerificationError,
+    AccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleProof,
 };
 
 /// Verifies that a `SignedTransaction` with hash value of `signed_transaction_hash`


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

With this change we will be able to get accumulator consistency proof from storage and verify it with root hashes.

It also moves the in-memory accumulator implementation from scratchpad to types so we are able to reuse the code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.