### PR TITLE
[types] Eliminate unused proto functions (Easy)

### DIFF
--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unit_arg)]
 
+#[cfg(any(test, feature = "testing"))]
 use crate::account_address::AccountAddress;
 #[cfg(any(test, feature = "testing"))]
 use canonical_serialization::SimpleSerializer;
@@ -15,6 +16,7 @@ use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
+#[cfg(any(test, feature = "testing"))]
 use tiny_keccak::sha3_256;
 
 /// Size of an event key.

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -11,19 +11,6 @@ import "proof.proto";
 import "transaction_info.proto";
 import "google/protobuf/wrappers.proto";
 
-// The code for the transaction to execute
-message Program {
-    bytes code = 1;
-    repeated TransactionArgument arguments = 2;
-    repeated bytes modules = 3;
-}
-
-// The code for the transaction to execute
-message Script {
-    bytes code = 1;
-    repeated TransactionArgument arguments = 2;
-}
-
 // An argument to the transaction if the transaction takes arguments
 message TransactionArgument {
     enum ArgType {
@@ -32,13 +19,6 @@ message TransactionArgument {
         STRING = 2;
         BYTEARRAY = 3;
     }
-    ArgType type = 1;
-    bytes data = 2;
-}
-
-// A Move Module to publish
-message Module {
-    bytes code = 1;
 }
 
 // A generic structure that represents signed RawTransaction
@@ -70,30 +50,6 @@ message SignedTransactionsBlock {
     bytes validator_public_key = 2;
     // Signature of the validator that created this block
     bytes validator_signature = 3;
-}
-
-// Set of WriteOps to save to storage.
-message WriteSet {
-    // Set of WriteOp for storage update.
-    repeated WriteOp write_set = 1;
-}
-
-// Write Operation on underlying storage.
-message WriteOp {
-    // AccessPath of the write set.
-    AccessPath access_path = 1;
-    // The value of the write op. Empty if `type` is Delete.
-    bytes value = 2;
-    // WriteOp type.
-    WriteOpType type = 3;
-}
-
-// Type of write operation
-enum WriteOpType {
-    // The WriteOp is to create/update the field from storage.
-    Write = 0;
-    // The WriteOp is to delete the field from storage.
-    Delete = 1;
 }
 
 // Account state as a whole.

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -5,7 +5,6 @@ use canonical_serialization::{
     CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
 };
 use failure::prelude::*;
-use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -35,24 +34,6 @@ impl fmt::Debug for Module {
         f.debug_struct("Module")
             .field("code", &String::from_utf8_lossy(&self.code))
             .finish()
-    }
-}
-
-impl FromProto for Module {
-    type ProtoType = crate::proto::transaction::Module;
-
-    fn from_proto(proto_module: Self::ProtoType) -> Result<Self> {
-        Ok(Module::new(proto_module.get_code().to_vec()))
-    }
-}
-
-impl IntoProto for Module {
-    type ProtoType = crate::proto::transaction::Module;
-
-    fn into_proto(self) -> Self::ProtoType {
-        let mut proto_module = Self::ProtoType::new();
-        proto_module.set_code(self.code);
-        proto_module
     }
 }
 

--- a/types/src/transaction/program.rs
+++ b/types/src/transaction/program.rs
@@ -1,20 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_address::AccountAddress,
-    byte_array::ByteArray,
-    proto::transaction::{TransactionArgument as ProtoArgument, TransactionArgument_ArgType},
-    transaction::transaction_argument::TransactionArgument,
-};
-use byteorder::{LittleEndian, WriteBytesExt};
+use crate::transaction::transaction_argument::TransactionArgument;
 use canonical_serialization::{
     CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
 };
 use failure::prelude::*;
-use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
+use std::fmt;
 
 pub const SCRIPT_HASH_LENGTH: usize = 32;
 
@@ -59,90 +52,6 @@ impl fmt::Debug for Program {
             .field("code", &String::from_utf8_lossy(&self.code))
             .field("args", &self.args)
             .finish()
-    }
-}
-
-impl FromProto for Program {
-    type ProtoType = crate::proto::transaction::Program;
-
-    fn from_proto(proto_program: Self::ProtoType) -> Result<Self> {
-        let mut args = vec![];
-        for arg in proto_program.get_arguments() {
-            let argument = match arg.get_field_type() {
-                TransactionArgument_ArgType::U64 => {
-                    let mut bytes = [0u8; 8];
-                    let data = arg.get_data();
-                    ensure!(
-                        bytes.len() == data.len(),
-                        "data has incorrect length: expected {} bytes, found {} bytes",
-                        bytes.len(),
-                        data.len()
-                    );
-                    bytes.copy_from_slice(arg.get_data());
-                    let amount = u64::from_le_bytes(bytes);
-                    TransactionArgument::U64(amount)
-                }
-                TransactionArgument_ArgType::ADDRESS => {
-                    TransactionArgument::Address(AccountAddress::try_from(arg.get_data())?)
-                }
-                TransactionArgument_ArgType::STRING => {
-                    TransactionArgument::String(String::from_utf8(arg.get_data().to_vec())?)
-                }
-                TransactionArgument_ArgType::BYTEARRAY => {
-                    TransactionArgument::ByteArray(ByteArray::new(arg.get_data().to_vec()))
-                }
-            };
-            args.push(argument);
-        }
-        let mut modules = vec![];
-        for m in proto_program.get_modules() {
-            modules.push(m.to_vec());
-        }
-        Ok(Program::new(
-            proto_program.get_code().to_vec(),
-            modules,
-            args,
-        ))
-    }
-}
-
-impl IntoProto for Program {
-    type ProtoType = crate::proto::transaction::Program;
-
-    fn into_proto(self) -> Self::ProtoType {
-        let mut proto_program = Self::ProtoType::new();
-        proto_program.set_code(self.code);
-        for arg in self.args {
-            let mut argument = ProtoArgument::new();
-
-            match arg {
-                TransactionArgument::U64(amount) => {
-                    argument.set_field_type(TransactionArgument_ArgType::U64);
-                    let mut amount_vec = vec![];
-                    amount_vec
-                        .write_u64::<LittleEndian>(amount)
-                        .expect("Writing to a vec is guaranteed to work");
-                    argument.set_data(amount_vec);
-                }
-                TransactionArgument::Address(address) => {
-                    argument.set_field_type(TransactionArgument_ArgType::ADDRESS);
-                    argument.set_data(address.as_ref().to_vec());
-                }
-                TransactionArgument::String(string) => {
-                    argument.set_field_type(TransactionArgument_ArgType::STRING);
-                    argument.set_data(string.into_bytes());
-                }
-                TransactionArgument::ByteArray(byte_array) => {
-                    argument.set_field_type(TransactionArgument_ArgType::BYTEARRAY);
-                    argument.set_data(byte_array.as_bytes().to_vec())
-                }
-            }
-            proto_program.mut_arguments().push(argument);
-        }
-        for m in self.modules {
-            proto_program.mut_modules().push(m);
-        }
-        proto_program
     }
 }
 

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -1,20 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_address::AccountAddress,
-    byte_array::ByteArray,
-    proto::transaction::{TransactionArgument as ProtoArgument, TransactionArgument_ArgType},
-    transaction::transaction_argument::TransactionArgument,
-};
-use byteorder::{LittleEndian, WriteBytesExt};
+use crate::transaction::transaction_argument::TransactionArgument;
 use canonical_serialization::{
     CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
 };
 use failure::prelude::*;
-use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
+use std::fmt;
 
 #[allow(dead_code)]
 pub const SCRIPT_HASH_LENGTH: usize = 32;
@@ -51,79 +44,6 @@ impl fmt::Debug for Script {
             .field("code", &String::from_utf8_lossy(&self.code))
             .field("args", &self.args)
             .finish()
-    }
-}
-
-impl FromProto for Script {
-    type ProtoType = crate::proto::transaction::Script;
-
-    fn from_proto(proto_script: Self::ProtoType) -> Result<Self> {
-        let mut args = vec![];
-        for arg in proto_script.get_arguments() {
-            let argument = match arg.get_field_type() {
-                TransactionArgument_ArgType::U64 => {
-                    let mut bytes = [0u8; 8];
-                    let data = arg.get_data();
-                    ensure!(
-                        bytes.len() == data.len(),
-                        "data has incorrect length: expected {} bytes, found {} bytes",
-                        bytes.len(),
-                        data.len()
-                    );
-                    bytes.copy_from_slice(arg.get_data());
-                    let amount = u64::from_le_bytes(bytes);
-                    TransactionArgument::U64(amount)
-                }
-                TransactionArgument_ArgType::ADDRESS => {
-                    TransactionArgument::Address(AccountAddress::try_from(arg.get_data())?)
-                }
-                TransactionArgument_ArgType::STRING => {
-                    TransactionArgument::String(String::from_utf8(arg.get_data().to_vec())?)
-                }
-                TransactionArgument_ArgType::BYTEARRAY => {
-                    TransactionArgument::ByteArray(ByteArray::new(arg.get_data().to_vec()))
-                }
-            };
-            args.push(argument);
-        }
-        Ok(Script::new(proto_script.get_code().to_vec(), args))
-    }
-}
-
-impl IntoProto for Script {
-    type ProtoType = crate::proto::transaction::Script;
-
-    fn into_proto(self) -> Self::ProtoType {
-        let mut proto_script = Self::ProtoType::new();
-        proto_script.set_code(self.code);
-        for arg in self.args {
-            let mut argument = ProtoArgument::new();
-
-            match arg {
-                TransactionArgument::U64(amount) => {
-                    argument.set_field_type(TransactionArgument_ArgType::U64);
-                    let mut amount_vec = vec![];
-                    amount_vec
-                        .write_u64::<LittleEndian>(amount)
-                        .expect("Writing to a vec is guaranteed to work");
-                    argument.set_data(amount_vec);
-                }
-                TransactionArgument::Address(address) => {
-                    argument.set_field_type(TransactionArgument_ArgType::ADDRESS);
-                    argument.set_data(address.as_ref().to_vec());
-                }
-                TransactionArgument::String(string) => {
-                    argument.set_field_type(TransactionArgument_ArgType::STRING);
-                    argument.set_data(string.into_bytes());
-                }
-                TransactionArgument::ByteArray(byte_array) => {
-                    argument.set_field_type(TransactionArgument_ArgType::BYTEARRAY);
-                    argument.set_data(byte_array.as_bytes().to_vec())
-                }
-            }
-            proto_script.mut_arguments().push(argument);
-        }
-        proto_script
     }
 }
 

--- a/types/src/unit_tests/transaction_proto_conversion_test.rs
+++ b/types/src/unit_tests/transaction_proto_conversion_test.rs
@@ -17,11 +17,6 @@ proptest! {
     }
 
     #[test]
-    fn test_program(program in any::<Program>()) {
-        assert_protobuf_encode_decode(&program);
-    }
-
-    #[test]
     fn test_transaction_info(txn_info in any::<TransactionInfo>()) {
         assert_protobuf_encode_decode(&txn_info);
     }

--- a/types/src/unit_tests/write_set_test.rs
+++ b/types/src/unit_tests/write_set_test.rs
@@ -6,14 +6,8 @@ use canonical_serialization::{
     CanonicalDeserializer, CanonicalSerializer, SimpleDeserializer, SimpleSerializer,
 };
 use proptest::prelude::*;
-use proto_conv::test_helper::assert_protobuf_encode_decode;
 
 proptest! {
-    #[test]
-    fn write_set_roundtrip(write_set in any::<WriteSet>()) {
-        assert_protobuf_encode_decode(&write_set);
-    }
-
     #[test]
     fn write_set_roundtrip_canonical_serialization(write_set in any::<WriteSet>()) {
         let mut serializer = SimpleSerializer::<Vec<u8>>::new();


### PR DESCRIPTION
Now that SignedTransaction is fully in LCS we can eliminate all this
unnecessary code. Yay.