### PR TITLE
[cluster_test] Build scripts

### DIFF
--- a/docker/cluster_test/build.sh
+++ b/docker/cluster_test/build.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+PROXY=""
+if [ "$https_proxy" ]; then
+  PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+fi
+
+rm -f cluster_test_docker_builder_cluster_test
+
+docker build -f $DIR/cluster_test_builder.Dockerfile $DIR/../.. --tag libra_cluster_test_builder $PROXY
+TARGET=$DIR/../../target/cluster_test_docker_builder/
+mkdir -p $TARGET
+if docker ps -f name=libra_cluster_test_builder_container -f ancestor=libra_cluster_test_builder | grep libra_cluster_test_builder_container ; then
+  echo "Builder container is running with latest builder image"
+else
+  echo "Builder image has changed, re-creating builder container"
+  docker rm -f libra_cluster_test_builder_container || echo "Build container did not exist"
+  docker run --name libra_cluster_test_builder_container -d -i -t -v $DIR/../..:/libra libra_cluster_test_builder bash
+fi
+
+docker exec -i -t libra_cluster_test_builder_container bash -c 'source /root/.cargo/env; cargo build -p cluster_test --target-dir /target && /bin/cp /target/debug/cluster_test target/cluster_test_docker_builder/'
+
+if [ "$1" = "--build-docker-image" ]; then
+  ln target/cluster_test_docker_builder/cluster_test cluster_test_docker_builder_cluster_test
+  docker build -f $DIR/cluster_test.Dockerfile $DIR/../.. --tag libra_cluster_test --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+  rm cluster_test_docker_builder_cluster_test
+else
+  echo "Not building docker container, run with --build-docker-image to build docker image"
+  echo "Built binary is in target/cluster_test_docker_builder/cluster_test"
+fi

--- a/docker/cluster_test/cluster_test.Dockerfile
+++ b/docker/cluster_test/cluster_test.Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:stretch
+
+RUN mkdir -p /opt/libra/bin /opt/libra/etc
+COPY cluster_test_docker_builder_cluster_test /opt/libra/bin/cluster_test
+
+# Capture backtrace on error
+ENV RUST_BACKTRACE 1
+
+# Define SEED_PEERS, NODE_CONFIG, PEER_KEYPAIRS, GENESIS_BLOB and PEER_ID environment variables when running
+CMD cd /opt/libra/etc && echo "$NODE_CONFIG" > node.config.toml && echo "$SEED_PEERS" > seed_peers.config.toml && echo "$PEER_KEYPAIRS" > peer_keypairs.config.toml && echo "$GENESIS_BLOB" | base64 -d > genesis.blob && exec /opt/libra/bin/libra_node -f node.config.toml --peer_id "$PEER_ID"
+
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.vcs-ref=$GIT_REV
+LABEL vcs-upstream=$GIT_UPSTREAM

--- a/docker/cluster_test/cluster_test_builder.Dockerfile
+++ b/docker/cluster_test/cluster_test_builder.Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:stretch
+
+# To use http/https proxy while building, use:
+# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
+
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake golang curl
+#     && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+RUN rustup install $(cat rust-toolchain)

--- a/docker/cluster_test/run.sh
+++ b/docker/cluster_test/run.sh
@@ -1,0 +1,10 @@
+# export SLACK_URL="<fill for slack integration>"
+export ALLOW_DEPLOY=yes
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+mv run.out run.out.bak || echo 'run.out does not exist'
+if ! ./cluster_test --workplace cluster-test --run > run.out ; then
+  REQUEST=\{\"text\":\"cluster_test\ terminated\"\}
+  curl -X POST -H 'Content-type: application/json' --data "$REQUEST" "$SLACK_URL"
+  exit 1
+fi


### PR DESCRIPTION
This PR introduces scripts for building cluster_test on mac(or any other platform that supports docker)
To use simply run `docker/cluster_test/build.sh`. First time build will take a lot of time, but then its going to be pretty much as fast as local build: build is incremental, unless `cluster_test_builder.Dockerfile` is changed, which should be rare (it pretty much depends on rust compiler version only)

Currently `build.sh` does not build docker image by default, but instead just produces binary compiled for x64 linux.
`build.sh --build-docker-image` can be used to build docker image as well.

This commit also contains separate run.sh file that can be used to launch cluster_test with nohup. Currently this file should be manually copied to node.
