### PR TITLE
Unify rand crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proto_conv 0.1.0",
  "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -708,7 +708,7 @@ dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proto_conv 0.1.0",
  "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemadb 0.1.0",
@@ -5037,7 +5037,7 @@ dependencies = [
  "chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.1.28"
 grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 lazy_static = "1.2.0"
 protobuf = "~2.7"
-rand = "0.7.0"
+rand = "0.6.5"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 structopt = "0.2.15"
 num_cpus = "1.10.1"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = { version = "0.2.5", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 parity-multiaddr = { version = "0.5.0", default-features = false }
 protobuf = "~2.7"
-rand = { version = "0.7.0", default-features = false }
+rand = { version = "0.6.5", default-features = false }
 rmp-serde = { version = "0.13.7", default-features = false }
 rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }

--- a/language/vm/vm_runtime/vm_cache_map/Cargo.toml
+++ b/language/vm/vm_runtime/vm_cache_map/Cargo.toml
@@ -13,4 +13,4 @@ typed-arena = "1.5.0"
 [dev-dependencies]
 crossbeam = "0.7.2"
 proptest = "0.9.4"
-rand = "0.7.0"
+rand = "0.6.5"


### PR DESCRIPTION
Currently code is mix of rand=0.7 and rand=0.6.5
This contributes to some compilation issues when rand object created in one crate is passed to another.
Since 0.6.5 is dominant in our codebase, this commit changes few crates that were using 0.7 to 0.6.5
