### PR TITLE
[config] removing unreachable panic

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -125,7 +125,7 @@ impl ConsensusPrivateKey {
                 let key = std::mem::replace(self, ConsensusPrivateKey::Removed);
                 match key {
                     ConsensusPrivateKey::Present(priv_key) => Some(priv_key),
-                    _ => unreachable!(),
+                    _ => None,
                 }
             }
             _ => None,


### PR DESCRIPTION
`ConsensusPrivateKey.take` has an unreachable path that will panic if taken.
Since we can instead return `None`, there's no reason not to return `None`.

