### PR TITLE
[state sync] use new API to fetch latest version

### DIFF
--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -119,6 +119,11 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         async move { Ok(response) }.boxed()
     }
 
+    fn get_latest_version(&self) -> Pin<Box<dyn Future<Output = Result<u64>> + Send>> {
+        let version = self.version.load(Ordering::Relaxed);
+        async move { Ok(version) }.boxed()
+    }
+
     fn execute_chunk(
         &self,
         request: ExecuteChunkRequest,


### PR DESCRIPTION
right now known_version in StateSyncrhonizer is derived from latest_ledger_info
it's not always correct. During cathing up phase, storage version will make progress, while latest ledger info will be the same until last chunk
