### PR TITLE
[state-sync] Additional invalid chunk logic for peer scoring

### DIFF
--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -335,10 +335,17 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             .map(|x| x.get_value())
             .into_option()
         {
+            let has_requested = self.peer_manager.has_requested(version, *peer_id);
             // node has received a response from peer, so remove peer entry from requests map
             self.peer_manager.process_response(version, *peer_id);
 
             if version != self.known_version + 1 {
+                // version was not requested, or version was requested from a different peer,
+                // so need to penalize peer for maliciously sending chunk
+                if has_requested {
+                    self.peer_manager
+                        .update_score(&peer_id, PeerScoreUpdateType::InvalidChunk)
+                }
                 return Err(format_err!(
                     "[state sync] non sequential chunk. Known version: {}, received: {}",
                     self.known_version,

--- a/state_synchronizer/src/peer_manager.rs
+++ b/state_synchronizer/src/peer_manager.rs
@@ -168,6 +168,13 @@ impl PeerManager {
         }
     }
 
+    pub fn has_requested(&self, version: u64, peer_id: PeerId) -> bool {
+        if let Some((id, _)) = self.requests.get(&version) {
+            return *id == peer_id;
+        }
+        false
+    }
+
     pub fn process_timeout(&mut self, current_requested_version: u64, timeout: u64) {
         let request = self.requests.get(&current_requested_version).cloned();
         if let Some((peer_id, request_time)) = request {


### PR DESCRIPTION
## Motivation

Additional invalid chunk logic for peer scoring when version received from a peer is out of sync. We cannot penalize whenever a peer sends chunk with wrong version, because it could have been due to previous peer acting maliciously. We only penalize peer if peer sent out of version chunk that the node has not explicitly requested for.

## Test Plan

unit test

## Related PRs

https://github.com/libra/libra/pull/932
