### PR TITLE
[types] proptest refactor to ease generating logical transaction update batches.

### DIFF
--- a/common/proptest_helpers/src/lib.rs
+++ b/common/proptest_helpers/src/lib.rs
@@ -102,7 +102,7 @@ pub fn pick_slice_idxs(max: usize, indexes: &[impl AsRef<PropIndex>]) -> Vec<usi
 ///
 /// There is no blanket `impl<T> AsRef<T> for T`, so `&[PropIndex]` doesn't work with
 /// `&[impl AsRef<PropIndex>]` (unless an impl gets added upstream). `Index` does.
-#[derive(Arbitrary, Clone, Debug)]
+#[derive(Arbitrary, Clone, Copy, Debug)]
 pub struct Index(PropIndex);
 
 impl AsRef<PropIndex> for Index {

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -104,6 +104,11 @@ impl EventHandle {
     }
 
     #[cfg(any(test, feature = "testing"))]
+    pub fn count_mut(&mut self) -> &mut u64 {
+        &mut self.count
+    }
+
+    #[cfg(any(test, feature = "testing"))]
     /// Create a random event handle for testing
     pub fn random_handle(count: u64) -> Self {
         Self {


### PR DESCRIPTION
Introducing the `Arena` and `xyzGen` types.
The `Universe` keeps track of a collection of accounts along with sequences numbers and event handles (which in turn has sequence numbers tracked).
The `xyzGen` types resolve "local" randomness upon creation and when they `materialize()`, get/update "global" info in the arena.

For example, a `RawTransactionGen` has determined Payload upon creation, while gets and increases the account sequence number in the `Universe` when it `materialize()`.


## Motivation

1. We don't need things like `renumber_events()` that's hacky and confusing.
2. Similarly, easy to support more "real" transaction sequence numbers in transaction batches.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes
## Test Plan
Existing coverage.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
