### PR TITLE
[VM] Add instructions that use references

### DIFF
--- a/language/tools/cost_synthesis/src/module_generator.rs
+++ b/language/tools/cost_synthesis/src/module_generator.rs
@@ -89,6 +89,19 @@ impl ModuleBuilder {
         self.module.string_pool.append(&mut strs);
     }
 
+    fn with_user_strings(&mut self) {
+        let mut strs = (0..self.table_size)
+            .map(|_| {
+                let len = self.gen.gen_range(1, MAX_STRING_SIZE);
+                (0..len)
+                    .map(|_| self.gen.gen::<char>())
+                    .collect::<String>()
+                    .into()
+            })
+            .collect();
+        self.module.user_strings.append(&mut strs);
+    }
+
     fn with_bytearrays(&mut self) {
         self.module.byte_array_pool = (0..self.table_size)
             .map(|_| {
@@ -359,6 +372,7 @@ impl ModuleBuilder {
         self.with_callee_modules();
         self.with_account_addresses();
         self.with_strings();
+        self.with_user_strings();
         self.with_bytearrays();
         self.with_structs();
         self.with_random_functions();

--- a/language/tools/test_generation/src/summaries.rs
+++ b/language/tools/test_generation/src/summaries.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    abstract_state::{AbstractState, AbstractValue, BorrowState},
+    abstract_state::{AbstractState, AbstractValue, BorrowState, Mutability},
     common::VMError,
-    state_local_availability_is, state_local_exists, state_local_kind_is, state_local_place,
-    state_local_set, state_local_take, state_local_take_borrow, state_never,
-    state_stack_create_struct, state_stack_has, state_stack_has_polymorphic_eq,
+    state_create_struct, state_local_availability_is, state_local_exists, state_local_kind_is,
+    state_local_place, state_local_set, state_local_take, state_local_take_borrow, state_never,
+    state_register_dereference, state_stack_function_call, state_stack_function_popn,
+    state_stack_has, state_stack_has_polymorphic_eq, state_stack_has_reference,
     state_stack_has_struct, state_stack_local_polymorphic_eq, state_stack_pop, state_stack_push,
-    state_stack_push_register, state_stack_satisfies_struct_signature, state_stack_struct_popn,
+    state_stack_push_register, state_stack_push_register_borrow, state_stack_ref_polymorphic_eq,
+    state_stack_satisfies_function_signature, state_stack_satisfies_struct_signature,
+    state_stack_struct_borrow_field, state_stack_struct_has_field, state_stack_struct_popn,
     state_stack_unpack_struct, state_struct_is_resource,
     transitions::*,
 };
@@ -109,7 +112,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 state_local_availability_is!(i, BorrowState::Available),
             ],
             effects: vec![
-                state_local_take_borrow!(i, true),
+                state_local_take_borrow!(i, Mutability::Mutable),
                 state_stack_push_register!(),
             ],
         },
@@ -119,8 +122,32 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 state_local_availability_is!(i, BorrowState::Available),
             ],
             effects: vec![
-                state_local_take_borrow!(i, false),
+                state_local_take_borrow!(i, Mutability::Immutable),
                 state_stack_push_register!(),
+            ],
+        },
+        Bytecode::ReadRef => Summary {
+            preconditions: vec![state_stack_has_reference!(0, Mutability::Either)],
+            effects: vec![
+                state_stack_pop!(),
+                state_register_dereference!(),
+                state_stack_push_register!(),
+            ],
+        },
+        Bytecode::WriteRef => Summary {
+            preconditions: vec![
+                state_stack_has_reference!(0, Mutability::Mutable),
+                state_stack_has!(1, None),
+                state_stack_ref_polymorphic_eq!(0, 1),
+            ],
+            effects: vec![state_stack_pop!(), state_stack_pop!()],
+        },
+        Bytecode::FreezeRef => Summary {
+            preconditions: vec![state_stack_has_reference!(0, Mutability::Mutable)],
+            effects: vec![
+                state_stack_pop!(),
+                state_register_dereference!(),
+                state_stack_push_register_borrow!(Mutability::Immutable),
             ],
         },
         Bytecode::Add => Summary {
@@ -359,16 +386,17 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![state_stack_satisfies_struct_signature!(i)],
             effects: vec![
                 state_stack_struct_popn!(i),
-                state_stack_create_struct!(i),
+                state_create_struct!(i),
                 state_stack_push_register!(),
             ],
         },
         Bytecode::Unpack(i, _) => Summary {
-            preconditions: vec![state_stack_has_struct!(i)],
+            preconditions: vec![state_stack_has_struct!(Some(i))],
             effects: vec![state_stack_pop!(), state_stack_unpack_struct!(i)],
         },
         Bytecode::Exists(i, _) => Summary {
-            // The bool is represented abstractly so concrete execution may differ
+            // The result of `state_struct_is_resource` is represented abstractly
+            // so concrete execution may differ
             preconditions: vec![
                 state_struct_is_resource!(i),
                 state_stack_has!(
@@ -381,6 +409,34 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 state_stack_push!(AbstractValue::new_primitive(SignatureToken::Bool)),
             ],
         },
+        Bytecode::MutBorrowField(i) => Summary {
+            preconditions: vec![
+                state_stack_has_reference!(0, Mutability::Mutable),
+                state_stack_struct_has_field!(i),
+            ],
+            effects: vec![state_stack_pop!(), state_stack_struct_borrow_field!(i)],
+        },
+        Bytecode::ImmBorrowField(i) => Summary {
+            preconditions: vec![
+                state_stack_has_reference!(0, Mutability::Immutable),
+                state_stack_struct_has_field!(i),
+            ],
+            effects: vec![state_stack_pop!(), state_stack_struct_borrow_field!(i)],
+        },
+        Bytecode::BorrowGlobal(i, _) => Summary {
+            preconditions: vec![
+                state_stack_has!(
+                    0,
+                    Some(AbstractValue::new_primitive(SignatureToken::Address))
+                ),
+                state_struct_is_resource!(i),
+            ],
+            effects: vec![
+                state_stack_pop!(),
+                state_create_struct!(i),
+                state_stack_push_register_borrow!(Mutability::Mutable),
+            ],
+        },
         Bytecode::MoveFrom(i, _) => Summary {
             preconditions: vec![
                 state_struct_is_resource!(i),
@@ -389,11 +445,18 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                     Some(AbstractValue::new_primitive(SignatureToken::Address))
                 ),
             ],
-            effects: vec![state_stack_create_struct!(i), state_stack_push_register!()],
+            effects: vec![state_create_struct!(i), state_stack_push_register!()],
         },
         Bytecode::MoveToSender(i, _) => Summary {
-            preconditions: vec![state_struct_is_resource!(i), state_stack_has_struct!(i)],
+            preconditions: vec![
+                state_struct_is_resource!(i),
+                state_stack_has_struct!(Some(i)),
+            ],
             effects: vec![state_stack_pop!()],
+        },
+        Bytecode::Call(i, _) => Summary {
+            preconditions: vec![state_stack_satisfies_function_signature!(i)],
+            effects: vec![state_stack_function_popn!(i), state_stack_function_call!(i)],
         },
         // Control flow instructions are called manually and thus have
         // `state_never!()` as their precondition
@@ -425,10 +488,6 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 state_stack_has!(0, Some(AbstractValue::new_primitive(SignatureToken::U64))),
             ],
             effects: vec![state_stack_pop!()],
-        },
-        _ => Summary {
-            preconditions: vec![state_never!()],
-            effects: vec![],
         },
     }
 }

--- a/language/tools/test_generation/tests/control_flow_instructions.rs
+++ b/language/tools/test_generation/tests/control_flow_instructions.rs
@@ -1,0 +1,89 @@
+extern crate test_generation;
+use std::collections::HashMap;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
+use vm::file_format::{
+    empty_module, Bytecode, CompiledModuleMut, FunctionHandle, FunctionHandleIndex,
+    FunctionSignature, FunctionSignatureIndex, LocalsSignature, LocalsSignatureIndex,
+    ModuleHandleIndex, SignatureToken, StringPoolIndex,
+};
+
+mod common;
+
+fn generate_module_with_function() -> CompiledModuleMut {
+    let mut module: CompiledModuleMut = empty_module();
+    let offset = module.string_pool.len();
+    let function_sig_offset = module.function_signatures.len();
+    module.string_pool.push("func0".to_string());
+
+    let sigs = vec![(
+        vec![],
+        FunctionSignature {
+            arg_types: vec![SignatureToken::U64, SignatureToken::Bool],
+            return_types: vec![SignatureToken::String, SignatureToken::Address],
+            type_formals: vec![],
+        },
+    )];
+
+    module.function_handles = sigs
+        .iter()
+        .enumerate()
+        .map(|(i, _)| FunctionHandle {
+            name: StringPoolIndex::new((i + offset) as u16),
+            signature: FunctionSignatureIndex::new((i + function_sig_offset) as u16),
+            module: ModuleHandleIndex::new(0),
+        })
+        .collect();
+    let (local_sigs, mut function_sigs): (Vec<_>, Vec<_>) = sigs.clone().into_iter().unzip();
+    module.function_signatures.append(&mut function_sigs);
+    module
+        .locals_signatures
+        .append(&mut local_sigs.into_iter().map(LocalsSignature).collect());
+    module
+}
+
+#[test]
+fn bytecode_call() {
+    let module = generate_module_with_function();
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    let state2 = common::run_instruction(
+        Bytecode::Call(FunctionHandleIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(AbstractValue::new_primitive(SignatureToken::Address)),
+        "stack type postcondition not satisfied",
+    );
+    assert_eq!(
+        state2.stack_peek(1),
+        Some(AbstractValue::new_primitive(SignatureToken::String)),
+        "stack type postcondition not satisfied",
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_call_function_signature_not_satisfied() {
+    let module = generate_module_with_function();
+    let state1 = AbstractState::from_locals(module, HashMap::new());
+    common::run_instruction(
+        Bytecode::Call(FunctionHandleIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_call_return_not_pushed() {
+    let module = generate_module_with_function();
+    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
+    let state2 = common::run_instruction(
+        Bytecode::Call(FunctionHandleIndex::new(0), LocalsSignatureIndex::new(0)),
+        state1,
+    );
+    assert_eq!(state2.stack_len(), 0,);
+}

--- a/language/tools/test_generation/tests/reference_instructions.rs
+++ b/language/tools/test_generation/tests/reference_instructions.rs
@@ -1,0 +1,116 @@
+extern crate test_generation;
+use test_generation::abstract_state::{AbstractState, AbstractValue};
+use vm::file_format::{Bytecode, Kind, SignatureToken};
+
+mod common;
+
+#[test]
+fn bytecode_readref() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    let state2 = common::run_instruction(Bytecode::ReadRef, state1);
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(AbstractValue::new_primitive(SignatureToken::U64)),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_readref_no_ref() {
+    let state1 = AbstractState::new();
+    common::run_instruction(Bytecode::ReadRef, state1);
+}
+
+#[test]
+#[should_panic]
+fn bytecode_readref_wrong_dereference() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    let state2 = common::run_instruction(Bytecode::ReadRef, state1);
+    assert!(
+        state2.stack_peek(0) != Some(AbstractValue::new_primitive(SignatureToken::U64)),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+fn bytecode_writeref() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    let state2 = common::run_instruction(Bytecode::WriteRef, state1);
+    assert_eq!(state2.stack_len(), 0, "stack type postcondition not met");
+}
+
+#[test]
+#[should_panic]
+fn bytecode_writeref_type_mismatch() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::String));
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    common::run_instruction(Bytecode::WriteRef, state1);
+}
+
+#[test]
+#[should_panic]
+fn bytecode_writeref_stack_len_mismatch() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    let state2 = common::run_instruction(Bytecode::WriteRef, state1);
+    assert!(state2.stack_len() != 0, "stack type postcondition not met");
+}
+
+#[test]
+fn bytecode_feezeref() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::MutableReference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    let state2 = common::run_instruction(Bytecode::FreezeRef, state1);
+    assert_eq!(state2.stack_len(), 1, "stack len postcondition not met");
+    assert_eq!(
+        state2.stack_peek(0),
+        Some(AbstractValue::new_reference(
+            SignatureToken::Reference(Box::new(SignatureToken::U64)),
+            Kind::Unrestricted
+        )),
+        "stack type postcondition not met"
+    );
+}
+
+#[test]
+#[should_panic]
+fn bytecode_feezeref_no_ref() {
+    let state1 = AbstractState::new();
+    common::run_instruction(Bytecode::FreezeRef, state1);
+}
+
+#[test]
+#[should_panic]
+fn bytecode_feezeref_already_immutable() {
+    let mut state1 = AbstractState::new();
+    state1.stack_push(AbstractValue::new_reference(
+        SignatureToken::Reference(Box::new(SignatureToken::U64)),
+        Kind::Unrestricted,
+    ));
+    common::run_instruction(Bytecode::FreezeRef, state1);
+}


### PR DESCRIPTION
## Motivation

This commit adds instructions that use references, modeling them in terms of type safety
and global state. Memory safety is not yet supported.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added tests for each instruction. Testing with `cargo test`. Safety analysis with MIRAI.

## Related PRs

N/A