### PR TITLE
[storage] enable the pruner

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -94,7 +94,7 @@ pub struct LibraDB {
 
 impl LibraDB {
     /// Config parameter for the pruner.
-    const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = u64::max_value();
+    const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = 1_000_000;
 
     /// This creates an empty LibraDB instance on disk or opens one if it already exists.
     pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {


### PR DESCRIPTION
https://github.com/libra/libra/commit/c433798c5282124014582a00e2d94be135e2f23c  made the client rely on `get_transaction_by_account` to wait for completion of a transaction, which unfortunately depends on full state history, hence the pruner won't be allowed on any node that serves read requests.
After #835 `get_transaction_by_account` no longer depends on full state history.

## Motivation

Resume testing the pruner in production.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

changed `MAX_HISTORICAL_VERSIONS_TO_KEEP` to 0 and started a local swarm, client was able to do txns etc which was not the case before #835 

## Related PRs

#835 