### PR TITLE
[consensus] cleanup after sequential event processor - part 4

### DIFF
--- a/consensus/src/chained_bft/liveness/pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_test.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     chained_bft::{
+        common::Round,
         consensus_types::timeout_msg::PacemakerTimeout,
         liveness::{
             pacemaker::{
@@ -38,27 +39,12 @@ fn test_pacemaker_time_interval() {
 #[test]
 /// Verify that Pacemaker properly outputs PacemakerTimeoutMsg upon timeout
 fn test_basic_timeout() {
-    let time_interval = Box::new(ExponentialTimeInterval::fixed(Duration::from_millis(2)));
-    let highest_certified_round = 1;
-    let simulated_time = SimulatedTimeService::auto_advance_until(Duration::from_millis(4));
-    let (new_round_events_sender, _new_round_events_receiver) = channel::new_test(1_024);
-    let (external_timeout_sender, mut external_timeout_receiver) = channel::new_test(1_024);
-    let mut pm = Pacemaker::new(
-        MockStorage::<TestPayload>::start_for_testing()
-            .0
-            .persistent_liveness_storage(),
-        time_interval,
-        0,
-        highest_certified_round,
-        Arc::new(simulated_time.clone()),
-        new_round_events_sender,
-        external_timeout_sender,
-        1,
-        HighestTimeoutCertificates::new(None, None),
-    );
+    let (mut pm, mut timeout_rx) = make_pacemaker();
 
+    // jump start the pacemaker
+    pm.process_certificates(1, None, None);
     for _ in 0..2 {
-        let round = block_on(external_timeout_receiver.next()).unwrap();
+        let round = block_on(timeout_rx.next()).unwrap();
         // Here we just test timeout send retry,
         // round for timeout is not changed as no timeout certificate was gathered at this point
         assert_eq!(2, round);
@@ -69,79 +55,65 @@ fn test_basic_timeout() {
 #[test]
 /// Verify that Pacemaker forms a timeout certificate on receiving sufficient timeout messages
 fn test_timeout_certificate() {
-    let rounds = 5;
+    let rounds: Round = 5;
     let mut signers: Vec<ValidatorSigner<Ed25519PrivateKey>> = vec![];
     for round in 1..rounds {
         let signer = ValidatorSigner::<Ed25519PrivateKey>::random([round as u8; 32]);
         signers.push(signer);
     }
-    let (mut pm, mut new_round_events_receiver) = make_pacemaker();
+    let (mut pm, _) = make_pacemaker();
 
-    block_on(async move {
-        // Wait for the initial event for the first round.
-        expect_qc(1, &mut new_round_events_receiver).await;
-
-        // Send timeout for rounds 1..5, each from a different author, so that they can be
-        // accumulated into single timeout certificate
-        for round in 1..rounds {
-            let signer = &signers[round - 1];
-            let pacemaker_timeout = PacemakerTimeout::new(round as u64, signer, None);
-            pm.process_remote_timeout(pacemaker_timeout).await;
+    // Send timeout for rounds 1..5, each from a different author, so that they can be
+    // accumulated into single timeout certificate
+    for round in 1..rounds {
+        let signer = &signers[(round - 1) as usize];
+        let pacemaker_timeout = PacemakerTimeout::new(round, signer, None);
+        let result = pm.process_remote_timeout(pacemaker_timeout);
+        // quorum size is 3 in make_pacemaker
+        if round >= 3 {
+            // Then timeout quorum for previous round (1,2,3) generates new round event for
+            // round 2, timeout quorum for previous round (2,3,4) generates
+            // new round event for round 3
+            expect_timeout(round - 1, result);
         }
-        // Then timeout quorum for previous round (1,2,3) generates new round event for round 2
-        expect_timeout(2, &mut new_round_events_receiver).await;
-        // Then timeout quorum for previous round (2,3,4) generates new round event for round 3
-        expect_timeout(3, &mut new_round_events_receiver).await;
-    });
+    }
 }
 
 #[test]
 fn test_basic_qc() {
-    let (mut pm, mut new_round_events_receiver) = make_pacemaker();
+    let (mut pm, _) = make_pacemaker();
 
-    block_on(async move {
-        // Wait for the initial event for the first round.
-        expect_qc(1, &mut new_round_events_receiver).await;
-
-        pm.process_certificates(2, None, None).await;
-        pm.process_certificates(3, None, None).await;
-
-        expect_qc(3, &mut new_round_events_receiver).await;
-        expect_qc(4, &mut new_round_events_receiver).await;
-    });
+    expect_qc(3, pm.process_certificates(2, None, None));
+    expect_qc(4, pm.process_certificates(3, None, None));
 }
 
-fn make_pacemaker() -> (Pacemaker, channel::Receiver<NewRoundEvent>) {
+fn make_pacemaker() -> (Pacemaker, channel::Receiver<Round>) {
     let time_interval = Box::new(ExponentialTimeInterval::fixed(Duration::from_millis(2)));
-    let simulated_time = SimulatedTimeService::new();
-    let (new_round_events_sender, new_round_events_receiver) = channel::new_test(1_024);
-    let (pacemaker_timeout_tx, _) = channel::new_test(1_024);
+    let simulated_time = SimulatedTimeService::auto_advance_until(Duration::from_millis(4));
+    let (timeout_tx, timeout_rx) = channel::new_test(1_024);
     (
         Pacemaker::new(
             MockStorage::<TestPayload>::start_for_testing()
                 .0
                 .persistent_liveness_storage(),
             time_interval,
-            0,
-            0,
             Arc::new(simulated_time.clone()),
-            new_round_events_sender,
-            pacemaker_timeout_tx,
+            timeout_tx,
             3,
-            HighestTimeoutCertificates::new(None, None),
+            HighestTimeoutCertificates::default(),
         ),
-        new_round_events_receiver,
+        timeout_rx,
     )
 }
 
-async fn expect_qc(round: u64, rx: &mut channel::Receiver<NewRoundEvent>) {
-    let event: NewRoundEvent = rx.next().await.unwrap();
+fn expect_qc(round: u64, event: Option<NewRoundEvent>) {
+    let event = event.unwrap();
     assert_eq!(round, event.round);
     assert_eq!(NewRoundReason::QCReady, event.reason);
 }
 
-async fn expect_timeout(round: u64, rx: &mut channel::Receiver<NewRoundEvent>) {
-    let event: NewRoundEvent = rx.next().await.unwrap();
+fn expect_timeout(round: u64, event: Option<NewRoundEvent>) {
+    let event = event.unwrap();
     assert_eq!(round, event.round);
     match event.reason {
         NewRoundReason::Timeout { .. } => (),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR simplifies pacemaker further:

- new_round_event is returned as function result instead of sending through channels
- remove await/async from pacemaker
- jump start is now more unified with existing certificates.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
