### PR TITLE
[vm_runtime] Implement runtime for generics

### DIFF
--- a/language/functional_tests/tests/testsuite/generics/coin_wrapper.mvir
+++ b/language/functional_tests/tests/testsuite/generics/coin_wrapper.mvir
@@ -1,0 +1,109 @@
+module M {
+    import 0x0.LibraCoin;
+    resource Foo<T: resource> { x: T }
+    resource CoinWrapper { f: Self.Foo<LibraCoin.T> }
+    resource InnerWrapper { f: Self.Foo<Self.Inner>}
+    resource Inner { b: bytearray }
+
+    public coin_wrapper(c: LibraCoin.T) {
+        let foo: Self.Foo<LibraCoin.T>;
+        let coin_wrapper: Self.CoinWrapper;
+
+        foo = Foo<LibraCoin.T> {x: move(c)};
+        coin_wrapper = CoinWrapper {f: move(foo)};
+        move_to_sender<CoinWrapper>(move(coin_wrapper));
+        return;
+    }
+
+    public inner_wrapper(b: bytearray) {
+        let foo: Self.Foo<Self.Inner>;
+        let inner_wrapper: Self.InnerWrapper;
+        let inner: Self.Inner;
+
+        inner = Inner { b: move(b) };
+        foo = Foo<Self.Inner> {x: move(inner)};
+        inner_wrapper = InnerWrapper {f: move(foo)};
+        move_to_sender<InnerWrapper>(move(inner_wrapper));
+        return;
+    }
+
+    public get_coin_value(): u64 acquires CoinWrapper {
+        let coin_wrapper_ref: &mut Self.CoinWrapper;
+        let foo_ref: &Self.Foo<LibraCoin.T>;
+        let coin_ref: &LibraCoin.T;
+
+        coin_wrapper_ref = borrow_global<CoinWrapper>(get_txn_sender());
+        foo_ref = &move(coin_wrapper_ref).f;
+        coin_ref = &move(foo_ref).x;
+
+        return LibraCoin.value(move(coin_ref));
+    }
+
+    public get_inner(): bytearray acquires InnerWrapper {
+        let inner_wrapper_ref: &mut Self.InnerWrapper;
+        let foo_ref: &Self.Foo<Self.Inner>;
+        let inner_ref: &Self.Inner;
+
+        inner_wrapper_ref = borrow_global<InnerWrapper>(get_txn_sender());
+        foo_ref = &move(inner_wrapper_ref).f;
+        inner_ref = &move(foo_ref).x;
+
+        return *(&move(inner_ref).b);
+    }
+
+
+    public destroy(): LibraCoin.T acquires CoinWrapper {
+        let coin_wrapper: Self.CoinWrapper;
+        let f: Self.Foo<LibraCoin.T>;
+        let x: LibraCoin.T;
+
+        coin_wrapper = move_from<CoinWrapper>(get_txn_sender());
+        CoinWrapper {f} = move(coin_wrapper);
+        Foo<LibraCoin.T> {x} = move(f);
+        return move(x);
+    }
+}
+
+//! new-transaction
+import {{default}}.M;
+import 0x0.LibraAccount;
+import 0x0.LibraCoin;
+
+main() {
+  let coin: LibraCoin.T;
+  let byte: bytearray;
+
+  byte = h"bac1ac";
+  coin = LibraAccount.withdraw_from_sender(1000);
+
+  M.coin_wrapper(move(coin));
+  M.inner_wrapper(move(byte));
+
+  return;
+}
+
+//! new-transaction
+import {{default}}.M;
+import 0x0.LibraCoin;
+
+main() {
+  let coin: LibraCoin.T;
+  let byte: bytearray;
+
+  byte = h"bac1ac";
+  assert(M.get_coin_value() == 1000, 4);
+  assert(M.get_inner() == move(byte), 4);
+  return;
+}
+
+//! new-transaction
+import {{default}}.M;
+import 0x0.LibraCoin;
+import 0x0.LibraAccount;
+
+main() {
+  let coin: LibraCoin.T;
+  coin = M.destroy();
+  LibraAccount.deposit(get_txn_sender(), move(coin));
+  return;
+}

--- a/language/vm/vm_runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm_runtime/src/code_cache/module_cache.rs
@@ -23,7 +23,10 @@ use vm::{
     views::{FunctionHandleView, StructHandleView},
 };
 use vm_cache_map::{Arena, CacheRefMap};
-use vm_runtime_types::loaded_data::{struct_def::StructDef, types::Type};
+use vm_runtime_types::{
+    loaded_data::{struct_def::StructDef, types::Type},
+    type_context::TypeContext,
+};
 
 #[cfg(test)]
 use crate::code_cache::module_adapter::FakeFetcher;
@@ -240,6 +243,7 @@ impl<'alloc> VMModuleCache<'alloc> {
         &'txn self,
         module: &LoadedModule,
         tok: &SignatureToken,
+        type_context: &TypeContext,
         gas_meter: &GasMeter,
         fetcher: &F,
     ) -> VMResult<Option<Type>> {
@@ -249,23 +253,52 @@ impl<'alloc> VMModuleCache<'alloc> {
             SignatureToken::String => Ok(Ok(Some(Type::String))),
             SignatureToken::ByteArray => Ok(Ok(Some(Type::ByteArray))),
             SignatureToken::Address => Ok(Ok(Some(Type::Address))),
-            SignatureToken::TypeParameter(_) => unimplemented!(),
-            SignatureToken::Struct(sh_idx, _) => {
+            SignatureToken::TypeParameter(idx) => Ok(Ok(Some(type_context.get_type(*idx)?))),
+            SignatureToken::Struct(sh_idx, tys) => {
+                let ctx = {
+                    let mut ctx = vec![];
+                    for ty in tys.iter() {
+                        let resolved_type = try_runtime!(self
+                            .resolve_signature_token_with_fetcher(
+                                module,
+                                ty,
+                                type_context,
+                                gas_meter,
+                                fetcher
+                            ));
+                        if let Some(t) = resolved_type {
+                            ctx.push(t);
+                        } else {
+                            return Ok(Ok(None));
+                        }
+                    }
+                    TypeContext::new(ctx)
+                };
                 let struct_def =
                     try_runtime!(self
-                        .resolve_struct_handle_with_fetcher(module, *sh_idx, gas_meter, fetcher));
+                        .resolve_struct_handle_with_fetcher(module, *sh_idx, gas_meter, fetcher))
+                    .map(|def| ctx.subst_struct_def(&def))
+                    .transpose()?;
                 Ok(Ok(struct_def.map(Type::Struct)))
             }
             SignatureToken::Reference(sub_tok) => {
-                let inner_ty =
-                    try_runtime!(self
-                        .resolve_signature_token_with_fetcher(module, sub_tok, gas_meter, fetcher));
+                let inner_ty = try_runtime!(self.resolve_signature_token_with_fetcher(
+                    module,
+                    sub_tok,
+                    type_context,
+                    gas_meter,
+                    fetcher
+                ));
                 Ok(Ok(inner_ty.map(|t| Type::Reference(Box::new(t)))))
             }
             SignatureToken::MutableReference(sub_tok) => {
-                let inner_ty =
-                    try_runtime!(self
-                        .resolve_signature_token_with_fetcher(module, sub_tok, gas_meter, fetcher));
+                let inner_ty = try_runtime!(self.resolve_signature_token_with_fetcher(
+                    module,
+                    sub_tok,
+                    type_context,
+                    gas_meter,
+                    fetcher
+                ));
                 Ok(Ok(inner_ty.map(|t| Type::MutableReference(Box::new(t)))))
             }
         }
@@ -285,6 +318,9 @@ impl<'alloc> VMModuleCache<'alloc> {
         }
         let def = {
             let struct_def = module.struct_def_at(idx);
+            let struct_handle = module.struct_handle_at(struct_def.struct_handle);
+            let type_context =
+                TypeContext::identity_mapping(struct_handle.type_formals.len() as u16);
             match &struct_def.field_information {
                 // TODO we might want a more informative error here
                 StructFieldInformation::Native => return Err(VMInvariantViolation::LinkerError),
@@ -297,6 +333,7 @@ impl<'alloc> VMModuleCache<'alloc> {
                         let ty = try_runtime!(self.resolve_signature_token_with_fetcher(
                             module,
                             &module.type_signature_at(field.signature).0,
+                            &type_context,
                             gas_meter,
                             fetcher
                         ));

--- a/language/vm/vm_runtime/vm_runtime_types/src/lib.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/lib.rs
@@ -14,4 +14,5 @@ mod proptest_types;
 pub mod loaded_data;
 pub mod native_functions;
 pub mod native_structs;
+pub mod type_context;
 pub mod value;

--- a/language/vm/vm_runtime/vm_runtime_types/src/loaded_data/types.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/loaded_data/types.rs
@@ -21,6 +21,7 @@ pub enum Type {
     Struct(StructDef),
     Reference(Box<Type>),
     MutableReference(Box<Type>),
+    TypeVariable(u16),
 }
 
 /// This isn't used by any normal code at the moment, but is used by the fuzzer to serialize types
@@ -51,6 +52,11 @@ impl CanonicalSerialize for Type {
                 ty.serialize(serializer)?;
                 serializer
             }
+            TypeVariable(idx) => {
+                serializer.encode_u8(0x09)?;
+                serializer.encode_u16(*idx)?;
+                serializer
+            }
         };
         Ok(())
     }
@@ -72,6 +78,7 @@ impl CanonicalDeserialize for Type {
             0x06 => Struct(StructDef::deserialize(deserializer)?),
             0x07 => Reference(Box::new(Type::deserialize(deserializer)?)),
             0x08 => MutableReference(Box::new(Type::deserialize(deserializer)?)),
+            0x09 => TypeVariable(u16::deserialize(deserializer)?),
             other => bail!(
                 "Error while deserializing type: found unexpected tag {:#x}",
                 other

--- a/language/vm/vm_runtime/vm_runtime_types/src/type_context.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/type_context.rs
@@ -1,0 +1,40 @@
+use crate::loaded_data::{struct_def::StructDef, types::Type};
+use vm::errors::VMInvariantViolation;
+
+pub struct TypeContext(Vec<Type>);
+
+impl TypeContext {
+    pub fn new(ty: Vec<Type>) -> Self {
+        Self(ty)
+    }
+
+    pub fn identity_mapping(num_type_args: u16) -> Self {
+        Self((0..num_type_args).map(Type::TypeVariable).collect())
+    }
+
+    pub fn subst_type(&self, ty: &Type) -> Result<Type, VMInvariantViolation> {
+        Ok(match ty {
+            Type::TypeVariable(idx) => self.get_type(*idx)?,
+            Type::Reference(ty) => Type::Reference(Box::new(self.subst_type(ty)?)),
+            Type::MutableReference(ty) => Type::MutableReference(Box::new(self.subst_type(ty)?)),
+            Type::Struct(s) => Type::Struct(self.subst_struct_def(s)?),
+            id => id.clone(),
+        })
+    }
+
+    pub fn subst_struct_def(&self, def: &StructDef) -> Result<StructDef, VMInvariantViolation> {
+        Ok(StructDef::new(
+            def.field_definitions()
+                .iter()
+                .map(|ty| self.subst_type(ty))
+                .collect::<Result<_, _>>()?,
+        ))
+    }
+
+    pub fn get_type(&self, idx: u16) -> Result<Type, VMInvariantViolation> {
+        self.0
+            .get(idx as usize)
+            .cloned()
+            .ok_or(VMInvariantViolation::InternalTypeError)
+    }
+}

--- a/language/vm/vm_runtime/vm_runtime_types/src/value_serializer.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/value_serializer.rs
@@ -107,6 +107,14 @@ fn deserialize_struct(
                     err: VMErrorKind::InvalidData,
                 })
             }
+            Type::TypeVariable(_) => {
+                // This case is not possible as we disallow calls like borrow_global<Foo<Coin>>()
+                // for now.
+                return Err(VMRuntimeError {
+                    loc: Location::new(),
+                    err: VMErrorKind::InvalidData,
+                });
+            }
         }
     }
     Ok(Value::Struct(s_vals))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
This will be a partial implementation for the runtime support for generics. To be specific, this diff will allow us to publish resources like:
`Resource FooCoin{
    f: Foo<LibraCoin.T>,
}`
And we can't publish resource with top level type arguments, such as
`Resource FooCoin<T> {
    f: Foo<T>
}`
and do `move_to<FooCoin<LibraCoin.T>>`.

In general the VM doesn't need to know about generic type parameters at runtime. The only exceptions are these global instructions (borrowGlobal, MoveFrom, MoveTo, Exists) as we need to know the exact struct layout to store them on chain. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a unit test for testing the caching behavior of type instantiation of generics.