### PR TITLE
[stdlib] Implement a padded p2p txn for testing.

### DIFF
--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -17,6 +17,7 @@ rand = "0.6.5"
 state_view = { path = "../../storage/state_view" }
 types = { path = "../../types" }
 vm = { path = "../vm" }
+vm_genesis = { path = "../vm/vm_genesis", features = ["testing"] }
 vm_runtime = { path = "../vm/vm_runtime" }
 vm_runtime_types = { path = "../vm/vm_runtime/vm_runtime_types" }
 proptest = "0.9.3"
@@ -29,5 +30,4 @@ logger = { path = "../../common/logger" }
 stdlib = { path = "../stdlib" }
 
 [dev-dependencies]
-vm_genesis = { path = "../vm/vm_genesis", features = ["testing"] }
 types = { path = "../../types", features = ["testing"] }

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -24,10 +24,10 @@ proptest-derive = "0.1.1"
 proptest_helpers = { path = "../../common/proptest_helpers" }
 protobuf = "~2.7"
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
-vm_genesis = { path = "../vm/vm_genesis" }
 config =  { path = "../../config" }
 logger = { path = "../../common/logger" }
 stdlib = { path = "../stdlib" }
 
 [dev-dependencies]
+vm_genesis = { path = "../vm/vm_genesis", features = ["testing"] }
 types = { path = "../../types", features = ["testing"] }

--- a/language/vm/vm_genesis/Cargo.toml
+++ b/language/vm/vm_genesis/Cargo.toml
@@ -29,3 +29,6 @@ proptest = "0.9.3"
 proptest-derive = "0.1.1"
 proptest_helpers = { path = "../../../common/proptest_helpers" }
 types = { path = "../../../types", features = ["testing"] }
+
+[features]
+testing = ["types/testing", "crypto/testing"]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As requested by @andll, we want to test out the overall performance when having a larger transaction. This helper function will pad the normal p2p transaction with a bunch of useless returns to get a larger transaction

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test case to make sure this padding behaves the same as a normal p2p transaction.