### PR TITLE
[admission control, client, language, testsuite] Other small refactors

### DIFF
--- a/admission_control/admission_control_service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission_control_service/src/unit_tests/admission_control_service_test.rs
@@ -34,11 +34,8 @@ pub fn create_ac_service_for_ut() -> AdmissionControlService<LocalMockMempool, M
 
 fn assert_status(response: ProtoSubmitTransactionResponse, status: VMStatus) {
     let rust_resp = SubmitTransactionResponse::from_proto(response).unwrap();
-    if rust_resp.ac_status.is_some() {
-        assert_eq!(
-            rust_resp.ac_status.unwrap(),
-            AdmissionControlStatus::Accepted
-        );
+    if let Some(resp_ac_status) = rust_resp.ac_status {
+        assert_eq!(resp_ac_status, AdmissionControlStatus::Accepted);
     } else {
         let decoded_response = rust_resp.vm_error.unwrap();
         assert_eq!(decoded_response.major_status, status.major_status);

--- a/client/src/query_commands.rs
+++ b/client/src/query_commands.rs
@@ -181,8 +181,7 @@ impl Command for QueryCommandGetTxnByRange {
                         cur_version,
                         txn.format_for_client(get_transaction_name)
                     );
-                    if opt_events.is_some() {
-                        let events = opt_events.unwrap();
+                    if let Some(events) = opt_events {
                         if events.is_empty() {
                             println!("No events returned");
                         } else {

--- a/language/bytecode_verifier/invalid_mutations/src/bounds.rs
+++ b/language/bytecode_verifier/invalid_mutations/src/bounds.rs
@@ -409,26 +409,26 @@ impl ApplyOutOfBoundsContext {
         module: &'b CompiledModule,
     ) -> impl Iterator<Item = FunctionSignatureTokenIndex> + 'b {
         let module_view = ModuleView::new(module);
-        let return_tokens = module_view
-            .function_signatures()
-            .enumerate()
-            .map(|(idx, signature)| {
-                let idx = FunctionSignatureIndex::new(idx as u16);
-                Self::find_struct_tokens(signature.return_tokens(), move |arg_idx| {
-                    FunctionSignatureTokenIndex::ReturnType(idx, arg_idx)
-                })
-            })
-            .flatten();
-        let arg_tokens = module_view
-            .function_signatures()
-            .enumerate()
-            .map(|(idx, signature)| {
-                let idx = FunctionSignatureIndex::new(idx as u16);
-                Self::find_struct_tokens(signature.arg_tokens(), move |arg_idx| {
-                    FunctionSignatureTokenIndex::ArgType(idx, arg_idx)
-                })
-            })
-            .flatten();
+        let return_tokens =
+            module_view
+                .function_signatures()
+                .enumerate()
+                .flat_map(|(idx, signature)| {
+                    let idx = FunctionSignatureIndex::new(idx as u16);
+                    Self::find_struct_tokens(signature.return_tokens(), move |arg_idx| {
+                        FunctionSignatureTokenIndex::ReturnType(idx, arg_idx)
+                    })
+                });
+        let arg_tokens =
+            module_view
+                .function_signatures()
+                .enumerate()
+                .flat_map(|(idx, signature)| {
+                    let idx = FunctionSignatureIndex::new(idx as u16);
+                    Self::find_struct_tokens(signature.arg_tokens(), move |arg_idx| {
+                        FunctionSignatureTokenIndex::ArgType(idx, arg_idx)
+                    })
+                });
         return_tokens.chain(arg_tokens)
     }
 
@@ -440,11 +440,10 @@ impl ApplyOutOfBoundsContext {
         module_view
             .locals_signatures()
             .enumerate()
-            .map(|(idx, signature)| {
+            .flat_map(|(idx, signature)| {
                 let idx = LocalsSignatureIndex::new(idx as u16);
                 Self::find_struct_tokens(signature.tokens(), move |arg_idx| (idx, arg_idx))
             })
-            .flatten()
     }
 
     #[inline]

--- a/language/bytecode_verifier/src/code_unit_verifier.rs
+++ b/language/bytecode_verifier/src/code_unit_verifier.rs
@@ -30,13 +30,12 @@ impl<'a> CodeUnitVerifier<'a> {
             .function_defs()
             .iter()
             .enumerate()
-            .map(move |(idx, function_definition)| {
+            .flat_map(move |(idx, function_definition)| {
                 verifier
                     .verify_function(function_definition)
                     .into_iter()
                     .map(move |err| append_err_info(err, IndexKind::FunctionDefinition, idx))
             })
-            .flatten()
             .collect()
     }
 

--- a/language/bytecode_verifier/src/signature.rs
+++ b/language/bytecode_verifier/src/signature.rs
@@ -64,12 +64,11 @@ impl<'a> SignatureChecker<'a> {
     ) -> Vec<VMStatus> {
         views
             .enumerate()
-            .map(move |(idx, view)| {
+            .flat_map(move |(idx, view)| {
                 view.check_signatures()
                     .into_iter()
                     .map(move |err| append_err_info(err, kind, idx))
             })
-            .flatten()
             .collect()
     }
 }

--- a/language/tools/cost_synthesis/src/bytecode_specifications/stack_transition_info.rs
+++ b/language/tools/cost_synthesis/src/bytecode_specifications/stack_transition_info.rs
@@ -175,9 +175,9 @@ fn type_transitions(args: Vec<(Vec<SignatureTy>, Vec<SignatureTy>)>) -> Vec<Call
 
 macro_rules! type_transition {
     (fixed: $e1:expr => $e2:expr) => {
-        $e1.into_iter().map(|vec| {
+        $e1.into_iter().flat_map(|vec| {
             type_transitions(vec![ (vec,$e2.clone())]).into_iter()
-        }).flatten().collect()
+        }).collect()
     };
     ($($e1:expr => $e2:expr),+) => {
         type_transitions(vec![ $(($e1,$e2)),+ ])

--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -90,12 +90,11 @@ impl<'a> BoundsChecker<'a> {
             .function_defs
             .iter()
             .enumerate()
-            .map(|(idx, elem)| {
+            .flat_map(|(idx, elem)| {
                 elem.check_code_unit_bounds(self.module)
                     .into_iter()
                     .map(move |err| append_err_info(err, IndexKind::FunctionDefinition, idx))
             })
-            .flatten()
             .collect()
     }
 
@@ -106,12 +105,11 @@ impl<'a> BoundsChecker<'a> {
         module: &CompiledModuleMut,
     ) -> Vec<VMStatus> {
         iter.enumerate()
-            .map(move |(idx, elem)| {
+            .flat_map(move |(idx, elem)| {
                 elem.check_bounds(module)
                     .into_iter()
                     .map(move |err| append_err_info(err, kind, idx))
             })
-            .flatten()
             .collect()
     }
 }

--- a/testsuite/cluster_test/src/health/aws_log_tail.rs
+++ b/testsuite/cluster_test/src/health/aws_log_tail.rs
@@ -310,11 +310,7 @@ impl AwsLogThread {
 
     fn log_stream_to_validator_short_str(&self, s: &str) -> Option<String> {
         let cap = self.re_validator.captures(s);
-        if let Some(cap) = cap {
-            Some(cap[1].into())
-        } else {
-            None
-        }
+        cap.map(|cap| cap[1].into())
     }
 
     fn parse_commit_log_entry(&self, e: &LogEntry) -> Option<Commit> {


### PR DESCRIPTION
Following in #999 footsteps:
- `iter.map(..).flatten()` is `iter.flat_map(..)`
- `if option.is_some() { let foo = option.unwrap(); .. }` is often `if let Some(foo) = option { .. }`
- `if let Some(foo) = option { Some(bar(foo)} } else { None }` is `option.map(bar)`