### PR TITLE
[VM][Tools] Add support for structs in bytecode generation

### DIFF
--- a/language/tools/cost_synthesis/src/common.rs
+++ b/language/tools/cost_synthesis/src/common.rs
@@ -31,9 +31,3 @@ pub const DEFAULT_FUNCTION_IDX: TableIndex = 0;
 
 /// The type of the value stack.
 pub type Stack = Vec<Local>;
-
-/// The minimum number of instructions to generate for function bodies
-pub const MIN_BYTECODE_INSTRUCTIONS: usize = 10;
-
-/// The maximum number of instructions to generate for function bodies
-pub const MAX_BYTECODE_INSTRUCTIONS: usize = 20;

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -18,7 +18,7 @@ use bytecode_generator::BytecodeGenerator;
 use bytecode_verifier::VerifiedModule;
 use cost_synthesis::module_generator::ModuleBuilder;
 use vm::{
-    file_format::{Bytecode, FunctionSignature, SignatureToken},
+    file_format::{Bytecode, CompiledModuleMut, FunctionSignature, SignatureToken},
     CompiledModule,
 };
 
@@ -41,11 +41,10 @@ fn run_verifier(module: CompiledModule) -> u64 {
 pub fn generate_bytecode(
     arguments: &[SignatureToken],
     signature: &FunctionSignature,
-    target_min: usize,
-    target_max: usize,
+    module: CompiledModuleMut,
 ) -> Vec<Bytecode> {
     let mut bytecode_generator = BytecodeGenerator::new(None);
-    bytecode_generator.generate(arguments, signature, target_min, target_max)
+    bytecode_generator.generate(arguments, signature, module)
 }
 
 /// Run generate_bytecode for 'iterations' iterations and test each generated module

--- a/language/tools/test_generation/src/summaries.rs
+++ b/language/tools/test_generation/src/summaries.rs
@@ -5,8 +5,9 @@ use crate::{
     abstract_state::{AbstractState, AbstractValue, BorrowState},
     state_local_availability_is, state_local_exists, state_local_kind_is, state_local_place,
     state_local_set, state_local_take, state_local_take_borrow, state_never, state_stack_has,
-    state_stack_has_polymorphic_eq, state_stack_local_polymorphic_eq, state_stack_pop,
-    state_stack_push, state_stack_push_register,
+    state_stack_has_polymorphic_eq, state_stack_has_struct, state_stack_local_polymorphic_eq,
+    state_stack_pack_struct, state_stack_pop, state_stack_push, state_stack_push_register,
+    state_stack_satisfies_struct_signature, state_stack_unpack_struct,
     transitions::*,
 };
 use vm::file_format::{Bytecode, Kind, SignatureToken};
@@ -344,6 +345,14 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
         Bytecode::BrFalse(_) => Summary {
             preconditions: vec![state_never!()],
             effects: vec![state_stack_pop!()],
+        },
+        Bytecode::Pack(i, _) => Summary {
+            preconditions: vec![state_stack_satisfies_struct_signature!(i)],
+            effects: vec![state_stack_pack_struct!(i), state_stack_push_register!()],
+        },
+        Bytecode::Unpack(i, _) => Summary {
+            preconditions: vec![state_stack_has_struct!(i)],
+            effects: vec![state_stack_pop!(), state_stack_unpack_struct!(i)],
         },
         _ => Summary {
             preconditions: vec![state_never!()],

--- a/language/tools/test_generation/tests/struct_instructions.rs
+++ b/language/tools/test_generation/tests/struct_instructions.rs
@@ -1,0 +1,167 @@
+extern crate test_generation;
+use std::collections::HashMap;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
+use vm::{
+    access::ModuleAccess,
+    file_format::{
+        empty_module, Bytecode, CompiledModule, CompiledModuleMut, FieldDefinition,
+        FieldDefinitionIndex, Kind, LocalsSignatureIndex, MemberCount, ModuleHandleIndex,
+        SignatureToken, StringPoolIndex, StructDefinition, StructDefinitionIndex,
+        StructFieldInformation, StructHandle, StructHandleIndex, TableIndex, TypeSignature,
+        TypeSignatureIndex,
+    },
+    views::{SignatureTokenView, StructDefinitionView, ViewInternals},
+};
+
+mod common;
+
+fn generate_module_with_struct() -> CompiledModuleMut {
+    let mut module: CompiledModuleMut = empty_module();
+    module.type_signatures = vec![
+        SignatureToken::Bool,
+        SignatureToken::U64,
+        SignatureToken::String,
+        SignatureToken::ByteArray,
+        SignatureToken::Address,
+    ]
+    .into_iter()
+    .map(TypeSignature)
+    .collect();
+
+    let struct_index = 0;
+    let num_fields = 5;
+    let offset = module.string_pool.len() as TableIndex;
+    module.string_pool.push("struct0".to_string());
+
+    let field_information = StructFieldInformation::Declared {
+        field_count: num_fields as MemberCount,
+        fields: FieldDefinitionIndex::new(module.field_defs.len() as TableIndex),
+    };
+    let struct_def = StructDefinition {
+        struct_handle: StructHandleIndex(struct_index),
+        field_information,
+    };
+    module.struct_defs.push(struct_def);
+
+    for i in 0..num_fields {
+        module.string_pool.push(format!("string{}", i));
+        let struct_handle_idx = StructHandleIndex::new(struct_index);
+        let typ_idx = TypeSignatureIndex::new(0);
+        let str_pool_idx = StringPoolIndex::new(i + 1 as TableIndex);
+        let field_def = FieldDefinition {
+            struct_: struct_handle_idx,
+            name: str_pool_idx,
+            signature: typ_idx,
+        };
+        module.field_defs.push(field_def);
+    }
+    module.struct_handles = vec![StructHandle {
+        module: ModuleHandleIndex::new(0),
+        name: StringPoolIndex::new((struct_index + offset) as TableIndex),
+        is_nominal_resource: false,
+        type_formals: vec![],
+    }];
+    module
+}
+
+#[test]
+#[should_panic]
+fn bytecode_pack_signature_not_satisfied() {
+    let module: CompiledModuleMut = generate_module_with_struct();
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::Pack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+fn bytecode_pack() {
+    let module: CompiledModuleMut = generate_module_with_struct();
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    let state1_copy = state1.clone();
+    let struct_def = state1_copy
+        .module
+        .struct_def_at(StructDefinitionIndex::new(0));
+    let struct_def_view = StructDefinitionView::new(&state1_copy.module, struct_def);
+    let token_views: Vec<SignatureTokenView<'_, CompiledModule>> = struct_def_view
+        .fields()
+        .into_iter()
+        .flatten()
+        .map(|field| field.type_signature().token())
+        .collect();
+    for token_view in token_views {
+        let abstract_value = AbstractValue {
+            token: token_view.as_inner().clone(),
+            kind: token_view.kind(),
+        };
+        state1.stack_push(abstract_value);
+    }
+    let state2 = common::run_instruction(
+        Bytecode::Pack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    let struct_value = state2.stack_peek(0).expect("struct not added to stack");
+    assert!(
+        match struct_value.token {
+            SignatureToken::Struct(struct_handle, _) => struct_handle == struct_def.struct_handle,
+            _ => false,
+        },
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_unpack_signature_not_satisfied() {
+    let module: CompiledModuleMut = generate_module_with_struct();
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+fn bytecode_unpack() {
+    let module: CompiledModuleMut = generate_module_with_struct();
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    let state1_copy = state1.clone();
+    let struct_def = state1_copy
+        .module
+        .struct_def_at(StructDefinitionIndex::new(0));
+    let struct_def_view = StructDefinitionView::new(&state1_copy.module, struct_def);
+    let tokens: Vec<SignatureToken> = struct_def_view
+        .fields()
+        .into_iter()
+        .flatten()
+        .map(|field| field.type_signature().token().as_inner().clone())
+        .collect();
+    let struct_kind = match struct_def_view.is_nominal_resource() {
+        true => Kind::Resource,
+        false => tokens
+            .iter()
+            .map(|token| SignatureTokenView::new(&state1_copy.module, token).kind())
+            .fold(Kind::Unrestricted, |acc_kind, next_kind| {
+                match (acc_kind, next_kind) {
+                    (Kind::All, _) | (_, Kind::All) => Kind::All,
+                    (Kind::Resource, _) | (_, Kind::Resource) => Kind::Resource,
+                    (Kind::Unrestricted, Kind::Unrestricted) => Kind::Unrestricted,
+                }
+            }),
+    };
+    let struct_value = AbstractValue::new_struct(
+        SignatureToken::Struct(struct_def.struct_handle, tokens.clone()),
+        struct_kind,
+    );
+    state1.stack_push(struct_value);
+    let state2 = common::run_instruction(
+        Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    assert_eq!(
+        state2.stack_len(),
+        tokens.len(),
+        "stack type postcondition not met"
+    );
+}


### PR DESCRIPTION
## Motivation

This commit adds module state to abstract states. This module state is then referenced for the creation and destruction of structs.

This commit also fixes a bug in `cost_synthesis` where a structure may be generated with duplicate field names. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test` and running on bytecode verifier. Added tests for `Pack` and `Unpack`.

## Related PRs

N/A
