### PR TITLE
[types] Propagate more use of crypto_proxies type aliases

### DIFF
--- a/execution/execution_client/src/lib.rs
+++ b/execution/execution_client/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::ed25519::*;
 use execution_proto::{
     proto::{execution::CommitBlockRequest, execution_grpc},
     ExecuteBlockRequest, ExecuteBlockResponse,
@@ -10,7 +9,7 @@ use failure::{bail, Result};
 use grpcio::{ChannelBuilder, Environment};
 use proto_conv::{FromProto, IntoProto};
 use std::sync::Arc;
-use types::ledger_info::LedgerInfoWithSignatures;
+use types::crypto_proxies::LedgerInfoWithSignatures;
 
 pub struct ExecutionClient {
     client: execution_grpc::ExecutionClient,
@@ -31,10 +30,7 @@ impl ExecutionClient {
         }
     }
 
-    pub fn commit_block(
-        &self,
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
-    ) -> Result<()> {
+    pub fn commit_block(&self, ledger_info_with_sigs: LedgerInfoWithSignatures) -> Result<()> {
         let proto_ledger_info = ledger_info_with_sigs.into_proto();
         let mut request = CommitBlockRequest::new();
         request.set_ledger_info_with_sigs(proto_ledger_info);

--- a/execution/execution_proto/src/lib.rs
+++ b/execution/execution_proto/src/lib.rs
@@ -6,13 +6,13 @@ pub mod proto;
 #[cfg(test)]
 mod protobuf_conversion_test;
 
-use crypto::{ed25519::*, HashValue};
+use crypto::HashValue;
 use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use types::{
-    ledger_info::LedgerInfoWithSignatures,
+    crypto_proxies::LedgerInfoWithSignatures,
     transaction::{SignedTransaction, TransactionListWithProof, TransactionStatus, Version},
     validator_set::ValidatorSet,
     vm_error::VMStatus,
@@ -149,7 +149,7 @@ impl IntoProto for ExecuteBlockResponse {
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 #[ProtoType(crate::proto::execution::CommitBlockRequest)]
 pub struct CommitBlockRequest {
-    pub ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+    pub ledger_info_with_sigs: LedgerInfoWithSignatures,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -190,7 +190,7 @@ impl IntoProto for CommitBlockResponse {
 #[ProtoType(crate::proto::execution::ExecuteChunkRequest)]
 pub struct ExecuteChunkRequest {
     pub txn_list_with_proof: TransactionListWithProof,
-    pub ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+    pub ledger_info_with_sigs: LedgerInfoWithSignatures,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, FromProto, IntoProto)]

--- a/execution/execution_tests/src/lib.rs
+++ b/execution/execution_tests/src/lib.rs
@@ -10,7 +10,7 @@
 mod tests;
 
 use config::config::NodeConfig;
-use crypto::{ed25519::*, HashValue};
+use crypto::HashValue;
 use execution_proto::proto::execution_grpc::create_execution;
 use execution_service::ExecutionService;
 use grpc_helpers::ServerHandle;
@@ -18,7 +18,7 @@ use grpcio::{EnvBuilder, ServerBuilder};
 use std::{collections::HashMap, sync::Arc};
 use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::start_storage_service;
-use types::ledger_info::{LedgerInfo, LedgerInfoWithSignatures};
+use types::{crypto_proxies::LedgerInfoWithSignatures, ledger_info::LedgerInfo};
 
 pub fn gen_block_id(index: u8) -> HashValue {
     HashValue::new([index; HashValue::LENGTH])
@@ -28,7 +28,7 @@ pub fn gen_ledger_info_with_sigs(
     version: u64,
     root_hash: HashValue,
     commit_block_id: HashValue,
-) -> LedgerInfoWithSignatures<Ed25519Signature> {
+) -> LedgerInfoWithSignatures {
     let ledger_info = LedgerInfo::new(
         version,
         root_hash,

--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -9,7 +9,6 @@ use crate::{
 use backoff::{ExponentialBackoff, Operation};
 use config::config::VMConfig;
 use crypto::{
-    ed25519::*,
     hash::{CryptoHash, EventAccumulatorHasher},
     HashValue,
 };
@@ -29,7 +28,7 @@ use storage_client::{StorageRead, StorageWrite, VerifiedStateView};
 use types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
-    ledger_info::LedgerInfoWithSignatures,
+    crypto_proxies::LedgerInfoWithSignatures,
     proof::{accumulator::Accumulator, SparseMerkleProof},
     transaction::{
         SignedTransaction, TransactionInfo, TransactionListWithProof, TransactionOutput,
@@ -281,7 +280,7 @@ where
     fn execute_and_commit_chunk(
         &mut self,
         txn_list_with_proof: TransactionListWithProof,
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> Result<()> {
         if ledger_info_with_sigs.ledger_info().timestamp_usecs() <= self.committed_timestamp_usecs {
             warn!(
@@ -425,7 +424,7 @@ where
     fn verify_chunk(
         &self,
         txn_list_with_proof: &TransactionListWithProof,
-        ledger_info_with_sigs: &LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: &LedgerInfoWithSignatures,
     ) -> Result<(u64, Version)> {
         txn_list_with_proof.verify(
             ledger_info_with_sigs.ledger_info(),

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -8,7 +8,7 @@ use crate::{
     Executor, OP_COUNTERS,
 };
 use config::config::{NodeConfig, NodeConfigHelpers};
-use crypto::{ed25519::*, hash::GENESIS_BLOCK_ID, HashValue};
+use crypto::{hash::GENESIS_BLOCK_ID, HashValue};
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, ServerBuilder};
 use proptest::prelude::*;
@@ -25,7 +25,8 @@ use storage_proto::proto::storage_grpc::create_storage;
 use storage_service::StorageService;
 use types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    crypto_proxies::LedgerInfoWithSignatures,
+    ledger_info::LedgerInfo,
     transaction::{SignedTransaction, TransactionListWithProof, Version},
 };
 use vm_genesis::{encode_genesis_transaction, GENESIS_KEYPAIR};
@@ -157,7 +158,7 @@ fn gen_ledger_info(
     root_hash: HashValue,
     commit_block_id: HashValue,
     timestamp_usecs: u64,
-) -> LedgerInfoWithSignatures<Ed25519Signature> {
+) -> LedgerInfoWithSignatures {
     let ledger_info = LedgerInfo::new(
         version,
         root_hash,
@@ -278,10 +279,7 @@ rusty_fork_test! {
 /// Generates a list of `TransactionListWithProof`s according to the given ranges.
 fn create_transaction_chunks(
     chunk_ranges: Vec<std::ops::Range<Version>>,
-) -> (
-    Vec<TransactionListWithProof>,
-    LedgerInfoWithSignatures<Ed25519Signature>,
-) {
+) -> (Vec<TransactionListWithProof>, LedgerInfoWithSignatures) {
     assert_eq!(chunk_ranges.first().unwrap().start, 1);
     for i in 1..chunk_ranges.len() {
         let previous_range = &chunk_ranges[i - 1];

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -13,7 +13,6 @@ mod mock_vm;
 use crate::block_processor::BlockProcessor;
 use config::config::NodeConfig;
 use crypto::{
-    ed25519::*,
     hash::{
         TransactionAccumulatorHasher, GENESIS_BLOCK_ID, PRE_GENESIS_BLOCK_ID,
         SPARSE_MERKLE_PLACEHOLDER_HASH,
@@ -34,7 +33,8 @@ use std::{
 };
 use storage_client::{StorageRead, StorageWrite};
 use types::{
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    crypto_proxies::LedgerInfoWithSignatures,
+    ledger_info::LedgerInfo,
     proof::accumulator::Accumulator,
     transaction::{SignedTransaction, TransactionListWithProof, Version},
 };
@@ -207,7 +207,7 @@ where
     /// Commits a block and all its ancestors.
     pub fn commit_block(
         &self,
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> oneshot::Receiver<Result<CommitBlockResponse>> {
         debug!(
             "Received request to commit block {:x}.",
@@ -239,7 +239,7 @@ where
     pub fn execute_chunk(
         &self,
         txn_list_with_proof: TransactionListWithProof,
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> oneshot::Receiver<Result<ExecuteChunkResponse>> {
         debug!(
             "Received request to execute chunk. Chunk size: {}. Target version: {}.",
@@ -295,12 +295,12 @@ enum Command {
         resp_sender: oneshot::Sender<Result<ExecuteBlockResponse>>,
     },
     CommitBlock {
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
         resp_sender: oneshot::Sender<Result<CommitBlockResponse>>,
     },
     ExecuteChunk {
         txn_list_with_proof: TransactionListWithProof,
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
         resp_sender: oneshot::Sender<Result<ExecuteChunkResponse>>,
     },
 }

--- a/execution/executor/src/transaction_block.rs
+++ b/execution/executor/src/transaction_block.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block_tree::Block, ExecutedTrees};
-use crypto::{ed25519::*, hash::EventAccumulatorHasher, HashValue};
+use crypto::{hash::EventAccumulatorHasher, HashValue};
 use execution_proto::{CommitBlockResponse, ExecuteBlockResponse};
 use failure::{format_err, Result};
 use futures::channel::oneshot;
@@ -16,7 +16,7 @@ use types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
     contract_event::ContractEvent,
-    ledger_info::LedgerInfoWithSignatures,
+    crypto_proxies::LedgerInfoWithSignatures,
     proof::accumulator::Accumulator,
     transaction::{SignedTransaction, TransactionStatus},
 };
@@ -44,7 +44,7 @@ pub struct TransactionBlock {
 
     /// The signatures on this block. Not all committed blocks will have signatures, if multiple
     /// blocks are committed at once.
-    ledger_info_with_sigs: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
+    ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
 
     /// The response for `execute_block` request.
     execute_response: Option<ExecuteBlockResponse>,
@@ -90,7 +90,7 @@ impl TransactionBlock {
     }
 
     /// Returns the signatures on this block.
-    pub fn ledger_info_with_sigs(&self) -> &Option<LedgerInfoWithSignatures<Ed25519Signature>> {
+    pub fn ledger_info_with_sigs(&self) -> &Option<LedgerInfoWithSignatures> {
         &self.ledger_info_with_sigs
     }
 
@@ -175,7 +175,7 @@ impl TransactionBlock {
 
 impl Block for TransactionBlock {
     type Output = ProcessedVMOutput;
-    type Signature = LedgerInfoWithSignatures<Ed25519Signature>;
+    type Signature = LedgerInfoWithSignatures;
 
     fn is_committed(&self) -> bool {
         self.committed

--- a/state_synchronizer/src/coordinator.rs
+++ b/state_synchronizer/src/coordinator.rs
@@ -8,7 +8,6 @@ use crate::{
     LedgerInfo, PeerId,
 };
 use config::config::StateSyncConfig;
-use crypto::ed25519::*;
 use execution_proto::proto::execution::{ExecuteChunkRequest, ExecuteChunkResponse};
 use failure::prelude::*;
 use futures::{
@@ -29,7 +28,9 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::timer::Interval;
-use types::{ledger_info::LedgerInfoWithSignatures, proto::transaction::TransactionListWithProof};
+use types::{
+    crypto_proxies::LedgerInfoWithSignatures, proto::transaction::TransactionListWithProof,
+};
 
 /// message used by StateSyncClient for communication with Coordinator
 pub enum CoordinatorMessage {
@@ -451,7 +452,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
 
     async fn store_transactions(
         &self,
-        ledger_info: LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info: LedgerInfoWithSignatures,
         txn_list_with_proof: TransactionListWithProof,
     ) -> Result<ExecuteChunkResponse> {
         let mut req = ExecuteChunkRequest::new();

--- a/state_synchronizer/src/executor_proxy.rs
+++ b/state_synchronizer/src/executor_proxy.rs
@@ -14,7 +14,10 @@ use network::proto::GetChunkResponse;
 use proto_conv::IntoProto;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient};
-use types::{crypto_proxies::ValidatorVerifier, ledger_info::LedgerInfoWithSignatures, PeerId};
+use types::{
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier},
+    PeerId,
+};
 
 /// Proxies interactions with execution and storage for state synchronization
 pub trait ExecutorProxyTrait: Sync + Send {
@@ -35,13 +38,10 @@ pub trait ExecutorProxyTrait: Sync + Send {
         &self,
         known_version: u64,
         limit: u64,
-        target: LedgerInfoWithSignatures<Ed25519Signature>,
+        target: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<GetChunkResponse>> + Send>>;
 
-    fn validate_ledger_info(
-        &self,
-        target: &LedgerInfoWithSignatures<Ed25519Signature>,
-    ) -> Result<()>;
+    fn validate_ledger_info(&self, target: &LedgerInfoWithSignatures) -> Result<()>;
 }
 
 pub(crate) struct ExecutorProxy {
@@ -103,7 +103,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
         &self,
         known_version: u64,
         limit: u64,
-        target: LedgerInfoWithSignatures<Ed25519Signature>,
+        target: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<GetChunkResponse>> + Send>> {
         let client = Arc::clone(&self.storage_client);
         async move {

--- a/state_synchronizer/src/lib.rs
+++ b/state_synchronizer/src/lib.rs
@@ -4,8 +4,7 @@
 //! Used for node restarts, network partitions, full node syncs
 #![feature(async_await)]
 #![recursion_limit = "1024"]
-use crypto::ed25519::*;
-use types::{account_address::AccountAddress, ledger_info::LedgerInfoWithSignatures};
+use types::{account_address::AccountAddress, crypto_proxies::LedgerInfoWithSignatures};
 
 pub use synchronizer::{StateSyncClient, StateSynchronizer};
 
@@ -16,7 +15,7 @@ mod peer_manager;
 mod synchronizer;
 
 type PeerId = AccountAddress;
-type LedgerInfo = LedgerInfoWithSignatures<Ed25519Signature>;
+type LedgerInfo = LedgerInfoWithSignatures;
 
 #[cfg(test)]
 mod tests;

--- a/state_synchronizer/src/synchronizer.rs
+++ b/state_synchronizer/src/synchronizer.rs
@@ -6,7 +6,6 @@ use crate::{
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
 };
 use config::config::{NodeConfig, StateSyncConfig};
-use crypto::ed25519::*;
 use failure::prelude::*;
 use futures::{
     channel::{mpsc, oneshot},
@@ -16,7 +15,7 @@ use futures::{
 use network::validator_network::{StateSynchronizerEvents, StateSynchronizerSender};
 use std::sync::Arc;
 use tokio::runtime::{Builder, Runtime};
-use types::ledger_info::LedgerInfoWithSignatures;
+use types::crypto_proxies::LedgerInfoWithSignatures;
 
 pub struct StateSynchronizer {
     _runtime: Runtime,
@@ -76,10 +75,7 @@ pub struct StateSyncClient {
 
 impl StateSyncClient {
     /// Sync validator's state up to given `version`
-    pub fn sync_to(
-        &self,
-        target: LedgerInfoWithSignatures<Ed25519Signature>,
-    ) -> impl Future<Output = Result<bool>> {
+    pub fn sync_to(&self, target: LedgerInfoWithSignatures) -> impl Future<Output = Result<bool>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
         async move {

--- a/state_synchronizer/src/tests/integration_tests.rs
+++ b/state_synchronizer/src/tests/integration_tests.rs
@@ -36,7 +36,8 @@ use std::{
 use tokio::runtime::{Builder, Runtime};
 use types::{
     account_address::AccountAddress,
-    ledger_info::{LedgerInfo as TypesLedgerInfo, LedgerInfoWithSignatures},
+    crypto_proxies::LedgerInfoWithSignatures,
+    ledger_info::LedgerInfo as TypesLedgerInfo,
     proof::AccumulatorProof,
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::{SignedTransaction, TransactionInfo, TransactionListWithProof},

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -18,10 +18,10 @@ prop_compose! {
 prop_compose! {
     fn arb_ledger_infos_with_sigs()(
         partial_ledger_infos_with_sigs in vec(
-            any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((1..3).into()).no_shrink(), 1..100
+            any_with::<LedgerInfoWithSignatures>((1..3).into()).no_shrink(), 1..100
         ),
         start_epoch in 0..10000u64,
-    ) -> Vec<LedgerInfoWithSignatures<Ed25519Signature>> {
+    ) -> Vec<LedgerInfoWithSignatures> {
         partial_ledger_infos_with_sigs
             .iter()
             .enumerate()

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -15,7 +15,6 @@ use crate::{
 use accumulator::{HashReader, MerkleAccumulator};
 use arc_swap::ArcSwap;
 use crypto::{
-    ed25519::*,
     hash::{CryptoHash, TransactionAccumulatorHasher},
     HashValue,
 };
@@ -24,7 +23,7 @@ use itertools::Itertools;
 use schemadb::{ReadOptions, DB};
 use std::{ops::Deref, sync::Arc};
 use types::{
-    ledger_info::LedgerInfoWithSignatures,
+    crypto_proxies::LedgerInfoWithSignatures,
     proof::{
         position::{FrozenSubTreeIterator, Position},
         AccumulatorProof,
@@ -38,7 +37,7 @@ pub(crate) struct LedgerStore {
     /// We almost always need the latest ledger info and signatures to serve read requests, so we
     /// cache it in memory in order to avoid reading DB and deserializing the object frequently. It
     /// should be updated every time new ledger info and signatures are persisted.
-    latest_ledger_info: ArcSwap<Option<LedgerInfoWithSignatures<Ed25519Signature>>>,
+    latest_ledger_info: ArcSwap<Option<LedgerInfoWithSignatures>>,
 }
 
 impl LedgerStore {
@@ -68,29 +67,24 @@ impl LedgerStore {
     pub fn get_latest_ledger_infos_per_epoch(
         &self,
         start_epoch: u64,
-    ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {
+    ) -> Result<Vec<LedgerInfoWithSignatures>> {
         let mut iter = self.db.iter::<LedgerInfoSchema>(ReadOptions::default())?;
         iter.seek(&start_epoch)?;
         Ok(iter.map(|kv| Ok(kv?.1)).collect::<Result<Vec<_>>>()?)
     }
 
-    pub fn get_latest_ledger_info_option(
-        &self,
-    ) -> Option<LedgerInfoWithSignatures<Ed25519Signature>> {
+    pub fn get_latest_ledger_info_option(&self) -> Option<LedgerInfoWithSignatures> {
         let ledger_info_ptr = self.latest_ledger_info.load();
         let ledger_info: &Option<_> = ledger_info_ptr.deref();
         ledger_info.clone()
     }
 
-    pub fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures<Ed25519Signature>> {
+    pub fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
         self.get_latest_ledger_info_option()
             .ok_or_else(|| LibraDbError::NotFound(String::from("Genesis LedgerInfo")).into())
     }
 
-    pub fn set_latest_ledger_info(
-        &self,
-        ledger_info_with_sigs: LedgerInfoWithSignatures<Ed25519Signature>,
-    ) {
+    pub fn set_latest_ledger_info(&self, ledger_info_with_sigs: LedgerInfoWithSignatures) {
         self.latest_ledger_info
             .store(Arc::new(Some(ledger_info_with_sigs)));
     }
@@ -169,7 +163,7 @@ impl LedgerStore {
     /// Write `ledger_info` to `cs`.
     pub fn put_ledger_info(
         &self,
-        ledger_info_with_sigs: &LedgerInfoWithSignatures<Ed25519Signature>,
+        ledger_info_with_sigs: &LedgerInfoWithSignatures,
         cs: &mut ChangeSet,
     ) -> Result<()> {
         cs.batch.put::<LedgerInfoSchema>(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -40,7 +40,7 @@ use crate::{
     system_store::SystemStore,
     transaction_store::TransactionStore,
 };
-use crypto::{ed25519::*, hash::CryptoHash, HashValue};
+use crypto::hash::{CryptoHash, HashValue};
 use failure::prelude::*;
 use itertools::{izip, zip_eq};
 use lazy_static::lazy_static;
@@ -55,14 +55,13 @@ use types::{
     account_config::AccountResource,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::EventWithProof,
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof},
     get_with_proof::{RequestItem, ResponseItem},
-    ledger_info::LedgerInfoWithSignatures,
     proof::{AccountStateProof, EventProof, SignedTransactionProof, SparseMerkleProof},
     transaction::{
         SignedTransactionWithProof, TransactionInfo, TransactionListWithProof, TransactionToCommit,
         Version,
     },
-    validator_change::ValidatorChangeEventWithProof,
 };
 
 lazy_static! {
@@ -309,7 +308,7 @@ impl LibraDB {
     pub fn get_latest_ledger_infos_per_epoch(
         &self,
         start_epoch: u64,
-    ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {
+    ) -> Result<Vec<LedgerInfoWithSignatures>> {
         self.ledger_store
             .get_latest_ledger_infos_per_epoch(start_epoch)
     }
@@ -326,7 +325,7 @@ impl LibraDB {
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
-        ledger_info_with_sigs: &Option<LedgerInfoWithSignatures<Ed25519Signature>>,
+        ledger_info_with_sigs: &Option<LedgerInfoWithSignatures>,
     ) -> Result<()> {
         let num_txns = txns_to_commit.len() as u64;
         // ledger_info_with_sigs could be None if we are doing state synchronization. In this case
@@ -446,8 +445,8 @@ impl LibraDB {
         request_items: Vec<RequestItem>,
     ) -> Result<(
         Vec<ResponseItem>,
-        LedgerInfoWithSignatures<Ed25519Signature>,
-        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
+        LedgerInfoWithSignatures,
+        Vec<ValidatorChangeEventWithProof>,
     )> {
         error_if_too_many_requested(request_items.len() as u64, MAX_REQUEST_ITEMS)?;
 

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -6,7 +6,7 @@ use crate::{
     mock_genesis::{db_with_mock_genesis, GENESIS_INFO},
     test_helper::arb_blocks_to_commit,
 };
-use crypto::{ed25519::*, hash::CryptoHash};
+use crypto::hash::CryptoHash;
 use proptest::prelude::*;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::collections::HashMap;
@@ -17,10 +17,7 @@ use types::{
 };
 
 fn test_save_blocks_impl(
-    input: Vec<(
-        Vec<TransactionToCommit>,
-        LedgerInfoWithSignatures<Ed25519Signature>,
-    )>,
+    input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
 ) -> Result<()> {
     let tmp_dir = TempPath::new();
     let db = db_with_mock_genesis(&tmp_dir)?;
@@ -73,10 +70,7 @@ fn test_save_blocks_impl(
 }
 
 fn test_sync_transactions_impl(
-    input: Vec<(
-        Vec<TransactionToCommit>,
-        LedgerInfoWithSignatures<Ed25519Signature>,
-    )>,
+    input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
 ) -> Result<()> {
     let tmp_dir = TempPath::new();
     let db = db_with_mock_genesis(&tmp_dir)?;
@@ -298,7 +292,7 @@ fn verify_committed_transactions(
     db: &LibraDB,
     txns_to_commit: &[TransactionToCommit],
     first_version: Version,
-    ledger_info_with_sigs: &LedgerInfoWithSignatures<Ed25519Signature>,
+    ledger_info_with_sigs: &LedgerInfoWithSignatures,
     is_latest: bool,
 ) -> Result<()> {
     let ledger_info = ledger_info_with_sigs.ledger_info();

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -19,7 +19,8 @@ use std::collections::HashMap;
 use types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    crypto_proxies::LedgerInfoWithSignatures,
+    ledger_info::LedgerInfo,
     proof::SparseMerkleLeafNode,
     transaction::{RawTransaction, Script, TransactionInfo, TransactionToCommit},
     vm_error::StatusCode,
@@ -27,7 +28,7 @@ use types::{
 
 fn gen_mock_genesis() -> (
     TransactionInfo,
-    LedgerInfoWithSignatures<Ed25519Signature>,
+    LedgerInfoWithSignatures,
     TransactionToCommit,
 ) {
     let mut seed_rng = OsRng::new().expect("can't access OsRng");
@@ -100,7 +101,7 @@ lazy_static! {
     /// other mocked information including validator signatures.
     pub static ref GENESIS_INFO: (
         TransactionInfo,
-        LedgerInfoWithSignatures<Ed25519Signature>,
+        LedgerInfoWithSignatures,
         TransactionToCommit
     ) = gen_mock_genesis();
 }

--- a/storage/libradb/src/schema/ledger_info/mod.rs
+++ b/storage/libradb/src/schema/ledger_info/mod.rs
@@ -14,7 +14,6 @@
 
 use crate::schema::ensure_slice_len_eq;
 use byteorder::{BigEndian, ReadBytesExt};
-use crypto::ed25519::*;
 use failure::prelude::*;
 use proto_conv::{FromProtoBytes, IntoProtoBytes};
 use schemadb::{
@@ -23,12 +22,12 @@ use schemadb::{
     DEFAULT_CF_NAME,
 };
 use std::mem::size_of;
-use types::ledger_info::LedgerInfoWithSignatures;
+use types::crypto_proxies::LedgerInfoWithSignatures;
 
 define_schema!(
     LedgerInfoSchema,
     u64, /* epoch num */
-    LedgerInfoWithSignatures<Ed25519Signature>,
+    LedgerInfoWithSignatures,
     DEFAULT_CF_NAME
 );
 
@@ -43,7 +42,7 @@ impl KeyCodec<LedgerInfoSchema> for u64 {
     }
 }
 
-impl ValueCodec<LedgerInfoSchema> for LedgerInfoWithSignatures<Ed25519Signature> {
+impl ValueCodec<LedgerInfoSchema> for LedgerInfoWithSignatures {
     fn encode_value(&self) -> Result<Vec<u8>> {
         self.clone().into_proto_bytes()
     }

--- a/storage/libradb/src/schema/ledger_info/test.rs
+++ b/storage/libradb/src/schema/ledger_info/test.rs
@@ -4,12 +4,12 @@
 use super::*;
 use proptest::prelude::*;
 use schemadb::schema::assert_encode_decode;
-use types::ledger_info::LedgerInfoWithSignatures;
+use types::crypto_proxies::LedgerInfoWithSignatures;
 
 proptest! {
     #[test]
     fn test_encode_decode(
-        ledger_info_with_sigs in any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((1..10).into())
+        ledger_info_with_sigs in any_with::<LedgerInfoWithSignatures>((1..10).into())
     ) {
         assert_encode_decode::<LedgerInfoSchema>(&0, &ledger_info_with_sigs);
     }

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -5,25 +5,18 @@
 
 use super::*;
 use crate::mock_genesis::{db_with_mock_genesis, GENESIS_INFO};
-use crypto::{ed25519::*, hash::CryptoHash};
+use crypto::hash::CryptoHash;
 use proptest::{collection::vec, prelude::*};
 use tools::tempdir::TempPath;
 use types::{
+    crypto_proxies::LedgerInfoWithSignatures,
     ledger_info::LedgerInfo,
     proptest_types::{AccountInfoUniverse, TransactionToCommitGen},
 };
 
 fn to_blocks_to_commit(
-    partial_blocks: Vec<(
-        Vec<TransactionToCommit>,
-        LedgerInfoWithSignatures<Ed25519Signature>,
-    )>,
-) -> Result<
-    Vec<(
-        Vec<TransactionToCommit>,
-        LedgerInfoWithSignatures<Ed25519Signature>,
-    )>,
-> {
+    partial_blocks: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,
+) -> Result<Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>> {
     // Use temporary LibraDB and STORE LEVEL APIs to calculate hashes on a per transaction basis.
     // Result is used to test the batch PUBLIC API for saving everything, i.e. `save_transactions()`
     let tmp_dir = TempPath::new();
@@ -106,14 +99,14 @@ prop_compose! {
         batches in vec(
             (
                 vec(any::<TransactionToCommitGen>(), 0..=2),
-                any::<LedgerInfoWithSignatures<Ed25519Signature>>()
+                any::<LedgerInfoWithSignatures>()
             ),
             1..10,
         ),
     ) ->
         Vec<(
             Vec<TransactionToCommit>,
-            LedgerInfoWithSignatures<Ed25519Signature>,
+            LedgerInfoWithSignatures,
         )>
     {
         let partial_blocks = batches

--- a/storage/storage_proto/src/lib.rs
+++ b/storage/storage_proto/src/lib.rs
@@ -25,7 +25,7 @@
 
 pub mod proto;
 
-use crypto::{ed25519::*, HashValue};
+use crypto::HashValue;
 use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
@@ -33,7 +33,8 @@ use proto_conv::{FromProto, IntoProto};
 use types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    crypto_proxies::LedgerInfoWithSignatures,
+    ledger_info::LedgerInfo,
     proof::SparseMerkleProof,
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
@@ -144,7 +145,7 @@ impl Into<(Option<AccountStateBlob>, SparseMerkleProof)>
 pub struct SaveTransactionsRequest {
     pub txns_to_commit: Vec<TransactionToCommit>,
     pub first_version: Version,
-    pub ledger_info_with_signatures: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
+    pub ledger_info_with_signatures: Option<LedgerInfoWithSignatures>,
 }
 
 impl SaveTransactionsRequest {
@@ -152,7 +153,7 @@ impl SaveTransactionsRequest {
     pub fn new(
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
-        ledger_info_with_signatures: Option<LedgerInfoWithSignatures<Ed25519Signature>>,
+        ledger_info_with_signatures: Option<LedgerInfoWithSignatures>,
     ) -> Self {
         SaveTransactionsRequest {
             txns_to_commit,
@@ -397,22 +398,20 @@ impl GetLatestLedgerInfosPerEpochRequest {
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
 #[ProtoType(crate::proto::storage::GetLatestLedgerInfosPerEpochResponse)]
 pub struct GetLatestLedgerInfosPerEpochResponse {
-    pub latest_ledger_infos: Vec<LedgerInfoWithSignatures<Ed25519Signature>>,
+    pub latest_ledger_infos: Vec<LedgerInfoWithSignatures>,
 }
 
 impl GetLatestLedgerInfosPerEpochResponse {
     /// Constructor.
-    pub fn new(latest_ledger_infos: Vec<LedgerInfoWithSignatures<Ed25519Signature>>) -> Self {
+    pub fn new(latest_ledger_infos: Vec<LedgerInfoWithSignatures>) -> Self {
         Self {
             latest_ledger_infos,
         }
     }
 }
 
-impl Into<Vec<LedgerInfoWithSignatures<Ed25519Signature>>>
-    for GetLatestLedgerInfosPerEpochResponse
-{
-    fn into(self) -> Vec<LedgerInfoWithSignatures<Ed25519Signature>> {
+impl Into<Vec<LedgerInfoWithSignatures>> for GetLatestLedgerInfosPerEpochResponse {
+    fn into(self) -> Vec<LedgerInfoWithSignatures> {
         self.latest_ledger_infos
     }
 }

--- a/storage/storage_service/src/mocks/mock_storage_client.rs
+++ b/storage/storage_service/src/mocks/mock_storage_client.rs
@@ -18,9 +18,9 @@ use storage_proto::StartupInfo;
 use types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_state_blob::AccountStateBlob,
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof},
     event::EventHandle,
     get_with_proof::{RequestItem, ResponseItem},
-    ledger_info::LedgerInfoWithSignatures,
     proof::SparseMerkleProof,
     proto::{
         account_state_blob::AccountStateWithProof,
@@ -36,7 +36,6 @@ use types::{
     },
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::Version,
-    validator_change::ValidatorChangeEventWithProof,
     vm_error::StatusCode,
 };
 
@@ -54,8 +53,8 @@ impl StorageRead for MockStorageReadClient {
         request_items: Vec<RequestItem>,
     ) -> Result<(
         Vec<ResponseItem>,
-        LedgerInfoWithSignatures<Ed25519Signature>,
-        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
+        LedgerInfoWithSignatures,
+        Vec<ValidatorChangeEventWithProof>,
     )> {
         let request = types::get_with_proof::UpdateToLatestLedgerRequest::new(
             client_known_version,
@@ -81,8 +80,8 @@ impl StorageRead for MockStorageReadClient {
             dyn Future<
                     Output = Result<(
                         Vec<ResponseItem>,
-                        LedgerInfoWithSignatures<Ed25519Signature>,
-                        Vec<ValidatorChangeEventWithProof<Ed25519Signature>>,
+                        LedgerInfoWithSignatures,
+                        Vec<ValidatorChangeEventWithProof>,
                     )>,
                 > + Send,
         >,
@@ -145,15 +144,14 @@ impl StorageRead for MockStorageReadClient {
     fn get_latest_ledger_infos_per_epoch(
         &self,
         _start_epoch: u64,
-    ) -> Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>> {
+    ) -> Result<Vec<LedgerInfoWithSignatures>> {
         unimplemented!()
     }
 
     fn get_latest_ledger_infos_per_epoch_async(
         &self,
         _start_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures<Ed25519Signature>>>> + Send>>
-    {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {
         unimplemented!()
     }
 }

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -22,6 +22,7 @@
 use crate::{
     account_address::AccountAddress,
     ledger_info::LedgerInfoWithSignatures as RawLedgerInfoWithSignatures,
+    validator_change::ValidatorChangeEventWithProof as RawValidatorChangeEventWithProof,
     validator_signer::ValidatorSigner as RawValidatorSigner,
     validator_verifier::{ValidatorVerifier as RawValidatorVerifier, VerifyError},
 };
@@ -85,3 +86,4 @@ pub type Signature = SignatureWrapper<Ed25519Signature>;
 pub type LedgerInfoWithSignatures = RawLedgerInfoWithSignatures<Ed25519Signature>;
 pub type ValidatorVerifier = RawValidatorVerifier<Ed25519PublicKey>;
 pub type ValidatorSigner = RawValidatorSigner<Ed25519PrivateKey>;
+pub type ValidatorChangeEventWithProof = RawValidatorChangeEventWithProof<Ed25519Signature>;

--- a/types/src/unit_tests/ledger_info_proto_conversion_test.rs
+++ b/types/src/unit_tests/ledger_info_proto_conversion_test.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ledger_info::{LedgerInfo, LedgerInfoWithSignatures};
-use crypto::ed25519::*;
+use crate::{crypto_proxies::LedgerInfoWithSignatures, ledger_info::LedgerInfo};
 use proptest::prelude::*;
 use proto_conv::test_helper::assert_protobuf_encode_decode;
 
@@ -14,7 +13,7 @@ proptest! {
 
     #[test]
     fn test_ledger_info_with_signatures(
-        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((0..11).into())
+        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures>((0..11).into())
     ) {
         assert_protobuf_encode_decode(&ledger_info_with_signatures);
     }
@@ -26,7 +25,7 @@ proptest! {
     #[test]
     fn test_ledger_info_with_many_signatures(
         // 100 is the number we have in mind in real world, setting 200 to have a good chance of hitting it
-        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures<Ed25519Signature>>((0..200).into())
+        ledger_info_with_signatures in any_with::<LedgerInfoWithSignatures>((0..200).into())
     ) {
         assert_protobuf_encode_decode(&ledger_info_with_signatures);
     }


### PR DESCRIPTION
Converted all the code outside of types to use
crypto_proxies::LedgerInfoWithSignatures and
crypto_proxies::ValidatorChangeEventWithProof.  This will help with
preparation for making changing signature schemes easier.

This is a mechanical change with no expected changes in semantics.

 This will help address part of #954.
