### PR TITLE
[language/vm] implement bounds checking for generics

### DIFF
--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -4,9 +4,9 @@
 use crate::{
     errors::{append_err_info, bounds_error, bytecode_offset_err, verification_error},
     file_format::{
-        Bytecode, CompiledModuleMut, FieldDefinition, FunctionDefinition, FunctionHandle,
-        FunctionSignature, LocalsSignature, ModuleHandle, SignatureToken, StructDefinition,
-        StructFieldInformation, StructHandle, TypeSignature,
+        Bytecode, CodeUnit, CompiledModuleMut, FieldDefinition, FunctionDefinition, FunctionHandle,
+        FunctionSignature, Kind, LocalsSignature, LocalsSignatureIndex, ModuleHandle,
+        SignatureToken, StructDefinition, StructFieldInformation, StructHandle, TypeSignature,
     },
     internals::ModuleIndex,
     IndexKind,
@@ -34,79 +34,113 @@ impl<'a> BoundsChecker<'a> {
             errors.push(vec![status]);
         }
 
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::ModuleHandle,
             self.module.module_handles.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::StructHandle,
             self.module.struct_handles.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::FunctionHandle,
             self.module.function_handles.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::StructDefinition,
             self.module.struct_defs.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::FieldDefinition,
             self.module.field_defs.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::FunctionDefinition,
             self.module.function_defs.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
-            IndexKind::TypeSignature,
-            self.module.type_signatures.iter(),
-            self.module,
-        ));
-        errors.push(Self::verify_impl(
+        errors.push(Self::verify_pool(
             IndexKind::FunctionSignature,
             self.module.function_signatures.iter(),
             self.module,
         ));
-        errors.push(Self::verify_impl(
-            IndexKind::LocalsSignature,
-            self.module.locals_signatures.iter(),
-            self.module,
-        ));
+
+        // Check the struct handle indices in locals signatures.
+        // Type parameter indices are checked later in a separate pass.
+        errors.push(
+            self.module
+                .locals_signatures
+                .iter()
+                .enumerate()
+                .map(|(idx, locals)| {
+                    locals
+                        .check_struct_handles(&self.module.struct_handles)
+                        .into_iter()
+                        .map(move |err| append_err_info(err, IndexKind::LocalsSignature, idx))
+                })
+                .flatten()
+                .collect(),
+        );
+
+        // Check the struct handle indices in type signatures.
+        errors.push(
+            self.module
+                .type_signatures
+                .iter()
+                .enumerate()
+                .map(|(idx, ty)| {
+                    ty.check_struct_handles(&self.module.struct_handles)
+                        .into_iter()
+                        .map(move |err| append_err_info(err, IndexKind::TypeSignature, idx))
+                })
+                .flatten()
+                .collect(),
+        );
 
         let errors: Vec<_> = errors.into_iter().flatten().collect();
         if !errors.is_empty() {
             return errors;
         }
 
-        // Code unit checking needs to be done once the rest of the module is validated.
-        self.module
-            .function_defs
-            .iter()
-            .enumerate()
-            .flat_map(|(idx, elem)| {
-                elem.check_code_unit_bounds(self.module)
-                    .into_iter()
-                    .map(move |err| append_err_info(err, IndexKind::FunctionDefinition, idx))
-            })
-            .collect()
+        // Fields and function bodies need to be done once the rest of the module is validated.
+        let errors_type_signatures = self.module.field_defs.iter().flat_map(|field_def| {
+            let sh = &self.module.struct_handles[field_def.struct_.0 as usize];
+            let sig = &self.module.type_signatures[field_def.signature.0 as usize];
+
+            sig.check_type_parameters(sh.type_formals.len())
+        });
+
+        let errors_code_units = self.module.function_defs.iter().flat_map(|function_def| {
+            if function_def.is_native() {
+                vec![]
+            } else {
+                let fh = &self.module.function_handles[function_def.function.0 as usize];
+                let sig = &self.module.function_signatures[fh.signature.0 as usize];
+                function_def.code.check_bounds((self.module, sig))
+            }
+        });
+
+        errors_type_signatures.chain(errors_code_units).collect()
     }
 
     #[inline]
-    fn verify_impl(
+    fn verify_pool<Context, Item: 'a>(
         kind: IndexKind,
-        iter: impl Iterator<Item = impl BoundsCheck>,
-        module: &CompiledModuleMut,
-    ) -> Vec<VMStatus> {
+        iter: impl Iterator<Item = &'a Item>,
+        context: Context,
+    ) -> Vec<VMStatus>
+    where
+        Context: Copy,
+        Item: BoundsCheck<Context>,
+    {
         iter.enumerate()
             .flat_map(move |(idx, elem)| {
-                elem.check_bounds(module)
+                elem.check_bounds(context)
                     .into_iter()
                     .map(move |err| append_err_info(err, kind, idx))
             })
@@ -114,8 +148,8 @@ impl<'a> BoundsChecker<'a> {
     }
 }
 
-pub trait BoundsCheck {
-    fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus>;
+pub trait BoundsCheck<Context: Copy> {
+    fn check_bounds(&self, context: Context) -> Vec<VMStatus>;
 }
 
 #[inline]
@@ -134,7 +168,7 @@ where
 }
 
 #[inline]
-fn check_code_unit_bounds_impl<T, I>(pool: &[T], bytecode_offset: usize, idx: I) -> Option<VMStatus>
+fn check_code_unit_bounds_impl<T, I>(pool: &[T], bytecode_offset: usize, idx: I) -> Vec<VMStatus>
 where
     I: ModuleIndex,
 {
@@ -148,13 +182,13 @@ where
             bytecode_offset,
             StatusCode::INDEX_OUT_OF_BOUNDS,
         );
-        Some(status)
+        vec![status]
     } else {
-        None
+        vec![]
     }
 }
 
-impl BoundsCheck for &ModuleHandle {
+impl BoundsCheck<&CompiledModuleMut> for ModuleHandle {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         vec![
@@ -167,7 +201,7 @@ impl BoundsCheck for &ModuleHandle {
     }
 }
 
-impl BoundsCheck for &StructHandle {
+impl BoundsCheck<&CompiledModuleMut> for StructHandle {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         vec![
@@ -180,7 +214,7 @@ impl BoundsCheck for &StructHandle {
     }
 }
 
-impl BoundsCheck for &FunctionHandle {
+impl BoundsCheck<&CompiledModuleMut> for FunctionHandle {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         vec![
@@ -194,7 +228,7 @@ impl BoundsCheck for &FunctionHandle {
     }
 }
 
-impl BoundsCheck for &StructDefinition {
+impl BoundsCheck<&CompiledModuleMut> for StructDefinition {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         vec![
@@ -213,7 +247,7 @@ impl BoundsCheck for &StructDefinition {
     }
 }
 
-impl BoundsCheck for &FieldDefinition {
+impl BoundsCheck<&CompiledModuleMut> for FieldDefinition {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         vec![
@@ -227,7 +261,7 @@ impl BoundsCheck for &FieldDefinition {
     }
 }
 
-impl BoundsCheck for &FunctionDefinition {
+impl BoundsCheck<&CompiledModuleMut> for FunctionDefinition {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         vec![
@@ -249,64 +283,169 @@ impl BoundsCheck for &FunctionDefinition {
     }
 }
 
-impl BoundsCheck for &TypeSignature {
+impl<Context> BoundsCheck<Context> for TypeSignature
+where
+    Context: Copy,
+    SignatureToken: BoundsCheck<Context>,
+{
     #[inline]
-    fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
-        self.0.check_bounds(module).into_iter().collect()
+    fn check_bounds(&self, context: Context) -> Vec<VMStatus> {
+        self.0.check_bounds(context).into_iter().collect()
     }
 }
 
-impl BoundsCheck for &FunctionSignature {
+impl TypeSignature {
+    fn check_struct_handles(&self, struct_handles: &[StructHandle]) -> Vec<VMStatus> {
+        self.0.check_struct_handles(struct_handles)
+    }
+
+    fn check_type_parameters(&self, type_formals_len: usize) -> Vec<VMStatus> {
+        self.0.check_type_parameters(type_formals_len)
+    }
+}
+
+impl BoundsCheck<&CompiledModuleMut> for FunctionSignature {
     #[inline]
     fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
         self.return_types
             .iter()
-            .filter_map(|token| token.check_bounds(module))
+            .map(|token| token.check_bounds((module, self)))
             .chain(
                 self.arg_types
                     .iter()
-                    .filter_map(|token| token.check_bounds(module)),
+                    .map(|token| token.check_bounds((module, self))),
             )
+            .flatten()
             .collect()
     }
 }
 
-impl BoundsCheck for &LocalsSignature {
-    #[inline]
-    fn check_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
+impl LocalsSignature {
+    fn check_type_parameters(&self, type_formals_len: usize) -> Vec<VMStatus> {
         self.0
             .iter()
-            .filter_map(|token| token.check_bounds(module))
+            .map(|ty| ty.check_type_parameters(type_formals_len))
+            .flatten()
+            .collect()
+    }
+
+    fn check_struct_handles(&self, struct_handles: &[StructHandle]) -> Vec<VMStatus> {
+        self.0
+            .iter()
+            .map(|ty| ty.check_struct_handles(struct_handles))
+            .flatten()
+            .collect()
+    }
+}
+
+impl BoundsCheck<(&[StructHandle], usize)> for SignatureToken {
+    fn check_bounds(&self, context: (&[StructHandle], usize)) -> Vec<VMStatus> {
+        self.check_type_parameters(context.1)
+            .into_iter()
+            .chain(self.check_struct_handles(context.0))
             .collect()
     }
 }
 
 impl SignatureToken {
-    #[inline]
-    fn check_bounds(&self, module: &CompiledModuleMut) -> Option<VMStatus> {
-        self.struct_index()
-            .and_then(|sh_idx| check_bounds_impl(&module.struct_handles, sh_idx))
+    pub fn check_type_parameters(&self, type_formals_len: usize) -> Vec<VMStatus> {
+        match self {
+            SignatureToken::Struct(_, type_actuals) => type_actuals
+                .iter()
+                .map(|ty| ty.check_type_parameters(type_formals_len))
+                .flatten()
+                .collect(),
+            SignatureToken::Reference(ty) | SignatureToken::MutableReference(ty) => {
+                ty.check_type_parameters(type_formals_len)
+            }
+            SignatureToken::TypeParameter(idx) => {
+                let idx = *idx as usize;
+                if idx >= type_formals_len {
+                    vec![bounds_error(
+                        IndexKind::TypeParameter,
+                        idx,
+                        type_formals_len,
+                        StatusCode::INDEX_OUT_OF_BOUNDS,
+                    )]
+                } else {
+                    vec![]
+                }
+            }
+            _ => vec![],
+        }
+    }
+
+    pub fn check_struct_handles(&self, struct_handles: &[StructHandle]) -> Vec<VMStatus> {
+        match self {
+            SignatureToken::Struct(idx, type_actuals) => {
+                let mut errors: Vec<_> = type_actuals
+                    .iter()
+                    .map(|ty| ty.check_struct_handles(struct_handles))
+                    .flatten()
+                    .collect();
+                if let Some(err) = check_bounds_impl(struct_handles, *idx) {
+                    errors.push(err);
+                }
+                errors
+            }
+            SignatureToken::Reference(ty) | SignatureToken::MutableReference(ty) => {
+                ty.check_struct_handles(struct_handles)
+            }
+            _ => vec![],
+        }
     }
 }
 
-impl FunctionDefinition {
-    // This is implemented separately because it depends on the locals signature index being
-    // checked.
-    fn check_code_unit_bounds(&self, module: &CompiledModuleMut) -> Vec<VMStatus> {
-        if self.is_native() {
-            return vec![];
-        }
+impl BoundsCheck<(&[StructHandle], &[Kind])> for SignatureToken {
+    fn check_bounds(&self, context: (&[StructHandle], &[Kind])) -> Vec<VMStatus> {
+        self.check_bounds((context.0, context.1.len()))
+    }
+}
 
-        let locals_len = module.locals_signatures[self.code.locals.0 as usize]
-            .0
-            .len();
+impl BoundsCheck<(&CompiledModuleMut, &FunctionSignature)> for SignatureToken {
+    fn check_bounds(&self, context: (&CompiledModuleMut, &FunctionSignature)) -> Vec<VMStatus> {
+        self.check_bounds((
+            context.0.struct_handles.as_slice(),
+            context.1.type_formals.as_slice(),
+        ))
+    }
+}
 
-        let code = &self.code.code;
+impl BoundsCheck<(&CompiledModuleMut, &StructHandle)> for SignatureToken {
+    fn check_bounds(&self, context: (&CompiledModuleMut, &StructHandle)) -> Vec<VMStatus> {
+        self.check_bounds((
+            context.0.struct_handles.as_slice(),
+            context.1.type_formals.as_slice(),
+        ))
+    }
+}
+
+fn check_type_actuals_bounds(
+    context: (&CompiledModuleMut, &FunctionSignature),
+    bytecode_offset: usize,
+    idx: LocalsSignatureIndex,
+) -> Vec<VMStatus> {
+    let (module, function_sig) = context;
+    let errs = check_code_unit_bounds_impl(&module.locals_signatures, bytecode_offset, idx);
+    if !errs.is_empty() {
+        return errs;
+    }
+    module.locals_signatures[idx.0 as usize].check_type_parameters(function_sig.type_formals.len())
+}
+
+impl BoundsCheck<(&CompiledModuleMut, &FunctionSignature)> for CodeUnit {
+    fn check_bounds(&self, context: (&CompiledModuleMut, &FunctionSignature)) -> Vec<VMStatus> {
+        let (module, _) = context;
+
+        let locals = &module.locals_signatures[self.locals.0 as usize];
+        let locals_len = locals.0.len();
+
+        let code = &self.code;
         let code_len = code.len();
 
         code.iter()
             .enumerate()
-            .filter_map(|(bytecode_offset, bytecode)| {
+            .map(|(bytecode_offset, bytecode)| {
                 use self::Bytecode::*;
 
                 match bytecode {
@@ -323,17 +462,31 @@ impl FunctionDefinition {
                     MutBorrowField(idx) | ImmBorrowField(idx) => {
                         check_code_unit_bounds_impl(&module.field_defs, bytecode_offset, *idx)
                     }
-                    Call(idx, _) => {
+                    Call(idx, type_actuals_idx) => {
                         check_code_unit_bounds_impl(&module.function_handles, bytecode_offset, *idx)
-                    } // FIXME: check bounds for type actuals?
-                    Pack(idx, _)
-                    | Unpack(idx, _)
-                    | Exists(idx, _)
-                    | MutBorrowGlobal(idx, _)
-                    | ImmBorrowGlobal(idx, _)
-                    | MoveFrom(idx, _)
-                    | MoveToSender(idx, _) => {
+                            .into_iter()
+                            .chain(check_type_actuals_bounds(
+                                context,
+                                bytecode_offset,
+                                *type_actuals_idx,
+                            ))
+                            .collect()
+                    }
+                    Pack(idx, type_actuals_idx)
+                    | Unpack(idx, type_actuals_idx)
+                    | Exists(idx, type_actuals_idx)
+                    | ImmBorrowGlobal(idx, type_actuals_idx)
+                    | MutBorrowGlobal(idx, type_actuals_idx)
+                    | MoveFrom(idx, type_actuals_idx)
+                    | MoveToSender(idx, type_actuals_idx) => {
                         check_code_unit_bounds_impl(&module.struct_defs, bytecode_offset, *idx)
+                            .into_iter()
+                            .chain(check_type_actuals_bounds(
+                                context,
+                                bytecode_offset,
+                                *type_actuals_idx,
+                            ))
+                            .collect()
                     }
                     // Instructions that refer to this code block.
                     BrTrue(offset) | BrFalse(offset) | Branch(offset) => {
@@ -346,9 +499,9 @@ impl FunctionDefinition {
                                 bytecode_offset,
                                 StatusCode::INDEX_OUT_OF_BOUNDS,
                             );
-                            Some(status)
+                            vec![status]
                         } else {
-                            None
+                            vec![]
                         }
                     }
                     // Instructions that refer to the locals.
@@ -363,9 +516,9 @@ impl FunctionDefinition {
                                 bytecode_offset,
                                 StatusCode::INDEX_OUT_OF_BOUNDS,
                             );
-                            Some(status)
+                            vec![status]
                         } else {
-                            None
+                            vec![]
                         }
                     }
 
@@ -375,9 +528,10 @@ impl FunctionDefinition {
                     | Add | Sub | Mul | Mod | Div | BitOr | BitAnd | Xor | Or | And | Not | Eq
                     | Neq | Lt | Gt | Le | Ge | Abort | GetTxnGasUnitPrice | GetTxnMaxGasUnits
                     | GetGasRemaining | GetTxnSenderAddress | CreateAccount
-                    | GetTxnSequenceNumber | GetTxnPublicKey => None,
+                    | GetTxnSequenceNumber | GetTxnPublicKey => vec![],
                 }
             })
+            .flatten()
             .collect()
     }
 }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1655,6 +1655,66 @@ pub fn empty_module() -> CompiledModuleMut {
     }
 }
 
+/// Create a module with one empty function & one struct with one field of type u64.
+/// This is convenient to tests.
+pub fn basic_test_module() -> CompiledModuleMut {
+    let mut m = empty_module();
+
+    m.function_signatures.push(FunctionSignature {
+        return_types: vec![],
+        arg_types: vec![],
+        type_formals: vec![],
+    });
+
+    m.function_handles.push(FunctionHandle {
+        module: ModuleHandleIndex::new(0),
+        name: IdentifierIndex::new(m.identifiers.len() as u16),
+        signature: FunctionSignatureIndex::new(0),
+    });
+    m.identifiers
+        .push(Identifier::new("foo".to_string()).unwrap());
+
+    m.function_defs.push(FunctionDefinition {
+        function: FunctionHandleIndex::new(0),
+        flags: 0,
+        acquires_global_resources: vec![],
+        code: CodeUnit {
+            max_stack_size: 0,
+            locals: LocalsSignatureIndex::new(0),
+            code: vec![],
+        },
+    });
+
+    m.struct_handles.push(StructHandle {
+        module: ModuleHandleIndex::new(0),
+        name: IdentifierIndex::new(m.identifiers.len() as u16),
+        is_nominal_resource: false,
+        type_formals: vec![],
+    });
+    m.identifiers
+        .push(Identifier::new("Bar".to_string()).unwrap());
+
+    m.struct_defs.push(StructDefinition {
+        struct_handle: StructHandleIndex::new(0),
+        field_information: StructFieldInformation::Declared {
+            field_count: 1,
+            fields: FieldDefinitionIndex::new(0),
+        },
+    });
+
+    m.field_defs.push(FieldDefinition {
+        struct_: StructHandleIndex::new(0),
+        name: IdentifierIndex::new(m.identifiers.len() as u16),
+        signature: TypeSignatureIndex::new(0),
+    });
+    m.identifiers
+        .push(Identifier::new("x".to_string()).unwrap());
+
+    m.type_signatures.push(TypeSignature(SignatureToken::U64));
+
+    m
+}
+
 /// Create a dummy module to wrap the bytecode program in local@code
 pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
     let mut module = empty_module();


### PR DESCRIPTION
## Summary

This implements bounds checking for generics. 

Notable changes:
  - Refactored the existing code a little bit.
    - `trait BoundsCheck` becomes `trait BoundsCheck<Context>`
      - This makes checking `SignatureToken`s much easier while allowing most existing code to work as is.
  - New checks added:
    - Bounds checking for `SignatureToken::TypeParameter`.
    - Recursive bounds checking for `SignatureToken`, due to structs now carry type actuals.
    - Bounds checking for all bytecode instructions with type actuals.

## Test Plan
Update: 
  - Implemented unused entry checker.
  - Added a few manually written test cases.
  - Left related prop tests untouched for now. Making them generate type parameters will require some rework of the system. We had some discussions on this and decided to visit it later.
-----------------------------------------------------------------------------------------------
Randomly generated tests currently **don't** pass.  All functional tests pass.

With the introduction of generics, we can no longer check the bounds of `TypeSignature` & `LocalsSignature` without a context that gives information about type formals (function/struct). This means, there can be unchecked entries in the `type_signatures` and `locals_signatures` tables, which may get generated in tests, causing them to fail.

After a talk with @sblackshear I can see two solutions:
1) Implement another checker that rules out all the "unused/unreachable" things in the file format.
2) Allow them in the file format, as they are not harmful, and don't generate those in tests.

Personally I'd prefer 1), but let me know your opinions!