### PR TITLE
[Executor] Handle empty chunks during state synchronization

### DIFF
--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -379,6 +379,22 @@ fn test_executor_execute_chunk() {
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
+    // Execute an empty chunk. After that we should still get the genesis ledger info from DB.
+    block_on(executor.execute_chunk(TransactionListWithProof::new_empty(), ledger_info.clone()))
+        .unwrap()
+        .unwrap();
+    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    assert_eq!(li.ledger_info().version(), 0);
+    assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
+
+    // Execute the second chunk again. After that we should still get the same thing.
+    block_on(executor.execute_chunk(chunks[1].clone(), ledger_info.clone()))
+        .unwrap()
+        .unwrap();
+    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    assert_eq!(li.ledger_info().version(), 0);
+    assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
+
     // Execute the third chunk. After that we should get the new ledger info.
     block_on(executor.execute_chunk(chunks[2].clone(), ledger_info.clone()))
         .unwrap()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently, if a transaction chunk is not the last chunk corresponding to the ledger info, and it is empty (or it is not empty but all the transactions in the chunk have been committed, for example this could happen if a chunk is sent to executor twice), storage would return an error since it expects either new transaction or new ledger info.

Fix this by not calling `save_transactions` in this case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a few test cases.

## Related PRs

None.
