### PR TITLE
[client] improve code readability: duplicate local var of child

### DIFF
--- a/client/libra_wallet/src/wallet_library.rs
+++ b/client/libra_wallet/src/wallet_library.rs
@@ -112,10 +112,10 @@ impl WalletLibrary {
     pub fn new_address(&mut self) -> Result<(AccountAddress, ChildNumber)> {
         let child = self.key_factory.private_child(self.key_leaf)?;
         let address = child.get_address()?;
-        let child = self.key_leaf;
+        let old_key_leaf = self.key_leaf;
         self.key_leaf.increment();
-        if self.addr_map.insert(address, child).is_none() {
-            Ok((address, child))
+        if self.addr_map.insert(address, old_key_leaf).is_none() {
+            Ok((address, old_key_leaf))
         } else {
             Err(WalletError::LibraWalletGeneric(
                 "This address is already in your wallet".to_string(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Improve code readability. The 'new_address' function in wallet_library.rs has two duplicate local variables named 'child', but those two child has different data types and different meanings. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Passed all client tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
