### PR TITLE
[logging] do not print full transaction content in Debug level

### DIFF
--- a/language/vm/vm_runtime/src/runtime.rs
+++ b/language/vm/vm_runtime/src/runtime.rs
@@ -66,7 +66,7 @@ impl<'alloc> VMRuntime<'alloc> {
         txn: SignedTransaction,
         data_view: &dyn StateView,
     ) -> Option<VMStatus> {
-        debug!("[VM] Verify transaction: {:?}", txn);
+        trace!("[VM] Verify transaction: {:?}", txn);
         // Treat a transaction as a single block.
         let module_cache =
             BlockModuleCache::new(&self.code_cache, ModuleFetcherImpl::new(data_view));


### PR DESCRIPTION
## Motivation

Make debug level logging sane again.
Printing all transaction content make all other logging disappear in the sea of bytecodes

This is a 1 word change: `debug!` -> `trace!`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(y)

## Test Plan
Hope for the best + CI

