### PR TITLE
[state sync] long polling support

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -618,6 +618,8 @@ pub struct StateSyncConfig {
     pub chunk_limit: u64,
     // interval used for checking state synchronization progress
     pub tick_interval_ms: u64,
+    // default timeout used for long polling to remote peer
+    pub long_poll_timeout_ms: u64,
 }
 
 impl Default for StateSyncConfig {
@@ -625,6 +627,7 @@ impl Default for StateSyncConfig {
         Self {
             chunk_limit: 1000,
             tick_interval_ms: 10,
+            long_poll_timeout_ms: 30000,
         }
     }
 }

--- a/network/src/validator_network/state_synchronizer.rs
+++ b/network/src/validator_network/state_synchronizer.rs
@@ -69,6 +69,7 @@ impl Stream for StateSynchronizerEvents {
     }
 }
 
+#[derive(Clone)]
 pub struct StateSynchronizerSender {
     inner: channel::Sender<NetworkRequest>,
 }

--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -8,7 +8,7 @@ use failure::prelude::*;
 use futures::{
     channel::{mpsc, oneshot},
     compat::Stream01CompatExt,
-    stream::Fuse,
+    stream::{futures_unordered::FuturesUnordered, Fuse},
     StreamExt,
 };
 use logger::prelude::*;
@@ -20,13 +20,13 @@ use nextgen_crypto::ed25519::*;
 use proto_conv::{FromProto, IntoProto};
 use rand::{thread_rng, Rng};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::timer::Interval;
 use types::{ledger_info::LedgerInfoWithSignatures, proto::transaction::TransactionListWithProof};
 
-/// message used for communication between Consensus and Coordinator
+/// message used by StateSyncClient for communication with Coordinator
 pub enum CoordinatorMessage {
     // used to initiate new sync
     Requested(LedgerInfo, oneshot::Sender<bool>),
@@ -36,14 +36,14 @@ pub enum CoordinatorMessage {
 }
 
 /// used to coordinate synchronization process
-/// handles Consensus requests and drives sync with remote peers
-pub struct SyncCoordinator<T> {
+/// handles external sync requests and drives synchronization with remote peers
+pub(crate) struct SyncCoordinator<T> {
     // used for interaction with remote peers
     network_sender: StateSynchronizerSender,
     // used for receiving events from peers
     network_events: Fuse<StateSynchronizerEvents>,
-    // used to process Consensus events
-    consensus_events: mpsc::UnboundedReceiver<CoordinatorMessage>,
+    // used to process client requests
+    client_events: mpsc::UnboundedReceiver<CoordinatorMessage>,
 
     // last committed version that validator is aware of
     known_version: u64,
@@ -56,11 +56,14 @@ pub struct SyncCoordinator<T> {
     autosync: bool,
     // peers used for synchronization. TBD: value is meta information about peer sync quality
     peers: HashMap<PeerId, ()>,
-    // subscribers of synchronization
-    // each of them will be notified once their target version is ready
-    subscribers: BTreeMap<u64, Vec<oneshot::Sender<bool>>>,
-    // timestamp of last peer sync request
-    last_sync: Option<SystemTime>,
+    // option callback. Called when state sync reaches target version
+    callback: Option<oneshot::Sender<bool>>,
+    // timestamp of next peer sync request
+    next_sync: Option<SystemTime>,
+    // queue of incoming long polling requests
+    // peer will be notified about new chunk of transactions if it's available before expiry time
+    // value format is (expiration_time, known_version, limit)
+    subscriptions: HashMap<PeerId, (SystemTime, u64, u64)>,
     executor_proxy: T,
 }
 
@@ -68,23 +71,23 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     pub fn new(
         network_sender: StateSynchronizerSender,
         network_events: StateSynchronizerEvents,
-        consensus_events: mpsc::UnboundedReceiver<CoordinatorMessage>,
+        client_events: mpsc::UnboundedReceiver<CoordinatorMessage>,
         node_config: &NodeConfig,
         executor_proxy: T,
     ) -> Self {
         Self {
             network_sender,
             network_events: network_events.fuse(),
-            consensus_events,
+            client_events,
 
             known_version: 0,
             target: None,
             config: node_config.state_sync.clone(),
             autosync: node_config.base.get_role() == RoleType::FullNode,
             peers: HashMap::new(),
-
-            subscribers: BTreeMap::new(),
-            last_sync: None,
+            subscriptions: HashMap::new(),
+            callback: None,
+            next_sync: None,
             executor_proxy,
         }
     }
@@ -103,13 +106,13 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
 
         loop {
             ::futures::select! {
-                msg = self.consensus_events.select_next_some() => {
+                msg = self.client_events.select_next_some() => {
                     match msg {
                         CoordinatorMessage::Requested(target, subscription) => {
-                            self.consensus_sync(target, subscription).await;
+                            self.request_sync(target, subscription).await;
                         }
                         CoordinatorMessage::Commit(version) => {
-                             self.handle_commit(version);
+                             self.commit(version).await;
                         }
                         CoordinatorMessage::GetState(callback) => {
                             self.get_state(callback);
@@ -123,6 +126,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                                 Event::NewPeer(peer_id) => {
                                     if self.autosync {
                                         self.peers.insert(peer_id, ());
+                                        self.check_progress().await;
                                     }
                                 }
                                 Event::LostPeer(peer_id) => {
@@ -130,7 +134,9 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                                 }
                                 Event::Message((peer_id, mut message)) => {
                                     if message.has_chunk_request() {
-                                        self.process_chunk_request(peer_id, message.take_chunk_request()).await;
+                                        if let Err(err) = self.process_chunk_request(peer_id, message.take_chunk_request()).await {
+                                            error!("[state sync] failed to serve chunk request: {:?}", err);
+                                        }
                                     }
                                     if message.has_chunk_response() {
                                         self.process_chunk_response(message.take_chunk_response()).await;
@@ -163,7 +169,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             .map(|li| li.ledger_info().version())
     }
 
-    async fn consensus_sync(&mut self, target: LedgerInfo, subscriber: oneshot::Sender<bool>) {
+    async fn request_sync(&mut self, target: LedgerInfo, callback: oneshot::Sender<bool>) {
         let requested_version = target.ledger_info().version();
         self.known_version = self
             .get_latest_version()
@@ -176,7 +182,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             self.store_transactions(target.clone(), TransactionListWithProof::new())
                 .await
                 .expect("[state sync] failed to execute empty blocks");
-            if subscriber.send(true).is_err() {
+            if callback.send(true).is_err() {
                 error!("[state sync] coordinator failed to notify subscriber");
             }
             return;
@@ -187,15 +193,28 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             self.target = Some(target);
             self.request_next_chunk(0).await;
         }
-
-        self.subscribers
-            .entry(requested_version)
-            .or_insert_with(|| vec![])
-            .push(subscriber);
+        self.callback = Some(callback);
     }
 
-    fn handle_commit(&mut self, version: u64) {
-        self.known_version = std::cmp::max(version, self.known_version);
+    async fn commit(&mut self, version: u64) {
+        if version <= self.known_version {
+            error!(
+                "[state sync] invalid commit. Known version: {}, commit version: {}",
+                self.known_version, version
+            );
+            return;
+        }
+        self.known_version = version;
+        if let Err(err) = self.check_subscriptions().await {
+            error!("[state sync] failed to check subscriptions: {:?}", err);
+        }
+        if self.known_version == self.target_version() {
+            if let Some(cb) = self.callback.take() {
+                if cb.send(true).is_err() {
+                    error!("[state sync] failed to notify subscriber");
+                }
+            }
+        }
     }
 
     fn get_state(&self, callback: oneshot::Sender<u64>) {
@@ -205,37 +224,59 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     }
 
     /// Get a batch of transactions
-    async fn process_chunk_request(&mut self, peer_id: PeerId, mut request: GetChunkRequest) {
-        let latest_ledger_info = match self.executor_proxy.get_latest_ledger_info().await {
-            Ok(li) => li,
-            Err(err) => {
-                error!("[state sync] failed to fetch latest ledger info: {:?}", err);
-                return;
-            }
-        };
+    async fn process_chunk_request(
+        &mut self,
+        peer_id: PeerId,
+        mut request: GetChunkRequest,
+    ) -> Result<()> {
+        let latest_ledger_info = self.executor_proxy.get_latest_ledger_info().await?;
         let target = LedgerInfo::from_proto(request.take_ledger_info_with_sigs())
             .unwrap_or(latest_ledger_info);
 
-        match self
-            .executor_proxy
-            .get_chunk(request.known_version, request.limit, target)
+        // if upstream synchronizer doesn't have new data and request timeout is set
+        // add peer request into subscription queue
+        if self.known_version <= request.known_version && request.timeout > 0 {
+            let expiration_time =
+                SystemTime::now().checked_add(Duration::from_millis(request.timeout));
+            if let Some(time) = expiration_time {
+                self.subscriptions
+                    .insert(peer_id, (time, request.known_version, request.limit));
+            }
+            Ok(())
+        } else {
+            self.deliver_chunk(
+                peer_id,
+                request.known_version,
+                request.limit,
+                target,
+                self.network_sender.clone(),
+            )
             .await
-        {
-            Ok(response) => {
-                let mut msg = StateSynchronizerMsg::new();
-                msg.set_chunk_response(response);
-                if self.network_sender.send_to(peer_id, msg).await.is_err() {
-                    error!("[state sync] failed to send p2p message");
-                }
-            }
-            Err(err) => {
-                error!("[state sync] executor error {:?}", err);
-            }
         }
     }
 
+    async fn deliver_chunk(
+        &self,
+        peer_id: PeerId,
+        known_version: u64,
+        limit: u64,
+        target: LedgerInfo,
+        mut network_sender: StateSynchronizerSender,
+    ) -> Result<()> {
+        let response = self
+            .executor_proxy
+            .get_chunk(known_version, limit, target)
+            .await?;
+        let mut msg = StateSynchronizerMsg::new();
+        msg.set_chunk_response(response);
+        if network_sender.send_to(peer_id, msg).await.is_err() {
+            error!("[state sync] failed to send p2p message");
+        }
+        Ok(())
+    }
+
     /// processes batch of transactions downloaded from peer
-    /// executes transactions, updates progress state, notifies subscribers if some sync is finished
+    /// executes transactions, updates progress state, calls callback if some sync is finished
     async fn process_chunk_response(&mut self, mut response: GetChunkResponse) {
         let txn_list_with_proof = response.take_txn_list_with_proof();
         // optimistically fetch next chunk
@@ -251,14 +292,13 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                 if status.is_ok() {
                     match self.get_latest_version().await {
                         Ok(version) => {
-                            self.known_version = version;
+                            self.commit(version).await;
                         }
                         Err(err) => {
                             error!("[state sync] storage version read failed {:?}", err);
                         }
                     }
                 }
-                self.notify_subscribers(status.is_ok());
             }
             Err(err) => {
                 error!("[state sync] invalid ledger info {:?}", err);
@@ -270,12 +310,8 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     /// if peer is not responding, issues new sync request
     async fn check_progress(&mut self) {
         if !self.peers.is_empty() && (self.autosync || self.target.is_some()) {
-            let timestamp = self.last_sync.unwrap_or(UNIX_EPOCH);
-            let delta = SystemTime::now()
-                .duration_since(timestamp)
-                .expect("system time failure");
-            if delta.as_millis() > (2 * u128::from(self.config.tick_interval_ms)) {
-                self.last_sync = None;
+            let timestamp = self.next_sync.unwrap_or(UNIX_EPOCH);
+            if SystemTime::now().duration_since(timestamp).is_ok() {
                 self.request_next_chunk(0).await;
             }
         }
@@ -294,35 +330,26 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             let mut req = GetChunkRequest::new();
             req.set_known_version(self.known_version + offset);
             req.set_limit(self.config.chunk_limit);
-            if let Some(target) = &self.target {
-                req.set_ledger_info_with_sigs(target.clone().into_proto());
-            }
+            let timeout = match &self.target {
+                Some(target) => {
+                    req.set_ledger_info_with_sigs(target.clone().into_proto());
+                    0
+                }
+                None => {
+                    req.set_timeout(self.config.long_poll_timeout_ms);
+                    self.config.long_poll_timeout_ms
+                }
+            };
+
             let mut msg = StateSynchronizerMsg::new();
             msg.set_chunk_request(req);
 
-            self.last_sync = Some(SystemTime::now());
+            self.next_sync = SystemTime::now().checked_add(Duration::from_millis(
+                timeout + self.config.tick_interval_ms,
+            ));
             if self.network_sender.send_to(peer_id, msg).await.is_err() {
                 error!("[state sync] failed to send p2p message");
             }
-        }
-    }
-
-    fn notify_subscribers(&mut self, result: bool) {
-        let mut active_subscribers = self.subscribers.split_off(&(self.known_version + 1));
-
-        // notify subscribers if some syncs are ready
-        for channels in self.subscribers.values_mut() {
-            channels.drain(..).for_each(|ch| {
-                if ch.send(result).is_err() {
-                    error!("[state sync] coordinator failed to notify subscriber");
-                }
-            });
-        }
-        self.subscribers.clear();
-        self.subscribers.append(&mut active_subscribers);
-        // reset sync state if done
-        if self.subscribers.is_empty() {
-            self.target = None;
         }
     }
 
@@ -335,5 +362,44 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         req.set_txn_list_with_proof(txn_list_with_proof);
         req.set_ledger_info_with_sigs(ledger_info.into_proto());
         self.executor_proxy.execute_chunk(req).await
+    }
+
+    async fn check_subscriptions(&mut self) -> Result<()> {
+        let ledger_info = self.executor_proxy.get_latest_ledger_info().await?;
+        let committed_version = self.known_version;
+        let mut ready = vec![];
+
+        self.subscriptions
+            .retain(|peer_id, (expiry, known_version, limit)| {
+                // filter out expired peer requests
+                if SystemTime::now().duration_since(expiry.clone()).is_ok() {
+                    return false;
+                }
+                if *known_version < committed_version {
+                    ready.push((*peer_id, *known_version, *limit));
+                    false
+                } else {
+                    true
+                }
+            });
+
+        let mut futures: FuturesUnordered<_> = ready
+            .into_iter()
+            .map(|(peer_id, known_version, limit)| {
+                self.deliver_chunk(
+                    peer_id,
+                    known_version,
+                    limit,
+                    ledger_info.clone(),
+                    self.network_sender.clone(),
+                )
+            })
+            .collect();
+        while let Some(res) = futures.next().await {
+            if let Err(err) = res {
+                error!("[state sync] failed to notify subscriber {:?}", err);
+            }
+        }
+        Ok(())
     }
 }

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -215,7 +215,6 @@ impl SynchronizerEnv {
             .executor()
             .spawn(network_provider.start().unit_error().compat());
 
-        let default_handler = Box::new(|resp| -> Result<GetChunkResponse> { Ok(resp) });
         // create synchronizers
         let mut config = get_test_config().0;
         if role == RoleType::FullNode {
@@ -226,7 +225,7 @@ impl SynchronizerEnv {
                 sender_a,
                 events_a,
                 &config,
-                MockExecutorProxy::new(peers[0], default_handler),
+                MockExecutorProxy::new(peers[0], Self::default_handler()),
             ),
             StateSynchronizer::bootstrap_with_executor_proxy(
                 sender_b,
@@ -245,9 +244,17 @@ impl SynchronizerEnv {
         }
     }
 
+    fn default_handler() -> MockRpcHandler {
+        Box::new(|resp| -> Result<GetChunkResponse> { Ok(resp) })
+    }
+
     fn sync_to(&self, peer_id: usize, version: u64) -> bool {
         let target = MockExecutorProxy::mock_ledger_info(self.peers[1], version);
         block_on(self.clients[peer_id].sync_to(target)).unwrap()
+    }
+
+    fn commit(&self, peer_id: usize, version: u64) {
+        block_on(self.clients[peer_id].commit(version)).unwrap();
     }
 
     fn wait_for_version(&self, peer_id: usize, target_version: u64) -> bool {
@@ -265,8 +272,7 @@ impl SynchronizerEnv {
 
 #[test]
 fn test_basic_catch_up() {
-    let handler = Box::new(|resp| -> Result<GetChunkResponse> { Ok(resp) });
-    let env = SynchronizerEnv::new(handler, RoleType::Validator);
+    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::Validator);
 
     // test small sequential syncs
     for version in 1..5 {
@@ -295,15 +301,12 @@ fn test_flaky_peer_sync() {
 
 #[test]
 fn test_full_node() {
-    let committed_version = 10;
-    let handler = Box::new(move |resp: GetChunkResponse| -> Result<GetChunkResponse> {
-        let v = resp.get_ledger_info_with_sigs().get_ledger_info().version;
-        if v <= committed_version {
-            Ok(resp)
-        } else {
-            bail!("no new data");
-        }
-    });
-    let env = SynchronizerEnv::new(handler, RoleType::FullNode);
+    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::FullNode);
+    env.commit(1, 10);
+    // first sync should be fulfilled immediately after peer discovery
     assert!(env.wait_for_version(0, 10));
+    env.commit(1, 20);
+    // second sync will be done via long polling cause first node should send new request
+    // after receiving first chunk immediately
+    assert!(env.wait_for_version(0, 20));
 }


### PR DESCRIPTION
If upstream synchronizer doesn't have required data and requested timeout > 0, we'll add it to subscription queue. Entry will be removed from queue once either new chunk is ready or request is expired

## Test Plan
modified full_node sync test
