### PR TITLE
[crypto] Derive Deref instances for new types

### DIFF
--- a/crypto/crypto/src/bls12381.rs
+++ b/crypto/crypto/src/bls12381.rs
@@ -33,7 +33,7 @@
 use crate::{traits::*, HashValue};
 use bincode::{deserialize, serialize};
 use core::convert::TryFrom;
-use crypto_derive::{SilentDebug, SilentDisplay};
+use crypto_derive::{Deref, SilentDebug, SilentDisplay};
 use failure::prelude::*;
 use pairing::{
     bls12_381::{Fr, FrRepr},
@@ -41,7 +41,6 @@ use pairing::{
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 
 /// The length of the BLS12381PrivateKey.
 pub const BLS12381_PRIVATE_KEY_LENGTH: usize = 32;
@@ -55,15 +54,15 @@ type ThresholdBLSPrivateKey =
     threshold_crypto::serde_impl::SerdeSecret<threshold_crypto::SecretKey>;
 
 /// A BLS12-381 private key.
-#[derive(Serialize, Deserialize, SilentDisplay, SilentDebug)]
+#[derive(Serialize, Deserialize, Deref, SilentDisplay, SilentDebug)]
 pub struct BLS12381PrivateKey(ThresholdBLSPrivateKey);
 
 /// A BLS12-381 public key.
-#[derive(Clone, Hash, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Hash, Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]
 pub struct BLS12381PublicKey(threshold_crypto::PublicKey);
 
 /// A BLS12-381 signature.
-#[derive(Clone, Hash, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Hash, Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]
 pub struct BLS12381Signature(threshold_crypto::Signature);
 
 impl BLS12381PublicKey {
@@ -174,14 +173,6 @@ impl Genesis for BLS12381PrivateKey {
     }
 }
 
-impl Deref for BLS12381PublicKey {
-    type Target = threshold_crypto::PublicKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 //////////////////////
 // PublicKey Traits //
 //////////////////////
@@ -234,14 +225,6 @@ impl ValidKey for BLS12381PublicKey {
     }
 }
 
-impl Deref for BLS12381PrivateKey {
-    type Target = ThresholdBLSPrivateKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 //////////////////////
 // Signature Traits //
 //////////////////////
@@ -282,13 +265,5 @@ impl TryFrom<&[u8]> for BLS12381Signature {
         let sig = threshold_crypto::Signature::from_bytes(&tmp)
             .map_err(|_err| CryptoMaterialError::ValidationError)?;
         Ok(BLS12381Signature(sig))
-    }
-}
-
-impl Deref for BLS12381Signature {
-    type Target = threshold_crypto::Signature;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/crypto/crypto/src/vrf/ecvrf.rs
+++ b/crypto/crypto/src/vrf/ecvrf.rs
@@ -47,6 +47,7 @@
 
 use crate::traits::*;
 use core::convert::TryFrom;
+use crypto_derive::Deref;
 use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT,
     edwards::{CompressedEdwardsY, EdwardsPoint},
@@ -57,7 +58,6 @@ use ed25519_dalek::{
 };
 use failure::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 
 const SUITE: u8 = 0x03;
 const ONE: u8 = 0x01;
@@ -70,11 +70,11 @@ pub const OUTPUT_LENGTH: usize = 64;
 pub const PROOF_LENGTH: usize = 80;
 
 /// An ECVRF private key
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Deref, Debug)]
 pub struct VRFPrivateKey(ed25519_PrivateKey);
 
 /// An ECVRF public key
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Deref, PartialEq, Eq)]
 pub struct VRFPublicKey(ed25519_PublicKey);
 
 /// A longer private key which is slightly optimized for proof generation.
@@ -131,14 +131,6 @@ impl TryFrom<&[u8]> for VRFPrivateKey {
         Ok(VRFPrivateKey(
             ed25519_PrivateKey::from_bytes(bytes).unwrap(),
         ))
-    }
-}
-
-impl Deref for VRFPrivateKey {
-    type Target = ed25519_PrivateKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -217,14 +209,6 @@ impl<'a> From<&'a VRFPrivateKey> for VRFPublicKey {
         let secret: &ed25519_PrivateKey = private_key;
         let public: ed25519_PublicKey = secret.into();
         VRFPublicKey(public)
-    }
-}
-
-impl Deref for VRFPublicKey {
-    type Target = ed25519_PublicKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -57,7 +57,7 @@
 //! ```
 
 use crate::{hkdf::Hkdf, traits::*};
-use crypto_derive::{SilentDebug, SilentDisplay};
+use crypto_derive::{Deref, SilentDebug, SilentDisplay};
 use rand::{rngs::EntropyRng, RngCore};
 use serde::{de, export, ser};
 use sha2::Sha256;
@@ -85,7 +85,7 @@ pub struct X25519EphemeralPrivateKey(x25519_dalek::EphemeralSecret);
 pub struct X25519StaticPrivateKey(x25519_dalek::StaticSecret);
 
 /// An x25519 public key
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deref)]
 pub struct X25519PublicKey(x25519_dalek::PublicKey);
 
 /// An x25519 public key to match the X25519Static key type, which
@@ -239,14 +239,6 @@ impl<'a> From<&'a X25519EphemeralPrivateKey> for X25519PublicKey {
 impl<'a> From<&'a X25519StaticPrivateKey> for X25519StaticPublicKey {
     fn from(ephemeral: &'a X25519StaticPrivateKey) -> X25519StaticPublicKey {
         X25519StaticPublicKey(X25519PublicKey(x25519_dalek::PublicKey::from(&ephemeral.0)))
-    }
-}
-
-impl Deref for X25519StaticPublicKey {
-    type Target = X25519PublicKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/crypto/secret_service/src/crypto_wrappers.rs
+++ b/crypto/secret_service/src/crypto_wrappers.rs
@@ -10,22 +10,13 @@ use crypto::{
     hash::HashValue,
 };
 use crypto_derive::{
-    PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidKey, VerifyingKey,
+    Deref, PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidKey, VerifyingKey,
 };
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 
 /// KeyID value is a handler to the secret key and a simple wrapper around the hash value.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Deref, PartialEq, Eq, Hash)]
 pub struct KeyID(pub HashValue);
-
-impl Deref for KeyID {
-    type Target = HashValue;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 ///////////////////////////////////////////////////////////////////
 // Declarations pulled from crypto/src/unit_tests/cross_test.rs  //


### PR DESCRIPTION
The crypto library frequently uses the [new type pattern](https://doc.rust-lang.org/rust-by-example/generics/new_types.html), on which it derives the canonical `Deref` instance repetitively.
This uses a macro to do so.
