### PR TITLE
[cluster_test] Use intermediate tag for cluster_test validators

### DIFF
--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -143,7 +143,7 @@ impl ClusterTestRunner {
     }
 
     fn redeploy(&mut self, hash: String) -> failure::Result<bool> {
-        if !self.deployment_manager.redeploy(hash) {
+        if !self.deployment_manager.redeploy(hash)? {
             return Ok(false);
         }
         println!("Waiting for 60 seconds to allow ECS to restart tasks...");


### PR DESCRIPTION
Previously ECS in cluster_test was configured to use `nightly` tag.
This introduced problem, because we don't control when nightly tag changes. If it changes during reboot experiment, validator come back with newer code, that might be incompatible with existing cluster.

This PR changed cluster_test to use separate `cluster_test` image tag. When `nightly` tag changes, we first re-tag this image with `cluster_test` tag, and then update cluster. This makes sure we are in control of a image version that cluster test currently running
