### PR TITLE
[ci][config] add instructions to failures in config-validate script

### DIFF
--- a/scripts/circle_validate_configs.sh
+++ b/scripts/circle_validate_configs.sh
@@ -9,23 +9,32 @@
 # - Script is run from repo's top level folder
 
 # Generate Configs
+echo "--- Generating all the configs ---"
 cd terraform/validator-sets
 ./build.sh dev -n 4
 ./build.sh 60 -n 60
 ./build.sh 100 -n 100
 
-
 # Compare configs
-# Notice: This is not comparing all configs just yet.
-# We're also not cerrectly regenerating all configs
+# Notice: This is not comparing all configs yet.
 
-if $(git diff --exit-code HEAD -- **/genesis.blob **/trusted_peers.config.toml **/node.keys.toml) ; then
+# Cleanup files we do compare yet
+git checkout -- '**/seed_peers.config.toml'
+git update-index --refresh
+
+echo "--- Compare configs ---"
+changes=$(git diff-index HEAD -- '**/genesis.blob' '**/trusted_peers.config.toml' '**/node.keys.toml')
+if [ -z "$changes" ];
+then
 	# nothing to do
+	echo "Done!"
 	exit 0
 else
-	# Config differs
+	# config differs
 	echo "Config Differs!!"
-	echo "Your change requires updating configuration. Build the config and commit it."
-	echo "Instructions for building config are in: terraform/validator-sets/build.sh"
+	echo $changes
+	echo "Your code changes require updating configuration"
+	echo "You can run this script itself: ${BASH_SOURCE[0]}"
+	echo "Verify that all modified files were expected to change and commit."
 	exit 1
 fi


### PR DESCRIPTION
# Motivation
This PR changes the instructions about what to do when config-validation script fails during CI.

The current instructions point to the original script that builds the config (`build.sh`), but it's hard to use because one would have to use it multiple times, for all the configs we use.
Now, we just instruct the config validation script itself -- since it does all config generation too.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
(y)
## Test Plan
Tested locally, we'll see on circle 