### PR TITLE
[VM][Tools] Bytecode test generator: Complete non-reference instructions

### DIFF
--- a/language/tools/test_generation/src/control_flow_graph.rs
+++ b/language/tools/test_generation/src/control_flow_graph.rs
@@ -170,6 +170,7 @@ impl CFG {
                 // A local is available for a block if it is available in every
                 // parent's outgoing locals
                 let basic_block = self.basic_blocks.get(block_id);
+                // Every block ID in the sequence should be valid
                 assume!(basic_block.is_some());
                 if basic_block.unwrap().locals_out[&local_index].1 == BorrowState::Unavailable {
                     availability = BorrowState::Unavailable;
@@ -258,10 +259,11 @@ impl CFG {
             // Basic blocks are indexed in increasing order
             assume!(block.is_some());
             let block = block.unwrap();
-            if block.instructions.is_empty() {
-                unreachable!("Error: block created with no instructions");
-            }
-            verify!(!block.instructions.is_empty());
+            // All basic blocks should have instructions filled in at this point
+            checked_assume!(
+                !block.instructions.is_empty(),
+                "Error: block created with no instructions",
+            );
             let last_instruction_index = block.instructions.len() - 1;
             if cfg_copy.num_children(block_id) == 2 {
                 let child_id: BlockIDSize = cfg_copy.get_children_ids(block_id)[1];

--- a/language/tools/test_generation/tests/special_instructions.rs
+++ b/language/tools/test_generation/tests/special_instructions.rs
@@ -11,3 +11,11 @@ fn bytecode_pop() {
     let state2 = common::run_instruction(Bytecode::Pop, state1);
     assert_eq!(state2.stack_len(), 0, "stack type postcondition not met");
 }
+
+#[test]
+fn bytecode_createaccount() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
+    let state2 = common::run_instruction(Bytecode::Pop, state1);
+    assert_eq!(state2.stack_len(), 0, "stack type postcondition not met");
+}

--- a/language/tools/test_generation/tests/struct_instructions.rs
+++ b/language/tools/test_generation/tests/struct_instructions.rs
@@ -15,7 +15,7 @@ use vm::{
 
 mod common;
 
-fn generate_module_with_struct() -> CompiledModuleMut {
+fn generate_module_with_struct(resource: bool) -> CompiledModuleMut {
     let mut module: CompiledModuleMut = empty_module();
     module.type_signatures = vec![
         SignatureToken::Bool,
@@ -58,16 +58,44 @@ fn generate_module_with_struct() -> CompiledModuleMut {
     module.struct_handles = vec![StructHandle {
         module: ModuleHandleIndex::new(0),
         name: StringPoolIndex::new((struct_index + offset) as TableIndex),
-        is_nominal_resource: false,
+        is_nominal_resource: resource,
         type_formals: vec![],
     }];
     module
 }
 
+fn create_struct_value(module: &CompiledModule) -> AbstractValue {
+    let struct_def = module.struct_def_at(StructDefinitionIndex::new(0));
+    let struct_def_view = StructDefinitionView::new(module, struct_def);
+    let tokens: Vec<SignatureToken> = struct_def_view
+        .fields()
+        .into_iter()
+        .flatten()
+        .map(|field| field.type_signature().token().as_inner().clone())
+        .collect();
+    let struct_kind = match struct_def_view.is_nominal_resource() {
+        true => Kind::Resource,
+        false => tokens
+            .iter()
+            .map(|token| SignatureTokenView::new(module, token).kind())
+            .fold(Kind::Unrestricted, |acc_kind, next_kind| {
+                match (acc_kind, next_kind) {
+                    (Kind::All, _) | (_, Kind::All) => Kind::All,
+                    (Kind::Resource, _) | (_, Kind::Resource) => Kind::Resource,
+                    (Kind::Unrestricted, Kind::Unrestricted) => Kind::Unrestricted,
+                }
+            }),
+    };
+    AbstractValue::new_struct(
+        SignatureToken::Struct(struct_def.struct_handle, tokens.clone()),
+        struct_kind,
+    )
+}
+
 #[test]
 #[should_panic]
 fn bytecode_pack_signature_not_satisfied() {
-    let module: CompiledModuleMut = generate_module_with_struct();
+    let module: CompiledModuleMut = generate_module_with_struct(false);
     let state1 = AbstractState::from_locals(module, HashMap::new());
     common::run_instruction(
         Bytecode::Pack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -77,28 +105,111 @@ fn bytecode_pack_signature_not_satisfied() {
 
 #[test]
 fn bytecode_pack() {
-    let module: CompiledModuleMut = generate_module_with_struct();
+    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    let struct_value1 = create_struct_value(&state1.module);
+    if let SignatureToken::Struct(_, tokens) = struct_value1.clone().token {
+        for token in tokens {
+            let abstract_value = AbstractValue {
+                token: token.clone(),
+                kind: SignatureTokenView::new(&state1.module, &token).kind(),
+            };
+            state1.stack_push(abstract_value);
+        }
+    }
+    let state2 = common::run_instruction(
+        Bytecode::Pack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    let struct_value2 = state2.stack_peek(0).expect("struct not added to stack");
+    assert_eq!(
+        struct_value1, struct_value2,
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_unpack_signature_not_satisfied() {
+    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+fn bytecode_unpack() {
+    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    let struct_value = create_struct_value(&state1.module);
+    state1.stack_push(struct_value.clone());
+    let state2 = common::run_instruction(
+        Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    if let SignatureToken::Struct(_, tokens) = struct_value.token {
+        assert_eq!(
+            state2.stack_len(),
+            tokens.len(),
+            "stack type postcondition not met"
+        );
+    } else {
+        panic!("Created struct is malformed");
+    }
+}
+
+#[test]
+fn bytecode_exists() {
+    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
+    let state2 = common::run_instruction(
+        Bytecode::Exists(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(AbstractValue::new_primitive(SignatureToken::Bool)),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_exists_struct_is_not_resource() {
+    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
+    common::run_instruction(
+        Bytecode::Exists(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_exists_no_address_on_stack() {
+    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::Exists(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+fn bytecode_movefrom() {
+    let module: CompiledModuleMut = generate_module_with_struct(true);
     let mut state1 = AbstractState::from_locals(module, HashMap::new());
     let state1_copy = state1.clone();
     let struct_def = state1_copy
         .module
         .struct_def_at(StructDefinitionIndex::new(0));
-    let struct_def_view = StructDefinitionView::new(&state1_copy.module, struct_def);
-    let token_views: Vec<SignatureTokenView<'_, CompiledModule>> = struct_def_view
-        .fields()
-        .into_iter()
-        .flatten()
-        .map(|field| field.type_signature().token())
-        .collect();
-    for token_view in token_views {
-        let abstract_value = AbstractValue {
-            token: token_view.as_inner().clone(),
-            kind: token_view.kind(),
-        };
-        state1.stack_push(abstract_value);
-    }
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     let state2 = common::run_instruction(
-        Bytecode::Pack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        Bytecode::MoveFrom(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
     );
     let struct_value = state2.stack_peek(0).expect("struct not added to stack");
@@ -113,55 +224,58 @@ fn bytecode_pack() {
 
 #[test]
 #[should_panic]
-fn bytecode_unpack_signature_not_satisfied() {
-    let module: CompiledModuleMut = generate_module_with_struct();
-    let state1 = AbstractState::from_locals(module, HashMap::new());
+fn bytecode_movefrom_struct_is_not_resource() {
+    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     common::run_instruction(
-        Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        Bytecode::MoveFrom(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
     );
 }
 
 #[test]
-fn bytecode_unpack() {
-    let module: CompiledModuleMut = generate_module_with_struct();
-    let mut state1 = AbstractState::from_locals(module, HashMap::new());
-    let state1_copy = state1.clone();
-    let struct_def = state1_copy
-        .module
-        .struct_def_at(StructDefinitionIndex::new(0));
-    let struct_def_view = StructDefinitionView::new(&state1_copy.module, struct_def);
-    let tokens: Vec<SignatureToken> = struct_def_view
-        .fields()
-        .into_iter()
-        .flatten()
-        .map(|field| field.type_signature().token().as_inner().clone())
-        .collect();
-    let struct_kind = match struct_def_view.is_nominal_resource() {
-        true => Kind::Resource,
-        false => tokens
-            .iter()
-            .map(|token| SignatureTokenView::new(&state1_copy.module, token).kind())
-            .fold(Kind::Unrestricted, |acc_kind, next_kind| {
-                match (acc_kind, next_kind) {
-                    (Kind::All, _) | (_, Kind::All) => Kind::All,
-                    (Kind::Resource, _) | (_, Kind::Resource) => Kind::Resource,
-                    (Kind::Unrestricted, Kind::Unrestricted) => Kind::Unrestricted,
-                }
-            }),
-    };
-    let struct_value = AbstractValue::new_struct(
-        SignatureToken::Struct(struct_def.struct_handle, tokens.clone()),
-        struct_kind,
-    );
-    state1.stack_push(struct_value);
-    let state2 = common::run_instruction(
-        Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+#[should_panic]
+fn bytecode_movefrom_no_address_on_stack() {
+    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::MoveFrom(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
     );
-    assert_eq!(
-        state2.stack_len(),
-        tokens.len(),
-        "stack type postcondition not met"
+}
+
+#[test]
+fn bytecode_movetosender() {
+    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(create_struct_value(&state1.module));
+    let state2 = common::run_instruction(
+        Bytecode::MoveToSender(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    assert_eq!(state2.stack_len(), 0, "stack type postcondition not met");
+}
+
+#[test]
+#[should_panic]
+fn bytecode_movetosender_struct_is_not_resource() {
+    let module: CompiledModuleMut = generate_module_with_struct(false);
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(create_struct_value(&state1.module));
+    common::run_instruction(
+        Bytecode::MoveToSender(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_movetosender_no_struct_on_stack() {
+    let module: CompiledModuleMut = generate_module_with_struct(true);
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::MoveToSender(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
     );
 }

--- a/language/tools/test_generation/tests/transaction_instructions.rs
+++ b/language/tools/test_generation/tests/transaction_instructions.rs
@@ -47,3 +47,25 @@ fn bytecode_getgasremaining() {
         "stack type postcondition not met"
     );
 }
+
+#[test]
+fn bytecode_gettxnsenderaddress() {
+    let state1 = AbstractState::new();
+    let state2 = common::run_instruction(Bytecode::GetTxnSenderAddress, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(AbstractValue::new_primitive(SignatureToken::Address)),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_gettxnpublickey() {
+    let state1 = AbstractState::new();
+    let state2 = common::run_instruction(Bytecode::GetTxnPublicKey, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(AbstractValue::new_primitive(SignatureToken::ByteArray)),
+        "stack type postcondition not met"
+    );
+}


### PR DESCRIPTION
## Motivation

This commit adds support to the bytecode test generator for the remaining
non-reference bytecode instructions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test`. Added tests for new instructions. Safety analysis with MIRAI.

## Related PRs

N/A
