### PR TITLE
Add an optional field `next_validator_set` to LedgerInfo

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -356,6 +356,7 @@ impl<T: Payload> BlockStore<T> {
             block_id,
             0, // TODO [Reconfiguration] use the real epoch number.
             block.timestamp_usecs(),
+            None,
         )
     }
 
@@ -370,6 +371,7 @@ impl<T: Payload> BlockStore<T> {
             HashValue::zero(),
             0,
             0,
+            None,
         )
     }
 

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -449,6 +449,7 @@ fn test_vote_aggregation() {
         HashValue::zero(),
         0,
         0,
+        None,
     );
     // No QC yet because LedgerInfo is different
     assert_eq!(

--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -167,7 +167,15 @@ where
         let genesis_quorum_cert = QuorumCert::new(
             VoteData::new(ancestor_id, state_id, 0, ancestor_id, 0, ancestor_id, 0),
             LedgerInfoWithSignatures::new(
-                LedgerInfo::new(0, state_id, HashValue::zero(), HashValue::zero(), 0, 0),
+                LedgerInfo::new(
+                    0,
+                    state_id,
+                    HashValue::zero(),
+                    HashValue::zero(),
+                    0,
+                    0,
+                    None,
+                ),
                 HashMap::new(),
             ),
         );

--- a/consensus/src/chained_bft/consensus_types/quorum_cert.rs
+++ b/consensus/src/chained_bft/consensus_types/quorum_cert.rs
@@ -111,6 +111,7 @@ impl QuorumCert {
             *GENESIS_BLOCK_ID,
             0,
             0,
+            None,
         );
         let signature = signer
             .sign_message(li.hash())

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -147,6 +147,7 @@ pub fn placeholder_ledger_info() -> LedgerInfo {
         HashValue::zero(),
         0,
         0,
+        None,
     )
 }
 

--- a/execution/execution_tests/src/lib.rs
+++ b/execution/execution_tests/src/lib.rs
@@ -36,6 +36,7 @@ pub fn gen_ledger_info_with_sigs(
         commit_block_id,
         0,
         /* timestamp = */ 0,
+        None,
     );
     LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new())
 }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -165,6 +165,7 @@ fn gen_ledger_info(
         commit_block_id,
         /* epoch_num = */ 0,
         timestamp_usecs,
+        None,
     );
     LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new())
 }

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -154,6 +154,7 @@ where
             *GENESIS_BLOCK_ID,
             /* epoch_num = */ 0,
             /* timestamp_usecs = */ 0,
+            None,
         );
         let ledger_info_with_sigs =
             LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new());

--- a/state_synchronizer/src/tests.rs
+++ b/state_synchronizer/src/tests.rs
@@ -69,6 +69,7 @@ impl MockExecutorProxy {
             HashValue::zero(),
             0,
             0,
+            None,
         );
         let mut signatures = HashMap::new();
         let private_key = Ed25519PrivateKey::genesis();

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -35,6 +35,7 @@ prop_compose! {
                         HashValue::zero(),
                         start_epoch + i as u64 /* epoch_num */,
                         ledger_info.timestamp_usecs(),
+                        None,
                     ),
                     p.signatures().clone(),
                 )

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -76,6 +76,7 @@ fn gen_mock_genesis() -> (
         *GENESIS_BLOCK_ID,
         0,
         0,
+        None,
     );
     let ledger_info_with_sigs =
         LedgerInfoWithSignatures::new(ledger_info, HashMap::new() /* signatures */);

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -76,6 +76,10 @@ fn to_blocks_to_commit(
                 partial_ledger_info_with_sigs
                     .ledger_info()
                     .timestamp_usecs(),
+                partial_ledger_info_with_sigs
+                    .ledger_info()
+                    .next_validator_set()
+                    .cloned(),
             );
             let ledger_info_with_sigs = LedgerInfoWithSignatures::new(
                 ledger_info,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -4,6 +4,7 @@
 use crate::{
     account_address::AccountAddress,
     transaction::Version,
+    validator_set::ValidatorSet,
     validator_verifier::{ValidatorVerifier, VerifyError},
 };
 use canonical_serialization::{CanonicalSerialize, CanonicalSerializer, SimpleSerializer};
@@ -38,9 +39,8 @@ use std::{
 /// LedgerInfo with the `version` being the latest version that will be committed if B gets 2f+1
 /// votes. It sets `consensus_data_hash` to represent B so that if those 2f+1 votes are gathered a
 /// QC is formed on B.
-#[derive(Clone, Debug, Eq, PartialEq, IntoProto, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[ProtoType(crate::proto::ledger_info::LedgerInfo)]
 pub struct LedgerInfo {
     /// The version of latest transaction in the ledger.
     version: Version,
@@ -65,17 +65,23 @@ pub struct LedgerInfo {
     // they can be certain that their transaction will never be included in a block in the future
     // (assuming that their transaction has not yet been included)
     timestamp_usecs: u64,
+
+    /// An optional field keeping the set of new validators to start the next epoch.
+    /// The very last ledger info of an epoch contains the validator set for the next one,
+    /// other ledger info instances are None.
+    next_validator_set: Option<ValidatorSet>,
 }
 
 impl Display for LedgerInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "LedgerInfo: [committed_block_id: {}, version: {}, epoch_num: {}, timestamp (us): {}]",
+            "LedgerInfo: [committed_block_id: {}, version: {}, epoch_num: {}, timestamp (us): {}, next_validator_set: {}]",
             self.consensus_block_id(),
             self.version(),
             self.epoch_num(),
-            self.timestamp_usecs()
+            self.timestamp_usecs(),
+            self.next_validator_set.as_ref().map_or("None".to_string(), |validator_set| format!("{}", validator_set)),
         )
     }
 }
@@ -90,6 +96,7 @@ impl LedgerInfo {
         consensus_block_id: HashValue,
         epoch_num: u64,
         timestamp_usecs: u64,
+        next_validator_set: Option<ValidatorSet>,
     ) -> Self {
         LedgerInfo {
             version,
@@ -98,6 +105,7 @@ impl LedgerInfo {
             consensus_block_id,
             epoch_num,
             timestamp_usecs,
+            next_validator_set,
         }
     }
 
@@ -136,19 +144,56 @@ impl LedgerInfo {
     pub fn is_zero(&self) -> bool {
         self.version == 0
     }
+
+    pub fn next_validator_set(&self) -> Option<&ValidatorSet> {
+        self.next_validator_set.as_ref()
+    }
+}
+
+impl IntoProto for LedgerInfo {
+    type ProtoType = crate::proto::ledger_info::LedgerInfo;
+
+    fn into_proto(self) -> Self::ProtoType {
+        let mut proto = Self::ProtoType::new();
+        proto.set_version(self.version);
+        proto.set_transaction_accumulator_hash(self.transaction_accumulator_hash.into_proto());
+        proto.set_consensus_data_hash(self.consensus_data_hash.into_proto());
+        proto.set_consensus_block_id(self.consensus_block_id.into_proto());
+        proto.set_epoch_num(self.epoch_num);
+        proto.set_timestamp_usecs(self.timestamp_usecs);
+        if let Some(next_validator_set) = self.next_validator_set {
+            proto.set_next_validator_set(next_validator_set.into_proto());
+        }
+        proto
+    }
 }
 
 impl FromProto for LedgerInfo {
     type ProtoType = crate::proto::ledger_info::LedgerInfo;
 
     fn from_proto(proto: Self::ProtoType) -> Result<Self> {
+        let version = proto.get_version();
+        let transaction_accumulator_hash =
+            HashValue::from_slice(proto.get_transaction_accumulator_hash())?;
+        let consensus_data_hash = HashValue::from_slice(proto.get_consensus_data_hash())?;
+        let consensus_block_id = HashValue::from_slice(proto.get_consensus_block_id())?;
+        let epoch_num = proto.get_epoch_num();
+        let timestamp_usecs = proto.get_timestamp_usecs();
+
+        let next_validator_set =
+            if let Some(validator_set_proto) = proto.next_validator_set.into_option() {
+                Some(ValidatorSet::from_proto(validator_set_proto)?)
+            } else {
+                None
+            };
         Ok(LedgerInfo::new(
-            proto.get_version(),
-            HashValue::from_slice(proto.get_transaction_accumulator_hash())?,
-            HashValue::from_slice(proto.get_consensus_data_hash())?,
-            HashValue::from_slice(proto.get_consensus_block_id())?,
-            proto.get_epoch_num(),
-            proto.get_timestamp_usecs(),
+            version,
+            transaction_accumulator_hash,
+            consensus_data_hash,
+            consensus_block_id,
+            epoch_num,
+            timestamp_usecs,
+            next_validator_set,
         ))
     }
 }
@@ -161,7 +206,8 @@ impl CanonicalSerialize for LedgerInfo {
             .encode_bytes(self.consensus_data_hash.as_ref())?
             .encode_bytes(self.consensus_block_id.as_ref())?
             .encode_u64(self.epoch_num)?
-            .encode_u64(self.timestamp_usecs)?;
+            .encode_u64(self.timestamp_usecs)?
+            .encode_optional(&self.next_validator_set)?;
         Ok(())
     }
 }

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -297,6 +297,7 @@ fn test_verify_signed_transaction() {
         *GENESIS_BLOCK_ID,
         0,
         /* timestamp = */ 10000,
+        None,
     );
 
     let ledger_info_to_transaction_info_proof =
@@ -397,6 +398,7 @@ fn test_verify_account_state_and_event() {
         *GENESIS_BLOCK_ID,
         0,
         /* timestamp = */ 10000,
+        None,
     );
 
     let ledger_info_to_transaction_info_proof =
@@ -591,6 +593,7 @@ proptest! {
             *GENESIS_BLOCK_ID,
             0,
             /* timestamp = */ 10000,
+            None,
         );
         let first_version = if txn_and_infos.is_empty() { None } else { Some(first_version as u64) };
         prop_assert!(txn_list_with_proof.verify(&ledger_info,first_version).is_ok());

--- a/types/src/proto/ledger_info.proto
+++ b/types/src/proto/ledger_info.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package types;
 
+import "validator_set.proto";
+
 /// Even though we don't always need all hashes, we pass them in and return them
 /// always so that we keep them in sync on the client and don't make the client
 /// worry about which one(s) to pass in which cases
@@ -60,6 +62,10 @@ message LedgerInfo {
   // they can be certain that their transaction will never be included in a block in the future
   // (assuming that their transaction has not yet been included)
   uint64 timestamp_usecs = 6;
+
+  // An optional field with the validator set for the next epoch in case it's the last
+  // ledger info in the current epoch.
+  ValidatorSet next_validator_set = 7;
 }
 
 /// The validator node returns this structure which includes signatures

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -14,7 +14,7 @@ use failure::Result;
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt};
 
 /// After executing a special transaction that sets the validators that should be used for the
 /// next epoch, consensus and networking get the new list of validators.  Consensus will have a
@@ -33,6 +33,12 @@ pub struct ValidatorPublicKeys {
     // This key establishes the corresponding PrivateKey holder's eligibility to join the p2p
     // network
     network_identity_public_key: X25519StaticPublicKey,
+}
+
+impl fmt::Display for ValidatorPublicKeys {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "account_address: {}", self.account_address.short_str())
+    }
 }
 
 impl ValidatorPublicKeys {

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -15,6 +15,7 @@ use failure::prelude::*;
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 pub const VALIDATOR_SET_MODULE_NAME: &str = "ValidatorSet";
 pub const VALIDATOR_SET_STRUCT_NAME: &str = "T";
@@ -35,6 +36,16 @@ pub(crate) fn validator_set_path() -> Vec<u8> {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 pub struct ValidatorSet(Vec<ValidatorPublicKeys>);
+
+impl fmt::Display for ValidatorSet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        write!(f, "[")?;
+        for validator in &self.0 {
+            write!(f, "{} ", validator)?;
+        }
+        write!(f, "]")
+    }
+}
 
 impl ValidatorSet {
     /// Constructs a ValidatorSet resource.


### PR DESCRIPTION
Summary: next_validator_set is not None for the very last LedgerInfo of an epoch:
it keeps the validator set for the next epoch.
This change is just introducing a field and is technically a noop: no one is writing or reading this field yet.

Tests: current test coverage

Issues: ref #849