### PR TITLE
Adds safety invariants (MIRAI annotations)

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -38,10 +38,18 @@ fn build_simple_tree() -> (Vec<Arc<Block<Vec<usize>>>>, Arc<BlockStore<Vec<usize
     // Genesis--> B1--> B2
     //             ╰--> C1
     let mut inserter = TreeInserter::new(block_store.clone());
-    let a1 = inserter.insert_block(genesis_block.as_ref(), 1);
+    let a1 = inserter.insert_block_with_qc(
+        QuorumCert::certificate_for_genesis(),
+        genesis_block.as_ref(),
+        1,
+    );
     let a2 = inserter.insert_block(a1.as_ref(), 2);
     let a3 = inserter.insert_block(a2.as_ref(), 3);
-    let b1 = inserter.insert_block(genesis_block.as_ref(), 4);
+    let b1 = inserter.insert_block_with_qc(
+        QuorumCert::certificate_for_genesis(),
+        genesis_block.as_ref(),
+        4,
+    );
     let b2 = inserter.insert_block(b1.as_ref(), 5);
     let c1 = inserter.insert_block(b1.as_ref(), 6);
 
@@ -107,7 +115,8 @@ fn test_highest_block_and_quorum_cert() {
     let mut inserter = TreeInserter::new(block_store.clone());
 
     // Genesis block and quorum certificate is still the highest
-    let block_round_1 = inserter.insert_block(genesis.as_ref(), 1);
+    let block_round_1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     assert_eq!(
         block_store.highest_certified_block().as_ref(),
         &Block::make_genesis_block()
@@ -152,7 +161,8 @@ fn test_qc_ancestry() {
     let block_store = build_empty_tree();
     let genesis = block_store.root();
     let mut inserter = TreeInserter::new(block_store.clone());
-    let block_a_1 = inserter.insert_block(genesis.as_ref(), 1);
+    let block_a_1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     let block_a_2 = inserter.insert_block(block_a_1.as_ref(), 2);
 
     assert_eq!(
@@ -284,7 +294,15 @@ fn test_block_tree_gc() {
 
     let mut inserter = TreeInserter::new(block_store.clone());
     for round in 1..100 {
-        cur_node = inserter.insert_block(cur_node.as_ref(), round);
+        if round == 1 {
+            cur_node = inserter.insert_block_with_qc(
+                QuorumCert::certificate_for_genesis(),
+                cur_node.as_ref(),
+                round,
+            );
+        } else {
+            cur_node = inserter.insert_block(cur_node.as_ref(), round);
+        }
         added_blocks.push(cur_node.clone());
     }
 
@@ -300,7 +318,8 @@ fn test_path_from_root() {
     let block_store = build_empty_tree();
     let genesis = block_store.get_block(block_store.root().id()).unwrap();
     let mut inserter = TreeInserter::new(block_store.clone());
-    let b1 = inserter.insert_block(genesis.as_ref(), 1);
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     let b2 = inserter.insert_block(b1.as_ref(), 2);
     let b3 = inserter.insert_block(b2.as_ref(), 3);
 
@@ -332,7 +351,8 @@ fn test_insert_vote() {
     let block_store = build_empty_tree_with_custom_signing(my_signer);
     let genesis = block_store.root();
     let mut inserter = TreeInserter::new(block_store.clone());
-    let block = inserter.insert_block(genesis.as_ref(), 1);
+    let block =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
 
     assert!(block_store.get_quorum_cert_for_block(block.id()).is_none());
     for (i, voter) in signers.iter().enumerate().take(10).skip(1) {
@@ -413,7 +433,8 @@ fn test_vote_aggregation() {
     let block_store = build_empty_tree_with_custom_signing(my_signer);
     let genesis = block_store.root();
     let mut inserter = TreeInserter::new(block_store.clone());
-    let block = inserter.insert_block(genesis.as_ref(), 1);
+    let block =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
 
     // The first two signers give the same vote data but different vote msgs
     let li1 = placeholder_ledger_info();
@@ -507,7 +528,8 @@ fn test_highest_qc() {
     // build a tree of the following form
     // genesis <- a1 <- a2 <- a3
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     assert_eq!(block_tree.highest_certified_block(), genesis.clone());
     let a2 = inserter.insert_block(a1.as_ref(), 2);
     assert_eq!(block_tree.highest_certified_block(), a1.clone());
@@ -523,7 +545,8 @@ fn test_need_fetch_for_qc() {
     // build a tree of the following form
     // genesis <- a1 <- a2 <- a3
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     let a2 = inserter.insert_block(a1.as_ref(), 2);
     let a3 = inserter.insert_block(a2.as_ref(), 3);
     block_tree.prune_tree(a2.id());
@@ -573,7 +596,8 @@ fn test_need_sync_for_qc() {
     // build a tree of the following form
     // genesis <- a1 <- a2 <- a3
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     let a2 = inserter.insert_block(a1.as_ref(), 2);
     let a3 = inserter.insert_block(a2.as_ref(), 3);
     block_tree.prune_tree(a3.id());

--- a/consensus/src/chained_bft/consensus_types/block_test.rs
+++ b/consensus/src/chained_bft/consensus_types/block_test.rs
@@ -36,12 +36,14 @@ prop_compose! {
         round_strategy: impl Strategy<Value = Round>,
         height: Height,
         signer_strategy: impl Strategy<Value = ValidatorSigner>,
+        parent_qc: QuorumCert,
     )(
         parent_id in parent_id_strategy,
         round in round_strategy,
         payload in 0usize..10usize,
         height in Just(height),
         signer in signer_strategy,
+        parent_qc in Just(parent_qc)
     ) -> Block<Vec<usize>> {
         Block::new_internal(
             vec![payload],
@@ -49,7 +51,7 @@ prop_compose! {
             round,
             height,
             get_current_timestamp().as_micros() as u64,
-            QuorumCert::certificate_for_genesis(),
+            parent_qc,
             &signer,
         )
     }
@@ -71,6 +73,7 @@ prop_compose! {
             Round::arbitrary(),
             123,
             proptests::arb_signer(),
+            QuorumCert::certificate_for_genesis(),
         )
     ) -> Block<Vec<usize>> {
         block
@@ -150,6 +153,8 @@ prop_compose! {
         forest_vec[parent_idx].height() + 1,
         // signer
         Just(signer),
+        // parent_qc
+        forest_vec[qc_idx].quorum_cert().clone(),
     ), mut forest in Just(forest_vec),
     ) -> LinearizedBlockForest<Vec<usize>> {
         forest.push(block);

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -4,7 +4,7 @@
 use crate::{
     chained_bft::{
         block_storage::BlockReader,
-        consensus_types::{vote_data::VoteData, vote_msg::VoteMsg},
+        consensus_types::{quorum_cert::QuorumCert, vote_data::VoteData, vote_msg::VoteMsg},
         liveness::proposal_generator::{ProposalGenerationError, ProposalGenerator},
         test_utils::{
             build_empty_tree, placeholder_ledger_info, MockTransactionManager, TreeInserter,
@@ -61,8 +61,10 @@ fn test_proposal_generation_parent() {
         true,
     );
     let genesis = block_store.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
-    let b1 = inserter.insert_block(genesis.as_ref(), 2);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 2);
 
     // With no certifications the parent is genesis
     // generate proposals for an empty tree.
@@ -141,7 +143,8 @@ fn test_old_proposal_generation() {
         true,
     );
     let genesis = block_store.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
     let vote_msg_a1 = VoteMsg::new(
         VoteData::new(
             a1.id(),

--- a/consensus/src/chained_bft/safety/safety_rules_test.rs
+++ b/consensus/src/chained_bft/safety/safety_rules_test.rs
@@ -4,7 +4,10 @@
 use crate::chained_bft::{
     block_storage::BlockReader,
     common::Round,
-    consensus_types::block::{block_test, Block},
+    consensus_types::{
+        block::{block_test, Block},
+        quorum_cert::QuorumCert,
+    },
     safety::safety_rules::{ConsensusState, ProposalReject, SafetyRules},
     test_utils::{build_empty_tree, build_empty_tree_with_custom_signing, TreeInserter},
 };
@@ -174,8 +177,10 @@ fn test_preferred_block_rule() {
     //
     // PB should change from genesis to b1, and then to a2.
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
-    let b1 = inserter.insert_block(genesis.as_ref(), 2);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 2);
     let b2 = inserter.insert_block(a1.as_ref(), 3);
     let a2 = inserter.insert_block(b1.as_ref(), 4);
     let b3 = inserter.insert_block(b2.as_ref(), 5);
@@ -250,8 +255,10 @@ fn test_voting() {
     // a4 (old proposal)
     // b4 (round lower then round of pb. PB: a2, parent(b4)=b2)
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
-    let b1 = inserter.insert_block(genesis.as_ref(), 2);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 2);
     let b2 = inserter.insert_block(a1.as_ref(), 3);
     let a2 = inserter.insert_block(b1.as_ref(), 4);
     let a3 = inserter.insert_block(a2.as_ref(), 5);
@@ -326,8 +333,10 @@ fn test_voting_potential_commit_id() {
     // A potential commit for proposal a4 is a2, a potential commit for proposal a5 is a3.
 
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
-    let b1 = inserter.insert_block(genesis.as_ref(), 2);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 2);
     let a2 = inserter.insert_block(a1.as_ref(), 3);
     let a3 = inserter.insert_block(a2.as_ref(), 4);
     let a4 = inserter.insert_block(a3.as_ref(), 5);
@@ -367,8 +376,10 @@ fn test_commit_rule_consecutive_rounds() {
     // a2 can be committed after a4 gathers QC
 
     let genesis = block_tree.root();
-    let a1 = inserter.insert_block(genesis.as_ref(), 1);
-    let b1 = inserter.insert_block(genesis.as_ref(), 2);
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 2);
     let b2 = inserter.insert_block(b1.as_ref(), 3);
     let a2 = inserter.insert_block(a1.as_ref(), 4);
     let a3 = inserter.insert_block(a2.as_ref(), 5);

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -116,15 +116,19 @@ impl TreeInserter {
             0
         };
 
-        let parent_qc = placeholder_certificate_for_block(
-            qc_signers,
-            block.parent_id(),
-            new_round,
-            block.quorum_cert().parent_block_id(),
-            block.quorum_cert().parent_block_round(),
-            block.quorum_cert().grandparent_block_id(),
-            block.quorum_cert().grandparent_block_round(),
-        );
+        let parent_qc = if new_round == 0 {
+            QuorumCert::certificate_for_genesis()
+        } else {
+            placeholder_certificate_for_block(
+                qc_signers,
+                block.parent_id(),
+                new_round,
+                block.quorum_cert().parent_block_id(),
+                block.quorum_cert().parent_block_round(),
+                block.quorum_cert().grandparent_block_id(),
+                block.quorum_cert().grandparent_block_round(),
+            )
+        };
 
         let new_block = Block::new_internal(
             block.get_payload().clone(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds invariants (in the form of MIRAI annotations) that must be maintained by the consensus code in order to guarantee the safety property (i.e no two conflicting blocks can be committed).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`