### PR TITLE
Clean up clippy::identity-conversion

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -189,11 +189,9 @@ fn verify_finality_proof(node: &SMRNode, ledger_info_with_sig: &LedgerInfoWithSi
     for (author, signature) in ledger_info_with_sig.signatures() {
         assert_eq!(
             Ok(()),
-            node.epoch_mgr.validators().verify_signature(
-                *author,
-                ledger_info_hash,
-                &(signature.clone().into())
-            )
+            node.epoch_mgr
+                .validators()
+                .verify_signature(*author, ledger_info_hash, &signature)
         );
     }
 }

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -181,7 +181,7 @@ pub fn placeholder_certificate_for_block(
         let li_sig = signer
             .sign_message(ledger_info_placeholder.hash())
             .expect("Failed to sign LedgerInfo");
-        signatures.insert(signer.author(), li_sig.into());
+        signatures.insert(signer.author(), li_sig);
     }
 
     QuorumCert::new(

--- a/execution/execution_tests/src/tests/execution_service_test.rs
+++ b/execution/execution_tests/src/tests/execution_service_test.rs
@@ -64,11 +64,8 @@ fn test_execution_service_basic() {
         .execute_block(execute_block_request)
         .unwrap();
 
-    let ledger_info_with_sigs = gen_ledger_info_with_sigs(
-        u64::from(version),
-        execute_block_response.root_hash(),
-        block_id,
-    );
+    let ledger_info_with_sigs =
+        gen_ledger_info_with_sigs(version, execute_block_response.root_hash(), block_id);
     execution_client
         .commit_block(ledger_info_with_sigs)
         .unwrap();

--- a/language/e2e_tests/src/account_universe/universe.rs
+++ b/language/e2e_tests/src/account_universe/universe.rs
@@ -179,10 +179,7 @@ impl AccountPicker {
         match pick_style {
             AccountPickStyle::Unlimited => AccountPicker::Unlimited(num_accounts),
             AccountPickStyle::Limited(limit) => {
-                let remaining = (0..num_accounts)
-                    .into_iter()
-                    .map(|idx| (idx, limit))
-                    .collect();
+                let remaining = (0..num_accounts).map(|idx| (idx, limit)).collect();
                 AccountPicker::Limited(remaining)
             }
         }

--- a/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
@@ -522,7 +522,7 @@ impl<'a> ModuleTranslator<'a> {
         let code = &self.stackless_bytecode[idx];
 
         res.push_str("\n{\n");
-        res.push_str("    // declare local variables\n".into());
+        res.push_str("    // declare local variables\n");
 
         let function_handle = self.module.function_handle_at(function_def.function);
         let function_signature = self.module.function_signature_at(function_handle.signature);
@@ -581,7 +581,7 @@ impl<'a> ModuleTranslator<'a> {
         res.push_str(&arg_assignment_str);
         res.push_str("\n    // assign ResourceStores to locals so they can be modified\n");
         res.push_str("    addr_exists' := addr_exists;\n");
-        res.push_str("\n    // bytecode translation starts here\n".into());
+        res.push_str("\n    // bytecode translation starts here\n");
 
         // identify all the branching targets so we can insert labels in front of them
         let mut branching_targets: BTreeSet<usize> = BTreeSet::new();
@@ -678,7 +678,7 @@ impl<'a> ModuleTranslator<'a> {
                 }
             }
         }
-        res.push_str("}\n".into());
+        res.push_str("}\n");
         res
     }
 

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -18,7 +18,7 @@ impl TransactionMetadata {
     pub fn new(txn: &SignedTransaction) -> Self {
         Self {
             sender: txn.sender(),
-            public_key: txn.public_key().into(),
+            public_key: txn.public_key(),
             sequence_number: txn.sequence_number(),
             max_gas_amount: GasUnits::new(txn.max_gas_amount()),
             gas_unit_price: GasPrice::new(txn.gas_unit_price()),

--- a/language/vm/vm_genesis/src/lib.rs
+++ b/language/vm/vm_genesis/src/lib.rs
@@ -143,7 +143,7 @@ impl Accounts {
             gas_unit_price,
             Duration::from_secs(u64::max_value()),
         )
-        .sign(&sender_account.privkey.into(), sender_account.pubkey.into())
+        .sign(&sender_account.privkey, sender_account.pubkey)
         .unwrap()
     }
 

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -76,14 +76,14 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
         (
             dialer_peer_id,
             NetworkPublicKeys {
-                signing_public_key: dialer_signing_public_key.clone().into(),
+                signing_public_key: dialer_signing_public_key.clone(),
                 identity_public_key: dialer_identity_public_key.clone(),
             },
         ),
         (
             listener_peer_id,
             NetworkPublicKeys {
-                signing_public_key: listener_signing_public_key.clone().into(),
+                signing_public_key: listener_signing_public_key.clone(),
                 identity_public_key: listener_identity_public_key.clone(),
             },
         ),
@@ -223,14 +223,14 @@ fn rpc_bench(b: &mut Bencher, msg_len: &usize) {
         (
             dialer_peer_id,
             NetworkPublicKeys {
-                signing_public_key: dialer_signing_public_key.clone().into(),
+                signing_public_key: dialer_signing_public_key.clone(),
                 identity_public_key: dialer_identity_public_key.clone(),
             },
         ),
         (
             listener_peer_id,
             NetworkPublicKeys {
-                signing_public_key: listener_signing_public_key.clone().into(),
+                signing_public_key: listener_signing_public_key.clone(),
                 identity_public_key: listener_identity_public_key.clone(),
             },
         ),

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -112,10 +112,10 @@ fn generate_network_pub_keys_and_signer(
     let (_, identity_pub_key) = x25519::compat::generate_keypair(&mut rng);
     (
         NetworkPublicKeys {
-            signing_public_key: signing_priv_key.public_key().clone().into(),
+            signing_public_key: signing_priv_key.public_key().clone(),
             identity_public_key: identity_pub_key,
         },
-        Signer::new(peer_id, signing_priv_key.into()),
+        Signer::new(peer_id, signing_priv_key),
     )
 }
 

--- a/network/src/validator_network/consensus.rs
+++ b/network/src/validator_network/consensus.rs
@@ -221,14 +221,14 @@ mod tests {
 
         // Consensus should receive deserialized message event
         let event = block_on(stream.next()).unwrap().unwrap();
-        assert_eq!(event, Event::Message((peer_id.into(), consensus_msg)));
+        assert_eq!(event, Event::Message((peer_id, consensus_msg)));
 
         // Network notifies consensus about new peer
         block_on(consensus_tx.send(NetworkNotification::NewPeer(peer_id))).unwrap();
 
         // Consensus should receive notification
         let event = block_on(stream.next()).unwrap().unwrap();
-        assert_eq!(event, Event::NewPeer(peer_id.into()));
+        assert_eq!(event, Event::NewPeer(peer_id));
     }
 
     // `ConsensusNetworkSender` should serialize outbound messages
@@ -245,7 +245,7 @@ mod tests {
         };
 
         // Send the message to network layer
-        block_on(sender.send_to(peer_id.into(), consensus_msg)).unwrap();
+        block_on(sender.send_to(peer_id, consensus_msg)).unwrap();
 
         // Network layer should receive serialized message to send out
         let event = block_on(network_reqs_rx.next()).unwrap();
@@ -284,7 +284,7 @@ mod tests {
 
         // request should be properly deserialized
         let (res_tx, _) = oneshot::channel();
-        let expected_event = Event::RpcRequest((peer_id.into(), req_msg_enum.clone(), res_tx));
+        let expected_event = Event::RpcRequest((peer_id, req_msg_enum.clone(), res_tx));
         let event = block_on(stream.next()).unwrap().unwrap();
         assert_eq!(event, expected_event);
     }
@@ -299,8 +299,7 @@ mod tests {
         // send get_block rpc request
         let peer_id = PeerId::random();
         let req_msg = RequestBlock::new();
-        let f_res_msg =
-            sender.request_block(peer_id.into(), req_msg.clone(), Duration::from_secs(5));
+        let f_res_msg = sender.request_block(peer_id, req_msg.clone(), Duration::from_secs(5));
 
         // build rpc response
         let res_msg = RespondBlock::new();

--- a/network/src/validator_network/mempool.rs
+++ b/network/src/validator_network/mempool.rs
@@ -149,17 +149,13 @@ mod tests {
             mdata: mempool_msg.write_to_bytes().unwrap().into(),
         };
 
-        block_on(mempool_tx.send(NetworkNotification::RecvMessage(
-            PeerId::from(peer_id),
-            network_msg,
-        )))
-        .unwrap();
+        block_on(mempool_tx.send(NetworkNotification::RecvMessage(peer_id, network_msg))).unwrap();
         let event = block_on(stream.next()).unwrap().unwrap();
-        assert_eq!(event, Event::Message((peer_id.into(), mempool_msg)));
+        assert_eq!(event, Event::Message((peer_id, mempool_msg)));
 
-        block_on(mempool_tx.send(NetworkNotification::NewPeer(PeerId::from(peer_id)))).unwrap();
+        block_on(mempool_tx.send(NetworkNotification::NewPeer(peer_id))).unwrap();
         let event = block_on(stream.next()).unwrap().unwrap();
-        assert_eq!(event, Event::NewPeer(peer_id.into()));
+        assert_eq!(event, Event::NewPeer(peer_id));
     }
 
     // `MempoolNetworkSender` should serialize outbound messages
@@ -182,7 +178,7 @@ mod tests {
         let event = block_on(network_reqs_rx.next()).unwrap();
         match event {
             NetworkRequest::SendMessage(recv_peer_id, network_msg) => {
-                assert_eq!(recv_peer_id, PeerId::from(peer_id));
+                assert_eq!(recv_peer_id, peer_id);
                 assert_eq!(network_msg, expected_network_msg);
             }
             event => panic!("Unexpected event: {:?}", event),

--- a/network/src/validator_network/state_synchronizer.rs
+++ b/network/src/validator_network/state_synchronizer.rs
@@ -119,7 +119,7 @@ mod tests {
         send_msg.set_chunk_request(chunk_request);
 
         // Send msg to network layer.
-        block_on(sender.send_to(peer_id.into(), send_msg.clone())).unwrap();
+        block_on(sender.send_to(peer_id, send_msg.clone())).unwrap();
 
         // Wait for msg at network layer.
         let event = block_on(network_reqs_rx.next()).unwrap();
@@ -159,7 +159,7 @@ mod tests {
         block_on(state_sync_tx.send(event)).unwrap();
 
         // request should be properly deserialized
-        let expected_event = Event::Message((peer_id.into(), state_sync_msg.clone()));
+        let expected_event = Event::Message((peer_id, state_sync_msg.clone()));
         let event = block_on(stream.next()).unwrap().unwrap();
         assert_eq!(event, expected_event);
     }

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -165,21 +165,21 @@ fn test_mempool_sync() {
     mempool_msg.set_peer_id(dialer_peer_id.into());
     let sender = AccountAddress::new([0; ADDRESS_LENGTH]);
     let keypair = compat::generate_keypair(&mut rng);
-    let txn = get_test_signed_txn(sender, 0, keypair.0.into(), keypair.1.into(), None);
+    let txn = get_test_signed_txn(sender, 0, keypair.0, keypair.1, None);
     mempool_msg.set_transactions(::protobuf::RepeatedField::from_vec(vec![txn.clone()]));
 
     let f_dialer = async move {
         // Wait until dialing finished and NewPeer event received
         match dialer_mp_net_events.next().await.unwrap().unwrap() {
             Event::NewPeer(peer_id) => {
-                assert_eq!(peer_id, listener_peer_id.into());
+                assert_eq!(peer_id, listener_peer_id);
             }
             event => panic!("Unexpected event {:?}", event),
         }
 
         // Dialer sends a mempool sync message
         dialer_mp_net_sender
-            .send_to(listener_peer_id.into(), mempool_msg)
+            .send_to(listener_peer_id, mempool_msg)
             .await
             .unwrap();
     };
@@ -189,7 +189,7 @@ fn test_mempool_sync() {
         // The listener receives a NewPeer event first
         match listener_mp_net_events.next().await.unwrap().unwrap() {
             Event::NewPeer(peer_id) => {
-                assert_eq!(peer_id, dialer_peer_id.into());
+                assert_eq!(peer_id, dialer_peer_id);
             }
             event => panic!("Unexpected event {:?}", event),
         }
@@ -197,7 +197,7 @@ fn test_mempool_sync() {
         // The listener then receives the mempool sync message
         match listener_mp_net_events.next().await.unwrap().unwrap() {
             Event::Message((peer_id, msg)) => {
-                assert_eq!(peer_id, dialer_peer_id.into());
+                assert_eq!(peer_id, dialer_peer_id);
                 let dialer_peer_id_bytes = Vec::from(&dialer_peer_id);
                 assert_eq!(msg.peer_id, dialer_peer_id_bytes);
                 let transactions: Vec<SignedTransaction> = msg.transactions.into();
@@ -308,21 +308,21 @@ fn test_permissionless_mempool_sync() {
     mempool_msg.set_peer_id(dialer_peer_id.into());
     let sender = AccountAddress::new([0; ADDRESS_LENGTH]);
     let keypair = compat::generate_keypair(&mut rng);
-    let txn = get_test_signed_txn(sender, 0, keypair.0.into(), keypair.1.into(), None);
+    let txn = get_test_signed_txn(sender, 0, keypair.0, keypair.1, None);
     mempool_msg.set_transactions(::protobuf::RepeatedField::from_vec(vec![txn.clone()]));
 
     let f_dialer = async move {
         // Wait until dialing finished and NewPeer event received
         match dialer_mp_net_events.next().await.unwrap().unwrap() {
             Event::NewPeer(peer_id) => {
-                assert_eq!(peer_id, listener_peer_id.into());
+                assert_eq!(peer_id, listener_peer_id);
             }
             event => panic!("Unexpected event {:?}", event),
         }
 
         // Dialer sends a mempool sync message
         dialer_mp_net_sender
-            .send_to(listener_peer_id.into(), mempool_msg)
+            .send_to(listener_peer_id, mempool_msg)
             .await
             .unwrap();
     };
@@ -332,7 +332,7 @@ fn test_permissionless_mempool_sync() {
         // The listener receives a NewPeer event first
         match listener_mp_net_events.next().await.unwrap().unwrap() {
             Event::NewPeer(peer_id) => {
-                assert_eq!(peer_id, dialer_peer_id.into());
+                assert_eq!(peer_id, dialer_peer_id);
             }
             event => panic!("Unexpected event {:?}", event),
         }
@@ -340,7 +340,7 @@ fn test_permissionless_mempool_sync() {
         // The listener then receives the mempool sync message
         match listener_mp_net_events.next().await.unwrap().unwrap() {
             Event::Message((peer_id, msg)) => {
-                assert_eq!(peer_id, dialer_peer_id.into());
+                assert_eq!(peer_id, dialer_peer_id);
                 let dialer_peer_id_bytes = Vec::from(&dialer_peer_id);
                 assert_eq!(msg.peer_id, dialer_peer_id_bytes);
                 let transactions: Vec<SignedTransaction> = msg.transactions.into();
@@ -452,7 +452,7 @@ fn test_consensus_rpc() {
         // Wait until dialing finished and NewPeer event received
         match dialer_con_net_events.next().await.unwrap().unwrap() {
             Event::NewPeer(peer_id) => {
-                assert_eq!(peer_id, listener_peer_id.into());
+                assert_eq!(peer_id, listener_peer_id);
             }
             event => panic!("Unexpected event {:?}", event),
         }
@@ -460,7 +460,7 @@ fn test_consensus_rpc() {
         // Dialer sends a RequestBlock rpc request.
         let res_block_msg = dialer_con_net_sender
             .request_block(
-                listener_peer_id.into(),
+                listener_peer_id,
                 req_block_msg_clone,
                 Duration::from_secs(10),
             )
@@ -477,7 +477,7 @@ fn test_consensus_rpc() {
         // The listener receives a NewPeer event first
         match listener_con_net_events.next().await.unwrap().unwrap() {
             Event::NewPeer(peer_id) => {
-                assert_eq!(peer_id, dialer_peer_id.into());
+                assert_eq!(peer_id, dialer_peer_id);
             }
             event => panic!("Unexpected event {:?}", event),
         }
@@ -485,7 +485,7 @@ fn test_consensus_rpc() {
         // The listener then handles the RequestBlock rpc request.
         match listener_con_net_events.next().await.unwrap().unwrap() {
             Event::RpcRequest((peer_id, mut req_msg, res_tx)) => {
-                assert_eq!(peer_id, dialer_peer_id.into());
+                assert_eq!(peer_id, dialer_peer_id);
 
                 // Check the request
                 assert!(req_msg.has_request_block());

--- a/scripts/clippy.args
+++ b/scripts/clippy.args
@@ -7,8 +7,6 @@ allowed_lints=(
 	"-A" "clippy::get_unwrap"
     "-A" "clippy::new_without_default"
 
-    # Added with compiler bump nightly-2019-04-13
-    "-A" "clippy::identity-conversion"
     # Clippy seems to complain about async functions
     "-A" "clippy::needless_lifetimes"
     # This ends up being platform dependent, e.g. the Instant type

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -84,7 +84,7 @@ impl MockExecutorProxy {
         let receiver = AccountAddress::new([0xff; 32]);
         let program = encode_transfer_program(&receiver, 1);
         let transaction = get_test_signed_txn(
-            sender.into(),
+            sender,
             version + 1,
             GENESIS_KEYPAIR.0.clone(),
             GENESIS_KEYPAIR.1.clone(),

--- a/storage/jellyfish_merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish_merkle/src/jellyfish_merkle_test.rs
@@ -87,21 +87,18 @@ fn test_insert_at_leaf_with_internal_created() {
         Child::new(leaf2.hash(), 1 /* version */, true /* is_leaf */),
     );
     let internal = Node::new_internal(children);
-    assert_eq!(
-        db.get_node(&NodeKey::new_empty_path(0)).unwrap(),
-        leaf1.clone().into()
-    );
+    assert_eq!(db.get_node(&NodeKey::new_empty_path(0)).unwrap(), leaf1);
     assert_eq!(
         db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, Nibble::from(0)))
             .unwrap(),
-        leaf1.into()
+        leaf1
     );
     assert_eq!(
         db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, Nibble::from(15)))
             .unwrap(),
-        leaf2.into()
+        leaf2
     );
-    assert_eq!(db.get_node(&internal_node_key).unwrap(), internal.into());
+    assert_eq!(db.get_node(&internal_node_key).unwrap(), internal);
 }
 
 #[test]
@@ -164,27 +161,21 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
         Node::new_internal(children)
     };
 
-    assert_eq!(
-        db.get_node(&NodeKey::new_empty_path(0)).unwrap(),
-        leaf1.clone().into()
-    );
+    assert_eq!(db.get_node(&NodeKey::new_empty_path(0)).unwrap(), leaf1);
     assert_eq!(
         db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, Nibble::from(0)))
             .unwrap(),
-        leaf1.clone().into()
+        leaf1,
     );
     assert_eq!(
         db.get_node(&internal_node_key.gen_child_node_key(1 /* version */, Nibble::from(1)))
             .unwrap(),
-        leaf2.clone().into()
+        leaf2,
     );
-    assert_eq!(
-        db.get_node(&internal_node_key).unwrap(),
-        internal.clone().into()
-    );
+    assert_eq!(db.get_node(&internal_node_key).unwrap(), internal);
     assert_eq!(
         db.get_node(&NodeKey::new_empty_path(1)).unwrap(),
-        root_internal.clone().into()
+        root_internal,
     );
 
     // 3. Update leaf2 with new value

--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -458,7 +458,7 @@ where
         );
 
         tree_cache.put_node(node_key.clone(), new_leaf_node.clone())?;
-        Ok((node_key, new_leaf_node.into()))
+        Ok((node_key, new_leaf_node))
     }
 
     /// Returns the account state blob (if applicable) and the corresponding merkle proof.

--- a/storage/jellyfish_merkle/src/nibble/nibble_path_test.rs
+++ b/storage/jellyfish_merkle/src/nibble/nibble_path_test.rs
@@ -215,7 +215,6 @@ proptest! {
     fn test_nibble_iter_to_bit_iter((current, nibble_path) in arb_nibble_path_and_current()) {
         let mut nibble_iter = nibble_path.nibbles();
         (0..current)
-            .into_iter()
             .for_each(|_| {
                 nibble_iter.next().unwrap();
             }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -602,7 +602,6 @@ impl LibraDB {
 
         let limit = std::cmp::min(limit, ledger_version - start_version + 1);
         let txn_and_txn_info_list = (start_version..start_version + limit)
-            .into_iter()
             .map(|version| {
                 Ok((
                     self.transaction_store.get_transaction(version)?,
@@ -625,7 +624,6 @@ impl LibraDB {
         let events = if fetch_events {
             Some(
                 (start_version..start_version + limit)
-                    .into_iter()
                     .map(|version| Ok(self.event_store.get_events_by_version(version)?))
                     .collect::<Result<Vec<_>>>()?,
             )

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -43,7 +43,7 @@ fn gen_mock_genesis() -> (
         /* expiration_time = */ std::time::Duration::new(0, 0),
     );
     let signed_txn = raw_txn
-        .sign(&privkey.into(), pubkey.into())
+        .sign(&privkey, pubkey)
         .expect("Signing failed.")
         .into_inner();
     let signed_txn_hash = signed_txn.hash();

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -287,7 +287,7 @@ mod tests {
         for validator in validator_signers.iter() {
             author_to_signature_map.insert(
                 validator.author(),
-                validator.sign_message(random_hash).unwrap().into(),
+                validator.sign_message(random_hash).unwrap(),
             );
         }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Right now this lint `clippy::identity-conversion` is allowed. Remove it from `clippy.args` and fix everything.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.
