### PR TITLE
[VM][Tools] AbstractValue: Extend stack values to include their kind

### DIFF
--- a/language/tools/test_generation/src/abstract_state.rs
+++ b/language/tools/test_generation/src/abstract_state.rs
@@ -2,36 +2,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use vm::file_format::SignatureToken;
+use vm::file_format::{Kind, SignatureToken};
 
 /// The BorrowState denotes whether a local is `Available` or
 /// has been moved and is `Unavailable`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BorrowState {
     Available,
     Unavailable,
 }
 
+/// This models a value on the stack or in the locals
+#[derive(Debug, Clone, PartialEq)]
+pub struct AbstractValue {
+    /// Represents the type of the value
+    pub token: SignatureToken,
+
+    /// Represents the kind of the value
+    pub kind: Kind,
+}
+
+impl AbstractValue {
+    /// Create a new primitive `AbstractValue` given its type; the kind will be `Unrestricted`
+    pub fn new_primitive(token: SignatureToken) -> AbstractValue {
+        assert!(
+            match token {
+                SignatureToken::Struct(_, _) => false,
+                SignatureToken::Reference(_) => false,
+                SignatureToken::MutableReference(_) => false,
+                _ => true,
+            },
+            "AbstractValue::new_primitive must be applied with primitive type"
+        );
+        AbstractValue {
+            token,
+            kind: Kind::Unrestricted,
+        }
+    }
+
+    /// Create a new reference `AbstractValue` given its type and kind
+    pub fn new_reference(token: SignatureToken, kind: Kind) -> AbstractValue {
+        assert!(
+            match token {
+                SignatureToken::Reference(_) => true,
+                SignatureToken::MutableReference(_) => true,
+                _ => false,
+            },
+            "AbstractValue::new_reference must be applied with a reference type"
+        );
+        AbstractValue { token, kind }
+    }
+}
+
 /// An AbstractState represents an abstract view of the execution of the
 /// Move VM. Rather than considering values of items on the stack or in
-/// the locals, we only consider their type, represented by a `SignatureToken`
+/// the locals, we only consider their type, represented by a `AbstractValue`
 /// and their availibility, represented by the `BorrowState`.
 #[derive(Debug, Clone)]
 pub struct AbstractState {
-    /// A Vector of `SignatureToken`s representing the VM value stack
-    stack: Vec<SignatureToken>,
+    /// A Vector of `AbstractValue`s representing the VM value stack
+    stack: Vec<AbstractValue>,
 
-    /// A HashMap mapping local indicies to `SignatureToken`s and `BorrowState`s
-    locals: HashMap<usize, (SignatureToken, BorrowState)>,
+    /// A HashMap mapping local indicies to `AbstractValue`s and `BorrowState`s
+    locals: HashMap<usize, (AbstractValue, BorrowState)>,
 
     /// Temporary location for storing the results of instruction effects for
     /// access by subsequent instructions' effects
-    register: Option<SignatureToken>,
+    register: Option<AbstractValue>,
 }
 
 impl AbstractState {
-    /// Create a new AbstractState given a list of `SignatureTokens` that will be
-    /// the (available) locals that the state will have.
+    /// Create a new AbstractState with empty stack, locals, and register
     pub fn new() -> AbstractState {
         AbstractState {
             stack: Vec::new(),
@@ -42,7 +83,7 @@ impl AbstractState {
 
     /// Create a new AbstractState given a list of `SignatureTokens` that will be
     /// the (available) locals that the state will have.
-    pub fn from_locals(locals: HashMap<usize, (SignatureToken, BorrowState)>) -> AbstractState {
+    pub fn from_locals(locals: HashMap<usize, (AbstractValue, BorrowState)>) -> AbstractState {
         AbstractState {
             stack: Vec::new(),
             locals,
@@ -51,34 +92,34 @@ impl AbstractState {
     }
 
     /// Get the register value and set it to `None`
-    fn get_register(&mut self) -> Option<SignatureToken> {
+    fn get_register(&mut self) -> Option<AbstractValue> {
         let value = self.register.clone();
         self.register = None;
         value
     }
 
-    /// Add a `SignatureToken` to the stack
-    pub fn stack_push(&mut self, item: SignatureToken) {
+    /// Add a `AbstractValue` to the stack
+    pub fn stack_push(&mut self, item: AbstractValue) {
         self.stack.push(item);
     }
 
-    /// Add a `SignatureToken` to the stack from the register
+    /// Add a `AbstractValue` to the stack from the register
     pub fn stack_push_register(&mut self) {
-        if let Some(token) = self.get_register() {
-            self.stack.push(token);
+        if let Some(abstract_value) = self.get_register() {
+            self.stack.push(abstract_value);
         } else {
             panic!("Error: No value in register");
         }
     }
 
-    /// Remove a `SignatureToken` from the stack if it exists to the register
+    /// Remove a `AbstractValue` from the stack if it exists to the register
     pub fn stack_pop(&mut self) {
         self.register = self.stack.pop();
     }
 
-    /// Get the `SignatureToken` at index `index` on the stack if it exists.
+    /// Get the `AbstractValue` at index `index` on the stack if it exists.
     /// Index 0 is the top of the stack.
-    pub fn stack_peek(&self, index: usize) -> Option<SignatureToken> {
+    pub fn stack_peek(&self, index: usize) -> Option<AbstractValue> {
         if index < self.stack.len() {
             Some(self.stack[self.stack.len() - 1 - index].clone())
         } else {
@@ -97,59 +138,71 @@ impl AbstractState {
     }
 
     /// Get the local at index `i` if it exists
-    pub fn local_get(&self, i: usize) -> Option<&(SignatureToken, BorrowState)> {
+    pub fn local_get(&self, i: usize) -> Option<&(AbstractValue, BorrowState)> {
         self.locals.get(&i)
     }
 
     /// Place the local at index `i` if it exists into the register
     pub fn local_take(&mut self, i: usize) {
         checked_precondition!(self.local_exists(i), "Failed to get local");
-        let (token, _) = self.locals.get(&i).unwrap();
-        self.register = Some(token.clone());
+        let (abstract_value, _) = self.locals.get(&i).unwrap();
+        self.register = Some(abstract_value.clone());
     }
 
     /// Place a reference to the local at index `i` if it exists into the register
     pub fn local_take_borrow(&mut self, i: usize, mutable: bool) {
         checked_precondition!(self.local_exists(i), "Failed to get reference to local");
-        let (token, _) = self.locals.get(&i).unwrap();
+        let (abstract_value, _) = self.locals.get(&i).unwrap();
         let ref_token = if mutable {
-            SignatureToken::MutableReference(Box::new(token.clone()))
+            SignatureToken::MutableReference(Box::new(abstract_value.token.clone()))
         } else {
-            SignatureToken::Reference(Box::new(token.clone()))
+            SignatureToken::Reference(Box::new(abstract_value.token.clone()))
         };
-        self.register = Some(ref_token);
+        self.register = Some(AbstractValue::new_reference(ref_token, abstract_value.kind));
     }
 
     /// Set the availability of the local at index `i`
     pub fn local_set(&mut self, i: usize, availability: BorrowState) {
         checked_precondition!(self.local_exists(i), "Failed to change local availability");
-        let (token, _) = self.locals.get(&i).unwrap().clone();
-        self.locals.insert(i, (token, availability));
+        let (abstract_value, _) = self.locals.get(&i).unwrap().clone();
+        self.locals.insert(i, (abstract_value, availability));
     }
 
     /// Check whether a local is in a particular `BorrowState`
-    pub fn local_is(&self, i: usize, availability: BorrowState) -> bool {
+    pub fn local_availability_is(&self, i: usize, availability: BorrowState) -> bool {
         checked_precondition!(self.local_exists(i), "Failed to check local availability");
         let (_, availability1) = self.locals.get(&i).unwrap();
         availability == *availability1
     }
 
+    /// Check whether a local is in a particular `Kind`
+    pub fn local_kind_is(&self, i: usize, kind: Kind) -> bool {
+        checked_precondition!(self.local_exists(i), "Failed to check local kind");
+        let (abstract_value, _) = self.locals.get(&i).unwrap();
+        abstract_value.kind == kind
+    }
+
     /// Insert a local at index `i` as `Available`
-    pub fn local_insert(&mut self, i: usize, token: SignatureToken, availability: BorrowState) {
-        self.locals.insert(i, (token, availability));
+    pub fn local_insert(
+        &mut self,
+        i: usize,
+        abstract_value: AbstractValue,
+        availability: BorrowState,
+    ) {
+        self.locals.insert(i, (abstract_value, availability));
     }
 
     /// Insert a local at index `i` as `Available` from the register
     pub fn local_place(&mut self, i: usize) {
         let value = self.get_register();
         assert!(value.is_some(), "Failed to insert local from stack");
-        let token = value.unwrap();
+        let abstract_value = value.unwrap();
         self.locals
-            .insert(i, (token.clone(), BorrowState::Available));
+            .insert(i, (abstract_value.clone(), BorrowState::Available));
     }
 
     /// Get all of the locals
-    pub fn get_locals(&self) -> &HashMap<usize, (SignatureToken, BorrowState)> {
+    pub fn get_locals(&self) -> &HashMap<usize, (AbstractValue, BorrowState)> {
         &self.locals
     }
 

--- a/language/tools/test_generation/src/bytecode_generator.rs
+++ b/language/tools/test_generation/src/bytecode_generator.rs
@@ -304,12 +304,12 @@ impl BytecodeGenerator {
             }
         }
         // Fix local availability
-        for (i, (token_type, target_availability)) in abstract_state_out.get_locals().iter() {
+        for (i, (abstract_value, target_availability)) in abstract_state_out.get_locals().iter() {
             if let Some((_, current_availability)) = state.local_get(*i) {
                 if *target_availability == BorrowState::Available
                     && *current_availability == BorrowState::Unavailable
                 {
-                    let next_instruction = match token_type {
+                    let next_instruction = match abstract_value.token {
                         SignatureToken::String => Bytecode::LdStr(StringPoolIndex::new(0)),
                         SignatureToken::Address => Bytecode::LdAddr(AddressPoolIndex::new(0)),
                         SignatureToken::U64 => Bytecode::LdConst(0),
@@ -317,7 +317,7 @@ impl BytecodeGenerator {
                         SignatureToken::ByteArray => {
                             Bytecode::LdByteArray(ByteArrayPoolIndex::new(0))
                         }
-                        _ => unimplemented!("Unsupported return type: {:#?}", token_type),
+                        _ => unimplemented!("Unsupported return type: {:#?}", abstract_value.token),
                     };
                     state = self.apply_instruction(state, &mut bytecode, next_instruction);
                     state = self.apply_instruction(state, &mut bytecode, Bytecode::StLoc(*i as u8));

--- a/language/tools/test_generation/tests/arithmetic_instructions.rs
+++ b/language/tools/test_generation/tests/arithmetic_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};
 
 mod common;
@@ -7,12 +7,12 @@ mod common;
 #[test]
 fn bytecode_add() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Add, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -20,12 +20,12 @@ fn bytecode_add() {
 #[test]
 fn bytecode_sub() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Sub, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -33,12 +33,12 @@ fn bytecode_sub() {
 #[test]
 fn bytecode_mul() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Mul, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -46,12 +46,12 @@ fn bytecode_mul() {
 #[test]
 fn bytecode_div() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Div, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -59,12 +59,12 @@ fn bytecode_div() {
 #[test]
 fn bytecode_mod() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Mod, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }

--- a/language/tools/test_generation/tests/bitwise_instructions.rs
+++ b/language/tools/test_generation/tests/bitwise_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};
 
 mod common;
@@ -7,12 +7,12 @@ mod common;
 #[test]
 fn bytecode_bitand() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::BitAnd, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -20,12 +20,12 @@ fn bytecode_bitand() {
 #[test]
 fn bytecode_bitor() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::BitAnd, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -33,12 +33,12 @@ fn bytecode_bitor() {
 #[test]
 fn bytecode_xor() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Xor, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }

--- a/language/tools/test_generation/tests/boolean_instructions.rs
+++ b/language/tools/test_generation/tests/boolean_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};
 
 mod common;
@@ -7,12 +7,12 @@ mod common;
 #[test]
 fn bytecode_and() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::Bool);
-    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(Bytecode::And, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -20,12 +20,12 @@ fn bytecode_and() {
 #[test]
 fn bytecode_or() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::Bool);
-    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(Bytecode::Or, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -33,12 +33,12 @@ fn bytecode_or() {
 #[test]
 fn bytecode_not() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::Bool);
-    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(Bytecode::Not, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }

--- a/language/tools/test_generation/tests/comparison_instructions.rs
+++ b/language/tools/test_generation/tests/comparison_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};
 
 mod common;
@@ -7,12 +7,12 @@ mod common;
 #[test]
 fn bytecode_gt() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Gt, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -20,12 +20,12 @@ fn bytecode_gt() {
 #[test]
 fn bytecode_lt() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Lt, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -33,12 +33,12 @@ fn bytecode_lt() {
 #[test]
 fn bytecode_ge() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Ge, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -46,12 +46,12 @@ fn bytecode_ge() {
 #[test]
 fn bytecode_le() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Le, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -59,12 +59,12 @@ fn bytecode_le() {
 #[test]
 fn bytecode_eq_u64() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Eq, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -72,12 +72,12 @@ fn bytecode_eq_u64() {
 #[test]
 fn bytecode_eq_bool() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::Bool);
-    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(Bytecode::Eq, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -85,12 +85,12 @@ fn bytecode_eq_bool() {
 #[test]
 fn bytecode_neq_u64() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Neq, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -98,12 +98,12 @@ fn bytecode_neq_u64() {
 #[test]
 fn bytecode_neq_bool() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::Bool);
-    state1.stack_push(SignatureToken::Bool);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(Bytecode::Neq, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }

--- a/language/tools/test_generation/tests/load_instructions.rs
+++ b/language/tools/test_generation/tests/load_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{AddressPoolIndex, Bytecode, SignatureToken, StringPoolIndex};
 
 mod common;
@@ -10,7 +10,7 @@ fn bytecode_ldconst() {
     let state2 = common::run_instruction(Bytecode::LdConst(0), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -21,7 +21,7 @@ fn bytecode_ldtrue() {
     let state2 = common::run_instruction(Bytecode::LdTrue, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -32,7 +32,7 @@ fn bytecode_ldfalse() {
     let state2 = common::run_instruction(Bytecode::LdFalse, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Bool),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
         "stack type postcondition not met"
     );
 }
@@ -43,7 +43,7 @@ fn bytecode_ldstr() {
     let state2 = common::run_instruction(Bytecode::LdStr(StringPoolIndex::new(0)), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::String),
+        Some(AbstractValue::new_primitive(SignatureToken::String)),
         "stack type postcondition not met"
     );
 }
@@ -54,7 +54,7 @@ fn bytecode_ldaddr() {
     let state2 = common::run_instruction(Bytecode::LdAddr(AddressPoolIndex::new(0)), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Address),
+        Some(AbstractValue::new_primitive(SignatureToken::Address)),
         "stack type postcondition not met"
     );
 }

--- a/language/tools/test_generation/tests/local_instructions.rs
+++ b/language/tools/test_generation/tests/local_instructions.rs
@@ -1,22 +1,29 @@
 extern crate test_generation;
-use test_generation::abstract_state::{AbstractState, BorrowState};
-use vm::file_format::{Bytecode, SignatureToken};
+use test_generation::abstract_state::{AbstractState, AbstractValue, BorrowState};
+use vm::file_format::{Bytecode, Kind, SignatureToken};
 
 mod common;
 
 #[test]
 fn bytecode_copyloc() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Available,
+    );
     let state2 = common::run_instruction(Bytecode::CopyLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
     assert_eq!(
         state2.local_get(0),
-        Some(&(SignatureToken::U64, BorrowState::Available)),
+        Some(&(
+            AbstractValue::new_primitive(SignatureToken::U64),
+            BorrowState::Available
+        )),
         "locals signature postcondition not met"
     );
 }
@@ -32,23 +39,34 @@ fn bytecode_copyloc_no_local() {
 #[should_panic]
 fn bytecode_copyloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Unavailable,
+    );
     common::run_instruction(Bytecode::CopyLoc(0), state1);
 }
 
 #[test]
 fn bytecode_moveloc() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Available,
+    );
     let state2 = common::run_instruction(Bytecode::MoveLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
     assert_eq!(
         state2.local_get(0),
-        Some(&(SignatureToken::U64, BorrowState::Unavailable)),
+        Some(&(
+            AbstractValue::new_primitive(SignatureToken::U64),
+            BorrowState::Unavailable
+        )),
         "locals signature postcondition not met"
     );
 }
@@ -64,25 +82,37 @@ fn bytecode_moveloc_no_local() {
 #[should_panic]
 fn bytecode_moveloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Unavailable,
+    );
     common::run_instruction(Bytecode::MoveLoc(0), state1);
 }
 
 #[test]
 fn bytecode_borrowloc() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Available,
+    );
     let state2 = common::run_instruction(Bytecode::MutBorrowLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::MutableReference(Box::new(
-            SignatureToken::U64
-        ))),
+        Some(AbstractValue::new_reference(
+            SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+            Kind::Unrestricted
+        )),
         "stack type postcondition not met"
     );
     assert_eq!(
         state2.local_get(0),
-        Some(&(SignatureToken::U64, BorrowState::Available)),
+        Some(&(
+            AbstractValue::new_primitive(SignatureToken::U64),
+            BorrowState::Available
+        )),
         "locals signature postcondition not met"
     );
 }
@@ -90,16 +120,26 @@ fn bytecode_borrowloc() {
 #[test]
 fn bytecode_imm_borrowloc() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Available);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Available,
+    );
     let state2 = common::run_instruction(Bytecode::ImmBorrowLoc(0), state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::Reference(Box::new(SignatureToken::U64))),
+        Some(AbstractValue::new_reference(
+            SignatureToken::Reference(Box::new(SignatureToken::U64),),
+            Kind::Unrestricted
+        )),
         "stack type postcondition not met"
     );
     assert_eq!(
         state2.local_get(0),
-        Some(&(SignatureToken::U64, BorrowState::Available)),
+        Some(&(
+            AbstractValue::new_primitive(SignatureToken::U64),
+            BorrowState::Available
+        )),
         "locals signature postcondition not met"
     );
 }
@@ -122,7 +162,11 @@ fn bytecode_imm_borrowloc_no_local() {
 #[should_panic]
 fn bytecode_borrowloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Unavailable,
+    );
     common::run_instruction(Bytecode::MutBorrowLoc(0), state1);
 }
 
@@ -130,6 +174,10 @@ fn bytecode_borrowloc_local_unavailable() {
 #[should_panic]
 fn bytecode_imm_borrowloc_local_unavailable() {
     let mut state1 = AbstractState::new();
-    state1.local_insert(0, SignatureToken::U64, BorrowState::Unavailable);
+    state1.local_insert(
+        0,
+        AbstractValue::new_primitive(SignatureToken::U64),
+        BorrowState::Unavailable,
+    );
     common::run_instruction(Bytecode::ImmBorrowLoc(0), state1);
 }

--- a/language/tools/test_generation/tests/special_instructions.rs
+++ b/language/tools/test_generation/tests/special_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};
 
 mod common;
@@ -7,7 +7,7 @@ mod common;
 #[test]
 fn bytecode_pop() {
     let mut state1 = AbstractState::new();
-    state1.stack_push(SignatureToken::U64);
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     let state2 = common::run_instruction(Bytecode::Pop, state1);
     assert_eq!(state2.stack_len(), 0, "stack type postcondition not met");
 }

--- a/language/tools/test_generation/tests/transaction_instructions.rs
+++ b/language/tools/test_generation/tests/transaction_instructions.rs
@@ -1,5 +1,5 @@
 extern crate test_generation;
-use test_generation::abstract_state::AbstractState;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};
 
 mod common;
@@ -10,7 +10,7 @@ fn bytecode_gettxngasunitprice() {
     let state2 = common::run_instruction(Bytecode::GetTxnGasUnitPrice, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -21,7 +21,7 @@ fn bytecode_gettxnmaxgasunits() {
     let state2 = common::run_instruction(Bytecode::GetTxnMaxGasUnits, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -32,7 +32,7 @@ fn bytecode_gettxnsequencenumber() {
     let state2 = common::run_instruction(Bytecode::GetTxnSequenceNumber, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }
@@ -43,7 +43,7 @@ fn bytecode_getgasremaining() {
     let state2 = common::run_instruction(Bytecode::GetGasRemaining, state1);
     assert_eq!(
         state2.stack_peek(0),
-        Some(SignatureToken::U64),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
         "stack type postcondition not met"
     );
 }


### PR DESCRIPTION
## Motivation

This PR replaces the use of `SignatureToken`s with `AbstractValue`s within the bytecode test generation tool. The `AbstractValue` contains both a `SignatureToken` and a `Kind` of `Resource`, `Unrestricted`, or `All`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test` and running on bytecode verifier.

## Related PRs

N/A