### PR TITLE
[storage] trivial: longer timeout in `Pruner::wake_and_wait()` (tests only)

### DIFF
--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -91,7 +91,8 @@ impl Pruner {
 
         if latest_version > self.num_historical_versions_to_keep {
             let least_readable_version = latest_version - self.num_historical_versions_to_keep;
-            const TIMEOUT: Duration = Duration::from_millis(100);
+            // Assuming no big pruning chunks will be issued by a test.
+            const TIMEOUT: Duration = Duration::from_secs(10);
             let end = Instant::now() + TIMEOUT;
 
             while Instant::now() < end {


### PR DESCRIPTION


## Motivation


Occationally this times out after code is just built.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

existing coverage

## Related PRs
