### PR TITLE
fix 58 out of date move scripts in functional_tests

### DIFF
--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_copy_ok.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_copy_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module B {
     struct T {g: u64}
 
@@ -16,8 +17,8 @@ module B {
 }
 
 //! new-transaction
-
-import {{default}}.B;
+script:
+import Transaction.B;
 
 main() {
     let x: B.T;

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_field_ok.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_field_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
 
     struct T{v: u64}
@@ -16,12 +17,12 @@ module A {
         let k: &u64;
         k = &(&move(this).f).v;
         return *move(k);
-    } 
+    }
 }
 
 //! new-transaction
-
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: A.T;

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_good.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_good.mvir
@@ -61,9 +61,13 @@ module A {
         return;
     }
 
-    public A5() acquires T {
+     public A5() acquires T {
+        let sender: address;
         let t_ref: &mut Self.T;
-        t_ref = borrow_global<T>(get_txn_sender());
+        sender = get_txn_sender();
+        t_ref = borrow_global<T>(copy(sender));
+        _ = move(t_ref);
         return;
     }
+
 }

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_local_bad.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_local_bad.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     struct T{v: u64}
 
@@ -13,8 +14,8 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
+script:
+import Transaction.A;
 main() {
     let x: A.T;
     let x_ref: u64;

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_move_ok.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_move_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     struct T {v: u64}
 
@@ -14,8 +15,8 @@ module M {
 }
 
 //! new-transaction
-
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main() {
     let x: M.T;

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_parens_ok.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_parens_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     struct T{v: u64}
 
@@ -12,8 +13,8 @@ module M {
 }
 
 //! new-transaction
-
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main(){
     let x: M.T;

--- a/language/functional_tests/tests/testsuite/builtins/get_missing_struct.mvir
+++ b/language/functional_tests/tests/testsuite/builtins/get_missing_struct.mvir
@@ -1,3 +1,4 @@
+modules:
 module Token {
     resource T { }
 
@@ -30,8 +31,8 @@ module Token {
 }
 
 //! new-transaction
-
-import {{default}}.Token;
+script:
+import Transaction.Token;
 
 main() {
     Token.test();

--- a/language/functional_tests/tests/testsuite/builtins/get_published_resource.mvir
+++ b/language/functional_tests/tests/testsuite/builtins/get_published_resource.mvir
@@ -1,3 +1,4 @@
+modules:
 module Token {
     resource T {v: u64}
 
@@ -45,8 +46,8 @@ module Token {
 }
 
 //! new-transaction
-
-import {{default}}.Token;
+script:
+import Transaction.Token;
 
 main() {
     Token.test();

--- a/language/functional_tests/tests/testsuite/builtins/has_published_struct.mvir
+++ b/language/functional_tests/tests/testsuite/builtins/has_published_struct.mvir
@@ -1,3 +1,4 @@
+modules:
 module Token {
     resource T { }
 
@@ -18,8 +19,8 @@ module Token {
 }
 
 //! new-transaction
-
-import {{default}}.Token;
+script:
+import Transaction.Token;
 
 main() {
     let z: Token.T;

--- a/language/functional_tests/tests/testsuite/builtins/move_published_resource.mvir
+++ b/language/functional_tests/tests/testsuite/builtins/move_published_resource.mvir
@@ -1,3 +1,4 @@
+modules:
 module TestMoveFrom {
     resource Counter { i: u64 }
 
@@ -48,8 +49,8 @@ module TestMoveFrom {
 }
 
 //! new-transaction
-
-import {{default}}.TestMoveFrom;
+script:
+import Transaction.TestMoveFrom;
 
 main() {
   let has1: bool;

--- a/language/functional_tests/tests/testsuite/commands/return_in_if_branch_taken.mvir
+++ b/language/functional_tests/tests/testsuite/commands/return_in_if_branch_taken.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     public t(): u64 {
         let x: u64;
@@ -11,8 +12,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/commands/return_in_if_branch_taken_no_else.mvir
+++ b/language/functional_tests/tests/testsuite/commands/return_in_if_branch_taken_no_else.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     public t(): u64 {
         if (true) {
@@ -8,8 +9,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/commands/unpack_resource.mvir
+++ b/language/functional_tests/tests/testsuite/commands/unpack_resource.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     resource X { }
     resource T { i: u64, x: Self.X, b: bool }
@@ -26,8 +27,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let x: Test.X;

--- a/language/functional_tests/tests/testsuite/data_types/fields_packed_in_order.mvir
+++ b/language/functional_tests/tests/testsuite/data_types/fields_packed_in_order.mvir
@@ -1,5 +1,5 @@
 // Pack operands should be evaluated in declaration order, not alphanumeric.
-
+modules:
 module M {
     struct T {
         b: u64,
@@ -15,7 +15,8 @@ module M {
 }
 
 //! new-transaction
-import {{default}}.M;
+script:
+import Transaction.M;
 main() {
   let m: M.T;
   m = M.new();

--- a/language/functional_tests/tests/testsuite/dereference_tests/deref_borrow_field_ok.mvir
+++ b/language/functional_tests/tests/testsuite/dereference_tests/deref_borrow_field_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     struct T{f: u64}
 
@@ -14,8 +15,8 @@ module M {
 }
 
 //! new-transaction
-
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main(){
     let x: M.T;

--- a/language/functional_tests/tests/testsuite/dereference_tests/deref_move_module_ok.mvir
+++ b/language/functional_tests/tests/testsuite/dereference_tests/deref_move_module_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     struct T {v : u64}
 
@@ -13,8 +14,8 @@ module M {
 }
 
 //! new-transaction
-
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main() {
     let x: M.T;

--- a/language/functional_tests/tests/testsuite/expressions/deref_value.mvir
+++ b/language/functional_tests/tests/testsuite/expressions/deref_value.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     struct T{f: u64}
 
@@ -17,8 +18,8 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: A.T;

--- a/language/functional_tests/tests/testsuite/expressions/deref_value_nested.mvir
+++ b/language/functional_tests/tests/testsuite/expressions/deref_value_nested.mvir
@@ -1,3 +1,4 @@
+modules:
 module B {
     struct T{g: u64}
 
@@ -35,9 +36,9 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
-import {{default}}.B;
+script:
+import Transaction.A;
+import Transaction.B;
 main() {
     let b: B.T;
     let x: A.T;

--- a/language/functional_tests/tests/testsuite/expressions/equality_reference_value.mvir
+++ b/language/functional_tests/tests/testsuite/expressions/equality_reference_value.mvir
@@ -1,3 +1,4 @@
+modules:
 module Token {
     resource T { count: u64 }
 
@@ -21,8 +22,8 @@ module Token {
 }
 
 //! new-transaction
-
-import {{default}}.Token;
+script:
+import Transaction.Token;
 
 main() {
     Token.test();

--- a/language/functional_tests/tests/testsuite/expressions/equality_resource_refs.mvir
+++ b/language/functional_tests/tests/testsuite/expressions/equality_resource_refs.mvir
@@ -1,3 +1,4 @@
+modules:
 module Token {
     resource T { }
 
@@ -13,8 +14,8 @@ module Token {
 }
 
 //! new-transaction
-
-import {{default}}.Token;
+script:
+import Transaction.Token;
 
 main() {
     Token.test();

--- a/language/functional_tests/tests/testsuite/expressions/multiple_return_values.mvir
+++ b/language/functional_tests/tests/testsuite/expressions/multiple_return_values.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     resource T { }
 
@@ -16,8 +17,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 main() {
     let i: u64;
     let t: Test.T;

--- a/language/functional_tests/tests/testsuite/function_calls/add_function_calls.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/add_function_calls.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     public foo(u: u64): u64 * u64 * u64 {
         let twice: u64;
@@ -13,7 +14,8 @@ module M {
 }
 
 //! new-transaction
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/assign_function_call.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/assign_function_call.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public ones_tens(f: u64): u64 * u64 {
         let k: u64;
@@ -9,7 +10,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/binop_function_calls_as_args.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/binop_function_calls_as_args.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public div_by_two(v: u64): bool {
         if (move(v) % 2 == 0) { return true;}
@@ -15,7 +16,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/function_composition.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/function_composition.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     public foo(v: u64): u64 * u64 {
         let one_less: u64;
@@ -15,7 +16,8 @@ module Test {
 }
 
 //! new-transaction
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/many_function_calls_as_args.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/many_function_calls_as_args.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     struct T {value: u64, even: bool}
 
@@ -28,7 +29,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: A.T;

--- a/language/functional_tests/tests/testsuite/function_calls/multiple_composite_functions.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/multiple_composite_functions.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     struct T {value: u64}
 
@@ -17,7 +18,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let z: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/pass_args_on_stack_as_expressions.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/pass_args_on_stack_as_expressions.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public sum(o: u64, k: u64, t: u64): u64 {
         return move(o) + move(k) + move(t);
@@ -5,7 +6,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let s: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/push_args_before_function_call.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/push_args_before_function_call.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public push_u64(): u64  {
         return 42;
@@ -14,7 +15,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let ans: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/push_args_before_function_composition.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/push_args_before_function_composition.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public push_u64(): u64  {
         return 42;
@@ -14,7 +15,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let k: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/return_expression_lists.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/return_expression_lists.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public foo(t: u64): u64 * u64 {
         let k: u64;
@@ -11,7 +12,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let y: u64;

--- a/language/functional_tests/tests/testsuite/function_calls/return_function_in_if_binop_in_else.mvir
+++ b/language/functional_tests/tests/testsuite/function_calls/return_function_in_if_binop_in_else.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     public foo(t: u64): u64 * u64 {
        return (copy(t), 2 * move(t));
@@ -13,7 +14,8 @@ module A {
 }
 
 //! new-transaction
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/global_ref_count/decrement_dereference.mvir
+++ b/language/functional_tests/tests/testsuite/global_ref_count/decrement_dereference.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     resource T { i: u64 }
 
@@ -23,8 +24,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 main() {
     Test.test();
     return;

--- a/language/functional_tests/tests/testsuite/global_ref_count/decrement_write.mvir
+++ b/language/functional_tests/tests/testsuite/global_ref_count/decrement_write.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     resource T { i: u64 }
 
@@ -23,8 +24,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 main() {
     Test.test();
     return;

--- a/language/functional_tests/tests/testsuite/method_decorators/non_internal_function_valid_call.mvir
+++ b/language/functional_tests/tests/testsuite/method_decorators/non_internal_function_valid_call.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     struct T{value: u64}
 
@@ -33,8 +34,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let obj: Test.T;

--- a/language/functional_tests/tests/testsuite/module_member_types/field_reads.mvir
+++ b/language/functional_tests/tests/testsuite/module_member_types/field_reads.mvir
@@ -1,3 +1,4 @@
+modules:
 module VTest {
     struct T{fint: u64, fv: bool}
 
@@ -66,9 +67,9 @@ module RTest {
 }
 
 //! new-transaction
-
-import {{default}}.RTest;
-import {{default}}.VTest;
+script:
+import Transaction.RTest;
+import Transaction.VTest;
 
 main() {
     let vt: VTest.T;

--- a/language/functional_tests/tests/testsuite/module_member_types/field_writes.mvir
+++ b/language/functional_tests/tests/testsuite/module_member_types/field_writes.mvir
@@ -1,3 +1,4 @@
+modules:
 module VTest {
     struct T{fint: u64, fv: bool}
 
@@ -82,9 +83,9 @@ module RTest {
 }
 
 //! new-transaction
-
-import {{default}}.RTest;
-import {{default}}.VTest;
+script:
+import Transaction.RTest;
+import Transaction.VTest;
 
 main() {
     let vt: VTest.T;

--- a/language/functional_tests/tests/testsuite/module_member_types/unrestricted_instantiate.mvir
+++ b/language/functional_tests/tests/testsuite/module_member_types/unrestricted_instantiate.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     struct T{fint: u64, fv: bool}
 
@@ -11,8 +12,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let t1: Test.T;

--- a/language/functional_tests/tests/testsuite/modules/access_public_function.mvir
+++ b/language/functional_tests/tests/testsuite/modules/access_public_function.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     public universal_truth(): u64 {
         return 42;
@@ -5,8 +6,8 @@ module M {
 }
 
 //! new-transaction
-
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main() {
     let x: u64;

--- a/language/functional_tests/tests/testsuite/modules/all_fields_accessible.mvir
+++ b/language/functional_tests/tests/testsuite/modules/all_fields_accessible.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     resource A{x: u64}
     struct B{y: u64}
@@ -41,7 +42,8 @@ module M {
 
 //! new-transaction
 
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main() {
     let a: M.A;

--- a/language/functional_tests/tests/testsuite/modules/module_struct_shared_name.mvir
+++ b/language/functional_tests/tests/testsuite/modules/module_struct_shared_name.mvir
@@ -1,3 +1,4 @@
+modules:
 module M {
     struct M { }
     public new(): Self.M {
@@ -6,8 +7,8 @@ module M {
 }
 
 //! new-transaction
-
-import {{default}}.M;
+script:
+import Transaction.M;
 
 main() {
     let x: M.M;

--- a/language/functional_tests/tests/testsuite/move_getting_started_examples/earmarked_libra.mvir
+++ b/language/functional_tests/tests/testsuite/move_getting_started_examples/earmarked_libra.mvir
@@ -2,6 +2,7 @@
 // Any changes to this code should also be reflected there.
 
 // A module for earmarking a coin for a specific recipient
+modules:
 module EarmarkedLibraCoin {
   import 0x0.LibraCoin;
 
@@ -81,10 +82,10 @@ module EarmarkedLibraCoin {
 // TODO: lines below this are tests
 
 //! new-transaction
-
+script:
 import 0x0.LibraAccount;
 import 0x0.LibraCoin;
-import {{default}}.EarmarkedLibraCoin;
+import Transaction.EarmarkedLibraCoin;
 
 main() {
   let recipient_address: address;

--- a/language/functional_tests/tests/testsuite/mutate_tests/mutate_borrow_field_ok.mvir
+++ b/language/functional_tests/tests/testsuite/mutate_tests/mutate_borrow_field_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module Test {
     struct T{v: u64}
 
@@ -18,8 +19,8 @@ module Test {
 }
 
 //! new-transaction
-
-import {{default}}.Test;
+script:
+import Transaction.Test;
 
 main() {
     let x: Test.T;

--- a/language/functional_tests/tests/testsuite/mutate_tests/mutate_move_ok.mvir
+++ b/language/functional_tests/tests/testsuite/mutate_tests/mutate_move_ok.mvir
@@ -1,3 +1,4 @@
+modules:
 module B {
   struct T{g: u64}
 
@@ -21,7 +22,8 @@ module B {
 
 //! new-transaction
 
-import {{default}}.B;
+script:
+import Transaction.B;
 
 main() {
   let x: B.T;

--- a/language/functional_tests/tests/testsuite/mutation/assign_local_struct.mvir
+++ b/language/functional_tests/tests/testsuite/mutation/assign_local_struct.mvir
@@ -1,3 +1,4 @@
+modules:
 module Tester {
     struct T{v: u64}
 
@@ -28,8 +29,8 @@ module Tester {
 }
 
 //! new-transaction
-
-import {{default}}.Tester;
+script:
+import Transaction.Tester;
 
 main() {
     let t: Tester.T;

--- a/language/functional_tests/tests/testsuite/mutation/destroy_resource_holder.mvir
+++ b/language/functional_tests/tests/testsuite/mutation/destroy_resource_holder.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     import 0x0.LibraCoin;
     resource A { c: LibraCoin.T }
@@ -13,8 +14,8 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
+script:
+import Transaction.A;
 import 0x0.LibraCoin;
 
 main() {

--- a/language/functional_tests/tests/testsuite/mutation/mut_call_from_get_resource.mvir
+++ b/language/functional_tests/tests/testsuite/mutation/mut_call_from_get_resource.mvir
@@ -1,3 +1,4 @@
+modules:
 module Token {
     resource T {balance: u64}
 
@@ -56,8 +57,8 @@ module Token {
 }
 
 //! new-transaction
-
-import {{default}}.Token;
+script:
+import Transaction.Token;
 
 main() {
     Token.test();

--- a/language/functional_tests/tests/testsuite/mutation/mutate_resource_holder_2.mvir
+++ b/language/functional_tests/tests/testsuite/mutation/mutate_resource_holder_2.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     resource Coin { balance: u64 }
     resource A { c: Self.Coin }
@@ -31,8 +32,8 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let zero_resource: A.Coin;

--- a/language/functional_tests/tests/testsuite/mutation/simple_mutate.mvir
+++ b/language/functional_tests/tests/testsuite/mutation/simple_mutate.mvir
@@ -1,3 +1,4 @@
+modules:
 module A {
     struct T{f: u64}
 
@@ -16,8 +17,8 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
+script:
+import Transaction.A;
 
 main() {
     let x: A.T;

--- a/language/functional_tests/tests/testsuite/mutation/use_prefix_after_move.mvir
+++ b/language/functional_tests/tests/testsuite/mutation/use_prefix_after_move.mvir
@@ -1,3 +1,4 @@
+modules:
 module B {
     struct T{g: u64}
 
@@ -34,9 +35,9 @@ module A {
 }
 
 //! new-transaction
-
-import {{default}}.A;
-import {{default}}.B;
+script:
+import Transaction.A;
+import Transaction.B;
 
 main() {
     let b: B.T;

--- a/language/functional_tests/tests/testsuite/payment_channel/payment_channel.mvir
+++ b/language/functional_tests/tests/testsuite/payment_channel/payment_channel.mvir
@@ -1,3 +1,4 @@
+modules:
 module PaymentChannel {
     import 0x0.Signature;
     import 0x0.LibraCoin;
@@ -7,7 +8,7 @@ module PaymentChannel {
 
     // This is the PaymentChannel resource
     // It keeps track of the balances for funder and counterparty
-    // 
+    //
     resource T {
         funder_capacity: LibraCoin.T,
         counterparty_capacity: LibraCoin.T,
@@ -92,7 +93,7 @@ module PaymentChannel {
         message = BytearrayUtil.bytearray_concat(move(amt_to_transfer_bytes), move(new_seq_id_bytes));
         ver = Signature.ed25519_verify(move(signature), move(public_key), move(message));
         return move(ver);
-    } 
+    }
 
     public update(this: &mut Self.T, amt_to_transfer: u64, new_seq_id: u64, funder_signature: bytearray, counterparty_signature: bytearray) {
         let ver_funder: bool;
@@ -161,7 +162,8 @@ module PaymentChannel {
 }
 
 //! new-transaction
-import {{default}}.PaymentChannel;
+script:
+import Transaction.PaymentChannel;
 
 main() {
     return;

--- a/language/functional_tests/tests/testsuite/payment_channel/payment_channel_no_fixed_counterparty.mvir
+++ b/language/functional_tests/tests/testsuite/payment_channel/payment_channel_no_fixed_counterparty.mvir
@@ -1,3 +1,4 @@
+modules:
 module PaymentChannel {
     import 0x0.Signature;
     import 0x0.LibraCoin;
@@ -168,7 +169,8 @@ module PaymentChannel {
 }
 
 //! new-transaction
-import {{default}}.PaymentChannel;
+script:
+import Transaction.PaymentChannel;
 
 main() {
     return;

--- a/language/functional_tests/tests/testsuite/payment_channel/payment_channel_no_fixed_counterparty_multi_hop.mvir
+++ b/language/functional_tests/tests/testsuite/payment_channel/payment_channel_no_fixed_counterparty_multi_hop.mvir
@@ -1,3 +1,4 @@
+modules:
 module PaymentChannel {
     import 0x0.Signature;
     import 0x0.LibraCoin;
@@ -225,7 +226,8 @@ module PaymentChannel {
 }
 
 //! new-transaction
-import {{default}}.PaymentChannel;
+script:
+import Transaction.PaymentChannel;
 
 main() {
     return;

--- a/language/functional_tests/tests/testsuite/publish/publish_module_and_use.mvir
+++ b/language/functional_tests/tests/testsuite/publish/publish_module_and_use.mvir
@@ -1,3 +1,4 @@
+modules:
 module MoneyHolder {
         import 0x0.LibraCoin;
 
@@ -25,8 +26,8 @@ module MoneyHolder {
 }
 
 //! new-transaction
-
-import {{default}}.MoneyHolder;
+script:
+import Transaction.MoneyHolder;
 import 0x0.LibraCoin;
 
 main() {

--- a/language/functional_tests/tests/testsuite/recursion/direct_recursion.mvir
+++ b/language/functional_tests/tests/testsuite/recursion/direct_recursion.mvir
@@ -1,3 +1,4 @@
+modules:
 module Math {
 
   public sum_(n: u64, acc: u64): u64 {
@@ -25,8 +26,8 @@ module Math {
 }
 
 //! new-transaction
-
-import {{default}}.Math;
+script:
+import Transaction.Math;
 
 main() {
     let sum1: u64;

--- a/language/functional_tests/tests/testsuite/recursion/mutual_recursion.mvir
+++ b/language/functional_tests/tests/testsuite/recursion/mutual_recursion.mvir
@@ -1,3 +1,4 @@
+modules:
 module Math {
 
   public even(n: u64): bool {
@@ -22,8 +23,8 @@ module Math {
 }
 
 //! new-transaction
-
-import {{default}}.Math;
+script:
+import Transaction.Math;
 
 main() {
     let zero_even: bool;

--- a/language/functional_tests/tests/testsuite/wallets/wallet_module.mvir
+++ b/language/functional_tests/tests/testsuite/wallets/wallet_module.mvir
@@ -1,3 +1,4 @@
+modules:
 module ApprovalGroup {
     import 0x0.Signature;
 
@@ -206,6 +207,7 @@ module ColdWallet {
 
 
 //! new-transaction
+script:
 import Transaction.ApprovalGroup;
 import Transaction.ColdWallet;
 main() {


### PR DESCRIPTION
Many old move functional_tests scripts are not working after update.
I go through all scripts in functional_tests and fixed 58 out of date move scripts in the functional_tests and list them as below.

functional_tests/tests/testsuite

-borrow_tests:
*borrow_copy_ok.mvir
*borrow_field_ok.mvir
*borrow_global_good.mvir
*borrow_local_bad.mvir
*borrow_move_ok.mvir
*borrow_parens_ok.mvir

-builtins:
*get_missing_struct.mvir
*get_published_resource.mvir
*has_published_struct.mvir
*move_published_resource.mvir

-commands:
*move_published_resource.mvir
*return_in_if_branch_taken.mvir
*return_in_if_branch_taken_no_else.mvir
*unpack_resource.mvir

-data_types
*fields_packed_in_order.mvir

-dereference_tests
*deref_borrow_field_ok.mvir
*deref_move_module_ok.mvir

-expressions
*deref_value.mvir
*deref_value_nested.mvir
*equality_reference_value.mvir
*equality_resource_refs.mvir
*multiple_return_values.mvir

-function_calls
*add_function_calls.mvir
*assign_function_call.mvir
*binop_function_calls_as_args.mvir
*function_composition.mvir
*many_function_calls_as_args.mvir
*multiple_composite_functions.mvir
*pass_args_on_stack_as_expressions.mvir
*push_args_before_function_call.mvir
*push_args_before_function_composition.mvir
*return_expression_lists.mvir
*return_function_in_if_binop_in_else.mvir

-global_ref_count
*return_function_in_if_binop_in_else.mvir
*decrement_dereference.mvir

-method_decorators
*non_internal_function_valid_call.mvir

-module_member_types
*field_reads.mvir
*field_writes.mvir

-modules
*access_public_function.mvir
*all_fields_accessible.mvir
*module_struct_shared_name.mvir

-move_getting_started_examples
*earmarked_libra.mvir

-mutate_tests
*mutate_borrow_field_ok.mvir
*mutate_move_ok.mvir

-mutation
*assign_local_struct.mvir
*destroy_resource_holder.mvir
*mut_call_from_get_resource.mvir
*mutate_resource_holder_2.mvir
*simple_mutate.mvir
*use_prefix_after_move.mvir

-payment_channel
*payment_channel.mvir
*payment_channel_no_fixed_counterparty.mvir
*payment_channel_no_fixed_counterparty_multi_hop.mvir

-publish
*publish_module_and_use.mvir

-recursion
*direct_recursion.mvir
*mutual_recursion.mvir

-wallets
*wallet_module.mvir

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Many old move functional_tests scripts are not working after update.
I go through all scripts in functional_tests and fixed 58 out of date move scripts in the functional_tests and list them as below.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Yes.)

## Test Plan

I already test all of them in the latest compiler in LIbraIDE (libraide.com)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
