### PR TITLE
[docker] fix docker image build error

### DIFF
--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stretch as builder
 
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl \
+    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake g++ curl \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stretch as builder
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl \
+    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake g++ curl \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none

--- a/docker/validator/validator.Dockerfile
+++ b/docker/validator/validator.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:stretch as builder
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl \
+    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake g++ curl \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none


### PR DESCRIPTION
## Motivation

To solve the issue https://github.com/libra/libra/issues/959 of failing to build the docker image. Add `install g++` to set `CMAKE_CXX_COMPILER`.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Only change the Dockerfile.

## Related PRs

No