### PR TITLE
[config] Serialize TrustedPeersConfig in sorted order

### DIFF
--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -10,9 +10,10 @@ use nextgen_crypto::{
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     convert::TryFrom,
     fs::File,
+    hash::BuildHasher,
     io::{Read, Write},
     path::Path,
 };
@@ -134,7 +135,20 @@ where
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TrustedPeersConfig {
     #[serde(flatten)]
+    #[serde(serialize_with = "serialize_ordered_map")]
     pub peers: HashMap<String, TrustedPeer>,
+}
+
+pub fn serialize_ordered_map<S, H>(
+    value: &HashMap<String, TrustedPeer, H>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    H: BuildHasher,
+{
+    let ordered: BTreeMap<_, _> = value.iter().collect();
+    ordered.serialize(serializer)
 }
 
 impl TrustedPeersConfig {


### PR DESCRIPTION
Copy the peer values into a BTreeMap so that they get written out in
sorted order. This should avoid unnecessary churn in the .toml file.

Test Plan: Ran "cargo test". Also ran "build.sh dev -n 4" in
the terraform/validator-sets/ directory and checked that the
order in the dev/trusted_peers.config.toml file was preserved.