### PR TITLE
[storage] `TransactionStore::lookup_transaction_by_account()`

### DIFF
--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -35,6 +35,7 @@ types = { path = "../../types" }
 
 [dev-dependencies]
 types = { path = "../../types", features = ["testing"]}
+proptest_helpers = { path = "../../common/proptest_helpers" }
 
 [features]
 default = []

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -52,7 +52,7 @@ use storage_proto::StartupInfo;
 use types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::{get_account_resource_or_default, AccountResource},
+    account_config::AccountResource,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::EventWithProof,
     get_with_proof::{RequestItem, ResponseItem},
@@ -115,6 +115,10 @@ impl LibraDB {
             (SIGNED_TRANSACTION_CF_NAME, ColumnFamilyOptions::default()),
             (
                 TRANSACTION_ACCUMULATOR_CF_NAME,
+                ColumnFamilyOptions::default(),
+            ),
+            (
+                TRANSACTION_BY_ACCOUNT_CF_NAME,
                 ColumnFamilyOptions::default(),
             ),
             (TRANSACTION_INFO_CF_NAME, ColumnFamilyOptions::default()),
@@ -274,43 +278,17 @@ impl LibraDB {
 
     /// Returns a signed transaction that is the `seq_num`-th one associated with the given account.
     /// If the signed transaction with given `seq_num` doesn't exist, returns `None`.
-    // TODO(gzh): Use binary search for now. We may create seq_num index in the future.
-    fn get_txn_by_account_and_seq(
+    fn get_txn_by_account(
         &self,
         address: AccountAddress,
         seq_num: u64,
         ledger_version: Version,
         fetch_events: bool,
     ) -> Result<Option<SignedTransactionWithProof>> {
-        // If txn with seq_num n is at some version, the corresponding account state at the
-        // same version will be the first account state that has seq_num n + 1.
-        let seq_num = seq_num + 1;
-        let (mut start_version, mut end_version) = (0, ledger_version);
-        while start_version < end_version {
-            let mid_version = start_version + (end_version - start_version) / 2;
-            let account_seq_num = self.get_account_seq_num_by_version(address, mid_version)?;
-            if account_seq_num >= seq_num {
-                end_version = mid_version;
-            } else {
-                start_version = mid_version + 1;
-            }
-        }
-        assert_eq!(start_version, end_version);
-
-        let seq_num_found = self.get_account_seq_num_by_version(address, start_version)?;
-        if seq_num_found < seq_num {
-            return Ok(None);
-        } else if seq_num_found > seq_num {
-            // log error
-            bail!("internal error: seq_num is not continuous.")
-        }
-        // start_version cannot be 0 (genesis version).
-        assert_eq!(
-            self.get_account_seq_num_by_version(address, start_version - 1)?,
-            seq_num_found - 1
-        );
-        self.get_transaction_with_proof(start_version, ledger_version, fetch_events)
-            .map(Some)
+        self.transaction_store
+            .lookup_transaction_by_account(address, seq_num, ledger_version)?
+            .map(|version| self.get_transaction_with_proof(version, ledger_version, fetch_events))
+            .transpose()
     }
 
     /// Gets the latest version number available in the ledger.
@@ -477,7 +455,7 @@ impl LibraDB {
                     sequence_number,
                     fetch_events,
                 } => {
-                    let signed_transaction_with_proof = self.get_txn_by_account_and_seq(
+                    let signed_transaction_with_proof = self.get_txn_by_account(
                         account,
                         sequence_number,
                         ledger_version,
@@ -687,19 +665,6 @@ impl LibraDB {
         }
 
         Ok(())
-    }
-
-    fn get_account_seq_num_by_version(
-        &self,
-        address: AccountAddress,
-        version: Version,
-    ) -> Result<u64> {
-        let (account_state_blob, _proof) = self
-            .state_store
-            .get_account_state_with_proof_by_version(address, version)?;
-
-        // If an account does not exist, we treat it as if it has sequence number 0.
-        Ok(get_account_resource_or_default(&account_state_blob)?.sequence_number())
     }
 
     fn get_transaction_with_proof(

--- a/storage/libradb/src/schema/mod.rs
+++ b/storage/libradb/src/schema/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod ledger_info;
 pub(crate) mod signed_transaction;
 pub(crate) mod stale_node_index;
 pub(crate) mod transaction_accumulator;
+pub(crate) mod transaction_by_account;
 pub(crate) mod transaction_info;
 pub(crate) mod validator;
 
@@ -29,6 +30,7 @@ pub(super) const LEDGER_COUNTERS_CF_NAME: ColumnFamilyName = "ledger_counters";
 pub(super) const STALE_NODE_INDEX_CF_NAME: ColumnFamilyName = "stale_node_index";
 pub(super) const SIGNED_TRANSACTION_CF_NAME: ColumnFamilyName = "signed_transaction";
 pub(super) const TRANSACTION_ACCUMULATOR_CF_NAME: ColumnFamilyName = "transaction_accumulator";
+pub(super) const TRANSACTION_BY_ACCOUNT_CF_NAME: ColumnFamilyName = "transaction_by_account";
 pub(super) const TRANSACTION_INFO_CF_NAME: ColumnFamilyName = "transaction_info";
 pub(super) const VALIDATOR_CF_NAME: ColumnFamilyName = "validator";
 

--- a/storage/libradb/src/schema/transaction_by_account/mod.rs
+++ b/storage/libradb/src/schema/transaction_by_account/mod.rs
@@ -1,0 +1,71 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines physical storage schema for a transaction index via which the version of a
+//! transaction sent by `account_address` with `sequence_number` can be found. With the version one
+//! can resort to `SignedTransactionSchema` for the transaction content.
+//!
+//! ```text
+//! |<-------key------->|<-value->|
+//! | address | seq_num | txn_ver |
+//! ```
+
+use crate::schema::{ensure_slice_len_eq, TRANSACTION_BY_ACCOUNT_CF_NAME};
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use failure::prelude::*;
+use schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+};
+use std::{convert::TryFrom, mem::size_of};
+use types::{
+    account_address::{AccountAddress, ADDRESS_LENGTH},
+    transaction::Version,
+};
+
+define_schema!(
+    TransactionByAccountSchema,
+    Key,
+    Value,
+    TRANSACTION_BY_ACCOUNT_CF_NAME
+);
+
+type SeqNum = u64;
+type Key = (AccountAddress, SeqNum);
+
+type Value = Version;
+
+impl KeyCodec<TransactionByAccountSchema> for Key {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        let (ref account_address, seq_num) = *self;
+
+        let mut encoded = account_address.to_vec();
+        encoded.write_u64::<BigEndian>(seq_num)?;
+
+        Ok(encoded)
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+
+        let event_key = AccountAddress::try_from(&data[..ADDRESS_LENGTH])?;
+        let seq_num = (&data[ADDRESS_LENGTH..]).read_u64::<BigEndian>()?;
+
+        Ok((event_key, seq_num))
+    }
+}
+
+impl ValueCodec<TransactionByAccountSchema> for Version {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(self.to_be_bytes().to_vec())
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        ensure_slice_len_eq(data, size_of::<Self>())?;
+
+        Ok((&data[..]).read_u64::<BigEndian>()?)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/libradb/src/schema/transaction_by_account/test.rs
+++ b/storage/libradb/src/schema/transaction_by_account/test.rs
@@ -1,0 +1,17 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use proptest::prelude::*;
+use schemadb::schema::assert_encode_decode;
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        address in any::<AccountAddress>(),
+        seq_num in any::<u64>(),
+        version in any::<Version>(),
+    ) {
+        assert_encode_decode::<TransactionByAccountSchema>(&(address, seq_num), &version);
+    }
+}

--- a/storage/libradb/src/transaction_store/mod.rs
+++ b/storage/libradb/src/transaction_store/mod.rs
@@ -4,11 +4,17 @@
 //! This file defines transaction store APIs that are related to committed signed transactions.
 
 use super::schema::signed_transaction::*;
-use crate::{change_set::ChangeSet, errors::LibraDbError};
+use crate::{
+    change_set::ChangeSet, errors::LibraDbError,
+    schema::transaction_by_account::TransactionByAccountSchema,
+};
 use failure::prelude::*;
 use schemadb::DB;
 use std::sync::Arc;
-use types::transaction::{SignedTransaction, Version};
+use types::{
+    account_address::AccountAddress,
+    transaction::{SignedTransaction, Version},
+};
 
 pub(crate) struct TransactionStore {
     db: Arc<DB>,
@@ -17,6 +23,25 @@ pub(crate) struct TransactionStore {
 impl TransactionStore {
     pub fn new(db: Arc<DB>) -> Self {
         Self { db }
+    }
+
+    /// Gets the version of a transaction by the sender `address` and `sequence_number`.
+    pub fn lookup_transaction_by_account(
+        &self,
+        address: AccountAddress,
+        sequence_number: u64,
+        ledger_version: Version,
+    ) -> Result<Option<Version>> {
+        if let Some(version) = self
+            .db
+            .get::<TransactionByAccountSchema>(&(address, sequence_number))?
+        {
+            if version <= ledger_version {
+                return Ok(Some(version));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Get signed transaction given `version`
@@ -33,8 +58,17 @@ impl TransactionStore {
         signed_transaction: &SignedTransaction,
         cs: &mut ChangeSet,
     ) -> Result<()> {
+        cs.batch.put::<TransactionByAccountSchema>(
+            &(
+                signed_transaction.sender(),
+                signed_transaction.sequence_number(),
+            ),
+            &version,
+        )?;
         cs.batch
-            .put::<SignedTransactionSchema>(&version, signed_transaction)
+            .put::<SignedTransactionSchema>(&version, signed_transaction)?;
+
+        Ok(())
     }
 }
 

--- a/storage/libradb/src/transaction_store/test.rs
+++ b/storage/libradb/src/transaction_store/test.rs
@@ -4,13 +4,26 @@
 use super::*;
 use crate::LibraDB;
 use proptest::{collection::vec, prelude::*};
+use proptest_helpers::Index;
 use tempfile::tempdir;
+use types::proptest_types::{AccountInfoUniverse, SignatureCheckedTransactionGen};
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
     #[test]
-    fn test_put_get(txns in vec(any::<SignedTransaction>(), 1..10)) {
+    fn test_put_get(
+        mut universe in any_with::<AccountInfoUniverse>(3),
+        gens in vec(
+            (any::<Index>(), any::<SignatureCheckedTransactionGen>()),
+            1..10
+        ),
+    ) {
+        let txns = gens
+            .into_iter()
+            .map(|(index, gen)| gen.materialize(index, &mut universe).into_inner())
+            .collect::<Vec<_>>();
+
         let tmp_dir = tempdir().unwrap();
         let db = LibraDB::new(&tmp_dir);
         let store = &db.transaction_store;
@@ -18,15 +31,28 @@ proptest! {
         prop_assert!(store.get_transaction(0).is_err());
 
         let mut cs = ChangeSet::new();
-        for (i, txn) in txns.iter().enumerate() {
-            store.put_transaction(i as u64, &txn, &mut cs).unwrap();
+        for (ver, txn) in txns.iter().enumerate() {
+            store
+                .put_transaction(ver as Version, &txn, &mut cs)
+                .unwrap();
         }
         store.db.write_schemas(cs.batch).unwrap();
 
-        for (i, txn) in txns.iter().enumerate() {
-            prop_assert_eq!(store.get_transaction(i as u64).unwrap(), txn.clone());
+        let ledger_version = txns.len() as Version - 1;
+        for (ver, txn) in txns.iter().enumerate() {
+            prop_assert_eq!(store.get_transaction(ver as Version).unwrap(), txn.clone());
+            prop_assert_eq!(
+                store
+                    .lookup_transaction_by_account(
+                        txn.sender(),
+                        txn.sequence_number(),
+                        ledger_version
+                    )
+                    .unwrap(),
+                Some(ver as Version)
+            );
         }
 
-        prop_assert!(store.get_transaction(txns.len() as u64).is_err());
+        prop_assert!(store.get_transaction(ledger_version + 1).is_err());
     }
 }

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -166,7 +166,7 @@ impl Arbitrary for AccountInfoUniverse {
 }
 
 #[derive(Arbitrary, Debug)]
-struct RawTransactionGen {
+pub struct RawTransactionGen {
     payload: TransactionPayload,
     max_gas_amount: u64,
     gas_unit_price: u64,
@@ -335,7 +335,7 @@ impl SignatureCheckedTransaction {
 }
 
 #[derive(Arbitrary, Debug)]
-struct SignatureCheckedTransactionGen {
+pub struct SignatureCheckedTransactionGen {
     raw_transaction_gen: RawTransactionGen,
 }
 


### PR DESCRIPTION
Built an index table to support looking up transaction versions by account_address and sequence_number. So that to serve the corresponding public API we don't need to binary search on the full state history, which in turn makes possible the pruning of state history on any node that serves read APIs.


## Motivation

To enable state history pruning on validators and "proxy" nodes that serves most reads.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests updated.

## Related PRs

#763 made the tests work without major change.