### PR TITLE
[language] Take code to compile as argument

### DIFF
--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -22,11 +22,9 @@ use vm::file_format::{CompiledModule, CompiledProgram, CompiledScript};
 
 /// An API for the compiler. Supports setting custom options.
 #[derive(Clone, Debug, Default)]
-pub struct Compiler<'a> {
+pub struct Compiler {
     /// The address used as the sender for the compiler.
     pub address: AccountAddress,
-    /// The Move IR code to compile.
-    pub code: &'a str,
     /// Skip stdlib dependencies if true.
     pub skip_stdlib_deps: bool,
     /// The address to use for stdlib.
@@ -46,28 +44,29 @@ pub struct Compiler<'a> {
     pub _non_exhaustive: (),
 }
 
-impl<'a> Compiler<'a> {
+impl Compiler {
     /// Compiles into a `CompiledProgram` where the bytecode hasn't been serialized.
-    pub fn into_compiled_program(mut self) -> Result<CompiledProgram> {
-        Ok(self.compile_impl()?.0)
+    pub fn into_compiled_program(mut self, code: &str) -> Result<CompiledProgram> {
+        Ok(self.compile_impl(code)?.0)
     }
 
     /// Compiles into a `CompiledProgram` and also returns the dependencies.
     pub fn into_compiled_program_and_deps(
         mut self,
+        code: &str,
     ) -> Result<(CompiledProgram, Vec<VerifiedModule>)> {
-        self.compile_impl()
+        self.compile_impl(code)
     }
 
     /// Compiles into a `CompiledScript`.
-    pub fn into_script(mut self) -> Result<CompiledScript> {
-        let compiled_program = self.compile_impl()?.0;
+    pub fn into_script(mut self, code: &str) -> Result<CompiledScript> {
+        let compiled_program = self.compile_impl(code)?.0;
         Ok(compiled_program.script)
     }
 
     /// Compiles the script into a serialized form.
-    pub fn into_script_blob(mut self) -> Result<Vec<u8>> {
-        let compiled_program = self.compile_impl()?.0;
+    pub fn into_script_blob(mut self, code: &str) -> Result<Vec<u8>> {
+        let compiled_program = self.compile_impl(code)?.0;
 
         let mut serialized_script = Vec::<u8>::new();
         compiled_program.script.serialize(&mut serialized_script)?;
@@ -75,13 +74,13 @@ impl<'a> Compiler<'a> {
     }
 
     /// Compiles the module.
-    pub fn into_compiled_module(mut self) -> Result<CompiledModule> {
-        Ok(self.compile_mod()?.0)
+    pub fn into_compiled_module(mut self, code: &str) -> Result<CompiledModule> {
+        Ok(self.compile_mod(code)?.0)
     }
 
     /// Compiles the module into a serialized form.
-    pub fn into_module_blob(mut self) -> Result<Vec<u8>> {
-        let compiled_module = self.compile_mod()?.0;
+    pub fn into_module_blob(mut self, code: &str) -> Result<Vec<u8>> {
+        let compiled_module = self.compile_mod(code)?.0;
 
         let mut serialized_module = Vec::<u8>::new();
         compiled_module.serialize(&mut serialized_module)?;
@@ -89,23 +88,19 @@ impl<'a> Compiler<'a> {
     }
 
     /// Compiles the code and arguments into a `Script` -- the bytecode is serialized.
-    pub fn into_program(mut self, args: Vec<TransactionArgument>) -> Result<Script> {
-        let compiled_program = self.compile_impl()?.0;
-
-        let mut serialized_script = Vec::<u8>::new();
-        compiled_program.script.serialize(&mut serialized_script)?;
-        Ok(Script::new(serialized_script, args))
+    pub fn into_program(self, code: &str, args: Vec<TransactionArgument>) -> Result<Script> {
+        Ok(Script::new(self.into_script_blob(code)?, args))
     }
 
-    fn compile_impl(&mut self) -> Result<(CompiledProgram, Vec<VerifiedModule>)> {
-        let parsed_program = parse_program(self.code)?;
+    fn compile_impl(&mut self, code: &str) -> Result<(CompiledProgram, Vec<VerifiedModule>)> {
+        let parsed_program = parse_program(code)?;
         let deps = self.deps();
         let compiled_program = compile_program(self.address, parsed_program, &deps)?;
         Ok((compiled_program, deps))
     }
 
-    fn compile_mod(&mut self) -> Result<(CompiledModule, Vec<VerifiedModule>)> {
-        let parsed_program = parse_program(self.code)?;
+    fn compile_mod(&mut self, code: &str) -> Result<(CompiledModule, Vec<VerifiedModule>)> {
+        let parsed_program = parse_program(code)?;
         let deps = self.deps();
         let mut modules = parsed_program.modules;
         assert_eq!(modules.len(), 1, "Must have single module");

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -147,13 +147,12 @@ fn main() {
         let source = fs::read_to_string(args.source_path.clone()).expect("Unable to read file");
         let compiler = Compiler {
             address,
-            code: &source,
             skip_stdlib_deps: args.no_stdlib,
             extra_deps: deps,
             ..Compiler::default()
         };
         let (compiled_program, dependencies) = compiler
-            .into_compiled_program_and_deps()
+            .into_compiled_program_and_deps(&source)
             .expect("Failed to compile program");
 
         let compiled_program = if !args.no_verify {

--- a/language/e2e_tests/src/compile.rs
+++ b/language/e2e_tests/src/compile.rs
@@ -15,20 +15,18 @@ use types::{
 /// The script is compiled with the default account address (`0x0`).
 pub fn compile_script(code: &str) -> Vec<u8> {
     let compiler = Compiler {
-        code,
         ..Compiler::default()
     };
-    compiler.into_script_blob().unwrap()
+    compiler.into_script_blob(code).unwrap()
 }
 
 /// Compile the provided Move code into a blob which can be used as a [`Script`].
 pub fn compile_script_with_address(address: &AccountAddress, code: &str) -> Vec<u8> {
     let compiler = Compiler {
         address: *address,
-        code,
         ..Compiler::default()
     };
-    compiler.into_script_blob().unwrap()
+    compiler.into_script_blob(code).unwrap()
 }
 
 /// Compile the provided Move code into a blob which can be used as the code to be published
@@ -36,8 +34,7 @@ pub fn compile_script_with_address(address: &AccountAddress, code: &str) -> Vec<
 pub fn compile_module_with_address(address: &AccountAddress, code: &str) -> TransactionPayload {
     let compiler = Compiler {
         address: *address,
-        code,
         ..Compiler::default()
     };
-    TransactionPayload::Module(Module::new(compiler.into_module_blob().unwrap()))
+    TransactionPayload::Module(Module::new(compiler.into_module_blob(code).unwrap()))
 }

--- a/language/e2e_tests/src/lib.rs
+++ b/language/e2e_tests/src/lib.rs
@@ -37,11 +37,12 @@ pub fn compile_and_execute(program: &str, args: Vec<TransactionArgument>) -> VMR
     let address = AccountAddress::default();
     println!("{}", address);
     let compiler = Compiler {
-        code: program,
         address,
         ..Compiler::default()
     };
-    let compiled_program = compiler.into_compiled_program().expect("Failed to compile");
+    let compiled_program = compiler
+        .into_compiled_program(program)
+        .expect("Failed to compile");
     let (verified_script, modules) =
         verify(&address, compiled_program.script, compiled_program.modules);
     execute(verified_script, args, modules)

--- a/language/e2e_tests/src/tests/verify_txn.rs
+++ b/language/e2e_tests/src/tests/verify_txn.rs
@@ -513,10 +513,11 @@ fn test_dependency_fails_verification() {
     }
     ";
     let compiler = Compiler {
-        code: bad_module_code,
         ..Compiler::default()
     };
-    let module = compiler.into_compiled_module().expect("Failed to compile");
+    let module = compiler
+        .into_compiled_module(bad_module_code)
+        .expect("Failed to compile");
     executor.add_module(&module.self_id(), &module);
 
     // Create a transaction that tries to use that module.
@@ -534,7 +535,6 @@ fn test_dependency_fails_verification() {
     ";
 
     let compiler = Compiler {
-        code,
         address: *sender.address(),
         // This is OK because we *know* the module is unverified.
         extra_deps: vec![VerifiedModule::bypass_verifier_DANGEROUS_FOR_TESTING_ONLY(
@@ -542,7 +542,7 @@ fn test_dependency_fails_verification() {
         )],
         ..Compiler::default()
     };
-    let script = compiler.into_script_blob().expect("Failed to compile");
+    let script = compiler.into_script_blob(code).expect("Failed to compile");
     let txn = sender.account().create_signed_txn(
         TransactionPayload::Script(Script::new(script, vec![])),
         10,

--- a/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
@@ -492,12 +492,11 @@ fn test_multi_level_cache_write_back() {
 
 fn parse_and_compile_modules(s: impl AsRef<str>) -> Vec<CompiledModule> {
     let compiler = Compiler {
-        code: s.as_ref(),
         skip_stdlib_deps: true,
         ..Compiler::default()
     };
     compiler
-        .into_compiled_program()
+        .into_compiled_program(s.as_ref())
         .expect("Failed to compile program")
         .modules
 }


### PR DESCRIPTION
Previously, the code was a field of the compiler struct. This change will make it easier to reuse a single Compiler instance for multiple code units, and also lets us remove the lifetime parameter on the struct.

## Motivation

Moving toward a compiler with a more flexible CLI (e.g., can support multiple source files).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Oh yeah.

## Test Plan

`cargo test`, should be pure refactoring.