### PR TITLE
[VM][Tools] Memory safety framework, add CLI arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4496,6 +4496,7 @@ dependencies = [
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
+ "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "types 0.1.0",
  "vm 0.1.0",
  "vm_cache_map 0.1.0",

--- a/language/tools/test_generation/Cargo.toml
+++ b/language/tools/test_generation/Cargo.toml
@@ -11,6 +11,7 @@ rand = "0.6.5"
 log = "0.4"
 env_logger = "0.6"
 mirai-annotations = "1.4.0"
+structopt = "0.2.15"
 bytecode_verifier = { path = "../../bytecode_verifier" }
 cost_synthesis = { path = "../cost_synthesis" }
 vm = { path = "../../vm" }

--- a/language/tools/test_generation/measure_coverage.sh
+++ b/language/tools/test_generation/measure_coverage.sh
@@ -87,7 +87,7 @@ cargo build
 
 # Run tests
 echo "Running bytecode test generator..."
-RUST_LOG=info cargo run
+RUST_LOG=info cargo run -- --iterations 1000
 
 # Make the coverage directory if it doesn't exist
 if [ ! -d $COVERAGE_DIR ]; then

--- a/language/tools/test_generation/src/borrow_graph.rs
+++ b/language/tools/test_generation/src/borrow_graph.rs
@@ -1,0 +1,131 @@
+use crate::abstract_state::Mutability;
+use std::collections::HashMap;
+
+/// Each partition is associated with a (unique) ID
+type PartitionID = u16;
+
+/// A nonce represents a runtime reference. It has a unique identifier and a mutability
+type Nonce = (u16, Mutability);
+
+/// A set of nonces
+type NonceSet = Vec<Nonce>;
+
+/// A path representing field accesses of a struct
+type Path = Vec<u8>;
+
+/// An edge in the graph. It consists of two partition IDs, a `Path` which
+/// may be empty, and an `EdgeType`
+type Edge = (PartitionID, PartitionID, Path, EdgeType);
+
+/// The `EdgeType` is either weak or strong. A weak edge represents imprecise information
+/// on the path along which the borrow takes place. A strong edge is precise.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EdgeType {
+    Weak,
+    Strong,
+}
+
+/// The `BorrowGraph` stores information sufficient to determine whether the instruction
+/// of a bytecode instruction that interacts with references is memory safe.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BorrowGraph {
+    /// All of the partitions that make up the graph
+    partitions: Vec<PartitionID>,
+
+    /// A mapping from partitions to the associated with them
+    partition_map: HashMap<PartitionID, NonceSet>,
+
+    /// The edges of the graph
+    edges: Vec<Edge>,
+
+    /// A counter for determining what the next partition ID should be
+    partition_counter: u16,
+}
+
+impl BorrowGraph {
+    /// Construct a new `BorrowGraph` given the number of locals it has
+    pub fn new(num_locals: u8) -> BorrowGraph {
+        BorrowGraph {
+            partitions: Vec::with_capacity(num_locals as usize),
+            partition_map: HashMap::new(),
+            edges: Vec::new(),
+            partition_counter: u16::from(num_locals),
+        }
+    }
+
+    /// Add a new partition to the graph containing nonce `n`
+    /// This operation may fail with an error a fresh partition ID
+    /// cannot be chosen.
+    pub fn fresh_partition(&mut self, n: Nonce) -> Result<(), String> {
+        if self.partition_counter.checked_add(1).is_some() {
+            if self.partition_map.get(&self.partition_counter).is_some() {
+                return Err("Partition map already contains ID".to_string());
+            }
+            self.partition_map.insert(self.partition_counter, vec![n]);
+            // Implication of `checked_add`
+            assume!(self.partitions.len() < usize::max_value());
+            self.partitions.push(self.partition_counter);
+            Ok(())
+        } else {
+            Err("Partition map is full".to_string())
+        }
+    }
+
+    /// Determine whether a partition is mutable, immutable, or either.
+    /// This operation may fail with an error if the given partition does
+    /// not exist in the graph.
+    pub fn partition_mutability(&self, partition_id: PartitionID) -> Result<Mutability, String> {
+        if let Some(nonce_set) = self.partition_map.get(&partition_id) {
+            if nonce_set
+                .iter()
+                .all(|(_, mutability)| *mutability == Mutability::Mutable)
+            {
+                Ok(Mutability::Mutable)
+            } else if nonce_set
+                .iter()
+                .all(|(_, mutability)| *mutability == Mutability::Immutable)
+            {
+                Ok(Mutability::Immutable)
+            } else {
+                Ok(Mutability::Either)
+            }
+        } else {
+            Err("Partition map does not contain given partition ID".to_string())
+        }
+    }
+
+    /// Determine whether the given partition is freezable. This operation may fail
+    /// with an error if the given partition ID is not in the graph.
+    pub fn partition_freezable(&self, partition_id: PartitionID) -> Result<bool, String> {
+        let mut freezable = true;
+        if self.partition_map.get(&partition_id).is_some() {
+            for (p1, p2, _, _) in self.edges.iter() {
+                if *p1 == partition_id && self.partition_mutability(*p2)? == Mutability::Mutable {
+                    freezable = false;
+                }
+            }
+            Ok(freezable)
+        } else {
+            Err("Partition map does not contain given partition ID".to_string())
+        }
+    }
+
+    /// Determine whether the `path_1` is a prefix of `path_2`
+    fn path_is_prefix(&self, path_1: Path, path_2: Path) -> bool {
+        let mut prefix = true;
+        for (i, field) in path_1.iter().enumerate() {
+            if *field != path_2[i] {
+                prefix = false;
+            }
+        }
+        prefix
+    }
+
+    /// Determine whether two edges are consistent; i.e. whether the path of the
+    /// first edge is a prefix of the second or vice versa.
+    pub fn edges_consistent(&self, edge_1: Edge, edge_2: Edge) -> bool {
+        let path_1 = edge_1.2;
+        let path_2 = edge_2.2;
+        self.path_is_prefix(path_1.clone(), path_2.clone()) || self.path_is_prefix(path_2, path_1)
+    }
+}

--- a/language/tools/test_generation/src/config.rs
+++ b/language/tools/test_generation/src/config.rs
@@ -1,21 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use structopt::StructOpt;
+
 /// This defines how tolerant the generator will be about deviating from
-/// the starting stack height. The higher the tolerance, the more likely
-/// it is for invalid programs to be generated within a given target number
-/// of instructions.
-/// Default is 0.9 for generating ~1000 instruction sequences.
+/// the starting stack height.
 pub const MUTATION_TOLERANCE: f32 = 0.9;
 
 /// This defines the maximum number of blocks that will be generated for
 /// a function body's CFG. During generation, a random number of blocks from
 /// 1 to this constant will be created.
 pub const MAX_CFG_BLOCKS: u16 = 10;
-
-/// This defines the number of programs that will be generated and then
-/// run on the bytecode verifier and transaction execution logic
-pub const NUM_ITERATIONS: u64 = 100;
 
 /// Whether preconditions will be negated to generate invalid programs
 /// in order to test error paths.
@@ -40,3 +35,21 @@ pub const EXECUTE_UNVERIFIED_MODULE: bool = true;
 /// Whether gas will be metered when running generated programs. The default
 /// is `true` to bound the execution time.
 pub const GAS_METERING: bool = true;
+
+/// Command line arguments for the tool
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Bytecode Test Generator",
+    author = "Libra",
+    about = "Tool for generating tests for the bytecode verifier and Move VM runtime."
+)]
+pub struct Args {
+    /// The number of programs that will be generated
+    #[structopt(short = "i", long = "iterations")]
+    pub num_iterations: u64,
+
+    /// Path where a serialized module should be saved.
+    /// If `None`, then the module will just be printed out.
+    #[structopt(short = "o", long = "output")]
+    pub output_path: Option<String>,
+}

--- a/language/tools/test_generation/src/error.rs
+++ b/language/tools/test_generation/src/error.rs
@@ -3,6 +3,8 @@
 
 use std::fmt;
 
+/// This struct represents an error that is returned during the
+/// testcase generation process.
 #[derive(Debug)]
 pub struct VMError {
     message: String,

--- a/language/tools/test_generation/src/main.rs
+++ b/language/tools/test_generation/src/main.rs
@@ -1,8 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use test_generation::{config::NUM_ITERATIONS, run_generation};
+use structopt::StructOpt;
+use test_generation::{config::Args, run_generation};
 
 pub fn main() {
-    run_generation(NUM_ITERATIONS);
+    let args = Args::from_args();
+    run_generation(args);
 }

--- a/language/tools/test_generation/src/transitions.rs
+++ b/language/tools/test_generation/src/transitions.rs
@@ -474,6 +474,11 @@ pub fn stack_function_popn(
     Ok(state)
 }
 
+/// Whether the function acquires any global resources or not
+pub fn function_can_acquire_resource(state: &AbstractState) -> bool {
+    !state.acquires_global_resources.is_empty()
+}
+
 /// TODO: This is a temporary function that represents memory
 /// safety for a reference. This should be removed and replaced
 /// with appropriate memory safety premises when the borrow checking
@@ -759,7 +764,7 @@ macro_rules! state_stack_function_call {
 #[macro_export]
 macro_rules! state_function_can_acquire_resource {
     () => {
-        Box::new(|_| false)
+        Box::new(move |state| function_can_acquire_resource(state))
     };
 }
 

--- a/language/tools/test_generation/tests/arithmetic_instructions.rs
+++ b/language/tools/test_generation/tests/arithmetic_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};

--- a/language/tools/test_generation/tests/bitwise_instructions.rs
+++ b/language/tools/test_generation/tests/bitwise_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};

--- a/language/tools/test_generation/tests/boolean_instructions.rs
+++ b/language/tools/test_generation/tests/boolean_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};

--- a/language/tools/test_generation/tests/comparison_instructions.rs
+++ b/language/tools/test_generation/tests/comparison_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};

--- a/language/tools/test_generation/tests/control_flow_instructions.rs
+++ b/language/tools/test_generation/tests/control_flow_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use std::collections::HashMap;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
@@ -45,7 +48,7 @@ fn generate_module_with_function() -> CompiledModuleMut {
 #[test]
 fn bytecode_call() {
     let module = generate_module_with_function();
-    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![]);
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(
@@ -68,7 +71,7 @@ fn bytecode_call() {
 #[should_panic]
 fn bytecode_call_function_signature_not_satisfied() {
     let module = generate_module_with_function();
-    let state1 = AbstractState::from_locals(module, HashMap::new());
+    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![]);
     common::run_instruction(
         Bytecode::Call(FunctionHandleIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -79,7 +82,7 @@ fn bytecode_call_function_signature_not_satisfied() {
 #[should_panic]
 fn bytecode_call_return_not_pushed() {
     let module = generate_module_with_function();
-    let mut state1 = AbstractState::from_locals(module, HashMap::new());
+    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![]);
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let state2 = common::run_instruction(

--- a/language/tools/test_generation/tests/load_instructions.rs
+++ b/language/tools/test_generation/tests/load_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{AddressPoolIndex, Bytecode, SignatureToken, UserStringIndex};

--- a/language/tools/test_generation/tests/local_instructions.rs
+++ b/language/tools/test_generation/tests/local_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue, BorrowState};
 use vm::file_format::{Bytecode, Kind, SignatureToken};

--- a/language/tools/test_generation/tests/reference_instructions.rs
+++ b/language/tools/test_generation/tests/reference_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, Kind, SignatureToken};

--- a/language/tools/test_generation/tests/special_instructions.rs
+++ b/language/tools/test_generation/tests/special_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};

--- a/language/tools/test_generation/tests/transaction_instructions.rs
+++ b/language/tools/test_generation/tests/transaction_instructions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 extern crate test_generation;
 use test_generation::abstract_state::{AbstractState, AbstractValue};
 use vm::file_format::{Bytecode, SignatureToken};


### PR DESCRIPTION
## Motivation

This commit adds a framework for memory safety premises of bytecode instructions. It also adds CLI arguments and serialization of error cases.

This commit also addresses a bug in the CFG generation where unreachable blocks can be generated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test`. Analysis with MIRAI.

## Related PRs

N/A
