### PR TITLE
[benchmark] cleanup: change timeouts; remove prints and confusing names

### DIFF
--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -117,11 +117,11 @@ mod tests {
                 num_rounds,
                 num_epochs,
             );
-            let requested_txns = OP_COUNTER.counter("requested_txns").get();
-            let created_txns = OP_COUNTER.counter("created_txns").get();
-            let sign_failed_txns = OP_COUNTER.counter("sign_failed_txns").get();
-            assert_eq!(requested_txns, created_txns + sign_failed_txns);
-            let accepted_txns = OP_COUNTER.counter("submit_txns.Accepted").get();
+            let created_txns = OP_COUNTER.counter("create_txn_request.success").get();
+            let failed_to_create = OP_COUNTER.counter("create_txn_request.failure").get();
+            assert!(created_txns + failed_to_create == (4 * 4 * 2 + 4));
+            let accepted_txns = OP_COUNTER.counter("submit_txns.success").get();
+            assert!(accepted_txns <= created_txns);
             let committed_txns = OP_COUNTER.counter("committed_txns").get();
             let timedout_txns = OP_COUNTER.counter("timedout_txns").get();
             // Why `<=`: timedout TXNs in previous epochs can be committed in the next epoch.

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -42,10 +42,10 @@ lazy_static! {
 ///    submit_requests_and_wait_txns_committed, measure_txn_throughput.
 /// Metrics reported include:
 /// * Counters related to:
-///   * TXN generation: requested_txns, created_txns, sign_failed_txns;
+///   * TXN generation: create_txn_request.(success|failure)
 ///   * Submission to AC and AC response: submit_requests (used to measure submission rate),
-///     submit_txns.{ac_status_code}, submit_txns.{mempool_status_code}, submit_txns.{vm_status},
-///     submit_txns.{grpc_error}, submit_read_requests.{error};
+///     submit_txns.failure.ac.{ac_status_code}, submit_txns.failure.mempool.{mempool_status_code},
+///     submit_txns.failure.vm..{vm_status}, submit_txns.{grpc_error}, submit_read_requests.{error};
 ///   * Final status within epoch: committed_txns, timedout_txns;
 /// * Gauges: request_duration_ms, running_duration_ms, request_throughput, txns_throughput.
 /// * Histograms: read_requests.response_bytes.

--- a/benchmark/src/load_generator.rs
+++ b/benchmark/src/load_generator.rs
@@ -90,7 +90,6 @@ fn gen_submit_transaction_request<T: TransactionSigner>(
     sender_account: &mut AccountData,
     signer: &T,
 ) -> Result<Request> {
-    OP_COUNTER.inc("requested_txns");
     // If generation fails here, sequence number will not be increased,
     // so it is fine to continue later generation.
     let signed_txn = create_signed_txn(
@@ -103,13 +102,13 @@ fn gen_submit_transaction_request<T: TransactionSigner>(
         TXN_EXPIRATION,
     )
     .or_else(|e| {
-        OP_COUNTER.inc("sign_failed_txns");
+        OP_COUNTER.inc("create_txn_request.failure");
         Err(e)
     })?;
     let mut req = SubmitTransactionRequest::new();
     req.set_signed_txn(signed_txn.into_proto());
     sender_account.sequence_number += 1;
-    OP_COUNTER.inc("created_txns");
+    OP_COUNTER.inc("create_txn_request.success");
     Ok(Request::WriteRequest(req))
 }
 

--- a/benchmark/src/submit_rate.rs
+++ b/benchmark/src/submit_rate.rs
@@ -69,12 +69,10 @@ mod tests {
         let flood = ConstantRate::new(std::u64::MAX, vec.into_iter());
 
         let now = time::Instant::now();
-        for item in flood {
-            let elapsed = now.elapsed().as_micros();
-            println!("Ret {:?} after {:?} us", item, elapsed);
-        }
+        // consume all elements
+        flood.into_iter().for_each(drop);
         let elapsed = now.elapsed().as_micros();
-        // Loop should finish at an glimpse.
+        // Loop should finish instantly
         assert!(elapsed < 1000);
     }
 
@@ -84,10 +82,9 @@ mod tests {
         let const_rate = ConstantRate::new(2, vec.into_iter());
 
         let mut now = time::Instant::now();
-        for item in const_rate {
+        for _item in const_rate {
             let new_now = time::Instant::now();
             let delta = new_now.duration_since(now).as_micros();
-            println!("Ret {:?} after {:?} us", item, delta);
             // Interval between each call to next() should be roughly 0.5 second.
             assert!(delta < 510_000);
             assert!(delta > 490_000);
@@ -101,10 +98,9 @@ mod tests {
         let const_rate = ConstantRate::new(2, vec.into_iter());
 
         let mut now = time::Instant::now();
-        for item in const_rate {
+        for _item in const_rate {
             let new_now = time::Instant::now();
             let delta = new_now.duration_since(now).as_micros();
-            println!("Ret {:?} after {:?} us", item, delta);
             // Interval between each call to next() should be roughly 0.5 second.
             assert!(delta < 510_000);
             assert!(delta > 490_000);


### PR DESCRIPTION
## Motivation
Small code cleanup: remove prints from code, change a const that 
Rename counters to something a bit less confusing (I'm was confused by what each name means).

Not much will change after this commit except for counters and also smoother operation, because there's no waiting for thousands of `UpdatetoLatestLedger` requests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
Tested on my test-env, with image from nightly + this commit.
Got smoother operation compared to before this change, counters are named OK