### PR TITLE
[types] Removes unused code from some crypto-related data structures

### DIFF
--- a/execution/execution_tests/src/tests/storage_integration_test.rs
+++ b/execution/execution_tests/src/tests/storage_integration_test.rs
@@ -11,7 +11,7 @@ use grpcio::EnvBuilder;
 use nextgen_crypto::{ed25519::*, test_utils::TEST_SEED};
 use proto_conv::FromProto;
 use rand::SeedableRng;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient};
 use types::{
     access_path::AccessPath,
@@ -241,7 +241,7 @@ fn test_execution_with_storage() {
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
-        Arc::new(ValidatorVerifier::new_empty()),
+        Arc::new(ValidatorVerifier::new(HashMap::new())),
         0,
         &request_items,
         &response_items,
@@ -434,7 +434,7 @@ fn test_execution_with_storage() {
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
-        Arc::new(ValidatorVerifier::new_empty()),
+        Arc::new(ValidatorVerifier::new(HashMap::new())),
         0,
         &request_items,
         &response_items,

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Integration tests for validator_network.
-#![cfg(test)]
 use crate::{
     common::NetworkPublicKeys,
     proto::{ConsensusMsg, MempoolSyncMsg, RequestBlock, RespondBlock, SignedTransaction},

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -5,13 +5,11 @@ use crate::{
     account_address::AccountAddress,
     proto::transaction::{
         RawTransaction as ProtoRawTransaction, SignedTransaction as ProtoSignedTransaction,
-        SignedTransactionsBlock,
     },
     transaction::{
         Program, RawTransaction, RawTransactionBytes, SignatureCheckedTransaction,
         SignedTransaction,
     },
-    transaction_helpers::get_signed_transactions_digest,
     write_set::WriteSet,
 };
 use crypto::hash::CryptoHash;
@@ -150,34 +148,4 @@ pub fn get_write_set_txn(
     RawTransaction::new_write_set(sender, sequence_number, write_set)
         .sign(&private_key, public_key)
         .unwrap()
-}
-
-// Test helper for transaction block creation
-pub fn create_signed_transactions_block(
-    sender: AccountAddress,
-    starting_sequence_number: u64,
-    num_transactions_in_block: u64,
-    priv_key: &Ed25519PrivateKey,
-    pub_key: &Ed25519PublicKey,
-    validator_priv_key: &Ed25519PrivateKey,
-    validator_pub_key: &Ed25519PublicKey,
-) -> SignedTransactionsBlock {
-    let mut signed_txns_block = SignedTransactionsBlock::new();
-    for i in starting_sequence_number..(starting_sequence_number + num_transactions_in_block) {
-        // Add some transactions to the block
-        signed_txns_block.transactions.push(get_test_signed_txn(
-            sender,
-            i, /* seq_number */
-            priv_key.clone(),
-            pub_key.clone(),
-            None,
-        ));
-    }
-
-    let message = get_signed_transactions_digest(&signed_txns_block.transactions);
-    let signature = validator_priv_key.sign_message(&message);
-    signed_txns_block.set_validator_signature(signature.to_bytes().to_vec());
-    signed_txns_block.set_validator_public_key(validator_pub_key.to_bytes().to_vec());
-
-    signed_txns_block
 }

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -356,11 +356,6 @@ pub struct SignedTransaction {
 pub struct SignatureCheckedTransaction(SignedTransaction);
 
 impl SignatureCheckedTransaction {
-    /// Returns a reference to the `SignedTransaction` within.
-    pub fn as_inner(&self) -> &SignedTransaction {
-        &self.0
-    }
-
     /// Returns the `SignedTransaction` within.
     pub fn into_inner(self) -> SignedTransaction {
         self.0

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -9,13 +9,11 @@ use crate::{
 };
 use canonical_serialization::{
     CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
-    SimpleDeserializer,
 };
 use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
-use std::collections::btree_map::BTreeMap;
 
 pub const VALIDATOR_SET_MODULE_NAME: &str = "ValidatorSet";
 pub const VALIDATOR_SET_STRUCT_NAME: &str = "T";
@@ -41,15 +39,6 @@ impl ValidatorSet {
     /// Constructs a ValidatorSet resource.
     pub fn new(payload: Vec<ValidatorPublicKeys>) -> Self {
         ValidatorSet(payload)
-    }
-
-    /// Given an account map (typically from storage) retrieves the validator resource associated.
-    pub fn make_from(account_map: &BTreeMap<Vec<u8>, Vec<u8>>) -> Result<Self> {
-        let ap = validator_set_path();
-        match account_map.get(&ap) {
-            Some(bytes) => SimpleDeserializer::deserialize(bytes),
-            None => bail!("No data for {:?}", ap),
-        }
     }
 
     pub fn payload(&self) -> &[ValidatorPublicKeys] {

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -41,15 +41,6 @@ impl<PrivateKey: SigningKey> ValidatorSigner<PrivateKey> {
         Ok(self.private_key.sign_message(&message))
     }
 
-    /// Checks that `signature` is valid for `message` using `public_key`.
-    pub fn verify_message(
-        &self,
-        message: HashValue,
-        signature: &<PrivateKey::VerifyingKeyMaterial as VerifyingKey>::SignatureMaterial,
-    ) -> Result<(), Error> {
-        signature.verify(&message, &self.public_key)
-    }
-
     /// Returns the author associated with this signer.
     pub fn author(&self) -> AccountAddress {
         self.author
@@ -150,12 +141,5 @@ pub mod proptests {
             prop_assert_eq!(public_key, signer.public_key());
         }
 
-        #[test]
-        fn test_signer(signer in arb_signer::<Ed25519PrivateKey>(), message in HashValue::arbitrary()) {
-            let signature = signer.sign_message(message).unwrap();
-            prop_assert!(signer
-                         .verify_message(message, &signature)
-                         .is_ok());
-        }
     }
 }

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -82,11 +82,6 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         Self::new(author_to_public_keys)
     }
 
-    /// Helper method to initialize with an empty validator set.
-    pub fn new_empty() -> Self {
-        Self::new(HashMap::new())
-    }
-
     /// Verify the correctness of a signature of a hash by a known author.
     pub fn verify_signature(
         &self,


### PR DESCRIPTION
- remove `verify_message` from `validator_signer` (SoC)
- remove, `new_empty` from `validator_verifier` (pedantic w/ good alternatives)
- remove `make_from` from `ValidatorSet` (unused, weird code path to deserialize from)
- remove `as_inner` from `transaction` (unused, good alternative nearby)
- remove `create_signed_transactions_block` from `transaction_test_helpers` (unused, pedantic, test helper)