### PR TITLE
[common] Eliminate raw byte access for canonical serialization

### DIFF
--- a/common/canonical_serialization/src/canonical_deserialize.rs
+++ b/common/canonical_serialization/src/canonical_deserialize.rs
@@ -19,6 +19,8 @@ pub trait CanonicalDeserialize {
 pub trait CanonicalDeserializer {
     fn decode_bool(&mut self) -> Result<bool>;
 
+    fn decode_bytes(&mut self) -> Result<Vec<u8>>;
+
     fn decode_i8(&mut self) -> Result<i8>;
 
     fn decode_i16(&mut self) -> Result<i16>;
@@ -64,9 +66,6 @@ pub trait CanonicalDeserializer {
         &mut self,
     ) -> Result<BTreeMap<K, V>>;
 
-    // decode a byte array with the given length as input
-    fn decode_bytes_with_len(&mut self, len: u32) -> Result<Vec<u8>>;
-
     fn decode_optional<T: CanonicalDeserialize>(&mut self) -> Result<Option<T>>;
 
     fn decode_struct<T>(&mut self) -> Result<T>
@@ -76,8 +75,6 @@ pub trait CanonicalDeserializer {
     {
         T::deserialize(self)
     }
-
-    fn decode_variable_length_bytes(&mut self) -> Result<Vec<u8>>;
 
     fn decode_vec<T: CanonicalDeserialize>(&mut self) -> Result<Vec<T>>;
 }

--- a/common/canonical_serialization/src/canonical_serialize.rs
+++ b/common/canonical_serialization/src/canonical_serialize.rs
@@ -17,6 +17,8 @@ pub trait CanonicalSerialize {
 pub trait CanonicalSerializer {
     fn encode_bool(&mut self, v: bool) -> Result<&mut Self>;
 
+    fn encode_bytes(&mut self, v: &[u8]) -> Result<&mut Self>;
+
     fn encode_i8(&mut self, v: i8) -> Result<&mut Self>;
 
     fn encode_i16(&mut self, v: i16) -> Result<&mut Self>;
@@ -66,12 +68,6 @@ pub trait CanonicalSerializer {
 
     fn encode_optional<T: CanonicalSerialize>(&mut self, v: &Option<T>) -> Result<&mut Self>;
 
-    // Use this encoder when the length of the array is known to be fixed and always known at
-    // deserialization time. The raw bytes of the array without length prefix are encoded.
-    // For deserialization, use decode_bytes_with_len() which requires giving the length
-    // as input
-    fn encode_raw_bytes(&mut self, bytes: &[u8]) -> Result<&mut Self>;
-
     fn encode_struct(&mut self, structure: &impl CanonicalSerialize) -> Result<&mut Self>
     where
         Self: std::marker::Sized,
@@ -79,10 +75,6 @@ pub trait CanonicalSerializer {
         structure.serialize(self)?;
         Ok(self)
     }
-
-    // Use this encoder to encode variable length byte arrays whose length may not be known at
-    // deserialization time.
-    fn encode_variable_length_bytes(&mut self, v: &[u8]) -> Result<&mut Self>;
 
     fn encode_vec<T: CanonicalSerialize>(&mut self, v: &[T]) -> Result<&mut Self>;
 }

--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -445,8 +445,8 @@ where
             .encode_u64(self.round)?
             .encode_u64(self.height)?
             .encode_struct(self.payload)?
-            .encode_raw_bytes(self.parent_id.as_ref())?
-            .encode_raw_bytes(self.quorum_cert.certified_block_id().as_ref())?
+            .encode_bytes(self.parent_id.as_ref())?
+            .encode_bytes(self.quorum_cert.certified_block_id().as_ref())?
             .encode_optional(&self.author)?;
         Ok(())
     }

--- a/consensus/src/chained_bft/consensus_types/timeout_msg.rs
+++ b/consensus/src/chained_bft/consensus_types/timeout_msg.rs
@@ -173,7 +173,7 @@ struct TimeoutMsgSerializer {
 
 impl CanonicalSerialize for TimeoutMsgSerializer {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> failure::Result<()> {
-        serializer.encode_raw_bytes(self.pacemaker_timeout_digest.as_ref())?;
+        serializer.encode_bytes(self.pacemaker_timeout_digest.as_ref())?;
         Ok(())
     }
 }

--- a/consensus/src/chained_bft/safety/vote_msg.rs
+++ b/consensus/src/chained_bft/safety/vote_msg.rs
@@ -50,12 +50,12 @@ struct VoteMsgSerializer {
 impl CanonicalSerialize for VoteMsgSerializer {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> failure::Result<()> {
         serializer
-            .encode_raw_bytes(self.proposed_block_id.as_ref())?
+            .encode_bytes(self.proposed_block_id.as_ref())?
             .encode_struct(&self.executed_state)?
             .encode_u64(self.round)?
-            .encode_raw_bytes(self.parent_block_id.as_ref())?
+            .encode_bytes(self.parent_block_id.as_ref())?
             .encode_u64(self.parent_block_round)?
-            .encode_raw_bytes(self.grandparent_block_id.as_ref())?
+            .encode_bytes(self.grandparent_block_id.as_ref())?
             .encode_u64(self.grandparent_block_round)?;
         Ok(())
     }

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -76,7 +76,7 @@ impl ExecutedState {
 
 impl CanonicalSerialize for ExecutedState {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
-        serializer.encode_raw_bytes(self.state_id.as_ref())?;
+        serializer.encode_bytes(self.state_id.as_ref())?;
         serializer.encode_u64(self.version)?;
         Ok(())
     }

--- a/language/e2e_tests/src/tests/peer_to_peer.rs
+++ b/language/e2e_tests/src/tests/peer_to_peer.rs
@@ -6,7 +6,6 @@ use crate::{
     common_transactions::peer_to_peer_txn,
     executor::FakeExecutor,
 };
-use canonical_serialization::SimpleDeserializer;
 use std::time::Instant;
 use types::{
     account_config::AccountEvent,
@@ -98,7 +97,7 @@ fn few_peer_to_peer_with_event() {
         // check events
         for event in txn_output.events() {
             let account_event: AccountEvent =
-                SimpleDeserializer::deserialize(event.event_data()).expect("event data must parse");
+                AccountEvent::try_from(event.event_data()).expect("event data must parse");
             assert_eq!(transfer_amount, account_event.amount());
             assert!(
                 &account_event.account() == sender.address()

--- a/language/vm/vm_runtime/vm_runtime_types/src/value_serializer.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/value_serializer.rs
@@ -52,7 +52,7 @@ fn deserialize_struct(
                 }
             }
             Type::String => {
-                if let Ok(bytes) = deserializer.decode_variable_length_bytes() {
+                if let Ok(bytes) = deserializer.decode_bytes() {
                     if let Ok(s) = String::from_utf8(bytes) {
                         s_vals.push(MutVal::new(Value::String(s)));
                         continue;
@@ -64,7 +64,7 @@ fn deserialize_struct(
                 });
             }
             Type::ByteArray => {
-                if let Ok(bytes) = deserializer.decode_variable_length_bytes() {
+                if let Ok(bytes) = deserializer.decode_bytes() {
                     s_vals.push(MutVal::new(Value::ByteArray(ByteArray::new(bytes))));
                     continue;
                 }
@@ -74,7 +74,7 @@ fn deserialize_struct(
                 });
             }
             Type::Address => {
-                if let Ok(bytes) = deserializer.decode_variable_length_bytes() {
+                if let Ok(bytes) = deserializer.decode_bytes() {
                     if let Ok(addr) = AccountAddress::try_from(bytes) {
                         s_vals.push(MutVal::new(Value::Address(addr)));
                         continue;
@@ -118,7 +118,7 @@ impl CanonicalSerialize for Value {
             Value::Address(addr) => {
                 // TODO: this is serializing as a vector but we want just raw bytes
                 // however the AccountAddress story is a bit difficult to work with right now
-                serializer.encode_variable_length_bytes(addr.as_ref())?;
+                serializer.encode_bytes(addr.as_ref())?;
             }
             Value::Bool(b) => {
                 serializer.encode_bool(*b)?;
@@ -129,7 +129,7 @@ impl CanonicalSerialize for Value {
             Value::String(s) => {
                 // TODO: must define an api for canonical serializations of string.
                 // Right now we are just using Rust to serialize the string
-                serializer.encode_variable_length_bytes(s.as_bytes())?;
+                serializer.encode_bytes(s.as_bytes())?;
             }
             Value::Struct(vals) => {
                 for mut_val in vals {
@@ -137,7 +137,7 @@ impl CanonicalSerialize for Value {
                 }
             }
             Value::ByteArray(bytearray) => {
-                serializer.encode_variable_length_bytes(bytearray.as_bytes())?;
+                serializer.encode_bytes(bytearray.as_bytes())?;
             }
         }
         Ok(())

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -379,7 +379,7 @@ impl CanonicalSerialize for AccessPath {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_struct(&self.address)?
-            .encode_variable_length_bytes(&self.path)?;
+            .encode_bytes(&self.path)?;
         Ok(())
     }
 }
@@ -387,7 +387,7 @@ impl CanonicalSerialize for AccessPath {
 impl CanonicalDeserialize for AccessPath {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
         let address = deserializer.decode_struct::<AccountAddress>()?;
-        let path = deserializer.decode_variable_length_bytes()?;
+        let path = deserializer.decode_bytes()?;
 
         Ok(Self { address, path })
     }

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -245,14 +245,14 @@ impl TryFrom<AccountAddress> for Bech32 {
 
 impl CanonicalSerialize for AccountAddress {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
-        serializer.encode_variable_length_bytes(&self.0)?;
+        serializer.encode_bytes(&self.0)?;
         Ok(())
     }
 }
 
 impl CanonicalDeserialize for AccountAddress {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
-        let bytes = deserializer.decode_variable_length_bytes()?;
+        let bytes = deserializer.decode_bytes()?;
         Self::try_from(bytes)
     }
 }

--- a/types/src/byte_array.rs
+++ b/types/src/byte_array.rs
@@ -57,14 +57,14 @@ impl std::ops::Index<usize> for ByteArray {
 
 impl CanonicalSerialize for ByteArray {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
-        serializer.encode_variable_length_bytes(&self.0)?;
+        serializer.encode_bytes(&self.0)?;
         Ok(())
     }
 }
 
 impl CanonicalDeserialize for ByteArray {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
-        let bytes = deserializer.decode_variable_length_bytes()?;
+        let bytes = deserializer.decode_bytes()?;
         Ok(ByteArray(bytes))
     }
 }

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -9,9 +9,7 @@ use crate::{
     proof::{verify_event, EventProof},
     transaction::Version,
 };
-use canonical_serialization::{
-    CanonicalSerialize, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
-};
+use canonical_serialization::{CanonicalSerialize, CanonicalSerializer, SimpleSerializer};
 use crypto::{
     hash::{ContractEventHasher, CryptoHash, CryptoHasher},
     HashValue,
@@ -69,7 +67,7 @@ impl std::fmt::Debug for ContractEvent {
 
 impl std::fmt::Display for ContractEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Ok(payload) = SimpleDeserializer::deserialize::<AccountEvent>(&self.event_data) {
+        if let Ok(payload) = AccountEvent::try_from(&self.event_data) {
             write!(
                 f,
                 "ContractEvent {{ key: {}, index: {:?}, event_data: {:?} }}",
@@ -86,7 +84,7 @@ impl CanonicalSerialize for ContractEvent {
         serializer
             .encode_struct(&self.key)?
             .encode_u64(self.sequence_number)?
-            .encode_variable_length_bytes(&self.event_data)?;
+            .encode_bytes(&self.event_data)?;
         Ok(())
     }
 }

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -161,14 +161,14 @@ impl CanonicalSerialize for EventKey {
         // We cannot use encode_raw_bytes as this structure will represent how Move Value of type
         // EventKey is serialized into. And since Move doesn't have fix length bytearray, values
         // can't be encoded in the fix length fasion.
-        serializer.encode_variable_length_bytes(&self.0)?;
+        serializer.encode_bytes(&self.0)?;
         Ok(())
     }
 }
 
 impl CanonicalDeserialize for EventKey {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
-        let bytes = deserializer.decode_variable_length_bytes()?;
+        let bytes = deserializer.decode_bytes()?;
         Self::try_from(bytes.as_slice())
     }
 }

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -86,7 +86,7 @@ impl CanonicalSerialize for ModuleId {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_struct(&self.address)?
-            .encode_variable_length_bytes(self.name.as_bytes())?;
+            .encode_bytes(self.name.as_bytes())?;
         Ok(())
     }
 }
@@ -94,7 +94,7 @@ impl CanonicalSerialize for ModuleId {
 impl CanonicalDeserialize for ModuleId {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
         let address = deserializer.decode_struct::<AccountAddress>()?;
-        let name = String::from_utf8(deserializer.decode_variable_length_bytes()?)?;
+        let name = String::from_utf8(deserializer.decode_bytes()?)?;
 
         Ok(Self { address, name })
     }
@@ -114,8 +114,8 @@ impl CanonicalSerialize for StructTag {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_struct(&self.address)?
-            .encode_variable_length_bytes(self.module.as_bytes())?
-            .encode_variable_length_bytes(self.name.as_bytes())?
+            .encode_bytes(self.module.as_bytes())?
+            .encode_bytes(self.name.as_bytes())?
             .encode_vec(&self.type_params)?;
         Ok(())
     }
@@ -124,8 +124,8 @@ impl CanonicalSerialize for StructTag {
 impl CanonicalDeserialize for StructTag {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
         let address = deserializer.decode_struct::<AccountAddress>()?;
-        let module = String::from_utf8(deserializer.decode_variable_length_bytes()?)?;
-        let name = String::from_utf8(deserializer.decode_variable_length_bytes()?)?;
+        let module = String::from_utf8(deserializer.decode_bytes()?)?;
+        let name = String::from_utf8(deserializer.decode_bytes()?)?;
         let type_params = deserializer.decode_vec::<StructTag>()?;
         Ok(Self {
             address,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -159,9 +159,9 @@ impl CanonicalSerialize for LedgerInfo {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_u64(self.version)?
-            .encode_raw_bytes(self.transaction_accumulator_hash.as_ref())?
-            .encode_raw_bytes(self.consensus_data_hash.as_ref())?
-            .encode_raw_bytes(self.consensus_block_id.as_ref())?
+            .encode_bytes(self.transaction_accumulator_hash.as_ref())?
+            .encode_bytes(self.consensus_data_hash.as_ref())?
+            .encode_bytes(self.consensus_block_id.as_ref())?
             .encode_u64(self.epoch_num)?
             .encode_u64(self.timestamp_usecs)?;
         Ok(())

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -717,9 +717,9 @@ impl IntoProto for SignedTransactionWithProof {
 impl CanonicalSerialize for SignedTransaction {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
-            .encode_variable_length_bytes(&self.raw_txn_bytes)?
-            .encode_variable_length_bytes(&self.public_key.to_bytes())?
-            .encode_variable_length_bytes(&self.signature.to_bytes())?;
+            .encode_bytes(&self.raw_txn_bytes)?
+            .encode_bytes(&self.public_key.to_bytes())?
+            .encode_bytes(&self.signature.to_bytes())?;
         Ok(())
     }
 }
@@ -729,9 +729,9 @@ impl CanonicalDeserialize for SignedTransaction {
     where
         Self: Sized,
     {
-        let raw_txn_bytes = deserializer.decode_variable_length_bytes()?;
-        let public_key_bytes = deserializer.decode_variable_length_bytes()?;
-        let signature_bytes = deserializer.decode_variable_length_bytes()?;
+        let raw_txn_bytes = deserializer.decode_bytes()?;
+        let public_key_bytes = deserializer.decode_bytes()?;
+        let signature_bytes = deserializer.decode_bytes()?;
         let proto_raw_transaction = protobuf::parse_from_bytes::<
             crate::proto::transaction::RawTransaction,
         >(raw_txn_bytes.as_ref())?;
@@ -898,9 +898,9 @@ impl TransactionInfo {
 impl CanonicalSerialize for TransactionInfo {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
-            .encode_raw_bytes(self.signed_transaction_hash.as_ref())?
-            .encode_raw_bytes(self.state_root_hash.as_ref())?
-            .encode_raw_bytes(self.event_root_hash.as_ref())?
+            .encode_bytes(self.signed_transaction_hash.as_ref())?
+            .encode_bytes(self.state_root_hash.as_ref())?
+            .encode_bytes(self.event_root_hash.as_ref())?
             .encode_u64(self.gas_used)?;
         Ok(())
     }

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -115,11 +115,9 @@ impl CanonicalSerialize for ValidatorPublicKeys {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_struct(&self.account_address)?
-            .encode_variable_length_bytes(&self.consensus_public_key.to_bytes())?
-            .encode_variable_length_bytes(
-                &X25519StaticPublicKey::to_bytes(&self.network_identity_public_key)[..],
-            )?
-            .encode_variable_length_bytes(&self.network_signing_public_key.to_bytes())?;
+            .encode_bytes(&self.consensus_public_key.to_bytes())?
+            .encode_bytes(&X25519StaticPublicKey::to_bytes(&self.network_identity_public_key)[..])?
+            .encode_bytes(&self.network_signing_public_key.to_bytes())?;
         Ok(())
     }
 }
@@ -127,12 +125,11 @@ impl CanonicalSerialize for ValidatorPublicKeys {
 impl CanonicalDeserialize for ValidatorPublicKeys {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
         let account_address = deserializer.decode_struct::<AccountAddress>()?;
-        let consensus_public_key =
-            Ed25519PublicKey::try_from(&deserializer.decode_variable_length_bytes()?[..])?;
+        let consensus_public_key = Ed25519PublicKey::try_from(&deserializer.decode_bytes()?[..])?;
         let network_identity_public_key =
-            X25519StaticPublicKey::try_from(&deserializer.decode_variable_length_bytes()?[..])?;
+            X25519StaticPublicKey::try_from(&deserializer.decode_bytes()?[..])?;
         let network_signing_public_key =
-            Ed25519PublicKey::try_from(&deserializer.decode_variable_length_bytes()?[..])?;
+            Ed25519PublicKey::try_from(&deserializer.decode_bytes()?[..])?;
         Ok(ValidatorPublicKeys::new(
             account_address,
             consensus_public_key,


### PR DESCRIPTION
We removed it from the spec due to likely confusion. Now all LCS byte arrays must be prefixed with data.

The api was consolidated into encode/decode bytes AccountEvent used canonical serialization to read data from the executor stack. This was a hack and isn't really supported, so it has been
changed to something a bit cleaner.

This stacks on #622 