### PR TITLE
[proof] fix limit on AccumulatorProof's sibling count.

### DIFF
--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -319,8 +319,8 @@ fn verify_accumulator_element<H: Clone + CryptoHasher>(
 ) -> Result<()> {
     let siblings = accumulator_proof.siblings();
     ensure!(
-        siblings.len() <= 63,
-        "Accumulator proof has more than 63 ({}) siblings.",
+        siblings.len() <= 64,
+        "Accumulator proof has more than 64 ({}) siblings.",
         siblings.len()
     );
 

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -99,10 +99,10 @@ fn test_verify_three_element_accumulator() {
 }
 
 #[test]
-fn test_accumulator_proof_63_siblings_leftmost() {
+fn test_accumulator_proof_64_siblings_leftmost() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..63 {
+    for i in 0..64 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings
@@ -117,10 +117,10 @@ fn test_accumulator_proof_63_siblings_leftmost() {
 }
 
 #[test]
-fn test_accumulator_proof_63_siblings_rightmost() {
+fn test_accumulator_proof_64_siblings_rightmost() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..63 {
+    for i in 0..64 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings
@@ -129,17 +129,17 @@ fn test_accumulator_proof_63_siblings_rightmost() {
         .fold(element_hash, |hash, sibling_hash| {
             TestAccumulatorInternalNode::new(*sibling_hash, hash).hash()
         });
-    let leaf_index = (std::u64::MAX - 1) / 2;
+    let leaf_index = std::u64::MAX;
     let proof = AccumulatorProof::new(siblings);
 
     assert!(verify_test_accumulator_element(root_hash, element_hash, leaf_index, &proof).is_ok());
 }
 
 #[test]
-fn test_accumulator_proof_64_siblings() {
+fn test_accumulator_proof_65_siblings() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..64 {
+    for i in 0..65 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings


### PR DESCRIPTION
## Motivation

N bit Merkle tree accumulator can have at most N siblings. Consider the following case where N=3.
To proof node 2, we need the siblings including 3, a, b.

```
                 root_hash
                   /   \
                  /     \
                 o       b
                / \     / \
               a   o   o   x
              / \ / \ / \
              0 1 2 3 4 5
```

In the case of ledger version which is 64-bit, there will be 64 siblings if the max version is greater or equal to 2^63 (i.e. MSB == 1). Although this is unlikely to be an issue in the foreseeable future, I thought we'd prefer to correct the code. 

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes. CLA signed and submitted. 

## Test Plan

cargo test

## Related PRs

None. 
