### PR TITLE
[terraform] Try to workaround instance type change issue

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -6,7 +6,7 @@ if [ -e /dev/nvme1n1 ]; then
 	fi
 
 	cat >> /etc/fstab <<-EOF
-	/dev/nvme1n1  /data  ext4  defaults,noatime  0  2
+	/dev/nvme1n1  /data  ext4  defaults,noatime,nofail  0  2
 	EOF
 
 	mkdir /data


### PR DESCRIPTION
When the instance type is changed the instance boots with the same EBS
root value on a clean machine. This means that the instance store is
empty, but still referenced in fstab, causing a boot error. This adds
`nofail` to the fstab entry to allow boot to continue.