### PR TITLE
[language][bytecode_verifier] implement unused entry checker

### DIFF
--- a/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/mod.rs
+++ b/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/mod.rs
@@ -8,3 +8,4 @@ pub mod negative_stack_size_tests;
 pub mod resources_tests;
 pub mod signature_tests;
 pub mod struct_defs_tests;
+pub mod unused_entry_tests;

--- a/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/unused_entry_tests.rs
+++ b/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/unused_entry_tests.rs
@@ -1,0 +1,80 @@
+use bytecode_verifier::UnusedEntryChecker;
+use proptest::prelude::*;
+use types::{identifier::Identifier, vm_error::StatusCode};
+use vm::file_format::{
+    CompiledModule, FieldDefinition, IdentifierIndex, LocalsSignature, ModuleHandleIndex,
+    SignatureToken, StructHandle, StructHandleIndex, TypeSignature, TypeSignatureIndex,
+};
+
+proptest! {
+    #[test]
+    fn unused_locals_signature(module in CompiledModule::valid_strategy(10)) {
+        let mut module = module.into_inner();
+        module.locals_signatures.push(LocalsSignature(vec![]));
+        let module = module.freeze().unwrap();
+        let unused_entry_checker = UnusedEntryChecker::new(&module);
+        prop_assert!(!unused_entry_checker.verify().is_empty());
+    }
+}
+
+proptest! {
+    #[test]
+    fn unused_type_signature(module in CompiledModule::valid_strategy(10)) {
+        let mut module = module.into_inner();
+        module.type_signatures.push(TypeSignature(SignatureToken::Bool));
+        let module = module.freeze().unwrap();
+        let unused_entry_checker = UnusedEntryChecker::new(&module);
+        prop_assert!(!unused_entry_checker.verify().is_empty());
+    }
+}
+
+proptest! {
+    #[test]
+    fn unused_field(module in CompiledModule::valid_strategy(10)) {
+        let mut module = module.into_inner();
+
+        let type_sig_idx = module.type_signatures.len() as u16;
+        module.type_signatures.push(TypeSignature(SignatureToken::Bool));
+
+        let struct_name_idx = module.identifiers.len() as u16;
+        module.identifiers.push(Identifier::new("foo".to_string()).unwrap());
+
+        let field_name_idx = module.identifiers.len() as u16;
+        module.identifiers.push(Identifier::new("bar".to_string()).unwrap());
+
+        let sh_idx = module.struct_handles.len() as u16;
+        module.struct_handles.push(StructHandle{
+            module: ModuleHandleIndex::new(0),
+            name: IdentifierIndex::new(struct_name_idx),
+            is_nominal_resource: false,
+            type_formals: vec![],
+        });
+
+        module.field_defs.push(FieldDefinition{
+            struct_: StructHandleIndex::new(sh_idx),
+            name: IdentifierIndex::new(field_name_idx),
+            signature: TypeSignatureIndex::new(type_sig_idx),
+        });
+
+        let module = module.freeze().unwrap();
+        let unused_entry_checker = UnusedEntryChecker::new(&module);
+
+        let errs = unused_entry_checker.verify();
+
+        let has_unused_fields = errs.iter().any(|err| {
+            match err.major_status {
+                StatusCode::UNUSED_FIELD => true,
+                _ => false,
+            }
+        });
+
+        let has_unused_type_signature = errs.iter().any(|err| {
+            match err.major_status {
+                StatusCode::UNUSED_TYPE_SIGNATURE => true,
+                _ => false,
+            }
+        });
+
+        prop_assert!(has_unused_fields && has_unused_type_signature);
+    }
+}

--- a/language/bytecode_verifier/src/check_duplication.rs
+++ b/language/bytecode_verifier/src/check_duplication.rs
@@ -181,12 +181,6 @@ impl<'a> DuplicationChecker<'a> {
                 idx,
                 StatusCode::INCONSISTENT_FIELDS,
             ));
-        } else if start_field_index != self.module.field_defs().len() {
-            errors.push(verification_error(
-                IndexKind::FieldDefinition,
-                start_field_index,
-                StatusCode::UNUSED_FIELDS,
-            ));
         }
 
         // Check that each struct definition is pointing to module handle with index

--- a/language/bytecode_verifier/src/lib.rs
+++ b/language/bytecode_verifier/src/lib.rs
@@ -18,6 +18,8 @@ pub mod signature;
 pub mod stack_usage_verifier;
 pub mod struct_defs;
 pub mod type_memory_safety;
+pub mod unused_entries;
+
 pub mod verifier;
 
 pub use check_duplication::DuplicationChecker;
@@ -26,6 +28,7 @@ pub use resources::ResourceTransitiveChecker;
 pub use signature::SignatureChecker;
 pub use stack_usage_verifier::StackUsageVerifier;
 pub use struct_defs::RecursiveStructDefChecker;
+pub use unused_entries::UnusedEntryChecker;
 pub use verifier::{
     verify_main_signature, verify_module_dependencies, verify_script_dependencies, VerifiedModule,
     VerifiedScript,

--- a/language/bytecode_verifier/src/unused_entries.rs
+++ b/language/bytecode_verifier/src/unused_entries.rs
@@ -1,0 +1,114 @@
+use types::vm_error::{StatusCode, VMStatus};
+use vm::{
+    access::ModuleAccess,
+    errors::verification_error,
+    file_format::{Bytecode, CompiledModule, StructFieldInformation},
+    IndexKind,
+};
+
+pub struct UnusedEntryChecker<'a> {
+    module: &'a CompiledModule,
+
+    field_defs: Vec<bool>,
+    locals_signatures: Vec<bool>,
+    type_signatures: Vec<bool>,
+}
+
+impl<'a> UnusedEntryChecker<'a> {
+    pub fn new(module: &'a CompiledModule) -> Self {
+        Self {
+            module,
+            field_defs: vec![false; module.field_defs().len()],
+            locals_signatures: vec![false; module.locals_signatures().len()],
+            type_signatures: vec![false; module.type_signatures().len()],
+        }
+    }
+
+    fn traverse_function_defs(&mut self) {
+        use Bytecode::*;
+
+        for func_def in self.module.function_defs() {
+            if func_def.is_native() {
+                continue;
+            }
+            self.locals_signatures[func_def.code.locals.0 as usize] = true;
+
+            for bytecode in &func_def.code.code {
+                match bytecode {
+                    Call(_, idx)
+                    | Pack(_, idx)
+                    | Unpack(_, idx)
+                    | MutBorrowGlobal(_, idx)
+                    | ImmBorrowGlobal(_, idx)
+                    | Exists(_, idx)
+                    | MoveToSender(_, idx)
+                    | MoveFrom(_, idx) => {
+                        self.locals_signatures[idx.0 as usize] = true;
+                    }
+                    _ => (),
+                }
+            }
+        }
+    }
+
+    fn traverse_struct_defs(&mut self) {
+        for struct_def in self.module.struct_defs() {
+            match struct_def.field_information {
+                StructFieldInformation::Native => (),
+                StructFieldInformation::Declared {
+                    field_count,
+                    fields,
+                } => {
+                    let start = fields.0 as usize;
+                    let end = start + (field_count as usize);
+
+                    for i in start..end {
+                        self.field_defs[i] = true;
+
+                        let field_def = &self.module.field_defs()[i];
+                        self.type_signatures[field_def.signature.0 as usize] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_errors<'b, F>(pool: &'b [bool], f: F) -> impl Iterator<Item = VMStatus> + 'b
+    where
+        F: Fn(usize) -> VMStatus + 'b,
+    {
+        pool.iter()
+            .enumerate()
+            .filter_map(move |(idx, visited)| if *visited { None } else { Some(f(idx)) })
+    }
+
+    pub fn verify(mut self) -> Vec<VMStatus> {
+        self.traverse_struct_defs();
+        self.traverse_function_defs();
+
+        let iter_field_defs = Self::collect_errors(&self.field_defs, |idx| {
+            verification_error(IndexKind::FieldDefinition, idx, StatusCode::UNUSED_FIELD)
+        });
+
+        let iter_locals_signatures = Self::collect_errors(&self.locals_signatures, |idx| {
+            verification_error(
+                IndexKind::LocalsSignature,
+                idx,
+                StatusCode::UNUSED_LOCALS_SIGNATURE,
+            )
+        });
+
+        let iter_type_signatures = Self::collect_errors(&self.type_signatures, |idx| {
+            verification_error(
+                IndexKind::TypeSignature,
+                idx,
+                StatusCode::UNUSED_TYPE_SIGNATURE,
+            )
+        });
+
+        iter_field_defs
+            .chain(iter_locals_signatures)
+            .chain(iter_type_signatures)
+            .collect()
+    }
+}

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -344,7 +344,7 @@ pub enum StatusCode {
     INVALID_MODULE_HANDLE = 1013,
     UNIMPLEMENTED_HANDLE = 1014,
     INCONSISTENT_FIELDS = 1015,
-    UNUSED_FIELDS = 1016,
+    UNUSED_FIELD = 1016,
     LOOKUP_FAILED = 1017,
     VISIBILITY_MISMATCH = 1018,
     TYPE_RESOLUTION_FAILURE = 1019,
@@ -408,6 +408,8 @@ pub enum StatusCode {
     CONTRAINT_KIND_MISMATCH = 1074,
     NUMBER_OF_TYPE_ACTUALS_MISMATCH = 1075,
     LOOP_IN_INSTANTIATION_GRAPH = 1076,
+    UNUSED_LOCALS_SIGNATURE = 1077,
+    UNUSED_TYPE_SIGNATURE = 1078,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.


### PR DESCRIPTION
## Summary
This implements a new checker that errors on unused entries in tables in the file format. It is required to cover cases the bounds checker can no longer handle with the introduction of generics.

Right now it checks for unused entries in the following pools:
- locals_signatures
- type_signatures
- field_defs

For details, see #841.

## Test Plan
New tests added.
```
cargo test
```