### PR TITLE
[consensus] init commit for fuzzing proposals messages

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -65,3 +65,7 @@ types = { path = "../types", features = ["testing"]}
 vm_genesis = { path = "../language/vm/vm_genesis" }
 vm_validator = { path = "../vm_validator" }
 proptest = "0.9.4"
+
+[features]
+default = []
+fuzzing = []

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -479,7 +479,8 @@ impl<T: Payload> BlockReader for BlockStore<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzzing"))]
+#[allow(dead_code)]
 impl<T: Payload> BlockStore<T> {
     /// Returns the number of blocks in the tree
     fn len(&self) -> usize {

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -410,7 +410,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzzing"))]
 impl<T> BlockTree<T>
 where
     T: Serialize + Default + Debug + CanonicalSerialize + PartialEq,

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -1,0 +1,204 @@
+use crate::{
+    chained_bft::{
+        block_storage::BlockStore,
+        consensus_types::proposal_msg::ProposalMsg,
+        epoch_manager::EpochManager,
+        event_processor::EventProcessor,
+        liveness::{
+            pacemaker::{ExponentialTimeInterval, NewRoundEvent, NewRoundReason, Pacemaker},
+            pacemaker_timeout_manager::HighestTimeoutCertificates,
+            proposal_generator::ProposalGenerator,
+            rotating_proposer_election::RotatingProposer,
+        },
+        network::ConsensusNetworkImpl,
+        persistent_storage::{PersistentStorage, RecoveryData},
+        safety::safety_rules::SafetyRules,
+        test_utils::{EmptyStateComputer, MockStorage, MockTransactionManager, TestPayload},
+    },
+    util::mock_time_service::SimulatedTimeService,
+};
+use futures::{channel::mpsc, executor::block_on};
+use lazy_static::lazy_static;
+use network::{
+    proto::Proposal,
+    validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
+};
+use proto_conv::{FromProto, IntoProto};
+use protobuf::Message as Message_imported_for_functions;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier};
+
+// This generates a proposal for round 1
+pub fn generate_corpus_proposal() -> Vec<u8> {
+    let event_processor = create_node_for_fuzzing();
+    block_on(async {
+        let proposal = event_processor
+            .generate_proposal(NewRoundEvent {
+                round: 1,
+                reason: NewRoundReason::QCReady,
+                timeout: std::time::Duration::new(5, 0),
+            })
+            .await;
+        // serialize and return proposal
+        let proposal = proposal.unwrap();
+        proposal.into_proto().write_to_bytes().unwrap()
+    })
+}
+
+// optimization for the fuzzer
+lazy_static! {
+    static ref STATIC_RUNTIME: Runtime = Runtime::new().unwrap();
+    static ref FUZZING_SIGNER: ValidatorSigner = ValidatorSigner::from_int(1);
+}
+
+// helpers
+fn build_empty_store(
+    signer: ValidatorSigner,
+    storage: Arc<dyn PersistentStorage<TestPayload>>,
+    initial_data: RecoveryData<TestPayload>,
+) -> Arc<BlockStore<TestPayload>> {
+    let (_commit_cb_sender, _commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
+
+    Arc::new(block_on(BlockStore::new(
+        storage,
+        initial_data,
+        signer,
+        Arc::new(EmptyStateComputer),
+        true,
+        10, // max pruned blocks in mem
+    )))
+}
+
+// TODO: MockStorage -> EmptyStorage
+fn create_pacemaker() -> Pacemaker {
+    let base_timeout = std::time::Duration::new(60, 0);
+    let time_interval = Box::new(ExponentialTimeInterval::fixed(base_timeout));
+    let (pacemaker_timeout_sender, _) = channel::new_test(1_024);
+    let time_service = Arc::new(SimulatedTimeService::new());
+    Pacemaker::new(
+        MockStorage::<TestPayload>::start_for_testing()
+            .0
+            .persistent_liveness_storage(),
+        time_interval,
+        time_service,
+        pacemaker_timeout_sender,
+        HighestTimeoutCertificates::default(),
+    )
+}
+
+// Creates an EventProcessor for fuzzing
+fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
+    // signer is re-used accross fuzzing runs
+    let signer = FUZZING_SIGNER.clone();
+
+    // TODO: remove
+    let validator = ValidatorVerifier::new_single(signer.author(), signer.public_key());
+
+    // EpochManager
+    let epoch_mgr = Arc::new(EpochManager::new(0, validator));
+
+    // TODO: EmptyStorage
+    let (storage, initial_data) = MockStorage::<TestPayload>::start_for_testing();
+    let consensus_state = initial_data.state();
+
+    // TODO: remove
+    let safety_rules = SafetyRules::new(consensus_state);
+
+    // TODO: mock channels
+    let (network_reqs_tx, _network_reqs_rx) = channel::new_test(8);
+    let (_consensus_tx, consensus_rx) = channel::new_test(8);
+    let network_sender = ConsensusNetworkSender::new(network_reqs_tx);
+    let network_events = ConsensusNetworkEvents::new(consensus_rx);
+    let network = ConsensusNetworkImpl::new(
+        signer.author(),
+        network_sender,
+        network_events,
+        Arc::clone(&epoch_mgr),
+    );
+
+    // TODO: mock
+    let block_store = build_empty_store(signer.clone(), storage.clone(), initial_data);
+
+    // TODO: remove
+    let time_service = Arc::new(SimulatedTimeService::new());
+
+    // TODO: remove
+    let proposal_generator = ProposalGenerator::new(
+        block_store.clone(),
+        Arc::new(MockTransactionManager::new()),
+        time_service.clone(),
+        1,
+        true,
+    );
+
+    //
+    let pacemaker = create_pacemaker();
+
+    // TODO: have two different nodes, one for proposing, one for accepting a proposal
+    let proposer_election = Box::new(RotatingProposer::new(vec![signer.author()], 1));
+
+    // TODO: do we want to fuzz the real StateComputer as well?
+    let empty_state_computer = Arc::new(EmptyStateComputer);
+
+    // We do not want to care about the time
+    let enforce_increasing_timestamps = false;
+
+    // event processor
+    EventProcessor::new(
+        signer.author(),
+        Arc::clone(&block_store),
+        pacemaker,
+        proposer_election,
+        proposal_generator,
+        safety_rules,
+        empty_state_computer,
+        Arc::new(MockTransactionManager::new()),
+        network,
+        storage.clone(),
+        time_service,
+        enforce_increasing_timestamps,
+        Arc::clone(&epoch_mgr),
+    )
+}
+
+// This functions fuzzes a Proposal protobuffer (not a ConsensusMsg)
+pub fn fuzz_proposal(data: &[u8]) {
+    // create node
+    let mut event_processor = create_node_for_fuzzing();
+
+    let proposal: Proposal = match protobuf::parse_from_bytes(data) {
+        Ok(xx) => xx,
+        Err(_) => {
+            if cfg!(test) {
+                panic!();
+            }
+            return;
+        }
+    };
+
+    let proposal = match ProposalMsg::<TestPayload>::from_proto(proposal) {
+        Ok(xx) => xx,
+        Err(_) => {
+            if cfg!(test) {
+                panic!();
+            }
+            return;
+        }
+    };
+
+    block_on(async move {
+        // TODO: make sure this obtains a vote when testing
+        // TODO: make sure that if this obtains a vote, it's for round 1, etc.
+        event_processor.process_proposal_msg(proposal).await;
+    });
+}
+
+// This test is here so that the fuzzer can be maintained
+#[test]
+fn test_consensus_proposal_fuzzer() {
+    // generate a proposal
+    let proposal = generate_corpus_proposal();
+    // successfully parse it
+    fuzz_proposal(&proposal);
+}

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -51,7 +51,7 @@ use tokio::runtime::TaskExecutor;
 use types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier};
 
 /// Auxiliary struct that is setting up node environment for the test.
-struct NodeSetup {
+pub struct NodeSetup {
     author: Author,
     block_store: Arc<BlockStore<TestPayload>>,
     event_processor: EventProcessor<TestPayload>,

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -92,7 +92,7 @@ pub struct ExponentialTimeInterval {
 }
 
 impl ExponentialTimeInterval {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn fixed(duration: Duration) -> Self {
         Self::new(duration, 1.0, 0)
     }

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager.rs
@@ -24,7 +24,7 @@ pub struct HighestTimeoutCertificates {
 }
 
 impl HighestTimeoutCertificates {
-    #[cfg(test)]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn new(
         highest_local_timeout_certificate: Option<PacemakerTimeoutCertificate>,
         highest_received_timeout_certificate: Option<PacemakerTimeoutCertificate>,

--- a/consensus/src/chained_bft/mod.rs
+++ b/consensus/src/chained_bft/mod.rs
@@ -4,14 +4,12 @@
 mod common;
 mod consensus_types;
 mod consensusdb;
-mod liveness;
 mod safety;
 
 mod block_storage;
 pub mod chained_bft_consensus_provider;
 pub use consensus_types::quorum_cert::QuorumCert;
 mod chained_bft_smr;
-mod event_processor;
 mod network;
 
 pub mod epoch_manager;
@@ -24,5 +22,16 @@ mod chained_bft_smr_test;
 mod network_tests;
 #[cfg(test)]
 mod proto_test;
-#[cfg(test)]
+
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod test_utils;
+
+#[cfg(not(any(test, feature = "fuzzing")))]
+mod liveness;
+#[cfg(any(test, feature = "fuzzing"))]
+pub mod liveness;
+
+#[cfg(not(feature = "fuzzing"))]
+mod event_processor;
+#[cfg(feature = "fuzzing")]
+pub mod event_processor;

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -24,7 +24,7 @@ mod mock_state_computer;
 mod mock_storage;
 mod mock_txn_manager;
 
-pub use mock_state_computer::MockStateComputer;
+pub use mock_state_computer::{EmptyStateComputer, MockStateComputer};
 pub use mock_storage::{EmptyStorage, MockStorage};
 pub use mock_txn_manager::MockTransactionManager;
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -7,7 +7,7 @@
 //! Currently, the only consensus protocol supported is LibraBFT (based on
 //! [HotStuff](https://arxiv.org/pdf/1803.05069.pdf)).
 
-#![deny(missing_docs)]
+#![cfg_attr(not(feature = "fuzzing"), deny(missing_docs))]
 #![feature(async_await)]
 #![recursion_limit = "512"]
 extern crate failure;
@@ -16,8 +16,15 @@ extern crate failure;
 #[macro_use]
 extern crate debug_interface;
 
+#[cfg(not(feature = "fuzzing"))]
 mod chained_bft;
+#[cfg(feature = "fuzzing")]
+pub mod chained_bft;
+
+#[cfg(not(any(test, feature = "fuzzing")))]
 mod util;
+#[cfg(any(test, feature = "fuzzing"))]
+pub mod util;
 
 /// Defines the public consensus provider traits to implement for
 /// use in the Libra Core blockchain.

--- a/consensus/src/util/mod.rs
+++ b/consensus/src/util/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod mock_time_service;
 pub mod time_service;
 #[cfg(test)]

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"
 edition = "2018"
 
+# common dependencies
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
 canonical_serialization = { path = "../../common/canonical_serialization" }
@@ -23,6 +24,9 @@ types = { path = "../../types" }
 vm = { path = "../../language/vm" }
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types" }
 
+# for fuzzing consensus
+consensus = { path = "../../consensus"}
+
 [dev-dependencies]
 datatest = "0.4.2"
 stats_alloc = "0.1.8"
@@ -33,5 +37,6 @@ vm = { path = "../../language/vm", features = ["testing"] }
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types", features = ["testing"] }
 
 [features]
-default = ["testing"]
+default = ["testing", "fuzzing"]
 testing = ["types/testing", "vm/testing", "vm_runtime_types/testing"]
+fuzzing = ["consensus/fuzzing"]

--- a/testsuite/libra_fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra_fuzzer/fuzz/Cargo.toml
@@ -13,11 +13,6 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 libra_fuzzer = { path = ".." }
 lazy_static = { version = "1.3.0", default-features = false }
 
-# futures-preview is pinned to 0.3.0-alpha.17 by some other packages. The latest version
-# 0.3.0-alpha.16 doesn't compile with the current Rust toolchain, and we don't depend on any
-# packages that pin futures exactly, so do it here.
-futures-preview = { version = "=0.3.0-alpha.17", default-features = false }
-
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/testsuite/libra_fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets.rs
@@ -58,6 +58,7 @@ macro_rules! proto_fuzz_target {
 
 // List fuzz target modules here.
 mod compiled_module;
+mod consensus_proposal;
 mod signed_transaction;
 mod vm_value;
 
@@ -68,6 +69,7 @@ lazy_static! {
             Box::new(compiled_module::CompiledModuleTarget::default()),
             Box::new(signed_transaction::SignedTransactionTarget::default()),
             Box::new(vm_value::ValueTarget::default()),
+            Box::new(consensus_proposal::ConsensusProposal::default()),
         ];
         targets.into_iter().map(|target| (target.name(), target)).collect()
     };

--- a/testsuite/libra_fuzzer/src/fuzz_targets/consensus_proposal.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets/consensus_proposal.rs
@@ -1,0 +1,26 @@
+use crate::FuzzTargetImpl;
+use consensus::chained_bft::event_processor::event_processor_fuzzing::{
+    fuzz_proposal, generate_corpus_proposal,
+};
+use proptest_helpers::ValueGenerator;
+
+#[derive(Clone, Debug, Default)]
+pub struct ConsensusProposal;
+
+impl FuzzTargetImpl for ConsensusProposal {
+    fn name(&self) -> &'static str {
+        module_name!()
+    }
+
+    fn description(&self) -> &'static str {
+        "Consensus proposal messages"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_corpus_proposal())
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzz_proposal(data);
+    }
+}

--- a/testsuite/libra_fuzzer/src/main.rs
+++ b/testsuite/libra_fuzzer/src/main.rs
@@ -1,6 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-
 //! Helpers for fuzz testing.
 
 use lazy_static::lazy_static;


### PR DESCRIPTION
**MOTIVATION:**

This PR sets up two things:

* an `event_processor_fuzzing.rs` next to `event_processor_test.rs`. The file contains a necessary function for a fuzzer, and a test so that breaking changes in EventProcessor won't break the fuzzer.
* calls from our test suite's Libra fuzzer.

The fuzzer is not finished, but this brings the foundation we can work on to finish the fuzzer.

**TEST PLAN:**

```
cargo test -p consensus
```
