### PR TITLE
[types] Adding a fuzzer for SignedTransaction deserialization

### DIFF
--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -23,8 +23,6 @@ structopt = { version = "0.2.18", default-features = false }
 types = { path = "../../types" }
 vm = { path = "../../language/vm" }
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types" }
-
-# for fuzzing consensus
 consensus = { path = "../../consensus"}
 
 [dev-dependencies]

--- a/testsuite/libra_fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets.rs
@@ -59,6 +59,7 @@ macro_rules! proto_fuzz_target {
 // List fuzz target modules here.
 mod compiled_module;
 mod consensus_proposal;
+mod inner_signed_transaction;
 mod signed_transaction;
 mod vm_value;
 
@@ -68,6 +69,7 @@ lazy_static! {
             // List fuzz targets here in this format.
             Box::new(compiled_module::CompiledModuleTarget::default()),
             Box::new(signed_transaction::SignedTransactionTarget::default()),
+            Box::new(inner_signed_transaction::SignedTransactionTarget::default()),
             Box::new(vm_value::ValueTarget::default()),
             Box::new(consensus_proposal::ConsensusProposal::default()),
         ];

--- a/testsuite/libra_fuzzer/src/fuzz_targets/inner_signed_transaction.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets/inner_signed_transaction.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::FuzzTargetImpl;
+use canonical_serialization::{SimpleDeserializer, SimpleSerializer};
+use failure::prelude::Result;
+use proptest::prelude::*;
+use proptest_helpers::ValueGenerator;
+use types::transaction::SignedTransaction;
+
+#[derive(Clone, Debug, Default)]
+pub struct SignedTransactionTarget;
+
+impl FuzzTargetImpl for SignedTransactionTarget {
+    fn name(&self) -> &'static str {
+        module_name!()
+    }
+
+    fn description(&self) -> &'static str {
+        "SignedTransaction (LCS deserializer)"
+    }
+
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        let value = gen.generate(any_with::<SignedTransaction>(()));
+        Some(SimpleSerializer::serialize(&value).expect("serialization should work"))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let _: Result<SignedTransaction> = SimpleDeserializer::deserialize(&data);
+    }
+}


### PR DESCRIPTION
MOTIVATION:

The current fuzzer for SignedTransaction also fuzzes the outer protobuf structure.
Since we specifically want to test the LCS (Libra Canonical (de)Serializer), this PR adds a fuzzer that does just that.

TEST PLAN:

The fuzzer works.