### PR TITLE
Introduce `datatest-stable` and drop dependency on `datatest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,19 +1045,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "datatest"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "datatest-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "datatest"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1069,16 +1056,6 @@ dependencies = [
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "datatest-derive"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1480,7 +1457,7 @@ version = "0.1.0"
 dependencies = [
  "bytecode_verifier 0.1.0",
  "config 0.1.0",
- "datatest 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datatest-stable 0.1.0",
  "failure_ext 0.1.0",
  "filecheck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir_to_bytecode 0.1.0",
@@ -5437,9 +5414,7 @@ dependencies = [
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 "checksum curve25519-fiat 0.1.0 (git+https://github.com/calibra/rust-curve25519-fiat.git)" = "<none>"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
-"checksum datatest 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "84e897b28c4c9b48f075c097e95166d20980fe677fbd9ee2a15f0ee0a75d357e"
 "checksum datatest 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "65953e846a0d185efc288231ddd168433b279ad844e74894a8aa161f7d068b67"
-"checksum datatest-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff6b740f8fae44d8b478755745ecb1f594233d14724410bb41d859b7460742ad"
 "checksum datatest-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7ceba1437c20ca644ddfad247dc326d7984ec99525aa7c3cefea51f6ec98c8c"
 "checksum derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "942ca430eef7a3806595a6737bc388bf51adb888d3fc0dd1b50f1c170167ee3a"
 "checksum derive-new 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,15 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,31 +1033,6 @@ source = "git+https://github.com/calibra/rust-curve25519-fiat.git#d7e302335abaaa
 name = "data-encoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "datatest"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ctor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "datatest-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "datatest-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "datatest-stable"
@@ -2089,7 +2055,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical_serialization 0.1.0",
  "consensus 0.1.0",
- "datatest 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datatest-stable 0.1.0",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3894,17 +3860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "serializer_tests"
 version = "0.1.0"
 dependencies = [
@@ -5024,11 +4979,6 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "version_check"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "vm"
 version = "0.1.0"
 dependencies = [
@@ -5302,14 +5252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "yamux"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,14 +5350,11 @@ dependencies = [
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ct-logs 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
-"checksum ctor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5b6b2f4752cc29efbfd03474c532ce8f916f2d44ec5bb8c21f93bc76e5365528"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)" = "<none>"
 "checksum curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 "checksum curve25519-fiat 0.1.0 (git+https://github.com/calibra/rust-curve25519-fiat.git)" = "<none>"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
-"checksum datatest 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "65953e846a0d185efc288231ddd168433b279ad844e74894a8aa161f7d068b67"
-"checksum datatest-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7ceba1437c20ca644ddfad247dc326d7984ec99525aa7c3cefea51f6ec98c8c"
 "checksum derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "942ca430eef7a3806595a6737bc388bf51adb888d3fc0dd1b50f1c170167ee3a"
 "checksum derive-new 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
@@ -5649,7 +5588,6 @@ dependencies = [
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
-"checksum serde_yaml 0.8.9 (registry+https://github.com/rust-lang/crates.io-index)" = "38b08a9a90e5260fe01c6480ec7c811606df6d3a660415808c3c3fa8ed95b582"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
@@ -5746,7 +5684,6 @@ dependencies = [
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
@@ -5767,6 +5704,5 @@ dependencies = [
 "checksum x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)" = "<none>"
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum yamux 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01bd67889938c48f0049fc60a77341039e6c3eaf16cb7693e6ead7c0ba701295"
 "checksum zstd-sys 1.4.13+zstd.1.4.3 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "datatest-stable"
+version = "0.1.0"
+dependencies = [
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "debug_interface"
 version = "0.1.0"
 dependencies = [
@@ -2943,6 +2953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4332,6 +4352,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "structopt"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "structopt-derive"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,6 +4369,18 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5545,6 +5586,7 @@ dependencies = [
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e688f31d92ffd7c1ddc57a1b4e6d773c0f2a14ee437a4b0a4f5a69c80eb221c8"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -5665,7 +5707,9 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+"checksum structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe8d3289b63ef2f196d89e7701f986583c0895e764b78f052a55b9b5d34d84a"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+"checksum structopt-derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3add731f5b4fb85931d362a3c92deb1ad7113649a8d51701fb257673705f122"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "common/bounded-executor",
     "common/canonical_serialization",
     "common/crash_handler",
+    "common/datatest-stable",
     "common/debug_interface",
     "common/executable_helpers",
     "common/failure_ext",

--- a/common/datatest-stable/Cargo.toml
+++ b/common/datatest-stable/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "datatest-stable"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+regex = "1.3.1"
+walkdir = "2.2.9"
+structopt = "0.3.2"
+termcolor = "1.0.5"
+
+[[test]]
+name = "example"
+harness = false

--- a/common/datatest-stable/src/lib.rs
+++ b/common/datatest-stable/src/lib.rs
@@ -1,0 +1,30 @@
+//! `datatest-stable` is a very simple test harness intended to meet some of the needs provided by
+//! the `datatest` crate when using a stable rust compiler without using the `RUSTC_BOOTSTRAP` hack
+//! to use nightly features on the stable track.
+//!
+//! In order to setup data-driven tests for a particular test target you must do the following:
+//! 1. Configure the test target by setting the following in the `Cargo.toml`
+//! ```lang=toml
+//! [[test]]
+//! name = "<test target name>"
+//! harness = false
+//! ```
+//!
+//! 2. Call the `datatest_stable::harness!(testfn, root, pattern)` macro with the following
+//! parameters:
+//! * `testfn` - The test function to be executed on each matching input. This function must have
+//!   the type `fn(&Path) -> datatest_stable::Result<()>`
+//! * `root` - The path to the root directory where the input files live. This path is relative to
+//!   the root of the crate.
+//! * `pattern` - the regex used to match against and select each file to be tested.
+//!
+//! The three parameters can be repeated if you have multiple sets of data-driven tests to be run:
+//! `datatest_stable::harness!(testfn1, root1, pattern1, testfn2, root2, pattern2)`
+
+mod macros;
+mod runner;
+mod utils;
+
+pub type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error>>;
+
+pub use self::runner::{runner, Requirements};

--- a/common/datatest-stable/src/macros.rs
+++ b/common/datatest-stable/src/macros.rs
@@ -1,0 +1,25 @@
+/// `datatest-stable` test harness entry point. Should be declared in the test module.
+///
+/// Also, `harness` should be set to `false` for that test module in `Cargo.toml` (see [Configuring
+/// a target](https://doc.rust-lang.org/cargo/reference/manifest.html#configuring-a-target)).
+#[macro_export]
+macro_rules! harness {
+    ( $( $name:path, $root:expr, $pattern:expr ),+ $(,)* ) => {
+        fn main() {
+            let mut requirements = Vec::new();
+
+            $(
+                requirements.push(
+                    $crate::Requirements::new(
+                        $name,
+                        stringify!($name).to_string(),
+                        $root.to_string(),
+                        $pattern.to_string()
+                    )
+                );
+            )+
+
+            $crate::runner(&requirements);
+        }
+    };
+}

--- a/common/datatest-stable/src/runner.rs
+++ b/common/datatest-stable/src/runner.rs
@@ -1,0 +1,285 @@
+use crate::{utils, Result};
+use std::{
+    io::{self, Write},
+    num::NonZeroUsize,
+    panic::{catch_unwind, AssertUnwindSafe},
+    path::Path,
+    process,
+    sync::mpsc::{channel, Sender},
+    thread,
+};
+use structopt::StructOpt;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+#[derive(Debug, StructOpt)]
+#[structopt(about = "Datatest-harness for running data-driven tests")]
+struct TestOpts {
+    /// The FILTER string is tested against the name of all tests, and only those tests whose names
+    /// contain the filter are run.
+    filter: Option<String>,
+    #[structopt(long = "exact")]
+    /// Exactly match filters rather than by substring
+    filter_exact: bool,
+    #[structopt(long, default_value = "32", env = "RUST_TEST_THREADS")]
+    /// Number of threads used for running tests in parallel
+    test_threads: NonZeroUsize,
+    #[structopt(short = "q", long)]
+    /// Output minimal information
+    quiet: bool,
+    #[structopt(long)]
+    /// We already can't capture anything but we don't want arg parsing to fail so this is a noop
+    nocapture: bool,
+}
+
+pub fn runner(reqs: &[Requirements]) {
+    let options = TestOpts::from_args();
+
+    let tests = reqs.iter().flat_map(|req| req.expand()).collect();
+
+    match run_tests(options, tests) {
+        Ok(true) => {}
+        Ok(false) => process::exit(101),
+        Err(e) => {
+            eprintln!("error: io error when running tests: {:?}", e);
+            process::exit(101);
+        }
+    }
+}
+
+struct Test {
+    testfn: Box<dyn Fn() -> Result<()> + Send>,
+    name: String,
+}
+
+enum TestResult {
+    Ok,
+    Failed,
+    FailedWithMsg(String),
+}
+
+fn run_tests(options: TestOpts, tests: Vec<Test>) -> io::Result<bool> {
+    let total = tests.len();
+
+    // Filter out tests
+    let mut remaining = match &options.filter {
+        None => tests,
+        Some(filter) => tests
+            .into_iter()
+            .filter(|test| {
+                if options.filter_exact {
+                    test.name == filter[..]
+                } else {
+                    test.name.contains(&filter[..])
+                }
+            })
+            .rev()
+            .collect(),
+    };
+
+    let filtered_out = total - remaining.len();
+    let mut summary = TestSummary::new(total, filtered_out);
+
+    if !options.quiet {
+        summary.write_starting_msg()?;
+    }
+
+    let (tx, rx) = channel();
+
+    let mut pending = 0;
+    while pending > 0 || !remaining.is_empty() {
+        while pending < options.test_threads.get() && !remaining.is_empty() {
+            let test = remaining.pop().unwrap();
+            run_test(test, tx.clone());
+            pending += 1;
+        }
+
+        let (name, result) = rx.recv().unwrap();
+        summary.handle_result(name, result)?;
+
+        pending -= 1;
+    }
+
+    // Write Test Summary
+    if !options.quiet {
+        summary.write_summary()?;
+    }
+
+    Ok(summary.success())
+}
+
+fn run_test(test: Test, channel: Sender<(String, TestResult)>) {
+    let Test { name, testfn } = test;
+
+    let cfg = thread::Builder::new().name(name.clone());
+    cfg.spawn(move || {
+        let result = match catch_unwind(AssertUnwindSafe(|| testfn())) {
+            Ok(Ok(())) => TestResult::Ok,
+            Ok(Err(e)) => TestResult::FailedWithMsg(format!("{:?}", e)),
+            Err(_) => TestResult::Failed,
+        };
+
+        channel.send((name, result)).unwrap();
+    })
+    .unwrap();
+}
+
+struct TestSummary {
+    stdout: StandardStream,
+    total: usize,
+    filtered_out: usize,
+    passed: usize,
+    failed: Vec<String>,
+}
+
+impl TestSummary {
+    fn new(total: usize, filtered_out: usize) -> Self {
+        Self {
+            stdout: StandardStream::stdout(ColorChoice::Auto),
+            total,
+            filtered_out,
+            passed: 0,
+            failed: Vec::new(),
+        }
+    }
+
+    fn handle_result(&mut self, name: String, result: TestResult) -> io::Result<()> {
+        write!(self.stdout, "test {} ... ", name)?;
+        match result {
+            TestResult::Ok => {
+                self.passed += 1;
+                self.write_ok()?;
+            }
+            TestResult::Failed => {
+                self.failed.push(name);
+                self.write_failed()?;
+            }
+            TestResult::FailedWithMsg(msg) => {
+                self.failed.push(name);
+                self.write_failed()?;
+                writeln!(self.stdout)?;
+
+                write!(self.stdout, "Error: {}", msg)?;
+            }
+        }
+        writeln!(self.stdout)?;
+        Ok(())
+    }
+
+    fn write_ok(&mut self) -> io::Result<()> {
+        self.stdout
+            .set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+        write!(self.stdout, "ok")?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    fn write_failed(&mut self) -> io::Result<()> {
+        self.stdout
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+        write!(self.stdout, "FAILED")?;
+        self.stdout.reset()?;
+        Ok(())
+    }
+
+    fn write_starting_msg(&mut self) -> io::Result<()> {
+        writeln!(self.stdout)?;
+        writeln!(
+            self.stdout,
+            "running {} tests",
+            self.total - self.filtered_out
+        )?;
+        Ok(())
+    }
+
+    fn write_summary(&mut self) -> io::Result<()> {
+        // Print out the failing tests
+        if !self.failed.is_empty() {
+            writeln!(self.stdout)?;
+            writeln!(self.stdout, "failures:")?;
+            for name in &self.failed {
+                writeln!(self.stdout, "    {}", name)?;
+            }
+        }
+
+        writeln!(self.stdout)?;
+        write!(self.stdout, "test result: ")?;
+        if self.failed.is_empty() {
+            self.write_ok()?;
+        } else {
+            self.write_failed()?;
+        }
+        writeln!(
+            self.stdout,
+            ". {} passed; {} failed; {} filtered out",
+            self.passed,
+            self.failed.len(),
+            self.filtered_out
+        )?;
+        writeln!(self.stdout)?;
+        Ok(())
+    }
+
+    fn success(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+pub struct Requirements {
+    test: fn(&Path) -> Result<()>,
+    test_name: String,
+    root: String,
+    pattern: String,
+}
+
+impl Requirements {
+    pub fn new(
+        test: fn(&Path) -> Result<()>,
+        test_name: String,
+        root: String,
+        pattern: String,
+    ) -> Self {
+        Self {
+            test,
+            test_name,
+            root,
+            pattern,
+        }
+    }
+
+    /// Generate standard test descriptors ([`test::TestDescAndFn`]) from the descriptor of
+    /// `#[datatest::files(..)]`.
+    ///
+    /// Scans all files in a given directory, finds matching ones and generates a test descriptor
+    /// for each of them.
+    fn expand(&self) -> Vec<Test> {
+        let root = Path::new(&self.root).to_path_buf();
+
+        let re = regex::Regex::new(&self.pattern)
+            .unwrap_or_else(|_| panic!("invalid regular expression: '{}'", self.pattern));
+
+        let tests: Vec<_> = utils::iterate_directory(&root)
+            .filter_map(|path| {
+                let input_path = path.to_string_lossy();
+                if re.is_match(&input_path) {
+                    let testfn = self.test;
+                    let name = utils::derive_test_name(&root, &path, &self.test_name);
+                    let testfn = Box::new(move || (testfn)(&path));
+
+                    Some(Test { testfn, name })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // We want to avoid silent fails due to typos in regexp!
+        if tests.is_empty() {
+            panic!(
+                "no test cases found for test '{}'. Scanned directory: '{}' with pattern '{}'",
+                self.test_name, self.root, self.pattern,
+            );
+        }
+
+        tests
+    }
+}

--- a/common/datatest-stable/src/utils.rs
+++ b/common/datatest-stable/src/utils.rs
@@ -1,0 +1,30 @@
+use std::path::{Path, PathBuf};
+
+/// Helper function to iterate through all the files in the given directory, skipping hidden files,
+/// and return an iterator of their paths.
+pub fn iterate_directory(path: &Path) -> impl Iterator<Item = PathBuf> {
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .map(::std::result::Result::unwrap)
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map_or(false, |s| !s.starts_with('.')) // Skip hidden files
+        })
+        .map(|entry| entry.path().to_path_buf())
+}
+
+pub fn derive_test_name(root: &Path, path: &Path, test_name: &str) -> String {
+    let relative = path.strip_prefix(root).unwrap_or_else(|_| {
+        panic!(
+            "failed to strip prefix '{}' from path '{}'",
+            root.display(),
+            path.display()
+        )
+    });
+    let mut test_name = test_name.to_string();
+    test_name.push_str(&format!("::{}", relative.display()));
+    test_name
+}

--- a/common/datatest-stable/tests/example.rs
+++ b/common/datatest-stable/tests/example.rs
@@ -1,0 +1,12 @@
+use datatest_stable::Result;
+use std::{fs::File, io::Read, path::Path};
+
+fn test_artifact(path: &Path) -> Result<()> {
+    let mut file = File::open(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+
+    Ok(())
+}
+
+datatest_stable::harness!(test_artifact, "tests/files", r"^.*/*");

--- a/common/datatest-stable/tests/files/a
+++ b/common/datatest-stable/tests/files/a
@@ -1,0 +1,1 @@
+baz stuff

--- a/common/datatest-stable/tests/files/b
+++ b/common/datatest-stable/tests/files/b
@@ -1,0 +1,1 @@
+This is a test file

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -17,9 +17,13 @@ language_e2e_tests = { path = "../e2e_tests" }
 config = { path = "../../config" }
 transaction_builder = { path = "../transaction_builder" }
 filecheck = "0.4.0"
-datatest = "0.3.5"
 lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 
 [dev-dependencies]
 types = { path = "../../types", features = ["testing"] }
+datatest-stable = { path = "../../common/datatest-stable" }
+
+[[test]]
+name = "testsuite"
+harness = false

--- a/language/functional_tests/tests/testsuite.rs
+++ b/language/functional_tests/tests/testsuite.rs
@@ -1,15 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![feature(custom_test_frameworks)]
-#![test_runner(datatest::runner)]
-
-use functional_tests::{checker::check, errors::*, evaluator::eval, utils::parse_input};
+use functional_tests::{checker::check, evaluator::eval, utils::parse_input};
+use std::{fs::File, io::Read, path::Path};
 
 // Runs all tests under the test/testsuite directory.
-#[datatest::files("tests/testsuite", { input in r".*\.mvir" })]
-fn functional_tests(input: &str) -> Result<()> {
-    let (config, directives, transactions) = parse_input(input)?;
+fn functional_tests(path: &Path) -> datatest_stable::Result<()> {
+    let mut file = File::open(path)?;
+    let mut input = String::new();
+    file.read_to_string(&mut input)?;
+
+    let (config, directives, transactions) = parse_input(&input)?;
     let res = eval(&config, &transactions)?;
     if let Err(e) = check(&res, &directives) {
         if res.use_debug_output {
@@ -17,7 +18,9 @@ fn functional_tests(input: &str) -> Result<()> {
         } else {
             println!("{}", res);
         }
-        return Err(e);
+        return Err(e.into());
     }
     Ok(())
 }
+
+datatest_stable::harness!(functional_tests, "tests/testsuite", r".*\.mvir");

--- a/language/vm/vm_runtime/src/process_txn/validate.rs
+++ b/language/vm/vm_runtime/src/process_txn/validate.rs
@@ -122,7 +122,7 @@ where
                 )?)
             }
             TransactionPayload::Module(module) => {
-                println!("validate module {:?}", module);
+                debug!("validate module {:?}", module);
                 Some(ValidatedTransaction::validate(
                     &txn,
                     module_cache,

--- a/scripts/nightly_features.sh
+++ b/scripts/nightly_features.sh
@@ -8,7 +8,6 @@ set -e
 # Allowed Features
 allowed_features=(
   "--and" "--not" "-e" "async_await"
-  "--and" "--not" "-e" "custom_test_frameworks"
 )
 
 # Search for nightly features

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -27,7 +27,7 @@ consensus = { path = "../../consensus" }
 admission_control_service = { path = "../../admission_control/admission_control_service" }
 
 [dev-dependencies]
-datatest = "0.4.2"
+datatest-stable = { path = "../../common/datatest-stable" }
 stats_alloc = "0.1.8"
 rusty-fork = "0.2.2"
 
@@ -39,3 +39,7 @@ vm_runtime_types = { path = "../../language/vm/vm_runtime/vm_runtime_types", fea
 default = ["testing", "fuzzing"]
 testing = ["types/testing", "vm/testing", "vm_runtime_types/testing"]
 fuzzing = ["consensus/fuzzing", "admission_control_service/fuzzing"]
+
+[[test]]
+name = "artifacts"
+harness = false

--- a/testsuite/libra_fuzzer/tests/artifacts.rs
+++ b/testsuite/libra_fuzzer/tests/artifacts.rs
@@ -3,9 +3,6 @@
 
 //! Test artifacts: examples known to have crashed in the past.
 
-#![feature(custom_test_frameworks)]
-#![test_runner(datatest::runner)]
-
 use libra_fuzzer::FuzzTarget;
 use rusty_fork::{fork, rusty_fork_id};
 use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
@@ -17,11 +14,9 @@ static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 /// The memory limit for each deserializer, in bytes.
 const MEMORY_LIMIT: usize = 256 * 1024 * 1024;
 
-#[datatest::files("artifacts", {
-    artifact_path in r"^.*/.*"
-})]
-#[test]
-fn test_artifact(artifact_path: &Path) {
+datatest_stable::harness!(test_artifact, "artifacts", r"^.*/.*");
+
+fn test_artifact(artifact_path: &Path) -> datatest_stable::Result<()> {
     let test_name = test_name(artifact_path);
 
     if no_fork() {
@@ -43,6 +38,8 @@ fn test_artifact(artifact_path: &Path) {
         )
         .expect("forking test failed");
     }
+
+    Ok(())
 }
 
 fn no_fork() -> bool {


### PR DESCRIPTION
* Introduce `datatest-stable`, a data-driven testing framework that is meant to be a simple version of `datatest` that is usable with a stable rust compiler without using the `RUSTC_BOOTSTRAP` mechanism for allowing nightly features to be used with a stable compiler.

* Convert `language/functional_tests` and `testsuite/libra_fuzzer` to use `datatest-stable

* Remove `custom_test_frameworks` from the whitelist of allowed nightly features.