### PR TITLE
[cluster_test] Fix commit_check OOMing cluster_test

### DIFF
--- a/testsuite/cluster_test/src/health/commit_check.rs
+++ b/testsuite/cluster_test/src/health/commit_check.rs
@@ -76,6 +76,9 @@ impl HealthCheck for CommitHistoryHealthCheck {
                 va.insert(commit.round);
             }
         }
+        if let Some(min_round) = self.latest_committed_round.values().min() {
+            self.round_to_commit.retain(|k, _v| *k >= *min_round);
+        }
     }
 
     fn name(&self) -> &'static str {


### PR DESCRIPTION
We maintain map from round to commit to check safety, this PR makes sure this map does not grow too large.
We verify separately, that committed rounds for each validator always go up.
This means we can pick lowest committed round across all validators and remove all entries from this map for rounds below lowest committed round.

Because we allow progress to happen between experiments, this technique should keep map relatively small.
