### PR TITLE
[benchmark] Fix unnecessary into_iter() call that failed clippy

### DIFF
--- a/benchmark/src/submit_rate.rs
+++ b/benchmark/src/submit_rate.rs
@@ -70,7 +70,7 @@ mod tests {
 
         let now = time::Instant::now();
         // consume all elements
-        flood.into_iter().for_each(drop);
+        flood.for_each(drop);
         let elapsed = now.elapsed().as_micros();
         // Loop should finish instantly
         assert!(elapsed < 1000);


### PR DESCRIPTION
## Motivation

Somehow the changes in #842 passed clippy but are causing master to now fail. This removes a 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Running `./scripts/clippy.sh` now passes.
