### PR TITLE
[executor][rfc] read and propagate validator set from genesis transaction

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -341,10 +341,11 @@ impl<T: Payload> BlockStore<T> {
                 return Self::zero_ledger_info_placeholder();
             }
         };
-        let (state_id, version) = match self.get_compute_result(block_id) {
+        let (state_id, version, next_validator_set) = match self.get_compute_result(block_id) {
             Some(compute_state) => (
                 compute_state.executed_state.state_id,
                 compute_state.executed_state.version,
+                compute_state.executed_state.validators.clone(),
             ),
             None => {
                 return Self::zero_ledger_info_placeholder();
@@ -357,7 +358,7 @@ impl<T: Payload> BlockStore<T> {
             block_id,
             0, // TODO [Reconfiguration] use the real epoch number.
             block.timestamp_usecs(),
-            None,
+            next_validator_set,
         )
     }
 

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -97,6 +97,7 @@ impl ExecutedState {
         ExecutedState {
             state_id: *ACCUMULATOR_PLACEHOLDER_HASH,
             version: 0,
+            // TODO: need to generalize this to compute the validators by executing the genesis tx?
             validators: None,
         }
     }
@@ -220,6 +221,12 @@ where
         .expect("Response sender was unexpectedly dropped.")
         .expect("Failed to execute genesis block.");
 
+        let next_validator_set = state_compute_result.executed_state.validators;
+        assert!(
+            next_validator_set.is_some(),
+            "Executing genesis transaction should always produce a validator set"
+        );
+
         let root_hash = state_compute_result.executed_state.state_id;
         let ledger_info = LedgerInfo::new(
             /* version = */ 0,
@@ -228,7 +235,7 @@ where
             *GENESIS_BLOCK_ID,
             /* epoch_num = */ 0,
             /* timestamp_usecs = */ 0,
-            None,
+            /* validators */ next_validator_set,
         );
         let ledger_info_with_sigs =
             LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new());

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -37,13 +37,9 @@
 
 use crate::{
     account_address::AccountAddress,
-    account_config::{
-        account_resource_path, association_address, ACCOUNT_RECEIVED_EVENT_PATH,
-        ACCOUNT_SENT_EVENT_PATH,
-    },
+    account_config::{account_resource_path, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH},
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, ResourceKey, StructTag},
-    validator_set::validator_set_path,
 };
 use canonical_serialization::{
     CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
@@ -51,7 +47,6 @@ use canonical_serialization::{
 use crypto::hash::{CryptoHash, HashValue};
 use failure::prelude::*;
 use hex;
-use lazy_static::lazy_static;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
@@ -192,12 +187,6 @@ impl TrieKey for Accesses {
     fn encode_bytes(&self) -> Vec<u8> {
         self.as_separated_string().into_bytes()
     }
-}
-
-lazy_static! {
-    /// The access path where the Validator Set resource is stored.
-    pub static ref VALIDATOR_SET_ACCESS_PATH: AccessPath =
-        AccessPath::new(association_address(), validator_set_path());
 }
 
 #[derive(


### PR DESCRIPTION
**[NOTE: tabling this PR for now because bootstrapping is complex and has dependencies on the ongoing waypoint discussion. Will focus on reconfiguration first]**
Since the genesis transaction now creates the validator set, the executor code can read it from the blockchain state and package it into the first ledger info. Additionally, now that the ledger info contains the new validator set, consensus can grab + propagate it.
    
This only implements configuring the initial validator set using the genesis transaction; it does not yet handle reconfiguration. That will work slightly differently: the ValidatorSet contract will emit a ValidatorSetChange event that the executor knows to look for. Unfortunately, we can't implement reading the validator set from genesis in the same way because write set transactions cannot emit events.

## Motivation

Working toward reconfiguration by first implementing configuration :).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Note: this is just an RFC for executor/consensus folks to make sure I'm moving in the right direction; I still need to add a ton of tests before landing.