### PR TITLE
[state-sync] Use btreemap to store sync requests

### DIFF
--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -240,6 +240,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                 }
             }
         }
+        self.peer_manager.remove_requests(version);
     }
 
     fn get_state(&self, callback: oneshot::Sender<u64>) {

--- a/state_synchronizer/src/peer_manager.rs
+++ b/state_synchronizer/src/peer_manager.rs
@@ -9,7 +9,7 @@ use rand::{
     thread_rng,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     time::{Duration, SystemTime},
 };
 
@@ -44,7 +44,7 @@ pub struct PeerManager {
     peers: HashMap<PeerId, PeerInfo>,
     network_senders: HashMap<PeerId, StateSynchronizerSender>,
     // Latest requested block versions from a peer
-    requests: HashMap<u64, (PeerId, SystemTime)>,
+    requests: BTreeMap<u64, (PeerId, SystemTime)>,
     weighted_index: Option<WeightedIndex<f64>>,
 }
 
@@ -57,7 +57,7 @@ impl PeerManager {
         Self {
             peers,
             network_senders: HashMap::new(),
-            requests: HashMap::new(),
+            requests: BTreeMap::new(),
             weighted_index: None,
         }
     }
@@ -192,6 +192,10 @@ impl PeerManager {
             return *id == peer_id;
         }
         false
+    }
+
+    pub fn remove_requests(&mut self, version: u64) {
+        self.requests = self.requests.split_off(&(version + 1));
     }
 
     pub fn process_timeout(&mut self, current_requested_version: u64, timeout: u64) {

--- a/state_synchronizer/src/tests/unit_tests.rs
+++ b/state_synchronizer/src/tests/unit_tests.rs
@@ -39,3 +39,23 @@ fn test_peer_manager() {
     assert!(pick_counts.get(&peers[0]).unwrap() < pick_counts.get(&peers[2]).unwrap());
     assert!(pick_counts.get(&peers[0]).unwrap() < pick_counts.get(&peers[3]).unwrap());
 }
+
+#[test]
+fn test_remove_requests() {
+    let peers = vec![PeerId::random(), PeerId::random()];
+    let mut peer_manager = PeerManager::new(peers.clone());
+
+    peer_manager.process_request(1, peers[0]);
+    peer_manager.process_request(3, peers[1]);
+    peer_manager.process_request(5, peers[0]);
+    peer_manager.process_request(10, peers[0]);
+    peer_manager.process_request(12, peers[1]);
+
+    peer_manager.remove_requests(5);
+
+    assert!(!peer_manager.has_requested(1, peers[0]));
+    assert!(!peer_manager.has_requested(3, peers[1]));
+    assert!(!peer_manager.has_requested(5, peers[0]));
+    assert!(peer_manager.has_requested(10, peers[0]));
+    assert!(peer_manager.has_requested(12, peers[1]));
+}


### PR DESCRIPTION
## Motivation

It is important to keep the requests map in sync with the committed version, so that the map doesn't continue to increase with old/stale versions that were not removed once the versions were committed. If we miss the version checks for removal due to some race condition, it could theoretically increase the requests map indefinitely and cause OOM. To prevent this, I have switched the requests hashmap to a btreemap, so that once a version is committed, all requests for versions equal to or less than that committed version can easily be removed.

## Test Plan

Added unit test for btree map ranged removal
