### PR TITLE
[language/functional tests] Function test output carries datatype as to a string.

### DIFF
--- a/language/functional_tests/src/checker.rs
+++ b/language/functional_tests/src/checker.rs
@@ -106,7 +106,11 @@ pub fn check(res: &EvaluationResult, directives: &[Directive]) -> Result<()> {
                             break;
                         }
                     }
-                    EvaluationOutput::Output(s) | EvaluationOutput::Error(s) => {
+                    EvaluationOutput::Output(output) => {
+                        outputs.push(output.to_check_string());
+                        i += 1;
+                    }
+                    EvaluationOutput::Error(s) => {
                         outputs.push(s.to_string());
                         i += 1;
                     }
@@ -122,7 +126,10 @@ pub fn check(res: &EvaluationResult, directives: &[Directive]) -> Result<()> {
 
     for output in &res.outputs[i..] {
         match output {
-            EvaluationOutput::Output(s) | EvaluationOutput::Error(s) => {
+            EvaluationOutput::Output(output) => {
+                outputs.push(output.to_check_string());
+            }
+            EvaluationOutput::Error(s) => {
                 outputs.push(s.to_string());
             }
             EvaluationOutput::Stage(_) | EvaluationOutput::Transaction => {}

--- a/language/functional_tests/tests/testsuite.rs
+++ b/language/functional_tests/tests/testsuite.rs
@@ -12,7 +12,11 @@ fn functional_tests(input: &str) -> Result<()> {
     let (config, directives, transactions) = parse_input(input)?;
     let res = eval(&config, &transactions)?;
     if let Err(e) = check(&res, &directives) {
-        println!("{:#?}", res);
+        if res.use_debug_output {
+            println!("{:?}", res);
+        } else {
+            println!("{}", res);
+        }
         return Err(e);
     }
     Ok(())


### PR DESCRIPTION
Previously the output for functional tests was immediately serialized to
a string. This leads to problems where you want to write the check text
against the debug output but, on failure, you want to see the
pretty-printed file format/AST.

This commit changes the underlying output type from a string to the
actual datatype. This allows us to present code and errors to the user
in a formatted way, while retaining debug format for filecheck commands.

## Tests
Same as is.

Previous example output on a tests failure: 
```
---- functional_tests::examples/gas_submitted_too_low.mvir stdout ----
EvaluationResult {
    outputs: [
        Transaction,
        Stage(
            Parser,
        ),
        Output(
            "Script(Script { imports: [], main: Function { visibility: Public, signature: FunctionSignature { formals: [], return_type: [], type_formals: [] }, acquires: [], body: Move { locals: [(Spanned { span: Span { start: ByteIndex(118), end: ByteIndex(119) }, value: Var(Identifier(\"x\")) }, U64), (Spanned { span: Span { start: ByteIndex(134), end: ByteIndex(135) }, value: Var(Identifier(\"y\")) }, U64)], code: Block { stmts: [CommandStatement(Spanned { span: Span { start: ByteIndex(146), end: ByteIndex(151) }, value: Assign([Spanned { span: Span { start: ByteIndex(146), end: ByteIndex(147) }, value: Var(Spanned { span: Span { start: ByteIndex(146), end: ByteIndex(147) }, value: Var(Identifier(\"x\")) }) }], Spanned { span: Span { start: ByteIndex(150), end: ByteIndex(151) }, value: Value(Spanned { span: Span { start: ByteIndex(150), end: ByteIndex(151) }, value: U64(3) }) }) }), CommandStatement(Spanned { span: Span { start: ByteIndex(157), end: ByteIndex(162) }, value: Assign([Spanned { span: Span { start: ByteIndex(157), end: ByteIndex(158) }, value: Var(Spanned { span: Span { start: ByteIndex(157), end: ByteIndex(158) }, value: Var(Identifier(\"y\")) }) }], Spanned { span: Span { start: ByteIndex(161), end: ByteIndex(162) }, value: Value(Spanned { span: Span { start: ByteIndex(161), end: ByteIndex(162) }, value: U64(5) }) }) }), IfElseStatement(IfElse { cond: Spanned { span: Span { start: ByteIndex(175), end: ByteIndex(197) }, value: UnaryExp(Not, Spanned { span: Span { start: ByteIndex(175), end: ByteIndex(197) }, value: BinopExp(Spanned { span: Span { start: ByteIndex(175), end: ByteIndex(192) }, value: BinopExp(Spanned { span: Span { start: ByteIndex(175), end: ByteIndex(182) }, value: Move(Spanned { span: Span { start: ByteIndex(180), end: ByteIndex(181) }, value: Var(Identifier(\"x\")) }) }, Add, Spanned { span: Span { start: ByteIndex(185), end: ByteIndex(192) }, value: Move(Spanned { span: Span { start: ByteIndex(190), end: ByteIndex(191) }, value: Var(Identifier(\"y\")) }) }) }, Eq, Spanned { span: Span { start: ByteIndex(196), end: ByteIndex(197) }, value: Value(Spanned { span: Span { start: ByteIndex(196), end: ByteIndex(197) }, value: U64(8) }) }) }) }, if_block: Block { stmts: [CommandStatement(Spanned { span: Span { start: ByteIndex(199), end: ByteIndex(201) }, value: Abort(Some(Spanned { span: Span { start: ByteIndex(199), end: ByteIndex(201) }, value: Value(Spanned { span: Span { start: ByteIndex(199), end: ByteIndex(201) }, value: U64(42) }) })) })] }, else_block: None }), EmptyStatement, CommandStatement(Spanned { span: Span { start: ByteIndex(208), end: ByteIndex(214) }, value: Return(Spanned { span: Span { start: ByteIndex(0), end: ByteIndex(0) }, value: ExprList([]) }) })] } } } })",
        ),
        Stage(
            Compiler,
        ),
        Output(
            "CompiledScript(CompiledScriptMut { module_handles: [ModuleHandle { address: AddressPoolIndex(0), name: IdentifierIndex(0) }], struct_handles: [], function_handles: [FunctionHandle { module: ModuleHandleIndex(0), name: IdentifierIndex(1), signature: FunctionSignatureIndex(0) }], type_signatures: [], function_signatures: [FunctionSignature { return_types: [], arg_types: [], type_formals: [] }], locals_signatures: [LocalsSignature([U64, U64])], identifiers: [Identifier(\"<SELF>\"), Identifier(\"main\")], user_strings: [], byte_array_pool: [], address_pool: [a0b00a9d2b3e218fa726a3570fbc2428b1650075ac92e43bd0c4f0f8f6da82da], main: FunctionDefinition { function: FunctionHandleIndex(0), flags: 1, acquires_global_resources: [], code: CodeUnit { max_stack_size: 2, locals: LocalsSignatureIndex(0), code: [LdConst(3), StLoc(0), LdConst(5), StLoc(1), MoveLoc(0), MoveLoc(1), Add, LdConst(8), Eq, Not, BrFalse(13), LdConst(42), Abort, Ret] } } })",
        ),
        Stage(
            Verifier,
        ),
        Stage(
            Serializer,
        ),
        Stage(
            Runtime,
        ),
        Error(
            "DiscardedTransaction(TransactionOutput { write_set: WriteSet(WriteSetMut { write_set: [] }), events: [], gas_used: 0, status: Discard(VMStatus { major_status: MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS, sub_status: None, message: Some(\"min gas required for txn: 600, gas submitted: 10\") }) })",
        ),
    ],
    status: Failure,
}
Error: CheckerFailure
```

New output on error with this PR:
```
---- functional_tests::examples/gas_submitted_too_low.mvir stdout ----
---------------------Outputs----------------
[0] Transaction
[1] Stage: Parser
[2] Script(
Imports()
Main(() (let x: u64;let y: u64;, x = (3);
, y = (5);
if ((!(== (+ move(x) move(y)) 8))) {
abort 42;

}
<empty statement>
return ();

)))
[3] Stage: Compiler
[4] CompiledScript(
    CompiledScriptMut {
        module_handles: [
            ModuleHandle {
                address: AddressPoolIndex(0),
                name: IdentifierIndex(0),
            },
        ],
        struct_handles: [],
        function_handles: [
            FunctionHandle {
                module: ModuleHandleIndex(0),
                name: IdentifierIndex(1),
                signature: FunctionSignatureIndex(0),
            },
        ],
        type_signatures: [],
        function_signatures: [
            FunctionSignature {
                return_types: [],
                arg_types: [],
                type_formals: [],
            },
        ],
        locals_signatures: [
            LocalsSignature(
                [
                    U64,
                    U64,
                ],
            ),
        ],
        identifiers: [
            Identifier(
                "<SELF>",
            ),
            Identifier(
                "main",
            ),
        ],
        user_strings: [],
        byte_array_pool: [],
        address_pool: [
            c80c3e6886968c9456109a27733054d784137cde32b3e0d056605326ea5a2cfa,
        ],
        main: FunctionDefinition {
            function: FunctionHandleIndex(0),
            flags: 1,
            acquires_global_resources: [],
            code: CodeUnit {
                max_stack_size: 2,
                locals: LocalsSignatureIndex(0),
                code: [
                    LdConst(3),
                    StLoc(0),
                    LdConst(5),
                    StLoc(1),
                    MoveLoc(0),
                    MoveLoc(1),
                    Add,
                    LdConst(8),
                    Eq,
                    Not,
                    BrFalse(13),
                    LdConst(42),
                    Abort,
                    Ret,
                ],
            },
        },
    },
)
[5] Stage: Verifier
[6] Stage: Serializer
[7] Stage: Runtime
[8] Error: DiscardedTransaction(
    TransactionOutput {
        write_set: WriteSet(
            WriteSetMut {
                write_set: [],
            },
        ),
        events: [],
        gas_used: 0,
        status: Discard(
            VMStatus {
                major_status: MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
                sub_status: None,
                message: Some(
                    "min gas required for txn: 600, gas submitted: 10",
                ),
            },
        ),
    },
)
-----------Status---------------
Failure
Error: CheckerFailure
```