### PR TITLE
Name threads for rayon thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "metrics 0.1.0",
  "network 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "state_synchronizer 0.1.0",
  "storage_client 0.1.0",

--- a/libra_node/Cargo.toml
+++ b/libra_node/Cargo.toml
@@ -11,6 +11,7 @@ grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-co
 grpcio-sys = "0.4.4"
 jemallocator = { version = "0.3.2", features = ["alloc_trait", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 parity-multiaddr = "0.5.0"
+rayon = "1.2.0"
 signal-hook = "0.1.10"
 tokio = "0.1.22"
 

--- a/libra_node/src/main_node.rs
+++ b/libra_node/src/main_node.rs
@@ -228,6 +228,13 @@ pub fn setup_network(
 pub fn setup_environment(node_config: &mut NodeConfig) -> (AdmissionControlClient, LibraHandle) {
     crash_handler::setup_panic_handler();
 
+    // Some of our code uses the rayon global thread pool. Name the rayon threads so it doesn't
+    // cause confusion, otherwise the threads would have their parent's name.
+    rayon::ThreadPoolBuilder::new()
+        .thread_name(|index| format!("rayon-global-{}", index))
+        .build_global()
+        .expect("Building rayon global thread pool should work.");
+
     let mut instant = Instant::now();
     let storage = start_storage_service(&node_config);
     debug!(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The code
https://github.com/libra/libra/blob/344391b12250d4c49cf31c71d70cf3b64050d38f/language/vm/vm_runtime/src/block_processor.rs#L64
uses rayon's parallel iterator, which initializes the rayon global thread pool the first time it runs. Since the parent thread is the `block_processor` thread in executor, all these rayon threads also have the name `block_processor`, which causes some confusion. We name these threads explicitly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

Run nodes locally and print out all thread names.

## Related PRs

None.
