### PR TITLE
[consensus] small refactorings in event_processor

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -284,13 +284,12 @@ where
             );
             // Note that the block might not be present locally, in which case we cannot calculate
             // time between block creation and qc
-            if let Some(block) = self.try_get_block(&block_id) {
-                if let Some(time_to_qc) = duration_since_epoch()
-                    .checked_sub(Duration::from_micros(block.timestamp_usecs()))
-                {
-                    counters::CREATION_TO_QC_S.observe_duration(time_to_qc);
-                }
+            if let Some(time_to_qc) = self.try_get_block(&block_id).and_then(|block| {
+                duration_since_epoch().checked_sub(Duration::from_micros(block.timestamp_usecs()))
+            }) {
+                counters::CREATION_TO_QC_S.observe_duration(time_to_qc);
             }
+
             return VoteReceptionResult::NewQuorumCertificate(Arc::new(quorum_cert));
         }
         VoteReceptionResult::VoteAdded(num_votes)

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -470,16 +470,18 @@ impl<T: Payload> EventProcessor<T> {
         self.safety_rules.update(qc);
 
         let mut highest_committed_proposal_round = None;
-        if let Some(new_commit) = qc.committed_block_id() {
-            if let Some(block) = self.block_store.get_block(new_commit) {
-                let finality_proof = qc.ledger_info().clone();
-                // We don't want to use NIL commits for pacemaker round interval calculations.
-                if !block.is_nil_block() {
-                    highest_committed_proposal_round = Some(block.round());
-                }
-                self.process_commit(block, finality_proof).await;
+        if let Some(block) = qc
+            .committed_block_id()
+            .and_then(|new_commit| self.block_store.get_block(new_commit))
+        {
+            // We don't want to use NIL commits for pacemaker round interval calculations.
+            if !block.is_nil_block() {
+                highest_committed_proposal_round = Some(block.round());
             }
+            let finality_proof = qc.ledger_info().clone();
+            self.process_commit(block, finality_proof).await;
         }
+
         if let Some(new_round_event) = self.pacemaker.process_certificates(
             qc.certified_block_round(),
             highest_committed_proposal_round,

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -402,17 +402,15 @@ impl<T: Payload> EventProcessor<T> {
             Some((vote, vote_round)) if (*vote_round == round) => Some(vote.clone()),
             _ => {
                 // Try to generate a backup vote
-                match self.gen_backup_vote(round).await {
+                let backup_vote_res = self.gen_backup_vote(round).await;
+                match &backup_vote_res {
                     Ok(backup_vote_msg) => {
                         self.last_vote_sent
                             .replace((backup_vote_msg.clone(), round));
-                        Some(backup_vote_msg)
                     }
-                    Err(e) => {
-                        warn!("Failed to generate a backup vote: {}", e);
-                        None
-                    }
-                }
+                    Err(e) => warn!("Failed to generate a backup vote: {}", e),
+                };
+                backup_vote_res.ok()
             }
         };
 


### PR DESCRIPTION
- reformulations with light Option / Result combinator usage
- removes a couple of `expect()` calls

Commits voluntarily split to ease review, will squash before bors merges.