### PR TITLE
[ir_to_bytecode_syntax] cleanup to align with Rust conventions

### DIFF
--- a/language/compiler/ir_to_bytecode/src/context.rs
+++ b/language/compiler/ir_to_bytecode/src/context.rs
@@ -106,7 +106,7 @@ impl<'a> CompiledDependency<'a> {
         let module_handle = self.module_pool.get(handle.module.0 as usize)?;
         let address = *self.address_pool.get(module_handle.address.0 as usize)?;
         let module = ModuleName::new(self.string_pool.get(module_handle.name.0 as usize)?.clone());
-        assert!(module.name_ref() != ModuleName::SELF);
+        assert!(module.as_inner() != ModuleName::SELF);
         let ident = QualifiedModuleIdent {
             address,
             name: module,
@@ -117,13 +117,13 @@ impl<'a> CompiledDependency<'a> {
 
     fn struct_handle(&self, name: &QualifiedStructIdent) -> Option<&'a StructHandle> {
         self.structs
-            .get(&(name.module.name_ref(), name.name.name_ref()))
+            .get(&(name.module.as_inner(), name.name.as_inner()))
             .and_then(|idx| self.struct_pool.get(*idx as usize))
     }
 
     fn function_signature(&self, name: &FunctionName) -> Option<&'a FunctionSignature> {
         self.functions
-            .get(name.name_ref())
+            .get(name.as_inner())
             .and_then(|idx| self.function_signatuire_pool.get(*idx as usize))
     }
 }
@@ -401,7 +401,7 @@ impl<'a> Context<'a> {
         // We don't care about duplicate aliases, if they exist
         self.aliases.insert(id.clone(), alias.clone());
         let address = self.address_index(id.address)?;
-        let name = self.string_index(id.name.name_ref())?;
+        let name = self.string_index(id.name.as_inner())?;
         self.modules
             .insert(alias.clone(), (id, ModuleHandle { address, name }));
         Ok(ModuleHandleIndex(get_or_add_item_ref(
@@ -419,7 +419,7 @@ impl<'a> Context<'a> {
         type_formals: Vec<Kind>,
     ) -> Result<StructHandleIndex> {
         let module = self.module_handle_index(&sname.module)?;
-        let name = self.string_index(sname.name.name_ref())?;
+        let name = self.string_index(sname.name.as_inner())?;
         self.structs.insert(
             sname.clone(),
             StructHandle {
@@ -461,7 +461,7 @@ impl<'a> Context<'a> {
     ) -> Result<()> {
         let m_f = (mname.clone(), fname.clone());
         let module = self.module_handle_index(&mname)?;
-        let name = self.string_index(fname.name_ref())?;
+        let name = self.string_index(fname.as_inner())?;
 
         let sidx = get_or_add_item_ref(&mut self.function_signature_pool, &signature)?;
         let signature_index = FunctionSignatureIndex(sidx as TableIndex);
@@ -520,7 +520,7 @@ impl<'a> Context<'a> {
     }
 
     fn dep_struct_handle(&mut self, s: &QualifiedStructIdent) -> Result<(bool, Vec<Kind>)> {
-        if s.module.name_ref() == ModuleName::SELF {
+        if s.module.as_inner() == ModuleName::SELF {
             bail!("Unbound struct {}", s)
         }
         let mident = self.module_ident(&s.module)?.clone();
@@ -613,7 +613,7 @@ impl<'a> Context<'a> {
         m: &ModuleName,
         f: &FunctionName,
     ) -> Result<FunctionSignature> {
-        if m.name_ref() == ModuleName::SELF {
+        if m.as_inner() == ModuleName::SELF {
             bail!("Unbound function {}.{}", m, f)
         }
         let mident = self.module_ident(m)?.clone();

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -538,7 +538,7 @@ fn get_external_deps(imports: &[ImportDefinition]) -> Vec<ModuleId> {
     let mut deps = HashSet::new();
     for dep in imports.iter() {
         if let ModuleIdent::Qualified(id) = &dep.ident {
-            deps.insert(ModuleId::new(id.address, id.name.name()));
+            deps.insert(ModuleId::new(id.address, id.name.clone().into_inner()));
         }
     }
     deps.into_iter().collect()
@@ -586,18 +586,13 @@ impl ModuleName {
         ModuleName::new(ModuleName::SELF.to_string())
     }
 
-    /// Returns the raw bytes of the module name's string value
-    pub fn as_bytes(&self) -> Vec<u8> {
-        self.0.as_bytes().to_vec()
-    }
-
-    /// Returns a cloned copy of the module name's string value
-    pub fn name(&self) -> String {
-        self.0.clone()
+    /// Converts self into a string.
+    pub fn into_inner(self) -> String {
+        self.0
     }
 
     /// Accessor for the module name's string value
-    pub fn name_ref(&self) -> &str {
+    pub fn as_inner(&self) -> &str {
         &self.0
     }
 }
@@ -610,18 +605,18 @@ impl QualifiedModuleIdent {
     }
 
     /// Accessor for the name of the fully qualified module identifier
-    pub fn get_name(&self) -> &ModuleName {
+    pub fn name(&self) -> &ModuleName {
         &self.name
     }
 
     /// Accessor for the address at which the module is published
-    pub fn get_address(&self) -> &AccountAddress {
+    pub fn address(&self) -> &AccountAddress {
         &self.address
     }
 }
 
 impl ModuleIdent {
-    pub fn get_name(&self) -> &ModuleName {
+    pub fn name(&self) -> &ModuleName {
         match self {
             ModuleIdent::Transaction(name) => &name,
             ModuleIdent::Qualified(id) => &id.name,
@@ -708,7 +703,7 @@ impl ImportDefinition {
     pub fn new(ident: ModuleIdent, alias_opt: Option<ModuleName>) -> Self {
         let alias = match alias_opt {
             Some(alias) => alias,
-            None => ident.get_name().clone(),
+            None => ident.name().clone(),
         };
         ImportDefinition { ident, alias }
     }
@@ -720,18 +715,13 @@ impl StructName {
         StructName(name)
     }
 
-    /// Returns the raw bytes of the struct name's string value
-    pub fn as_bytes(&self) -> Vec<u8> {
-        self.0.as_bytes().to_vec()
-    }
-
-    /// Returns a cloned copy of the struct name's string value
-    pub fn name(&self) -> String {
-        self.0.clone()
+    /// Converts self to a string.
+    pub fn into_inner(self) -> String {
+        self.0
     }
 
     /// Accessor for the name of the struct
-    pub fn name_ref(&self) -> &str {
+    pub fn as_inner(&self) -> &str {
         &self.0
     }
 }
@@ -779,13 +769,13 @@ impl FunctionName {
         FunctionName(name)
     }
 
-    /// Returns a cloned copy of the function name's string value
-    pub fn name(&self) -> String {
-        self.0.clone()
+    /// Converts self into a string.
+    pub fn into_inner(self) -> String {
+        self.0
     }
 
     /// Accessor for the name of the function
-    pub fn name_ref(&self) -> &str {
+    pub fn as_inner(&self) -> &str {
         &self.0
     }
 }
@@ -1109,7 +1099,7 @@ impl fmt::Display for QualifiedModuleIdent {
 
 impl fmt::Display for ModuleDefinition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Module({}, ", self.name.name())?;
+        writeln!(f, "Module({}, ", self.name)?;
         write!(f, "Structs(")?;
         for struct_def in &self.structs {
             write!(f, "{}, ", struct_def)?;
@@ -1201,7 +1191,7 @@ impl fmt::Display for FunctionSignature {
 
 impl fmt::Display for QualifiedStructIdent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}.{}", self.module, self.name.name())
+        write!(f, "{}.{}", self.module, self.name)
     }
 }
 

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -551,7 +551,7 @@ ModuleIdent: ModuleIdent = {
 
 ImportAlias: ModuleName = {
     "as" <alias: ModuleName> => {
-        if alias.name_ref() == ModuleName::SELF {
+        if alias.as_inner() == ModuleName::SELF {
             panic!("Invalid use of reserved module alias '{}'", ModuleName::SELF);
         }
         alias


### PR DESCRIPTION
I'm touching some of this code right now, wanted to clean some of this up and avoid some copies.

I removed the as_bytes methods because they weren't being used.
