### PR TITLE
[language][errors] insert space when appending error messages

### DIFF
--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    errors::{bounds_error, bytecode_offset_err, verification_error},
+    errors::{append_err_info, bounds_error, bytecode_offset_err, verification_error},
     file_format::{
         Bytecode, CompiledModuleMut, FieldDefinition, FunctionDefinition, FunctionHandle,
         FunctionSignature, LocalsSignature, ModuleHandle, SignatureToken, StructDefinition,
@@ -93,13 +93,7 @@ impl<'a> BoundsChecker<'a> {
             .map(|(idx, elem)| {
                 elem.check_code_unit_bounds(self.module)
                     .into_iter()
-                    .map(move |err| {
-                        err.append_message(format!(
-                            " at index {} while indexing {}",
-                            idx,
-                            IndexKind::FunctionDefinition
-                        ))
-                    })
+                    .map(move |err| append_err_info(err, IndexKind::FunctionDefinition, idx))
             })
             .flatten()
             .collect()
@@ -113,9 +107,9 @@ impl<'a> BoundsChecker<'a> {
     ) -> Vec<VMStatus> {
         iter.enumerate()
             .map(move |(idx, elem)| {
-                elem.check_bounds(module).into_iter().map(move |err| {
-                    err.append_message(format!(" at index {} while indexing {}", idx, kind))
-                })
+                elem.check_bounds(module)
+                    .into_iter()
+                    .map(move |err| append_err_info(err, kind, idx))
             })
             .flatten()
             .collect()

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -124,7 +124,7 @@ pub fn verification_error(kind: IndexKind, idx: usize, err: StatusCode) -> VMSta
 
 pub fn append_err_info(status: VMStatus, kind: IndexKind, idx: usize) -> VMStatus {
     let msg = format!("at index {} while indexing {}", idx, kind);
-    status.append_message(msg)
+    status.append_message_with_separator(' ', msg)
 }
 
 pub fn err_at_offset(status: StatusCode, offset: usize) -> VMStatus {

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -137,10 +137,13 @@ impl VMStatus {
     pub fn set_message(&mut self, message: String) {
         self.message = Some(message);
     }
-
-    /// Append the message `message` to the message field of the VM status.
-    pub fn append_message(mut self, message: String) -> Self {
+    /// Append the message `message` to the message field of the VM status, and insert a seperator
+    /// if the original message is non-empty.
+    pub fn append_message_with_separator(mut self, separator: char, message: String) -> Self {
         if let Some(ref mut msg) = self.message {
+            if !msg.is_empty() {
+                msg.push(separator);
+            }
             msg.push_str(&message);
         } else {
             self.message = Some(message);
@@ -192,8 +195,8 @@ impl VMStatus {
 
     /// Append two VMStatuses together. The major status is kept from the caller.
     pub fn append(self, other: Self) -> Self {
-        let msg = format!("\n{}", other);
-        self.append_message(msg)
+        let msg = format!("{}", other);
+        self.append_message_with_separator('\n', msg)
     }
 }
 


### PR DESCRIPTION
## Summary
Error messages in errors are messed up:
```
reference not allowedat index 10 while indexing locals signatureat index 9 while indexing function definition
```
This gets it fixed by inserting a space when appending if the original message is non-empty. The above now looks like this:
```
reference not allowed at index 10 while indexing locals signature at index 9 while indexing function definition
```

## Test Plan
Manually print sth out. Place the following function in `vm/src/errors.rs` and run `cargo test`.
```
#[test]
fn append_err_test() {
    println!(
        "{}",
        append_err_info(
            VMStatus::new(StatusCode::INVALID_SIGNATURE_TOKEN),
            IndexKind::FieldDefinition,
            5
        )
    );

    println!(
        "{}",
        append_err_info(
            VMStatus::new(StatusCode::INVALID_SIGNATURE_TOKEN).with_message("".to_string()),
            IndexKind::FieldDefinition,
            5
        )
    );

    println!(
        "{}",
        append_err_info(
            verification_error(
                IndexKind::TypeSignature,
                10,
                StatusCode::INVALID_SIGNATURE_TOKEN
            ),
            IndexKind::FieldDefinition,
            9
        )
    );
    assert!(false);
}
```