### PR TITLE
[language, types] Remove erroneous masking import, last non-test private key clone

### DIFF
--- a/common/executable_helpers/Cargo.toml
+++ b/common/executable_helpers/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 clap = "2.32.0"
 slog-scope = "4.0"
 
-config = { path = "../../config", features = ["testing"]}
+config = { path = "../../config"}
 crash_handler = { path = "../crash_handler" }
 logger =  { path = "../logger" }
 metrics = { path = "../metrics" }

--- a/language/vm/vm_genesis/src/lib.rs
+++ b/language/vm/vm_genesis/src/lib.rs
@@ -55,7 +55,8 @@ pub fn sign_genesis_transaction(raw_txn: RawTransaction) -> Result<SignatureChec
     raw_txn.sign(private_key, public_key.clone())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
+#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
 pub struct Account {
     pub addr: AccountAddress,
     pub privkey: Ed25519PrivateKey,
@@ -116,12 +117,12 @@ impl Accounts {
         self.accounts[account].addr
     }
 
-    pub fn get_account(&self, account: usize) -> Account {
-        self.accounts[account].clone()
+    pub fn get_account(&self, account: usize) -> &Account {
+        &self.accounts[account]
     }
 
     pub fn get_public_key(&self, account: usize) -> Ed25519PublicKey {
-        self.accounts[account].clone().pubkey
+        self.accounts[account].pubkey.clone()
     }
 
     pub fn create_txn_with_args(

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -14,6 +14,7 @@ pub mod proof;
 #[cfg(any(test, feature = "testing"))]
 pub mod proptest_types;
 pub mod proto;
+#[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 pub mod transaction;
 pub mod transaction_helpers;


### PR DESCRIPTION
*The behavior this modifies*:
- don't import config in a "testing" context in executable_helpers' [dependencies]
- remove uneeded private key cloning in vm_genesis

*Why this is better*:
- fixes a subtle transitive import of crypto under [test]
- removes uneeded private key cloning

*Why this is worse*:
- n/a

*Test*:
`find ./ -iname "Cargo.toml" -execdir cargo check --all-targets \;`
to check there's no more bad version of the testing import:
` ag '\[dependencies\](\n|[^\[])*testing'`

*TODO*:
linter for Cargo.toml files (#627)