### PR TITLE
[storage] trivial: libradb cargo.toml ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,7 +1935,6 @@ dependencies = [
  "ir_to_bytecode_syntax 0.1.0",
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "types 0.1.0",
  "vm 0.1.0",
 ]

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -13,7 +13,10 @@ itertools = "0.7.3"
 lazy_static = "1.2.0"
 num-derive = "0.2"
 num-traits = "0.2"
+proptest = "0.9.2"
+proptest-derive = "0.1.2"
 rand = "0.6.5"
+rusty-fork = "0.2.1"
 strum = "0.15.0"
 strum_macros = "0.15.0"
 tempfile = "3.0.6"
@@ -25,9 +28,6 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 jellyfish_merkle = { path = "../jellyfish_merkle" }
 logger = { path = "../../common/logger" }
 metrics = { path = "../../common/metrics" }
-proptest = "0.9.2"
-proptest-derive = "0.1.2"
-rusty-fork = "0.2.1"
 proto_conv = { path = "../../common/proto_conv" }
 schemadb = { path = "../schemadb" }
 storage_proto = { path = "../storage_proto" }


### PR DESCRIPTION


## Motivation

Regroup / reorder it so that external and internal dependencies are separate and in alphabetic order respectively.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

Existing coverage.

## Related PRs
