### PR TITLE
[easy][vm_runtime] Bring unit tests in line with overall coding conventions

### DIFF
--- a/language/vm/vm_runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm_runtime/src/code_cache/module_cache.rs
@@ -26,8 +26,7 @@ use vm_cache_map::{Arena, CacheRefMap};
 use vm_runtime_types::loaded_data::{struct_def::StructDef, types::Type};
 
 #[cfg(test)]
-#[path = "../unit_tests/module_cache_tests.rs"]
-mod module_cache_tests;
+use crate::code_cache::module_adapter::FakeFetcher;
 
 /// Trait that describe a cache for modules. The idea is that this trait will in charge of
 /// loading resolving all dependencies of needed module from the storage.
@@ -389,6 +388,13 @@ where
             vm_cache,
             storage: module_fetcher,
         }
+    }
+}
+
+#[cfg(test)]
+impl<'alloc, 'blk> BlockModuleCache<'alloc, 'blk, FakeFetcher> {
+    pub(crate) fn clear(&mut self) {
+        self.storage.clear();
     }
 }
 

--- a/language/vm/vm_runtime/src/identifier.rs
+++ b/language/vm/vm_runtime/src/identifier.rs
@@ -9,10 +9,6 @@ use types::{
 };
 use vm::{access::ModuleAccess, file_format::StructDefinitionIndex};
 
-#[cfg(test)]
-#[path = "unit_tests/identifier_prop_tests.rs"]
-mod identifier_prop_tests;
-
 /// Get the StructTag for a StructDefinition defined in a published module.
 pub fn resource_storage_key(module: &impl ModuleAccess, idx: StructDefinitionIndex) -> StructTag {
     let resource = module.struct_def_at(idx);

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -117,6 +117,8 @@ mod gas_meter;
 mod move_vm;
 mod process_txn;
 mod runtime;
+#[cfg(test)]
+mod unit_tests;
 
 pub mod code_cache;
 pub mod data_cache;

--- a/language/vm/vm_runtime/src/txn_executor.rs
+++ b/language/vm/vm_runtime/src/txn_executor.rs
@@ -42,10 +42,6 @@ use vm_runtime_types::{
     value::{Local, MutVal, Reference, Value},
 };
 
-#[cfg(test)]
-#[path = "unit_tests/runtime_tests.rs"]
-mod runtime_tests;
-
 // Metadata needed for resolving the account module.
 lazy_static! {
     /// The ModuleId for the Account module

--- a/language/vm/vm_runtime/src/unit_tests/mod.rs
+++ b/language/vm/vm_runtime/src/unit_tests/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod identifier_prop_tests;
+mod module_cache_tests;
+mod runtime_tests;

--- a/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
@@ -1,21 +1,30 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
 use crate::{
-    code_cache::{module_adapter::FakeFetcher, module_cache::ModuleCache},
-    loaded_data::function::{FunctionRef, FunctionReference},
+    code_cache::{
+        module_adapter::FakeFetcher,
+        module_cache::{BlockModuleCache, ModuleCache, TransactionModuleCache, VMModuleCache},
+    },
+    gas_meter::GasMeter,
+    loaded_data::{
+        function::{FunctionRef, FunctionReference},
+        loaded_module::LoadedModule,
+    },
 };
 use assert_matches::assert_matches;
-use bytecode_verifier::VerifiedScript;
+use bytecode_verifier::{VerifiedModule, VerifiedScript};
 use compiler::Compiler;
 use hex;
-use types::account_address::AccountAddress;
+use types::{account_address::AccountAddress, language_storage::ModuleId};
 use vm::{
+    access::ModuleAccess,
+    errors::{VMErrorKind, VMRuntimeError, VerificationStatus},
     file_format::*,
     gas_schedule::{GasAlgebra, GasUnits},
 };
 use vm_cache_map::Arena;
+use vm_runtime_types::loaded_data::{struct_def::StructDef, types::Type};
 
 fn test_module(name: String) -> VerifiedModule {
     let compiled_module = CompiledModuleMut {
@@ -293,7 +302,7 @@ fn test_cache_with_storage() {
         assert_eq!(func2.code_definition(), vec![Bytecode::Ret].as_slice());
 
         // Clean the fetcher so that there's nothing in the fetcher.
-        block_cache.storage.clear();
+        block_cache.clear();
 
         let func1 = block_cache
             .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))

--- a/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
@@ -1,13 +1,22 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
-use crate::{code_cache::module_cache::VMModuleCache, txn_executor::TransactionExecutor};
+use crate::{
+    code_cache::module_cache::{ModuleCache, VMModuleCache},
+    data_cache::RemoteCache,
+    loaded_data::{
+        function::{FunctionRef, FunctionReference},
+        loaded_module::LoadedModule,
+    },
+    txn_executor::TransactionExecutor,
+};
 use bytecode_verifier::{VerifiedModule, VerifiedScript};
 use crypto::ed25519::compat;
 use std::collections::HashMap;
 use types::{access_path::AccessPath, account_address::AccountAddress, byte_array::ByteArray};
 use vm::{
+    access::ModuleAccess,
+    errors::{VMErrorKind, VMInvariantViolation, VMResult},
     file_format::{
         AddressPoolIndex, Bytecode, CodeUnit, CompiledModuleMut, CompiledScript, CompiledScriptMut,
         FunctionDefinition, FunctionHandle, FunctionHandleIndex, FunctionSignature,


### PR DESCRIPTION
I want to add a helper to `unit_tests/mod.rs`, so I had an incentive to do this. :)