### PR TITLE
[config] Move trusted_peers, keys and role to NetworkConfig from BaseConfig

### DIFF
--- a/config/config_builder/src/bin/libra-config.rs
+++ b/config/config_builder/src/bin/libra-config.rs
@@ -112,7 +112,7 @@ fn main() {
         );
         println!(
             "Node Keys for PeerId({}): {:?}",
-            node_config.base.peer_id, node_config.base.peer_keypairs_file
+            node_config.base.peer_id, node_config.network.peer_keypairs_file
         );
     }
 }

--- a/config/data/configs/full_node.config.toml
+++ b/config/data/configs/full_node.config.toml
@@ -1,12 +1,10 @@
 # Defaults are now set in config.rs
 
-[base]
+[network]
+seed_peers_file = ""  # For direct validation of this file
 peer_keypairs_file = ""  # For direct validation of this file
 trusted_peers_file = ""  # For direct validation of this file
 role = "full_node"
-
-[network]
-seed_peers_file = ""  # For direct validation of this file
 
 [execution]
 genesis_file_location = "<USE_TEMP_DIR>"

--- a/config/data/configs/node.config.toml
+++ b/config/data/configs/node.config.toml
@@ -1,11 +1,9 @@
 # Defaults are now set in config.rs
 
-[base]
-peer_keypairs_file = ""  # For direct validation of this file
-trusted_peers_file = ""  # For direct validation of this file
-
 [network]
 seed_peers_file = ""  # For direct validation of this file
+peer_keypairs_file = ""  # For direct validation of this file
+trusted_peers_file = ""  # For direct validation of this file
 
 [execution]
 genesis_file_location = "<USE_TEMP_DIR>"

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -113,7 +113,7 @@ impl ChainedBftProvider {
         let author =
             AccountAddress::try_from(peer_id_str).expect("Failed to parse peer id of a validator");
         let private_key = node_config
-            .base
+            .network
             .peer_keypairs
             .take_consensus_private()
             .expect(
@@ -121,7 +121,10 @@ impl ChainedBftProvider {
         );
 
         let signer = ValidatorSigner::new(author, private_key);
-        let peers_with_public_keys = node_config.base.trusted_peers.get_trusted_consensus_peers();
+        let peers_with_public_keys = node_config
+            .network
+            .trusted_peers
+            .get_trusted_consensus_peers();
         let peers = Arc::new(
             peers_with_public_keys
                 .keys()

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
     );
 
     let config = &swarm.config.get_configs()[0].1;
-    let validator_set_file = &config.base.trusted_peers_file;
+    let validator_set_file = &config.network.trusted_peers_file;
     println!("To run the Libra CLI client in a separate process and connect to the local cluster of nodes you just spawned, use this command:");
     println!(
         "\tcargo run --bin client -- -a localhost -p {} -s {:?} -m {:?}",

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -343,7 +343,7 @@ impl LibraSwarm {
                 tee_logs,
             )
             .unwrap();
-            match node_config.base.get_role() {
+            match (&node_config.network.role).into() {
                 RoleType::Validator => {
                     swarm.validator_nodes.insert(node.peer_id(), node);
                 }

--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -83,7 +83,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             known_version: 0,
             target: None,
             config: node_config.state_sync.clone(),
-            autosync: node_config.base.get_role() == RoleType::FullNode,
+            autosync: (RoleType::FullNode == (&node_config.network.role).into()),
             peers: HashMap::new(),
             subscriptions: HashMap::new(),
             callback: None,

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -230,7 +230,7 @@ impl SynchronizerEnv {
         // create synchronizers
         let mut config = get_test_config().0;
         if role == RoleType::FullNode {
-            config.base.role = "full_node".to_string();
+            config.network.role = "full_node".to_string();
         }
         let synchronizers: Vec<StateSynchronizer> = vec![
             StateSynchronizer::bootstrap_with_executor_proxy(


### PR DESCRIPTION
## Motivation

Since we need to run multiple network stacks in parallel, each would need its own set of trusted peers, role and keys. As such this PR moves these fields into NetworkConfig.

Next step for enabling Full Nodes will be to allow multiple NetworkConfigs in a NodeConfig and initialize different network stacks for each.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Ran local libra swarm and tested with some transactions

## Related PRs

#686