### PR TITLE
[easy] Trim the regex dependency

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -12,7 +12,7 @@ grpcio = "0.4"
 lazy_static = "1.2.0"
 protobuf = "~2.7"
 rand = "0.7.0"
-regex = "1.2.1"
+regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 structopt = "0.2.15"
 num_cpus = "1.10.1"
 

--- a/common/grpcio-client/Cargo.toml
+++ b/common/grpcio-client/Cargo.toml
@@ -11,6 +11,6 @@ protobuf = "~2.7"
 protobuf-codegen = "2.*"
 protoc = "2.*"
 protoc-grpcio = "1.0.1"
-regex = "1.2.1"
+regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 
 tools = { path = "../tools/"}

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -33,4 +33,4 @@ failure = { package = "failure_ext", path = "../failure_ext" }
 
 [dev-dependencies]
 rand = "0.6.5"
-regex = "1.2.1"
+regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }

--- a/language/compiler/ir_to_bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/syntax/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 codespan = "0.1.3"
 hex = "0.3.2"
 lalrpop-util = "0.16.3"
-regex = "1.2.1"
+regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 types = { path = "../../../../types" }
 
 [dev-dependencies]

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -19,7 +19,7 @@ transaction_builder = { path = "../transaction_builder" }
 filecheck = "0.4.0"
 datatest = "0.3.5"
 lazy_static = "1.3.0"
-regex = "1.2.1"
+regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 
 [dev-dependencies]
 types = { path = "../../types", features = ["testing"] }

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -12,7 +12,7 @@ flate2 = { version = "1.0", features = ["rust_backend"], default-features = fals
 grpcio = { version = "0.4.4", default-features = false }
 itertools = "0.8.0"
 rand = "0.6.5"
-regex = "1.2.1"
+regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 reqwest = { version="0.9.19", features=["rustls-tls"], default_features = false }
 rusoto_core = {version = "0.40.0", features=["rustls"], default_features = false}
 rusoto_ec2 = {version = "0.40.0", features=["rustls"], default_features = false}


### PR DESCRIPTION
See https://github.com/rust-lang/regex/pull/613

as it turns out we never use regex in a Unicode context, trim it.
