### PR TITLE
[types] Add major VM status to TransactionInfo

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -368,6 +368,7 @@ where
                 txn_data.account_blobs().clone(),
                 txn_data.events().to_vec(),
                 txn_data.gas_used(),
+                txn_data.status().vm_status().major_status,
             ));
         }
 
@@ -500,6 +501,7 @@ where
                         txn_data.account_blobs().clone(),
                         txn_data.events().to_vec(),
                         txn_data.gas_used(),
+                        txn_data.status().vm_status().major_status,
                     ));
                     num_accounts_created += txn_data.num_account_created();
                 }
@@ -698,7 +700,7 @@ where
                 .append(vm_output.events().iter().map(CryptoHash::hash).collect());
 
             match vm_output.status() {
-                TransactionStatus::Keep(_) => {
+                TransactionStatus::Keep(status) => {
                     ensure!(
                         !vm_output.write_set().is_empty(),
                         "Transaction with empty write set should be discarded.",
@@ -710,6 +712,7 @@ where
                         state_tree.root_hash(),
                         event_tree.root_hash(),
                         vm_output.gas_used(),
+                        status.major_status,
                     );
                     txn_info_hashes.push(txn_info.hash());
                 }

--- a/state_synchronizer/src/tests/integration_tests.rs
+++ b/state_synchronizer/src/tests/integration_tests.rs
@@ -40,6 +40,7 @@ use types::{
     proof::AccumulatorProof,
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::{SignedTransaction, TransactionInfo, TransactionListWithProof},
+    vm_error::StatusCode,
 };
 use vm_genesis::{encode_transfer_program, GENESIS_KEYPAIR};
 
@@ -92,8 +93,13 @@ impl MockExecutorProxy {
             Some(program),
         );
 
-        let txn_info =
-            TransactionInfo::new(HashValue::zero(), HashValue::zero(), HashValue::zero(), 0);
+        let txn_info = TransactionInfo::new(
+            HashValue::zero(),
+            HashValue::zero(),
+            HashValue::zero(),
+            0,
+            StatusCode::EXECUTED,
+        );
         let accumulator_proof = AccumulatorProof::new(vec![]);
         let txns = TransactionListWithProof::new(
             vec![(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -424,7 +424,9 @@ impl LibraDB {
 
         // Transaction accumulator updates. Get result root hash.
         let txn_infos = izip!(txns_to_commit, state_root_hashes, event_root_hashes)
-            .map(|(t, s, e)| TransactionInfo::new(t.signed_txn().hash(), s, e, t.gas_used()))
+            .map(|(t, s, e)| {
+                TransactionInfo::new(t.signed_txn().hash(), s, e, t.gas_used(), t.major_status())
+            })
             .collect::<Vec<_>>();
         assert_eq!(txn_infos.len(), txns_to_commit.len());
 

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -22,6 +22,7 @@ use types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::SparseMerkleLeafNode,
     transaction::{Program, RawTransaction, TransactionInfo, TransactionToCommit},
+    vm_error::StatusCode,
 };
 
 fn gen_mock_genesis() -> (
@@ -58,6 +59,7 @@ fn gen_mock_genesis() -> (
         account_states.clone(),
         vec![], /* events */
         0,      /* gas_used */
+        StatusCode::EXECUTED,
     );
 
     // The genesis state tree has a single leaf node, so the root hash is the hash of that node.
@@ -67,6 +69,7 @@ fn gen_mock_genesis() -> (
         state_root_hash,
         *ACCUMULATOR_PLACEHOLDER_HASH,
         0,
+        StatusCode::EXECUTED,
     );
 
     let ledger_info = LedgerInfo::new(

--- a/storage/libradb/src/schema/transaction_info/test.rs
+++ b/storage/libradb/src/schema/transaction_info/test.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crypto::HashValue;
 use schemadb::schema::assert_encode_decode;
-use types::transaction::TransactionInfo;
+use types::{transaction::TransactionInfo, vm_error::StatusCode};
 
 #[test]
 fn test_encode_decode() {
@@ -13,6 +13,7 @@ fn test_encode_decode() {
         HashValue::random(),
         HashValue::random(),
         7,
+        StatusCode::EXECUTED,
     );
     assert_encode_decode::<TransactionInfoSchema>(&0u64, &txn_info);
 }

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -55,6 +55,7 @@ fn to_blocks_to_commit(
                     state_root_hash,
                     event_root_hash,
                     txn_to_commit.gas_used(),
+                    txn_to_commit.major_status(),
                 );
                 let txn_accu_hash =
                     db.ledger_store

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -37,6 +37,7 @@ use types::{
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::Version,
     validator_change::ValidatorChangeEventWithProof,
+    vm_error::StatusCode,
 };
 
 /// This is a mock of the storage read client used in tests.
@@ -207,6 +208,7 @@ fn get_mock_response_item(request_item: &ProtoRequestItem) -> Result<ProtoRespon
                         HashValue::zero(),
                         HashValue::zero(),
                         0,
+                        StatusCode::UNKNOWN_STATUS,
                     );
                     let transaction_info_to_account_proof = types::proof::SparseMerkleProof::new(None, vec![]);
                     types::proof::AccountStateProof::new(
@@ -285,5 +287,6 @@ fn get_transaction_info() -> types::transaction::TransactionInfo {
         HashValue::zero(),
         HashValue::zero(),
         0,
+        StatusCode::UNKNOWN_STATUS,
     )
 }

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -15,6 +15,7 @@ use crate::{
     transaction::{
         Program, RawTransaction, SignedTransaction, TransactionInfo, TransactionListWithProof,
     },
+    vm_error::StatusCode,
 };
 use crypto::{
     ed25519::*,
@@ -279,6 +280,7 @@ fn test_verify_signed_transaction() {
         state_root1_hash,
         event_root1_hash,
         /* gas_used = */ 0,
+        /* major_status = */ StatusCode::EXECUTED,
     );
     let txn_info1_hash = txn_info1.hash();
 
@@ -378,6 +380,7 @@ fn test_verify_account_state_and_event() {
         state_root_hash,
         event_root_hash,
         /* gas_used = */ 0,
+        /* major_status = */ StatusCode::EXECUTED,
     );
     let txn_info2_hash = txn_info2.hash();
 
@@ -498,6 +501,7 @@ fn arb_signed_txn_list_and_range(
                         txn_info.state_root_hash(),
                         txn_info.event_root_hash(),
                         txn_info.gas_used(),
+                        txn_info.major_status(),
                     ),
                 )
             })

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -72,6 +72,8 @@ message TransactionToCommit {
     repeated Event events = 3;
     // The amount of gas used.
     uint64 gas_used = 4;
+    // The major status of executing the transaction.
+    uint64 major_status = 5;
 }
 
 // A list of consecutive transactions with proof. This is mainly used for state

--- a/types/src/proto/transaction_info.proto
+++ b/types/src/proto/transaction_info.proto
@@ -23,4 +23,7 @@ message TransactionInfo {
 
   // The amount of gas used by this transaction.
   uint64 gas_used = 4;
+
+  // The major status of executing this transaction.
+  uint64 major_status = 5;
 }


### PR DESCRIPTION
This PR adds the status of execution to the `TransactionInfo` struct. It does
not keep track of sub statuses, or the messages with the VM status, so
the fidelity of reporting is much lower than with e.g. a
`TransactionStatus`. However, the major status provides enough
information to determine if the transaction has been executed
correctly/applied or not, and `StatusCode` is much lighter weight than a normal `VMStatus`.