### PR TITLE
[state-sync] Add upstream/downstream info in PeerManager

### DIFF
--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -188,12 +188,10 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             return;
         }
 
-        if requested_version > self.target_version() {
-            self.peer_manager
-                .set_peers(target.signatures().keys().copied().collect());
-            self.target = Some(target);
-            self.request_next_chunk(0).await;
-        }
+        self.peer_manager
+            .set_peers(target.signatures().keys().copied().collect());
+        self.target = Some(target);
+        self.request_next_chunk(0).await;
         self.callback = Some(callback);
     }
 


### PR DESCRIPTION
## Motivation

Adding is_upstream to PeerInfo in PeerManager class, so that we can keep track of which peers are upstream (validators or upstream full nodes) and which are downstream (peer full nodes). When we pick the peer to sync from, we will for now only sync from upstream nodes. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test in state_synchronizer crate

