### PR TITLE
[VM][Tools] Randomly assign basic block locals

### DIFF
--- a/language/tools/test_generation/src/abstract_state.rs
+++ b/language/tools/test_generation/src/abstract_state.rs
@@ -25,7 +25,7 @@ pub struct AbstractState {
     locals: HashMap<usize, (SignatureToken, BorrowState)>,
 
     /// Temporary location for storing the results of instruction effects for
-    /// access by subsequent instructions
+    /// access by subsequent instructions' effects
     register: Option<SignatureToken>,
 }
 

--- a/language/tools/test_generation/src/bytecode_generator.rs
+++ b/language/tools/test_generation/src/bytecode_generator.rs
@@ -3,10 +3,11 @@
 
 use crate::{
     abstract_state::{AbstractState, BorrowState},
-    common, summaries,
+    common,
+    control_flow_graph::CFG,
+    summaries,
 };
 use rand::{rngs::StdRng, FromEntropy, Rng, SeedableRng};
-use std::collections::HashMap;
 use vm::file_format::{
     AddressPoolIndex, ByteArrayPoolIndex, Bytecode, FunctionSignature, SignatureToken,
     StringPoolIndex,
@@ -66,62 +67,6 @@ enum StackEffect {
 
     /// Represents no change in stack size
     Nop,
-}
-
-/// This datatype holds basic block identifiers
-type BlockIDSize = u16;
-
-/// This represents a basic block in a control flow graph
-#[derive(Debug, Clone)]
-pub struct BasicBlock {
-    /// The starting locals
-    locals_in: HashMap<usize, (SignatureToken, BorrowState)>,
-
-    /// The locals at the end of the block
-    locals_out: HashMap<usize, (SignatureToken, BorrowState)>,
-
-    /// The instructions that comprise the block
-    instructions: Vec<Bytecode>,
-}
-
-impl BasicBlock {
-    fn new() -> BasicBlock {
-        BasicBlock {
-            locals_in: HashMap::new(),
-            locals_out: HashMap::new(),
-            instructions: Vec::new(),
-        }
-    }
-}
-
-/// A control flow graph
-#[derive(Debug, Clone)]
-pub struct CFG {
-    /// The set of basic blocks that make up the graph, mapped to `BlockIDSize`'s used
-    /// as their identifiers
-    basic_blocks: HashMap<BlockIDSize, BasicBlock>,
-
-    /// The directed edges of the graph represented by pairs of basic block identifiers
-    edges: Vec<(BlockIDSize, BlockIDSize)>,
-}
-
-impl CFG {
-    /// Retrieve the block IDs of all children of the given basic block `block_id`
-    fn get_children_ids(&self, block_id: BlockIDSize) -> Vec<BlockIDSize> {
-        let mut children_ids: Vec<BlockIDSize> = Vec::new();
-        for (parent, child) in self.edges.iter() {
-            if *parent == block_id {
-                children_ids.push(*child);
-            }
-        }
-        children_ids
-    }
-
-    /// Retrieve the number of children the given basic block `block_id`
-    fn num_children(&self, block_id: BlockIDSize) -> u8 {
-        // A `u8` is sufficient; blocks will have at most two children
-        self.get_children_ids(block_id).len() as u8
-    }
 }
 
 /// Generates a sequence of bytecode instructions.
@@ -285,7 +230,6 @@ impl BytecodeGenerator {
                 })
                 .cloned()
                 .collect();
-            debug!("Add candidates: [{:?}]", add_candidates);
             // Add candidates should not be empty unless the list of bytecode instructions is
             // changed
             if add_candidates.is_empty() {
@@ -301,7 +245,6 @@ impl BytecodeGenerator {
                 })
                 .cloned()
                 .collect();
-            debug!("Sub candidates: [{:?}]", sub_candidates);
             // Sub candidates should not be empty unless the list of bytecode instructions is
             // changed
             if sub_candidates.is_empty() {
@@ -328,7 +271,6 @@ impl BytecodeGenerator {
         instruction: Bytecode,
     ) -> AbstractState {
         debug!("**********************");
-        debug!("Bytecode: [{:?}]", bytecode);
         debug!("State1: [{:?}]", state);
         debug!("Next instr: {:?}", instruction);
         state = self.abstract_step(state, instruction.clone());
@@ -347,17 +289,10 @@ impl BytecodeGenerator {
     ) -> Vec<Bytecode> {
         let mut bytecode: Vec<Bytecode> = Vec::new();
         let mut state = abstract_state_in.clone();
-        // Make all locals unavailable
-        for (i, _) in abstract_state_in.get_locals().iter() {
-            // TODO: Check that this is not a resource or reference
-            let next_instruction = Bytecode::MoveLoc(*i as u8);
-            state = self.apply_instruction(state.clone(), &mut bytecode, next_instruction);
-        }
         // Generate block body
         loop {
             let candidates =
                 self.candidate_instructions(state.clone(), abstract_state_in.get_locals().len());
-            debug!("Candidates: [{:?}]", candidates);
             if candidates.is_empty() {
                 warn!("No candidates found for state: [{:?}]", state);
                 break;
@@ -368,137 +303,36 @@ impl BytecodeGenerator {
                 break;
             }
         }
-        // Add in available locals
-        for (i, (token_type, availability)) in abstract_state_out.get_locals().iter() {
-            if *availability == BorrowState::Available {
-                let next_instruction = match token_type {
-                    SignatureToken::String => Bytecode::LdStr(StringPoolIndex::new(0)),
-                    SignatureToken::Address => Bytecode::LdAddr(AddressPoolIndex::new(0)),
-                    SignatureToken::U64 => Bytecode::LdConst(0),
-                    SignatureToken::Bool => Bytecode::LdFalse,
-                    SignatureToken::ByteArray => Bytecode::LdByteArray(ByteArrayPoolIndex::new(0)),
-                    _ => panic!("Unsupported return type: {:#?}", token_type),
-                };
-                state = self.apply_instruction(state, &mut bytecode, next_instruction);
-                state = self.apply_instruction(state, &mut bytecode, Bytecode::StLoc(*i as u8));
+        // Fix local availability
+        for (i, (token_type, target_availability)) in abstract_state_out.get_locals().iter() {
+            if let Some((_, current_availability)) = state.local_get(*i) {
+                if *target_availability == BorrowState::Available
+                    && *current_availability == BorrowState::Unavailable
+                {
+                    let next_instruction = match token_type {
+                        SignatureToken::String => Bytecode::LdStr(StringPoolIndex::new(0)),
+                        SignatureToken::Address => Bytecode::LdAddr(AddressPoolIndex::new(0)),
+                        SignatureToken::U64 => Bytecode::LdConst(0),
+                        SignatureToken::Bool => Bytecode::LdFalse,
+                        SignatureToken::ByteArray => {
+                            Bytecode::LdByteArray(ByteArrayPoolIndex::new(0))
+                        }
+                        _ => unimplemented!("Unsupported return type: {:#?}", token_type),
+                    };
+                    state = self.apply_instruction(state, &mut bytecode, next_instruction);
+                    state = self.apply_instruction(state, &mut bytecode, Bytecode::StLoc(*i as u8));
+                } else if *target_availability == BorrowState::Unavailable
+                    && *current_availability == BorrowState::Available
+                {
+                    state =
+                        self.apply_instruction(state, &mut bytecode, Bytecode::MoveLoc(*i as u8));
+                    state = self.apply_instruction(state, &mut bytecode, Bytecode::Pop);
+                }
+            } else {
+                unreachable!("Target locals out contains new local");
             }
         }
         bytecode
-    }
-
-    /// Add the incoming and outgoing locals for each basic block in the control flow graph.
-    /// Currently the incoming and outgoing locals are the same for each block.
-    pub fn add_locals(&self, locals: &[SignatureToken], cfg: &mut CFG) {
-        let locals1: HashMap<usize, (SignatureToken, BorrowState)> = locals
-            .iter()
-            .enumerate()
-            .map(|(i, token)| (i, (token.clone(), BorrowState::Available)))
-            .collect();
-        for (_, block) in cfg.basic_blocks.iter_mut() {
-            let locals2 = locals1.clone();
-            block.locals_in = locals1.clone();
-            block.locals_out = locals2;
-        }
-    }
-
-    /// Construct a control flow graph that contains empty basic blocks with set incoming
-    /// and outgoing locals.
-    /// Currently the control flow graph is acyclic.
-    pub fn build_cfg(
-        &mut self,
-        locals: &[SignatureToken],
-        _signature: &FunctionSignature,
-        target_blocks: BlockIDSize,
-    ) -> CFG {
-        let mut basic_blocks: HashMap<BlockIDSize, BasicBlock> = HashMap::new();
-        // Generate basic blocks
-        for i in 0..target_blocks {
-            basic_blocks.insert(i, BasicBlock::new());
-        }
-        // Generate control flow edges
-        let mut edges: Vec<(BlockIDSize, BlockIDSize)> = Vec::new();
-        for i in 0..target_blocks {
-            let child_1 = self.rng.gen_range(i, target_blocks);
-            edges.push((i, child_1));
-            // At most two children per block
-            if self.rng.gen_range(0, 1) == 1 {
-                let child_2 = self.rng.gen_range(i, target_blocks);
-                if child_2 != child_1 {
-                    edges.push((i, child_2));
-                }
-            }
-        }
-        // Build the CFG
-        let mut cfg = CFG {
-            basic_blocks,
-            edges,
-        };
-        // Assign locals to basic blocks
-        self.add_locals(locals, &mut cfg);
-        cfg
-    }
-
-    /// Get the serialized code offset of a basic block based on its position in the serialized
-    /// instruction sequence.
-    pub fn get_block_offset(&self, cfg: &CFG, block_id: BlockIDSize) -> u16 {
-        let mut offset: u16 = 0;
-        for i in 0..block_id {
-            if let Some(block) = cfg.basic_blocks.get(&i) {
-                offset += block.instructions.len() as u16;
-            } else {
-                panic!("Error: Invalid block_id given: {:#?}", i);
-            }
-        }
-        offset
-    }
-
-    /// Serialize the control flow graph into a sequence of instructions. Set the offsets of branch
-    /// instructions appropriately.
-    pub fn serialize_cfg(&self, mut cfg: CFG) -> Vec<Bytecode> {
-        let cfg_copy = cfg.clone();
-        if !cfg.basic_blocks.is_empty() {
-            let mut bytecode: Vec<Bytecode> = Vec::new();
-            for i in 0..cfg.basic_blocks.len() {
-                let block_id = i as BlockIDSize;
-                let block = cfg.basic_blocks.get_mut(&block_id).unwrap();
-                let last_instruction_index = block.instructions.len() - 1;
-                if cfg_copy.num_children(block_id) == 2 {
-                    let child_id: BlockIDSize = cfg_copy.get_children_ids(block_id)[1];
-                    // The left child (fallthrough) is serialized before the right (jump)
-                    let offset = self.get_block_offset(&cfg_copy, child_id);
-                    match block.instructions.last() {
-                        Some(Bytecode::BrTrue(_)) => {
-                            block.instructions[last_instruction_index] =
-                                Bytecode::BrTrue(offset as u16);
-                        }
-                        Some(Bytecode::BrFalse(_)) => {
-                            block.instructions[last_instruction_index] =
-                                Bytecode::BrFalse(offset as u16);
-                        }
-                        _ => panic!(
-                            "Error: unsupported two target jump instruction, {:#?}",
-                            block.instructions.last()
-                        ),
-                    };
-                } else if cfg_copy.num_children(block_id) == 1 {
-                    let child_id: BlockIDSize = cfg_copy.get_children_ids(block_id)[0];
-                    let offset = self.get_block_offset(&cfg_copy, child_id);
-                    match block.instructions.last() {
-                        Some(Bytecode::Branch(_)) => {
-                            block.instructions[last_instruction_index] = Bytecode::Branch(offset);
-                        }
-                        _ => panic!(
-                            "Error: unsupported one target jump instruction, {:#?}",
-                            block.instructions.last()
-                        ),
-                    }
-                }
-                bytecode.extend(block.instructions.clone());
-            }
-            debug!("Final bytecode: {:#?}", bytecode);
-            return bytecode;
-        }
-        panic!("Error: CFG has no basic blocks");
     }
 
     /// Generate the body of a function definition given a set of starting `locals` and a target
@@ -511,11 +345,12 @@ impl BytecodeGenerator {
         _target_min: usize,
         _target_max: usize,
     ) -> Vec<Bytecode> {
-        let mut cfg = self.build_cfg(locals, signature, 3);
+        let mut cfg = CFG::new(&mut self.rng, locals, signature, 3);
         let cfg_copy = cfg.clone();
-        for (block_id, block) in cfg.basic_blocks.iter_mut() {
-            let state1 = AbstractState::from_locals(block.locals_in.clone());
-            let state2 = AbstractState::from_locals(block.locals_out.clone());
+        for (block_id, block) in cfg.get_basic_blocks_mut().iter_mut() {
+            debug!("+++++++++++++++++ Starting new block +++++++++++++++++");
+            let state1 = AbstractState::from_locals(block.get_locals_in().clone());
+            let state2 = AbstractState::from_locals(block.get_locals_out().clone());
             let mut bytecode = self.generate_block(state1, state2.clone());
             let mut state_f = state2;
             if cfg_copy.num_children(*block_id) == 2 {
@@ -541,16 +376,16 @@ impl BytecodeGenerator {
                         SignatureToken::ByteArray => {
                             Bytecode::LdByteArray(ByteArrayPoolIndex::new(0))
                         }
-                        _ => panic!("Unsupported return type: {:#?}", token_type),
+                        _ => unimplemented!("Unsupported return type: {:#?}", token_type),
                     };
                     state_f = self.apply_instruction(state_f, &mut bytecode, next_instruction);
                 }
                 self.apply_instruction(state_f, &mut bytecode, Bytecode::Ret);
             }
             debug!("Instructions generated: {}", bytecode.len());
-            block.instructions = bytecode;
+            block.set_instructions(bytecode);
         }
 
-        self.serialize_cfg(cfg)
+        cfg.serialize()
     }
 }

--- a/language/tools/test_generation/src/control_flow_graph.rs
+++ b/language/tools/test_generation/src/control_flow_graph.rs
@@ -1,0 +1,271 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::abstract_state::BorrowState;
+use rand::{rngs::StdRng, Rng};
+use std::collections::HashMap;
+use vm::file_format::{Bytecode, FunctionSignature, SignatureToken};
+
+/// This type holds basic block identifiers
+type BlockIDSize = u16;
+
+/// This type represents the locals that a basic block has
+type BlockLocals = HashMap<usize, (SignatureToken, BorrowState)>;
+
+/// This represents a basic block in a control flow graph
+#[derive(Debug, Clone)]
+pub struct BasicBlock {
+    /// The starting locals
+    locals_in: BlockLocals,
+
+    /// The locals at the end of the block
+    locals_out: BlockLocals,
+
+    /// The instructions that comprise the block
+    instructions: Vec<Bytecode>,
+}
+
+impl BasicBlock {
+    pub fn new() -> BasicBlock {
+        BasicBlock {
+            locals_in: HashMap::new(),
+            locals_out: HashMap::new(),
+            instructions: Vec::new(),
+        }
+    }
+
+    /// Get the locals coming into the block
+    pub fn get_locals_in(&self) -> &BlockLocals {
+        &self.locals_in
+    }
+
+    /// Get the locals going out of the block
+    pub fn get_locals_out(&self) -> &BlockLocals {
+        &self.locals_out
+    }
+
+    /// Set the list of instructions that comprise the block
+    pub fn set_instructions(&mut self, instructions: Vec<Bytecode>) {
+        self.instructions = instructions
+    }
+}
+
+/// A control flow graph
+#[derive(Debug, Clone)]
+pub struct CFG {
+    /// The set of basic blocks that make up the graph, mapped to `BlockIDSize`'s used
+    /// as their identifiers
+    basic_blocks: HashMap<BlockIDSize, BasicBlock>,
+
+    /// The directed edges of the graph represented by pairs of basic block identifiers
+    edges: Vec<(BlockIDSize, BlockIDSize)>,
+}
+
+impl CFG {
+    /// Construct a control flow graph that contains empty basic blocks with set incoming
+    /// and outgoing locals.
+    /// Currently the control flow graph is acyclic.
+    pub fn new(
+        mut rng: &mut StdRng,
+        locals: &[SignatureToken],
+        _signature: &FunctionSignature,
+        target_blocks: BlockIDSize,
+    ) -> CFG {
+        let mut basic_blocks: HashMap<BlockIDSize, BasicBlock> = HashMap::new();
+        // Generate basic blocks
+        for i in 0..target_blocks {
+            basic_blocks.insert(i, BasicBlock::new());
+        }
+        // Generate control flow edges
+        let mut edges: Vec<(BlockIDSize, BlockIDSize)> = Vec::new();
+        for i in 0..target_blocks {
+            let child_1 = rng.gen_range(i, target_blocks);
+            edges.push((i, child_1));
+            // At most two children per block
+            if rng.gen_range(0, 1) == 1 {
+                let child_2 = rng.gen_range(i, target_blocks);
+                if child_2 != child_1 {
+                    edges.push((i, child_2));
+                }
+            }
+        }
+        // Build the CFG
+        let mut cfg = CFG {
+            basic_blocks,
+            edges,
+        };
+        // Assign locals to basic blocks
+        CFG::add_locals(&mut cfg, &mut rng, locals);
+        cfg
+    }
+
+    /// Get a mutable reference to all of the basic blocks of the CFG
+    pub fn get_basic_blocks_mut(&mut self) -> &mut HashMap<BlockIDSize, BasicBlock> {
+        &mut self.basic_blocks
+    }
+
+    /// Retrieve the block IDs of all children of the given basic block `block_id`
+    pub fn get_children_ids(&self, block_id: BlockIDSize) -> Vec<BlockIDSize> {
+        let mut children_ids: Vec<BlockIDSize> = Vec::new();
+        for (parent, child) in self.edges.iter() {
+            if *parent == block_id {
+                children_ids.push(*child);
+            }
+        }
+        children_ids
+    }
+
+    /// Retrieve the number of children the given basic block `block_id`
+    pub fn num_children(&self, block_id: BlockIDSize) -> u8 {
+        // A `u8` is sufficient; blocks will have at most two children
+        self.get_children_ids(block_id).len() as u8
+    }
+
+    /// Retrieve the block IDs of all parents of the given basic block `block_id`
+    pub fn get_parent_ids(&self, block_id: BlockIDSize) -> Vec<BlockIDSize> {
+        let mut parent_ids: Vec<BlockIDSize> = Vec::new();
+        for (parent, child) in self.edges.iter() {
+            if *child == block_id {
+                parent_ids.push(*parent);
+            }
+        }
+        parent_ids
+    }
+
+    /// Retrieve the number of parents the given basic block `block_id`
+    pub fn num_parents(&self, block_id: BlockIDSize) -> u8 {
+        // A `u8` is sufficient; blocks will have at most two children
+        self.get_parent_ids(block_id).len() as u8
+    }
+
+    /// Merge the outgoing locals of a set of blocks
+    fn merge_locals(&self, block_ids: Vec<BlockIDSize>) -> BlockLocals {
+        checked_precondition!(
+            !block_ids.is_empty(),
+            "Cannot merge locals of empty block list"
+        );
+        let mut locals_out = BlockLocals::new();
+        let locals_len = self
+            .basic_blocks
+            .get(&block_ids[0])
+            .unwrap()
+            .locals_out
+            .len();
+        for local_index in 0..locals_len {
+            let token = self.basic_blocks.get(&block_ids[0]).unwrap().locals_out[&local_index]
+                .0
+                .clone();
+            let mut availability = BorrowState::Available;
+            for block_id in block_ids.iter() {
+                // A local is available for a block if it is available in every
+                // parent's outgoing locals
+                if self.basic_blocks.get(block_id).unwrap().locals_out[&local_index].1
+                    == BorrowState::Unavailable
+                {
+                    availability = BorrowState::Unavailable;
+                }
+            }
+            locals_out.insert(local_index, (token, availability));
+        }
+        locals_out
+    }
+
+    /// Randomly vary the availability of locals
+    fn vary_locals(rng: &mut StdRng, locals: BlockLocals) -> BlockLocals {
+        let mut locals = locals.clone();
+        for (_, (_, availability)) in locals.iter_mut() {
+            if rng.gen_range(0, 1) == 0 {
+                if *availability == BorrowState::Available {
+                    *availability = BorrowState::Unavailable;
+                } else {
+                    *availability = BorrowState::Available;
+                }
+            }
+        }
+        locals
+    }
+
+    /// Add the incoming and outgoing locals for each basic block in the control flow graph.
+    /// Currently the incoming and outgoing locals are the same for each block.
+    fn add_locals(cfg: &mut CFG, mut rng: &mut StdRng, locals: &[SignatureToken]) {
+        let cfg_copy = cfg.clone();
+        for (block_id, basic_block) in cfg.basic_blocks.iter_mut() {
+            if cfg_copy.num_parents(*block_id) == 0 {
+                basic_block.locals_in = locals
+                    .iter()
+                    .enumerate()
+                    .map(|(i, token)| (i, (token.clone(), BorrowState::Available)))
+                    .collect();
+            } else {
+                basic_block.locals_in = cfg_copy.merge_locals(cfg_copy.get_parent_ids(*block_id));
+            }
+            basic_block.locals_out = CFG::vary_locals(&mut rng, basic_block.locals_in.clone());
+        }
+    }
+
+    /// Get the serialized code offset of a basic block based on its position in the serialized
+    /// instruction sequence.
+    fn get_block_offset(cfg: &CFG, block_id: BlockIDSize) -> u16 {
+        checked_assume!(
+            (0..block_id).all(|id| cfg.basic_blocks.get(&id).is_some()),
+            "Error: Invalid block_id given"
+        );
+        let mut offset: u16 = 0;
+        for i in 0..block_id {
+            if let Some(block) = cfg.basic_blocks.get(&i) {
+                offset += block.instructions.len() as u16;
+            }
+        }
+        offset
+    }
+
+    /// Serialize the control flow graph into a sequence of instructions. Set the offsets of branch
+    /// instructions appropriately.
+    pub fn serialize(&mut self) -> Vec<Bytecode> {
+        checked_precondition!(
+            !self.basic_blocks.is_empty(),
+            "Error: CFG has no basic blocks"
+        );
+        let cfg_copy = self.clone();
+        let mut bytecode: Vec<Bytecode> = Vec::new();
+        for i in 0..self.basic_blocks.len() {
+            let block_id = i as BlockIDSize;
+            let block = self.basic_blocks.get_mut(&block_id).unwrap();
+            let last_instruction_index = block.instructions.len() - 1;
+            if cfg_copy.num_children(block_id) == 2 {
+                let child_id: BlockIDSize = cfg_copy.get_children_ids(block_id)[1];
+                // The left child (fallthrough) is serialized before the right (jump)
+                let offset = CFG::get_block_offset(&cfg_copy, child_id);
+                match block.instructions.last() {
+                    Some(Bytecode::BrTrue(_)) => {
+                        block.instructions[last_instruction_index] =
+                            Bytecode::BrTrue(offset as u16);
+                    }
+                    Some(Bytecode::BrFalse(_)) => {
+                        block.instructions[last_instruction_index] =
+                            Bytecode::BrFalse(offset as u16);
+                    }
+                    _ => unreachable!(
+                        "Error: unsupported two target jump instruction, {:#?}",
+                        block.instructions.last()
+                    ),
+                };
+            } else if cfg_copy.num_children(block_id) == 1 {
+                let child_id: BlockIDSize = cfg_copy.get_children_ids(block_id)[0];
+                let offset = CFG::get_block_offset(&cfg_copy, child_id);
+                match block.instructions.last() {
+                    Some(Bytecode::Branch(_)) => {
+                        block.instructions[last_instruction_index] = Bytecode::Branch(offset);
+                    }
+                    _ => unreachable!(
+                        "Error: unsupported one target jump instruction, {:#?}",
+                        block.instructions.last()
+                    ),
+                }
+            }
+            bytecode.extend(block.instructions.clone());
+        }
+        debug!("Final bytecode: {:#?}", bytecode);
+        bytecode
+    }
+}

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod abstract_state;
 pub mod bytecode_generator;
 pub mod common;
+pub mod control_flow_graph;
 pub mod summaries;
 pub mod transitions;
 
@@ -55,7 +56,7 @@ pub fn run_generation(iterations: usize) {
     let mut valid_programs: u64 = 0;
     for _ in 0..iterations {
         let module =
-            ModuleBuilder::new(2, Some(Box::new(generate_bytecode))).materialize_unverified();
+            ModuleBuilder::new(1, Some(Box::new(generate_bytecode))).materialize_unverified();
         valid_programs += run_verifier(module);
     }
 


### PR DESCRIPTION
## Motivation

This commit allows for correct random assignment of locals to basic blocks in the control flow
graph through implementation of local merging.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing via `cargo test` and running on bytecode verifier.

## Related PRs

N/A
