### PR TITLE
[language] test that flags genesis blob changes

### DIFF
--- a/language/vm/vm_genesis/src/main.rs
+++ b/language/vm/vm_genesis/src/main.rs
@@ -9,6 +9,13 @@ const GENESIS_LOCATION: &str = "genesis/genesis.blob";
 
 use proto_conv::IntoProtoBytes;
 
+/// Generate the genesis blob used by the Libra blockchain
+fn generate_genesis_blob() -> Vec<u8> {
+    encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1.clone())
+        .into_proto_bytes()
+        .expect("Generating genesis block failed")
+}
+
 fn main() {
     println!(
         "Creating genesis binary blob at {} from configuration file {}",
@@ -17,9 +24,20 @@ fn main() {
     let config = default_config();
     config.save_config(CONFIG_LOCATION);
 
-    // Generate a genesis blob used for vm tests.
-    let genesis_txn = encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1.clone());
     let mut file = File::create(GENESIS_LOCATION).unwrap();
-    file.write_all(&genesis_txn.into_proto_bytes().unwrap())
-        .unwrap();
+    file.write_all(&generate_genesis_blob()).unwrap();
+}
+
+// A test that fails if the generated genesis blob is different from the one on  disk. Intended
+// to catch commits that
+// - accidentally change the genesis block
+// - change it without remembering to update the on-disk copy
+// - cause generation of the genesis block to fail
+#[test]
+fn genesis_blob_unchanged() {
+    let mut genesis_file = File::open(GENESIS_LOCATION).unwrap();
+    let mut old_genesis_bytes = vec![];
+    genesis_file.read_to_end(&mut old_genesis_bytes).unwrap();
+    assert!(old_genesis_bytes == generate_genesis_blob(),
+            format!("The freshly generated genesis file is different from the one on disk at {}. Did you forget to regenerate the genesis file via `cargo run` inside libra/language/vm/vm_genesis?", GENESIS_LOCATION));
 }


### PR DESCRIPTION
# Motivation
It's easy to commit code that would change the genesis blob without regenerating it. This PR adds a test that will flag such changes.

# Test plan
Added code that changed the genesis blob without updating it, checked that the test failed