### PR TITLE
[language/functional_tests] add tests for import function & struct

### DIFF
--- a/language/functional_tests/tests/testsuite/generics/import_function.mvir
+++ b/language/functional_tests/tests/testsuite/generics/import_function.mvir
@@ -1,0 +1,47 @@
+//! no-run: verifier, runtime
+
+module M {
+    resource R {}
+
+    public foo<T>(x: T) {
+        return;
+    }
+
+    public bar<T1, T2: resource, T3: unrestricted>(x: T3, y: T2, z: T1) {
+        return;
+    }
+}
+
+
+
+
+//! new-transaction
+//! no-run: verifier, runtime
+
+import {{default}}.M;
+
+main() {
+    M.foo<u64>();
+    return;
+}
+
+//! check: FunctionSignature
+//! check: TypeParameter(0)
+//! check: [All]
+
+
+
+
+//! new-transaction
+//! no-run: verifier, runtime
+
+import {{default}}.M;
+
+main() {
+    M.bar<u64, M.R, bool>();
+    return;
+}
+
+//! check: FunctionSignature
+//! check: [TypeParameter(2), TypeParameter(1), TypeParameter(0)]
+//! check: [Unrestricted, Resource, All]

--- a/language/functional_tests/tests/testsuite/generics/import_struct.mvir
+++ b/language/functional_tests/tests/testsuite/generics/import_struct.mvir
@@ -1,0 +1,39 @@
+//! no-run: verifier, runtime
+
+module M {
+    struct Foo<T> { x: T }
+
+    struct Bar<T1, T2: resource, T3: unrestricted> { x: T3, y: T2, z: T1 }
+}
+
+
+
+
+//! new-transaction
+//! no-run: verifier, runtime
+
+import {{default}}.M;
+
+main() {
+    let x: M.Foo<u64>;
+    return;
+}
+
+// check: StructHandle
+// check: [All]
+
+
+
+
+//! new-transaction
+//! no-run: verifier, runtime
+
+import {{default}}.M;
+
+main() {
+    let x: M.Bar<u64, M.Foo<u64>, bool>;
+    return;
+}
+
+// check: StructHandle
+// check: [All, Resource, Unrestricted]


### PR DESCRIPTION
## Summary
When a move script/module uses a function or a handle in another module, it needs to import the corresponding function/struct handle. These two tests check that the imported handles have the correct kind constraints.

Note: with these two tests we now have a 100% coverage on parsing & compiling generics. They weren't added in the first place due to the lack of the feature later added in #697.

## Test Plan
cargo test