### PR TITLE
[language] Add display for Script and ScriptOrModule

### DIFF
--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -1140,6 +1140,41 @@ impl fmt::Display for Kind {
     }
 }
 
+impl fmt::Display for ScriptOrModule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ScriptOrModule::*;
+        match self {
+            Module(module_def) => write!(f, "{}", module_def),
+            Script(script) => write!(f, "{}", script),
+        }
+    }
+}
+
+impl fmt::Display for Script {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Script(")?;
+        write!(f, "Imports(")?;
+        write!(f, "{}", intersperse(&self.imports, ", "))?;
+        writeln!(f, ")")?;
+        write!(f, "Main(")?;
+        write!(f, "{}", self.main)?;
+        write!(f, ")")?;
+        write!(f, ")")
+    }
+}
+
+impl fmt::Display for ImportDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ModuleIdent::*;
+        write!(f, "ImportDefinition(")?;
+        match &self.ident {
+            Transaction(module_name) => write!(f, "{}", module_name)?,
+            Qualified(qual_module_ident) => write!(f, "{}", qual_module_ident)?,
+        };
+        write!(f, " => {})", self.alias)
+    }
+}
+
 impl fmt::Display for ModuleName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
Does what the title says -- it adds implementation of fmt::Diplay for
these structs in the AST for the IR to bytecode tool.

Let me know if these look good -- I'm not familiar with how we want the AST to be displayed. I tried to keep to the rules that were already there, but I may have missed something. 