### PR TITLE
[doc, network] Document profiles in conditional compilation

### DIFF
--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -302,6 +302,8 @@ As a consequence, it is recommended that you set up your test-only code in the f
 
 *A final note on integration tests*: All tests that use conditional test-only elements in another crate need to activate the "testing" feature through the `[features]` section in their `Cargo.toml`. [Integration tests](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) can neither rely on the `test` flag nor do they have a proper `Cargo.toml` for feature activation. In the Libra codebase, we therefore recommend that *integration tests which depend on test-only code in their tested crate* be extracted to their own crate. You can look at `language/vm/serializer_tests` for an example of such an extracted integration test.
 
+*Note for developers*: The reason we use a feature re-export (in the `[features]` section of the `Cargo.toml` is that a profile is not enough to activate the `"testing"` feature flag. See [cargo-issue #291](https://github.com/rust-lang/cargo/issues/2911) for details).
+
 *Fuzzing*
 
 Libra contains harnesses for fuzzing crash-prone code like deserializers, using [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html) through [`cargo fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html). For more examples, see the `testsuite/libra_fuzzer` directory.

--- a/execution/execution_tests/Cargo.toml
+++ b/execution/execution_tests/Cargo.toml
@@ -30,3 +30,4 @@ vm_genesis = { path = "../../language/vm/vm_genesis" }
 [dev-dependencies]
 rand = "0.6.5"
 nextgen_crypto = { path = "../../crypto/nextgen_crypto", features = ["testing"] }
+types = { path = "../../types", features = ["testing"]}

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -35,8 +35,9 @@ types = { path = "../types" }
 
 [dev-dependencies]
 criterion = "0.2.11"
-
 nextgen_crypto = { path = "../crypto/nextgen_crypto", features = ["testing"] }
+types = { path = "../types", features = ["testing"]}
+
 
 [build-dependencies]
 protoc-rust = "2.5.0"


### PR DESCRIPTION
*What this does*:
- document profiles are not a good way out of conditional test compilation and why,
- adds a "testing" flag to network, execution_tests imports, uncaught by CI

*Why this is better*:
- You'll know to avoid trying to re-do feature activation through profiles,
- Can compile network /execution independently

*Why this is worse*:
- n/a

*Testing*:
```
find ./ -iname Cargo.toml -execdir cargo check --all-targets \;
```