### PR TITLE
[language][Bytecode Verifier] Fix Stack Usage Verifier

### DIFF
--- a/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/mod.rs
+++ b/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/mod.rs
@@ -4,6 +4,7 @@
 pub mod bounds_tests;
 pub mod code_unit_tests;
 pub mod duplication_tests;
+pub mod negative_stack_size_tests;
 pub mod resources_tests;
 pub mod signature_tests;
 pub mod struct_defs_tests;

--- a/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/negative_stack_size_tests.rs
+++ b/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/negative_stack_size_tests.rs
@@ -1,0 +1,50 @@
+use bytecode_verifier::CodeUnitVerifier;
+use types::vm_error::StatusCode;
+use vm::file_format::{self, Bytecode};
+
+#[test]
+fn one_pop_no_push() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::Pop, Bytecode::Ret]);
+    let errors = CodeUnitVerifier::verify(&module);
+    println!("{:?}", errors);
+    assert_eq!(
+        errors[0].major_status,
+        StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
+    );
+}
+
+#[test]
+fn one_pop_one_push() {
+    // Height: 0 + (-1 + 1) = 0 would have passed original usage verifier
+    let module = file_format::dummy_procedure_module(vec![Bytecode::ReadRef, Bytecode::Ret]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert_eq!(
+        errors[0].major_status,
+        StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
+    );
+}
+
+#[test]
+fn two_pop_one_push() {
+    // Height: 0 + 1 + (-2 + 1) = 0 would have passed original usage verifier
+    let module = file_format::dummy_procedure_module(vec![
+        Bytecode::LdConst(0),
+        Bytecode::Add,
+        Bytecode::Ret,
+    ]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert_eq!(
+        errors[0].major_status,
+        StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
+    );
+}
+
+#[test]
+fn two_pop_no_push() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::WriteRef, Bytecode::Ret]);
+    let errors = CodeUnitVerifier::verify(&module);
+    assert_eq!(
+        errors[0].major_status,
+        StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK
+    );
+}


### PR DESCRIPTION
## Motivation

The Stack Usage Verifier must maintain the invariant that the stack height never goes below zero. Currently, it fails to do this in some cases. This is because the Stack Usage Verifier only tracks the net change in stack height of an instruction. If an instruction performs one pop and one push, the net change will be zero. Thus, the Stack Usage Verifier would allow this instruction even if the stack was empty before the instruction.

The fix is to track the number of pops and the number of pushes an instruction does separately. The number of pops are decremented from the stack height first, and then the invariant of the stack height never going below zero is checked.

This is a fix for issue #1001 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added tests in `bytecode_verifier_tests`. Local testing with `cargo test` and with 10,000 iterations of the test generation tool (`language/tools/test_generation`).

## Related PRs

N/A
