### PR TITLE
[execution][vm] Introduce Script and Module transactions.

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -813,7 +813,9 @@ where
                     // should not reach this code path. The exception is genesis transaction (and
                     // maybe other FTVM transactions).
                     match transaction.payload() {
-                        TransactionPayload::Program(_) => {
+                        TransactionPayload::Program(_)
+                        | TransactionPayload::Module(_)
+                        | TransactionPayload::Script(_) => {
                             bail!("Write set should be a subset of read set.")
                         }
                         TransactionPayload::WriteSet(_) => (),

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -306,5 +306,11 @@ fn decode_transaction(txn: &SignedTransaction) -> Transaction {
         TransactionPayload::WriteSet(_) => {
             unimplemented!("MockVM does not support WriteSet transaction payload.")
         }
+        TransactionPayload::Script(_) => {
+            unimplemented!("MockVM does not support Script transaction payload.")
+        }
+        TransactionPayload::Module(_) => {
+            unimplemented!("MockVM does not support Module transaction payload.")
+        }
     }
 }

--- a/language/e2e_tests/src/account.rs
+++ b/language/e2e_tests/src/account.rs
@@ -12,7 +12,9 @@ use types::{
     account_address::AccountAddress,
     account_config::{self, EventHandle},
     byte_array::ByteArray,
-    transaction::{Program, RawTransaction, SignedTransaction, TransactionArgument},
+    transaction::{
+        Program, RawTransaction, SignedTransaction, TransactionArgument, TransactionPayload,
+    },
 };
 use vm_genesis::GENESIS_KEYPAIR;
 use vm_runtime::identifier::create_access_path;
@@ -121,21 +123,51 @@ impl Account {
     // Helpers for transaction creation with Account instance as sender
     //
 
-    /// Returns a [`SignedTransaction`] with no arguments and this account as the sender.
+    /// Returns a [`SignedTransaction`] with a payload and this account as the sender.
+    ///
+    /// This is the most generic way to create a transaction for testing.
+    /// Max gas amount and gas unit price are ignored for WriteSet transactions.
     pub fn create_signed_txn(
         &self,
-        program: Vec<u8>,
+        payload: TransactionPayload,
         sequence_number: u64,
         max_gas_amount: u64,
         gas_unit_price: u64,
     ) -> SignedTransaction {
-        self.create_signed_txn_with_args(
-            program,
-            vec![],
-            sequence_number,
-            max_gas_amount,
-            gas_unit_price,
-        )
+        let raw_txn = match payload {
+            TransactionPayload::Program(program) => RawTransaction::new(
+                *self.address(),
+                sequence_number,
+                program,
+                max_gas_amount,
+                gas_unit_price,
+                Duration::from_secs(u64::max_value()),
+            ),
+            TransactionPayload::WriteSet(writeset) => {
+                RawTransaction::new_write_set(*self.address(), sequence_number, writeset)
+            }
+            TransactionPayload::Module(module) => RawTransaction::new_module(
+                *self.address(),
+                sequence_number,
+                module,
+                max_gas_amount,
+                gas_unit_price,
+                Duration::from_secs(u64::max_value()),
+            ),
+            TransactionPayload::Script(script) => RawTransaction::new_script(
+                *self.address(),
+                sequence_number,
+                script,
+                max_gas_amount,
+                gas_unit_price,
+                Duration::from_secs(u64::max_value()),
+            ),
+        };
+
+        raw_txn
+            .sign(&self.privkey, self.pubkey.clone())
+            .unwrap()
+            .into_inner()
     }
 
     /// Returns a [`SignedTransaction`] with the arguments defined in `args` and this account as

--- a/language/e2e_tests/src/tests.rs
+++ b/language/e2e_tests/src/tests.rs
@@ -20,3 +20,5 @@ mod pack_unpack;
 mod peer_to_peer;
 mod rotate_key;
 mod verify_txn;
+// Remove once we enable Module and Script transactions
+mod bad_txn;

--- a/language/e2e_tests/src/tests/bad_txn.rs
+++ b/language/e2e_tests/src/tests/bad_txn.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{account::AccountData, executor::FakeExecutor};
+use types::{
+    transaction::{Module, Script, SignedTransaction, TransactionPayload, TransactionStatus},
+    vm_error::{VMStatus, VMValidationStatus},
+};
+
+#[test]
+fn module_script_disabled() {
+    // create a FakeExecutor with a genesis from file
+    let mut executor = FakeExecutor::from_genesis_file();
+
+    // create and publish a sender
+    let sender = AccountData::new(1_000_000, 10);
+    executor.add_account_data(&sender);
+
+    let module = TransactionPayload::Module(Module::new(vec![]));
+    let mod_txn = sender.account().create_signed_txn(module, 10, 0, 0);
+    let mod_txns: Vec<SignedTransaction> = vec![mod_txn];
+    let mod_output = executor.execute_block(mod_txns);
+    assert_eq!(
+        mod_output[0].status(),
+        &TransactionStatus::Discard(VMStatus::Validation(VMValidationStatus::UnknownModule)),
+    );
+
+    let script = TransactionPayload::Script(Script::new(vec![], vec![]));
+    let script_txn = sender.account().create_signed_txn(script, 10, 0, 0);
+    let script_txns: Vec<SignedTransaction> = vec![script_txn];
+    let script_output = executor.execute_block(script_txns);
+    assert_eq!(
+        script_output[0].status(),
+        &TransactionStatus::Discard(VMStatus::Validation(VMValidationStatus::UnknownScript)),
+    );
+}

--- a/language/functional_tests/_old_move_ir_tests/src/tests/transactions.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/transactions.rs
@@ -17,7 +17,7 @@ fn write_set_txn_roundtrip() {
     proptest!(|(signed_txn in SignedTransaction::genesis_strategy())| {
         let write_set = match signed_txn.payload() {
             TransactionPayload::WriteSet(write_set) => write_set.clone(),
-            TransactionPayload::Program(_) => unreachable!(
+            TransactionPayload::Program(_) | TransactionPayload::Script(_) | TransactionPayload::Module(_) => unreachable!(
                 "write set strategy should only generate write set transactions",
             ),
         };

--- a/language/functional_tests/_old_move_ir_tests/src/tests/verify_transaction.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/verify_transaction.rs
@@ -124,8 +124,8 @@ fn verify_txn_rejects_genesis_deletion() {
     proptest!(|(txn in SignedTransaction::write_set_strategy())| {
         let write_set = match txn.payload() {
             TransactionPayload::WriteSet(write_set) => write_set,
-            TransactionPayload::Program(_) => panic!(
-                "write_set_strategy shouldn't generate programs",
+            TransactionPayload::Program(_) | TransactionPayload::Script(_) | TransactionPayload::Module(_) => panic!(
+                "write_set_strategy shouldn't generate other transactions",
             ),
         };
         let any_deletions = write_set.iter().any(|(_, write_op)| write_op.is_deletion());

--- a/language/vm/vm_runtime/src/process_txn/execute.rs
+++ b/language/vm/vm_runtime/src/process_txn/execute.rs
@@ -122,6 +122,12 @@ where
             0,
             VMStatus::Execution(ExecutionStatus::Executed).into(),
         ),
+        TransactionPayload::Module(_) | TransactionPayload::Script(_) => {
+            // This is an impossible condition at the moment and for a short time.
+            // ValidatedTransaction is never built with Module or Script so there
+            // is no way to reach this state
+            panic!("Unknown Transaction")
+        }
     }
 }
 

--- a/language/vm/vm_runtime/src/process_txn/validate.rs
+++ b/language/vm/vm_runtime/src/process_txn/validate.rs
@@ -251,6 +251,18 @@ where
 
                 None
             }
+            TransactionPayload::Module(_) => {
+                // UnknownModule is a good enough error for this temporary condition.
+                // It usually signals the VM does not allow publishing which is reasonable.
+                // Adding new errors does not seem a smart choice
+                return Err(VMStatus::Validation(VMValidationStatus::UnknownModule));
+            }
+            TransactionPayload::Script(_) => {
+                // UnknownScript is a good enough error for this temporary condition.
+                // It usually signals the VM does not allow custom script which is reasonable.
+                // Adding new errors does not seem a smart choice
+                return Err(VMStatus::Validation(VMValidationStatus::UnknownScript));
+            }
         };
 
         Ok(Self { txn, txn_state })

--- a/language/vm/vm_runtime/src/process_txn/verify.rs
+++ b/language/vm/vm_runtime/src/process_txn/verify.rs
@@ -63,6 +63,12 @@ where
                 // here.
                 None
             }
+            TransactionPayload::Module(_) | TransactionPayload::Script(_) => {
+                // This is an impossible condition at the moment and for a short time.
+                // ValidatedTransaction is never built with Module or Script so there
+                // is no way to reach this state
+                panic!("Unknown Transaction")
+            }
         };
 
         Ok(Self {

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -13,7 +13,7 @@ use crate::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::AccumulatorProof,
     transaction::{
-        Program, RawTransaction, SignatureCheckedTransaction, SignedTransaction,
+        Module, Program, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction,
         TransactionArgument, TransactionInfo, TransactionListWithProof, TransactionPayload,
         TransactionStatus, TransactionToCommit, Version,
     },
@@ -133,6 +133,22 @@ impl RawTransaction {
                             gas_unit_price,
                             Duration::from_secs(expiration_time_secs),
                         ),
+                        TransactionPayload::Module(module) => RawTransaction::new_module(
+                            sender,
+                            sequence_number,
+                            module,
+                            max_gas_amount,
+                            gas_unit_price,
+                            Duration::from_secs(expiration_time_secs),
+                        ),
+                        TransactionPayload::Script(script) => RawTransaction::new_script(
+                            sender,
+                            sequence_number,
+                            script,
+                            max_gas_amount,
+                            gas_unit_price,
+                            Duration::from_secs(expiration_time_secs),
+                        ),
                         TransactionPayload::WriteSet(write_set) => {
                             // It's a bit unfortunate that max_gas_amount etc is generated but
                             // not used, but it isn't a huge deal.
@@ -160,6 +176,18 @@ impl SignatureCheckedTransaction {
         keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(keypair_strategy, TransactionPayload::program_strategy())
+    }
+
+    pub fn script_strategy(
+        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+    ) -> impl Strategy<Value = Self> {
+        Self::strategy_impl(keypair_strategy, TransactionPayload::script_strategy())
+    }
+
+    pub fn module_strategy(
+        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+    ) -> impl Strategy<Value = Self> {
+        Self::strategy_impl(keypair_strategy, TransactionPayload::module_strategy())
     }
 
     pub fn write_set_strategy(
@@ -220,6 +248,14 @@ impl TransactionPayload {
         any::<Program>().prop_map(TransactionPayload::Program)
     }
 
+    pub fn script_strategy() -> impl Strategy<Value = Self> {
+        any::<Script>().prop_map(TransactionPayload::Script)
+    }
+
+    pub fn module_strategy() -> impl Strategy<Value = Self> {
+        any::<Module>().prop_map(TransactionPayload::Module)
+    }
+
     pub fn write_set_strategy() -> impl Strategy<Value = Self> {
         any::<WriteSet>().prop_map(TransactionPayload::WriteSet)
     }
@@ -252,7 +288,9 @@ impl Arbitrary for TransactionPayload {
         // at least not choke on write set strategies so introduce them with decent probability.
         // The figures below are probability weights.
         prop_oneof![
-            9 => Self::program_strategy(),
+            4 => Self::program_strategy(),
+            4 => Self::script_strategy(),
+            1 => Self::module_strategy(),
             1 => Self::write_set_strategy(),
         ]
         .boxed()
@@ -277,6 +315,33 @@ impl Arbitrary for Program {
     }
 
     type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for Script {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: ()) -> Self::Strategy {
+        // XXX This should eventually be an actually valid program, maybe?
+        // The vector sizes are picked out of thin air.
+        (
+            vec(any::<u8>(), 0..100),
+            vec(any::<TransactionArgument>(), 0..10),
+        )
+            .prop_map(|(code, args)| Script::new(code, args))
+            .boxed()
+    }
+}
+
+impl Arbitrary for Module {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: ()) -> Self::Strategy {
+        // XXX How should we generate random modules?
+        // The vector sizes are picked out of thin air.
+        vec(any::<u8>(), 0..100).prop_map(Module::new).boxed()
+    }
 }
 
 impl Arbitrary for TransactionArgument {

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -24,6 +24,10 @@ message RawTransaction {
         // This bypasses the rules for regular transactions so will typically be
         // rejected. Only under special circumstances will it be accepted.
         WriteSet write_set = 4;
+        // The transaction script to execute.
+        Script script = 8;
+        // The MOVE Module to publish.
+        Module module = 9;
     }
     // Maximal total gas specified by wallet to spend for this transaction.
     uint64 max_gas_amount = 5;
@@ -44,6 +48,12 @@ message Program {
     repeated bytes modules = 3;
 }
 
+// The code for the transaction to execute
+message Script {
+    bytes code = 1;
+    repeated TransactionArgument arguments = 2;
+}
+
 // An argument to the transaction if the transaction takes arguments
 message TransactionArgument {
     enum ArgType {
@@ -54,6 +64,11 @@ message TransactionArgument {
     }
     ArgType type = 1;
     bytes data = 2;
+}
+
+// A Move Module to publish
+message Module {
+    bytes code = 1;
 }
 
 // A generic structure that represents signed RawTransaction

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -1,0 +1,71 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use canonical_serialization::{
+    CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
+};
+use failure::prelude::*;
+use proto_conv::{FromProto, IntoProto};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Module {
+    code: Vec<u8>,
+}
+
+impl Module {
+    pub fn new(code: Vec<u8>) -> Module {
+        Module { code }
+    }
+
+    pub fn code(&self) -> &[u8] {
+        &self.code
+    }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.code
+    }
+}
+
+impl fmt::Debug for Module {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // XXX note that "code" will eventually be encoded bytecode and will no longer be a
+        // UTF8-ish string -- at that point the from_utf8_lossy will stop making sense.
+        f.debug_struct("Module")
+            .field("code", &String::from_utf8_lossy(&self.code))
+            .finish()
+    }
+}
+
+impl FromProto for Module {
+    type ProtoType = crate::proto::transaction::Module;
+
+    fn from_proto(proto_module: Self::ProtoType) -> Result<Self> {
+        Ok(Module::new(proto_module.get_code().to_vec()))
+    }
+}
+
+impl IntoProto for Module {
+    type ProtoType = crate::proto::transaction::Module;
+
+    fn into_proto(self) -> Self::ProtoType {
+        let mut proto_module = Self::ProtoType::new();
+        proto_module.set_code(self.code);
+        proto_module
+    }
+}
+
+impl CanonicalSerialize for Module {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_vec(&self.code)?;
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for Module {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
+        let code: Vec<u8> = deserializer.decode_vec()?;
+        Ok(Module::new(code))
+    }
+}

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -3,10 +3,37 @@
 
 //use crate::errors::*;
 use crate::{
-    account_address::AccountAddress, byte_array::ByteArray, transaction::TransactionArgument,
+    account_address::AccountAddress, byte_array::ByteArray,
+    proto::transaction::TransactionArgument_ArgType,
+};
+use canonical_serialization::{
+    CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
 };
 use failure::prelude::*;
-use std::convert::TryFrom;
+use protobuf::ProtobufEnum;
+use serde::{Deserialize, Serialize};
+use std::{convert::TryFrom, fmt};
+
+#[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TransactionArgument {
+    U64(u64),
+    Address(AccountAddress),
+    ByteArray(ByteArray),
+    String(String),
+}
+
+impl fmt::Debug for TransactionArgument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransactionArgument::U64(value) => write!(f, "{{U64: {}}}", value),
+            TransactionArgument::Address(address) => write!(f, "{{ADDRESS: {:?}}}", address),
+            TransactionArgument::String(string) => write!(f, "{{STRING: {}}}", string),
+            TransactionArgument::ByteArray(byte_array) => {
+                write!(f, "{{ByteArray: 0x{}}}", byte_array)
+            }
+        }
+    }
+}
 
 #[derive(Clone, Debug, Fail)]
 pub enum ErrorKind {
@@ -139,6 +166,56 @@ mod test_transaction_argument {
 
         for s in &["garbage", ""] {
             parse_as_transaction_argument(s).unwrap_err();
+        }
+    }
+}
+
+impl CanonicalSerialize for TransactionArgument {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        match self {
+            TransactionArgument::U64(value) => {
+                serializer.encode_u32(TransactionArgument_ArgType::U64 as u32)?;
+                serializer.encode_u64(*value)?;
+            }
+            TransactionArgument::Address(address) => {
+                serializer.encode_u32(TransactionArgument_ArgType::ADDRESS as u32)?;
+                serializer.encode_struct(address)?;
+            }
+            TransactionArgument::String(string) => {
+                serializer.encode_u32(TransactionArgument_ArgType::STRING as u32)?;
+                serializer.encode_string(string)?;
+            }
+            TransactionArgument::ByteArray(byte_array) => {
+                serializer.encode_u32(TransactionArgument_ArgType::BYTEARRAY as u32)?;
+                serializer.encode_struct(byte_array)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for TransactionArgument {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
+        let decoded_value = deserializer.decode_u32()? as i32;
+        let arg_type = TransactionArgument_ArgType::from_i32(decoded_value);
+        match arg_type {
+            Some(TransactionArgument_ArgType::U64) => {
+                Ok(TransactionArgument::U64(deserializer.decode_u64()?))
+            }
+            Some(TransactionArgument_ArgType::ADDRESS) => {
+                Ok(TransactionArgument::Address(deserializer.decode_struct()?))
+            }
+            Some(TransactionArgument_ArgType::STRING) => {
+                Ok(TransactionArgument::String(deserializer.decode_string()?))
+            }
+            Some(TransactionArgument_ArgType::BYTEARRAY) => Ok(TransactionArgument::ByteArray(
+                deserializer.decode_struct()?,
+            )),
+            None => Err(format_err!(
+                "ParseError: Unable to decode TransactionArgument_ArgType, found {}",
+                decoded_value
+            )),
         }
     }
 }

--- a/types/src/transaction/unit_tests/program_test.rs
+++ b/types/src/transaction/unit_tests/program_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transaction::program::{Program, TransactionArgument};
+use crate::transaction::{program::Program, transaction_argument::TransactionArgument};
 use canonical_serialization::{
     CanonicalDeserializer, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
 };


### PR DESCRIPTION
## Motivation
We want to move away from Program transactions where execution and
publishing are in a single transaction.
There are several problems and complications with that model.
The plan is to have 2 kind of transactions:
- Script which are execution only transactions (CompiledScript)
- Module which are publishing only transactions (CompiledModule)

This diff defines the 2 type of transactions without removing Program yet.
This diff should be backward compatible and it should change nothing in the way
transactions are submitted and executed.
We are only defining the transaction type (Script/Module) and enabling
ser/deser tests for them. However the transactions are not supported yet by the VM
and they report an error if they are submitted to AC or the Executor.

The sequence of diffs and PRs is going to be the following:
- this PR introduces the transaction types
- next PR will enable the transaction in the VM
- then another PR we will move tests to use the new model
- finally we will have a PR that disables Program (that will be the breaking change)

## Test Plan
cargo test
