### PR TITLE
[terraform] Allow validator public IPs

### DIFF
--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -111,7 +111,8 @@ resource "aws_security_group_rule" "validator-node" {
   from_port         = 6180
   to_port           = 6180
   protocol          = "tcp"
-  self              = true
+  cidr_blocks       = concat(var.validator_node_sources_ipv4, [aws_vpc.testnet.cidr_block])
+  ipv6_cidr_blocks  = concat(var.validator_node_sources_ipv6, [aws_vpc.testnet.ipv6_cidr_block])
 }
 
 resource "aws_security_group_rule" "validator-ac" {

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -3,6 +3,10 @@ peer_ids = ["8deeeaed65f0cd7484a9e4e5ac51fbac548f2f71299a05e000156031ca78fb9f", 
 #api_sources_ipv4 = []  # Specify a list of IPv4 IPs/CIDRs which can access API load balancers
 #ssh_sources_ipv4 = []  # Specify a list of IPv4 IPs/CIDRs which can SSH to instances
 #ssh_sources_ipv6 = []  # Specify a list of IPv6 IPs/CIDRs which can SSH to instances
+#
+#validator_node_sources_ipv4 = []
+#validator_node_sources_ipv6 = []
+#
 
 #ssh_pub_key       =  ""  # Specify the content of your SSH public key
 #ssh_priv_key_file =  ""  # Specify the filename of your SSH private key

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -75,6 +75,23 @@ variable "validator_linux_capabilities" {
   default     = []
 }
 
+variable "validator_node_sources_ipv4" {
+  type        = list(string)
+  description = "List of IPv4 CIDR blocks from which to allow Validator Node access"
+  default     = []
+}
+
+variable "validator_node_sources_ipv6" {
+  type        = list(string)
+  description = "List of IPv6 CIDR blocks from which to allow Validator Node access"
+  default     = []
+}
+
+variable "validator_use_public_ip" {
+  type        = bool
+  default     = false
+}
+
 variable "append_workspace_dns" {
   description = "Append Terraform workspace to DNS names created"
   default     = true


### PR DESCRIPTION
## Motivation

Easily allow Validators to have public IPs, and also allow for custom IP access rules to validators.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Diff versus existing master below shows only expected changes:

Terraform will perform the following actions:

  # aws_security_group_rule.validator-node must be replaced
-/+ resource "aws_security_group_rule" "validator-node" {
      ~ cidr_blocks              = [ # forces replacement
          + "0.0.0.0/32",
          + "10.0.0.0/16",
        ]
        from_port                = 6180
      ~ id                       = "sgrule-35464105" -> (known after apply)
      ~ ipv6_cidr_blocks         = [ # forces replacement
          + "::/128",
          + "2600:1f14:9ff:c500::/56",
        ]
      - prefix_list_ids          = [] -> null
        protocol                 = "tcp"
        security_group_id        = "sg-0ecb41195112ec114"
      ~ self                     = true -> false # forces replacement
      ~ source_security_group_id = "sg-0ecb41195112ec114" -> (known after apply)
        to_port                  = 6180
        type                     = "ingress"
    }

Plan: 1 to add, 0 to change, 1 to destroy.


