### PR TITLE
[Consensus] Fixes #384 Remember only last vote from Validator

### DIFF
--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -259,6 +259,10 @@ impl<Sig: Signature> LedgerInfoWithSignatures<Sig> {
         self.signatures.entry(validator).or_insert(signature);
     }
 
+    pub fn remove_signature(&mut self, validator: AccountAddress) {
+        self.signatures.remove(&validator);
+    }
+
     pub fn signatures(&self) -> &HashMap<AccountAddress, Sig> {
         &self.signatures
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently we aggregate all incoming votes. Malicious Validator can send large number of dummy votes leading to OOM because it's trying to keep them all in memory for potential aggregation. Proposed change only accounts of last vote from Author, older votes are pruned.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
1. Ran unit tests (`cargo test -p consensus`)
2. Added unit test (`test_malicious_vote_validator`)
2. Verified with debug logs to make sure exercised code behaves as expected.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
