### PR TITLE
[Storage] Add get_node_option interface to TreeReader

### DIFF
--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -83,8 +83,14 @@ const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;
 /// `TreeReader` defines the interface between [`JellyfishMerkleTree`] and underlying storage
 /// holding nodes.
 pub trait TreeReader {
-    /// Get node given a node key.
-    fn get_node(&self, node_key: &NodeKey) -> Result<Node>;
+    /// Gets node given a node key. Returns error if the node does not exist.
+    fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
+        self.get_node_option(node_key)?
+            .ok_or_else(|| format_err!("Missing node at {:?}.", node_key))
+    }
+
+    /// Gets node given a node key. Returns `None` if the node does not exist.
+    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>>;
 }
 
 /// Node batch that will be written into db atomically with other batches.

--- a/storage/jellyfish_merkle/src/mock_tree_store.rs
+++ b/storage/jellyfish_merkle/src/mock_tree_store.rs
@@ -16,15 +16,8 @@ use types::transaction::Version;
 pub(crate) struct MockTreeStore(RwLock<(HashMap<NodeKey, Node>, BTreeSet<StaleNodeIndex>)>);
 
 impl TreeReader for MockTreeStore {
-    fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
-        Ok(self
-            .0
-            .read()
-            .unwrap()
-            .0
-            .get(node_key)
-            .cloned()
-            .ok_or_else(|| format_err!("Failed to find node with hash {:?}", node_key))?)
+    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
+        Ok(self.0.read().unwrap().0.get(node_key).cloned())
     }
 }
 

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -100,10 +100,7 @@ impl StateStore {
 }
 
 impl TreeReader for StateStore {
-    fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
-        Ok(self
-            .db
-            .get::<JellyfishMerkleNodeSchema>(node_key)?
-            .ok_or_else(|| format_err!("Failed to find node with node_key {:?}", node_key))?)
+    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
+        Ok(self.db.get::<JellyfishMerkleNodeSchema>(node_key)?)
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In some cases I need to know whether a node exists or not, so there needs to be an API that returns an `Option`.

For example, if we are doing state sync by re-constructing the tree using small chunks, and we crashed in the middle of the process, we need to determine what we have in storage so we can resume.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

None.
