### PR TITLE
[Proof] Derive Arbitrary instead of manually implementing it for a few types

### DIFF
--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unit_arg)]
+
 //! This module has definition of various proofs.
 
 #[cfg(test)]
@@ -14,6 +16,8 @@ use crypto::{
     HashValue,
 };
 use failure::prelude::*;
+#[cfg(any(test, feature = "testing"))]
+use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 
 /// A proof that can be used authenticate an element in an accumulator given trusted root hash. For
@@ -306,6 +310,7 @@ impl AccumulatorConsistencyProof {
 /// the correctness of the `TransactionInfo` object, and the `TransactionInfo` object that is
 /// supposed to match the `SignedTransaction`.
 #[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
+#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 #[ProtoType(crate::proto::proof::SignedTransactionProof)]
 pub struct SignedTransactionProof {
     /// The accumulator proof from ledger info root to leaf that authenticates the hash of the
@@ -344,6 +349,7 @@ impl SignedTransactionProof {
 /// `AccumulatorProof` from `LedgerInfo` to `TransactionInfo`, the `TransactionInfo` object and the
 /// `SparseMerkleProof` from state root to the account.
 #[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
+#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 #[ProtoType(crate::proto::proof::AccountStateProof)]
 pub struct AccountStateProof {
     /// The accumulator proof from ledger info root to leaf that authenticates the hash of the
@@ -392,6 +398,7 @@ impl AccountStateProof {
 /// `AccumulatorProof` from `LedgerInfo` to `TransactionInfo`, the `TransactionInfo` object and the
 /// `AccumulatorProof` from event accumulator root to the event.
 #[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
+#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 #[ProtoType(crate::proto::proof::EventProof)]
 pub struct EventProof {
     /// The accumulator proof from ledger info root to leaf that authenticates the hash of the

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -4,12 +4,7 @@
 //! All proofs generated in this module are not valid proofs. They are only for the purpose of
 //! testing conversion between Rust and Protobuf.
 
-use crate::{
-    proof::{
-        AccountStateProof, AccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleProof,
-    },
-    transaction::TransactionInfo,
-};
+use crate::proof::{AccumulatorProof, SparseMerkleProof};
 use crypto::{
     hash::{ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
@@ -54,43 +49,6 @@ prop_compose! {
     }
 }
 
-prop_compose! {
-    fn arb_signed_transaction_proof()(
-        ledger_info_to_transaction_info_proof in any::<AccumulatorProof>(),
-        transaction_info in any::<TransactionInfo>(),
-    ) -> SignedTransactionProof {
-        SignedTransactionProof::new(ledger_info_to_transaction_info_proof, transaction_info)
-    }
-}
-
-prop_compose! {
-    fn arb_account_state_proof()(
-        ledger_info_to_transaction_info_proof in any::<AccumulatorProof>(),
-        transaction_info in any::<TransactionInfo>(),
-        transaction_info_to_account_proof in any::<SparseMerkleProof>(),
-    ) -> AccountStateProof {
-        AccountStateProof::new(
-            ledger_info_to_transaction_info_proof,
-            transaction_info,
-            transaction_info_to_account_proof,
-        )
-    }
-}
-
-prop_compose! {
-    fn arb_event_proof()(
-        ledger_info_to_transaction_info_proof in any::<AccumulatorProof>(),
-        transaction_info in any::<TransactionInfo>(),
-        transaction_info_to_event_proof in any::<AccumulatorProof>(),
-    ) -> EventProof {
-        EventProof::new(
-            ledger_info_to_transaction_info_proof,
-            transaction_info,
-            transaction_info_to_event_proof,
-        )
-    }
-}
-
 macro_rules! impl_arbitrary_for_proof {
     ($proof_type: ident, $arb_func: ident) => {
         impl Arbitrary for $proof_type {
@@ -106,6 +64,3 @@ macro_rules! impl_arbitrary_for_proof {
 
 impl_arbitrary_for_proof!(AccumulatorProof, arb_accumulator_proof);
 impl_arbitrary_for_proof!(SparseMerkleProof, arb_sparse_merkle_proof);
-impl_arbitrary_for_proof!(SignedTransactionProof, arb_signed_transaction_proof);
-impl_arbitrary_for_proof!(AccountStateProof, arb_account_state_proof);
-impl_arbitrary_for_proof!(EventProof, arb_event_proof);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

These traits implementations can be derived.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI
