### PR TITLE
[network] Add ability to create permissionless network end-point

### DIFF
--- a/config/config_builder/src/swarm_config.rs
+++ b/config/config_builder/src/swarm_config.rs
@@ -209,6 +209,7 @@ impl SwarmConfig {
             enable_encryption_and_authentication: template
                 .network
                 .enable_encryption_and_authentication,
+            is_permissioned: template.network.is_permissioned,
         };
         let mut config = NodeConfig {
             base: base_config,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -524,7 +524,13 @@ pub struct NetworkConfig {
     pub advertised_address: Multiaddr,
     pub discovery_interval_ms: u64,
     pub connectivity_check_interval_ms: u64,
+    // Flag to toggle if Noise is used for encryption and authentication.
     pub enable_encryption_and_authentication: bool,
+    // If the network is permissioned, only trusted peers are allowed to connect. Otherwise, any
+    // node can connect. If this flag is set to true, the `enable_encryption_and_authentication`
+    // must also be set to true.
+    pub is_permissioned: bool,
+    // The role of the node in the network. One of: {"validator", "full_node"}.
     pub role: String,
     // peer_keypairs contains all the node's private keys,
     // it is filled later on from peer_keypairs_file.
@@ -552,6 +558,7 @@ impl Default for NetworkConfig {
             discovery_interval_ms: 1000,
             connectivity_check_interval_ms: 5000,
             enable_encryption_and_authentication: true,
+            is_permissioned: true,
             peer_keypairs_file: PathBuf::from("peer_keypairs.config.toml"),
             peer_keypairs: KeyPairs::default(),
             trusted_peers_file: PathBuf::from("trusted_peers.config.toml"),
@@ -572,6 +579,7 @@ impl Clone for NetworkConfig {
             discovery_interval_ms: self.discovery_interval_ms,
             connectivity_check_interval_ms: self.connectivity_check_interval_ms,
             enable_encryption_and_authentication: self.enable_encryption_and_authentication,
+            is_permissioned: self.is_permissioned,
             role: self.role.clone(),
             peer_keypairs: self.peer_keypairs.clone(),
             peer_keypairs_file: self.peer_keypairs_file.clone(),

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -98,9 +98,11 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
         listener_addr,
         RoleType::Validator,
     )
-    .transport(TransportType::TcpNoise)
+    .transport(TransportType::TcpNoise(Some((
+        listener_identity_private_key,
+        listener_identity_public_key,
+    ))))
     .trusted_peers(trusted_peers.clone())
-    .identity_keys((listener_identity_private_key, listener_identity_public_key))
     .signing_keys((listener_signing_private_key, listener_signing_public_key))
     .discovery_interval_ms(HOUR_IN_MS)
     .direct_send_protocols(vec![ProtocolId::from_static(
@@ -122,9 +124,11 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
         dialer_addr,
         RoleType::Validator,
     )
-    .transport(TransportType::TcpNoise)
+    .transport(TransportType::TcpNoise(Some((
+        dialer_identity_private_key,
+        dialer_identity_public_key,
+    ))))
     .trusted_peers(trusted_peers.clone())
-    .identity_keys((dialer_identity_private_key, dialer_identity_public_key))
     .signing_keys((dialer_signing_private_key, dialer_signing_public_key))
     .seed_peers(
         [(listener_peer_id, vec![listen_addr])]
@@ -241,9 +245,11 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
         listener_addr,
         RoleType::Validator,
     )
-    .transport(TransportType::TcpNoise)
+    .transport(TransportType::TcpNoise(Some((
+        listener_identity_private_key,
+        listener_identity_public_key,
+    ))))
     .trusted_peers(trusted_peers.clone())
-    .identity_keys((listener_identity_private_key, listener_identity_public_key))
     .signing_keys((listener_signing_private_key, listener_signing_public_key))
     .discovery_interval_ms(HOUR_IN_MS)
     .rpc_protocols(vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)])
@@ -261,9 +267,11 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
         dialer_addr,
         RoleType::Validator,
     )
-    .transport(TransportType::TcpNoise)
+    .transport(TransportType::TcpNoise(Some((
+        dialer_identity_private_key,
+        dialer_identity_public_key,
+    ))))
     .trusted_peers(trusted_peers.clone())
-    .identity_keys((dialer_identity_private_key, dialer_identity_public_key))
     .signing_keys((dialer_signing_private_key, dialer_signing_public_key))
     .seed_peers(
         [(listener_peer_id, vec![listen_addr])]

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -116,6 +116,46 @@ pub fn build_memory_noise_transport(
         .boxed()
 }
 
+pub fn build_permissionless_memory_noise_transport(
+    own_identity: Identity,
+    identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
+) -> boxed::BoxedTransport<(Identity, impl StreamMultiplexer), impl ::std::error::Error> {
+    let memory_transport = memory::MemoryTransport::default();
+    let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
+    memory_transport
+        .and_then(move |socket, origin| {
+            async move {
+                let (remote_static_key, socket) =
+                    noise_config.upgrade_connection(socket, origin).await?;
+                // Generate PeerId from X25519StaticPublicKey.
+                // Note: This is inconsistent with current types because AccountAddress is derived
+                // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
+                // not mean anything in the permissionless setting, we use the network public key
+                // to generate a peer_id for the peer. The only reason this works is that both are
+                // 32 bytes in size. If/when this condition no longer holds, we will receive an
+                // error.
+                let peer_id = PeerId::try_from(remote_static_key).unwrap();
+                Ok((peer_id, socket))
+            }
+        })
+        .and_then(|(peer_id, socket), origin| {
+            async move {
+                let muxer = Yamux::upgrade_connection(socket, origin).await?;
+                Ok((peer_id, muxer))
+            }
+        })
+        .and_then(move |(peer_id, muxer), origin| {
+            async move {
+                let (identity, muxer) = exchange_identity(&own_identity, muxer, origin).await?;
+                match_peer_id(identity, peer_id)
+                    .and_then(|identity| check_role(&own_identity, identity))
+                    .and_then(|identity| Ok((identity, muxer)))
+            }
+        })
+        .with_timeout(TRANSPORT_TIMEOUT)
+        .boxed()
+}
+
 pub fn build_memory_transport(
     own_identity: Identity,
 ) -> boxed::BoxedTransport<(Identity, impl StreamMultiplexer), impl ::std::error::Error> {

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -1,6 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Permission-less vs Permissioned network end-points:
+//! ---------------------------------------------------
+//! A network end-point is permissioned if it only wants to accept connections from a known set
+//! of peers (`trusted_peers`) identified by their network identity keys. This does not mean
+//! that the other end-point of a connection also needs to run in permissioned mode --
+//! a network end-point running in permissioned mode will connect to or accept connections from
+//! an end-point running in permissionless mode as long as the latter is in its trusted peers
+//! set.
 use crate::{
     common::NetworkPublicKeys,
     connectivity_manager::ConnectivityManager,
@@ -55,10 +63,11 @@ pub const MAX_CONNECTION_DELAY_MS: u64 = 10 * 60 * 1000 /* 10 minutes */;
 /// with or without Noise encryption
 pub enum TransportType {
     Memory,
-    MemoryNoise,
+    MemoryNoise(Option<(X25519StaticPrivateKey, X25519StaticPublicKey)>),
+    PermissionlessMemoryNoise(Option<(X25519StaticPrivateKey, X25519StaticPublicKey)>),
     Tcp,
-    TcpNoise,
-    PermissionlessTcpNoise,
+    TcpNoise(Option<(X25519StaticPrivateKey, X25519StaticPublicKey)>),
+    PermissionlessTcpNoise(Option<(X25519StaticPrivateKey, X25519StaticPublicKey)>),
 }
 
 /// Build Network module with custom configuration values.
@@ -91,7 +100,7 @@ pub struct NetworkBuilder {
     max_concurrent_network_notifs: u32,
     max_connection_delay_ms: u64,
     signing_keys: Option<(Ed25519PrivateKey, Ed25519PublicKey)>,
-    identity_keys: Option<(X25519StaticPrivateKey, X25519StaticPublicKey)>,
+    is_permissioned: bool,
 }
 
 impl NetworkBuilder {
@@ -127,7 +136,7 @@ impl NetworkBuilder {
             max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
             max_connection_delay_ms: MAX_CONNECTION_DELAY_MS,
             signing_keys: None,
-            identity_keys: None,
+            is_permissioned: true,
         }
     }
 
@@ -155,15 +164,6 @@ impl NetworkBuilder {
     /// Set signing keys of local node.
     pub fn signing_keys(&mut self, keys: (Ed25519PrivateKey, Ed25519PublicKey)) -> &mut Self {
         self.signing_keys = Some(keys);
-        self
-    }
-
-    /// Set identity keys of local node.
-    pub fn identity_keys(
-        &mut self,
-        keys: (X25519StaticPrivateKey, X25519StaticPublicKey),
-    ) -> &mut Self {
-        self.identity_keys = Some(keys);
         self
     }
 
@@ -284,16 +284,26 @@ impl NetworkBuilder {
         self
     }
 
+    /// Set the is_permissioned flag to make the network permissioned or permission-less.
+    pub fn permissioned(&mut self, is_permissioned: bool) -> &mut Self {
+        self.is_permissioned = is_permissioned;
+        self
+    }
+
     fn supported_protocols(&self) -> Vec<ProtocolId> {
-        self.direct_send_protocols
+        let mut supported_protocols: Vec<ProtocolId> = self
+            .direct_send_protocols
             .iter()
             .chain(&self.rpc_protocols)
-            .chain(&vec![
-                ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
-                ProtocolId::from_static(PING_PROTOCOL_NAME),
-            ])
+            .chain(&vec![ProtocolId::from_static(PING_PROTOCOL_NAME)])
             .cloned()
-            .collect()
+            .collect();
+        // TODO: This check is performed at 2 places to modify how protocols are setup. Ideally we
+        // should do it at only 1 place.
+        if self.is_permissioned {
+            supported_protocols.push(ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME));
+        }
+        supported_protocols
     }
 
     /// Create the configured `NetworkBuilder`
@@ -301,24 +311,32 @@ impl NetworkBuilder {
     pub fn build(&mut self) -> (Multiaddr, Box<dyn LibraNetworkProvider>) {
         let identity = Identity::new(self.peer_id, self.supported_protocols(), self.role.clone());
         // Build network based on the transport type
-        let own_identity_keys = self.identity_keys.take().expect("Identity keys not set");
         let trusted_peers = self.trusted_peers.clone();
         match self.transport {
             TransportType::Memory => self.build_with_transport(build_memory_transport(identity)),
-            TransportType::MemoryNoise => self.build_with_transport(build_memory_noise_transport(
-                identity,
-                own_identity_keys,
-                trusted_peers,
-            )),
+            TransportType::MemoryNoise(ref mut keys) => {
+                let keys = keys.take().expect("Identity keys not set");
+                self.build_with_transport(build_memory_noise_transport(
+                    identity,
+                    keys,
+                    trusted_peers,
+                ))
+            }
+            TransportType::PermissionlessMemoryNoise(ref mut keys) => {
+                let keys = keys.take().expect("Identity keys not set");
+                self.build_with_transport(build_permissionless_memory_noise_transport(
+                    identity, keys,
+                ))
+            }
             TransportType::Tcp => self.build_with_transport(build_tcp_transport(identity)),
-            TransportType::TcpNoise => self.build_with_transport(build_tcp_noise_transport(
-                identity,
-                own_identity_keys,
-                trusted_peers,
-            )),
-            TransportType::PermissionlessTcpNoise => self.build_with_transport(
-                build_permissionless_tcp_noise_transport(identity, own_identity_keys),
-            ),
+            TransportType::TcpNoise(ref mut keys) => {
+                let keys = keys.take().expect("Identity keys not set");
+                self.build_with_transport(build_tcp_noise_transport(identity, keys, trusted_peers))
+            }
+            TransportType::PermissionlessTcpNoise(ref mut keys) => {
+                let keys = keys.take().expect("Identity keys not set");
+                self.build_with_transport(build_permissionless_tcp_noise_transport(identity, keys))
+            }
         }
     }
 
@@ -331,91 +349,29 @@ impl NetworkBuilder {
             impl ::std::error::Error + Send + Sync + 'static,
         >,
     ) -> (Multiaddr, Box<dyn LibraNetworkProvider>) {
-        // Setup communication channels.
-        let (network_reqs_tx, network_reqs_rx) =
-            channel::new(self.channel_size, &counters::PENDING_NETWORK_REQUESTS);
+        // Initialize lists of protocol handlers and peer event handlers.
+        let mut peer_event_handlers = vec![];
+        let mut protocol_handlers = HashMap::new();
+        // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) =
             channel::new(self.channel_size, &counters::PENDING_PEER_MANAGER_REQUESTS);
-        let (pm_net_notifs_tx, pm_net_notifs_rx) = channel::new(
+
+        // Initialize and start DirectSend actor.
+        let (pm_ds_notifs_tx, pm_ds_notifs_rx) = channel::new(
             self.channel_size,
-            &counters::PENDING_PEER_MANAGER_NET_NOTIFICATIONS,
+            &counters::PENDING_PEER_MANAGER_DIRECT_SEND_NOTIFICATIONS,
         );
-        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
-            self.channel_size,
-            &counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
-        );
-        let (rpc_reqs_tx, rpc_reqs_rx) =
-            channel::new(self.channel_size, &counters::PENDING_RPC_REQUESTS);
-        let (rpc_net_notifs_tx, rpc_net_notifs_rx) =
-            channel::new(self.channel_size, &counters::PENDING_RPC_NOTIFICATIONS);
+        let direct_send_handlers = self
+            .direct_send_protocols
+            .iter()
+            .map(|p| (p.clone(), pm_ds_notifs_tx.clone()));
+        protocol_handlers.extend(direct_send_handlers);
         let (ds_reqs_tx, ds_reqs_rx) =
             channel::new(self.channel_size, &counters::PENDING_DIRECT_SEND_REQUESTS);
         let (ds_net_notifs_tx, ds_net_notifs_rx) = channel::new(
             self.channel_size,
             &counters::PENDING_DIRECT_SEND_NOTIFICATIONS,
         );
-        let (pm_ds_notifs_tx, pm_ds_notifs_rx) = channel::new(
-            self.channel_size,
-            &counters::PENDING_PEER_MANAGER_DIRECT_SEND_NOTIFICATIONS,
-        );
-        let (pm_rpc_notifs_tx, pm_rpc_notifs_rx) = channel::new(
-            self.channel_size,
-            &counters::PENDING_PEER_MANAGER_RPC_NOTIFICATIONS,
-        );
-        let (pm_discovery_notifs_tx, pm_discovery_notifs_rx) = channel::new(
-            self.channel_size,
-            &counters::PENDING_PEER_MANAGER_DISCOVERY_NOTIFICATIONS,
-        );
-        let (pm_ping_notifs_tx, pm_ping_notifs_rx) = channel::new(
-            self.channel_size,
-            &counters::PENDING_PEER_MANAGER_PING_NOTIFICATIONS,
-        );
-        let (pm_conn_mgr_notifs_tx, pm_conn_mgr_notifs_rx) = channel::new(
-            self.channel_size,
-            &counters::PENDING_PEER_MANAGER_CONNECTIVITY_MANAGER_NOTIFICATIONS,
-        );
-
-        // Initialize and start Peer manager.
-        let direct_send_handlers = self
-            .direct_send_protocols
-            .iter()
-            .map(|p| (p.clone(), pm_ds_notifs_tx.clone()));
-        let rpc_handlers = self
-            .rpc_protocols
-            .iter()
-            .map(|p| (p.clone(), pm_rpc_notifs_tx.clone()));
-        let discovery_handler = vec![(
-            ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
-            pm_discovery_notifs_tx.clone(),
-        )];
-        let ping_handler = vec![(
-            ProtocolId::from_static(PING_PROTOCOL_NAME),
-            pm_ping_notifs_tx.clone(),
-        )];
-        let protocol_handlers = direct_send_handlers
-            .chain(rpc_handlers)
-            .chain(discovery_handler)
-            .chain(ping_handler)
-            .collect();
-        let peer_mgr = PeerManager::new(
-            transport,
-            self.executor.clone(),
-            self.peer_id,
-            self.addr.clone(),
-            pm_reqs_rx,
-            protocol_handlers,
-            vec![
-                pm_net_notifs_tx,
-                pm_conn_mgr_notifs_tx,
-                pm_ping_notifs_tx,
-                pm_discovery_notifs_tx,
-            ],
-        );
-        let listen_addr = peer_mgr.listen_addr().clone();
-        self.executor
-            .spawn(peer_mgr.start().boxed().unit_error().compat());
-
-        // Initialize and start DirectSend actor.
         let ds = DirectSend::new(
             self.executor.clone(),
             ds_reqs_rx,
@@ -427,6 +383,19 @@ impl NetworkBuilder {
             .spawn(ds.start().boxed().unit_error().compat());
 
         // Initialize and start RPC actor.
+        let (pm_rpc_notifs_tx, pm_rpc_notifs_rx) = channel::new(
+            self.channel_size,
+            &counters::PENDING_PEER_MANAGER_RPC_NOTIFICATIONS,
+        );
+        let rpc_handlers = self
+            .rpc_protocols
+            .iter()
+            .map(|p| (p.clone(), pm_rpc_notifs_tx.clone()));
+        protocol_handlers.extend(rpc_handlers);
+        let (rpc_net_notifs_tx, rpc_net_notifs_rx) =
+            channel::new(self.channel_size, &counters::PENDING_RPC_NOTIFICATIONS);
+        let (rpc_reqs_tx, rpc_reqs_rx) =
+            channel::new(self.channel_size, &counters::PENDING_RPC_REQUESTS);
         let rpc = Rpc::new(
             self.executor.clone(),
             rpc_reqs_rx,
@@ -440,49 +409,16 @@ impl NetworkBuilder {
         self.executor
             .spawn(rpc.start().boxed().unit_error().compat());
 
-        // Initialize and start connectivity manager.
-        let conn_mgr = ConnectivityManager::new(
-            self.trusted_peers.clone(),
-            Compat01As03::new(Interval::new_interval(Duration::from_millis(
-                self.connectivity_check_interval_ms,
-            )))
-            .fuse(),
-            PeerManagerRequestSender::new(pm_reqs_tx.clone()),
-            pm_conn_mgr_notifs_rx,
-            conn_mgr_reqs_rx,
-            ExponentialBackoff::from_millis(2).factor(1000 /* seconds */),
-            self.max_connection_delay_ms,
-        );
-        self.executor
-            .spawn(conn_mgr.start().boxed().unit_error().compat());
-
-        // Initialize and start Discovery actor.
-        // Setup signer from keys.
-        let (signing_private_key, _signing_public_key) =
-            self.signing_keys.take().expect("Signing keys not set");
-        let signer = ValidatorSigner::new(self.peer_id, signing_private_key);
-        let discovery = Discovery::new(
-            self.peer_id,
-            vec![self
-                .advertised_address
-                .clone()
-                .unwrap_or_else(|| listen_addr.clone())],
-            signer,
-            self.seed_peers.clone(),
-            self.trusted_peers.clone(),
-            Compat01As03::new(Interval::new_interval(Duration::from_millis(
-                self.discovery_interval_ms,
-            )))
-            .fuse(),
-            PeerManagerRequestSender::new(pm_reqs_tx.clone()),
-            pm_discovery_notifs_rx,
-            conn_mgr_reqs_tx.clone(),
-            Duration::from_millis(self.discovery_msg_timeout_ms),
-        );
-        self.executor
-            .spawn(discovery.start().boxed().unit_error().compat());
-
         // Initialize and start HealthChecker.
+        let (pm_ping_notifs_tx, pm_ping_notifs_rx) = channel::new(
+            self.channel_size,
+            &counters::PENDING_PEER_MANAGER_PING_NOTIFICATIONS,
+        );
+        protocol_handlers.insert(
+            ProtocolId::from_static(PING_PROTOCOL_NAME),
+            pm_ping_notifs_tx.clone(),
+        );
+        peer_event_handlers.push(pm_ping_notifs_tx);
         let health_checker = HealthChecker::new(
             Compat01As03::new(Interval::new_interval(Duration::from_millis(
                 self.ping_interval_ms,
@@ -496,13 +432,101 @@ impl NetworkBuilder {
         self.executor
             .spawn(health_checker.start().boxed().unit_error().compat());
 
+        let mut net_conn_mgr_reqs_tx = None;
+
+        // We start the discovery and connectivity_manager module only if the network is
+        // permissioned.
+        if self.is_permissioned {
+            // Initialize and start connectivity manager.
+            let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
+                self.channel_size,
+                &counters::PENDING_CONNECTIVITY_MANAGER_REQUESTS,
+            );
+            net_conn_mgr_reqs_tx = Some(conn_mgr_reqs_tx.clone());
+            let (pm_conn_mgr_notifs_tx, pm_conn_mgr_notifs_rx) = channel::new(
+                self.channel_size,
+                &counters::PENDING_PEER_MANAGER_CONNECTIVITY_MANAGER_NOTIFICATIONS,
+            );
+            peer_event_handlers.push(pm_conn_mgr_notifs_tx);
+            let conn_mgr = ConnectivityManager::new(
+                self.trusted_peers.clone(),
+                Compat01As03::new(Interval::new_interval(Duration::from_millis(
+                    self.connectivity_check_interval_ms,
+                )))
+                .fuse(),
+                PeerManagerRequestSender::new(pm_reqs_tx.clone()),
+                pm_conn_mgr_notifs_rx,
+                conn_mgr_reqs_rx,
+                ExponentialBackoff::from_millis(2).factor(1000 /* seconds */),
+                self.max_connection_delay_ms,
+            );
+            self.executor
+                .spawn(conn_mgr.start().boxed().unit_error().compat());
+
+            // Initialize and start Discovery actor.
+            let (pm_discovery_notifs_tx, pm_discovery_notifs_rx) = channel::new(
+                self.channel_size,
+                &counters::PENDING_PEER_MANAGER_DISCOVERY_NOTIFICATIONS,
+            );
+            protocol_handlers.insert(
+                ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
+                pm_discovery_notifs_tx.clone(),
+            );
+            peer_event_handlers.push(pm_discovery_notifs_tx);
+            let (signing_private_key, _signing_public_key) =
+                self.signing_keys.take().expect("Signing keys not set");
+            // Setup signer from keys.
+            let signer = ValidatorSigner::new(self.peer_id, signing_private_key);
+            let discovery = Discovery::new(
+                self.peer_id,
+                vec![self
+                    .advertised_address
+                    .clone()
+                    .unwrap_or_else(|| self.addr.clone())],
+                signer,
+                self.seed_peers.clone(),
+                self.trusted_peers.clone(),
+                Compat01As03::new(Interval::new_interval(Duration::from_millis(
+                    self.discovery_interval_ms,
+                )))
+                .fuse(),
+                PeerManagerRequestSender::new(pm_reqs_tx.clone()),
+                pm_discovery_notifs_rx,
+                conn_mgr_reqs_tx.clone(),
+                Duration::from_millis(self.discovery_msg_timeout_ms),
+            );
+            self.executor
+                .spawn(discovery.start().boxed().unit_error().compat());
+        }
+
+        let (pm_net_notifs_tx, pm_net_notifs_rx) = channel::new(
+            self.channel_size,
+            &counters::PENDING_PEER_MANAGER_NET_NOTIFICATIONS,
+        );
+        peer_event_handlers.push(pm_net_notifs_tx);
+        let peer_mgr = PeerManager::new(
+            transport,
+            self.executor.clone(),
+            self.peer_id,
+            self.addr.clone(),
+            pm_reqs_rx,
+            protocol_handlers,
+            peer_event_handlers,
+        );
+        let listen_addr = peer_mgr.listen_addr().clone();
+        self.executor
+            .spawn(peer_mgr.start().boxed().unit_error().compat());
+
+        // Setup communication channels.
+        let (network_reqs_tx, network_reqs_rx) =
+            channel::new(self.channel_size, &counters::PENDING_NETWORK_REQUESTS);
         let validator_network = NetworkProvider::new(
             pm_net_notifs_rx,
             rpc_reqs_tx,
             rpc_net_notifs_rx,
             ds_reqs_tx,
             ds_net_notifs_rx,
-            conn_mgr_reqs_tx.clone(),
+            net_conn_mgr_reqs_tx,
             network_reqs_rx,
             network_reqs_tx,
             self.max_concurrent_network_reqs,

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -168,9 +168,9 @@ impl SynchronizerEnv {
         let (a_signing_private_key, a_signing_public_key) = compat::generate_keypair(&mut rng);
         let (b_signing_private_key, b_signing_public_key) = compat::generate_keypair(&mut rng);
         // Setup identity public keys.
-        let (a_identity_private_key, a_identity_public_key) =
+        let (_a_identity_private_key, a_identity_public_key) =
             x25519::compat::generate_keypair(&mut rng);
-        let (b_identity_private_key, b_identity_public_key) =
+        let (_b_identity_private_key, b_identity_public_key) =
             x25519::compat::generate_keypair(&mut rng);
 
         let trusted_peers: HashMap<_, _> = vec![
@@ -199,7 +199,6 @@ impl SynchronizerEnv {
             RoleType::Validator,
         )
         .signing_keys((b_signing_private_key, b_signing_public_key))
-        .identity_keys((b_identity_private_key, b_identity_public_key))
         .trusted_peers(trusted_peers.clone())
         .transport(TransportType::Memory)
         .direct_send_protocols(protocols.clone())
@@ -217,7 +216,6 @@ impl SynchronizerEnv {
         )
         .transport(TransportType::Memory)
         .signing_keys((a_signing_private_key, a_signing_public_key))
-        .identity_keys((a_identity_private_key, a_identity_public_key))
         .trusted_peers(trusted_peers.clone())
         .seed_peers([(peers[1], vec![listener_addr])].iter().cloned().collect())
         .direct_send_protocols(protocols.clone())


### PR DESCRIPTION
## Motivation

This PR builds on top of #692. To support public full nodes, the validator-trusted full nodes will need to run a permission-less network end-point -- i.e., accept connections from any public entity without knowing about it beforehand.

This PR allows instantiation of network stack without the discovery and connectivity manager modules which are designed to operate in a permissioned mode only.

Side-effect of this change is that a node started in permission-less mode will not dial any peer, but will accept incoming connections from any peer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a new test where we instantiate 2 network end-points - the listener is permission-less and the dialer is permissioned. We observe that the dialer is able to successfully connect to the listener and execute the mempool sync protocol.

## Related PRs
#703, #692