### PR TITLE
[storage] disable pruner (by hacking max-versions-to-keep)

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -94,7 +94,7 @@ pub struct LibraDB {
 
 impl LibraDB {
     /// Config parameter for the pruner.
-    const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = 1_000_000;
+    const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = u64::max_value();
 
     /// This creates an empty LibraDB instance on disk or opens one if it already exists.
     pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {


### PR DESCRIPTION
## Motivation

We have places in the code that assume existence of all versions between (0, current_version). With pruning, this assumption breaks.
Instead of fixing these places in code, we're going to unblock ourselves quickly by disabling pruning (in a somewhat hacky way).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(y)
## Test Plan
Tested with a build from https://github.com/fbandersnatch/libra/tree/testing-release

