### PR TITLE
[cluster_test] Add dependencies to benchmark and debug_interface

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -35,3 +35,7 @@ vm_genesis = { path = "../language/vm/vm_genesis" }
 
 [dev-dependencies]
 crypto = { path = "../crypto/crypto", features = ["testing"] }
+
+[features]
+default = []
+testing = ["crypto/testing", "libra_swarm/testing"]

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -9,15 +9,18 @@ edition = "2018"
 [dependencies]
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 rand = "0.6.5"
-rusoto_core = "0.40.0"
-rusoto_kinesis = "0.40.0"
-rusoto_ec2 = "0.40.0"
-rusoto_ecr = "0.40.0"
-rusoto_ecs = "0.40.0"
+rusoto_core = {version = "0.40.0", features=["rustls"], default_features = false}
+rusoto_kinesis = {version = "0.40.0", features=["rustls"], default_features = false}
+rusoto_ec2 = {version = "0.40.0", features=["rustls"], default_features = false}
+rusoto_ecr = {version = "0.40.0", features=["rustls"], default_features = false}
+rusoto_ecs = {version = "0.40.0", features=["rustls"], default_features = false}
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 serde_json = "1.0"
 regex = "1.2.1"
 clap = "2.32"
 termion = "1.5.3"
 itertools = "0.8.0"
-reqwest = "0.9.19"
+reqwest = { version="0.9.19", features=["rustls-tls"], default_features = false }
+benchmark = { path = "../../benchmark", features = ["testing"]}
+debug_interface = { path = "../../common/debug_interface"}
+grpcio = "0.4.4"


### PR DESCRIPTION
This PR lays ground for submitting transactions during cluster test and for using debug_interface to retrieve structured events from validator

While it seem small, adding those dependencies actually was not easy:

- Adding benchmark as dependency requires adding testing feature to benchmark crate itself in order to be able to include it in cluster_test (Thanks @huitseeker for figuring out how to fix it)

- Adding grpcio for accessing debug_interface introduces conflict with `rusoto_` libraries. By default, rusoto uses hyper-tls, that depends on openssl-sys crate. This crate requires `libssl-dev`, or similar package to be installed. However, this does not work well when grpcio also added as dependency - it result in linking problems. Currently my solution is to switch `rusoto` crates to use `rustls`, that does not conflict with `grpcio`.
