### PR TITLE
[Storage] Remove append_siblings

### DIFF
--- a/storage/scratchpad/src/accumulator/accumulator_test.rs
+++ b/storage/scratchpad/src/accumulator/accumulator_test.rs
@@ -6,12 +6,8 @@ use crypto::{
     hash::{CryptoHash, TestOnlyHash, TestOnlyHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
-use proptest::{collection::vec, prelude::*};
 use std::collections::HashMap;
-use types::proof::{
-    position::{FrozenSubtreeSiblingIterator, Position},
-    TestAccumulatorInternalNode,
-};
+use types::proof::{position::Position, TestAccumulatorInternalNode};
 
 fn compute_parent_hash(left_hash: HashValue, right_hash: HashValue) -> HashValue {
     if left_hash == *ACCUMULATOR_PLACEHOLDER_HASH && right_hash == *ACCUMULATOR_PLACEHOLDER_HASH {
@@ -107,6 +103,7 @@ fn test_accumulator_append() {
     }
 }
 
+/* TODO(wqfish): re-implement append_siblings and restore the test.
 proptest! {
     #[test]
     fn test_accumulator_append_siblings(
@@ -131,3 +128,4 @@ proptest! {
         );
     }
 }
+*/

--- a/storage/scratchpad/src/accumulator/mod.rs
+++ b/storage/scratchpad/src/accumulator/mod.rs
@@ -124,129 +124,6 @@ where
         }
     }
 
-    /// Computes what the root hash would become if the current accumulator is extended with a list
-    /// of new leaves. This is similar to [`append`](Accumulator::append) except that the new
-    /// leaves themselves are not known and they are represented by `siblings`, so we would not be
-    /// able to construct a new list of frozen subtrees, but would just compute the root hash of
-    /// the new accumulator. As an example, given the following accumulator that currently has 10
-    /// leaves, the frozen subtree roots and the siblings are annotated below. Note that in this
-    /// case `siblings[0]` represents two new leaves `A` and `B`, `siblings[1]` represents four new
-    /// leaves, and the last `siblings[2]` may represent 1~16 new leaves.
-    ///
-    /// ```text
-    ///                                                 new_root
-    ///                                                /        \
-    ///                                               /          \
-    ///                                       old_root            siblings[2]
-    ///                                      /        \
-    ///                                    /            \
-    ///                                  /                \
-    ///                                /                    \
-    ///                              /                        \
-    ///                            /                            \
-    ///                          /                                \
-    ///                        /                                    \
-    /// frozen_subtree_roots[0]                                      o
-    ///                    /   \                                    / \
-    ///                   /     \                                  /   \
-    ///                  o       o                                o     siblings[1]
-    ///                 / \     / \                              / \
-    ///                o   o   o   o      frozen_subtree_roots[1]   siblings[0]
-    ///               / \ / \ / \ / \                         / \           / \
-    ///               o o o o o o o o                         o o           A B
-    /// ```
-    pub fn append_siblings(&self, siblings: &[HashValue]) -> Result<HashValue> {
-        Self::append_siblings_impl(&self.frozen_subtree_roots, self.num_leaves, siblings)
-    }
-
-    fn append_siblings_impl(
-        frozen_subtree_roots: &[HashValue],
-        num_existing_leaves: u64,
-        siblings: &[HashValue],
-    ) -> Result<HashValue> {
-        if frozen_subtree_roots.is_empty() {
-            ensure!(
-                siblings.len() == 1,
-                "{} siblings are provided when only one is required.",
-                siblings.len(),
-            );
-            return Ok(siblings[0]);
-        }
-        if siblings.is_empty() {
-            ensure!(
-                frozen_subtree_roots.len() == 1,
-                "No siblings are provided when some are required to compute root hash."
-            );
-            return Ok(frozen_subtree_roots[0]);
-        }
-
-        Self::validate_siblings(num_existing_leaves, siblings)?;
-
-        let mut frozen_subtree_iter = frozen_subtree_roots.iter().rev().peekable();
-        let mut sibling_iter = siblings.iter().peekable();
-        let mut current_hash = *sibling_iter
-            .next()
-            .expect("Code would have returned if siblings is empty.");
-
-        // Using the above example, num_existing_leaves = 10 = 0b1010. We check each bit from right
-        // to left starting from the rightmost one bit. If a bit is 0, it means there is no
-        // existing frozen subtree on this level, so we combine current hash with a sibling.
-        // Otherwise we combine it with the corresponding frozen subtree.
-        let mut bitmap = num_existing_leaves >> num_existing_leaves.trailing_zeros();
-        while frozen_subtree_iter.peek().is_some() || sibling_iter.peek().is_some() {
-            current_hash = if bitmap & 1 == 0 {
-                MerkleTreeInternalNode::<H>::new(
-                    current_hash,
-                    *sibling_iter.next().expect("This sibling should exist."),
-                )
-            } else {
-                MerkleTreeInternalNode::<H>::new(
-                    *frozen_subtree_iter
-                        .next()
-                        .expect("This frozen subtree should exist."),
-                    current_hash,
-                )
-            }
-            .hash();
-            bitmap >>= 1;
-        }
-        assert_eq!(bitmap, 0);
-
-        Ok(current_hash)
-    }
-
-    /// Does some basic validation on the input siblings.
-    fn validate_siblings(num_existing_leaves: u64, siblings: &[HashValue]) -> Result<()> {
-        // `siblings` should start with 0 or more non-placeholder trees, followed by 0 or more
-        // placeholder ones.
-        for i in 1..siblings.len() {
-            if siblings[i] != *ACCUMULATOR_PLACEHOLDER_HASH {
-                ensure!(
-                    siblings[i - 1] != *ACCUMULATOR_PLACEHOLDER_HASH,
-                    "Placeholder sibling should not be followed by non-placeholder sibling.",
-                );
-            }
-        }
-
-        let max_num_siblings =
-            num_existing_leaves.count_zeros() - num_existing_leaves.trailing_zeros();
-        ensure!(
-            siblings.len() <= max_num_siblings as usize,
-            "Max number of siblings: {}. {} are provided.",
-            max_num_siblings,
-            siblings.len(),
-        );
-        let min_num_siblings = max_num_siblings - num_existing_leaves.leading_zeros();
-        ensure!(
-            siblings.len() >= min_num_siblings as usize,
-            "Min number of siblings: {}. {} are provided.",
-            min_num_siblings,
-            siblings.len(),
-        );
-
-        Ok(())
-    }
-
     /// Returns the root hash of the accumulator.
     pub fn root_hash(&self) -> HashValue {
         self.root_hash
@@ -255,28 +132,34 @@ where
     /// Computes the root hash of an accumulator given the frozen subtree roots and the number of
     /// leaves in this accumulator.
     fn compute_root_hash(frozen_subtree_roots: &[HashValue], num_leaves: u64) -> HashValue {
-        if frozen_subtree_roots.is_empty() {
-            return *ACCUMULATOR_PLACEHOLDER_HASH;
+        match frozen_subtree_roots.len() {
+            0 => return *ACCUMULATOR_PLACEHOLDER_HASH,
+            1 => return frozen_subtree_roots[0],
+            _ => (),
         }
 
-        // Computing the root hash is equivalent to calling `append_siblings` with a list of
-        // placeholder siblings.
+        // The trailing zeros do not matter since anything below the lowest frozen subtree is
+        // already represented by the subtree roots.
+        let mut bitmap = num_leaves >> num_leaves.trailing_zeros();
+        let mut current_hash = *ACCUMULATOR_PLACEHOLDER_HASH;
+        let mut frozen_subtree_iter = frozen_subtree_roots.iter().rev();
 
-        // For any accumulator, if we add two children to every existing leaf, the positions of the
-        // frozen subtrees do no change, so the trailing zeros do not matter.
-        let num_leaves = num_leaves >> num_leaves.trailing_zeros();
-        // Because every time we combine two hashes to compute its parent, the tree can be made one
-        // level smaller. So the total number of hashes needed to compute the root hash is
-        // `num_levels`.
-        let num_levels = num_leaves.next_power_of_two().trailing_zeros() + 1;
-        let num_placeholders = num_levels as usize - frozen_subtree_roots.len();
+        while bitmap > 0 {
+            current_hash = if bitmap & 1 != 0 {
+                MerkleTreeInternalNode::<H>::new(
+                    *frozen_subtree_iter
+                        .next()
+                        .expect("This frozen subtree should exist."),
+                    current_hash,
+                )
+            } else {
+                MerkleTreeInternalNode::<H>::new(current_hash, *ACCUMULATOR_PLACEHOLDER_HASH)
+            }
+            .hash();
+            bitmap >>= 1;
+        }
 
-        Self::append_siblings_impl(
-            frozen_subtree_roots,
-            num_leaves,
-            &vec![*ACCUMULATOR_PLACEHOLDER_HASH; num_placeholders],
-        )
-        .expect("Computing root hash should succeed.")
+        current_hash
     }
 
     /// Returns the total number of leaves in this accumulator.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I'm planning to re-implement the function so it returns a new accumulator instead of just the new root hash. Then we will no longer be able to use it to compute the root hash. Use the old way to compute root hash.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

None.
