### PR TITLE
[libra_fuzzer] disable test target for fuzz_runner

### DIFF
--- a/testsuite/libra_fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra_fuzzer/fuzz/Cargo.toml
@@ -25,3 +25,4 @@ members = ["."]
 [[bin]]
 name = "fuzz_runner"
 path = "fuzz_targets/fuzz_runner.rs"
+test = false


### PR DESCRIPTION
Testing for fuzz targets is covered by `cargo test` in `testsuite/libra_fuzzer`.

Closes #624.