### PR TITLE
Clippy: allow unit_arg globally

### DIFF
--- a/common/canonical_serialization/src/canonical_serialization_test.rs
+++ b/common/canonical_serialization/src/canonical_serialization_test.rs
@@ -1,9 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Required to allow Arbitrary
-#![allow(clippy::unit_arg)]
-
 //https://rust-lang.github.io/rust-clippy/master/index.html#blacklisted_name
 //disable it in test so that we can use variable names such as 'foo' and 'bar'
 #![allow(clippy::blacklisted_name)]

--- a/common/proptest_helpers/src/lib.rs
+++ b/common/proptest_helpers/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// clippy warns on the Arbitrary impl for `Index` -- it's how Arbitrary works so ignore it.
-#![allow(clippy::unit_arg)]
-
 #[cfg(test)]
 mod unit_tests;
 

--- a/common/proto_conv/tests/derive.rs
+++ b/common/proto_conv/tests/derive.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 mod proto;
 
 use proptest::prelude::*;

--- a/consensus/src/chained_bft/common.rs
+++ b/consensus/src/chained_bft/common.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use canonical_serialization::{CanonicalDeserialize, CanonicalSerialize};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -68,8 +68,6 @@
 //! }
 //! ```
 
-#![allow(clippy::unit_arg)]
-
 use bytes::Bytes;
 use failure::prelude::*;
 use lazy_static::lazy_static;

--- a/execution/execution_proto/src/lib.rs
+++ b/execution/execution_proto/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 pub mod proto;
 
 #[cfg(test)]

--- a/execution/executor/src/block_tree/block_tree_test.rs
+++ b/execution/executor/src/block_tree/block_tree_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use super::{AddBlockError, Block, CommitBlockError};
 use crypto::HashValue;
 use std::collections::HashSet;

--- a/language/e2e_tests/src/account_universe.rs
+++ b/language/e2e_tests/src/account_universe.rs
@@ -11,9 +11,6 @@
 //! For examples of property-based tests written against this model, see the
 //! `tests/account_universe` directory.
 
-// clippy warns on the Arbitrary impl for `AccountPairGen` -- it's how Arbitrary works so ignore it.
-#![allow(clippy::unit_arg)]
-
 mod create_account;
 mod peer_to_peer;
 mod rotate_key;

--- a/scripts/clippy.args
+++ b/scripts/clippy.args
@@ -3,9 +3,12 @@
 
 # Allowed lints
 allowed_lints=(
-	"-A" "clippy::match_bool"
-	"-A" "clippy::get_unwrap"
+    "-A" "clippy::get_unwrap"
+    "-A" "clippy::match_bool"
     "-A" "clippy::new_without_default"
+
+    # Deriving Arbitrary often causes this warning to show up.
+    "-A" "clippy::unit_arg"
 
     # Clippy seems to complain about async functions
     "-A" "clippy::needless_lifetimes"

--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -59,8 +59,6 @@
 //! [Internal]: crate::node_type::Internal
 //! [Leaf]: crate::node_type::Leaf
 
-#![allow(clippy::unit_arg)]
-
 pub mod iterator;
 #[cfg(test)]
 mod jellyfish_merkle_test;

--- a/storage/jellyfish_merkle/src/node_type/mod.rs
+++ b/storage/jellyfish_merkle/src/node_type/mod.rs
@@ -10,8 +10,6 @@
 //! chidren at the lowest level. [`LeafNode`] stores the full key and the account blob data
 //! associated.
 
-#![allow(clippy::unit_arg)]
-
 #[cfg(test)]
 mod node_type_test;
 

--- a/storage/storage_proto/src/lib.rs
+++ b/storage/storage_proto/src/lib.rs
@@ -23,8 +23,6 @@
 //! [`storage_client`](../storage_client/index.html) don't need to depending on the entire
 //! [`storage_service`](../storage_client/index.html).
 
-#![allow(clippy::unit_arg)]
-
 pub mod proto;
 
 use crypto::{ed25519::*, HashValue};

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -35,9 +35,6 @@
 //! On the other hand, if you want to query only <Alice>/a/*, `address` will be set to Alice and
 //! `path` will be set to "/a" and use the `get_prefix()` method from statedb
 
-// This is caused by deriving Arbitrary for AccessPath.
-#![allow(clippy::unit_arg)]
-
 use crate::{
     account_address::AccountAddress,
     account_config::{

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use bech32::{Bech32, FromBase32, ToBase32};
 use bytes::Bytes;
 use canonical_serialization::{

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 #[cfg(any(test, feature = "testing"))]
 use crate::account_config::{account_resource_path, AccountResource};
 use crate::{

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
 use crate::{
     account_config::AccountEvent,
     event::EventKey,

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::unit_arg)]
-
 #[cfg(any(test, feature = "testing"))]
 use crate::account_address::AccountAddress;
 #[cfg(any(test, feature = "testing"))]

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::{
     account_address::AccountAddress,
     transaction::Version,

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 //! This module has definition of various proofs.
 
 #[cfg(test)]

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1,6 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-#![allow(clippy::unit_arg)]
 
 use crate::{
     access_path::AccessPath,

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::{contract_event::EventWithProof, ledger_info::LedgerInfoWithSignatures};
 use crypto::*;
 use proto_conv::{FromProto, IntoProto};

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::{
     account_address::AccountAddress,
     proto::validator_public_keys::ValidatorPublicKeys as ProtoValidatorPublicKeys,

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::unit_arg)]
-
 use crate::language_storage::ModuleId;
 use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It seems that we are suppressing this lint everywhere, so having it is not providing a lot of value. I think allowing this one globally would not be terrible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.
