### PR TITLE
[VM] Fix foreign contracts in VM runtime unhooked

### DIFF
--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -107,6 +107,9 @@ extern crate rental;
 #[macro_use]
 extern crate mirai_annotations;
 
+#[cfg(feature = "mirai-contracts")]
+pub mod foreign_contracts;
+
 mod block_processor;
 mod counters;
 mod frame;


### PR DESCRIPTION
## Motivation

This commit addresses issue #781  by including `foreign_contracts` in `vm_runtime/src/lib.rs`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test`.

## Related PRs

N/A
