### PR TITLE
[consensus] Move ProposalMsg signature verification to a different fn

### DIFF
--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -274,10 +274,31 @@ where
         &self.payload
     }
 
-    pub fn verify(
+    /// Verifies that the proposal and the QC are correctly signed.
+    /// If this is the genesis block, we skip these checks.
+    pub fn validate_signatures(
         &self,
         validator: &ValidatorVerifier,
     ) -> ::std::result::Result<(), BlockVerificationError> {
+        // if genesis block, we don't verify anything
+        if self.is_genesis_block() {
+            return Ok(());
+        }
+        // verify signature from leader if it's a real proposal
+        if let BlockSource::Proposal { author, signature } = &self.block_source {
+            signature
+                .verify(validator, *author, self.hash())
+                .map_err(|_| BlockVerificationError::SigVerifyError)?;
+        }
+        // verify signatures of quorum cert
+        self.quorum_cert
+            .verify(validator)
+            .map_err(BlockVerificationError::QCVerificationError)
+    }
+
+    /// Makes sure that the proposal makes sense, independently of the current state.
+    /// If this is the genesis block, we skip these checks.
+    pub fn verify_well_formed(&self) -> ::std::result::Result<(), BlockVerificationError> {
         if self.is_genesis_block() {
             return Ok(());
         }
@@ -292,17 +313,11 @@ where
         {
             return Err(BlockVerificationError::InvalidBlockRound);
         }
-        if let BlockSource::Proposal { author, signature } = &self.block_source {
-            signature
-                .verify(validator, *author, self.hash())
-                .map_err(|_| BlockVerificationError::SigVerifyError)?;
-        } else if self.payload != T::default() {
-            // NIL block must not carry payload
+        // NIL block must not carry payload
+        if self.block_source == BlockSource::NilBlock && self.payload != T::default() {
             return Err(BlockVerificationError::NilBlockWithPayload);
         }
-        self.quorum_cert
-            .verify(validator)
-            .map_err(BlockVerificationError::QCVerificationError)
+        Ok(())
     }
 
     pub fn id(&self) -> HashValue {

--- a/consensus/src/chained_bft/consensus_types/block_test.rs
+++ b/consensus/src/chained_bft/consensus_types/block_test.rs
@@ -216,7 +216,10 @@ fn test_nil_block() {
     assert!(nil_block.author().is_none());
 
     let dummy_verifier = Arc::new(ValidatorVerifier::new(HashMap::new()));
-    assert!(nil_block.verify(dummy_verifier.as_ref()).is_ok());
+    assert!(nil_block
+        .validate_signatures(dummy_verifier.as_ref())
+        .is_ok());
+    assert!(nil_block.verify_well_formed().is_ok());
 
     let signer = ValidatorSigner::random(None);
     let payload = 101;

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -368,10 +368,10 @@ fn test_network_api() {
     );
     let previous_block = Block::make_genesis_block();
     let previous_qc = QuorumCert::certificate_for_genesis();
-    let proposal = ProposalMsg {
-        proposal: Block::make_block(&previous_block, 0, 1, 0, previous_qc.clone(), &signers[0]),
-        sync_info: SyncInfo::new(previous_qc.clone(), previous_qc.clone(), None),
-    };
+    let proposal = ProposalMsg::new(
+        Block::make_block(&previous_block, 0, 1, 0, previous_qc.clone(), &signers[0]),
+        SyncInfo::new(previous_qc.clone(), previous_qc.clone(), None),
+    );
     block_on(async move {
         nodes[0].send_vote(vote.clone(), peers[2..5].to_vec()).await;
         playground

--- a/consensus/src/chained_bft/proto_test.rs
+++ b/consensus/src/chained_bft/proto_test.rs
@@ -4,15 +4,22 @@
 use crate::{
     chained_bft::{
         consensus_types::{
-            block::Block, proposal_msg::ProposalMsg, quorum_cert::QuorumCert, sync_info::SyncInfo,
-            vote_data::VoteData, vote_msg::VoteMsg,
+            block::Block,
+            proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
+            quorum_cert::QuorumCert,
+            sync_info::SyncInfo,
+            vote_data::VoteData,
+            vote_msg::VoteMsg,
         },
         test_utils::placeholder_ledger_info,
     },
     state_replication::ExecutedState,
 };
 use crypto::HashValue;
-use proto_conv::test_helper::assert_protobuf_encode_decode;
+use proto_conv::{
+    test_helper::assert_protobuf_encode_decode, FromProto, FromProtoBytes, IntoProto,
+    IntoProtoBytes,
+};
 use types::validator_signer::ValidatorSigner;
 
 #[test]
@@ -24,11 +31,26 @@ fn test_proto_convert_block() {
 #[test]
 fn test_proto_convert_proposal() {
     let genesis_qc = QuorumCert::certificate_for_genesis();
-    let proposal = ProposalMsg {
-        proposal: Block::<u64>::make_genesis_block(),
-        sync_info: SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
-    };
-    assert_protobuf_encode_decode(&proposal);
+    let proposal = ProposalMsg::new(
+        Block::<u64>::make_genesis_block(),
+        SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+    );
+    //
+    let protoed = proposal.clone().into_proto();
+    let unprotoed: ProposalMsg<u64> = ProposalUncheckedSignatures::<u64>::from_proto(protoed)
+        .expect("Should convert.")
+        .into();
+    assert_eq!(proposal, unprotoed);
+    //
+    let protoed = proposal
+        .clone()
+        .into_proto_bytes()
+        .expect("Should convert.");
+    let unprotoed: ProposalMsg<u64> =
+        ProposalUncheckedSignatures::<u64>::from_proto_bytes(&protoed)
+            .expect("Should convert.")
+            .into();
+    assert_eq!(proposal, unprotoed);
 }
 
 #[test]


### PR DESCRIPTION
**MOTIVATION**: This PR adds a wrapper type to `ProposalMsg` called `ProposalUncheckedSignatures`.
When decoding a protobuf message, the wrapper type will be returned instead.
`ProposalMsg` can be obtained from the wrapper only when all signatures have been verified.

This also splits the `verify()` functions of both ProposalMsg and its block into two different functions:

* validate_signatures()
* verify_well_formed()

This will allow me to skip signature verification when fuzzing or for certain tests.

**Test Plan**:

```
cargo test -p consensus --lib
```