### PR TITLE
[language][Bytecode Verifier] Remove unused code

### DIFF
--- a/language/bytecode_verifier/src/abstract_state.rs
+++ b/language/bytecode_verifier/src/abstract_state.rs
@@ -130,16 +130,6 @@ impl AbstractState {
         self.locals.insert(idx, value);
     }
 
-    /// checks if local@idx is a reference
-    pub fn is_reference(&self, idx: LocalIndex) -> bool {
-        self.locals[&idx].is_reference()
-    }
-
-    /// checks if local@idx is a value
-    pub fn is_value(&self, idx: LocalIndex) -> bool {
-        self.locals[&idx].is_value()
-    }
-
     /// Return true if self may safely be destroyed
     pub fn is_safe_to_destroy(&self) -> bool {
         self.locals.values().all(|x| x.is_safe_to_destroy())
@@ -575,8 +565,8 @@ impl AbstractState {
 
 impl AbstractDomain for AbstractState {
     /// attempts to join state to self and returns the result
-    /// both self.is_canonical() and state.is_canonical() must be true
     fn join(&mut self, state: &AbstractState) -> JoinResult {
+        checked_verify!(self.is_canonical() && state.is_canonical());
         // A join failure occurs in each of the following situations:
         // - an unrestricted value is borrowed along one path but unavailable along the other
         // - a value that is not unrestricted, i.e., either reference or resource, is available


### PR DESCRIPTION
## Motivation

I've been looking at improving the code coverage in our testing, and I noticed some functions in the bytecode verifier that appear to be unused. Removing those functions seems preferable to adding tests to exercise them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran "cargo test" in the language directory.

