### PR TITLE
[executor] create ExecutedTrees to encapsulate both state tree and tx…

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -14,7 +14,10 @@ use crate::block_processor::BlockProcessor;
 use config::config::NodeConfig;
 use crypto::{
     ed25519::*,
-    hash::{GENESIS_BLOCK_ID, PRE_GENESIS_BLOCK_ID, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    hash::{
+        TransactionAccumulatorHasher, GENESIS_BLOCK_ID, PRE_GENESIS_BLOCK_ID,
+        SPARSE_MERKLE_PLACEHOLDER_HASH,
+    },
     HashValue,
 };
 use execution_proto::{CommitBlockResponse, ExecuteBlockResponse, ExecuteChunkResponse};
@@ -22,15 +25,18 @@ use failure::{format_err, Result};
 use futures::{channel::oneshot, executor::block_on};
 use lazy_static::lazy_static;
 use logger::prelude::*;
+use scratchpad::SparseMerkleTree;
 use std::{
     collections::HashMap,
     marker::PhantomData,
+    rc::Rc,
     sync::{mpsc, Arc, Mutex},
 };
 use storage_client::{StorageRead, StorageWrite};
 use types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    transaction::{SignedTransaction, TransactionListWithProof},
+    proof::accumulator::Accumulator,
+    transaction::{SignedTransaction, TransactionListWithProof, Version},
 };
 use vm_runtime::VMExecutor;
 
@@ -296,4 +302,37 @@ enum Command {
         ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
         resp_sender: oneshot::Sender<Result<ExecuteChunkResponse>>,
     },
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecutedTrees {
+    /// The in-memory Sparse Merkle Tree representing a specific state after execution. If this
+    /// tree is presenting the latest commited state, it will have a single Subtree node (or
+    /// Empty node) whose hash equals the root hash of the newest Sparse Merkle Tree in
+    /// storage.
+    state_tree: Rc<SparseMerkleTree>,
+
+    /// The in-memory Merkle Accumulator representing a blockchain state consistent with the
+    /// `state_tree`.
+    transaction_accumulator: Rc<Accumulator<TransactionAccumulatorHasher>>,
+}
+
+impl ExecutedTrees {
+    pub fn state_tree(&self) -> &Rc<SparseMerkleTree> {
+        &self.state_tree
+    }
+
+    pub fn txn_accumulator(&self) -> &Rc<Accumulator<TransactionAccumulatorHasher>> {
+        &self.transaction_accumulator
+    }
+
+    pub fn version_and_state_root(&self) -> (Option<Version>, HashValue) {
+        let num_elements = self.txn_accumulator().num_leaves();
+        let version = if num_elements > 0 {
+            Some(num_elements - 1)
+        } else {
+            None
+        };
+        (version, self.state_tree().root_hash())
+    }
 }

--- a/storage/storage_client/src/state_view.rs
+++ b/storage/storage_client/src/state_view.rs
@@ -81,18 +81,18 @@ impl<'a> VerifiedStateView<'a> {
     /// on top of it represented by `speculative_state`.
     pub fn new(
         reader: Arc<dyn StorageRead>,
-        num_elements_in_accumulator: u64,
-        latest_persistent_state_root: HashValue,
+        latest_persistent_version_and_state_root: (Option<Version>, HashValue),
         speculative_state: &'a SparseMerkleTree,
     ) -> Self {
         Self {
             reader,
-            latest_persistent_version: if num_elements_in_accumulator > 0 {
-                Some(num_elements_in_accumulator - 1)
-            } else {
-                None
-            },
-            latest_persistent_state_root,
+            latest_persistent_version: latest_persistent_version_and_state_root.0,
+            // if num_elements_in_accumulator > 0 {
+            //     Some(num_elements_in_accumulator - 1)
+            // } else {
+            //     None
+            // },
+            latest_persistent_state_root: latest_persistent_version_and_state_root.1,
             speculative_state,
             account_to_btree_cache: RefCell::new(HashMap::new()),
             account_to_proof_cache: RefCell::new(HashMap::new()),

--- a/vm_validator/src/vm_validator.rs
+++ b/vm_validator/src/vm_validator.rs
@@ -88,8 +88,10 @@ impl TransactionValidation for VMValidator {
                         let smt = SparseMerkleTree::new(state_root);
                         let state_view = VerifiedStateView::new(
                             Arc::clone(&self.storage_read_client),
-                            ledger_info_with_sigs.ledger_info().version() + 1,
-                            state_root,
+                            (
+                                Some(ledger_info_with_sigs.ledger_info().version()),
+                                state_root,
+                            ),
                             &smt,
                         );
                         Box::new(ok(self.vm.validate_transaction(txn, &state_view)))


### PR DESCRIPTION
…n accumulator

## Motivation

Create a struct `ExecutedTrees` to encapsulate the two trees amended in speculation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
