### PR TITLE
[vm_runtime] Pass type actuals to the native function dispatcher.

### DIFF
--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/vector.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/vector.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::dispatch::NativeReturnStatus;
-use crate::value::Local;
+use crate::{loaded_data::types::Type, value::Local};
 use std::collections::VecDeque;
 
 const LENGTH_COST: u64 = 30; // TODO: determine experimentally
 
 #[allow(unreachable_code)]
-pub fn native_length(_arguments: VecDeque<Local>) -> NativeReturnStatus {
+pub fn native_length(_types: VecDeque<Type>, _arguments: VecDeque<Local>) -> NativeReturnStatus {
     unimplemented!("Computing length of a vector collection");
     let cost = LENGTH_COST;
     let return_values = vec![Local::u64(0)];


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Previously native functions doesn't require any type actuals, which will no longer be the case due to the existence of native structs. This PR will change the definition of a NativeFunction so that the dispatcher will be able to read the type actuals.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs
#694 