### PR TITLE
[language] make vectors generic

### DIFF
--- a/language/stdlib/modules/vector.mvir
+++ b/language/stdlib/modules/vector.mvir
@@ -2,12 +2,15 @@
 
 module Vector {
 
-  native struct T;
+  // Vector containing data of type Item
+  native struct T<Element: all>;
 
-  native public length(v: &Self.T): u64;
+  // Return the length of the vector
+  native public length<Element: all>(v: &Self.T<Element>): u64;
 
-  public is_empty(v: &Self.T): bool {
-    return Self.length(move(v)) == 0;
+  // Return true if the vector has no elements
+  public is_empty<Element: all>(v: &Self.T<Element>): bool {
+    return Self.length<Element>(move(v)) == 0;
   }
 
 }

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/dispatch.rs
@@ -5,7 +5,7 @@ use super::{hash, primitive_helpers, signature, vector};
 use crate::{native_structs::dispatch::dispatch_native_struct, value::Local};
 use std::collections::{HashMap, VecDeque};
 use types::{account_address::AccountAddress, account_config, language_storage::ModuleId};
-use vm::file_format::{FunctionSignature, SignatureToken};
+use vm::file_format::{FunctionSignature, Kind, SignatureToken};
 
 /// Enum representing the result of running a native function
 pub enum NativeReturnStatus {
@@ -151,7 +151,8 @@ lazy_static! {
         // Vector
         add!(m, addr, "Vector", "length",
             vector::native_length,
-            vec![Reference(Box::new(tstruct(addr, "Vector", "T", vec![])))],
+            vec![Kind::All],
+            vec![Reference(Box::new(tstruct(addr, "Vector", "T", vec![SignatureToken::TypeParameter(0)])))],
             vec![U64]
         );
         // Event

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_structs/dispatch.rs
@@ -26,9 +26,6 @@ pub fn dispatch_native_struct(
 }
 
 macro_rules! add {
-    ($m:ident, $addr:expr, $module:expr, $name:expr, $resource: expr) => {{
-        add!($m, $addr, $module, $name, $resource, vec![])
-    }};
     ($m:ident, $addr:expr, $module:expr, $name:expr, $resource: expr, $ty_kinds: expr) => {{
         let id = ModuleId::new($addr, $module.into());
         let struct_table = $m.entry(id).or_insert_with(HashMap::new);
@@ -50,7 +47,7 @@ lazy_static! {
     static ref NATIVE_STRUCT_MAP: NativeStructMap = {
         let mut m: NativeStructMap = HashMap::new();
         let addr = account_config::core_code_address();
-        add!(m, addr, "Vector", "T", false);
+        add!(m, addr, "Vector", "T", false, vec![Kind::All]);
         m
     };
 }


### PR DESCRIPTION
Now that parser support for generics has landed, we can make the native struct type that backs a vector generic. This diff does that + updates the procedures of Vector appropriately.

## Motivation

Moving toward a real vector implementation!

## Test Plan

Ran bytecode verifier on `Vector` after changes.