### PR TITLE
[state sync] support multiple network

### DIFF
--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -241,8 +241,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> (AdmissionControlClien
         )]);
 
     let state_synchronizer = StateSynchronizer::bootstrap(
-        state_sync_network_sender,
-        state_sync_network_events,
+        vec![(state_sync_network_sender, state_sync_network_events)],
         &node_config,
         vec![], // TODO: pass in empty vector for now, will be derived from node config later
     );

--- a/state_synchronizer/src/peer_manager.rs
+++ b/state_synchronizer/src/peer_manager.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::PeerId;
+use network::validator_network::StateSynchronizerSender;
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 use types::account_address::AccountAddress;
@@ -19,6 +20,7 @@ impl PeerInfo {
 
 pub struct PeerManager {
     upstream_peers: HashMap<PeerId, PeerInfo>,
+    network_senders: HashMap<PeerId, StateSynchronizerSender>,
 }
 
 impl PeerManager {
@@ -27,7 +29,10 @@ impl PeerManager {
             .into_iter()
             .map(|peer_id| (peer_id, PeerInfo::default()))
             .collect();
-        Self { upstream_peers }
+        Self {
+            upstream_peers,
+            network_senders: HashMap::new(),
+        }
     }
 
     pub fn set_peers(&mut self, peer_ids: Vec<PeerId>) {
@@ -38,13 +43,15 @@ impl PeerManager {
         self.upstream_peers = new_peers;
     }
 
-    pub fn enable_peer(&mut self, peer_id: &PeerId) {
-        if let Some(peer_info) = self.upstream_peers.get_mut(peer_id) {
+    pub fn enable_peer(&mut self, peer_id: PeerId, sender: StateSynchronizerSender) {
+        self.network_senders.insert(peer_id, sender);
+        if let Some(peer_info) = self.upstream_peers.get_mut(&peer_id) {
             peer_info.is_alive = true;
         };
     }
 
     pub fn disable_peer(&mut self, peer_id: &PeerId) {
+        self.network_senders.remove(&peer_id);
         if let Some(peer_info) = self.upstream_peers.get_mut(peer_id) {
             peer_info.is_alive = false;
         };
@@ -54,14 +61,16 @@ impl PeerManager {
         self.get_active_peer_ids().is_empty()
     }
 
-    pub fn pick_peer(&mut self) -> Option<AccountAddress> {
+    pub fn pick_peer(&mut self) -> Option<(AccountAddress, StateSynchronizerSender)> {
         let active_peers = self.get_active_peer_ids();
         if !active_peers.is_empty() {
             let idx = thread_rng().gen_range(0, active_peers.len());
-            Some(*active_peers[idx])
-        } else {
-            None
+            let peer_id = *active_peers[idx];
+            if let Some(sender) = self.get_network_sender(&peer_id) {
+                return Some((peer_id, sender));
+            }
         }
+        None
     }
 
     fn get_active_peer_ids(&self) -> Vec<&AccountAddress> {
@@ -70,5 +79,9 @@ impl PeerManager {
             .filter(|&(_, peer_info)| peer_info.is_alive)
             .map(|(peer_id, _)| peer_id)
             .collect()
+    }
+
+    pub fn get_network_sender(&self, peer_id: &PeerId) -> Option<StateSynchronizerSender> {
+        self.network_senders.get(peer_id).cloned()
     }
 }

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -234,15 +234,13 @@ impl SynchronizerEnv {
         }
         let synchronizers: Vec<StateSynchronizer> = vec![
             StateSynchronizer::bootstrap_with_executor_proxy(
-                sender_a,
-                events_a,
+                vec![(sender_a, events_a)],
                 &config,
                 MockExecutorProxy::new(peers[0], Self::default_handler()),
                 vec![peers[1]],
             ),
             StateSynchronizer::bootstrap_with_executor_proxy(
-                sender_b,
-                events_b,
+                vec![(sender_b, events_b)],
                 &get_test_config().0,
                 MockExecutorProxy::new(peers[1], handler),
                 vec![],


### PR DESCRIPTION
node will support multiple p2p networks
For example, validator could participate in two networks: existing validator network and its trusted full node network
this diff adds support to StateSynchronizer to support potentially multiple networks
