### PR TITLE
[state-sync] Validate request chunk parameters

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -620,6 +620,10 @@ pub struct StateSyncConfig {
     pub tick_interval_ms: u64,
     // default timeout used for long polling to remote peer
     pub long_poll_timeout_ms: u64,
+    // valid maximum chunk limit for sanity check
+    pub max_chunk_limit: u64,
+    // valid maximum timeout limit for sanity check
+    pub max_timeout_ms: u64,
 }
 
 impl Default for StateSyncConfig {
@@ -628,6 +632,8 @@ impl Default for StateSyncConfig {
             chunk_limit: 1000,
             tick_interval_ms: 10,
             long_poll_timeout_ms: 30000,
+            max_chunk_limit: 1000,
+            max_timeout_ms: 120_000,
         }
     }
 }

--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -229,6 +229,18 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         peer_id: PeerId,
         mut request: GetChunkRequest,
     ) -> Result<()> {
+        if request.timeout > self.config.max_timeout_ms
+            || request.limit > self.config.max_chunk_limit
+        {
+            return Err(format_err!(
+                "[state sync] timeout: {:?}, chunk limit: {:?}, but timeout must not exceed {:?} ms, and chunk limit must not exceed {:?}",
+                request.timeout,
+                request.limit,
+                self.config.max_timeout_ms,
+                self.config.max_chunk_limit
+            ));
+        }
+
         let latest_ledger_info = self.executor_proxy.get_latest_ledger_info().await?;
         let target = LedgerInfo::from_proto(request.take_ledger_info_with_sigs())
             .unwrap_or(latest_ledger_info);


### PR DESCRIPTION
## Motivation

Sanity check for chunk limit and timeout parameters for chunk request. If the parameters are above certain value as passed in through state synchronizer config, abandon request and log an error message. 