### PR TITLE
[state-sync] Add UpstreamPeersConfig field to StateSyncConfig

### DIFF
--- a/config/data/configs/full_node.config.toml
+++ b/config/data/configs/full_node.config.toml
@@ -10,6 +10,9 @@ role = "full_node"
 consensus_keypair_file = "" # For direct validation of this file
 consensus_peers_file = ""  # For direct validation of this file
 
+[state_sync]
+upstream_peers = ["ae1b54220905fca36d046a6e093632ed1f219e0a35a4fd7ba82e6e0d515f0b8e"]
+
 [execution]
 genesis_file_location = "<USE_TEMP_DIR>"
 

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -7,6 +7,7 @@ use crate::{
     seed_peers::{SeedPeersConfig, SeedPeersConfigHelpers},
     trusted_peers::{
         ConfigHelpers, ConsensusPeersConfig, NetworkPeerPrivateKeys, NetworkPeersConfig,
+        UpstreamPeersConfig,
     },
     utils::{deserialize_whitelist, get_available_port, get_local_ip, serialize_whitelist},
 };
@@ -572,6 +573,9 @@ pub struct StateSyncConfig {
     pub max_chunk_limit: u64,
     // valid maximum timeout limit for sanity check
     pub max_timeout_ms: u64,
+    // List of peers to use as upstream in state sync protocols.
+    #[serde(flatten)]
+    pub upstream_peers: UpstreamPeersConfig,
 }
 
 impl Default for StateSyncConfig {
@@ -582,6 +586,7 @@ impl Default for StateSyncConfig {
             long_poll_timeout_ms: 30000,
             max_chunk_limit: 1000,
             max_timeout_ms: 120_000,
+            upstream_peers: UpstreamPeersConfig::default(),
         }
     }
 }

--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -64,7 +64,7 @@ pub struct ConsensusPeersConfig {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct UpstreamPeersConfig {
     /// List of PeerIds serialized as string.
-    pub peers: Vec<String>,
+    pub upstream_peers: Vec<String>,
 }
 
 impl NetworkPeersConfig {
@@ -172,13 +172,8 @@ impl ConfigHelpers {
     pub fn get_test_upstream_peers_config(
         network_peers: &NetworkPeersConfig,
     ) -> UpstreamPeersConfig {
-        let mut upstream_peers = Vec::new();
-        for peer in network_peers.peers.keys() {
-            upstream_peers.push(peer.clone());
-        }
-        UpstreamPeersConfig {
-            peers: upstream_peers,
-        }
+        let upstream_peers = network_peers.peers.keys().cloned().collect();
+        UpstreamPeersConfig { upstream_peers }
     }
 }
 

--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -281,11 +281,8 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> (AdmissionControlClien
     let metric_host = node_config.debug_interface.address.clone();
     thread::spawn(move || metric_server::start_server((metric_host.as_str(), metrics_port)));
 
-    let state_synchronizer = StateSynchronizer::bootstrap(
-        state_sync_network_handles,
-        &node_config,
-        vec![], // TODO: pass in empty vector for now, will be derived from node config later
-    );
+    let state_synchronizer = StateSynchronizer::bootstrap(state_sync_network_handles, &node_config);
+
     let mut mempool = None;
     let mut consensus = None;
     if let Some((peer_id, runtime, mut network_provider)) = validator_network_provider {

--- a/state_synchronizer/src/synchronizer.rs
+++ b/state_synchronizer/src/synchronizer.rs
@@ -4,7 +4,6 @@
 use crate::{
     coordinator::{CoordinatorMessage, SyncCoordinator},
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
-    PeerId,
 };
 use config::config::{NodeConfig, StateSyncConfig};
 use crypto::ed25519::*;
@@ -29,26 +28,19 @@ impl StateSynchronizer {
     pub fn bootstrap(
         network: Vec<(StateSynchronizerSender, StateSynchronizerEvents)>,
         config: &NodeConfig,
-        upstream_peer_ids: Vec<PeerId>,
     ) -> Self {
         let executor_proxy = ExecutorProxy::new(
             &config.execution,
             &config.storage,
             config.consensus.get_consensus_peers(),
         );
-        Self::bootstrap_with_executor_proxy(
-            network,
-            &config.state_sync,
-            executor_proxy,
-            upstream_peer_ids,
-        )
+        Self::bootstrap_with_executor_proxy(network, &config.state_sync, executor_proxy)
     }
 
     pub fn bootstrap_with_executor_proxy<E: ExecutorProxyTrait + 'static>(
         network: Vec<(StateSynchronizerSender, StateSynchronizerEvents)>,
         state_sync_config: &StateSyncConfig,
         executor_proxy: E,
-        upstream_peer_ids: Vec<PeerId>,
     ) -> Self {
         let runtime = Builder::new()
             .name_prefix("state-sync-")
@@ -62,7 +54,6 @@ impl StateSynchronizer {
             coordinator_receiver,
             state_sync_config.clone(),
             executor_proxy,
-            upstream_peer_ids.clone(),
         );
         executor.spawn(coordinator.start(network).boxed().unit_error().compat());
 

--- a/state_synchronizer/src/tests/integration_tests.rs
+++ b/state_synchronizer/src/tests/integration_tests.rs
@@ -159,10 +159,10 @@ impl ExecutorProxyTrait for MockExecutorProxy {
 }
 
 struct SynchronizerEnv {
+    _runtime: Runtime,
+    _synchronizers: Vec<StateSynchronizer>,
     peers: Vec<PeerId>,
     clients: Vec<Arc<StateSyncClient>>,
-    _synchronizers: Vec<StateSynchronizer>,
-    _runtime: Runtime,
 }
 
 impl SynchronizerEnv {
@@ -244,18 +244,21 @@ impl SynchronizerEnv {
         } else {
             config.networks.get_mut(0).unwrap().role = "validator".to_string();
         }
+        config
+            .state_sync
+            .upstream_peers
+            .upstream_peers
+            .push(peers[1].to_string());
         let synchronizers: Vec<StateSynchronizer> = vec![
             StateSynchronizer::bootstrap_with_executor_proxy(
                 vec![(sender_a, events_a)],
                 &config.state_sync,
                 MockExecutorProxy::new(peers[0], Self::default_handler()),
-                vec![peers[1]],
             ),
             StateSynchronizer::bootstrap_with_executor_proxy(
                 vec![(sender_b, events_b)],
                 &get_test_config().0.state_sync,
                 MockExecutorProxy::new(peers[1], handler),
-                vec![],
             ),
         ];
         let clients = synchronizers.iter().map(|s| s.create_client()).collect();


### PR DESCRIPTION
## Motivation

Full nodes will use this field to distinguish between their upstream nodes and other peers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Related PRs
#825 