### PR TITLE
[Storage] Do not implement TreeReader for TreeCache

### DIFF
--- a/storage/jellyfish_merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish_merkle/src/tree_cache/mod.rs
@@ -131,22 +131,6 @@ pub struct TreeCache<'a, R: 'a + TreeReader> {
     reader: &'a R,
 }
 
-impl<'a, R> TreeReader for TreeCache<'a, R>
-where
-    R: 'a + TreeReader,
-{
-    /// Gets a node with given hash. If it doesn't exist in node cache, read from `reader`.
-    fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
-        Ok(if let Some(node) = self.node_cache.get(node_key) {
-            node.clone()
-        } else if let Some(node) = self.frozen_cache.node_cache.get(node_key) {
-            node.clone()
-        } else {
-            self.reader.get_node(node_key)?
-        })
-    }
-}
-
 impl<'a, R> TreeCache<'a, R>
 where
     R: 'a + TreeReader,
@@ -172,6 +156,17 @@ where
             num_stale_leaves: 0,
             num_new_leaves: 0,
         }
+    }
+
+    /// Gets a node with given node key. If it doesn't exist in node cache, read from `reader`.
+    pub fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
+        Ok(if let Some(node) = self.node_cache.get(node_key) {
+            node.clone()
+        } else if let Some(node) = self.frozen_cache.node_cache.get(node_key) {
+            node.clone()
+        } else {
+            self.reader.get_node(node_key)?
+        })
     }
 
     /// Gets the current root node key.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Conceptually `TreeReader` is a trait that describes the underlying storage (`StateStore` in case of real storage and `MockTreeStore` in case of unit tests). Implementing it for `TreeCache` does not make sense.

(I'm adding some more interface to `TreeReader` and do not want to implement it for `TreeCache`.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI.

## Related PRs

None.