### PR TITLE
[language/verifier] fix type & memory safety checks for generics

### DIFF
--- a/language/bytecode_verifier/invalid_mutations/src/bounds.rs
+++ b/language/bytecode_verifier/invalid_mutations/src/bounds.rs
@@ -64,6 +64,7 @@ impl PointerKind {
             // XXX maybe don't treat LocalPool and CodeDefinition the same way as the others?
             LocalPool => &[],
             CodeDefinition => &[],
+            TypeParameter => &[],
         }
     }
 

--- a/language/bytecode_verifier/src/resources.rs
+++ b/language/bytecode_verifier/src/resources.rs
@@ -28,9 +28,11 @@ impl<'a> ResourceTransitiveChecker<'a> {
                 match struct_def.fields() {
                     None => (),
                     Some(mut fields) => {
-                        // TODO must be rethought with generics
-                        let any_resource_field =
-                            fields.any(|field| field.type_signature().contains_nominal_resource());
+                        let any_resource_field = fields.any(|field| {
+                            field
+                                .type_signature()
+                                .contains_nominal_resource(struct_def.type_formals())
+                        });
                         if any_resource_field {
                             errors.push(VerificationError {
                                 kind: IndexKind::StructDefinition,

--- a/language/bytecode_verifier/src/type_memory_safety.rs
+++ b/language/bytecode_verifier/src/type_memory_safety.rs
@@ -57,10 +57,9 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     AbstractValue::Reference(Nonce::new(arg_idx)),
                 );
             } else {
-                locals.insert(
-                    arg_idx as LocalIndex,
-                    AbstractValue::full_value(arg_type_view.kind()),
-                );
+                let arg_kind = arg_type_view
+                    .kind(&function_definition_view.signature().as_inner().type_formals);
+                locals.insert(arg_idx as LocalIndex, AbstractValue::full_value(arg_kind));
             }
         }
         let initial_state = AbstractState::new(locals, BTreeMap::new());
@@ -127,6 +126,15 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
         existing_borrows.is_empty()
     }
 
+    /// Gives the current constraints on the type formals in the current function.
+    fn type_formals(&self) -> &[Kind] {
+        &self
+            .function_definition_view
+            .signature()
+            .as_inner()
+            .type_formals
+    }
+
     fn is_readable_reference(
         &self,
         state: &AbstractState,
@@ -190,7 +198,8 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
         match bytecode {
             Bytecode::Pop => {
                 let operand = self.stack.pop().unwrap();
-                let kind = SignatureTokenView::new(self.module(), &operand.signature).kind();
+                let kind = SignatureTokenView::new(self.module(), &operand.signature)
+                    .kind(self.type_formals());
                 if kind != Kind::Unrestricted {
                     return Err(VMStaticViolation::PopResourceError(offset));
                 }
@@ -300,7 +309,11 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     .0
                     .clone();
                 self.stack.push(StackAbstractValue {
-                    signature: SignatureToken::MutableReference(Box::new(field_signature)),
+                    signature: SignatureToken::MutableReference(Box::new(
+                        field_signature.substitute(
+                            operand.signature.get_type_actuals_from_reference().unwrap(),
+                        ),
+                    )),
                     value: AbstractValue::Reference(nonce.clone()),
                 });
                 state.borrow_field_from_nonce(
@@ -335,7 +348,11 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     .0
                     .clone();
                 self.stack.push(StackAbstractValue {
-                    signature: SignatureToken::Reference(Box::new(field_signature)),
+                    signature: SignatureToken::Reference(Box::new(
+                        field_signature.substitute(
+                            operand.signature.get_type_actuals_from_reference().unwrap(),
+                        ),
+                    )),
                     value: AbstractValue::Reference(nonce.clone()),
                 });
                 state.borrow_field_from_nonce(
@@ -400,7 +417,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     });
                     Ok(())
                 } else {
-                    match signature_view.kind() {
+                    match signature_view.kind(self.type_formals()) {
                         Kind::Resource | Kind::All => {
                             Err(VMStaticViolation::CopyLocResourceError(offset))
                         }
@@ -474,12 +491,13 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 Ok(())
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::Call(idx, _) => {
+            Bytecode::Call(idx, type_actuals_idx) => {
                 let function_handle = self.module().function_handle_at(*idx);
                 let function_signature = self
                     .module()
                     .function_signature_at(function_handle.signature);
+
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
 
                 let function_acquired_resources = self
                     .module_view
@@ -496,7 +514,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 let mut mutable_references_to_borrow_from = BTreeSet::new();
                 for arg_type in function_signature.arg_types.iter().rev() {
                     let arg = self.stack.pop().unwrap();
-                    if arg.signature != *arg_type {
+                    if arg.signature != arg_type.substitute(type_actuals) {
                         return Err(VMStaticViolation::CallTypeMismatchError(offset));
                     }
                     if arg_type.is_mutable_reference() && !state.is_full(&arg.value) {
@@ -521,13 +539,16 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                             state.borrow_from_nonces(&all_references_to_borrow_from, nonce.clone());
                         }
                         self.stack.push(StackAbstractValue {
-                            signature: return_type_view.as_inner().clone(),
+                            signature: return_type_view.as_inner().substitute(type_actuals),
                             value: AbstractValue::Reference(nonce),
                         });
                     } else {
+                        let return_type = return_type_view.as_inner().substitute(type_actuals);
+                        let kind = SignatureTokenView::new(self.module(), &return_type)
+                            .kind(self.type_formals());
                         self.stack.push(StackAbstractValue {
-                            signature: return_type_view.as_inner().clone(),
-                            value: AbstractValue::full_value(return_type_view.kind()),
+                            signature: return_type,
+                            value: AbstractValue::full_value(kind),
                         });
                     }
                 }
@@ -537,9 +558,15 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 Ok(())
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::Pack(idx, _) => {
+            Bytecode::Pack(idx, type_actuals_idx) => {
+                // Build and verify the struct type.
                 let struct_definition = self.module().struct_def_at(*idx);
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
+                let struct_type =
+                    SignatureToken::Struct(struct_definition.struct_handle, type_actuals.clone());
+                let kind =
+                    SignatureTokenView::new(self.module(), &struct_type).kind(self.type_formals());
+
                 let struct_definition_view =
                     StructDefinitionView::new(self.module(), struct_definition);
                 match struct_definition_view.fields() {
@@ -551,36 +578,43 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     Some(fields) => {
                         for field_definition_view in fields.rev() {
                             let field_signature_view = field_definition_view.type_signature();
+                            // Substitute type variables with actual types.
+                            let field_type = field_signature_view
+                                .token()
+                                .as_inner()
+                                .substitute(type_actuals);
+                            // TODO: is it necessary to verify kind constraints here?
                             let arg = self.stack.pop().unwrap();
-                            if arg.signature != *field_signature_view.token().as_inner() {
+                            if arg.signature != field_type {
                                 self.errors
                                     .push(VMStaticViolation::PackTypeMismatchError(offset));
                             }
                         }
                     }
                 }
-                // TODO Handle type arguments for kind
-                let kind = if struct_definition_view.is_nominal_resource() {
-                    Kind::Resource
-                } else {
-                    Kind::Unrestricted
-                };
+
                 self.stack.push(StackAbstractValue {
-                    signature: SignatureToken::Struct(struct_definition.struct_handle, vec![]),
+                    signature: struct_type,
                     value: AbstractValue::full_value(kind),
                 });
                 Ok(())
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::Unpack(idx, _) => {
+            Bytecode::Unpack(idx, type_actuals_idx) => {
+                // Build and verify the struct type.
                 let struct_definition = self.module().struct_def_at(*idx);
-                let struct_arg = self.stack.pop().unwrap();
-                if struct_arg.signature
-                    != SignatureToken::Struct(struct_definition.struct_handle, vec![])
-                {
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
+                let struct_type =
+                    SignatureToken::Struct(struct_definition.struct_handle, type_actuals.clone());
+
+                // Pop an abstract value from the stack and check if its type is equal to the one
+                // declared. TODO: is it safe to not call verify the kinds if the types are equal?
+                let arg = self.stack.pop().unwrap();
+                if arg.signature != struct_type {
                     return Err(VMStaticViolation::UnpackTypeMismatchError(offset));
                 }
+
+                // For each field, push an abstract value to the stack.
                 let struct_definition_view =
                     StructDefinitionView::new(self.module(), struct_definition);
                 match struct_definition_view.fields() {
@@ -592,9 +626,17 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     Some(fields) => {
                         for field_definition_view in fields {
                             let field_signature_view = field_definition_view.type_signature();
+                            // Substitute type variables with actual types.
+                            let field_type = field_signature_view
+                                .token()
+                                .as_inner()
+                                .substitute(type_actuals);
+                            // Get the kind of the type.
+                            let kind = SignatureTokenView::new(self.module(), &field_type)
+                                .kind(self.type_formals());
                             self.stack.push(StackAbstractValue {
-                                signature: field_signature_view.token().as_inner().clone(),
-                                value: AbstractValue::full_value(field_signature_view.kind()),
+                                signature: field_type,
+                                value: AbstractValue::full_value(kind),
                             })
                         }
                     }
@@ -619,7 +661,8 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                         SignatureToken::MutableReference(signature) => signature,
                         _ => panic!("Unreachable"),
                     };
-                    if SignatureTokenView::new(self.module(), &inner_signature).kind()
+                    if SignatureTokenView::new(self.module(), &inner_signature)
+                        .kind(self.type_formals())
                         != Kind::Unrestricted
                     {
                         Err(VMStaticViolation::ReadRefResourceError(offset))
@@ -638,7 +681,8 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 let ref_operand = self.stack.pop().unwrap();
                 let val_operand = self.stack.pop().unwrap();
                 if let SignatureToken::MutableReference(signature) = ref_operand.signature {
-                    let kind = SignatureTokenView::new(self.module(), &signature).kind();
+                    let kind = SignatureTokenView::new(self.module(), &signature)
+                        .kind(self.type_formals());
                     match kind {
                         Kind::Resource | Kind::All => {
                             Err(VMStaticViolation::WriteRefResourceError(offset))
@@ -716,7 +760,8 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
             Bytecode::Eq | Bytecode::Neq => {
                 let operand1 = self.stack.pop().unwrap();
                 let operand2 = self.stack.pop().unwrap();
-                let kind1 = SignatureTokenView::new(self.module(), &operand1.signature).kind();
+                let kind1 = SignatureTokenView::new(self.module(), &operand1.signature)
+                    .kind(self.type_formals());
                 let is_copyable = kind1 == Kind::Unrestricted;
                 if is_copyable && operand1.signature == operand2.signature {
                     if let AbstractValue::Reference(nonce) = operand1.value {
@@ -759,14 +804,18 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 }
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::Exists(idx, _) => {
+            Bytecode::Exists(idx, type_actuals_idx) => {
                 let struct_definition = self.module().struct_def_at(*idx);
                 if !StructDefinitionView::new(self.module(), struct_definition)
                     .is_nominal_resource()
                 {
                     return Err(VMStaticViolation::ExistsNoResourceError(offset));
                 }
+
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
+                let struct_type =
+                    SignatureToken::Struct(struct_definition.struct_handle, type_actuals.clone());
+                SignatureTokenView::new(self.module(), &struct_type).kind(self.type_formals());
 
                 let operand = self.stack.pop().unwrap();
                 if operand.signature == SignatureToken::Address {
@@ -780,8 +829,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 }
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::BorrowGlobal(idx, _) => {
+            Bytecode::BorrowGlobal(idx, type_actuals_idx) => {
                 let struct_definition = self.module().struct_def_at(*idx);
                 if !StructDefinitionView::new(self.module(), struct_definition)
                     .is_nominal_resource()
@@ -791,14 +839,17 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     return Err(VMStaticViolation::GlobalReferenceError(offset));
                 }
 
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
+                let struct_type =
+                    SignatureToken::Struct(struct_definition.struct_handle, type_actuals.clone());
+                SignatureTokenView::new(self.module(), &struct_type).kind(self.type_formals());
+
                 let operand = self.stack.pop().unwrap();
                 if operand.signature == SignatureToken::Address {
                     let nonce = self.get_nonce(&mut state);
                     state.borrow_from_global_value(*idx, nonce.clone());
                     self.stack.push(StackAbstractValue {
-                        signature: SignatureToken::MutableReference(Box::new(
-                            SignatureToken::Struct(struct_definition.struct_handle, vec![]),
-                        )),
+                        signature: SignatureToken::MutableReference(Box::new(struct_type)),
                         value: AbstractValue::Reference(nonce),
                     });
                     Ok(())
@@ -807,8 +858,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 }
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::MoveFrom(idx, _) => {
+            Bytecode::MoveFrom(idx, type_actuals_idx) => {
                 let struct_definition = self.module().struct_def_at(*idx);
                 if !StructDefinitionView::new(self.module(), struct_definition)
                     .is_nominal_resource()
@@ -818,10 +868,15 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     return Err(VMStaticViolation::GlobalReferenceError(offset));
                 }
 
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
+                let struct_type =
+                    SignatureToken::Struct(struct_definition.struct_handle, type_actuals.clone());
+                SignatureTokenView::new(self.module(), &struct_type).kind(self.type_formals());
+
                 let operand = self.stack.pop().unwrap();
                 if operand.signature == SignatureToken::Address {
                     self.stack.push(StackAbstractValue {
-                        signature: SignatureToken::Struct(struct_definition.struct_handle, vec![]),
+                        signature: struct_type,
                         value: AbstractValue::full_value(Kind::Resource),
                     });
                     Ok(())
@@ -830,8 +885,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                 }
             }
 
-            // TODO: Handle type actuals for generics
-            Bytecode::MoveToSender(idx, _) => {
+            Bytecode::MoveToSender(idx, type_actuals_idx) => {
                 let struct_definition = self.module().struct_def_at(*idx);
                 if !StructDefinitionView::new(self.module(), struct_definition)
                     .is_nominal_resource()
@@ -839,10 +893,13 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     return Err(VMStaticViolation::MoveToSenderNoResourceError(offset));
                 }
 
+                let type_actuals = &self.module().locals_signature_at(*type_actuals_idx).0;
+                let struct_type =
+                    SignatureToken::Struct(struct_definition.struct_handle, type_actuals.clone());
+                SignatureTokenView::new(self.module(), &struct_type).kind(self.type_formals());
+
                 let value_operand = self.stack.pop().unwrap();
-                if value_operand.signature
-                    == SignatureToken::Struct(struct_definition.struct_handle, vec![])
-                {
+                if value_operand.signature == struct_type {
                     Ok(())
                 } else {
                     Err(VMStaticViolation::MoveToSenderTypeMismatchError(offset))

--- a/language/functional_tests/tests/testsuite/generics/id_function.mvir
+++ b/language/functional_tests/tests/testsuite/generics/id_function.mvir
@@ -1,0 +1,19 @@
+module M {
+    public id<T>(x: T): T {
+        return move(x);
+    }
+}
+
+
+
+//! new-transaction
+
+import {{default}}.M;
+
+main() {
+    let x: u64;
+    let y: u64;
+    y = 42;
+    x = M.id<u64>(move(y));
+    return;
+}

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_field.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_field.mvir
@@ -1,0 +1,16 @@
+module M {
+    struct Foo<T>{ x: T }
+
+    baz(x: u64) {
+        return;
+    }
+
+    bar<T>(x: Self.Foo<u64>) {
+        let y: &mut u64;
+        let z: u64;
+        y = &mut (&mut x).x;
+        _ = move(y);
+        Foo<u64> { x: z } = move(x);
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_global.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_global.mvir
@@ -1,0 +1,16 @@
+module M {
+    resource Foo<T> { x: T }
+
+    drop_ref(ref: &mut Self.Foo<u64>) {
+        _ = move(ref);
+        return;
+    }
+
+    bar() acquires Foo {
+        let x: &mut Self.Foo<u64>;
+        let y: Self.Foo<u64>;
+        x = borrow_global<Foo<u64>>(0x100);
+        Self.drop_ref(move(x));
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/call.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/call.mvir
@@ -1,0 +1,14 @@
+module M {
+    id<T>(x: T): T {
+        return move(x);
+    }
+
+    foo<T: resource>(x: T)  {
+        let y: T;
+        y = Self.id<T>(move(x));
+        y = copy(y);
+        return;
+    }
+}
+
+// check: CopyLocResourceError

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/imm_borrow_field.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/imm_borrow_field.mvir
@@ -1,0 +1,19 @@
+module M {
+    struct Foo<T>{ x: T }
+
+    baz(x: u64) {
+        return;
+    }
+
+    bar<T>(x: Self.Foo<u64>) {
+        let ref: &Self.Foo<u64>;
+        let y: &u64;
+        let z: u64;
+        ref = &x;
+        y = &(&x).x;
+        _ = move(ref);
+        _ = move(y);
+        Foo<u64> { x: z } = move(x);
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/move_from.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/move_from.mvir
@@ -1,0 +1,11 @@
+module M {
+    resource Foo<T> { x: T }
+
+    bar<T: resource>() acquires Foo {
+        let x: Self.Foo<T>;
+        x = move_from<Foo<T>>(0x0);
+        return;
+    }
+}
+
+// check: RetUnsafeToDestroyError

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/pack.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/pack.mvir
@@ -1,0 +1,9 @@
+module M {
+    struct Foo<T1, T2> { x: T1, y: T2 }
+
+    foo<T>(x: T): Self.Foo<u64, T> {
+        let f: Self.Foo<u64, T>;
+        f = Foo<u64, T> { x: 42, y: move(x) };
+        return move(f);
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/struct_non_nominal_resource.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/struct_non_nominal_resource.mvir
@@ -1,0 +1,12 @@
+module M {
+    resource R {}
+    struct Box<T> { x: T }
+
+    foo(x: Self.Box<Self.R>): Self.Box<Self.R> {
+        let y: Self.Box<Self.R>;
+        y = copy(x);
+        return move(y);
+    }
+}
+
+//check: CopyLocResourceError

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/type_param_all.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/type_param_all.mvir
@@ -1,0 +1,9 @@
+module M {
+    foo<T>(x: T): T {
+        let y: T;
+        y = copy(x);
+        return move(y);
+    }
+}
+
+//check: CopyLocResourceError

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/type_param_resource.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/type_param_resource.mvir
@@ -1,0 +1,9 @@
+module M {
+    foo<T: resource>(x: T) {
+        let y: T;
+        y = copy(x);
+        return;
+    }
+}
+
+//check: CopyLocResourceError

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/unpack.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/unpack.mvir
@@ -1,0 +1,11 @@
+module M {
+    resource Foo<T> { x: T }
+
+    baz<T>(x: Self.Foo<T>) {
+        let y: T;
+        Foo<T> { x: y } = move(x);
+        return;
+    }
+}
+
+// check: RetUnsafeToDestroyError

--- a/language/tools/test_generation/src/transitions.rs
+++ b/language/tools/test_generation/src/transitions.rs
@@ -142,7 +142,7 @@ pub fn stack_satisfies_struct_signature(
     for (i, token_view) in field_token_views.enumerate() {
         let abstract_value = AbstractValue {
             token: token_view.as_inner().clone(),
-            kind: token_view.kind(),
+            kind: token_view.kind(&[]),
         };
         if !stack_has(state, i, Some(abstract_value)) {
             satisfied = false;
@@ -190,7 +190,7 @@ pub fn stack_create_struct(
         true => Kind::Resource,
         false => tokens
             .iter()
-            .map(|token| SignatureTokenView::new(&state.module, token).kind())
+            .map(|token| SignatureTokenView::new(&state.module, token).kind(&[]))
             .fold(Kind::Unrestricted, |acc_kind, next_kind| {
                 match (acc_kind, next_kind) {
                     (Kind::All, _) | (_, Kind::All) => Kind::All,
@@ -246,7 +246,7 @@ pub fn stack_unpack_struct(
     for token_view in token_views {
         let abstract_value = AbstractValue {
             token: token_view.as_inner().clone(),
-            kind: token_view.kind(),
+            kind: token_view.kind(&[]),
         };
         state = stack_push(&state, abstract_value)?;
     }

--- a/language/tools/test_generation/tests/struct_instructions.rs
+++ b/language/tools/test_generation/tests/struct_instructions.rs
@@ -77,7 +77,7 @@ fn create_struct_value(module: &CompiledModule) -> AbstractValue {
         true => Kind::Resource,
         false => tokens
             .iter()
-            .map(|token| SignatureTokenView::new(module, token).kind())
+            .map(|token| SignatureTokenView::new(module, token).kind(&[]))
             .fold(Kind::Unrestricted, |acc_kind, next_kind| {
                 match (acc_kind, next_kind) {
                     (Kind::All, _) | (_, Kind::All) => Kind::All,
@@ -112,7 +112,7 @@ fn bytecode_pack() {
         for token in tokens {
             let abstract_value = AbstractValue {
                 token: token.clone(),
-                kind: SignatureTokenView::new(&state1.module, &token).kind(),
+                kind: SignatureTokenView::new(&state1.module, &token).kind(&[]),
             };
             state1.stack_push(abstract_value);
         }

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -321,6 +321,12 @@ pub enum VMStaticViolation {
         display = "Duplicate acquires resource annotaiton. The struct is not a nominal resource."
     )]
     InvalidAcquiresResourceAnnotationError,
+
+    #[fail(display = "The kind of the type actual does not satisfy the constraint.")]
+    ConstraintKindMismatch,
+
+    #[fail(display = "Expected {} type actuals got {}", _0, _1)]
+    NumberOfTypeActualsMismatch(usize, usize),
 }
 
 #[derive(Clone, Debug, Eq, Fail, Ord, PartialEq, PartialOrd)]
@@ -749,6 +755,12 @@ impl From<&VerificationError> for VMVerificationError {
             }
             VMStaticViolation::DuplicateAcquiresResourceAnnotationError => {
                 VMVerificationError::DuplicateAcquiresResourceAnnotationError(message)
+            }
+            VMStaticViolation::ConstraintKindMismatch => {
+                VMVerificationError::ConstraintKindMismatch(message)
+            }
+            VMStaticViolation::NumberOfTypeActualsMismatch(_, _) => {
+                VMVerificationError::NumberOfTypeActualsMismatch(message)
             }
         }
     }

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -48,6 +48,7 @@ pub enum IndexKind {
     AddressPool,
     LocalPool,
     CodeDefinition,
+    TypeParameter,
 }
 
 impl IndexKind {
@@ -69,6 +70,7 @@ impl IndexKind {
             AddressPool,
             LocalPool,
             CodeDefinition,
+            TypeParameter,
         ]
     }
 }
@@ -92,12 +94,14 @@ impl fmt::Display for IndexKind {
             AddressPool => "address pool",
             LocalPool => "local pool",
             CodeDefinition => "code definition pool",
+            TypeParameter => "type parameter",
         };
 
         f.write_str(desc)
     }
 }
 
+// TODO: is this outdated?
 /// Represents the kind of a signature token.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum SignatureTokenKind {

--- a/types/src/proto/vm_errors.proto
+++ b/types/src/proto/vm_errors.proto
@@ -177,6 +177,8 @@ enum VMVerificationErrorKind {
     ExtraneousAcquiresResourceAnnotationError = 72;
     DuplicateAcquiresResourceAnnotationError = 73;
     InvalidAcquiresResourceAnnotationError = 74;
+    ConstraintKindMismatch = 75;
+    NumberOfTypeActualsMismatch = 76;
 }
 
 // These are errors that the VM might raise if a violation of internal

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -114,6 +114,8 @@ pub enum VMVerificationError {
     ExtraneousAcquiresResourceAnnotationError(String),
     DuplicateAcquiresResourceAnnotationError(String),
     InvalidAcquiresResourceAnnotationError(String),
+    ConstraintKindMismatch(String),
+    NumberOfTypeActualsMismatch(String),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -591,6 +593,12 @@ impl IntoProto for VMVerificationError {
             VMVerificationError::DuplicateAcquiresResourceAnnotationError(message) => {
                 (ProtoKind::DuplicateAcquiresResourceAnnotationError, message)
             }
+            VMVerificationError::ConstraintKindMismatch(message) => {
+                (ProtoKind::ConstraintKindMismatch, message)
+            }
+            VMVerificationError::NumberOfTypeActualsMismatch(message) => {
+                (ProtoKind::NumberOfTypeActualsMismatch, message)
+            }
         }
     }
 }
@@ -789,6 +797,12 @@ impl FromProto for VMVerificationError {
             ProtoKind::InvalidAcquiresResourceAnnotationError => Ok(
                 VMVerificationError::InvalidAcquiresResourceAnnotationError(message),
             ),
+            ProtoKind::ConstraintKindMismatch => {
+                Ok(VMVerificationError::ConstraintKindMismatch(message))
+            }
+            ProtoKind::NumberOfTypeActualsMismatch => {
+                Ok(VMVerificationError::NumberOfTypeActualsMismatch(message))
+            }
             ProtoKind::UnknownVerificationError => {
                 bail_err!(DecodingError::UnknownVerificationErrorEncountered)
             }


### PR DESCRIPTION
## Summary
This implements type & memory safety checking for generics. More specifically, it defines how the kind of a (generic) type should be derived, and enforces subkind checking in the verifier.

Here is the list of changes:
- `SIgnatureTokenView`:
  - Reimplemented `fn kind` & fixed `fn contains_nominal_resource`
    - Right now the implementation is kinda hacky. I'm planning to refactor views in the future.
- `bytecode_verifier::type_memory_safety`
  - `ReadRef`, `WriteRef`, `Eq`, `Pop`, `CopyLoc`
    - Now uses the new `SIgnatureTokenView::kind()`. 
    - Other logic unchanged.
  - `Pack`, `Unpack`
    - Kind checking** & substitution*.
  - `Call`
    - Kind checking & substitution.
  - `Exists`, `BorrowGlobal`, `MoveFrom`, `MoveToSender`
    - Kind checking.
    - Fixed the type to be put onto the abstract interpreter stack (if any).
  - `BorrowField`, `ImmBorrowField`
    - Substitution.

**Reviewers: please make sure you verify all of the checks I listed above carefully. It is very easy to forget/mess up something here and we want to make sure that doesn't happen.**

*Substitution means to replace type variables with type actuals.
**Technically speaking kind checking isn't necessary in this module. They're better to be done in the `bytecode_verifier::signature` module. I'll remove these once I get that implemented.

## Test Plan
cargo test