### PR TITLE
[VM] Remove duplicate MIRAI annotations import

### DIFF
--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -125,8 +125,6 @@ pub mod txn_executor;
 pub mod execution_stack;
 #[cfg(not(feature = "instruction_synthesis"))]
 mod execution_stack;
-#[macro_use]
-extern crate mirai_annotations;
 
 pub use move_vm::MoveVM;
 pub use process_txn::verify::static_verify_program;


### PR DESCRIPTION
## Motivation

Remove the duplicate MIRAI annotations import in `vm_runtime/src/lib.rs`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test`.

## Related PRs

N/A
