### PR TITLE
Revert "[proof] fix limit on AccumulatorProof's sibling count."

### DIFF
--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -28,6 +28,11 @@ pub struct AccumulatorProof {
     siblings: Vec<HashValue>,
 }
 
+/// Because leaves can only take half the space in the tree, any numbering of the tree leaves
+/// must not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm
+/// proof depth is limited to 63.
+pub const MAX_PROOF_DEPTH: usize = 63;
+
 impl AccumulatorProof {
     /// Constructs a new `AccumulatorProof` using a list of siblings.
     pub fn new(siblings: Vec<HashValue>) -> Self {
@@ -315,7 +320,7 @@ impl FromProto for AccumulatorConsistencyProof {
 
         let num_siblings = proto_proof.get_num_siblings() as usize;
         ensure!(
-            num_siblings <= 63,
+            num_siblings <= MAX_PROOF_DEPTH,
             "Too many ({}) siblings in the proof.",
             num_siblings,
         );

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -31,7 +31,7 @@ pub struct AccumulatorProof {
 /// Because leaves can only take half the space in the tree, any numbering of the tree leaves
 /// must not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm
 /// proof depth is limited to 63.
-pub const MAX_PROOF_DEPTH: usize = 63;
+pub const MAX_ACCUMULATOR_PROOF_DEPTH: usize = 63;
 
 impl AccumulatorProof {
     /// Constructs a new `AccumulatorProof` using a list of siblings.
@@ -320,7 +320,7 @@ impl FromProto for AccumulatorConsistencyProof {
 
         let num_siblings = proto_proof.get_num_siblings() as usize;
         ensure!(
-            num_siblings <= MAX_PROOF_DEPTH,
+            num_siblings <= MAX_ACCUMULATOR_PROOF_DEPTH,
             "Too many ({}) siblings in the proof.",
             num_siblings,
         );

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     account_state_blob::AccountStateBlob,
     contract_event::ContractEvent,
     ledger_info::LedgerInfo,
+    proof::definition::MAX_PROOF_DEPTH,
     transaction::{TransactionInfo, TransactionListWithProof, Version},
 };
 use crypto::{
@@ -319,8 +320,9 @@ fn verify_accumulator_element<H: Clone + CryptoHasher>(
 ) -> Result<()> {
     let siblings = accumulator_proof.siblings();
     ensure!(
-        siblings.len() <= 64,
-        "Accumulator proof has more than 64 ({}) siblings.",
+        siblings.len() <= MAX_PROOF_DEPTH,
+        "Accumulator proof has more than {} ({}) siblings.",
+        MAX_PROOF_DEPTH,
         siblings.len()
     );
 

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     account_state_blob::AccountStateBlob,
     contract_event::ContractEvent,
     ledger_info::LedgerInfo,
-    proof::definition::MAX_PROOF_DEPTH,
+    proof::definition::MAX_ACCUMULATOR_PROOF_DEPTH,
     transaction::{TransactionInfo, TransactionListWithProof, Version},
 };
 use crypto::{
@@ -320,9 +320,9 @@ fn verify_accumulator_element<H: Clone + CryptoHasher>(
 ) -> Result<()> {
     let siblings = accumulator_proof.siblings();
     ensure!(
-        siblings.len() <= MAX_PROOF_DEPTH,
+        siblings.len() <= MAX_ACCUMULATOR_PROOF_DEPTH,
         "Accumulator proof has more than {} ({}) siblings.",
-        MAX_PROOF_DEPTH,
+        MAX_ACCUMULATOR_PROOF_DEPTH,
         siblings.len()
     );
 

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -6,11 +6,12 @@ use crate::{
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfo,
     proof::{
-        definition::MAX_PROOF_DEPTH, verify_account_state, verify_event, verify_signed_transaction,
-        verify_sparse_merkle_element, verify_test_accumulator_element, AccountStateProof,
-        AccumulatorProof, EventAccumulatorInternalNode, EventProof, MerkleTreeInternalNode,
-        SignedTransactionProof, SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleProof,
-        TestAccumulatorInternalNode, TransactionAccumulatorInternalNode,
+        definition::MAX_ACCUMULATOR_PROOF_DEPTH, verify_account_state, verify_event,
+        verify_signed_transaction, verify_sparse_merkle_element, verify_test_accumulator_element,
+        AccountStateProof, AccumulatorProof, EventAccumulatorInternalNode, EventProof,
+        MerkleTreeInternalNode, SignedTransactionProof, SparseMerkleInternalNode,
+        SparseMerkleLeafNode, SparseMerkleProof, TestAccumulatorInternalNode,
+        TransactionAccumulatorInternalNode,
     },
     transaction::{
         RawTransaction, Script, SignedTransaction, TransactionInfo, TransactionListWithProof,
@@ -102,7 +103,7 @@ fn test_verify_three_element_accumulator() {
 fn test_accumulator_proof_max_siblings_leftmost() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..MAX_PROOF_DEPTH as u8 {
+    for i in 0..MAX_ACCUMULATOR_PROOF_DEPTH as u8 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings
@@ -120,7 +121,7 @@ fn test_accumulator_proof_max_siblings_leftmost() {
 fn test_accumulator_proof_max_siblings_rightmost() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..MAX_PROOF_DEPTH as u8 {
+    for i in 0..MAX_ACCUMULATOR_PROOF_DEPTH as u8 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings
@@ -139,7 +140,7 @@ fn test_accumulator_proof_max_siblings_rightmost() {
 fn test_accumulator_proof_sibling_overflow() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..MAX_PROOF_DEPTH as u8 + 1 {
+    for i in 0..MAX_ACCUMULATOR_PROOF_DEPTH as u8 + 1 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -137,6 +137,7 @@ fn test_accumulator_proof_max_siblings_rightmost() {
 }
 
 #[test]
+#[allow(clippy::range_plus_one)]
 fn test_accumulator_proof_sibling_overflow() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -6,7 +6,7 @@ use crate::{
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfo,
     proof::{
-        verify_account_state, verify_event, verify_signed_transaction,
+        definition::MAX_PROOF_DEPTH, verify_account_state, verify_event, verify_signed_transaction,
         verify_sparse_merkle_element, verify_test_accumulator_element, AccountStateProof,
         AccumulatorProof, EventAccumulatorInternalNode, EventProof, MerkleTreeInternalNode,
         SignedTransactionProof, SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleProof,
@@ -99,10 +99,10 @@ fn test_verify_three_element_accumulator() {
 }
 
 #[test]
-fn test_accumulator_proof_64_siblings_leftmost() {
+fn test_accumulator_proof_max_siblings_leftmost() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..64 {
+    for i in 0..MAX_PROOF_DEPTH as u8 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings
@@ -117,10 +117,10 @@ fn test_accumulator_proof_64_siblings_leftmost() {
 }
 
 #[test]
-fn test_accumulator_proof_64_siblings_rightmost() {
+fn test_accumulator_proof_max_siblings_rightmost() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..64 {
+    for i in 0..MAX_PROOF_DEPTH as u8 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings
@@ -129,17 +129,17 @@ fn test_accumulator_proof_64_siblings_rightmost() {
         .fold(element_hash, |hash, sibling_hash| {
             TestAccumulatorInternalNode::new(*sibling_hash, hash).hash()
         });
-    let leaf_index = std::u64::MAX;
+    let leaf_index = (std::u64::MAX - 1) / 2;
     let proof = AccumulatorProof::new(siblings);
 
     assert!(verify_test_accumulator_element(root_hash, element_hash, leaf_index, &proof).is_ok());
 }
 
 #[test]
-fn test_accumulator_proof_65_siblings() {
+fn test_accumulator_proof_sibling_overflow() {
     let element_hash = b"hello".test_only_hash();
     let mut siblings = vec![];
-    for i in 0..65 {
+    for i in 0..MAX_PROOF_DEPTH as u8 + 1 {
         siblings.push(HashValue::new([i; 32]));
     }
     let root_hash = siblings


### PR DESCRIPTION
This reverts commit 9eb4fedd522de536f427bf61a2bc49040117968c.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Node numbering prevents using all 64-bits for leaf index.

### Have you read the [Contributing Guidelines on pull requests]

我看不懂

## Test Plan

Unit tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
