### PR TITLE
[VM][Tools] Run Generated Programs on VM Runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,11 +4491,16 @@ dependencies = [
  "bytecode_verifier 0.1.0",
  "cost_synthesis 0.1.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language_e2e_tests 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdlib 0.1.0",
  "types 0.1.0",
  "vm 0.1.0",
+ "vm_cache_map 0.1.0",
+ "vm_runtime 0.1.0",
+ "vm_runtime_types 0.1.0",
 ]
 
 [[package]]

--- a/language/tools/test_generation/Cargo.toml
+++ b/language/tools/test_generation/Cargo.toml
@@ -14,9 +14,13 @@ mirai-annotations = "1.4.0"
 bytecode_verifier = { path = "../../bytecode_verifier" }
 cost_synthesis = { path = "../cost_synthesis" }
 vm = { path = "../../vm" }
-
-[dev-dependencies]
+vm_runtime = { path = "../../vm/vm_runtime" }
+vm_runtime_types = { path = "../../vm/vm_runtime/vm_runtime_types" }
+vm_cache_map = { path = "../../vm/vm_runtime/vm_cache_map" }
+language_e2e_tests = { path = "../../e2e_tests" }
+stdlib = { path = "../../stdlib" }
 types = { path = "../../../types", features = ["testing"] }
 
 [features]
 mirai-contracts = []
+default = ["vm_runtime/instruction_synthesis"]

--- a/language/tools/test_generation/measure_coverage.sh
+++ b/language/tools/test_generation/measure_coverage.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Check that the test directory and report path arguments are provided
+if [ $# -lt 1 ]
+then
+	echo "Usage: $0 <outdir> [--batch]"
+	echo "The resulting coverage report will be stored in <outdir>."
+	echo "--batch will skip all prompts."
+	exit 1
+fi
+
+# User prompts will be skipped if '--batch' is given as the third argument
+SKIP_PROMPTS=0
+if [ $# -eq 2 -a "$2" == "--batch" ]
+then
+	SKIP_PROMPTS=1
+fi
+
+# Set the directory to which the report will be saved
+COVERAGE_DIR=$1
+
+# This needs to run in test_generation
+TOOL_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+if [ $(pwd) != $TOOL_DIR  ]
+then
+	echo "Error: This needs to run from test_generation/, not in $(pwd)" >&2
+	exit 1
+fi
+
+set -e
+
+# Check that grcov is installed
+if ! [ -x "$(command -v grcov)" ]; then
+	echo "Error: grcov is not installed." >&2
+	if [ $SKIP_PROMPTS -eq 0 ]
+	then
+		read -p "Install grcov? [yY/*] " -n 1 -r
+		echo ""
+		if [[ ! $REPLY =~ ^[Yy]$ ]]
+		then
+			[[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+		fi
+		cargo install grcov
+	else
+		exit 1
+	fi
+fi
+
+# Check that lcov is installed
+if ! [ -x "$(command -v lcov)" ]; then
+	echo "Error: lcov is not installed." >&2
+	echo "Documentation for lcov can be found at http://ltp.sourceforge.net/coverage/lcov.php"
+	echo "If on macOS and using homebrew, run 'brew install lcov'"
+	exit 1
+fi
+
+# Warn that cargo clean will happen
+if [ $SKIP_PROMPTS -eq 0 ]
+then
+	read -p "Generate coverage report? This will run cargo clean. [yY/*] " -n 1 -r
+	echo ""
+	if [[ ! $REPLY =~ ^[Yy]$ ]]
+	then
+		[[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+	fi
+fi
+
+# Set flags for coverage generation
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Zno-landing-pads"
+export CARGO_INCREMENTAL=0
+
+# Remove existing coverage output
+echo "Cleaning existing coverage info..."
+if [ -d "$TOOL_DIR/../../../target/" ]
+then
+	find $TOOL_DIR/../../../target/ -type f -name "*.gcda" -delete
+	find $TOOL_DIR/../../../target/ -type f -name "*.gcno" -delete
+fi
+
+# Clean the project
+echo "Cleaning project..."
+cargo clean
+
+# Build test generator with flags necessary for coverage output
+echo "Building test generator with coverage instrumentation..."
+cargo build
+
+# Run tests
+echo "Running bytecode test generator..."
+RUST_LOG=info cargo run
+
+# Make the coverage directory if it doesn't exist
+if [ ! -d $COVERAGE_DIR ]; then
+	mkdir $COVERAGE_DIR;
+fi
+
+# Generate lcov report
+echo "Generating lcov report at ${COVERAGE_DIR}/lcov.info..."
+grcov $TOOL_DIR/../../../target/ -t lcov --llvm --branch --ignore-dir "/*" -o $COVERAGE_DIR/lcov.info
+
+# Generate HTML report
+echo "Generating report at ${COVERAGE_DIR}..."
+# Flag "--ignore-errors source" ignores missing source files
+(cd $TOOL_DIR/../../../; genhtml -o $COVERAGE_DIR --show-details --highlight --ignore-errors source --legend $COVERAGE_DIR/lcov.info)
+
+echo "Done. Please view report at ${COVERAGE_DIR}/index.html"

--- a/language/tools/test_generation/src/bytecode_generator.rs
+++ b/language/tools/test_generation/src/bytecode_generator.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     abstract_state::{AbstractState, BorrowState},
-    common,
+    config::{MAX_CFG_BLOCKS, MUTATION_TOLERANCE, NEGATE_PRECONDITIONS, NEGATION_PROBABILITY},
     control_flow_graph::CFG,
     summaries,
 };
@@ -326,8 +326,14 @@ impl BytecodeGenerator {
             let unsatisfied_preconditions = summary
                 .preconditions
                 .iter()
-                .any(|precondition| !precondition(&state));
-            if !unsatisfied_preconditions {
+                .filter(|precondition| !precondition(&state))
+                .count();
+            if (NEGATE_PRECONDITIONS
+                && !summary.preconditions.is_empty()
+                && unsatisfied_preconditions > self.rng.gen_range(0, summary.preconditions.len())
+                && self.rng.gen_range(0, 101) > 100 - (NEGATION_PROBABILITY * 100.0) as u8)
+                || unsatisfied_preconditions == 0
+            {
                 // The size of matches cannot be greater than the number of bytecode instructions
                 verify!(matches.len() < usize::max_value());
                 matches.push((*stack_effect, instruction));
@@ -343,10 +349,11 @@ impl BytecodeGenerator {
         return_len: usize,
         state: &AbstractState,
         candidates: &[(StackEffect, Bytecode)],
-    ) -> Bytecode {
+    ) -> Result<Bytecode, String> {
+        debug!("Candidates: {:?}", candidates);
         let stack_len = state.stack_len();
         let prob_add = if stack_len > return_len {
-            common::MUTATION_TOLERANCE / (stack_len as f32)
+            MUTATION_TOLERANCE / (stack_len as f32)
         } else {
             1.0
         };
@@ -363,10 +370,10 @@ impl BytecodeGenerator {
             // Add candidates should not be empty unless the list of bytecode instructions is
             // changed
             if add_candidates.is_empty() {
-                panic!("Could not find valid candidate");
+                return Err("Could not find valid add candidate".to_string());
             }
             next_instruction_index = self.rng.gen_range(0, add_candidates.len());
-            add_candidates[next_instruction_index].1.clone()
+            Ok(add_candidates[next_instruction_index].1.clone())
         } else {
             let sub_candidates: Vec<(StackEffect, Bytecode)> = candidates
                 .iter()
@@ -378,10 +385,10 @@ impl BytecodeGenerator {
             // Sub candidates should not be empty unless the list of bytecode instructions is
             // changed
             if sub_candidates.is_empty() {
-                panic!("Could not find valid candidate");
+                return Err("Could not find sub valid candidate".to_string());
             }
             next_instruction_index = self.rng.gen_range(0, sub_candidates.len());
-            sub_candidates[next_instruction_index].1.clone()
+            Ok(sub_candidates[next_instruction_index].1.clone())
         }
     }
 
@@ -389,14 +396,24 @@ impl BytecodeGenerator {
     /// of a particular bytecode instruction, `instruction`.
     fn abstract_step(&self, state: AbstractState, instruction: Bytecode) -> AbstractState {
         // TODO: Handle error case in way that reflects VM behavior
-        summaries::instruction_summary(instruction)
-            .effects
+        let should_error = summaries::instruction_summary(instruction.clone())
+            .preconditions
             .iter()
-            .fold(state, |acc, effect| {
-                effect(&acc).unwrap_or_else(|err| {
-                    unreachable!("Error applying instruction effect: {}", err)
+            .any(|precondition| !precondition(&state));
+        if should_error {
+            let mut state = state.clone();
+            state.abort();
+            state
+        } else {
+            summaries::instruction_summary(instruction)
+                .effects
+                .iter()
+                .fold(state, |acc, effect| {
+                    effect(&acc).unwrap_or_else(|err| {
+                        unreachable!("Error applying instruction effect: {}", err)
+                    })
                 })
-            })
+        }
     }
 
     /// Transition an abstract state, `state` to the next state and add the instruction
@@ -410,10 +427,10 @@ impl BytecodeGenerator {
         // Bytecode will never be generated this large
         assume!(bytecode.len() < usize::max_value());
         debug!("**********************");
-        debug!("State1: [{:?}]", state);
+        debug!("State1: {}", state);
         debug!("Next instr: {:?}", instruction);
         state = self.abstract_step(state, instruction.clone());
-        debug!("State2: {:?}", state);
+        debug!("State2: {}", state);
         bytecode.push(instruction);
         debug!("**********************\n");
         state
@@ -440,10 +457,18 @@ impl BytecodeGenerator {
                 warn!("No candidates found for state: [{:?}]", state);
                 break;
             }
-            let next_instruction = self.select_candidate(0, &state, &candidates);
-            state = self.apply_instruction(state, &mut bytecode, next_instruction);
-            if state.is_final() {
-                break;
+            match self.select_candidate(0, &state, &candidates) {
+                Ok(next_instruction) => {
+                    state = self.apply_instruction(state, &mut bytecode, next_instruction);
+                    if state.is_final() {
+                        break;
+                    }
+                }
+                Err(err) => {
+                    // Could not complete the bytecode sequence; reset to empty
+                    error!("{}", err);
+                    return Vec::new();
+                }
             }
         }
         // Fix local availability
@@ -487,7 +512,10 @@ impl BytecodeGenerator {
         signature: &FunctionSignature,
         module: CompiledModuleMut,
     ) -> Vec<Bytecode> {
-        let number_of_blocks = 3;
+        let number_of_blocks = self.rng.gen_range(1, MAX_CFG_BLOCKS + 1);
+        // The number of basic blocks must be at least one based on the
+        // generation range.
+        assume!(number_of_blocks > 0);
         let mut cfg = CFG::new(&mut self.rng, locals, signature, number_of_blocks);
         let cfg_copy = cfg.clone();
         for (block_id, block) in cfg.get_basic_blocks_mut().iter_mut() {

--- a/language/tools/test_generation/src/config.rs
+++ b/language/tools/test_generation/src/config.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// This defines how tolerant the generator will be about deviating from
+/// the starting stack height. The higher the tolerance, the more likely
+/// it is for invalid programs to be generated within a given target number
+/// of instructions.
+/// Default is 0.9 for generating ~1000 instruction sequences.
+pub const MUTATION_TOLERANCE: f32 = 0.9;
+
+/// This defines the maximum number of blocks that will be generated for
+/// a function body's CFG. During generation, a random number of blocks from
+/// 1 to this constant will be created.
+pub const MAX_CFG_BLOCKS: u16 = 10;
+
+/// This defines the number of programs that will be generated and then
+/// run on the bytecode verifier and transaction execution logic
+pub const NUM_ITERATIONS: u64 = 100;
+
+/// Whether preconditions will be negated to generate invalid programs
+/// in order to test error paths.
+pub const NEGATE_PRECONDITIONS: bool = false;
+
+/// The probability that preconditions will be negated for a pariticular
+/// bytecode instruction.
+pub const NEGATION_PROBABILITY: f64 = 0.1;
+
+/// Whether generation of instructions that require borrow checking will
+/// be allowed. (Note that if `NEGATE_PRECONDITIONS` is true then these
+/// instructions can still come up).
+pub const ALLOW_MEMORY_UNSAFE: bool = false;
+
+/// Whether the generated programs should be run on the VM
+pub const RUN_ON_VM: bool = true;
+
+/// Whether generated modules will be executed even if they fail the
+/// the bytecode verifier.
+pub const EXECUTE_UNVERIFIED_MODULE: bool = true;
+
+/// Whether gas will be metered when running generated programs. The default
+/// is `true` to bound the execution time.
+pub const GAS_METERING: bool = true;

--- a/language/tools/test_generation/src/error.rs
+++ b/language/tools/test_generation/src/error.rs
@@ -1,14 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/// This defines how tolerant the generator will be about deviating from
-/// the starting stack height. The higher the tolerance, the more likely
-/// it is for invalid programs to be generated within a given target number
-/// of instructions.
-/// Default is 0.9 for generating 1000 instruction sequences.
 use std::fmt;
-
-pub const MUTATION_TOLERANCE: f32 = 0.9;
 
 #[derive(Debug)]
 pub struct VMError {

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -3,8 +3,9 @@
 
 pub mod abstract_state;
 pub mod bytecode_generator;
-pub mod common;
+pub mod config;
 pub mod control_flow_graph;
+pub mod error;
 pub mod summaries;
 pub mod transitions;
 
@@ -14,23 +15,86 @@ extern crate mirai_annotations;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+use crate::config::{EXECUTE_UNVERIFIED_MODULE, GAS_METERING, RUN_ON_VM};
 use bytecode_generator::BytecodeGenerator;
 use bytecode_verifier::VerifiedModule;
 use cost_synthesis::module_generator::ModuleBuilder;
+use language_e2e_tests::data_store::FakeDataStore;
+use std::panic;
+use types::{account_address::AccountAddress, byte_array::ByteArray};
 use vm::{
-    file_format::{Bytecode, CompiledModuleMut, FunctionSignature, SignatureToken},
+    file_format::{
+        Bytecode, CompiledModuleMut, FunctionDefinitionIndex, FunctionSignature, SignatureToken,
+    },
+    transaction_metadata::TransactionMetadata,
     CompiledModule,
 };
+use vm_cache_map::Arena;
+use vm_runtime::{
+    code_cache::module_cache::{ModuleCache, VMModuleCache},
+    loaded_data::function::{FunctionRef, FunctionReference},
+    txn_executor::TransactionExecutor,
+};
+use vm_runtime_types::value::Value;
 
 /// This function calls the Bytecode verifier to test it
-fn run_verifier(module: CompiledModule) -> u64 {
-    match VerifiedModule::new(module) {
-        Ok(_) => 1,
-        Err((_, errs)) => {
-            // error!("Module: {:#?}", module.clone());
-            error!("Module verification failed: {:#?}", errs);
-            0
+fn run_verifier(module: CompiledModule) -> Result<VerifiedModule, String> {
+    let verifier_panic = panic::catch_unwind(|| {
+        match VerifiedModule::new(module.clone()) {
+            Ok(verified_module) => Ok(verified_module),
+            Err((_, errs)) => {
+                // info!("Generated module: {:#?}", module);
+                Err(format!("Module verification failed: {:#?}", errs))
+            }
         }
+    });
+    verifier_panic.unwrap_or_else(|err| Err(format!("Verifier panic: {:#?}", err)))
+}
+
+/// This function runs a verified module in the VM runtime
+/// This code is based on `cost_synthesis/src/vm_runner.rs`
+fn run_vm(module: VerifiedModule) -> Result<(), String> {
+    use vm::access::ModuleAccess;
+    let mut modules = ::stdlib::stdlib_modules().to_vec();
+    // The standard library modules are bounded
+    assume!(modules.len() < usize::max_value());
+    modules.push(module);
+    let root_module = modules
+        .last()
+        .expect("[VM Setup] Unable to get root module");
+    let allocator = Arena::new();
+    let module_id = root_module.self_id();
+    let module_cache = VMModuleCache::new(&allocator);
+    let entry_idx = FunctionDefinitionIndex::new(0);
+    let data_cache = FakeDataStore::default();
+    module_cache.cache_module(root_module.clone());
+    let loaded_module = module_cache
+        .get_loaded_module(&module_id)
+        .expect("[Module Lookup] Invariant violation while looking up module")
+        .expect("[Module Lookup] Runtime error while looking up module");
+    for m in modules.clone() {
+        module_cache.cache_module(m);
+    }
+    let mut vm =
+        TransactionExecutor::new(&module_cache, &data_cache, TransactionMetadata::default());
+    let entry_func = FunctionRef::new(&loaded_module, entry_idx);
+    let mut function_args: Vec<Value> = Vec::new();
+    for arg_type in entry_func.signature().arg_types.clone() {
+        function_args.push(match arg_type {
+            SignatureToken::Address => Value::address(AccountAddress::new([0; 32])),
+            SignatureToken::U64 => Value::u64(0),
+            SignatureToken::Bool => Value::bool(true),
+            SignatureToken::String => Value::string("".into()),
+            SignatureToken::ByteArray => Value::byte_array(ByteArray::new(vec![])),
+            _ => unimplemented!("Unsupported argument type: {:#?}", arg_type),
+        });
+    }
+    if !GAS_METERING {
+        vm.turn_off_gas_metering();
+    }
+    match vm.execute_function(&module_id, &entry_func.name(), function_args) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("Runtime error: {:?}", e)),
     }
 }
 
@@ -49,20 +113,55 @@ pub fn generate_bytecode(
 
 /// Run generate_bytecode for 'iterations' iterations and test each generated module
 /// on the bytecode verifier.
-pub fn run_generation(iterations: usize) {
+pub fn run_generation(iterations: u64) {
     env_logger::init();
 
-    let mut valid_programs: u64 = 0;
-    for _ in 0..iterations {
+    let mut verified_programs: u64 = 0;
+    let mut executed_programs: u64 = 0;
+    for i in 0..iterations {
         let module =
             ModuleBuilder::new(1, Some(Box::new(generate_bytecode))).materialize_unverified();
-        valid_programs += run_verifier(module);
+        debug!("Running on verifier...");
+        let verified_module = match run_verifier(module.clone()) {
+            Ok(verified_module) => {
+                // We cannot execute more than u64::max_value() iterations.
+                verify!(verified_programs < u64::max_value());
+                verified_programs += 1;
+                Some(verified_module)
+            }
+            Err(e) => {
+                error!("{}", e);
+                if EXECUTE_UNVERIFIED_MODULE {
+                    Some(VerifiedModule::bypass_verifier_DANGEROUS_FOR_TESTING_ONLY(
+                        module.clone(),
+                    ))
+                } else {
+                    None
+                }
+            }
+        };
+        if let Some(verified_module) = verified_module {
+            if RUN_ON_VM {
+                debug!("Running on VM...");
+                match run_vm(verified_module) {
+                    Ok(_) => {
+                        // We cannot execute more than u64::max_value() iterations.
+                        verify!(executed_programs < u64::max_value());
+                        executed_programs += 1
+                    }
+                    Err(e) => error!("{}", e),
+                }
+            }
+        };
+        if iterations > 10 && i % (iterations / 10) == 0 {
+            info!("Iteration: {} / {}", i, iterations);
+        }
     }
 
     info!(
-        "Total valid: {}, Total programs: {}, Percent valid: {:.2}",
-        valid_programs,
+        "Total programs: {}, Percent valid: {:.2}, Percent executed {:.2}",
         iterations,
-        (valid_programs as f64) / (iterations as f64) * 100.0
+        (verified_programs as f64) / (iterations as f64) * 100.0,
+        (executed_programs as f64) / (iterations as f64) * 100.0,
     );
 }

--- a/language/tools/test_generation/src/main.rs
+++ b/language/tools/test_generation/src/main.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use test_generation::run_generation;
+use test_generation::{config::NUM_ITERATIONS, run_generation};
 
 pub fn main() {
-    run_generation(1000);
+    run_generation(NUM_ITERATIONS);
 }

--- a/language/tools/test_generation/src/summaries.rs
+++ b/language/tools/test_generation/src/summaries.rs
@@ -3,12 +3,13 @@
 
 use crate::{
     abstract_state::{AbstractState, AbstractValue, BorrowState, Mutability},
-    common::VMError,
-    state_create_struct, state_local_availability_is, state_local_exists, state_local_kind_is,
-    state_local_place, state_local_set, state_local_take, state_local_take_borrow, state_never,
-    state_register_dereference, state_stack_function_call, state_stack_function_popn,
-    state_stack_has, state_stack_has_polymorphic_eq, state_stack_has_reference,
-    state_stack_has_struct, state_stack_local_polymorphic_eq, state_stack_pop, state_stack_push,
+    error::VMError,
+    state_create_struct, state_function_can_acquire_resource, state_local_availability_is,
+    state_local_exists, state_local_kind_is, state_local_place, state_local_set, state_local_take,
+    state_local_take_borrow, state_memory_safe, state_never, state_register_dereference,
+    state_stack_function_call, state_stack_function_popn, state_stack_has,
+    state_stack_has_polymorphic_eq, state_stack_has_reference, state_stack_has_struct,
+    state_stack_kind_is, state_stack_local_polymorphic_eq, state_stack_pop, state_stack_push,
     state_stack_push_register, state_stack_push_register_borrow, state_stack_ref_polymorphic_eq,
     state_stack_satisfies_function_signature, state_stack_satisfies_struct_signature,
     state_stack_struct_borrow_field, state_stack_struct_has_field, state_stack_struct_popn,
@@ -34,7 +35,11 @@ pub struct Summary {
 pub fn instruction_summary(instruction: Bytecode) -> Summary {
     match instruction {
         Bytecode::Pop => Summary {
-            preconditions: vec![state_stack_has!(0, None)],
+            preconditions: vec![
+                state_stack_has!(0, None),
+                state_stack_kind_is!(0, Kind::Unrestricted),
+                state_memory_safe!(Some(0)),
+            ],
             effects: vec![state_stack_pop!()],
         },
         Bytecode::LdConst(_) => Summary {
@@ -78,6 +83,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 state_local_exists!(i),
                 state_local_kind_is!(i, Kind::Unrestricted),
                 state_local_availability_is!(i, BorrowState::Available),
+                state_memory_safe!(None),
             ],
             effects: vec![state_local_take!(i), state_stack_push_register!()],
         },
@@ -85,6 +91,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_local_exists!(i),
                 state_local_availability_is!(i, BorrowState::Available),
+                state_memory_safe!(None),
             ],
             effects: vec![
                 state_local_take!(i),
@@ -99,6 +106,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 // TODO: This covers storing on an unrestricted local only
                 state_local_kind_is!(i, Kind::Unrestricted),
                 state_stack_local_polymorphic_eq!(0, i as usize),
+                state_memory_safe!(None),
             ],
             effects: vec![
                 state_stack_pop!(),
@@ -110,6 +118,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_local_exists!(i),
                 state_local_availability_is!(i, BorrowState::Available),
+                state_memory_safe!(None),
             ],
             effects: vec![
                 state_local_take_borrow!(i, Mutability::Mutable),
@@ -120,6 +129,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_local_exists!(i),
                 state_local_availability_is!(i, BorrowState::Available),
+                state_memory_safe!(None),
             ],
             effects: vec![
                 state_local_take_borrow!(i, Mutability::Immutable),
@@ -127,7 +137,10 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             ],
         },
         Bytecode::ReadRef => Summary {
-            preconditions: vec![state_stack_has_reference!(0, Mutability::Either)],
+            preconditions: vec![
+                state_stack_has_reference!(0, Mutability::Either),
+                state_memory_safe!(None),
+            ],
             effects: vec![
                 state_stack_pop!(),
                 state_register_dereference!(),
@@ -139,11 +152,15 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                 state_stack_has_reference!(0, Mutability::Mutable),
                 state_stack_has!(1, None),
                 state_stack_ref_polymorphic_eq!(0, 1),
+                state_memory_safe!(None),
             ],
             effects: vec![state_stack_pop!(), state_stack_pop!()],
         },
         Bytecode::FreezeRef => Summary {
-            preconditions: vec![state_stack_has_reference!(0, Mutability::Mutable)],
+            preconditions: vec![
+                state_stack_has_reference!(0, Mutability::Mutable),
+                state_memory_safe!(None),
+            ],
             effects: vec![
                 state_stack_pop!(),
                 state_register_dereference!(),
@@ -275,7 +292,10 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_stack_has!(0, None),
                 state_stack_has!(1, None),
+                state_stack_kind_is!(0, Kind::Unrestricted),
                 state_stack_has_polymorphic_eq!(0, 1),
+                state_memory_safe!(Some(0)),
+                state_memory_safe!(Some(1)),
             ],
             effects: vec![
                 state_stack_pop!(),
@@ -287,7 +307,10 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_stack_has!(0, None),
                 state_stack_has!(1, None),
+                state_stack_kind_is!(0, Kind::Unrestricted),
                 state_stack_has_polymorphic_eq!(0, 1),
+                state_memory_safe!(Some(0)),
+                state_memory_safe!(Some(1)),
             ],
             effects: vec![
                 state_stack_pop!(),
@@ -413,6 +436,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_stack_has_reference!(0, Mutability::Mutable),
                 state_stack_struct_has_field!(i),
+                state_memory_safe!(None),
             ],
             effects: vec![state_stack_pop!(), state_stack_struct_borrow_field!(i)],
         },
@@ -420,6 +444,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
             preconditions: vec![
                 state_stack_has_reference!(0, Mutability::Immutable),
                 state_stack_struct_has_field!(i),
+                state_memory_safe!(None),
             ],
             effects: vec![state_stack_pop!(), state_stack_struct_borrow_field!(i)],
         },
@@ -430,6 +455,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                     Some(AbstractValue::new_primitive(SignatureToken::Address))
                 ),
                 state_struct_is_resource!(i),
+                state_memory_safe!(None),
             ],
             effects: vec![
                 state_stack_pop!(),
@@ -444,6 +470,7 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
                     Some(AbstractValue::new_primitive(SignatureToken::Address))
                 ),
                 state_struct_is_resource!(i),
+                state_memory_safe!(None),
             ],
             effects: vec![
                 state_stack_pop!(),
@@ -453,13 +480,18 @@ pub fn instruction_summary(instruction: Bytecode) -> Summary {
         },
         Bytecode::MoveFrom(i, _) => Summary {
             preconditions: vec![
+                state_function_can_acquire_resource!(),
                 state_struct_is_resource!(i),
                 state_stack_has!(
                     0,
                     Some(AbstractValue::new_primitive(SignatureToken::Address))
                 ),
             ],
-            effects: vec![state_create_struct!(i), state_stack_push_register!()],
+            effects: vec![
+                state_stack_pop!(),
+                state_create_struct!(i),
+                state_stack_push_register!(),
+            ],
         },
         Bytecode::MoveToSender(i, _) => Summary {
             preconditions: vec![

--- a/language/tools/test_generation/src/transitions.rs
+++ b/language/tools/test_generation/src/transitions.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     abstract_state::{AbstractState, AbstractValue, BorrowState, Mutability},
-    common::VMError,
+    config::ALLOW_MEMORY_UNSAFE,
+    error::VMError,
 };
 use vm::{
     access::*,
@@ -26,6 +27,20 @@ pub fn stack_has(
         }
         None => index < state.stack_len(),
     }
+}
+
+/// Determine the abstract value at `index` is of the given kind, if it exists.
+/// If it does not exist, return `false`.
+pub fn stack_kind_is(state: &AbstractState, index: usize, kind: Kind) -> bool {
+    if index < state.stack_len() {
+        match state.stack_peek(index) {
+            Some(abstract_value) => {
+                return abstract_value.kind == kind;
+            }
+            None => return false,
+        }
+    }
+    false
 }
 
 /// Determine whether two tokens on the stack have the same type
@@ -459,12 +474,40 @@ pub fn stack_function_popn(
     Ok(state)
 }
 
+/// TODO: This is a temporary function that represents memory
+/// safety for a reference. This should be removed and replaced
+/// with appropriate memory safety premises when the borrow checking
+/// infrastructure is fully implemented.
+/// `index` is `Some(i)` if the instruction can be memory safe when operating
+/// on non-reference types.
+pub fn memory_safe(state: &AbstractState, index: Option<usize>) -> bool {
+    match index {
+        Some(index) => {
+            if stack_has_reference(state, index, Mutability::Either) {
+                ALLOW_MEMORY_UNSAFE
+            } else {
+                true
+            }
+        }
+        None => ALLOW_MEMORY_UNSAFE,
+    }
+}
+
 /// Wrapper for enclosing the arguments of `stack_has` so that only the `state` needs
 /// to be given.
 #[macro_export]
 macro_rules! state_stack_has {
     ($e1: expr, $e2: expr) => {
         Box::new(move |state| stack_has(state, $e1, $e2))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `stack_kind_is` so that only the `state` needs
+/// to be given.
+#[macro_export]
+macro_rules! state_stack_kind_is {
+    ($e: expr, $a: expr) => {
+        Box::new(move |state| stack_kind_is(state, $e, $a))
     };
 }
 
@@ -708,6 +751,24 @@ macro_rules! state_stack_function_popn {
 macro_rules! state_stack_function_call {
     ($e: expr) => {
         Box::new(move |state| stack_function_call(state, $e))
+    };
+}
+
+/// Wrapper for enclosing the arguments of `function_can_acquire_resource` so that only the
+/// `state` needs to be given.
+#[macro_export]
+macro_rules! state_function_can_acquire_resource {
+    () => {
+        Box::new(|_| false)
+    };
+}
+
+/// Wrapper for enclosing the arguments of `memory_safe` so that only the
+/// `state` needs to be given.
+#[macro_export]
+macro_rules! state_memory_safe {
+    ($e: expr) => {
+        Box::new(move |state| memory_safe(state, $e))
     };
 }
 

--- a/language/tools/test_generation/tests/common.rs
+++ b/language/tools/test_generation/tests/common.rs
@@ -1,13 +1,54 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
-use test_generation::{abstract_state::AbstractState, summaries::instruction_summary};
+use test_generation::{
+    abstract_state::AbstractState, config::ALLOW_MEMORY_UNSAFE, summaries::instruction_summary,
+};
 use vm::file_format::Bytecode;
 
 pub fn run_instruction(instruction: Bytecode, initial_state: AbstractState) -> AbstractState {
-    let summary = instruction_summary(instruction);
-    let unsatisfied_preconditions = summary
-        .preconditions
-        .iter()
-        .any(|precondition| !precondition(&initial_state));
+    let summary = instruction_summary(instruction.clone());
+    // The following is temporary code. If ALLOW_MEMORY_UNSAFE is false,
+    // we have to ignore that precondition so that we can test the instructions.
+    // When memory safety is implemented, only the false branch should be used.
+    let unsatisfied_preconditions = if !ALLOW_MEMORY_UNSAFE {
+        match instruction {
+            Bytecode::Pop
+            | Bytecode::MoveLoc(_)
+            | Bytecode::CopyLoc(_)
+            | Bytecode::MutBorrowLoc(_)
+            | Bytecode::ImmBorrowLoc(_)
+            | Bytecode::StLoc(_)
+            | Bytecode::ReadRef
+            | Bytecode::WriteRef
+            | Bytecode::FreezeRef
+            | Bytecode::MutBorrowField(_)
+            | Bytecode::ImmBorrowField(_)
+            | Bytecode::MutBorrowGlobal(_, _)
+            | Bytecode::ImmBorrowGlobal(_, _) => {
+                let len = summary.preconditions.len();
+                summary.preconditions[..(len - 1)]
+                    .iter()
+                    .any(|precondition| !precondition(&initial_state))
+            }
+            Bytecode::Eq | Bytecode::Neq => {
+                let len = summary.preconditions.len();
+                summary.preconditions[..(len - 2)]
+                    .iter()
+                    .any(|precondition| !precondition(&initial_state))
+            }
+            _ => summary
+                .preconditions
+                .iter()
+                .any(|precondition| !precondition(&initial_state)),
+        }
+    } else {
+        summary
+            .preconditions
+            .iter()
+            .any(|precondition| !precondition(&initial_state))
+    };
     assert_eq!(
         unsatisfied_preconditions, false,
         "preconditions of instruction not satisfied"

--- a/language/tools/test_generation/tests/local_instructions.rs
+++ b/language/tools/test_generation/tests/local_instructions.rs
@@ -91,7 +91,7 @@ fn bytecode_moveloc_local_unavailable() {
 }
 
 #[test]
-fn bytecode_borrowloc() {
+fn bytecode_mutborrowloc() {
     let mut state1 = AbstractState::new();
     state1.local_insert(
         0,
@@ -118,7 +118,7 @@ fn bytecode_borrowloc() {
 }
 
 #[test]
-fn bytecode_imm_borrowloc() {
+fn bytecode_immborrowloc() {
     let mut state1 = AbstractState::new();
     state1.local_insert(
         0,
@@ -146,21 +146,21 @@ fn bytecode_imm_borrowloc() {
 
 #[test]
 #[should_panic]
-fn bytecode_borrowloc_no_local() {
+fn bytecode_mutborrowloc_no_local() {
     let state1 = AbstractState::new();
     common::run_instruction(Bytecode::MutBorrowLoc(0), state1);
 }
 
 #[test]
 #[should_panic]
-fn bytecode_imm_borrowloc_no_local() {
+fn bytecode_immborrowloc_no_local() {
     let state1 = AbstractState::new();
     common::run_instruction(Bytecode::ImmBorrowLoc(0), state1);
 }
 
 #[test]
 #[should_panic]
-fn bytecode_borrowloc_local_unavailable() {
+fn bytecode_mutborrowloc_local_unavailable() {
     let mut state1 = AbstractState::new();
     state1.local_insert(
         0,
@@ -172,7 +172,7 @@ fn bytecode_borrowloc_local_unavailable() {
 
 #[test]
 #[should_panic]
-fn bytecode_imm_borrowloc_local_unavailable() {
+fn bytecode_immborrowloc_local_unavailable() {
     let mut state1 = AbstractState::new();
     state1.local_insert(
         0,

--- a/language/tools/test_generation/tests/struct_instructions.rs
+++ b/language/tools/test_generation/tests/struct_instructions.rs
@@ -202,6 +202,9 @@ fn bytecode_exists_no_address_on_stack() {
     );
 }
 
+// TODO: This will be ignored until the `state_function_acquires_resource` precondition
+// can be satisfied.
+#[ignore]
 #[test]
 fn bytecode_movefrom() {
     let module: CompiledModuleMut = generate_module_with_struct(true);


### PR DESCRIPTION
## Motivation

This commit adds the ability to run generated bytecode programs on the Move VM runtime.
Additionally, it makes explicit the functions that depend on memory safety checks so
that they can be disabled if generation of only valid programs is desired.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test` and safety analysis with MIRAI.

## Related PRs

N/A
