### PR TITLE
[common] Moving dependencies -> dev-dependencies when possible

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -11,11 +11,9 @@ byteorder = "1.3.2"
 bytes = "0.4.12"
 grpcio = "0.4.3"
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["io-compat", "compat"] }
-futures_locks = { version = "=0.3.0", package = "futures-locks", features=["tokio"]}
 mirai-annotations = "1.3.1"
 num-traits = "0.2"
 num-derive = "0.2"
-proptest = "0.9"
 protobuf = "~2.7"
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
@@ -50,10 +48,10 @@ features = ["push"]
 build_helpers = { path = "../common/build_helpers" }
 
 [dev-dependencies]
-cached = "0.8.1"
+cached = "0.9.0"
 tempfile = "3.1.0"
-parity-multiaddr = "0.4.0"
-rusty-fork = "0.2.1"
+parity-multiaddr = "0.5.0"
+rusty-fork = "0.2.2"
 
 config_builder = { path = "../config/config_builder" }
 execution_service = { path = "../execution/execution_service" }
@@ -62,3 +60,5 @@ crypto = { path = "../crypto/crypto", features = ["testing"]}
 types = { path = "../types", features = ["testing"]}
 vm_genesis = { path = "../language/vm/vm_genesis" }
 vm_validator = { path = "../vm_validator" }
+futures-locks = "0.3.3"
+proptest = "0.9.4"

--- a/language/vm/vm_runtime/vm_cache_map/Cargo.toml
+++ b/language/vm/vm_runtime/vm_cache_map/Cargo.toml
@@ -12,5 +12,5 @@ typed-arena = "1.5.0"
 
 [dev-dependencies]
 crossbeam = "0.7.2"
-proptest = "0.9"
-rand = "0.6.5"
+proptest = "0.9.4"
+rand = "0.7.0"

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -24,7 +24,7 @@ vm_runtime = { path = "../../language/vm/vm_runtime"}
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types" }
 
 [dev-dependencies]
-datatest = "0.3.5"
+datatest = "0.4.2"
 stats_alloc = "0.1.8"
 rusty-fork = "0.2.2"
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,8 +15,6 @@ hex = "0.3.2"
 itertools = "0.8.0"
 lazy_static = "1.3.0"
 logger = { path = "../common/logger" }
-proptest = "0.9"
-proptest-derive = "0.1.0"
 protobuf = "~2.7"
 radix_trie = "0.1.3"
 rand = "0.6.5"
@@ -34,6 +32,8 @@ build_helpers = { path = "../common/build_helpers" }
 
 [dev-dependencies]
 crypto = { path = "../crypto/crypto", features = ["testing"] }
+proptest = "0.9.4"
+proptest-derive = "0.1.2"
 
 [features]
 default = []


### PR DESCRIPTION
*This modifies the following behavior*:
This moves the maximum doable numebr of dependencies to dev-dependencies when possible.

*Why this is better*:
- hygiene
- Since we've noticed we ere affected by https://github.com/rust-lang/cargo/issues/1796 wherein the trigger is having the same dependencies in deps and dev-deps, let's reduce those

*Why this is worse*:
n/a

*Tests*:
existing