### PR TITLE
[storage] rename executor_startup_info to startup_info

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -61,7 +61,7 @@ where
         config: &NodeConfig,
     ) -> Self {
         let startup_info = storage_read_client
-            .get_executor_startup_info()
+            .get_startup_info()
             .expect("Failed to read startup info from storage.");
 
         let (

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -48,7 +48,7 @@ use logger::prelude::*;
 use metrics::OpMetrics;
 use schemadb::{ColumnFamilyOptions, ColumnFamilyOptionsMap, DB, DEFAULT_CF_NAME};
 use std::{convert::TryInto, iter::Iterator, path::Path, sync::Arc, time::Instant};
-use storage_proto::ExecutorStartupInfo;
+use storage_proto::StartupInfo;
 use types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -540,12 +540,12 @@ impl LibraDB {
         ))
     }
 
-    // =========================== Execution Internal APIs ========================================
+    // =========================== Libra Core Internal APIs ========================================
 
     /// Gets an account state by account address, out of the ledger state indicated by the state
     /// Merkle tree root hash.
     ///
-    /// This is used by the executor module internally.
+    /// This is used by libra core (executor) internally.
     pub fn get_account_state_with_proof_by_version(
         &self,
         address: AccountAddress,
@@ -555,10 +555,11 @@ impl LibraDB {
             .get_account_state_with_proof_by_version(address, version)
     }
 
-    /// Gets information needed from storage during the startup of the executor module.
+    /// Gets information needed from storage during the startup of the executor or state
+    /// synchronizer module.
     ///
-    /// This is used by the executor module internally.
-    pub fn get_executor_startup_info(&self) -> Result<Option<ExecutorStartupInfo>> {
+    /// This is used by the libra core (executor, state synchronizer) internally.
+    pub fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         // Get the latest ledger info. Return None if not bootstrapped.
         let ledger_info_with_sigs = match self.ledger_store.get_latest_ledger_info_option() {
             Some(x) => x,
@@ -574,7 +575,7 @@ impl LibraDB {
             .ledger_store
             .get_ledger_frozen_subtree_hashes(latest_version)?;
 
-        Ok(Some(ExecutorStartupInfo {
+        Ok(Some(StartupInfo {
             ledger_info,
             latest_version,
             account_state_root_hash,

--- a/storage/storage_client/src/lib.rs
+++ b/storage/storage_client/src/lib.rs
@@ -20,10 +20,10 @@ use protobuf::Message;
 use rand::Rng;
 use std::{pin::Pin, sync::Arc};
 use storage_proto::{
-    proto::{storage::GetExecutorStartupInfoRequest, storage_grpc},
-    ExecutorStartupInfo, GetAccountStateWithProofByVersionRequest,
-    GetAccountStateWithProofByVersionResponse, GetExecutorStartupInfoResponse,
-    GetTransactionsRequest, GetTransactionsResponse, SaveTransactionsRequest,
+    proto::{storage::GetStartupInfoRequest, storage_grpc},
+    GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
+    GetStartupInfoResponse, GetTransactionsRequest, GetTransactionsResponse,
+    SaveTransactionsRequest, StartupInfo,
 };
 use types::{
     account_address::AccountAddress,
@@ -203,17 +203,17 @@ impl StorageRead for StorageReadServiceClient {
         .boxed()
     }
 
-    fn get_executor_startup_info(&self) -> Result<Option<ExecutorStartupInfo>> {
-        block_on(self.get_executor_startup_info_async())
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        block_on(self.get_startup_info_async())
     }
 
-    fn get_executor_startup_info_async(
+    fn get_startup_info_async(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<ExecutorStartupInfo>>> + Send>> {
-        let proto_req = GetExecutorStartupInfoRequest::new();
-        convert_grpc_response(self.client().get_executor_startup_info_async(&proto_req))
+    ) -> Pin<Box<dyn Future<Output = Result<Option<StartupInfo>>> + Send>> {
+        let proto_req = GetStartupInfoRequest::new();
+        convert_grpc_response(self.client().get_startup_info_async(&proto_req))
             .map(|resp| {
-                let resp = GetExecutorStartupInfoResponse::from_proto(resp?)?;
+                let resp = GetStartupInfoResponse::from_proto(resp?)?;
                 Ok(resp.info)
             })
             .boxed()
@@ -349,19 +349,19 @@ pub trait StorageRead: Send + Sync {
         version: Version,
     ) -> Pin<Box<dyn Future<Output = Result<(Option<AccountStateBlob>, SparseMerkleProof)>> + Send>>;
 
-    /// See [`LibraDB::get_executor_startup_info`].
+    /// See [`LibraDB::get_startup_info`].
     ///
-    /// [`LibraDB::get_executor_startup_info`]:
-    /// ../libradb/struct.LibraDB.html#method.get_executor_startup_info
-    fn get_executor_startup_info(&self) -> Result<Option<ExecutorStartupInfo>>;
+    /// [`LibraDB::get_startup_info`]:
+    /// ../libradb/struct.LibraDB.html#method.get_startup_info
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>>;
 
-    /// See [`LibraDB::get_executor_startup_info`].
+    /// See [`LibraDB::get_startup_info`].
     ///
-    /// [`LibraDB::get_executor_startup_info`]:
-    /// ../libradb/struct.LibraDB.html#method.get_executor_startup_info
-    fn get_executor_startup_info_async(
+    /// [`LibraDB::get_startup_info`]:
+    /// ../libradb/struct.LibraDB.html#method.get_startup_info
+    fn get_startup_info_async(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<ExecutorStartupInfo>>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Option<StartupInfo>>> + Send>>;
 }
 
 /// This trait defines interfaces to be implemented by a storage write client.

--- a/storage/storage_proto/src/lib.rs
+++ b/storage/storage_proto/src/lib.rs
@@ -284,21 +284,21 @@ impl GetTransactionsResponse {
     }
 }
 
-/// Helper to construct and parse [`proto::storage::ExecutorStartupInfo`]
+/// Helper to construct and parse [`proto::storage::StartupInfo`]
 ///
 /// It does so by implementing [`IntoProto`](#impl-IntoProto) and [`FromProto`](#impl-FromProto),
 /// providing [`into_proto`](IntoProto::into_proto) and [`from_proto`](FromProto::from_proto).
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-pub struct ExecutorStartupInfo {
+pub struct StartupInfo {
     pub ledger_info: LedgerInfo,
     pub latest_version: Version,
     pub account_state_root_hash: HashValue,
     pub ledger_frozen_subtree_hashes: Vec<HashValue>,
 }
 
-impl FromProto for ExecutorStartupInfo {
-    type ProtoType = crate::proto::storage::ExecutorStartupInfo;
+impl FromProto for StartupInfo {
+    type ProtoType = crate::proto::storage::StartupInfo;
 
     fn from_proto(mut object: Self::ProtoType) -> Result<Self> {
         let ledger_info = LedgerInfo::from_proto(object.take_ledger_info())?;
@@ -319,8 +319,8 @@ impl FromProto for ExecutorStartupInfo {
     }
 }
 
-impl IntoProto for ExecutorStartupInfo {
-    type ProtoType = crate::proto::storage::ExecutorStartupInfo;
+impl IntoProto for StartupInfo {
+    type ProtoType = crate::proto::storage::StartupInfo;
 
     fn into_proto(self) -> Self::ProtoType {
         let mut proto = Self::ProtoType::new();
@@ -337,22 +337,22 @@ impl IntoProto for ExecutorStartupInfo {
     }
 }
 
-/// Helper to construct and parse [`proto::storage::GetExecutorStartupInfoResponse`]
+/// Helper to construct and parse [`proto::storage::GetStartupInfoResponse`]
 ///
 /// It does so by implementing [`IntoProto`](#impl-IntoProto) and [`FromProto`](#impl-FromProto),
 /// providing [`into_proto`](IntoProto::into_proto) and [`from_proto`](FromProto::from_proto).
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-pub struct GetExecutorStartupInfoResponse {
-    pub info: Option<ExecutorStartupInfo>,
+pub struct GetStartupInfoResponse {
+    pub info: Option<StartupInfo>,
 }
 
-impl FromProto for GetExecutorStartupInfoResponse {
-    type ProtoType = crate::proto::storage::GetExecutorStartupInfoResponse;
+impl FromProto for GetStartupInfoResponse {
+    type ProtoType = crate::proto::storage::GetStartupInfoResponse;
 
     fn from_proto(mut object: Self::ProtoType) -> Result<Self> {
         let info = if object.has_info() {
-            Some(ExecutorStartupInfo::from_proto(object.take_info())?)
+            Some(StartupInfo::from_proto(object.take_info())?)
         } else {
             None
         };
@@ -361,8 +361,8 @@ impl FromProto for GetExecutorStartupInfoResponse {
     }
 }
 
-impl IntoProto for GetExecutorStartupInfoResponse {
-    type ProtoType = crate::proto::storage::GetExecutorStartupInfoResponse;
+impl IntoProto for GetStartupInfoResponse {
+    type ProtoType = crate::proto::storage::GetStartupInfoResponse;
 
     fn into_proto(self) -> Self::ProtoType {
         let mut proto = Self::ProtoType::new();

--- a/storage/storage_proto/src/proto/storage.proto
+++ b/storage/storage_proto/src/proto/storage.proto
@@ -42,9 +42,9 @@ service Storage {
     GetAccountStateWithProofByVersionRequest)
     returns (GetAccountStateWithProofByVersionResponse);
 
-    // Returns information needed for Executor to start up.
-    rpc GetExecutorStartupInfo(GetExecutorStartupInfoRequest)
-    returns (GetExecutorStartupInfoResponse);
+    // Returns information needed for libra core to start up.
+    rpc GetStartupInfo(GetStartupInfoRequest)
+    returns (GetStartupInfoResponse);
 }
 
 message SaveTransactionsRequest {
@@ -94,14 +94,14 @@ message GetAccountStateWithProofByVersionResponse {
     types.SparseMerkleProof sparse_merkle_proof = 2;
 }
 
-message GetExecutorStartupInfoRequest {}
+message GetStartupInfoRequest {}
 
-message GetExecutorStartupInfoResponse {
+message GetStartupInfoResponse {
     // When this is empty, Storage needs to be bootstrapped via the bootstrap API
-    ExecutorStartupInfo info = 1;
+    StartupInfo info = 1;
 }
 
-message ExecutorStartupInfo {
+message StartupInfo {
     // The latest LedgerInfo. Note that at start up storage can have more
     // transactions than the latest LedgerInfo indicates due to an incomplete
     // start up sync.

--- a/storage/storage_proto/src/tests.rs
+++ b/storage/storage_proto/src/tests.rs
@@ -24,12 +24,12 @@ proptest! {
     }
 
     #[test]
-    fn test_executor_startup_info(executor_startup_info in any::<ExecutorStartupInfo>()) {
-        assert_protobuf_encode_decode(&executor_startup_info);
+    fn test_startup_info(startup_info in any::<StartupInfo>()) {
+        assert_protobuf_encode_decode(&startup_info);
     }
 
     #[test]
-    fn test_get_executor_startup_info_response(res in any::<GetExecutorStartupInfoResponse>()) {
+    fn test_get_startup_info_response(res in any::<GetStartupInfoResponse>()) {
         assert_protobuf_encode_decode(&res);
     }
 }

--- a/storage/storage_service/src/lib.rs
+++ b/storage/storage_service/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
 use storage_proto::proto::{
     storage::{
         GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
-        GetExecutorStartupInfoRequest, GetExecutorStartupInfoResponse, GetTransactionsRequest,
+        GetStartupInfoRequest, GetStartupInfoResponse, GetTransactionsRequest,
         GetTransactionsResponse, SaveTransactionsRequest, SaveTransactionsResponse,
     },
     storage_grpc::{create_storage, Storage},
@@ -205,9 +205,9 @@ impl StorageService {
         Ok(SaveTransactionsResponse::new())
     }
 
-    fn get_executor_startup_info_inner(&self) -> Result<GetExecutorStartupInfoResponse> {
-        let info = self.db.get_executor_startup_info()?;
-        let rust_resp = storage_proto::GetExecutorStartupInfoResponse { info };
+    fn get_startup_info_inner(&self) -> Result<GetStartupInfoResponse> {
+        let info = self.db.get_startup_info()?;
+        let rust_resp = storage_proto::GetStartupInfoResponse { info };
         Ok(rust_resp.into_proto())
     }
 }
@@ -261,15 +261,15 @@ impl Storage for StorageService {
         provide_grpc_response(resp, ctx, sink);
     }
 
-    fn get_executor_startup_info(
+    fn get_startup_info(
         &mut self,
         ctx: grpcio::RpcContext,
-        _req: GetExecutorStartupInfoRequest,
-        sink: grpcio::UnarySink<GetExecutorStartupInfoResponse>,
+        _req: GetStartupInfoRequest,
+        sink: grpcio::UnarySink<GetStartupInfoResponse>,
     ) {
-        debug!("[GRPC] Storage::get_executor_startup_info");
+        debug!("[GRPC] Storage::get_startup_info");
         let _timer = SVC_COUNTERS.req(&ctx);
-        let resp = self.get_executor_startup_info_inner();
+        let resp = self.get_startup_info_inner();
         provide_grpc_response(resp, ctx, sink);
     }
 }

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -14,7 +14,7 @@ use rand::{
 };
 use std::{collections::BTreeMap, pin::Pin};
 use storage_client::StorageRead;
-use storage_proto::ExecutorStartupInfo;
+use storage_proto::StartupInfo;
 use types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_config::EventHandle,
@@ -131,13 +131,13 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!();
     }
 
-    fn get_executor_startup_info(&self) -> Result<Option<ExecutorStartupInfo>> {
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         unimplemented!()
     }
 
-    fn get_executor_startup_info_async(
+    fn get_startup_info_async(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<ExecutorStartupInfo>>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Option<StartupInfo>>> + Send>> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
## Motivation

Currently state synchronizer has no way to get the latest `transaction_info`. So we rename `startup_info` to make it general since it can be used by both `executor` and `state_synchronizer`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

## Related PRs

