### PR TITLE
[cluster_test] Add start/stop container command

### DIFF
--- a/testsuite/cluster_test/src/effects/mod.rs
+++ b/testsuite/cluster_test/src/effects/mod.rs
@@ -1,9 +1,17 @@
 mod reboot;
+mod stop_container;
 
 use failure;
 pub use reboot::Reboot;
+use std::fmt::Display;
+pub use stop_container::StopContainer;
 
-pub trait Effect {
+pub trait Action: Display {
     fn apply(&self) -> failure::Result<()>;
     fn is_complete(&self) -> bool;
+}
+
+pub trait Effect: Display {
+    fn activate(&self) -> failure::Result<()>;
+    fn deactivate(&self) -> failure::Result<()>;
 }

--- a/testsuite/cluster_test/src/effects/reboot.rs
+++ b/testsuite/cluster_test/src/effects/reboot.rs
@@ -1,5 +1,6 @@
-use crate::{effects::Effect, instance::Instance};
+use crate::{effects::Action, instance::Instance};
 use failure;
+use std::fmt;
 
 pub struct Reboot {
     instance: Instance,
@@ -11,7 +12,7 @@ impl Reboot {
     }
 }
 
-impl Effect for Reboot {
+impl Action for Reboot {
     fn apply(&self) -> failure::Result<()> {
         println!("Rebooting {}", self.instance);
         self.instance.run_cmd(vec![
@@ -36,5 +37,11 @@ impl Effect for Reboot {
                 false
             }
         }
+    }
+}
+
+impl fmt::Display for Reboot {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Reboot {}", self.instance)
     }
 }

--- a/testsuite/cluster_test/src/effects/stop_container.rs
+++ b/testsuite/cluster_test/src/effects/stop_container.rs
@@ -1,0 +1,32 @@
+use crate::{effects::Effect, instance::Instance};
+use failure;
+use std::fmt;
+
+pub struct StopContainer {
+    instance: Instance,
+}
+
+impl StopContainer {
+    pub fn new(instance: Instance) -> Self {
+        Self { instance }
+    }
+}
+
+impl Effect for StopContainer {
+    fn activate(&self) -> failure::Result<()> {
+        self.instance
+            .run_cmd(vec!["sudo /usr/sbin/service docker stop"])
+    }
+
+    fn deactivate(&self) -> failure::Result<()> {
+        self.instance.run_cmd(vec![
+            "sudo /usr/sbin/service docker start && sudo /usr/sbin/service ecs start",
+        ])
+    }
+}
+
+impl fmt::Display for StopContainer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Stop container {}", self.instance)
+    }
+}

--- a/testsuite/cluster_test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster_test/src/experiments/reboot_random_validator.rs
@@ -1,6 +1,6 @@
 use crate::{
     cluster::Cluster,
-    effects::{Effect, Reboot},
+    effects::{Action, Reboot},
     experiments::Experiment,
     instance::Instance,
 };

--- a/testsuite/cluster_test/src/health/commit_check.rs
+++ b/testsuite/cluster_test/src/health/commit_check.rs
@@ -81,6 +81,11 @@ impl HealthCheck for CommitHistoryHealthCheck {
         }
     }
 
+    fn clear(&mut self) {
+        self.round_to_commit.clear();
+        self.latest_committed_round.clear();
+    }
+
     fn name(&self) -> &'static str {
         "commit_check"
     }

--- a/testsuite/cluster_test/src/health/mod.rs
+++ b/testsuite/cluster_test/src/health/mod.rs
@@ -60,6 +60,9 @@ pub trait HealthCheck {
     /// Optionally marks validator as failed, requiring waiting for at least one event from it to
     /// mark it as healthy again
     fn invalidate(&mut self, _validator: &str) {}
+    /// Clean is invoked when cluster is wiped
+    /// This means that checks like commit history check should wipe internal state
+    fn clear(&mut self) {}
 
     fn name(&self) -> &'static str;
 }
@@ -143,6 +146,12 @@ impl HealthCheckRunner {
     pub fn invalidate(&mut self, validator: &str) {
         for hc in self.health_checks.iter_mut() {
             hc.invalidate(validator);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        for hc in self.health_checks.iter_mut() {
+            hc.clear();
         }
     }
 }


### PR DESCRIPTION
This diff add commands to stop and start containers for given validators:
```
cluster_test --stop [--peers hash1,hash2,...]
cluster_test --start [--peers hash1,hash2,...]
```

Unlike reboot/restart, `--stop` keeps container stopped, until `--start` is applied.
This is useful in multiple scenarios:

1) **It helps to add stability to deployment process.** We need to wipe db during deploy to protect against incompatibilities in code. However, wiping db when validators are running is very error prone. So new deployment process is this:
  (a) stop containers
  (b) wipe database
  (c) update ECS task definitions
  (d) start containers

2) **It can be used to measure performance when 1,2,.. validators are down.** Reboot effect can not be reliably used for this, because it brings validator back quite fast, we might not be able to reliably measure throughput in this short window
