### PR TITLE
[storage] make node_cache sorted

### DIFF
--- a/storage/jellyfish_merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish_merkle/src/jellyfish_merkle_test.rs
@@ -6,6 +6,7 @@ use crate::nibble::Nibble;
 use crypto::HashValue;
 use mock_tree_store::MockTreeStore;
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::collections::HashMap;
 use types::proof::verify_sparse_merkle_element;
 
 fn update_nibble(original_key: &HashValue, n: usize, nibble: u8) -> HashValue {

--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -74,7 +74,7 @@ use failure::prelude::*;
 use nibble::{skip_common_prefix, NibbleIterator, NibblePath};
 use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey};
 use proptest_derive::Arbitrary;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use tree_cache::TreeCache;
 use types::{account_state_blob::AccountStateBlob, proof::SparseMerkleProof, transaction::Version};
 
@@ -89,9 +89,9 @@ pub trait TreeReader {
 }
 
 /// Node batch that will be written into db atomically with other batches.
-pub type NodeBatch = HashMap<NodeKey, Node>;
+pub type NodeBatch = BTreeMap<NodeKey, Node>;
 /// [`RetireNodeIndex`] batch that will be written into db atomically with other batches.
-pub type StaleNodeIndexBatch = HashSet<StaleNodeIndex>;
+pub type StaleNodeIndexBatch = BTreeSet<StaleNodeIndex>;
 
 /// Indicates a node becomes stale since `stale_since_version`.
 #[derive(Arbitrary, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/storage/jellyfish_merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish_merkle/src/tree_cache/mod.rs
@@ -76,7 +76,7 @@ use crate::{
 use crypto::HashValue;
 use failure::prelude::*;
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet},
     convert::Into,
 };
 use types::transaction::Version;
@@ -88,13 +88,13 @@ use types::transaction::Version;
 #[derive(Default)]
 struct FrozenTreeCache {
     /// Immutable node_cache.
-    node_cache: HashMap<NodeKey, Node>,
+    node_cache: BTreeMap<NodeKey, Node>,
 
     /// # of leaves in the `node_cache`,
     num_new_leaves: usize,
 
     /// Immutable stale_node_index_cache.
-    stale_node_index_cache: HashSet<StaleNodeIndex>,
+    stale_node_index_cache: BTreeSet<StaleNodeIndex>,
 
     /// # of leaves in the `stale_node_index_cache`,
     num_stale_leaves: usize,


### PR DESCRIPTION
## Motivation

unsorted node cache may result in overlapping L0 files in rocksdb.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

## Related PRs

