### PR TITLE
[language] add testing script running all verified tests in functional_tests

### DIFF
--- a/language/stackless_bytecode/bytecode_to_boogie/Cargo.toml
+++ b/language/stackless_bytecode/bytecode_to_boogie/Cargo.toml
@@ -13,7 +13,8 @@ ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
 stackless_bytecode_generator = { path = "../generator"}
 stdlib = { path = "../../stdlib" }
 num = "0.2.0"
-
+functional_tests = { path = "../../functional_tests" }
+datatest = "0.3.5"
 [dev-dependencies]
 proptest = "0.9"
 types = { path = "../../../types", features = ["testing"]}

--- a/language/stackless_bytecode/bytecode_to_boogie/run_boogie.sh
+++ b/language/stackless_bytecode/bytecode_to_boogie/run_boogie.sh
@@ -1,0 +1,5 @@
+for file in output/*.bpl
+do
+  echo "verifying $file..."
+  boogie /doModSetAnalysis "$file"
+done

--- a/language/stackless_bytecode/bytecode_to_boogie/src/bytecode_instrs.bpl
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/bytecode_instrs.bpl
@@ -94,7 +94,9 @@ procedure {:inline 1} MoveFrom(address: Value, rs: ResourceStore) returns (dst: 
     var a: Address;
     assert is#Address(address);
     a := a#Address(address);
-    assert domain#ResourceStore(rs)[a];
+    if (!domain#ResourceStore(rs)[a]) {
+        abort_flag := true;
+    }
     dst := contents#ResourceStore(rs)[a];
     rs' := ResourceStore(domain#ResourceStore(rs)[a := false], contents#ResourceStore(rs));
 }
@@ -361,9 +363,9 @@ returns (addr_exists': [Address]bool)
 {
   var a: Address;
   a := a#Address(addr_val);
-  if (domain#ResourceStore(rs_LibraAccount_T)[a]) {
+  if (domain#ResourceStore(rs__0_LibraAccount_T)[a]) {
       abort_flag := true;
   }
-  rs_LibraAccount_T := ResourceStore(domain#ResourceStore(rs_LibraAccount_T)[a := true], contents#ResourceStore(rs_LibraAccount_T)[a := Map(DefaultMap[Field(LibraAccount_T_balance) := Map(DefaultMap[Field(LibraCoin_T_value) := Integer(0)])])]);
-  assert domain#ResourceStore(rs_LibraAccount_T)[a];
+  rs__0_LibraAccount_T := ResourceStore(domain#ResourceStore(rs__0_LibraAccount_T)[a := true], contents#ResourceStore(rs__0_LibraAccount_T)[a := Map(DefaultMap[Field(_0_LibraAccount_T_balance) := Map(DefaultMap[Field(_0_LibraCoin_T_value) := Integer(0)])])]);
+  assert domain#ResourceStore(rs__0_LibraAccount_T)[a];
  }

--- a/language/stackless_bytecode/bytecode_to_boogie/src/main.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/main.rs
@@ -9,12 +9,9 @@ use std::{
     fs::{self, File},
     io::prelude::*,
 };
-use stdlib::stdlib_modules;
 use types::account_address::AccountAddress;
 
-// mod translator;
 fn compile_files(file_names: Vec<String>) -> Vec<VerifiedModule> {
-    // let mut verified_modules = stdlib_modules().to_vec();
     let mut verified_modules = vec![];
     let files_len = file_names.len();
     let dep_files = &file_names[0..files_len - 1];

--- a/language/stackless_bytecode/bytecode_to_boogie/src/main.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/main.rs
@@ -14,7 +14,8 @@ use types::account_address::AccountAddress;
 
 // mod translator;
 fn compile_files(file_names: Vec<String>) -> Vec<VerifiedModule> {
-    let mut verified_modules = stdlib_modules().to_vec();
+    // let mut verified_modules = stdlib_modules().to_vec();
+    let mut verified_modules = vec![];
     let files_len = file_names.len();
     let dep_files = &file_names[0..files_len - 1];
 

--- a/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
@@ -41,7 +41,8 @@ impl BoogieTranslator {
             let module_name = module
                 .string_at(module.module_handle_at(ModuleHandleIndex::new(0)).name)
                 .to_string();
-            let address = module.address_at(module.module_handle_at(ModuleHandleIndex::new(0)).address);
+            let address =
+                module.address_at(module.module_handle_at(ModuleHandleIndex::new(0)).address);
             let addr_name = BigInt::from_str_radix(&address.to_string(), 16).unwrap();
             let module_full_name = format!("_{}_{}", addr_name, module_name);
             module_name_to_idx.insert(module_full_name.clone(), module_idx);
@@ -348,17 +349,10 @@ impl<'a> ModuleTranslator<'a> {
                     ));
                 }
                 let mut res_vec = vec![];
-                res_vec.push(
-                if dests_str.is_empty() {
-                    format!(
-                        "call Unpack_{}(t{});",
-                        struct_str, src
-                    )
+                res_vec.push(if dests_str.is_empty() {
+                    format!("call Unpack_{}(t{});", struct_str, src)
                 } else {
-                    format!(
-                        "call {} := Unpack_{}(t{});",
-                        dests_str, struct_str, src
-                    )
+                    format!("call {} := Unpack_{}(t{});", dests_str, struct_str, src)
                 });
                 res_vec.extend(dest_type_assumptions);
                 res_vec
@@ -440,12 +434,7 @@ impl<'a> ModuleTranslator<'a> {
             Eq(dest, op1, op2) => {
                 let operand_type = self.get_local_type(*op1, func_idx);
                 if self.is_local_ref(*op1, func_idx) {
-                    vec![format!(
-                        "t{} := Boolean(t{} == t{});",
-                        dest,
-                        op1,
-                        op2
-                    )]
+                    vec![format!("t{} := Boolean(t{} == t{});", dest, op1, op2)]
                 } else {
                     vec![format!(
                         "call t{} := Eq_{}(t{}, t{});",
@@ -455,17 +444,11 @@ impl<'a> ModuleTranslator<'a> {
                         op2
                     )]
                 }
-
             }
             Neq(dest, op1, op2) => {
                 let operand_type = self.get_local_type(*op1, func_idx);
                 if self.is_local_ref(*op1, func_idx) {
-                    vec![format!(
-                        "t{} := Boolean(t{} != t{});",
-                        dest,
-                        op1,
-                        op2
-                    )]
+                    vec![format!("t{} := Boolean(t{} != t{});", dest, op1, op2)]
                 } else {
                     vec![format!(
                         "call t{} := Neq_{}(t{}, t{});",
@@ -534,7 +517,7 @@ impl<'a> ModuleTranslator<'a> {
         }
         if inline {
             format!(
-                "procedure {{:inline 1}} {}_inline (c: CreationTime, addr_exists: [Address]bool{}) returns (addr_exists': [Address]bool{})",
+                "procedure {{:inline 1}} {} (c: CreationTime, addr_exists: [Address]bool{}) returns (addr_exists': [Address]bool{})",
                 fun_name, args, rets
             )
         } else {
@@ -763,7 +746,9 @@ impl<'a> ModuleTranslator<'a> {
         if module_name == "<SELF>" {
             module_name = "self";
         } // boogie doesn't allow '<' or '>'
-        let address = self.module.address_at(self.module.module_handle_at(module_handle_index).address);
+        let address = self
+            .module
+            .address_at(self.module.module_handle_at(module_handle_index).address);
         let addr_name = BigInt::from_str_radix(&address.to_string(), 16).unwrap();
         let module_full_name = format!("_{}_{}", addr_name, module_name);
         let function_handle_view = FunctionHandleView::new(self.module, function_handle);

--- a/language/stackless_bytecode/bytecode_to_boogie/tests/run_functional_tests.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/tests/run_functional_tests.rs
@@ -5,19 +5,41 @@
 #![test_runner(datatest::runner)]
 
 use functional_tests::{checker::check, errors::*, evaluator::eval, utils::parse_input};
+use bytecode_to_boogie::translator::BoogieTranslator;
+use bytecode_verifier::verifier::{
+    verify_module_dependencies, verify_script_dependencies, VerifiedModule, VerifiedProgram,
+};
+use ir_to_bytecode::{
+    compiler::{compile_module, compile_program},
+    parser::{parse_module, parse_program},
+};
+use stdlib::stdlib_modules;
+use std::{
+    env,
+    fs::{self, File},
+    io::prelude::*,
+};
+use std::path::Path;
+use std::process::Command;
+
+fn is_ignore(path: &Path) -> bool {
+    path.parent().unwrap().display().to_string().ends_with("generics")
+}
 
 // Runs all tests under the functional_tests/tests/testsuite directory.
-#[datatest::files("../../functional_tests/tests/testsuite/dereference_tests", { input in r".*\.mvir" })]
-fn functional_tests(input: &str) -> Result<()> {
+#[datatest::files("../../functional_tests/tests/testsuite/",
+{ input in r"(.*)\.mvir" if !is_ignore,
+  path = r"${1}" })]
+fn functional_tests(input: &str, path: &Path) -> Result<()> {
     let (config, directives, transactions) = parse_input(input)?;
     let mut deps = stdlib_modules().to_vec();
-    for transaction in transactions {
+    for (i, transaction) in transactions.iter().enumerate() {
         // get the account data of the sender
         let data = config.accounts.get(&transaction.config.sender).unwrap();
         let addr = data.address();
 
         // stage 1: parse the program
-        let parsed_program_res = parse_program(&transaction.program);
+        let parsed_program_res = parse_program(&transaction.input);
         if let Err(e) = parsed_program_res {
             continue;
         }
@@ -33,12 +55,14 @@ fn functional_tests(input: &str) -> Result<()> {
         // stage 3: verify the program
         let verified_program_res = VerifiedProgram::new(compiled_program, &deps);
         if let Err(e) = verified_program_res {
+            // Only translate programs that pass the verifier
             continue;
         }
+
         let verified_program = verified_program_res.unwrap();
 
         let new_modules = verified_program.modules().to_vec();
-        let modules = deps.to_vec();
+        let mut modules = deps.to_vec();
         modules.extend(verified_program.modules().to_vec());
         modules.push(verified_program.script().clone().into_module());
 
@@ -49,14 +73,20 @@ fn functional_tests(input: &str) -> Result<()> {
         let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
         res.push_str(&written_code);
         res.push_str(&ts.translate());
-        let mut f = File::create("output.bpl").expect("Unable to create file");
+
+        // let input_path_str = input.display().to_string();
+        let op = Path::new("output");
+        let folder_name = path.parent().unwrap().file_name().unwrap().to_str().unwrap();
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+        let output_path = op.join(&format!("{}__{}_{}.bpl", folder_name, file_name, i));
+        // output.display().to_string();
+        println!("{}", output_path.to_str().unwrap());
+        let output_path_str = output_path.to_str().unwrap();
+        let mut f = File::create(output_path_str).expect("Unable to create file");
 
         // write resulting code into output.bpl
         write!(f, "{}", res).expect("unable to write file");
 
-        // This has to be before deps.extend since verified_program holds a reference to the
-        // deps.
-        // let compiled_program = verified_program.into_inner();
         deps.extend(new_modules);
     }
 

--- a/language/stackless_bytecode/bytecode_to_boogie/tests/run_functional_tests.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/tests/run_functional_tests.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![feature(custom_test_frameworks)]
+#![test_runner(datatest::runner)]
+
+use functional_tests::{checker::check, errors::*, evaluator::eval, utils::parse_input};
+
+// Runs all tests under the functional_tests/tests/testsuite directory.
+#[datatest::files("../../functional_tests/tests/testsuite/dereference_tests", { input in r".*\.mvir" })]
+fn functional_tests(input: &str) -> Result<()> {
+    let (config, directives, transactions) = parse_input(input)?;
+    let mut deps = stdlib_modules().to_vec();
+    for transaction in transactions {
+        // get the account data of the sender
+        let data = config.accounts.get(&transaction.config.sender).unwrap();
+        let addr = data.address();
+
+        // stage 1: parse the program
+        let parsed_program_res = parse_program(&transaction.program);
+        if let Err(e) = parsed_program_res {
+            continue;
+        }
+        let parsed_program = parsed_program_res.unwrap();
+
+        // stage 2: compile the program
+        let compiled_program_res = compile_program(addr, &parsed_program, &deps);
+        if let Err(e) = compiled_program_res {
+            continue;
+        }
+        let compiled_program = compiled_program_res.unwrap();
+
+        // stage 3: verify the program
+        let verified_program_res = VerifiedProgram::new(compiled_program, &deps);
+        if let Err(e) = verified_program_res {
+            continue;
+        }
+        let verified_program = verified_program_res.unwrap();
+
+        let new_modules = verified_program.modules().to_vec();
+        let modules = deps.to_vec();
+        modules.extend(verified_program.modules().to_vec());
+        modules.push(verified_program.script().clone().into_module());
+
+        let mut ts = BoogieTranslator::new(&modules);
+        let mut res = String::new();
+
+        // handwritten boogie code
+        let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+        res.push_str(&written_code);
+        res.push_str(&ts.translate());
+        let mut f = File::create("output.bpl").expect("Unable to create file");
+
+        // write resulting code into output.bpl
+        write!(f, "{}", res).expect("unable to write file");
+
+        // This has to be before deps.extend since verified_program holds a reference to the
+        // deps.
+        // let compiled_program = verified_program.into_inner();
+        deps.extend(new_modules);
+    }
+
+    let res = eval(&config, &transactions)?;
+    if let Err(e) = check(&res, &directives) {
+        println!("{:#?}", res);
+        return Err(e);
+    }
+    println!("test");
+    Ok(())
+}

--- a/language/stackless_bytecode/bytecode_to_boogie/tests/run_functional_tests.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/tests/run_functional_tests.rs
@@ -4,26 +4,19 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(datatest::runner)]
 
-use functional_tests::{checker::check, errors::*, evaluator::eval, utils::parse_input};
 use bytecode_to_boogie::translator::BoogieTranslator;
-use bytecode_verifier::verifier::{
-    verify_module_dependencies, verify_script_dependencies, VerifiedModule, VerifiedProgram,
-};
-use ir_to_bytecode::{
-    compiler::{compile_module, compile_program},
-    parser::{parse_module, parse_program},
-};
+use bytecode_verifier::verifier::VerifiedProgram;
+use functional_tests::{checker::check, errors::*, evaluator::eval, utils::parse_input};
+use ir_to_bytecode::{compiler::compile_program, parser::parse_program};
+use std::{fs, path::Path};
 use stdlib::stdlib_modules;
-use std::{
-    env,
-    fs::{self, File},
-    io::prelude::*,
-};
-use std::path::Path;
-use std::process::Command;
 
 fn is_ignore(path: &Path) -> bool {
-    path.parent().unwrap().display().to_string().ends_with("generics")
+    path.parent()
+        .unwrap()
+        .display()
+        .to_string()
+        .ends_with("generics")
 }
 
 // Runs all tests under the functional_tests/tests/testsuite directory.
@@ -40,21 +33,21 @@ fn functional_tests(input: &str, path: &Path) -> Result<()> {
 
         // stage 1: parse the program
         let parsed_program_res = parse_program(&transaction.input);
-        if let Err(e) = parsed_program_res {
+        if parsed_program_res.is_err() {
             continue;
         }
         let parsed_program = parsed_program_res.unwrap();
 
         // stage 2: compile the program
         let compiled_program_res = compile_program(addr, &parsed_program, &deps);
-        if let Err(e) = compiled_program_res {
+        if compiled_program_res.is_err() {
             continue;
         }
         let compiled_program = compiled_program_res.unwrap();
 
         // stage 3: verify the program
         let verified_program_res = VerifiedProgram::new(compiled_program, &deps);
-        if let Err(e) = verified_program_res {
+        if verified_program_res.is_err() {
             // Only translate programs that pass the verifier
             continue;
         }
@@ -74,18 +67,22 @@ fn functional_tests(input: &str, path: &Path) -> Result<()> {
         res.push_str(&written_code);
         res.push_str(&ts.translate());
 
-        // let input_path_str = input.display().to_string();
-        let op = Path::new("output");
-        let folder_name = path.parent().unwrap().file_name().unwrap().to_str().unwrap();
+        let output_folder = Path::new("output");
+        let folder_name = path
+            .parent()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
         let file_name = path.file_name().unwrap().to_str().unwrap();
-        let output_path = op.join(&format!("{}__{}_{}.bpl", folder_name, file_name, i));
-        // output.display().to_string();
+        let output_path = output_folder.join(&format!("{}__{}_{}.bpl", folder_name, file_name, i));
         println!("{}", output_path.to_str().unwrap());
-        let output_path_str = output_path.to_str().unwrap();
-        let mut f = File::create(output_path_str).expect("Unable to create file");
+        let _output_path_str = output_path.to_str().unwrap();
 
-        // write resulting code into output.bpl
-        write!(f, "{}", res).expect("unable to write file");
+        // uncomment the code to write to Boogie files
+        // let mut f = File::create(_output_path_str).expect("Unable to create file");
+        // write!(f, "{}", res).expect("unable to write file");
 
         deps.extend(new_modules);
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I added a script in `tests/run_functional_tests` that would run every test in `functional_tests/tests/testsuite` except for tests in `generics` since we don't support those now. 

The script runs the translator on all the mvir files that have passed `bytecode_verifier`, outputs Boogie code into `FOLDERNAME__FILENAME_TXNUMBER.bpl` inside `output` folder. We need to include transaction number because there might be multiple transactions inside a test file. For example, the first transaction of `testsuite/borrow_tests/borrow_copy_ok.mvir` will be outputted into `output/borrow_tests__borrow_copy_ok_0.bpl`.

I have also written a bash script `run_boogie.sh` that would run Boogie on everything in `output` folder.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
```
cargo test
```
