### PR TITLE
[language] Cfg trait

### DIFF
--- a/language/bytecode_verifier/src/absint.rs
+++ b/language/bytecode_verifier/src/absint.rs
@@ -1,4 +1,4 @@
-use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use crate::control_flow_graph::{BlockId, ControlFlowGraph};
 use std::collections::HashMap;
 use vm::{
     file_format::{Bytecode, CompiledModule},
@@ -87,7 +87,7 @@ pub trait AbstractInterpreter: TransferFunctions {
         &mut self,
         initial_state: Self::State,
         function_view: &FunctionDefinitionView<CompiledModule>,
-        cfg: &VMControlFlowGraph,
+        cfg: &dyn ControlFlowGraph,
     ) -> InvariantMap<Self::State> {
         let mut inv_map: InvariantMap<Self::State> = InvariantMap::new();
         let entry_block_id = 0; // 0 is always the entry block
@@ -124,7 +124,7 @@ pub trait AbstractInterpreter: TransferFunctions {
                 }
             };
             let block_ends_in_error = self
-                .execute_block(block_id, &mut state, &function_view, &cfg)
+                .execute_block(block_id, &mut state, &function_view, cfg)
                 .is_err();
             if block_ends_in_error {
                 block_invariant.post = BlockPostcondition::Error;
@@ -185,7 +185,7 @@ pub trait AbstractInterpreter: TransferFunctions {
         block_id: BlockId,
         state: &mut Self::State,
         function_view: &FunctionDefinitionView<CompiledModule>,
-        cfg: &VMControlFlowGraph,
+        cfg: &dyn ControlFlowGraph,
     ) -> Result<(), Self::AnalysisError> {
         let block = cfg
             .block_of_id(block_id)

--- a/language/bytecode_verifier/src/code_unit_verifier.rs
+++ b/language/bytecode_verifier/src/code_unit_verifier.rs
@@ -4,7 +4,7 @@
 //! This module implements the checker for verifying correctness of function bodies.
 //! The overall verification is split between stack_usage_verifier.rs and
 //! abstract_interpreter.rs. CodeUnitVerifier simply orchestrates calls into these two files.
-use crate::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
+use crate::control_flow_graph::VMControlFlowGraph;
 use vm::{
     access::ModuleAccess,
     errors::{VMStaticViolation, VerificationError},

--- a/language/compiler/src/unit_tests/cfg_tests.rs
+++ b/language/compiler/src/unit_tests/cfg_tests.rs
@@ -16,7 +16,7 @@ fn cfg_compile_script_ret() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 1);
     assert_eq!(cfg.num_blocks(), 1);
@@ -40,7 +40,7 @@ fn cfg_compile_script_let() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 1);
@@ -65,7 +65,7 @@ fn cfg_compile_if() {
 
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 3);
@@ -93,7 +93,7 @@ fn cfg_compile_if_else() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 4);
@@ -119,7 +119,7 @@ fn cfg_compile_if_else_with_else_return() {
 
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 4);
@@ -148,7 +148,7 @@ fn cfg_compile_nested_if() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 6);
@@ -173,7 +173,7 @@ fn cfg_compile_if_else_with_if_return() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 3);
@@ -199,7 +199,7 @@ fn cfg_compile_if_else_with_two_returns() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 4);
@@ -228,7 +228,7 @@ fn cfg_compile_if_else_with_else_abort() {
 
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {:?}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 4);
@@ -253,7 +253,7 @@ fn cfg_compile_if_else_with_if_abort() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 3);
@@ -279,7 +279,7 @@ fn cfg_compile_if_else_with_two_aborts() {
     );
     let compiled_script_res = compile_script_string(&code);
     let compiled_script = compiled_script_res.unwrap();
-    let cfg: VMControlFlowGraph = ControlFlowGraph::new(&compiled_script.main().code.code);
+    let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&compiled_script.main().code.code);
     println!("SCRIPT:\n {}", compiled_script);
     cfg.display();
     assert_eq!(cfg.blocks.len(), 4);


### PR DESCRIPTION
## Motivation

The abstract interpreter relies on a specific implementation of the CFG. This commit makes it rely on a CFG trait instead. Making the CFG more abstract will make it easier to support useful features like backward analysis without changing the interpreter.

## Test Plan

Existing tests, Should be pure refactoring.

