### PR TITLE
[state sync] switch ensuring progress to last commit

### DIFF
--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -100,7 +100,7 @@ impl MockExecutorProxy {
                 txn_info,
             )],
             None,
-            Some(0),
+            Some(version + 1),
             Some(accumulator_proof),
             None,
         );


### PR DESCRIPTION
as a protection from malicious peers and execution failures we need to switch to last commit timestamp to ensure progress
currently check is done based on last sync request timestamp
with such approach malicious node can keep sending us bad data and `check_progress` will be satisfied
so to ensure real progress we need to check timestamp of last commit instead
