### PR TITLE
[network] Add ability to construct permissionless TCP + Noise transport

### DIFF
--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -15,10 +15,7 @@ use crate::{
         identity::Identity,
         rpc::Rpc,
     },
-    transport::{
-        build_memory_noise_transport, build_memory_transport, build_tcp_noise_transport,
-        build_tcp_transport,
-    },
+    transport::*,
     ProtocolId,
 };
 use channel;
@@ -61,6 +58,7 @@ pub enum TransportType {
     MemoryNoise,
     Tcp,
     TcpNoise,
+    PermissionlessTcpNoise,
 }
 
 /// Build Network module with custom configuration values.
@@ -318,6 +316,9 @@ impl NetworkBuilder {
                 own_identity_keys,
                 trusted_peers,
             )),
+            TransportType::PermissionlessTcpNoise => self.build_with_transport(
+                build_permissionless_tcp_noise_transport(identity, own_identity_keys),
+            ),
         }
     }
 


### PR DESCRIPTION
## Motivation

For a validator's full node that wants to accept connections from any public full node, we need permissioned connections on one end (public full node) and permissionless connections on the other (validator's full node). This is to allow any public node to be able to connect to and receive block updates from the validator full node. Since it's not possible for the trusted full node to a priori know the identity of all public full nodes that would want to connect to it, it's end of the network needs to be permissionless. On the other hand, the public full node would want to only connect to the validator's full node and needs to know its identity beforehand, making a permissioned transport suitable for this use case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Related PRs

#686 #690 