### PR TITLE
[terraform] update instance type map; add t2.xlarge

### DIFF
--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -21,6 +21,7 @@ locals {
     "t2.small"     = 1024
     "t2.large"     = 2048
     "t2.medium"    = 2048
+    "t2.xlarge"    = 4096
     "t3.medium"    = 2048
     "m5.large"     = 2048
     "m5.xlarge"    = 4096
@@ -46,6 +47,7 @@ locals {
     "t2.small"     = 1800
     "t2.medium"    = 3943
     "t2.large"     = 7975
+    "t2.xlarge"    = 16039
     "t3.medium"    = 3884
     "m5.large"     = 7680
     "m5.xlarge"    = 15576


### PR DESCRIPTION
## Motivation
Add mem + cpu mapping for `t2.xlarge` instance type that's used in some testing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
(y)
## Test Plan

Deployed to local test env with this type
