### PR TITLE
[block_tree] Introduce LinkableBlock 

### DIFF
--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -3,7 +3,10 @@
 
 use crate::chained_bft::{
     common::{Author, Round},
-    consensus_types::{block::Block, quorum_cert::QuorumCert},
+    consensus_types::{
+        block::{Block, ExecutedBlock},
+        quorum_cert::QuorumCert,
+    },
 };
 use crypto::HashValue;
 use std::sync::Arc;
@@ -150,7 +153,7 @@ pub trait BlockReader: Send + Sync {
     fn block_exists(&self, block_id: HashValue) -> bool;
 
     /// Try to get a block with the block_id, return an Arc of it if found.
-    fn get_block(&self, block_id: HashValue) -> Option<Arc<Block<Self::Payload>>>;
+    fn get_block(&self, block_id: HashValue) -> Option<Arc<ExecutedBlock<Self::Payload>>>;
 
     /// Try to get a compute result given the specified block id.
     ///
@@ -159,7 +162,7 @@ pub trait BlockReader: Send + Sync {
     fn get_compute_result(&self, block_id: HashValue) -> Option<Arc<StateComputeResult>>;
 
     /// Get the current root block of the BlockTree.
-    fn root(&self) -> Arc<Block<Self::Payload>>;
+    fn root(&self) -> Arc<ExecutedBlock<Self::Payload>>;
 
     fn get_quorum_cert_for_block(&self, block_id: HashValue) -> Option<Arc<QuorumCert>>;
 
@@ -170,10 +173,8 @@ pub trait BlockReader: Send + Sync {
     /// path_from_root(b2) -> Some([b2, b1])
     /// path_from_root(b0) -> Some([])
     /// path_from_root(a) -> None
-    fn path_from_root(
-        &self,
-        block: Arc<Block<Self::Payload>>,
-    ) -> Option<Vec<Arc<Block<Self::Payload>>>>;
+    fn path_from_root(&self, block_id: HashValue)
+        -> Option<Vec<Arc<ExecutedBlock<Self::Payload>>>>;
 
     /// Generates and returns a block with the given parent and payload.
     /// Note that it does not add the block to the tree, just generates it.
@@ -192,7 +193,7 @@ pub trait BlockReader: Send + Sync {
     ) -> Block<Self::Payload>;
 
     /// Return the certified block with the highest round.
-    fn highest_certified_block(&self) -> Arc<Block<Self::Payload>>;
+    fn highest_certified_block(&self) -> Arc<ExecutedBlock<Self::Payload>>;
 
     /// Return the quorum certificate with the highest round
     fn highest_quorum_cert(&self) -> Arc<QuorumCert>;

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -135,7 +135,7 @@ impl<T: Payload> ProposalGenerator<T> {
         // One needs to hold the blocks with the references to the payloads while get_block is
         // being executed: pending blocks vector keeps all the pending ancestors of the extended
         // branch.
-        let pending_blocks = match self.block_store.path_from_root(Arc::clone(&hqc_block)) {
+        let pending_blocks = match self.block_store.path_from_root(hqc_block.id()) {
             Some(res) => res,
             // In case the whole system moved forward between the check of a round and getting
             // path from root.

--- a/consensus/src/chained_bft/safety/safety_rules_test.rs
+++ b/consensus/src/chained_bft/safety/safety_rules_test.rs
@@ -5,7 +5,7 @@ use crate::chained_bft::{
     block_storage::BlockReader,
     common::Round,
     consensus_types::{
-        block::{block_test, Block},
+        block::{block_test, ExecutedBlock},
         quorum_cert::QuorumCert,
     },
     safety::safety_rules::{ConsensusState, ProposalReject, SafetyRules},
@@ -96,7 +96,7 @@ proptest! {
             }
 
             let insert_res = inserter.insert_pre_made_block(block.clone(), &first_signer, qc_signers.iter().collect());
-            let id_and_qc = |ref block: Arc<Block<Vec<usize>>>| { (block.id(), block.quorum_cert().clone()) };
+            let id_and_qc = |ref block: Arc<ExecutedBlock<Vec<usize>>>| { (block.id(), block.quorum_cert().clone()) };
             let (inserted_id, inserted_qc) = id_and_qc(insert_res.clone());
             safety_rules.update(&inserted_qc);
 

--- a/consensus/src/chained_bft/sync_manager.rs
+++ b/consensus/src/chained_bft/sync_manager.rs
@@ -5,7 +5,11 @@ use crate::{
     chained_bft::{
         block_storage::{BlockReader, BlockStore, InsertError, NeedFetchResult},
         common::{Author, Payload},
-        consensus_types::{block::Block, quorum_cert::QuorumCert, sync_info::SyncInfo},
+        consensus_types::{
+            block::{Block, ExecutedBlock},
+            quorum_cert::QuorumCert,
+            sync_info::SyncInfo,
+        },
         network::ConsensusNetworkImpl,
         persistent_storage::PersistentStorage,
     },
@@ -114,7 +118,7 @@ where
     pub async fn execute_and_insert_block(
         &self,
         block: Block<T>,
-    ) -> Result<Arc<Block<T>>, InsertError> {
+    ) -> Result<Arc<ExecutedBlock<T>>, InsertError> {
         // execute_and_insert_block has shortcut to return block if it exists
         self.block_store.execute_and_insert_block(block).await
     }

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -4,7 +4,11 @@
 use crate::chained_bft::{
     block_storage::BlockStore,
     common::Round,
-    consensus_types::{block::Block, quorum_cert::QuorumCert, vote_data::VoteData},
+    consensus_types::{
+        block::{Block, ExecutedBlock},
+        quorum_cert::QuorumCert,
+        vote_data::VoteData,
+    },
 };
 use crypto::{hash::CryptoHash, HashValue};
 use executor::ExecutedState;
@@ -68,7 +72,7 @@ impl TreeInserter {
         &mut self,
         parent: &Block<Vec<usize>>,
         round: Round,
-    ) -> Arc<Block<Vec<usize>>> {
+    ) -> Arc<ExecutedBlock<Vec<usize>>> {
         // Node must carry a QC to its parent
         let parent_qc = placeholder_certificate_for_block(
             vec![self.block_store.signer()],
@@ -88,7 +92,7 @@ impl TreeInserter {
         parent_qc: QuorumCert,
         parent: &Block<Vec<usize>>,
         round: Round,
-    ) -> Arc<Block<Vec<usize>>> {
+    ) -> Arc<ExecutedBlock<Vec<usize>>> {
         self.payload_val += 1;
         block_on(self.block_store.insert_block_with_qc(Block::make_block(
             parent,
@@ -106,7 +110,7 @@ impl TreeInserter {
         block: Block<Vec<usize>>,
         block_signer: &ValidatorSigner,
         qc_signers: Vec<&ValidatorSigner>,
-    ) -> Arc<Block<Vec<usize>>> {
+    ) -> Arc<ExecutedBlock<Vec<usize>>> {
         self.payload_val += 1;
         let new_round = if block.round() > 0 {
             block.round() - 1

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -54,7 +54,7 @@ lazy_static! {
 /// of success / failure of the transactions.
 /// Note that the specific details of compute_status are opaque to StateMachineReplication,
 /// which is going to simply pass the results between StateComputer and TxnManager.
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct StateComputeResult {
     pub executed_state: ExecutedState,
     /// The compute status (success/failure) of the given payload. The specific details are opaque


### PR DESCRIPTION
## Motivation

1.  Introduce `LinkableBlock` to separate mutable and immutable parts of an executed block. So any read API could hold an `Arc<ExecutedBlock>` while another thread can still mutate the `children` set of this block since block content/result(immutable) is now separated from `children`(mutable). This is necessary for incoming refactoring to dedup block trees.

2. Replace the params of most block_tree read APIs from `Arc<Block>` to block_id (HashValue). Since we have `Block`, `ExecutedBlock`( Block + execution_result) and `LinkableBlock`( ExecutedBlock + children), we want to identify them in different context using the same identifier. As they are different forms of the same thing, `Arc<T>` is not a good id. But hash is.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

