### PR TITLE
[storage] change ledger_info key from Verison to epoch_num

### DIFF
--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -20,7 +20,7 @@ prop_compose! {
         partial_ledger_infos_with_sigs in vec(
             any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((1..3).into()).no_shrink(), 1..100
         ),
-        start_version in 0..10000u64,
+        start_epoch in 0..10000u64,
     ) -> Vec<LedgerInfoWithSignatures<Ed25519Signature>> {
         partial_ledger_infos_with_sigs
             .iter()
@@ -29,11 +29,11 @@ prop_compose! {
                 let ledger_info = p.ledger_info();
                 LedgerInfoWithSignatures::new(
                     LedgerInfo::new(
-                        start_version + i as u64,
+                        start_epoch + i as Version,
                         ledger_info.transaction_accumulator_hash(),
                         ledger_info.consensus_data_hash(),
                         HashValue::zero(),
-                        ledger_info.epoch_num(),
+                        start_epoch + i as u64 /* epoch_num */,
                         ledger_info.timestamp_usecs(),
                     ),
                     p.signatures().clone(),
@@ -53,7 +53,7 @@ proptest! {
         let tmp_dir = tempdir().unwrap();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.ledger_store;
-        let start_version = ledger_infos_with_sigs.first().unwrap().ledger_info().version();
+        let start_epoch = ledger_infos_with_sigs.first().unwrap().ledger_info().epoch_num();
 
         let mut cs = ChangeSet::new();
         ledger_infos_with_sigs
@@ -62,6 +62,6 @@ proptest! {
             .collect::<Result<Vec<_>>>()
             .unwrap();
         store.db.write_schemas(cs.batch).unwrap();
-        prop_assert_eq!(db.ledger_store.get_ledger_infos(start_version).unwrap(), ledger_infos_with_sigs);
+        prop_assert_eq!(db.ledger_store.get_ledger_infos(start_epoch).unwrap(), ledger_infos_with_sigs);
     }
 }

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -68,10 +68,10 @@ impl LedgerStore {
     #[cfg(test)]
     fn get_ledger_infos(
         &self,
-        start_version: Version,
+        start_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {
         let mut iter = self.db.iter::<LedgerInfoSchema>(ReadOptions::default())?;
-        iter.seek(&start_version)?;
+        iter.seek(&start_epoch)?;
         Ok(iter.map(|kv| Ok(kv?.1)).collect::<Result<Vec<_>>>()?)
     }
 
@@ -174,7 +174,7 @@ impl LedgerStore {
         cs: &mut ChangeSet,
     ) -> Result<()> {
         cs.batch.put::<LedgerInfoSchema>(
-            &ledger_info_with_sigs.ledger_info().version(),
+            &ledger_info_with_sigs.ledger_info().epoch_num(),
             ledger_info_with_sigs,
         )
     }

--- a/storage/libradb/src/schema/ledger_info/mod.rs
+++ b/storage/libradb/src/schema/ledger_info/mod.rs
@@ -3,13 +3,13 @@
 
 //! This module defines physical storage schema for LedgerInfoWithSignatures structure.
 //!
-//! Serialized LedgerInfoWithSignatures identified by version.
+//! Serialized LedgerInfoWithSignatures identified by `epoch_num`.
 //! ```text
-//! |<--key-->|<---------------value------------->|
-//! | version | ledger_info_with_signatures bytes |
+//! |<---key--->|<---------------value------------->|
+//! | epoch_num | ledger_info_with_signatures bytes |
 //! ```
 //!
-//! `Version` is serialized in big endian so that records in RocksDB will be in order of it's
+//! `epoch_num` is serialized in big endian so that records in RocksDB will be in order of it's
 //! numeric value.
 
 use crate::schema::ensure_slice_len_eq;
@@ -23,22 +23,22 @@ use schemadb::{
     DEFAULT_CF_NAME,
 };
 use std::mem::size_of;
-use types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
+use types::ledger_info::LedgerInfoWithSignatures;
 
 define_schema!(
     LedgerInfoSchema,
-    Version,
+    u64, /* epoch num */
     LedgerInfoWithSignatures<Ed25519Signature>,
     DEFAULT_CF_NAME
 );
 
-impl KeyCodec<LedgerInfoSchema> for Version {
+impl KeyCodec<LedgerInfoSchema> for u64 {
     fn encode_key(&self) -> Result<Vec<u8>> {
         Ok(self.to_be_bytes().to_vec())
     }
 
     fn decode_key(data: &[u8]) -> Result<Self> {
-        ensure_slice_len_eq(data, size_of::<Version>())?;
+        ensure_slice_len_eq(data, size_of::<Self>())?;
         Ok((&data[..]).read_u64::<BigEndian>()?)
     }
 }


### PR DESCRIPTION
## Motivation

we will use mostly epoch number to query `ledger_info`, needed by consensus reconfig.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

