### PR TITLE
[ci] Remove lock file generation now that the lock file exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ jobs:
           name: Cargo Audit
           command: |
             cargo install --force cargo-audit
-            cargo generate-lockfile
             cargo audit
   terraform:
     docker:


### PR DESCRIPTION
## Motivation

Cargo.lock now exists in the repo, so generating it to run cargo audit is no longer needed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo audit now succeeds without needing to call generate-lockfile. Prior to #814 Cargo.lock needed to be generated first or cargo audit would fail.