### PR TITLE
[language] Make execution stack visible for runtime tests

### DIFF
--- a/language/vm/vm_runtime/src/txn_executor.rs
+++ b/language/vm/vm_runtime/src/txn_executor.rs
@@ -88,10 +88,10 @@ where
     'alloc: 'txn,
     P: ModuleCache<'alloc>,
 {
-    #[cfg(feature = "instruction_synthesis")]
+    #[cfg(any(test, feature = "instruction_synthesis"))]
     pub execution_stack: ExecutionStack<'alloc, 'txn, P>,
 
-    #[cfg(not(feature = "instruction_synthesis"))]
+    #[cfg(not(any(test, feature = "instruction_synthesis")))]
     execution_stack: ExecutionStack<'alloc, 'txn, P>,
     gas_meter: GasMeter,
     txn_data: TransactionMetadata,


### PR DESCRIPTION
tests in the vm_runtime directory were broken since the execution_stack
was not available when testing. This updates the config variable around
this field to make this field visible for both instruction synthesis,
and testing.
