### PR TITLE
[memsocket] fix overflow bug

### DIFF
--- a/network/memsocket/src/lib.rs
+++ b/network/memsocket/src/lib.rs
@@ -107,7 +107,20 @@ impl MemoryListener {
                     Some(p) => p,
                     None => unreachable!(),
                 };
-                switchboard.1 += 1;
+
+                // The switchboard is full and all ports are in use
+                if switchboard.0.len() == (std::u16::MAX - 1) as usize {
+                    return Err(ErrorKind::AddrInUse.into());
+                }
+
+                // Instead of overflowing to 0, resume searching at port 1 since port 0 isn't a
+                // valid port to bind to.
+                if switchboard.1 == std::u16::MAX {
+                    switchboard.1 = 1;
+                } else {
+                    switchboard.1 += 1;
+                }
+
                 if !switchboard.0.contains_key(&port) {
                     break port;
                 }


### PR DESCRIPTION
When searching for an open port there is the potential for overflowing
which would cause a panic when trying to convert a 0 into a
`NonZeroU16`. Instead of overflowing, detect that the overflow would
happen and instead resume searching from port 1 if the switchboard isn't
full.