### PR TITLE
[terraform] add a variable for adding capabilities as linux parameter

### DIFF
--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -22,6 +22,11 @@
             {"name": "GENESIS_BLOB", "value": ${genesis_blob}},
             {"name": "RUST_LOG", "value": "${log_level}"}
         ],
+        "linuxParameters": {
+            "capabilities": {
+                 "add": ${capabilities}
+             }
+        },
         "ulimits": [
             {"name": "nofile", "softLimit": 131072, "hardLimit": 131072}
         ],

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -208,6 +208,7 @@ data "template_file" "ecs_task_definition" {
     log_group     = aws_cloudwatch_log_group.testnet.name
     log_region    = var.region
     log_prefix    = "validator-${substr(var.peer_ids[count.index], 0, 8)}"
+    capabilities  = jsonencode(var.validator_linux_capabilities)
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,6 +69,12 @@ variable "validator_log_level" {
   default     = "debug"
 }
 
+variable "validator_linux_capabilities" {
+  type        = list(string)
+  description = "List of capabilities needed as Linux parameters"
+  default     = []
+}
+
 variable "append_workspace_dns" {
   description = "Append Terraform workspace to DNS names created"
   default     = true


### PR DESCRIPTION
To run some experiments, we may need to add additional capabilities to the
ecs task. For example, to inject network delay using the `netem` tool,
`net_admin` capability is needed.
This PR adds the parameter for adding capabilities, but the default value
is empty which doesn't affect production. In the experiments we run,
just set this parameter explicitly to add the special capabilities.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Deployed with 100 nodes with `net_admin` capability, was able to inject network delay using `netem`
