### PR TITLE
[fucntional_tests] fix publish modules with verifier disabled

### DIFF
--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -244,8 +244,12 @@ pub fn eval(config: &GlobalConfig, transactions: &[Transaction]) -> Result<Evalu
 
             compiled_program
         } else {
-            // Even if the verifier stage is disabled, we should still add the modules to the deps.
-            // TODO: add a bypass function to the verifier and fix this
+            // Add the to-be-published modules to the dependency list without using verifier.
+            let new_modules = compiled_program
+                .modules
+                .iter()
+                .map(|m| VerifiedModule::bypass_verifier_DANGEROUS_FOR_TESTING_ONLY(m.clone()));
+            deps.extend(new_modules);
 
             compiled_program
         };


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Previously we won't add a module to the dependency list if we turn off the verifier pass, which is not ideal.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes