### PR TITLE
Remove tempfile as a dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
  "vm_genesis 0.1.0",
 ]
@@ -465,7 +465,7 @@ name = "cc"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "jobserver 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -562,8 +562,8 @@ dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
  "vm_genesis 0.1.0",
 ]
@@ -653,8 +653,8 @@ dependencies = [
  "proto_conv 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
 ]
 
@@ -716,9 +716,9 @@ dependencies = [
  "state_synchronizer 0.1.0",
  "storage_client 0.1.0",
  "storage_service 0.1.0",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
  "vm_genesis 0.1.0",
  "vm_validator 0.1.0",
@@ -1608,7 +1608,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
 ]
 
 [[package]]
@@ -1699,12 +1699,12 @@ dependencies = [
 name = "grpcio-client"
 version = "0.1.0"
 dependencies = [
- "mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-grpcio 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
 ]
 
 [[package]]
@@ -2026,12 +2026,12 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2208,7 +2208,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
 ]
 
 [[package]]
@@ -2229,7 +2229,7 @@ dependencies = [
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
 ]
 
@@ -2260,7 +2260,7 @@ dependencies = [
  "storage_proto 0.1.0",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
 ]
 
@@ -2436,7 +2436,6 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage_client 0.1.0",
  "storage_service 0.1.0",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ttl_cache 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "types 0.1.0",
@@ -2575,14 +2574,6 @@ dependencies = [
 name = "mirai-annotations"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "mktemp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "net2"
@@ -3826,7 +3817,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics 0.1.0",
  "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=ea24c53b8f2e1f8a1d22f739cb5db4681d2d21ff)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
 ]
 
 [[package]]
@@ -4318,7 +4309,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage_client 0.1.0",
  "storage_proto 0.1.0",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
  "types 0.1.0",
 ]
 
@@ -4454,15 +4445,6 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,7 +4536,7 @@ dependencies = [
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tools 0.1.0",
 ]
 
 [[package]]
@@ -4872,6 +4854,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tools"
+version = "0.1.0"
+dependencies = [
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "traitobject"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5041,15 +5031,6 @@ dependencies = [
 name = "utf8parse"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "uuid"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "uuid"
@@ -5547,7 +5528,7 @@ dependencies = [
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 "checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-"checksum jobserver 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "f74e73053eaf95399bf926e48fc7a2a3ce50bd0eaaa2357d391e95b2dcdd4f10"
+"checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2e80bee40b22bca46665b4ef1f3cd88ed0fb043c971407eac17a0712c02572"
@@ -5581,7 +5562,6 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04d2c9c31e9c7fb10c69843da5a44c19f1e2b2896036e0ed3cb526829f53e529"
-"checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum new_debug_unreachable 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f40f005c60db6e03bae699e414c58bf9aa7ea02a2d0b9bfbcf19286cc4c82b30"
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
@@ -5752,7 +5732,6 @@ dependencies = [
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
@@ -5805,7 +5784,6 @@ dependencies = [
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
-"checksum uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "78c590b5bd79ed10aad8fb75f078a59d8db445af6c743e55c4a53227fc01c13f"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -14,7 +14,6 @@ protobuf = "~2.7"
 rand = "0.7.0"
 regex = "1.2.1"
 structopt = "0.2.15"
-tempdir = "0.3.7"
 num_cpus = "1.10.1"
 
 admission_control_proto = { path = "../admission_control/admission_control_proto" }
@@ -30,6 +29,7 @@ metrics = { path = "../common/metrics" }
 crypto = { path = "../crypto/crypto" }
 proto_conv = { path = "../common/proto_conv" }
 rusty-fork = "0.2.1"
+tools = { path = "../common/tools" }
 types = { path = "../types" }
 vm_genesis = { path = "../language/vm/vm_genesis" }
 

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -70,11 +70,11 @@ mod tests {
     use libra_swarm::swarm::LibraSwarm;
     use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
     use std::ops::Range;
-    use tempdir::TempDir;
+    use tools::tempdir::TempPath;
 
     /// Start libra_swarm and create a BenchOpt struct for testing.
-    /// Must return the TempDir otherwise it will be freed somehow.
-    fn start_swarm_and_setup_arguments() -> (LibraSwarm, BenchOpt, Option<TempDir>) {
+    /// Must return the TempPath otherwise it will be freed somehow.
+    fn start_swarm_and_setup_arguments() -> (LibraSwarm, BenchOpt, Option<TempPath>) {
         let (faucet_account_keypair, faucet_key_file_path, temp_dir) =
             generate_keypair::load_faucet_key_or_create_default(None);
         let topology = LibraSwarmTopology::create_validator_network(4);

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,7 +21,6 @@ num-traits = "0.2"
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 structopt = "0.2.15"
-tempfile = "3.1.0"
 
 admission_control_proto = { version = "0.1.0", path = "../admission_control/admission_control_proto" }
 config = { path = "../config" }
@@ -33,6 +32,7 @@ logger =  { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 proto_conv = { path = "../common/proto_conv" }
 types = { path = "../types" }
+tools = { path = "../common/tools/" }
 vm_genesis = { path = "../language/vm/vm_genesis" }
 
 [dev-dependencies]

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -36,5 +36,5 @@ path = "../../common/failure_ext"
 package = "failure_ext"
 
 [dev-dependencies]
-tempfile = "3.1.0"
 types = { path = "../../types", features = ["testing"]}
+tools = { path = "../../common/tools"}

--- a/client/libra_wallet/src/mnemonic.rs
+++ b/client/libra_wallet/src/mnemonic.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 #[cfg(test)]
-use tempfile::NamedTempFile;
+use tools::tempdir::TempPath;
 
 /// Mnemonic seed for deterministic key derivation based on [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).
 /// The mnemonic must encode entropy in a multiple of 32 bits. With more entropy, security is
@@ -447,8 +447,8 @@ fn test_roundtrip_mnemonic() {
     let mut rng = EntropyRng::new();
     let mut buf = [0u8; 32];
     rng.fill_bytes(&mut buf[..]);
-    let file = NamedTempFile::new().unwrap();
-    let path = file.into_temp_path();
+    let file = TempPath::new();
+    let path = file.path();
     let mnemonic = Mnemonic::mnemonic(&buf[..]).unwrap();
     mnemonic.write(&path).unwrap();
     let other_mnemonic = Mnemonic::read(&path).unwrap();

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -22,14 +22,14 @@ use std::{
     convert::TryFrom,
     fmt, fs,
     io::{stdout, Seek, SeekFrom, Write},
-    path::{Display, Path},
+    path::{Display, Path, PathBuf},
     process::{Command, Stdio},
     str::{self, FromStr},
     sync::Arc,
     thread, time,
 };
-use tempfile::{NamedTempFile, TempPath};
 use tokio::{self, runtime::Runtime};
+use tools::tempdir::TempPath;
 use types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
@@ -101,7 +101,7 @@ pub struct ClientProxy {
     /// Whether to sync with validator on account creation.
     sync_on_wallet_recovery: bool,
     /// temp files (alive for duration of program)
-    temp_files: Vec<TempPath>,
+    temp_files: Vec<PathBuf>,
 }
 
 impl ClientProxy {
@@ -464,22 +464,24 @@ impl ClientProxy {
             if space_delim_strings.len() == 5 {
                 space_delim_strings[4].to_string()
             } else {
-                let tmp_path = NamedTempFile::new()?.into_temp_path();
+                let tmp_path = TempPath::new();
                 let path = tmp_path
+                    .as_ref()
                     .to_str()
                     .ok_or_else(|| format_err!("failed to create tmp file"))?
                     .to_string();
-                self.temp_files.push(tmp_path);
+                self.temp_files.push(tmp_path.as_ref().to_path_buf());
                 path
             }
         };
-        let mut tmp_source_file = NamedTempFile::new()?;
+        let tmp_source_path = TempPath::new();
+        let mut tmp_source_file = std::fs::File::create(tmp_source_path.as_ref())?;
         let mut code = fs::read_to_string(file_path)?;
         code = code.replace("{{sender}}", &format!("0x{}", address));
         writeln!(tmp_source_file, "{}", code)?;
 
         let dependencies_file =
-            self.handle_dependencies(tmp_source_file.path().display(), is_module)?;
+            self.handle_dependencies(tmp_source_path.path().display(), is_module)?;
 
         // custom handler of old module format
         // TODO: eventually retire code after vm separation between modules and scripts
@@ -493,10 +495,10 @@ impl ClientProxy {
             "run -p compiler -- -a {} -o {} {}",
             address,
             output_path,
-            tmp_source_file.path().display(),
+            tmp_source_path.path().display(),
         );
         if let Some(file) = &dependencies_file {
-            args.push_str(&format!(" --deps={}", file.path().display()));
+            args.push_str(&format!(" --deps={}", file.as_ref().display()));
         }
 
         let status = Command::new("cargo")
@@ -513,7 +515,7 @@ impl ClientProxy {
         &mut self,
         source_path: Display,
         is_module: bool,
-    ) -> Result<Option<NamedTempFile>> {
+    ) -> Result<Option<TempPath>> {
         let mut args = format!("run -p compiler -- -l {}", source_path);
         if is_module {
             args.push_str(" -m");
@@ -538,9 +540,10 @@ impl ClientProxy {
         if dependencies.is_empty() {
             return Ok(None);
         }
-        let mut file = NamedTempFile::new()?;
+        let path = TempPath::new();
+        let mut file = std::fs::File::create(path.as_ref())?;
         file.write_all(&serde_json::to_vec(&dependencies)?)?;
-        Ok(Some(file))
+        Ok(Some(path))
     }
 
     /// Submit a transaction to the network given the unsigned raw transaction, sender public key
@@ -1099,16 +1102,16 @@ mod tests {
     use config::trusted_peers::TrustedPeersConfigHelpers;
     use libra_wallet::io_utils;
     use proptest::prelude::*;
-    use tempfile::NamedTempFile;
+    use tools::tempdir::TempPath;
 
     fn generate_accounts_from_wallet(count: usize) -> (ClientProxy, Vec<AddressAndIndex>) {
         let mut accounts = Vec::new();
         accounts.reserve(count);
-        let file = NamedTempFile::new().unwrap();
-        let mnemonic_path = file.into_temp_path().to_str().unwrap().to_string();
-        let trust_peer_file = NamedTempFile::new().unwrap();
+        let file = TempPath::new();
+        let mnemonic_path = file.path().to_str().unwrap().to_string();
+        let trust_peer_file = TempPath::new();
         let (_, trust_peer_config) = TrustedPeersConfigHelpers::get_test_config(1, None);
-        let trust_peer_path = trust_peer_file.into_temp_path();
+        let trust_peer_path = trust_peer_file.path();
         trust_peer_config.save_config(&trust_peer_path);
 
         let val_set_file = trust_peer_path.to_str().unwrap().to_string();
@@ -1179,8 +1182,8 @@ mod tests {
         let (client, accounts) = generate_accounts_from_wallet(num);
         assert_eq!(accounts.len(), num);
 
-        let file = NamedTempFile::new().unwrap();
-        let path = file.into_temp_path();
+        let file = TempPath::new();
+        let path = file.path();
         io_utils::write_recovery(&client.wallet, &path).expect("failed to write to file");
 
         let wallet = io_utils::recover(&path).expect("failed to load from file");

--- a/common/grpcio-client/src/util.rs
+++ b/common/grpcio-client/src/util.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use mktemp::Temp;
 use protobuf::{compiler_plugin, descriptor::FileDescriptorSet, error::ProtobufError};
 use protoc::{DescriptorSetOutArgs, Protoc};
 use protoc_grpcio::CompileResult;
@@ -11,6 +10,7 @@ use std::{
     io::{Read, Write},
     path::Path,
 };
+use tools::tempdir::TempPath;
 
 /// copied from protoc-grpcio
 /// it's not public there
@@ -73,7 +73,8 @@ pub fn protoc_descriptor_set(
         .check()
         .expect("failed to find `protoc`, `protoc` must be available in `PATH`");
 
-    let descriptor_set = Temp::new_file()?;
+    let descriptor_set = TempPath::new();
+    descriptor_set.create_as_file()?;
 
     protoc
         .write_descriptor_set(DescriptorSetOutArgs {

--- a/common/tools/Cargo.toml
+++ b/common/tools/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "grpcio-client"
+name = "tools"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
@@ -7,10 +7,5 @@ publish = false
 edition = "2018"
 
 [dependencies]
-protobuf = "~2.7"
-protobuf-codegen = "2.*"
-protoc = "2.*"
-protoc-grpcio = "1.0.1"
-regex = "1.2.1"
-
-tools = { path = "../tools/"}
+hex = "0.3.2"
+rand = "0.6.5"

--- a/common/tools/src/lib.rs
+++ b/common/tools/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod tempdir;

--- a/common/tools/src/tempdir.rs
+++ b/common/tools/src/tempdir.rs
@@ -1,0 +1,73 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::RngCore;
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// A simple wrapper for creating a temporary directory that is
+/// automatically deleted when it's dropped.
+///
+/// We use this in lieu of tempfile because tempfile brings in too many
+/// dependencies.
+#[derive(Debug)]
+pub struct TempPath(PathBuf);
+
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.0)
+            .or_else(|_| fs::remove_file(&self.0))
+            .unwrap_or(());
+    }
+}
+
+impl TempPath {
+    /// Create new uninitialized temporary path, i.e. a file or directory
+    /// isn't created automatically
+    pub fn new() -> Self {
+        let tmpdir = create_path();
+        TempPath(tmpdir)
+    }
+
+    /// Return the underlying path to this temporary directory.
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+
+    pub fn create_as_file(&self) -> io::Result<()> {
+        let mut builder = fs::OpenOptions::new();
+        builder.write(true).create_new(true);
+
+        builder.open(self.path())?;
+        Ok(())
+    }
+
+    pub fn create_as_dir(&self) -> io::Result<()> {
+        let builder = fs::DirBuilder::new();
+        builder.create(self.path())?;
+        Ok(())
+    }
+}
+
+fn create_path() -> PathBuf {
+    create_path_in_dir(std::env::temp_dir())
+}
+
+fn create_path_in_dir(path: PathBuf) -> PathBuf {
+    let mut path = path;
+    let mut rng = rand::thread_rng();
+    let mut bytes = [0_u8; 16];
+    rng.fill_bytes(&mut bytes);
+    let path_string = hex::encode(&bytes);
+
+    path.push(path_string);
+    path
+}
+
+impl std::convert::AsRef<Path> for TempPath {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -12,13 +12,13 @@ hex = { version = "0.3.2", default-features = false }
 parity-multiaddr = { version = "0.5.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }
-tempfile = { version = "3.1.0", default-features = false }
 toml = { version = "0.5.3", default-features = false }
 
 crypto = { path = "../crypto/crypto" }
 proto_conv = { path = "../common/proto_conv" }
 logger = { path = "../common/logger" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
+tools = { path = "../common/tools" }
 types = { path = "../types" }
 
 [dev-dependencies]

--- a/config/generate_keypair/Cargo.toml
+++ b/config/generate_keypair/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bincode = { version = "1.1.4", default-features = false }
 clap = { version = "2.33.0", default-features = false }
-tempdir = { version = "0.3.7", default-features = false }
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 crypto = { path = "../../crypto/crypto/"}
+tools = { path = "../../common/tools" }

--- a/config/generate_keypair/src/lib.rs
+++ b/config/generate_keypair/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     io::Write,
     path::Path,
 };
-use tempdir::TempDir;
+use tools::tempdir::TempPath;
 
 pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
     let output_file_path = Path::new(&output_file);
@@ -45,7 +45,7 @@ pub fn load_faucet_key_or_create_default(
 ) -> (
     KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
     String,
-    Option<TempDir>,
+    Option<TempPath>,
 ) {
     // If there is already a faucet key file, then open it and parse the keypair.  If there
     // isn't one, then create a temp directory and generate the keypair
@@ -61,8 +61,10 @@ pub fn load_faucet_key_or_create_default(
         }
     } else {
         // Generate keypair in temp directory
-        let tmp_dir =
-            TempDir::new("keypair").expect("Unable to create temp dir for faucet keypair");
+        let tmp_dir = TempPath::new();
+        tmp_dir
+            .create_as_dir()
+            .expect("Unable to create temp dir for faucet keypair");
         let faucet_key_file_path = tmp_dir
             .path()
             .join("temp_faucet_keys")

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -19,8 +19,8 @@ use crypto::{
 use logger::LoggerType;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tempfile::TempDir;
 use toml;
+use tools::tempdir::TempPath;
 
 use failure::prelude::*;
 use proto_conv::FromProtoBytes;
@@ -88,7 +88,7 @@ pub struct NodeConfig {
 pub struct BaseConfig {
     pub data_dir_path: PathBuf,
     #[serde(skip)]
-    temp_data_dir: Option<TempDir>,
+    temp_data_dir: Option<TempPath>,
     // Number of retries per chunk download
     pub node_sync_retries: usize,
     // Buffer size for sync_channel used for node syncing (number of elements that it can
@@ -834,7 +834,8 @@ impl NodeConfigHelpers {
         base_path: P,
     ) -> Result<()> {
         if config.base.data_dir_path == Path::new(DISPOSABLE_DIR_MARKER) {
-            let dir = tempfile::tempdir().context("error creating tempdir")?;
+            let dir = TempPath::new();
+            dir.create_as_dir().expect("error creating tempdir");
             config.base.data_dir_path = dir.path().to_owned();
             config.base.temp_data_dir = Some(dir);
         }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -40,6 +40,7 @@ proto_conv = { path = "../common/proto_conv" }
 state_synchronizer = { path = "../state_synchronizer" }
 schemadb = { path = "../storage/schemadb" }
 storage_client = { path = "../storage/storage_client" }
+tools = { path = "../common/tools" }
 types = { path = "../types" }
 debug_interface = { path = "../common/debug_interface" }
 
@@ -53,7 +54,6 @@ build_helpers = { path = "../common/build_helpers" }
 
 [dev-dependencies]
 cached = "0.9.0"
-tempfile = "3.1.0"
 parity-multiaddr = "0.5.0"
 rusty-fork = "0.2.2"
 

--- a/consensus/src/chained_bft/consensusdb/consensusdb_test.rs
+++ b/consensus/src/chained_bft/consensusdb/consensusdb_test.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 
 #[test]
 fn test_put_get() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = ConsensusDB::new(&tmp_dir);
 
     let block = Block::<i64>::make_genesis_block();
@@ -30,7 +30,7 @@ fn test_put_get() {
 
 #[test]
 fn test_delete_block_and_qc() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = ConsensusDB::new(&tmp_dir);
 
     assert!(db.get_state().unwrap().is_none());

--- a/libra_swarm/Cargo.toml
+++ b/libra_swarm/Cargo.toml
@@ -11,7 +11,6 @@ client_lib = { package = "client", path = "../client" }
 ctrlc = { version = "3.1.3", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 structopt = { version = "0.2.18", default-features = false }
-tempfile = { version = "3.1.0", default-features = false }
 
 config = { path = "../config" }
 config_builder = { path = "../config/config_builder" }
@@ -20,6 +19,7 @@ failure = { path = "../common/failure_ext", package = "failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }
 logger = { path = "../common/logger" }
 crypto = { path = "../crypto/crypto" }
+tools = { path = "../common/tools" }
 
 [dev-dependencies]
 crypto = { path = "../crypto/crypto", features = ["testing"]}

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -6,6 +6,7 @@ use config_builder::swarm_config::LibraSwarmTopology;
 use libra_swarm::{client, swarm::LibraSwarm};
 use std::path::Path;
 use structopt::StructOpt;
+use tools::tempdir::TempPath;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -71,12 +72,13 @@ fn main() {
         faucet_key_file_path,
     );
 
-    let tmp_mnemonic_file = tempfile::NamedTempFile::new().unwrap();
+    let tmp_mnemonic_file = TempPath::new();
+    tmp_mnemonic_file.create_as_file().unwrap();
     if args.start_client {
         let client = client::InteractiveClient::new_with_inherit_io(
             swarm.get_ac_port(0, RoleType::Validator),
             Path::new(&faucet_key_file_path),
-            &tmp_mnemonic_file.into_temp_path(),
+            &tmp_mnemonic_file.path(),
             swarm.get_trusted_peers_config_path(),
         );
         println!("Loading client...");

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -33,7 +33,6 @@ vm_validator = { path = "../vm_validator" }
 
 [dev-dependencies]
 rand = "0.6.5"
-tempfile = "3.1.0"
 channel = { path = "../common/channel" }
 storage_service = { path = "../storage/storage_service" }
 types = { path = "../types", features = ["testing"] }

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -19,7 +19,6 @@ rand = "0.6.5"
 rusty-fork = "0.2.1"
 strum = "0.15.0"
 strum_macros = "0.15.0"
-tempfile = "3.0.6"
 
 accumulator = { path = "../accumulator" }
 canonical_serialization = { path = "../../common/canonical_serialization" }
@@ -31,6 +30,7 @@ metrics = { path = "../../common/metrics" }
 proto_conv = { path = "../../common/proto_conv" }
 schemadb = { path = "../schemadb" }
 storage_proto = { path = "../storage_proto" }
+tools = { path = "../../common/tools" }
 types = { path = "../../types" }
 
 [dev-dependencies]

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -13,7 +13,7 @@ use proptest::{
 use proptest_helpers::Index;
 use rand::Rng;
 use std::collections::HashMap;
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 use types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,
@@ -36,7 +36,7 @@ fn save(store: &EventStore, version: Version, events: &[ContractEvent]) -> HashV
 
 #[test]
 fn test_put_empty() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.event_store;
     let mut cs = ChangeSet::new();
@@ -48,7 +48,7 @@ fn test_put_empty() {
 
 #[test]
 fn test_error_on_get_from_empty() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.event_store;
 
@@ -62,7 +62,7 @@ proptest! {
 
     #[test]
     fn test_put_get_verify(events in vec(any::<ContractEvent>().no_shrink(), 1..100)) {
-        let tmp_dir = tempdir().unwrap();
+        let tmp_dir = TempPath::new();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.event_store;
 
@@ -94,7 +94,7 @@ proptest! {
         events3 in vec(any::<ContractEvent>().no_shrink(), 1..100),
     ) {
 
-        let tmp_dir = tempdir().unwrap();
+        let tmp_dir = TempPath::new();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.event_store;
         // Save 3 chunks at different versions
@@ -186,7 +186,7 @@ proptest! {
 
 fn test_get_events_by_access_path_impl(event_batches: Vec<Vec<ContractEvent>>) {
     // Put into db.
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.event_store;
 

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{change_set::ChangeSet, LibraDB};
 use proptest::{collection::vec, prelude::*};
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 use types::ledger_info::LedgerInfo;
 
 prop_compose! {
@@ -51,7 +51,7 @@ proptest! {
     fn test_ledger_info_put_get_verify(
         ledger_infos_with_sigs in arb_ledger_infos_with_sigs()
     ) {
-        let tmp_dir = tempdir().unwrap();
+        let tmp_dir = TempPath::new();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.ledger_store;
         let start_epoch = ledger_infos_with_sigs.first().unwrap().ledger_info().epoch_num();

--- a/storage/libradb/src/ledger_store/transaction_info_test.rs
+++ b/storage/libradb/src/ledger_store/transaction_info_test.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::LibraDB;
 use proptest::{collection::vec, prelude::*};
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 use types::proof::verify_transaction_accumulator_element;
 
 fn verify(
@@ -48,7 +48,7 @@ proptest! {
         batch2 in vec(any::<TransactionInfo>(), 1..100),
     ) {
 
-        let tmp_dir = tempdir().unwrap();
+        let tmp_dir = TempPath::new();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.ledger_store;
 

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -10,6 +10,7 @@ use crypto::{ed25519::*, hash::CryptoHash};
 use proptest::prelude::*;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::collections::HashMap;
+use tools::tempdir::TempPath;
 use types::{
     account_config::get_account_resource_or_default, contract_event::ContractEvent,
     ledger_info::LedgerInfo,
@@ -21,7 +22,7 @@ fn test_save_blocks_impl(
         LedgerInfoWithSignatures<Ed25519Signature>,
     )>,
 ) -> Result<()> {
-    let tmp_dir = tempfile::tempdir()?;
+    let tmp_dir = TempPath::new();
     let db = db_with_mock_genesis(&tmp_dir)?;
 
     let num_batches = input.len();
@@ -77,7 +78,7 @@ fn test_sync_transactions_impl(
         LedgerInfoWithSignatures<Ed25519Signature>,
     )>,
 ) -> Result<()> {
-    let tmp_dir = tempfile::tempdir()?;
+    let tmp_dir = TempPath::new();
     let db = db_with_mock_genesis(&tmp_dir)?;
 
     let num_batches = input.len();
@@ -366,7 +367,7 @@ proptest! {
 
 #[test]
 fn test_bootstrap() {
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
 
     let genesis_txn_info = GENESIS_INFO.0.clone();
@@ -394,7 +395,7 @@ fn test_bootstrap() {
 rusty_fork_test! {
 #[test]
 fn test_committed_txns_counter() {
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
 
     let genesis_ledger_info_with_sigs = GENESIS_INFO.1.clone();
@@ -410,7 +411,7 @@ fn test_committed_txns_counter() {
 
 #[test]
 fn test_bootstrapping_already_bootstrapped_db() {
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = db_with_mock_genesis(&tmp_dir).unwrap();
     let ledger_info = db.ledger_store.get_latest_ledger_info().unwrap();
 
@@ -442,7 +443,7 @@ fn test_get_first_seq_num_and_limit() {
 
 #[test]
 fn test_too_many_requested() {
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
 
     assert!(db

--- a/storage/libradb/src/pruner/test.rs
+++ b/storage/libradb/src/pruner/test.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::{change_set::ChangeSet, state_store::StateStore, LibraDB};
 use crypto::HashValue;
 use std::collections::HashMap;
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 use types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_state_blob::AccountStateBlob,
@@ -49,7 +49,7 @@ fn test_pruner() {
     let value1 = AccountStateBlob::from(vec![0x02]);
     let value2 = AccountStateBlob::from(vec![0x03]);
 
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir).db;
     let state_store = &StateStore::new(Arc::clone(&db));
     let pruner = Pruner::new(
@@ -113,7 +113,7 @@ fn test_worker_quit_eagerly() {
     let value1 = AccountStateBlob::from(vec![0x02]);
     let value2 = AccountStateBlob::from(vec![0x03]);
 
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir).db;
     let state_store = &StateStore::new(Arc::clone(&db));
 

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{pruner, LibraDB};
 use crypto::hash::CryptoHash;
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 use types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_state_blob::AccountStateBlob,
@@ -76,7 +76,7 @@ fn verify_state_in_store(
 
 #[test]
 fn test_empty_store() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.state_store;
     let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
@@ -87,7 +87,7 @@ fn test_empty_store() {
 
 #[test]
 fn test_state_store_reader_writer() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.state_store;
     let address1 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
@@ -141,7 +141,7 @@ fn test_retired_records() {
     let value3 = AccountStateBlob::from(vec![0x03]);
     let value3_update = AccountStateBlob::from(vec![0x13]);
 
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.state_store;
 

--- a/storage/libradb/src/system_store/test.rs
+++ b/storage/libradb/src/system_store/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{ledger_counters::LedgerCounter, LibraDB};
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 
 fn bump_ledger_counters(
     store: &SystemStore,
@@ -19,7 +19,7 @@ fn bump_ledger_counters(
 
 #[test]
 fn test_inc_ledger_counters() {
-    let tmp_dir = tempdir().unwrap();
+    let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.system_store;
 

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::mock_genesis::{db_with_mock_genesis, GENESIS_INFO};
 use crypto::{ed25519::*, hash::CryptoHash};
 use proptest::{collection::vec, prelude::*};
+use tools::tempdir::TempPath;
 use types::{
     ledger_info::LedgerInfo,
     proptest_types::{AccountInfoUniverse, TransactionToCommitGen},
@@ -25,8 +26,8 @@ fn to_blocks_to_commit(
 > {
     // Use temporary LibraDB and STORE LEVEL APIs to calculate hashes on a per transaction basis.
     // Result is used to test the batch PUBLIC API for saving everything, i.e. `save_transactions()`
-    let tmp_dir = tempfile::tempdir()?;
-    let db = db_with_mock_genesis(&tmp_dir)?;
+    let tmp_dir = TempPath::new();
+    let db = db_with_mock_genesis(&tmp_dir.path())?;
 
     let genesis_ledger_info_with_sigs = GENESIS_INFO.1.clone();
     let genesis_ledger_info = genesis_ledger_info_with_sigs.ledger_info();

--- a/storage/libradb/src/transaction_store/test.rs
+++ b/storage/libradb/src/transaction_store/test.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::LibraDB;
 use proptest::{collection::vec, prelude::*};
 use proptest_helpers::Index;
-use tempfile::tempdir;
+use tools::tempdir::TempPath;
 use types::proptest_types::{AccountInfoUniverse, SignatureCheckedTransactionGen};
 
 proptest! {
@@ -24,7 +24,7 @@ proptest! {
             .map(|(index, gen)| gen.materialize(index, &mut universe).into_inner())
             .collect::<Vec<_>>();
 
-        let tmp_dir = tempdir().unwrap();
+        let tmp_dir = TempPath::new();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.transaction_store;
 

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -18,4 +18,4 @@ rev = "ea24c53b8f2e1f8a1d22f739cb5db4681d2d21ff"
 
 [dev-dependencies]
 byteorder = "1.3.2"
-tempfile = "3.1.0"
+tools = { path = "../../common/tools" }

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -70,7 +70,7 @@ impl ValueCodec<TestSchema2> for TestField {
     }
 }
 
-fn open_db(dir: &tempfile::TempDir) -> DB {
+fn open_db(dir: &tools::tempdir::TempPath) -> DB {
     let cf_opts_map: ColumnFamilyOptionsMap = [
         (DEFAULT_CF_NAME, ColumnFamilyOptions::default()),
         (
@@ -85,17 +85,17 @@ fn open_db(dir: &tempfile::TempDir) -> DB {
     .iter()
     .cloned()
     .collect();
-    DB::open(&dir, cf_opts_map).expect("Failed to open DB.")
+    DB::open(&dir.path(), cf_opts_map).expect("Failed to open DB.")
 }
 
 struct TestDB {
-    _tmpdir: tempfile::TempDir,
+    _tmpdir: tools::tempdir::TempPath,
     db: DB,
 }
 
 impl TestDB {
     fn new() -> Self {
-        let tmpdir = tempfile::tempdir().expect("Failed to create temporary directory.");
+        let tmpdir = tools::tempdir::TempPath::new();
         let db = open_db(&tmpdir);
 
         TestDB {
@@ -253,7 +253,7 @@ fn test_two_schema_batches() {
 
 #[test]
 fn test_reopen() {
-    let tmpdir = tempfile::tempdir().expect("Failed to create temporary directory.");
+    let tmpdir = tools::tempdir::TempPath::new();
     {
         let db = open_db(&tmpdir);
         db.put::<TestSchema1>(&TestField(0), &TestField(0)).unwrap();

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -71,13 +71,13 @@ fn collect_values(iter: SchemaIterator<TestSchema>) -> Vec<u32> {
 }
 
 struct TestDB {
-    _tmpdir: tempfile::TempDir,
+    _tmpdir: tools::tempdir::TempPath,
     db: DB,
 }
 
 impl TestDB {
     fn new() -> Self {
-        let tmpdir = tempfile::tempdir().expect("Failed to create temporary directory.");
+        let tmpdir = tools::tempdir::TempPath::new();
         let cf_opts_map: ColumnFamilyOptionsMap = [
             (DEFAULT_CF_NAME, ColumnFamilyOptions::default()),
             (
@@ -88,7 +88,7 @@ impl TestDB {
         .iter()
         .cloned()
         .collect();
-        let db = DB::open(&tmpdir, cf_opts_map).unwrap();
+        let db = DB::open(&tmpdir.path(), cf_opts_map).unwrap();
 
         db.put::<TestSchema>(&TestKey(1, 0, 0), &TestValue(100))
             .unwrap();

--- a/storage/storage_service/Cargo.toml
+++ b/storage/storage_service/Cargo.toml
@@ -30,7 +30,7 @@ rand = "0.6.5"
 [dev-dependencies]
 itertools = "0.8.0"
 proptest = "0.9.2"
-tempfile = "3.1.0"
+tools = { path = "../../common/tools" }
 libradb = { path = "../libradb", features = ["testing"] }
 types = { path = "../../types", features = ["testing"] }
 

--- a/storage/storage_service/src/storage_service_test.rs
+++ b/storage/storage_service/src/storage_service_test.rs
@@ -18,13 +18,13 @@ use types::get_with_proof::{RequestItem, ResponseItem};
 fn start_test_storage_with_read_write_client(
     need_to_use_genesis: bool,
 ) -> (
-    tempfile::TempDir,
+    tools::tempdir::TempPath,
     ServerHandle,
     StorageReadServiceClient,
     StorageWriteServiceClient,
 ) {
     let mut config = NodeConfigHelpers::get_single_node_test_config(/* random_ports = */ true);
-    let tmp_dir = tempfile::tempdir().unwrap();
+    let tmp_dir = tools::tempdir::TempPath::new();
     config.storage.dir = tmp_dir.path().to_path_buf();
 
     // initialize db with genesis info.

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -25,5 +25,5 @@ libra_swarm = { path = "../libra_swarm", features = ["testing"]}
 logger = { path = "../common/logger" }
 config = { path = "../config" }
 config_builder = { path = "../config/config_builder" }
-tempfile = "3.1.0"
+tools = { path = "../common/tools" }
 crypto = { path = "../crypto/crypto" }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -31,7 +31,10 @@ fn setup_env(
         template_path,
     );
     let port = swarm.get_ac_port(client_port_index, role);
-    let tmp_mnemonic_file = tempfile::NamedTempFile::new().unwrap();
+    let tmp_mnemonic_file = tools::tempdir::TempPath::new();
+    tmp_mnemonic_file
+        .create_as_file()
+        .expect("could not create temporary mnemonic_file_path");
     let client_proxy = ClientProxy::new(
         "localhost",
         port.to_string().as_str(),
@@ -41,7 +44,8 @@ fn setup_env(
         /* faucet server */ None,
         Some(
             tmp_mnemonic_file
-                .into_temp_path()
+                .path()
+                .to_path_buf()
                 .canonicalize()
                 .expect("Unable to get canonical path of mnemonic_file_path")
                 .to_str()
@@ -289,7 +293,10 @@ fn test_basic_state_synchronization() {
     swarm.wait_for_all_nodes_to_catchup();
 
     // Connect to the newly recovered node and verify its state
-    let tmp_mnemonic_file = tempfile::NamedTempFile::new().unwrap();
+    let tmp_mnemonic_file = tools::tempdir::TempPath::new();
+    tmp_mnemonic_file
+        .create_as_file()
+        .expect("could not create temporary mnemonic_file_path");
     let ac_port = swarm.get_validator(&node_to_restart).unwrap().ac_port();
     let mut client_proxy2 = ClientProxy::new(
         "localhost",
@@ -300,7 +307,8 @@ fn test_basic_state_synchronization() {
         /* faucet server */ None,
         Some(
             tmp_mnemonic_file
-                .into_temp_path()
+                .path()
+                .to_path_buf()
                 .canonicalize()
                 .expect("Unable to get canonical path of mnemonic_file_path")
                 .to_str()


### PR DESCRIPTION
See https://github.com/BurntSushi/quickcheck/issues/241 : tempfile depends on an antiquated rand (+ the ecosystem is just not needed here)

Sadly this is not enough to meaningfully stop the import of rand:
https://gist.github.com/e2ecc6522581bce7773a2f6a4432578d
