### PR TITLE
[consensus] Remove future_lock dependency

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -11,7 +11,6 @@ byteorder = "1.3.2"
 bytes = "0.4.12"
 grpcio = "0.4.3"
 futures = { version = "=0.3.0-alpha.17", package = "futures-preview", features = ["io-compat", "compat"] }
-futures_locks = { version = "=0.3.0", package = "futures-locks", features=["tokio"]}
 mirai-annotations = "1.3.1"
 num-traits = "0.2"
 num-derive = "0.2"


### PR DESCRIPTION
We no longer use it after simplifying concurrency in event_processor
Hopefully we not going to need it in future as well.
