### PR TITLE
[config] Add MIRAI annotation for unreachable call after mem::replace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ dependencies = [
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
+ "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proto_conv 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 get_if_addrs = { version = "0.5.3", default-features = false }
 hex = { version = "0.3.2", default-features = false }
+mirai-annotations = "1.4.0"
 parity-multiaddr = { version = "0.5.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -5,6 +5,7 @@ use crypto::{
     x25519::{self, X25519StaticPrivateKey, X25519StaticPublicKey},
     PrivateKey, ValidKeyStringExt,
 };
+use mirai_annotations::verify_unreachable;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -26,7 +27,9 @@ where
                 let key = std::mem::replace(self, PrivateKeyContainer::Removed);
                 match key {
                     PrivateKeyContainer::Present(priv_key) => Some(priv_key),
-                    _ => unreachable!(),
+                    _ => verify_unreachable!(
+                        "mem::replace returned value for PrivateKeyContainer different from the one observed right before the call"
+                    ),
                 }
             }
             _ => None,


### PR DESCRIPTION
## Motivation

Goal is to have the call to `unreachble!(...)` be verifiable by MIRAI

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes