### PR TITLE
[Proof] Implement FromProto and IntoProto for AccumulatorConsistencyProof

### DIFF
--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -4,7 +4,7 @@
 //! All proofs generated in this module are not valid proofs. They are only for the purpose of
 //! testing conversion between Rust and Protobuf.
 
-use crate::proof::{AccumulatorProof, SparseMerkleProof};
+use crate::proof::{AccumulatorConsistencyProof, AccumulatorProof, SparseMerkleProof};
 use crypto::{
     hash::{ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
@@ -49,6 +49,18 @@ prop_compose! {
     }
 }
 
+prop_compose! {
+    fn arb_accumulator_consistency_proof()(
+        frozen_subtree_roots in vec(any::<HashValue>(), 1..64),
+        non_default_siblings in vec(any::<HashValue>(), 0..30),
+        default_siblings in vec(any::<HashValue>(), 0..30),
+    ) -> AccumulatorConsistencyProof {
+        let mut siblings = non_default_siblings;
+        siblings.extend(default_siblings.into_iter());
+        AccumulatorConsistencyProof::new(frozen_subtree_roots, siblings)
+    }
+}
+
 macro_rules! impl_arbitrary_for_proof {
     ($proof_type: ident, $arb_func: ident) => {
         impl Arbitrary for $proof_type {
@@ -64,3 +76,7 @@ macro_rules! impl_arbitrary_for_proof {
 
 impl_arbitrary_for_proof!(AccumulatorProof, arb_accumulator_proof);
 impl_arbitrary_for_proof!(SparseMerkleProof, arb_sparse_merkle_proof);
+impl_arbitrary_for_proof!(
+    AccumulatorConsistencyProof,
+    arb_accumulator_consistency_proof
+);

--- a/types/src/proof/unit_tests/proof_proto_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_proto_conversion_test.rs
@@ -3,7 +3,8 @@
 
 use crate::proof::{
     definition::bitmap::{AccumulatorBitmap, SparseMerkleBitmap},
-    AccountStateProof, AccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleProof,
+    AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, EventProof,
+    SignedTransactionProof, SparseMerkleProof,
 };
 use crypto::{
     hash::{TestOnlyHash, ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -310,6 +311,13 @@ proptest! {
 
     #[test]
     fn test_sparse_merkle_protobuf_conversion_roundtrip(proof in any::<SparseMerkleProof>()) {
+        assert_protobuf_encode_decode(&proof);
+    }
+
+    #[test]
+    fn test_accumulator_consistency_protobuf_conversion_roundtrip(
+        proof in any::<AccumulatorConsistencyProof>(),
+    ) {
         assert_protobuf_encode_decode(&proof);
     }
 

--- a/types/src/proto/proof.proto
+++ b/types/src/proto/proof.proto
@@ -51,6 +51,21 @@ message SparseMerkleProof {
   repeated bytes non_default_siblings = 3;
 }
 
+message AccumulatorConsistencyProof {
+  // The root hashes of the frozen subtrees that form the small accumulator.
+  // Note that none of these hashes should be default hash.
+  repeated bytes frozen_subtree_roots = 1;
+
+  // The total number of siblings.
+  uint32 num_siblings = 2;
+
+  // The non-default siblings. Note that the entire list of siblings always
+  // start of zero or more non-default siblings, followed by zero of more
+  // default siblings. So given the total number of siblings and the non-default
+  // siblings we should be able to construct the entire sibling list.
+  repeated bytes non_default_siblings = 3;
+}
+
 // The complete proof used to authenticate a signed transaction.
 message SignedTransactionProof {
   AccumulatorProof ledger_info_to_transaction_info_proof = 1;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

For the frozen subtree roots, they should not contain any default hashes, so we simply write these hashes. For the siblings, note that they always start with some non-default hashes, followed by some default hashes, so we just need to write the non-default ones as well as the total number of siblings.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.
