### PR TITLE
[language/functional_tests] separate script execution & module publis…

### DIFF
--- a/language/compiler/ir_to_bytecode/src/parser.rs
+++ b/language/compiler/ir_to_bytecode/src/parser.rs
@@ -25,6 +25,17 @@ fn strip_comments(string: &str) -> String {
     line_comments.replace_all(string, "$1").into_owned()
 }
 
+/// Given the raw input of a file, creates a `ScriptOrModule` enum
+/// Fails with `Err(_)` if the text cannot be parsed`
+pub fn parse_script_or_module(s: &str) -> Result<ast::ScriptOrModule> {
+    let stripped_string = &strip_comments(s);
+    let parser = syntax::ScriptOrModuleParser::new();
+    match parser.parse(stripped_string) {
+        Ok(result) => Ok(result),
+        Err(e) => handle_error(e, s),
+    }
+}
+
 /// Given the raw input of a file, creates a `Program` struct
 /// Fails with `Err(_)` if the text cannot be parsed
 pub fn parse_program(program_str: &str) -> Result<ast::Program> {

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -24,14 +24,27 @@ pub type Loc = Span<ByteIndex>;
 //**************************************************************************************************
 // Program
 //**************************************************************************************************
+
 #[derive(Debug, Clone)]
 /// A set of move modules and a Move transaction script
-
 pub struct Program {
     /// The modules to publish
     pub modules: Vec<ModuleDefinition>,
     /// The transaction script to execute
     pub script: Script,
+}
+
+//**************************************************************************************************
+// ScriptOrModule
+//**************************************************************************************************
+
+#[derive(Debug, Clone)]
+/// A script or a module, used to represent the two types of transactions.
+pub enum ScriptOrModule {
+    /// The script to execute.
+    Script(Script),
+    /// The module to publish.
+    Module(ModuleDefinition),
 }
 
 //**************************************************************************************************

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::collections::BTreeMap;
 use codespan::{ByteIndex, Span};
 
-use crate::ast::{ModuleDefinition, StructDefinition, Script, Program};
+use crate::ast::{ModuleDefinition, StructDefinition, Script, Program, ScriptOrModule};
 use crate::ast::{
     FunctionBody, FunctionVisibility, ImportDefinition, ModuleName,
     Block, Cmd, CopyableVal, Spanned, Kind, TypeVar,
@@ -569,4 +569,9 @@ pub Module : ModuleDefinition = {
         <structs: (StructDecl)*>
         <functions: (FunctionDecl)*>
     "}" => ModuleDefinition::new(n.to_string(), imports, structs, functions),
+}
+
+pub ScriptOrModule: ScriptOrModule = {
+    <s: Script> => ScriptOrModule::Script(s),
+    <m: Module> => ScriptOrModule::Module(m),
 }

--- a/language/e2e_tests/src/lib.rs
+++ b/language/e2e_tests/src/lib.rs
@@ -32,6 +32,7 @@ mod proptest_types;
 /// Compiles a program with the given arguments and executes it in the VM.
 pub fn compile_and_execute(program: &str, args: Vec<TransactionArgument>) -> VMResult<()> {
     let address = AccountAddress::default();
+    println!("{}", address);
     let compiler = Compiler {
         code: program,
         address,

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+ir_to_bytecode_syntax = { path = "../compiler/ir_to_bytecode/syntax" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 stdlib = { path = "../stdlib" }
 types = { path = "../../types" }

--- a/language/functional_tests/src/utils.rs
+++ b/language/functional_tests/src/utils.rs
@@ -103,7 +103,7 @@ pub fn parse_input(s: &str) -> Result<(GlobalConfig, Vec<Directive>, Vec<Transac
             let config = TransactionConfig::build(&global_config, &config)?;
             Ok(Transaction {
                 config,
-                program: substitute_addresses(&global_config.accounts, &text.join("\n")),
+                input: substitute_addresses(&global_config.accounts, &text.join("\n")),
             })
         })
         .collect::<Result<Vec<_>>>()?;

--- a/language/functional_tests/tests/testsuite/wallets/wallet_module.mvir
+++ b/language/functional_tests/tests/testsuite/wallets/wallet_module.mvir
@@ -1,4 +1,3 @@
-modules:
 module ApprovalGroup {
     import 0x0.Signature;
 
@@ -64,6 +63,9 @@ module ApprovalGroup {
 
 }
 
+
+
+//! new-transaction
 module ColdWallet {
     import 0x0.AddressUtil;
     import 0x0.U64Util;
@@ -199,12 +201,9 @@ module ColdWallet {
         transaction_bytes = BytearrayUtil.bytearray_concat(move(first_three), move(seq_bytes));
         return move(transaction_bytes);
     }
- }
-
-script:
-main() {
-    return;
 }
+
+
 
 //! new-transaction
 import Transaction.ApprovalGroup;


### PR DESCRIPTION
## Summary
We are going to allow only the two new types of transactions (running a script & publishing a single module) and drop support for program (script + zero or more modules). This separates the transactions into these two kinds in functional tests.

## Test Plan
`cargo test`