### PR TITLE
[crypto, language, mempool, types] Even more combinator refactorings

### DIFF
--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -499,10 +499,7 @@ impl<'de> de::Visitor<'de> for Ed25519PrivateKeyVisitor {
     where
         E: de::Error,
     {
-        match Ed25519PrivateKey::try_from(value) {
-            Ok(key) => Ok(key),
-            Err(error) => Err(E::custom(error)),
-        }
+        Ed25519PrivateKey::try_from(value).map_err(E::custom)
     }
 }
 
@@ -517,10 +514,7 @@ impl<'de> de::Visitor<'de> for Ed25519PublicKeyVisitor {
     where
         E: de::Error,
     {
-        match Ed25519PublicKey::try_from(value) {
-            Ok(key) => Ok(key),
-            Err(error) => Err(E::custom(error)),
-        }
+        Ed25519PublicKey::try_from(value).map_err(E::custom)
     }
 }
 
@@ -535,10 +529,7 @@ impl<'de> de::Visitor<'de> for Ed25519SignatureVisitor {
     where
         E: de::Error,
     {
-        match Ed25519Signature::try_from(value) {
-            Ok(key) => Ok(key),
-            Err(error) => Err(E::custom(error)),
-        }
+        Ed25519Signature::try_from(value).map_err(E::custom)
     }
 }
 

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -326,10 +326,7 @@ impl<'de> de::Visitor<'de> for X25519StaticPrivateKeyVisitor {
     where
         E: de::Error,
     {
-        match X25519StaticPrivateKey::try_from(value) {
-            Ok(key) => Ok(key),
-            Err(error) => Err(E::custom(error)),
-        }
+        X25519StaticPrivateKey::try_from(value).map_err(E::custom)
     }
 }
 
@@ -344,10 +341,7 @@ impl<'de> de::Visitor<'de> for X25519StaticPublicKeyVisitor {
     where
         E: de::Error,
     {
-        match X25519StaticPublicKey::try_from(value) {
-            Ok(key) => Ok(key),
-            Err(error) => Err(E::custom(error)),
-        }
+        X25519StaticPublicKey::try_from(value).map_err(E::custom)
     }
 }
 

--- a/crypto/secret_service/src/unit_tests/secret_service_node_test.rs
+++ b/crypto/secret_service/src/unit_tests/secret_service_node_test.rs
@@ -81,8 +81,7 @@ fn test_generate_key() {
     gen_req.set_spec(KeyType::Ed25519);
 
     let result = client.generate_key(&gen_req);
-    if result.is_ok() {
-        let response = result.ok().unwrap();
+    if let Ok(response) = result {
         let is_successful = response.get_code() == ErrorCode::Success;
         assert!(is_successful);
     } else {

--- a/language/compiler/ir_to_bytecode/src/parser.rs
+++ b/language/compiler/ir_to_bytecode/src/parser.rs
@@ -85,10 +85,9 @@ fn strip_comments_and_verify(string: &str) -> Result<String> {
 pub fn parse_script_or_module(s: &str) -> Result<ast::ScriptOrModule> {
     let stripped_string = &strip_comments(s);
     let parser = syntax::ScriptOrModuleParser::new();
-    match parser.parse(stripped_string) {
-        Ok(result) => Ok(result),
-        Err(e) => handle_error(e, s),
-    }
+    parser
+        .parse(stripped_string)
+        .or_else(|e| handle_error(e, s))
 }
 
 /// Given the raw input of a file, creates a `Program` struct
@@ -96,10 +95,9 @@ pub fn parse_script_or_module(s: &str) -> Result<ast::ScriptOrModule> {
 pub fn parse_program(program_str: &str) -> Result<ast::Program> {
     let stripped_string = &strip_comments_and_verify(program_str)?;
     let parser = syntax::ProgramParser::new();
-    match parser.parse(stripped_string) {
-        Ok(program) => Ok(program),
-        Err(e) => handle_error(e, stripped_string),
-    }
+    parser
+        .parse(stripped_string)
+        .or_else(|e| handle_error(e, stripped_string))
 }
 
 /// Given the raw input of a file, creates a `Script` struct
@@ -107,10 +105,9 @@ pub fn parse_program(program_str: &str) -> Result<ast::Program> {
 pub fn parse_script(script_str: &str) -> Result<ast::Script> {
     let stripped_string = &strip_comments_and_verify(script_str)?;
     let parser = syntax::ScriptParser::new();
-    match parser.parse(stripped_string) {
-        Ok(script) => Ok(script),
-        Err(e) => handle_error(e, stripped_string),
-    }
+    parser
+        .parse(stripped_string)
+        .or_else(|e| handle_error(e, stripped_string))
 }
 
 /// Given the raw input of a file, creates a single `ModuleDefinition` struct
@@ -118,10 +115,9 @@ pub fn parse_script(script_str: &str) -> Result<ast::Script> {
 pub fn parse_module(modules_str: &str) -> Result<ast::ModuleDefinition> {
     let stripped_string = &strip_comments_and_verify(modules_str)?;
     let parser = syntax::ModuleParser::new();
-    match parser.parse(stripped_string) {
-        Ok(module) => Ok(module),
-        Err(e) => handle_error(e, stripped_string),
-    }
+    parser
+        .parse(stripped_string)
+        .or_else(|e| handle_error(e, stripped_string))
 }
 
 /// Given the raw input of a file, creates a single `Cmd` struct
@@ -129,10 +125,9 @@ pub fn parse_module(modules_str: &str) -> Result<ast::ModuleDefinition> {
 pub fn parse_cmd(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast::Cmd> {
     let stripped_string = &strip_comments_and_verify(cmd_str)?;
     let parser = syntax::CmdParser::new();
-    match parser.parse(stripped_string) {
-        Ok(cmd) => Ok(cmd),
-        Err(e) => handle_error(e, stripped_string),
-    }
+    parser
+        .parse(stripped_string)
+        .or_else(|e| handle_error(e, stripped_string))
 }
 
 fn handle_error<'input, T, Token>(

--- a/language/tools/test_generation/src/lib.rs
+++ b/language/tools/test_generation/src/lib.rs
@@ -41,9 +41,9 @@ use vm_runtime_types::value::Value;
 
 /// This function calls the Bytecode verifier to test it
 fn run_verifier(module: CompiledModule) -> Result<VerifiedModule, String> {
-    let verifier_panic = panic::catch_unwind(|| match VerifiedModule::new(module.clone()) {
-        Ok(verified_module) => Ok(verified_module),
-        Err((_, errs)) => Err(format!("Module verification failed: {:#?}", errs)),
+    let verifier_panic = panic::catch_unwind(|| {
+        VerifiedModule::new(module.clone())
+            .map_err(|(_, errs)| format!("Module verification failed: {:#?}", errs))
     });
     verifier_panic.unwrap_or_else(|err| Err(format!("Verifier panic: {:#?}", err)))
 }

--- a/language/tools/test_generation/src/transitions.rs
+++ b/language/tools/test_generation/src/transitions.rs
@@ -301,14 +301,12 @@ pub fn stack_unpack_struct(
 }
 
 pub fn stack_struct_has_field(state: &AbstractState, field_index: FieldDefinitionIndex) -> bool {
-    if let Some(abstract_value) = state.stack_peek(0).clone() {
-        if let Some(struct_handle_index) =
-            SignatureToken::get_struct_handle_from_reference(&abstract_value.token)
-        {
-            return state
-                .module
-                .is_field_in_struct(field_index, struct_handle_index);
-        }
+    if let Some(struct_handle_index) = state.stack_peek(0).clone().and_then(|abstract_value| {
+        SignatureToken::get_struct_handle_from_reference(&abstract_value.token)
+    }) {
+        return state
+            .module
+            .is_field_in_struct(field_index, struct_handle_index);
     }
     false
 }

--- a/language/vm/vm_runtime/src/block_processor.rs
+++ b/language/vm/vm_runtime/src/block_processor.rs
@@ -62,9 +62,9 @@ pub fn execute_block<'alloc>(
 
     let signature_verified_block: Vec<Result<SignatureCheckedTransaction, VMStatus>> = txn_block
         .into_par_iter()
-        .map(|txn| match txn.check_signature() {
-            Ok(t) => Ok(t),
-            Err(_) => Err(VMStatus::new(StatusCode::INVALID_SIGNATURE)),
+        .map(|txn| {
+            txn.check_signature()
+                .map_err(|_| VMStatus::new(StatusCode::INVALID_SIGNATURE))
         })
         .collect();
 

--- a/language/vm/vm_runtime/src/data_cache.rs
+++ b/language/vm/vm_runtime/src/data_cache.rs
@@ -264,10 +264,9 @@ impl<'txn> TransactionDataCache<'txn> {
             return Err(vm_error(Location::new(), StatusCode::INVALID_DATA));
         }
 
-        match write_set.freeze() {
-            Ok(ws) => Ok(ws),
-            Err(_) => Err(vm_error(Location::new(), StatusCode::DATA_FORMAT_ERROR)),
-        }
+        write_set
+            .freeze()
+            .map_err(|_| vm_error(Location::new(), StatusCode::DATA_FORMAT_ERROR))
     }
 
     /// Flush out the cache and restart from a clean state

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/signature.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/signature.rs
@@ -68,10 +68,7 @@ pub fn native_ed25519_signature_verification(mut arguments: VecDeque<Value>) -> 
         }
     };
 
-    let bool_value = match sig.verify_arbitrary_msg(msg.as_bytes(), &pk) {
-        Ok(()) => true,
-        Err(_) => false,
-    };
+    let bool_value = sig.verify_arbitrary_msg(msg.as_bytes(), &pk).is_ok();
     let return_values = vec![Value::bool(bool_value)];
     NativeReturnStatus::Success {
         cost,

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -70,10 +70,12 @@ impl TransactionStore {
         address: &AccountAddress,
         sequence_number: u64,
     ) -> Option<SignedTransaction> {
-        if let Some(txns) = self.transactions.get(&address) {
-            if let Some(txn) = txns.get(&sequence_number) {
-                return Some(txn.txn.clone());
-            }
+        if let Some(txn) = self
+            .transactions
+            .get(&address)
+            .and_then(|txns| txns.get(&sequence_number))
+        {
+            return Some(txn.txn.clone());
         }
         None
     }
@@ -144,10 +146,12 @@ impl TransactionStore {
         if self.system_ttl_index.size() >= self.capacity {
             // try to free some space in Mempool from ParkingLot
             if let Some((address, sequence_number)) = self.parking_lot_index.pop() {
-                if let Some(txns) = self.transactions.get_mut(&address) {
-                    if let Some(txn) = txns.remove(&sequence_number) {
-                        self.index_remove(&txn);
-                    }
+                if let Some(txn) = self
+                    .transactions
+                    .get_mut(&address)
+                    .and_then(|txns| txns.remove(&sequence_number))
+                {
+                    self.index_remove(&txn);
                 }
             }
         }
@@ -260,12 +264,14 @@ impl TransactionStore {
         let mut batch = vec![];
         let mut last_timeline_id = timeline_id;
         for (address, sequence_number) in self.timeline_index.read_timeline(timeline_id, count) {
-            if let Some(txns) = self.transactions.get_mut(&address) {
-                if let Some(txn) = txns.get(&sequence_number) {
-                    batch.push(txn.txn.clone());
-                    if let TimelineState::Ready(timeline_id) = txn.timeline_state {
-                        last_timeline_id = timeline_id;
-                    }
+            if let Some(txn) = self
+                .transactions
+                .get_mut(&address)
+                .and_then(|txns| txns.get(&sequence_number))
+            {
+                batch.push(txn.txn.clone());
+                if let TimelineState::Ready(timeline_id) = txn.timeline_state {
+                    last_timeline_id = timeline_id;
                 }
             }
         }

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -259,10 +259,7 @@ impl IntoProto for StatusCode {
 impl FromProto for StatusCode {
     type ProtoType = u64;
     fn from_proto(proto_code: Self::ProtoType) -> Result<Self> {
-        match StatusCode::try_from(proto_code) {
-            Ok(status) => Ok(status),
-            Err(_) => Ok(StatusCode::UNKNOWN_STATUS),
-        }
+        StatusCode::try_from(proto_code).or_else(|_| Ok(StatusCode::UNKNOWN_STATUS))
     }
 }
 


### PR DESCRIPTION
```
result match {
  case Err(x) => Err(f(x))
  case Ok(x) => Ok(x)
}
``` 
is `result.map_err(f)`

```
result match {
  case Err(x) => foo(x)
  case Ok(x) => Ok(x)
}
``` 
is `result.or_else(|x| foo(x))` (unless it fits in the previous case)

```
if let Some(x) = outerpattern {
  if let Some(y) = innerpattern(x) {
 ...
  }
}
``` 
is often (though [not always](https://github.com/libra/libra/pull/982/files#r325742507)) 
```
if let Some(y) = outerpattern.and_then(|x| innerpattern(x)) {
 ...
}
```

```
result match {
  Ok(_) => true
  None => false
}
```
is `result.is_ok()`

