### PR TITLE
[VM][Tools] Branch coverage measurement for bytecode generator

### DIFF
--- a/language/tools/test_generation/measure_coverage.sh
+++ b/language/tools/test_generation/measure_coverage.sh
@@ -89,6 +89,6 @@ grcov $TOOL_DIR/../../../target/ -t lcov --llvm --branch --ignore-dir "/*" -o $C
 # Generate HTML report
 echo "Generating report at ${COVERAGE_DIR}..."
 # Flag "--ignore-errors source" ignores missing source files
-(cd $TOOL_DIR/../../../; genhtml -o $COVERAGE_DIR --show-details --highlight --ignore-errors source --legend $COVERAGE_DIR/lcov.info)
+(cd $TOOL_DIR/../../../; genhtml -o $COVERAGE_DIR --show-details --highlight --ignore-errors source --legend --branch-coverage $COVERAGE_DIR/lcov.info)
 
 echo "Done. Please view report at ${COVERAGE_DIR}/index.html"

--- a/language/tools/test_generation/src/control_flow_graph.rs
+++ b/language/tools/test_generation/src/control_flow_graph.rs
@@ -286,7 +286,7 @@ impl CFG {
                 block_queue.push_back(child_ids[1]);
             } else if child_ids.len() == 1 {
                 block_queue.push_back(child_ids[0]);
-            } else if child_ids.is_empty() {
+            } else if !child_ids.is_empty() {
                 // We construct the CFG such that blocks have either 0, 1, or 2
                 // children.
                 unreachable!(


### PR DESCRIPTION
## Motivation

This commit adds output of branch coverage data in generated coverage reports.

This commit also fixes a bug where an unreachable path became reachable due to
a typo.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Local testing with `cargo test`. 

## Related PRs

N/A
