### PR TITLE
[state-sync] Verify signatures on LedgerInfo before processing

### DIFF
--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -145,6 +145,10 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         let response = (self.handler)(self.mock_chunk_response(known_version));
         async move { response }.boxed()
     }
+
+    fn validate_ledger_info(&self, _target: &LedgerInfo) -> Result<()> {
+        Ok(())
+    }
 }
 
 struct SynchronizerEnv {


### PR DESCRIPTION
## Motivation

Before coordinator can process chunk response, we need to check that there are 2f+1 signatures on ledger info and each of them are valid (signed by trusted nodes). Later on executor should check each chunk before applying it to storage, but putting in state sync layer for now since executor doesn't check for signatures at the moment.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests in state_synchronizer crate + integration test passes