### PR TITLE
[network] Removing a panic, just in case

### DIFF
--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -411,7 +411,8 @@ async fn handle_inbound_substream<TSubstream>(
                 );
             }
         }
-        notif => unreachable!(
+        notif => debug_assert!(
+            false,
             "Received unexpected event from PeerManager: {:?}, expected NewInboundSubstream",
             notif
         ),


### PR DESCRIPTION
MOTIVATION:

In `handle_inbound_substream` we panic if it is called with something else than a `PeerManagerNotification::NewInboundSubstream`.
I'd rather we do nothing in release, and panic in debug.

TEST PLAN:

cargo test -p network --lib


