### PR TITLE
[network] update error message for logging

### DIFF
--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -50,7 +50,7 @@ pub enum NetworkErrorKind {
     #[fail(display = "Parsing error")]
     ParsingError,
 
-    #[fail(display = "Peer disconnected")]
+    #[fail(display = "Failed to connect to peer")]
     NotConnected,
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Issue #961, change the error message to be more clear when we failed to connect to peer, instead of saying "Peer disconnected" which sounds like it was connected but dropped by peer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Run network validator
`cargo run -p libra_swarm -- -s -n 4 -l`
kill one of the node and then check the log:
```
W0918 12:56:15.431775 123145525075968 network/src/protocols/direct_send/mod.rs:315] DirectSend to peer 57ff8374 failed: Failed to connect to peer
W0918 12:56:15.431878 123145525075968 network/src/protocols/direct_send/mod.rs:315] DirectSend to peer 8deeeaed failed: Failed to connect to peer
W0918 12:56:15.432001 123145525075968 network/src/protocols/direct_send/mod.rs:315] DirectSend to peer ab0d6a54 failed: Failed to connect to peer
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
