### PR TITLE
[security] admission control fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,8 @@ dependencies = [
  "logger 0.1.0",
  "mempool 0.1.0",
  "metrics 0.1.0",
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest_helpers 0.1.0",
  "proto_conv 0.1.0",
  "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2105,6 +2107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libra_fuzzer"
 version = "0.1.0"
 dependencies = [
+ "admission_control_service 0.1.0",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical_serialization 0.1.0",
  "consensus 0.1.0",

--- a/admission_control/admission_control_service/Cargo.toml
+++ b/admission_control/admission_control_service/Cargo.toml
@@ -28,11 +28,21 @@ storage_client = { path = "../../storage/storage_client" }
 types = { path = "../../types" }
 vm_validator = { path = "../../vm_validator" }
 
+storage_service = { path = "../../storage/storage_service", optional = true }
+proptest_helpers = { path = "../../common/proptest_helpers", optional = true }
+proptest = { version = "0.9.4", optional = true }
+
 [dev-dependencies]
 assert_matches = "1.3.0"
 rand = "0.6.5"
 storage_service = { path = "../../storage/storage_service" }
 types = { path = "../../types", features = ["testing"] }
+proptest_helpers = { path = "../../common/proptest_helpers" }
+proptest = "0.9.4"
 
 [build-dependencies]
 build_helpers = { path = "../../common/build_helpers" }
+
+[features]
+default = []
+fuzzing = ["storage_service", "proptest_helpers", "proptest"]

--- a/admission_control/admission_control_service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission_control_service/src/admission_control_fuzzing.rs
@@ -1,0 +1,63 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::AdmissionControlService;
+use crate::{
+    admission_control_service::SubmitTransactionRequest,
+    mocks::local_mock_mempool::LocalMockMempool,
+};
+use proptest;
+use proptest_helpers::ValueGenerator;
+use proto_conv::IntoProto;
+use protobuf;
+use std::sync::Arc;
+use storage_service::mocks::mock_storage_client::MockStorageReadClient;
+use types::transaction::SignedTransaction;
+use vm_validator::mocks::mock_vm_validator::MockVMValidator;
+
+#[test]
+fn test_fuzzer() {
+    let mut gen = ValueGenerator::new();
+    let data = generate_corpus(&mut gen);
+    fuzzer(&data);
+}
+
+/// generate_corpus produces an arbitrary SubmitTransactionRequest for admission control
+pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
+    // use proptest to generate a SignedTransaction
+    let signed_txn = gen.generate(proptest::arbitrary::any::<SignedTransaction>());
+    // wrap it in a SubmitTransactionRequest
+    let mut req = SubmitTransactionRequest::new();
+    req.set_signed_txn(signed_txn.into_proto());
+
+    protobuf::Message::write_to_bytes(&req).unwrap()
+}
+
+/// fuzzer takes a serialized SubmitTransactionRequest an process it with an admission control
+/// service
+pub fn fuzzer(data: &[u8]) {
+    // parse SubmitTransactionRequest
+    let req: SubmitTransactionRequest = match protobuf::parse_from_bytes(data) {
+        Ok(value) => value,
+        Err(_) => {
+            if cfg!(test) {
+                panic!();
+            }
+            return;
+        }
+    };
+
+    // create service to receive it
+    let ac_service = AdmissionControlService::new(
+        Some(Arc::new(LocalMockMempool::new())),
+        Arc::new(MockStorageReadClient),
+        Arc::new(MockVMValidator),
+        false,
+    );
+
+    // process the request
+    let res = ac_service.submit_transaction_inner(req);
+    if cfg!(test) && res.is_err() {
+        panic!();
+    }
+}

--- a/admission_control/admission_control_service/src/admission_control_service.rs
+++ b/admission_control/admission_control_service/src/admission_control_service.rs
@@ -40,6 +40,11 @@ use vm_validator::vm_validator::{get_account_state, TransactionValidation};
 #[path = "unit_tests/admission_control_service_test.rs"]
 mod admission_control_service_test;
 
+#[cfg(any(feature = "fuzzing", test))]
+#[path = "admission_control_fuzzing.rs"]
+/// fuzzing module for admission control
+pub mod fuzzing;
+
 /// Struct implementing trait (service handle) AdmissionControlService.
 #[derive(Clone)]
 pub struct AdmissionControlService<M, V> {

--- a/admission_control/admission_control_service/src/lib.rs
+++ b/admission_control/admission_control_service/src/lib.rs
@@ -14,12 +14,12 @@
 pub mod admission_control_node;
 /// AC gRPC service.
 pub mod admission_control_service;
+#[cfg(any(test, feature = "fuzzing"))]
+/// Useful Mocks
+pub mod mocks;
 use lazy_static::lazy_static;
 use metrics::OpMetrics;
 
 lazy_static! {
     static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("admission_control");
 }
-
-#[cfg(test)]
-mod unit_tests;

--- a/admission_control/admission_control_service/src/mocks/local_mock_mempool.rs
+++ b/admission_control/admission_control_service/src/mocks/local_mock_mempool.rs
@@ -13,13 +13,15 @@ use proto_conv::FromProto;
 use std::time::SystemTime;
 use types::{account_address::ADDRESS_LENGTH, transaction::SignedTransaction};
 
-// Define a local mempool to use for unit tests here, ignore methods not used by the test
+/// Define a local mempool to use for unit tests and fuzzing,
+/// ignore methods not used
 #[derive(Clone)]
 pub struct LocalMockMempool {
     created_time: SystemTime,
 }
 
 impl LocalMockMempool {
+    /// Creates a new instance of localMockMempool
     pub fn new() -> Self {
         Self {
             created_time: SystemTime::now(),

--- a/admission_control/admission_control_service/src/mocks/mod.rs
+++ b/admission_control/admission_control_service/src/mocks/mod.rs
@@ -1,0 +1,2 @@
+/// Mocker for the local mempool
+pub mod local_mock_mempool;

--- a/admission_control/admission_control_service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission_control_service/src/unit_tests/admission_control_service_test.rs
@@ -6,7 +6,7 @@ use crate::{
         AdmissionControlService, SubmitTransactionRequest,
         SubmitTransactionResponse as ProtoSubmitTransactionResponse,
     },
-    unit_tests::LocalMockMempool,
+    mocks::local_mock_mempool::LocalMockMempool,
 };
 use admission_control_proto::{AdmissionControlStatus, SubmitTransactionResponse};
 
@@ -23,7 +23,7 @@ use types::{
 };
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
-fn create_ac_service_for_ut() -> AdmissionControlService<LocalMockMempool, MockVMValidator> {
+pub fn create_ac_service_for_ut() -> AdmissionControlService<LocalMockMempool, MockVMValidator> {
     AdmissionControlService::new(
         Some(Arc::new(LocalMockMempool::new())),
         Arc::new(MockStorageReadClient),

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -23,7 +23,8 @@ structopt = { version = "0.2.18", default-features = false }
 types = { path = "../../types" }
 vm = { path = "../../language/vm" }
 vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types" }
-consensus = { path = "../../consensus"}
+consensus = { path = "../../consensus" }
+admission_control_service = { path = "../../admission_control/admission_control_service" }
 
 [dev-dependencies]
 datatest = "0.4.2"
@@ -37,4 +38,4 @@ vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types", fea
 [features]
 default = ["testing", "fuzzing"]
 testing = ["types/testing", "vm/testing", "vm_runtime_types/testing"]
-fuzzing = ["consensus/fuzzing"]
+fuzzing = ["consensus/fuzzing", "admission_control_service/fuzzing"]

--- a/testsuite/libra_fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets.rs
@@ -57,6 +57,7 @@ macro_rules! proto_fuzz_target {
 }
 
 // List fuzz target modules here.
+mod admission_control;
 mod compiled_module;
 mod consensus_proposal;
 mod inner_signed_transaction;
@@ -72,6 +73,7 @@ lazy_static! {
             Box::new(inner_signed_transaction::SignedTransactionTarget::default()),
             Box::new(vm_value::ValueTarget::default()),
             Box::new(consensus_proposal::ConsensusProposal::default()),
+            Box::new(admission_control::AdmissionControlSubmitTransactionRequest::default()),
         ];
         targets.into_iter().map(|target| (target.name(), target)).collect()
     };

--- a/testsuite/libra_fuzzer/src/fuzz_targets/admission_control.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets/admission_control.rs
@@ -1,0 +1,24 @@
+use crate::FuzzTargetImpl;
+use admission_control_service::admission_control_service::fuzzing::{fuzzer, generate_corpus};
+use proptest_helpers::ValueGenerator;
+
+#[derive(Clone, Debug, Default)]
+pub struct AdmissionControlSubmitTransactionRequest;
+
+impl FuzzTargetImpl for AdmissionControlSubmitTransactionRequest {
+    fn name(&self) -> &'static str {
+        module_name!()
+    }
+
+    fn description(&self) -> &'static str {
+        "Admission Control SubmitTransactionRequest"
+    }
+
+    fn generate(&self, _idx: usize, gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        Some(generate_corpus(gen))
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        fuzzer(data);
+    }
+}


### PR DESCRIPTION
MOTIVATION:

This PR adds a new fuzzer to our libra_fuzzer. It simply fuzzes admission_control's submit_transaction_inner() function.

TEST PLAN:

the fuzzer runs and the admission control tests still run
