### PR TITLE
[VM][Tools] Refactor summaries that use locals

### DIFF
--- a/language/tools/test_generation/Cargo.toml
+++ b/language/tools/test_generation/Cargo.toml
@@ -10,9 +10,13 @@ edition = "2018"
 rand = "0.6.5"
 log = "0.4"
 env_logger = "0.6"
+mirai-annotations = "1.3.1"
 bytecode_verifier = { path = "../../bytecode_verifier" }
 cost_synthesis = { path = "../cost_synthesis" }
 vm = { path = "../../vm" }
 
 [dev-dependencies]
 types = { path = "../../../types", features = ["testing"] }
+
+[features]
+mirai-contracts = []

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -8,6 +8,9 @@ pub mod summaries;
 pub mod transitions;
 
 #[macro_use]
+extern crate mirai_annotations;
+
+#[macro_use]
 extern crate log;
 extern crate env_logger;
 use bytecode_generator::BytecodeGenerator;

--- a/language/tools/test_generation/tests/local_instructions.rs
+++ b/language/tools/test_generation/tests/local_instructions.rs
@@ -7,7 +7,7 @@ mod common;
 #[test]
 fn bytecode_copyloc() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
     let state2 = common::run_instruction(Bytecode::CopyLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
@@ -15,7 +15,7 @@ fn bytecode_copyloc() {
         "stack type postcondition not met"
     );
     assert_eq!(
-        state2.get_local(0),
+        state2.local_get(0),
         Some(&(SignatureToken::U64, BorrowState::Available)),
         "locals signature postcondition not met"
     );
@@ -32,15 +32,14 @@ fn bytecode_copyloc_no_local() {
 #[should_panic]
 fn bytecode_copyloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
-    state1.move_local(0);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
     common::run_instruction(Bytecode::CopyLoc(0), state1);
 }
 
 #[test]
 fn bytecode_moveloc() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
     let state2 = common::run_instruction(Bytecode::MoveLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
@@ -48,7 +47,7 @@ fn bytecode_moveloc() {
         "stack type postcondition not met"
     );
     assert_eq!(
-        state2.get_local(0),
+        state2.local_get(0),
         Some(&(SignatureToken::U64, BorrowState::Unavailable)),
         "locals signature postcondition not met"
     );
@@ -65,15 +64,14 @@ fn bytecode_moveloc_no_local() {
 #[should_panic]
 fn bytecode_moveloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
-    state1.move_local(0);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
     common::run_instruction(Bytecode::MoveLoc(0), state1);
 }
 
 #[test]
 fn bytecode_borrowloc() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
     let state2 = common::run_instruction(Bytecode::MutBorrowLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
@@ -83,7 +81,7 @@ fn bytecode_borrowloc() {
         "stack type postcondition not met"
     );
     assert_eq!(
-        state2.get_local(0),
+        state2.local_get(0),
         Some(&(SignatureToken::U64, BorrowState::Available)),
         "locals signature postcondition not met"
     );
@@ -92,7 +90,7 @@ fn bytecode_borrowloc() {
 #[test]
 fn bytecode_imm_borrowloc() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
     let state2 = common::run_instruction(Bytecode::ImmBorrowLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
@@ -100,7 +98,7 @@ fn bytecode_imm_borrowloc() {
         "stack type postcondition not met"
     );
     assert_eq!(
-        state2.get_local(0),
+        state2.local_get(0),
         Some(&(SignatureToken::U64, BorrowState::Available)),
         "locals signature postcondition not met"
     );
@@ -124,8 +122,7 @@ fn bytecode_imm_borrowloc_no_local() {
 #[should_panic]
 fn bytecode_borrowloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
-    state1.move_local(0);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
     common::run_instruction(Bytecode::MutBorrowLoc(0), state1);
 }
 
@@ -133,7 +130,6 @@ fn bytecode_borrowloc_local_unavailable() {
 #[should_panic]
 fn bytecode_imm_borrowloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.insert_local(0, SignatureToken::U64);
-    state1.move_local(0);
+    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
     common::run_instruction(Bytecode::ImmBorrowLoc(0), state1);
 }


### PR DESCRIPTION
## Motivation

This commit refactors the way locals are accessed and modified to make bytecode
instruction summaries less brittle and more compositional.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test` and running on bytecode verifier.

## Related PRs

N/A
