### PR TITLE
[language] remove output-path compiler argument

### DIFF
--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -8,7 +8,12 @@ use bytecode_verifier::{
 use compiler::{util, Compiler};
 use ir_to_bytecode::parser::{parse_module, parse_script};
 use serde_json;
-use std::{convert::TryFrom, fs, io::Write, path::PathBuf};
+use std::{
+    convert::TryFrom,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 use stdlib::stdlib_modules;
 use structopt::StructOpt;
 use types::{
@@ -26,9 +31,6 @@ use vm::file_format::CompiledModule;
     about = "Move IR to bytecode compiler."
 )]
 struct Args {
-    /// Serialize and write the compiled output to this file
-    #[structopt(short = "o", long = "output")]
-    pub output_path: Option<String>,
     /// Treat input file as a module (default is to treat file as a program)
     #[structopt(short = "m", long = "module")]
     pub module_input: bool,
@@ -72,11 +74,11 @@ fn do_verify_module(module: CompiledModule, dependencies: &[VerifiedModule]) -> 
     verified_module
 }
 
-fn write_output(path: &str, buf: &[u8]) {
+fn write_output(path: &PathBuf, buf: &[u8]) {
     let mut f = fs::File::create(path)
-        .unwrap_or_else(|err| panic!("Unable to open output file {}: {}", path, err));
+        .unwrap_or_else(|err| panic!("Unable to open output file {:?}: {}", path, err));
     f.write_all(&buf)
-        .unwrap_or_else(|err| panic!("Unable to write to output file {}: {}", path, err));
+        .unwrap_or_else(|err| panic!("Unable to write to output file {:?}: {}", path, err));
 }
 
 fn main() {
@@ -86,9 +88,22 @@ fn main() {
         .address
         .map(|a| AccountAddress::try_from(a).unwrap())
         .unwrap_or_else(AccountAddress::default);
+    let source_path = Path::new(&args.source_path);
+    let mvir_extension = "mvir";
+    let mv_extension = "mv";
+    let extension = source_path
+        .extension()
+        .expect("Missing file extension for input source file");
+    if extension != mvir_extension {
+        println!(
+            "Bad source file extension {:?}; expected {}",
+            extension, mvir_extension
+        );
+        std::process::exit(1);
+    }
 
     if args.list_dependencies {
-        let source = fs::read_to_string(args.source_path).expect("Unable to read file");
+        let source = fs::read_to_string(args.source_path.clone()).expect("Unable to read file");
         let dependency_list: Vec<AccessPath> = if args.module_input {
             let module = parse_module(&source).expect("Unable to parse module");
             module.get_external_deps()
@@ -99,17 +114,10 @@ fn main() {
         .into_iter()
         .map(|m| AccessPath::code_access_path(&m))
         .collect();
-        match args.output_path {
-            Some(path) => {
-                let deps_bytes =
-                    serde_json::to_vec(&dependency_list).expect("Unable to serialize dependencies");
-                write_output(&path, &deps_bytes);
-            }
-            None => println!(
-                "{}",
-                serde_json::to_string(&dependency_list).expect("Unable to serialize dependencies")
-            ),
-        }
+        println!(
+            "{}",
+            serde_json::to_string(&dependency_list).expect("Unable to serialize dependencies")
+        );
         return;
     }
 
@@ -136,7 +144,7 @@ fn main() {
     };
 
     if !args.module_input {
-        let source = fs::read_to_string(args.source_path).expect("Unable to read file");
+        let source = fs::read_to_string(args.source_path.clone()).expect("Unable to read file");
         let compiler = Compiler {
             address,
             code: &source,
@@ -156,22 +164,14 @@ fn main() {
             compiled_program
         };
 
-        match args.output_path {
-            Some(path) => {
-                let mut script = vec![];
-                compiled_program
-                    .script
-                    .serialize(&mut script)
-                    .expect("Unable to serialize script");
-                let payload = Script::new(script, vec![]);
-                let payload_bytes =
-                    serde_json::to_vec(&payload).expect("Unable to serialize program");
-                write_output(&path, &payload_bytes);
-            }
-            None => {
-                println!("{}", compiled_program);
-            }
-        }
+        let mut script = vec![];
+        compiled_program
+            .script
+            .serialize(&mut script)
+            .expect("Unable to serialize script");
+        let payload = Script::new(script, vec![]);
+        let payload_bytes = serde_json::to_vec(&payload).expect("Unable to serialize program");
+        write_output(&source_path.with_extension(mv_extension), &payload_bytes);
     } else {
         let compiled_module = util::do_compile_module(&args.source_path, address, &deps);
         let compiled_module = if !args.no_verify {
@@ -180,20 +180,12 @@ fn main() {
         } else {
             compiled_module
         };
-        match args.output_path {
-            Some(path) => {
-                let mut module = vec![];
-                compiled_module
-                    .serialize(&mut module)
-                    .expect("Unable to serialize module");
-                let payload = Module::new(module);
-                let payload_bytes =
-                    serde_json::to_vec(&payload).expect("Unable to serialize program");
-                write_output(&path, &payload_bytes);
-            }
-            None => {
-                println!("{}", compiled_module);
-            }
-        }
+        let mut module = vec![];
+        compiled_module
+            .serialize(&mut module)
+            .expect("Unable to serialize module");
+        let payload = Module::new(module);
+        let payload_bytes = serde_json::to_vec(&payload).expect("Unable to serialize program");
+        write_output(&source_path.with_extension(mv_extension), &payload_bytes);
     }
 }


### PR DESCRIPTION
After this change, the compiler always outputs the bytecode produced by compilation. It uses the input file name with .mvir replaced with .mv as the output file name. The compiler will now fail immediately if the file extension is not .mvir.

This is working toward allowing the compiler to support multiple source files on the command line.

## Motivation

See above. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Indeed.

## Test Plan

Ran on an `.mvir` to verify that output gets produced, ran on a file with a bad extension to verify that it gets rejected with a helpful error message.
