### PR TITLE
[mempool] removing unreachable

### DIFF
--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -359,7 +359,7 @@ async fn inbound_network_task<V>(
                         .error("UnexpectedNetworkEvent")
                         .data(&network_event)
                         .log();
-                    unreachable!("Unexpected network event")
+                    debug_assert!(false, "Unexpected network event");
                 }
             },
             Err(e) => {


### PR DESCRIPTION
`inbound_network_task()` will panic if it ever receives an `Event` enum that is not listed.
As this list of event enums might grow, we should not panic here.