### PR TITLE
[language][bytecode verifier] implement instantiation loop checker

### DIFF
--- a/language/bytecode_verifier/src/instantiation_loops.rs
+++ b/language/bytecode_verifier/src/instantiation_loops.rs
@@ -1,0 +1,282 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This implements an algorithm that detects loops during the instantiation of generics.
+//!
+//! It builds a graph from the given `CompiledModule` and converts the original problem into
+//! finding strongly connected components in the graph with certain properties. Read the
+//! documentation of the types/functions below for details of how it works.
+//!
+//! Note: We're doing generics only up to specialization, and are doing a conservative check of
+//! generic call sites to eliminate those which could lead to an infinite number of specialized
+//! instances. We do reject recursive functions that create a new type upon each call but do
+//! terminate eventually.
+
+use petgraph::{
+    algo::tarjan_scc,
+    graph::{EdgeIndex, NodeIndex},
+    visit::EdgeRef,
+    Graph,
+};
+use std::collections::{hash_map, HashMap, HashSet};
+use types::vm_error::{StatusCode, VMStatus};
+use vm::{
+    access::ModuleAccess,
+    file_format::{
+        Bytecode, CompiledModule, FunctionDefinition, FunctionDefinitionIndex, FunctionHandleIndex,
+        LocalsSignatureIndex, SignatureToken, TypeParameterIndex,
+    },
+};
+
+/// Data attached to each node.
+/// Each node corresponds to a type formal of a generic function in the module.
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+struct Node(FunctionDefinitionIndex, TypeParameterIndex);
+
+/// Data attached to each edge. Indicating the type of the edge.
+enum Edge<'a> {
+    /// This type of edge from type formal T1 to T2 means the type bound to T1 is used to
+    /// instantiate T2 unmodified, thus the name `Identity`.
+    ///
+    /// Example:
+    /// ```
+    /// //    foo<T>() { bar<T>(); return; }
+    /// //
+    /// //    edge: foo_T --Id--> bar_T
+    /// ```
+    Identity,
+    /// This type of edge from type formal T1 to T2 means T2 is instantiated with a type resulted
+    /// by applying one or more type constructors to T1 (potentially with other types).
+    ///
+    /// This is interesting to us as it creates a new (and bigger) type.
+    ///
+    /// Example:
+    /// ```
+    /// //    struct Baz<T> {}
+    /// //    foo<T>() { bar<Baz<T>>(); return; }
+    /// //
+    /// //    edge: foo_T --TyConApp(Baz<T>)--> bar_T
+    /// ```
+    TyConApp(&'a SignatureToken),
+}
+
+pub struct InstantiationLoopChecker<'a> {
+    module: &'a CompiledModule,
+
+    graph: Graph<Node, Edge<'a>>,
+    node_map: HashMap<Node, NodeIndex>,
+    func_handle_def_map: HashMap<FunctionHandleIndex, FunctionDefinitionIndex>,
+}
+
+impl<'a> InstantiationLoopChecker<'a> {
+    pub fn new(module: &'a CompiledModule) -> Self {
+        Self {
+            module,
+            graph: Graph::new(),
+            node_map: HashMap::new(),
+            func_handle_def_map: module
+                .function_defs()
+                .iter()
+                .enumerate()
+                .map(|(def_idx, def)| (def.function, FunctionDefinitionIndex::new(def_idx as u16)))
+                .collect(),
+        }
+    }
+
+    /// Retrives the node corresponding to the specified type formal.
+    /// If none exists in the graph yet, create one.
+    fn get_or_add_node(&mut self, node: Node) -> NodeIndex {
+        match self.node_map.entry(node) {
+            hash_map::Entry::Occupied(entry) => *entry.get(),
+            hash_map::Entry::Vacant(entry) => {
+                let idx = self.graph.add_node(node);
+                entry.insert(idx);
+                idx
+            }
+        }
+    }
+
+    /// Helper function that extracts type parameters from a given type.
+    /// Duplicated entries are removed.
+    fn extract_type_parameters(ty: &SignatureToken) -> HashSet<TypeParameterIndex> {
+        use SignatureToken::*;
+
+        let mut type_params = HashSet::new();
+
+        fn rec(type_params: &mut HashSet<TypeParameterIndex>, ty: &SignatureToken) {
+            match ty {
+                Bool | Address | U64 | String | ByteArray => (),
+                TypeParameter(idx) => {
+                    type_params.insert(*idx);
+                }
+                Reference(ty) | MutableReference(ty) => rec(type_params, ty),
+                Struct(_, tys) => {
+                    for ty in tys {
+                        rec(type_params, ty);
+                    }
+                }
+            }
+        }
+
+        rec(&mut type_params, ty);
+        type_params
+    }
+
+    /// Helper function that creates an edge from one given node to the other.
+    /// If a node does not exist, create one.
+    fn add_edge(&mut self, node_from: Node, node_to: Node, edge: Edge<'a>) {
+        let node_from_idx = self.get_or_add_node(node_from);
+        let node_to_idx = self.get_or_add_node(node_to);
+        self.graph.add_edge(node_from_idx, node_to_idx, edge);
+    }
+
+    /// Helper of 'fn build_graph' that inspects a function call. If type parameters of the caller
+    /// appear in the type actuals to the callee, nodes and edges are added to the graph.
+    fn build_graph_call(
+        &mut self,
+        caller_idx: FunctionDefinitionIndex,
+        callee_idx: FunctionDefinitionIndex,
+        type_actuals_idx: LocalsSignatureIndex,
+    ) {
+        let type_actuals = &self.module.locals_signature_at(type_actuals_idx).0;
+
+        for (formal_idx, ty) in type_actuals.iter().enumerate() {
+            let formal_idx = formal_idx as TypeParameterIndex;
+            match ty {
+                SignatureToken::TypeParameter(actual_idx) => self.add_edge(
+                    Node(caller_idx, *actual_idx),
+                    Node(callee_idx, formal_idx),
+                    Edge::Identity,
+                ),
+                _ => {
+                    for type_param in Self::extract_type_parameters(ty) {
+                        self.add_edge(
+                            Node(caller_idx, type_param),
+                            Node(callee_idx, formal_idx),
+                            Edge::TyConApp(&ty),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Helper of `fn build_graph` that inspects a function definition for calls between two generic
+    /// functions defined in the current module.
+    fn build_graph_function_def(
+        &mut self,
+        caller_idx: FunctionDefinitionIndex,
+        caller_def: &FunctionDefinition,
+    ) {
+        for instr in &caller_def.code.code {
+            if let Bytecode::Call(callee_handle_idx, type_actuals_idx) = instr {
+                // Get the id of the definition of the function being called.
+                // Skip if the function is not defined in the current module, as we do not
+                // have mutual recursions across module boundaries.
+                if let Some(callee_idx) = self.func_handle_def_map.get(&callee_handle_idx) {
+                    let callee_idx = *callee_idx;
+                    self.build_graph_call(caller_idx, callee_idx, *type_actuals_idx)
+                }
+            }
+        }
+    }
+
+    /// Builds a graph G such that
+    ///   - Each type formal of a generic function is a node in G.
+    ///   - There is an edge from type formal f_T to g_T if f_T is used to instantiate g_T in a
+    ///     call.
+    ///     - Each edge is labeled either `Identity` or `TyConApp`. See `Edge` for details.
+    fn build_graph(&mut self) {
+        for (def_idx, func_def) in self
+            .module
+            .function_defs()
+            .iter()
+            .filter(|def| !def.is_native())
+            .enumerate()
+        {
+            self.build_graph_function_def(FunctionDefinitionIndex::new(def_idx as u16), func_def)
+        }
+    }
+
+    /// Computes the strongly connected components of the graph built and keep the ones that
+    /// contain at least one `TyConApp` edge. Such components indicate there exists a loop such
+    /// that an input type can get "bigger" infinitely many times along the loop, also creating
+    /// infinitely many types. This is precisely the kind of constructs we want to forbid.
+    fn find_non_trivial_components(&self) -> Vec<(Vec<NodeIndex>, Vec<EdgeIndex>)> {
+        tarjan_scc(&self.graph)
+            .into_iter()
+            .filter_map(move |nodes| {
+                let node_set: HashSet<_> = nodes.iter().cloned().collect();
+
+                let edges: Vec<_> = nodes
+                    .iter()
+                    .flat_map(|node_idx| {
+                        self.graph.edges(*node_idx).filter_map(|edge| {
+                            if node_set.contains(&edge.target()) {
+                                Some(edge.id())
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .collect();
+
+                if edges.iter().any(
+                    |edge_idx| match self.graph.edge_weight(*edge_idx).unwrap() {
+                        Edge::Identity => false,
+                        Edge::TyConApp(_) => true,
+                    },
+                ) {
+                    Some((nodes, edges))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn format_node(&self, node_idx: NodeIndex) -> String {
+        let Node(def_idx, param_idx) = self.graph.node_weight(node_idx).unwrap();
+        format!("f{}#{}", def_idx, param_idx)
+    }
+
+    fn format_edge(&self, edge_idx: EdgeIndex) -> String {
+        let (node_idx_1, node_idx_2) = self.graph.edge_endpoints(edge_idx).unwrap();
+        let node_1 = self.format_node(node_idx_1);
+        let node_2 = self.format_node(node_idx_2);
+
+        match self.graph.edge_weight(edge_idx).unwrap() {
+            Edge::TyConApp(ty) => format!("{} --{:?}--> {}", node_1, ty, node_2,),
+            Edge::Identity => format!("{} ----> {}", node_1, node_2),
+        }
+    }
+
+    pub fn verify(mut self) -> Vec<VMStatus> {
+        self.build_graph();
+        let components = self.find_non_trivial_components();
+
+        components
+            .into_iter()
+            .map(|(nodes, edges)| {
+                let msg_edges = edges
+                    .into_iter()
+                    .filter_map(|edge_idx| match self.graph.edge_weight(edge_idx).unwrap() {
+                        Edge::TyConApp(_) => Some(self.format_edge(edge_idx)),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let msg_nodes = nodes
+                    .into_iter()
+                    .map(|node_idx| self.format_node(node_idx))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let msg = format!(
+                    "edges with constructors: [{}], nodes: [{}]",
+                    msg_edges, msg_nodes
+                );
+                VMStatus::new(StatusCode::LOOP_IN_INSTANTIATION_GRAPH).with_message(msg)
+            })
+            .collect()
+    }
+}

--- a/language/bytecode_verifier/src/lib.rs
+++ b/language/bytecode_verifier/src/lib.rs
@@ -10,6 +10,7 @@ pub mod acquires_list_verifier;
 pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod control_flow_graph;
+pub mod instantiation_loops;
 pub mod nonce;
 pub mod partition;
 pub mod resources;

--- a/language/bytecode_verifier/src/verifier.rs
+++ b/language/bytecode_verifier/src/verifier.rs
@@ -4,8 +4,8 @@
 //! This module contains the public APIs supported by the bytecode verifier.
 use crate::{
     check_duplication::DuplicationChecker, code_unit_verifier::CodeUnitVerifier,
-    resources::ResourceTransitiveChecker, signature::SignatureChecker,
-    struct_defs::RecursiveStructDefChecker,
+    instantiation_loops::InstantiationLoopChecker, resources::ResourceTransitiveChecker,
+    signature::SignatureChecker, struct_defs::RecursiveStructDefChecker,
 };
 use failure::Error;
 use std::{collections::BTreeMap, fmt};
@@ -162,6 +162,9 @@ impl VerifiedModule {
         }
         if errors.is_empty() {
             errors.append(&mut RecursiveStructDefChecker::new(&module).verify());
+        }
+        if errors.is_empty() {
+            errors.append(&mut InstantiationLoopChecker::new(&module).verify())
         }
         if errors.is_empty() {
             errors.append(&mut CodeUnitVerifier::verify(&module));

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/complex_1.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/complex_1.mvir
@@ -1,0 +1,48 @@
+module M {
+    struct S<T> {}
+
+    a<T>() {
+        Self.b<Self.S<T>, u64>();
+        return;
+    }
+
+    b<T1, T2>() {
+        Self.f<T1>();
+        Self.c<Self.S<T2>, bool>();
+        return;
+    }
+
+    c<T1, T2>() {
+        Self.c<u64, T1>();
+        Self.d<T2>();
+        Self.e<T2>();
+        return;
+    }
+
+    d<T>() {
+        Self.b<u64, T>();
+        return;
+    }
+
+    e<T>() {
+        return;
+    }
+
+    f<T>() {
+        Self.g<T>();
+        return;
+    }
+
+    g<T>() {
+        Self.f<Self.S<T>>();
+        return;
+    }
+}
+
+// There are two disjoint loops in the resulting graph:
+
+// loop 1: f#T --> g#T --S<T>--> f#T
+// check: LOOP_IN_INSTANTIATION_GRAPH
+
+// loop 2: c#T1 --> c#T2 --> d#T --> b#T2 --S<T2>--> c#T1
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_just_type_params_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_just_type_params_ok.mvir
@@ -1,0 +1,11 @@
+module M {
+    f<T>() {
+        Self.g<T>();
+        return;
+    }
+
+    g<T>() {
+        Self.f<T>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_non_generic_type_ok.mvir
@@ -1,0 +1,13 @@
+module M {
+    struct S<T> {}
+
+    f<T>() {
+        Self.g<Self.S<T>>();
+        return;
+    }
+
+    g<T>() {
+        Self.f<u64>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.mvir
@@ -1,0 +1,16 @@
+module M {
+    f<T1, T2, T3>() {
+        Self.g<T2, T3, T1>();
+        return;
+    }
+
+    g<T1, T2, T3>() {
+        Self.h<T1, T2, T3>();
+        return;
+    }
+
+    h<T1, T2, T3>() {
+        Self.f<T1, T2, T3>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.mvir
@@ -1,0 +1,19 @@
+module M {
+    struct S<T> {}
+
+    f<T1, T2, T3>() {
+        Self.g<T2, T3, T1>();
+        return;
+    }
+
+    g<T1, T2, T3>() {
+        Self.h<T1, T2, Self.S<T3>>();
+        return;
+    }
+
+    h<T1, T2, T3>() {
+        // The bool breaks the chain.
+        Self.f<T1, bool, T3>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
@@ -1,0 +1,20 @@
+module M {
+    struct S<T> {}
+
+    f<T1, T2, T3>() {
+        Self.g<T2, T3, T1>();
+        return;
+    }
+
+    g<T1, T2, T3>() {
+        Self.h<T1, T2, Self.S<T3>>();
+        return;
+    }
+
+    h<T1, T2, T3>() {
+        Self.f<T1, T2, T3>();
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.mvir
@@ -1,0 +1,11 @@
+module M {
+    f<T1, T2>() {
+        Self.g<u64, T1>();
+        return;
+    }
+
+    g<T1, T2>() {
+        Self.f<bool, T1>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.mvir
@@ -1,0 +1,11 @@
+module M {
+    f<T1, T2>() {
+        Self.g<T2, T1>();
+        return;
+    }
+
+    g<T1, T2>() {
+        Self.f<T1, T2>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
@@ -1,0 +1,15 @@
+module M {
+    struct S<T> {}
+
+    f<T1, T2>() {
+        Self.g<T2, T1>();
+        return;
+    }
+
+    g<T1, T2>() {
+        Self.f<T1, Self.S<T2>>();
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_type_con.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/mutually_recursive_type_con.mvir
@@ -1,0 +1,18 @@
+// Not good: infinitely many types/instances.
+//           f<T>, g<S<T>>, f<S<T>>, g<S<S<T>>>, ...
+
+module M {
+    struct S<T> {}
+
+    f<T>() {
+        Self.g<Self.S<T>>();
+        return;
+    }
+
+    g<T>() {
+        Self.f<T>();
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/nested_types_1.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/nested_types_1.mvir
@@ -1,0 +1,10 @@
+module M {
+    struct S<T> {}
+
+    foo<T>() {
+        Self.foo<Self.S<Self.S<T>>>();
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/nested_types_2.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/nested_types_2.mvir
@@ -1,0 +1,11 @@
+module M {
+    struct S<T> {}
+    struct R<T1, T2> {}
+
+    foo<T>() {
+        Self.foo<Self.R<u64, Self.S<Self.S<T>>>>();
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_infinite_type_terminates.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_infinite_type_terminates.mvir
@@ -1,0 +1,40 @@
+module M {
+    struct Box<T> { x: T }
+
+    unbox<T>(b: Self.Box<T>): T {
+        let x: T;
+        Box<T> { x: x } = move(b);
+        return move(x);
+    }
+
+    f<T>(n: u64, x: T): T {
+        if (copy(n) == 0) {
+            return move(x);
+        }
+        return Self.unbox<T>(Self.f<Self.Box<T>>(copy(n) - 1, Box<T> { x: move(x) }));
+    }
+}
+
+// Function f calls an instance of itself instantiated with a boxed type, but it does
+// terminate properly if we allow new types to be created on the fly.
+//
+// As reference, the equivalent Haskell code compiles & terminates:
+//
+//   data Boxed a = Box a
+//
+//   unbox (Box a) = a
+//
+//   f :: Integer -> a -> a
+//   f 0 x = x
+//   f n x = unbox (f (n-1) (Box x))
+//
+//    main = do
+//      let x = 42
+//      putStrLn (show (f 5 x))
+//
+// Without the annotation f :: Integer -> a -> a GHC complains about not being able to
+// construct the infinite type a ~ Boxed a.
+//
+// We are taking a conservative approach and forbids such construction in move.
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_one_arg_just_type_params_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_one_arg_just_type_params_ok.mvir
@@ -1,0 +1,8 @@
+// This is good as there is only one instance foo<T> for any T.
+
+module M {
+    f<T>(x: T) {
+        Self.f<T>(move(x));
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_one_arg_non_generic_type_ok.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_one_arg_non_generic_type_ok.mvir
@@ -1,0 +1,8 @@
+// Good: two instances foo<T> & foo<u64> (if T != u64) for any T.
+
+module M {
+    f<T>() {
+        Self.f<u64>();
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_one_arg_type_con.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_one_arg_type_con.mvir
@@ -1,0 +1,12 @@
+// Bad! Can have infinitely many instances: f<T>, f<S<T>>, f<S<S<T>>>, ...
+
+module M {
+    struct S<T> {}
+
+    f<T>(x: T) {
+        Self.f<Self.S<T>>(S<T> {});
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_two_args_swapping_type_con.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/recursive_two_args_swapping_type_con.mvir
@@ -1,0 +1,13 @@
+// Similar to the case with one argument, but swaps the two type parameters.
+// f<T1, T2> => f<S<T2>, T1> => f<S<T1>, S<T2>> => f<S<S<T2>>, S<T1>> => ...
+
+module M {
+    struct S<T> { x: T }
+
+    f<T1, T2>(a: T1, b: T2) {
+        Self.f<Self.S<T2>, T1>(S<T2> { x: move(b) }, move(a));
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/instantiation_loops/two_loops.mvir
+++ b/language/functional_tests/tests/testsuite/generics/instantiation_loops/two_loops.mvir
@@ -1,0 +1,19 @@
+// Two loops in the resulting graph.
+// One error for each loop.
+
+module M {
+    struct S<T> {}
+
+    f<T>() {
+        Self.f<Self.S<T>>();
+        return;
+    }
+
+    g<T>() {
+        Self.g<Self.S<T>>();
+        return;
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/functional_tests/tests/testsuite/generics/option.mvir
+++ b/language/functional_tests/tests/testsuite/generics/option.mvir
@@ -1,0 +1,31 @@
+module Option {
+    import 0x0.Vector;
+
+    struct T<E> {
+        v: Vector.T<E>
+    }
+
+    public none<E>(): Self.T<E> {
+        return T<E> { v: Vector.empty<E>() };
+    }
+
+    public some<E>(e: E): Self.T<E> {
+        let v: Vector.T<E>;
+        v = Vector.empty<E>();
+        Vector.push_back<E>(&mut v, move(e));
+        return T<E> { v: move(v) };
+    }
+
+    public unwrap_or<E: unrestricted>(x: Self.T<E>, e: E): E {
+        let v: Vector.T<E>;
+        T<E> { v: v } = move(x);
+        if (Vector.is_empty<E>(&v)) {
+            return move(e);
+        }
+        return Vector.pop_back<E>(&mut v);
+    }
+
+    public really_none<E: unrestricted>(): Self.T<E> {
+        return Self.unwrap_or<Self.T<E>>(Self.none<Self.T<E>>(), Self.none<E>());
+    }
+}

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -407,6 +407,7 @@ pub enum StatusCode {
     GLOBAL_REFERENCE_ERROR = 1073,
     CONTRAINT_KIND_MISMATCH = 1074,
     NUMBER_OF_TYPE_ACTUALS_MISMATCH = 1075,
+    LOOP_IN_INSTANTIATION_GRAPH = 1076,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.


### PR DESCRIPTION
## Summary
Inside the scope of a generic function, it is possible to use a (bound) type parameter as type argument to another generic function. This can be categorized into two forms:

1) Simply passing the type parameter through. 
```
// non-recursive
foo<T>() {
    bar<T>();
}

// recursive
foo<T>() {
    foo<T>();
}
```
This form is benign even when recursive, as there is only a finite number of instances/types.

2) Some type constructor is applied to a (bound) type parameter and the resulting type is used as an argument to some other generic function. 
```
struct S<T> {}

foo<T>() {
    foo<S<T>>();
}
```
This is problematic when one or more functions are mutually recursive (form a loop), as it creates infinitely many types & (monomorphic) instances of the function.

This PR implements a checker that catches and errors on such cases.

## Algorithm Overview
Let `f_i,j` be the `j^th` type parameter of the `i^th` function.

Let `G` be a directed graph where
- Each `f_i,j` is a node.
- There is an edge from `f_a,b` to `f_c,d` if `f_a,b` is used as argument bound to `f_c,d`.
  - Mark the edge as blue if no type constructors are involved. (Case 1 above.)
  - Mark the edge as red if there are type constructor applications. (Case 2 above.)
- Detecting loops is equivalent to finding strongly connected components in `G` with at least one red edge.

## Test Plan
New tests added.
```
cargo test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/libra/libra/1002)
<!-- Reviewable:end -->
