### PR TITLE
[logging][small] make state sync errors logs useful by printing peers/versions

### DIFF
--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -141,13 +141,14 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                                 }
                                 Event::Message((peer_id, mut message)) => {
                                     if message.has_chunk_request() {
+                                        let known_version = message.get_chunk_request().get_known_version();
                                         if let Err(err) = self.process_chunk_request(peer_id, message.take_chunk_request()).await {
-                                            error!("[state sync] failed to serve chunk request: {:?}", err);
+                                            error!("[state sync] failed to serve chunk request to {} with known version {}: {:?}", peer_id, known_version, err);
                                         }
                                     }
                                     if message.has_chunk_response() {
                                         if let Err(err) = self.process_chunk_response(&peer_id, message.take_chunk_response()).await {
-                                            error!("[state sync] failed to process chunk response: {:?}", err);
+                                            error!("[state sync] failed to process chunk response from {}: {:?}", peer_id, err);
                                         } else {
                                             self.peer_manager.update_score(&peer_id, PeerScoreUpdateType::Success);
                                         }

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -202,7 +202,7 @@ impl HashReader for LedgerStore {
     fn get(&self, position: Position) -> Result<HashValue> {
         self.db
             .get::<TransactionAccumulatorSchema>(&position)?
-            .ok_or_else(|| format_err!("Does not exist."))
+            .ok_or_else(|| format_err!("{} does not exist.", position))
     }
 }
 

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -23,6 +23,8 @@
 //! Note2: The level of tree counts from leaf level, start from 0
 //! Note3: The leaf index starting from left-most leaf, starts from 0
 
+use std::fmt;
+
 #[cfg(test)]
 mod position_test;
 
@@ -280,6 +282,12 @@ impl Position {
     /// Creates an `AncestorSiblingIterator` using this position.
     pub fn iter_ancestor_sibling(self) -> AncestorSiblingIterator {
         AncestorSiblingIterator { position: self }
+    }
+}
+
+impl fmt::Display for Position {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Pos({})", self.to_inorder_index())
     }
 }
 


### PR DESCRIPTION
## Motivation
More visibility into what happens in state sync, current errors are not helping with this, because it's impossible to know what was requested and what was failing.

@phoenix-antigravity I donno if this code is going to change soon, or what changes are planned for state sync. Right now, debugging is hard, and not enough counters (next pr)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
(y)
## Test Plan
CI