### PR TITLE
[language][VM][Bytecode Verifier] Relax rules around StLoc

### DIFF
--- a/language/bytecode_verifier/src/abstract_state.rs
+++ b/language/bytecode_verifier/src/abstract_state.rs
@@ -46,9 +46,8 @@ impl AbstractValue {
 
     pub fn is_safe_to_destroy(&self) -> bool {
         match self {
-            AbstractValue::Reference(_)
-            | AbstractValue::Value(Kind::All, _)
-            | AbstractValue::Value(Kind::Resource, _) => false,
+            AbstractValue::Reference(_) => true,
+            AbstractValue::Value(Kind::All, _) | AbstractValue::Value(Kind::Resource, _) => false,
             AbstractValue::Value(Kind::Unrestricted, borrowed_nonces) => borrowed_nonces.is_empty(),
         }
     }

--- a/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc.mvir
@@ -1,0 +1,10 @@
+module M {
+    t1() {
+        let x: u64;
+        let y: &u64;
+        x = 0;
+        y = &x;
+        y = &x;
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc_invalid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc_invalid.mvir
@@ -1,0 +1,14 @@
+module M {
+    t1() {
+        let x: u64;
+        let y: &u64;
+        x = 0;
+        y = &x;
+        x = 0;
+        return;
+    }
+
+}
+
+// check: VerificationFailure
+// check: STLOC_UNSAFE_TO_DESTROY_ERROR

--- a/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc_resource_invalid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc_resource_invalid.mvir
@@ -1,0 +1,17 @@
+module M {
+    resource X {}
+    t1() {
+        let x: Self.X;
+        let y: &Self.X;
+        x = X {};
+        y = &x;
+        x = X {};
+        _ = move(y);
+        X {} = move(x);
+        return;
+    }
+
+}
+
+// check: VerificationFailure
+// check: STLOC_UNSAFE_TO_DESTROY_ERROR

--- a/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc_struct_invalid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/mutate_with_borrowed_loc_struct_invalid.mvir
@@ -1,5 +1,6 @@
 module M {
     resource X {}
+    struct S { z: u64 }
     t1() {
         let x: Self.X;
         let y: &Self.X;
@@ -11,7 +12,19 @@ module M {
         return;
     }
 
+    t2() {
+        let s: Self.S;
+        let y: &Self.S;
+        let z: &u64;
+        s = S { z: 2 };
+        y = &s;
+        z = &move(y).z;
+        s = S { z: 7 };
+        return;
+    }
+
 }
 
 // check: VerificationFailure
+// check: STLOC_UNSAFE_TO_DESTROY_ERROR
 // check: STLOC_UNSAFE_TO_DESTROY_ERROR


### PR DESCRIPTION
## Motivation

- StLoc now implicitly releases its references
- In a similar change to Ret recently, this means StLoc can now be used even if the local is holding a reference
- The old rule was necessary due to global reference counting done by the VM

## Test Plan

- new tests
- cargo check; cargo test

## Related PRs

#813
