### PR TITLE
[scripts] Clean up unnecessary steps in coverage_report.sh

### DIFF
--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -69,27 +69,13 @@ then
 	fi
 fi
 
+# Set the flags necessary for coverage output
 export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Zno-landing-pads"
 export CARGO_INCREMENTAL=0
 
 # Clean the project
 echo "Cleaning project..."
 (cd $TEST_DIR; cargo clean)
-
-# Build with flags necessary for coverage output
-echo "Building with coverage instrumentation..."
-(cd $TEST_DIR; cargo build)
-
-# Remove existing coverage output
-echo "Cleaning existing coverage info..."
-if [ -d "./target" ]
-then
-	find target -type f -name "*.gcda" -delete
-	find target -type f -name "*.gcno" -delete
-else
-	echo "Error: target directory does not exist. Did cargo build fail?" >&2
-	exit 1
-fi
 
 # Run tests
 echo "Running tests..."


### PR DESCRIPTION

### Motivation

There should never be a need to remove gcda and gcno files
from the target directory:
- The script first runs "cargo clean", which removes the old target
  directory.
- Running "cargo build" will not create any data (gcda) files.
- Any gcno files created during the build should be kept, except...
There is no need to first run "cargo build" since "cargo test" will
also build the files to be tested.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I've run the coverage_report.sh script locally and manually verified that the results look sane.