### PR TITLE
[storage] refine get_events_by_event_access_path

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -34,8 +34,8 @@ use types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_config::{
-        account_received_event_path, account_sent_event_path, association_address,
-        core_code_address, get_account_resource_or_default, AccountResource,
+        association_address, core_code_address, get_account_resource_or_default, AccountResource,
+        ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
     },
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::{ContractEvent, EventWithProof},
@@ -720,8 +720,8 @@ impl ClientProxy {
         );
         let account = self.get_account_address_from_parameter(space_delim_strings[1])?;
         let path = match space_delim_strings[2] {
-            "sent" => account_sent_event_path(),
-            "received" => account_received_event_path(),
+            "sent" => ACCOUNT_SENT_EVENT_PATH.to_vec(),
+            "received" => ACCOUNT_RECEIVED_EVENT_PATH.to_vec(),
             _ => bail!(
                 "Unknown event type: {:?}, only sent and received are supported",
                 space_delim_strings[2]

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -188,7 +188,7 @@ impl LibraDB {
     /// `start_seq_num`, `ascending` and `limit`. If ascending is true this query will return up to
     /// `limit` events that were emitted after `start_event_seq_num`. Otherwise, it will return up
     /// to `limit` events in the reverse order. Both cases are inclusive.
-    fn get_events_by_event_access_path(
+    fn get_events_by_query_path(
         &self,
         query_path: &AccessPath,
         start_seq_num: u64,
@@ -207,7 +207,7 @@ impl LibraDB {
             bail!("Nothing stored under address: {}", query_path.address);
         };
         let event_key = account_resource
-            .get_event_handle_by_query_path(query_path)?
+            .get_event_handle_by_query_path(&query_path.path)?
             .key();
         let cursor = if get_latest {
             // Caller wants the latest, figure out the latest seq_num.
@@ -506,7 +506,7 @@ impl LibraDB {
                     limit,
                 } => {
                     let (events_with_proof, proof_of_latest_event) = self
-                        .get_events_by_event_access_path(
+                        .get_events_by_query_path(
                             &access_path,
                             start_event_seq_num,
                             ascending,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -130,7 +130,7 @@ fn get_events_by_query_path(
 
     let mut ret = Vec::new();
     loop {
-        let (events_with_proof, proof_of_latest_event) = db.get_events_by_event_access_path(
+        let (events_with_proof, proof_of_latest_event) = db.get_events_by_query_path(
             query_path,
             cursor,
             ascending,
@@ -140,7 +140,7 @@ fn get_events_by_query_path(
 
         let account_resource = get_account_resource_or_default(&proof_of_latest_event.blob)?;
         let expected_event_key = account_resource
-            .get_event_handle_by_query_path(query_path)?
+            .get_event_handle_by_query_path(&query_path.path)?
             .key();
 
         let num_events = events_with_proof.len() as u64;
@@ -446,7 +446,7 @@ fn test_too_many_requested() {
         .is_err());
     assert!(db.get_transactions(0, 1001 /* limit */, 0, true).is_err());
     assert!(db
-        .get_events_by_event_access_path(
+        .get_events_by_query_path(
             &AccessPath::new_for_sent_event(AccountAddress::random()),
             0,
             true,

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -41,8 +41,8 @@
 use crate::{
     account_address::AccountAddress,
     account_config::{
-        account_received_event_path, account_resource_path, account_sent_event_path,
-        association_address,
+        account_resource_path, association_address, ACCOUNT_RECEIVED_EVENT_PATH,
+        ACCOUNT_SENT_EVENT_PATH,
     },
     language_storage::{ModuleId, ResourceKey, StructTag},
     validator_set::validator_set_path,
@@ -288,7 +288,7 @@ impl AccessPath {
     /// That AccessPath can be used as a key into the event storage to retrieve all sent
     /// events for a given account.
     pub fn new_for_sent_event(address: AccountAddress) -> Self {
-        Self::new(address, account_sent_event_path())
+        Self::new(address, ACCOUNT_SENT_EVENT_PATH.to_vec())
     }
 
     /// Create an AccessPath to the event for the target account (the receiver)
@@ -298,7 +298,7 @@ impl AccessPath {
     /// That AccessPath can be used as a key into the event storage to retrieve all received
     /// events for a given account.
     pub fn new_for_received_event(address: AccountAddress) -> Self {
-        Self::new(address, account_received_event_path())
+        Self::new(address, ACCOUNT_RECEIVED_EVENT_PATH.to_vec())
     }
 
     pub fn resource_access_vec(tag: &StructTag, accesses: &Accesses) -> Vec<u8> {

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -16,6 +16,7 @@ use canonical_serialization::{
     SimpleDeserializer,
 };
 use failure::prelude::*;
+use lazy_static::lazy_static;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use std::{
@@ -144,13 +145,13 @@ impl AccountResource {
         self.delegated_withdrawal_capability
     }
 
-    pub fn get_event_handle_by_query_path(&self, query_path: &AccessPath) -> Result<&EventHandle> {
-        if account_received_event_path() == query_path.path {
+    pub fn get_event_handle_by_query_path(&self, query_path: &[u8]) -> Result<&EventHandle> {
+        if *ACCOUNT_RECEIVED_EVENT_PATH == query_path {
             Ok(&self.received_events)
-        } else if account_sent_event_path() == query_path.path {
+        } else if *ACCOUNT_SENT_EVENT_PATH == query_path {
             Ok(&self.sent_events)
         } else {
-            bail!("Unrecognized query path: {}", query_path);
+            bail!("Unrecognized query path: {:?}", query_path);
         }
     }
 }
@@ -208,24 +209,22 @@ pub fn account_resource_path() -> Vec<u8> {
     AccessPath::resource_access_vec(&account_struct_tag(), &Accesses::empty())
 }
 
-/// Return the path to the sent event counter for an Account resource.
-/// It can be used to query the event DB for the given event.
-pub fn account_sent_event_path() -> Vec<u8> {
-    let mut path = account_resource_path();
-    path.push(b'/');
-    path.extend_from_slice(b"sent_events_count");
-    path.push(b'/');
-    path
-}
+lazy_static! {
+    /// The path to the sent event counter for an Account resource.
+    /// It can be used to query the event DB for the given event.
+    pub static ref ACCOUNT_SENT_EVENT_PATH: Vec<u8> = {
+        let mut path = account_resource_path();
+        path.extend_from_slice(b"/sent_events_count/");
+        path
+    };
 
-/// Return the path to the received event counter for an Account resource.
-/// It can be used to query the event DB for the given event.
-pub fn account_received_event_path() -> Vec<u8> {
-    let mut path = account_resource_path();
-    path.push(b'/');
-    path.extend_from_slice(b"received_events_count");
-    path.push(b'/');
-    path
+    /// Returns the path to the received event counter for an Account resource.
+    /// It can be used to query the event DB for the given event.
+    pub static ref ACCOUNT_RECEIVED_EVENT_PATH: Vec<u8> = {
+        let mut path = account_resource_path();
+        path.extend_from_slice(b"/received_events_count/");
+        path
+    };
 }
 
 /// Generic struct that represents an Account event.

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -295,7 +295,8 @@ fn verify_get_events_by_access_path_resp(
             ledger_info.version(),
             req_access_path.address,
         )?;
-        let event_handle = account_resource.get_event_handle_by_query_path(&req_access_path)?;
+        let event_handle =
+            account_resource.get_event_handle_by_query_path(&req_access_path.path)?;
         (event_handle.count(), event_handle.key())
     };
 


### PR DESCRIPTION


## Motivation

1. rename to `get_events_by_query_path`, to be consistent with its own parameter
2. `AccountResource::get_event_handle_by_query_path()` now takes the `path` part of the access path, since the address part is not used.
3. ACCOUNT_SENT_EVENT_ACCESS_PATH is now a lazy static so the API doesn't need to create a new Vec<u8> every time it checks against the parameter.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Existing Coverage

## Related PRs
