### PR TITLE
Add get_latest_ledger_infos functionality to storage service.

### DIFF
--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -63,6 +63,6 @@ proptest! {
             .collect::<Result<Vec<_>>>()
             .unwrap();
         store.db.write_schemas(cs.batch).unwrap();
-        prop_assert_eq!(db.ledger_store.get_ledger_infos(start_epoch).unwrap(), ledger_infos_with_sigs);
+        prop_assert_eq!(db.ledger_store.get_latest_ledger_infos_per_epoch(start_epoch).unwrap(), ledger_infos_with_sigs);
     }
 }

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -61,12 +61,11 @@ impl LedgerStore {
         }
     }
 
-    /// Return the ledger infos with their least 2f+1 signatures starting from `start_version` to
+    /// Return the ledger infos with their least 2f+1 signatures starting from `start_epoch` to
     /// the most recent one.
     /// Note: ledger infos and signatures are only available at the last version of each earlier
     /// epoch and at the latest version of current epoch.
-    #[cfg(test)]
-    fn get_ledger_infos(
+    pub fn get_latest_ledger_infos_per_epoch(
         &self,
         start_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -300,6 +300,20 @@ impl LibraDB {
             .version())
     }
 
+    /// Returns the latest ledger infos per epoch starting with the given epoch num:
+    /// - the latest ledger info of the current epoch is just the last ledger info in the system
+    /// - the latest ledger infos of previous epochs contain reconfiguration validator sets.
+    /// Returns error in case `start_epoch` is higher than the currently known epoch.
+    /// The returned vector is not necessarily sorted: the client should make sure to sort it
+    /// by epoch number.
+    pub fn get_latest_ledger_infos_per_epoch(
+        &self,
+        start_epoch: u64,
+    ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {
+        self.ledger_store
+            .get_latest_ledger_infos_per_epoch(start_epoch)
+    }
+
     /// Persist transactions. Called by the executor module when either syncing nodes or committing
     /// blocks during normal operation.
     ///

--- a/storage/storage_proto/src/lib.rs
+++ b/storage/storage_proto/src/lib.rs
@@ -371,6 +371,52 @@ impl IntoProto for GetStartupInfoResponse {
     }
 }
 
+/// Helper to construct and parse [`proto::storage::GetLatestLedgerInfosPerEpochRequest`]
+///
+/// It does so by implementing [`IntoProto`](#impl-IntoProto) and [`FromProto`](#impl-FromProto),
+/// providing [`into_proto`](IntoProto::into_proto) and [`from_proto`](FromProto::from_proto).
+#[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
+#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[ProtoType(crate::proto::storage::GetLatestLedgerInfosPerEpochRequest)]
+pub struct GetLatestLedgerInfosPerEpochRequest {
+    pub start_epoch: u64,
+}
+
+impl GetLatestLedgerInfosPerEpochRequest {
+    /// Constructor.
+    pub fn new(start_epoch: u64) -> Self {
+        Self { start_epoch }
+    }
+}
+
+/// Helper to construct and parse [`proto::storage::GetLatestLedgerInfosPerEpochResponse`]
+///
+/// It does so by implementing [`IntoProto`](#impl-IntoProto) and [`FromProto`](#impl-FromProto),
+/// providing [`into_proto`](IntoProto::into_proto) and [`from_proto`](FromProto::from_proto).
+#[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]
+#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[ProtoType(crate::proto::storage::GetLatestLedgerInfosPerEpochResponse)]
+pub struct GetLatestLedgerInfosPerEpochResponse {
+    pub latest_ledger_infos: Vec<LedgerInfoWithSignatures<Ed25519Signature>>,
+}
+
+impl GetLatestLedgerInfosPerEpochResponse {
+    /// Constructor.
+    pub fn new(latest_ledger_infos: Vec<LedgerInfoWithSignatures<Ed25519Signature>>) -> Self {
+        Self {
+            latest_ledger_infos,
+        }
+    }
+}
+
+impl Into<Vec<LedgerInfoWithSignatures<Ed25519Signature>>>
+    for GetLatestLedgerInfosPerEpochResponse
+{
+    fn into(self) -> Vec<LedgerInfoWithSignatures<Ed25519Signature>> {
+        self.latest_ledger_infos
+    }
+}
+
 pub mod prelude {
     pub use super::*;
 }

--- a/storage/storage_proto/src/proto/storage.proto
+++ b/storage/storage_proto/src/proto/storage.proto
@@ -45,6 +45,10 @@ service Storage {
     // Returns information needed for libra core to start up.
     rpc GetStartupInfo(GetStartupInfoRequest)
     returns (GetStartupInfoResponse);
+
+    // Returns latest ledger infos per epoch.
+    rpc GetLatestLedgerInfosPerEpoch(GetLatestLedgerInfosPerEpochRequest)
+    returns (GetLatestLedgerInfosPerEpochResponse);
 }
 
 message SaveTransactionsRequest {
@@ -112,4 +116,14 @@ message StartupInfo {
     bytes account_state_root_hash = 3;
     // From left to right, root hashes of all frozen subtrees.
     repeated bytes ledger_frozen_subtree_hashes = 4;
+}
+
+message GetLatestLedgerInfosPerEpochRequest {
+    /// The last epoch number with available information to the client.
+    uint64 start_epoch = 1;
+}
+
+message GetLatestLedgerInfosPerEpochResponse {
+    /// Vector of latest ledger infos per epoch (not sorted)
+    repeated types.LedgerInfoWithSignatures latest_ledger_infos = 1;
 }

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -140,6 +140,21 @@ impl StorageRead for MockStorageReadClient {
     ) -> Pin<Box<dyn Future<Output = Result<Option<StartupInfo>>> + Send>> {
         unimplemented!()
     }
+
+    fn get_latest_ledger_infos_per_epoch(
+        &self,
+        _start_epoch: u64,
+    ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {
+        unimplemented!()
+    }
+
+    fn get_latest_ledger_infos_per_epoch_async(
+        &self,
+        _start_epoch: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>>> + Send>>
+    {
+        unimplemented!()
+    }
 }
 
 fn get_mock_update_to_latest_ledger(


### PR DESCRIPTION
Summary:
Ledger store has been already keeping ledger infos keyed by their epoch number, hence it could already return all the latest ledger infos per epoch.
In this diff we're merely exposing this functionality all the way up to the storage client (which requires adding the protobuf function for the storage service).
This is a purely technical change that doesn't involve any change in the business logic: no one is calling the `get_latest_ledger_infos()` function yet.

Testing: existing unit test coverage

Issue: ref #849
