### PR TITLE
[fuzzing][draft] Trying AFL as a fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "afl"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2001,7 @@ name = "libra_fuzzer"
 version = "0.1.0"
 dependencies = [
  "admission_control_service 0.1.0",
+ "afl 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical_serialization 0.1.0",
  "consensus 0.1.0",
@@ -5195,6 +5207,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "xml-rs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5230,6 +5247,7 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
+"checksum afl 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2b15f7ed343b7446090d0de7789a640c22b163fb200d81cef958fcb9856692"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
@@ -5653,6 +5671,7 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)" = "<none>"
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
+"checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum yamux 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01bd67889938c48f0049fc60a77341039e6c3eaf16cb7693e6ead7c0ba701295"
 "checksum zstd-sys 1.4.13+zstd.1.4.3 (git+https://github.com/gyscos/zstd-rs.git)" = "<none>"

--- a/testsuite/libra_fuzzer/Cargo.toml
+++ b/testsuite/libra_fuzzer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 # common dependencies
 [dependencies]
+afl = "0.4"
 byteorder = { version = "1.3.2", default-features = false }
 canonical_serialization = { path = "../../common/canonical_serialization" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
@@ -43,3 +44,10 @@ fuzzing = ["consensus/fuzzing", "admission_control_service/fuzzing"]
 [[test]]
 name = "artifacts"
 harness = false
+
+[[bin]]
+name = "inner_signature"
+path = "afl_fuzz/inner_signature.rs"
+[[bin]]
+name = "consensus_proposal"
+path = "afl_fuzz/consensus_proposal.rs"

--- a/testsuite/libra_fuzzer/afl_fuzz/consensus_proposal.rs
+++ b/testsuite/libra_fuzzer/afl_fuzz/consensus_proposal.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+extern crate afl;
+
+use consensus::chained_bft::event_processor::event_processor_fuzzing::{
+    fuzz_proposal, generate_corpus_proposal,
+};
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        fuzz_proposal(data);
+    });
+}

--- a/testsuite/libra_fuzzer/afl_fuzz/inner_signature.rs
+++ b/testsuite/libra_fuzzer/afl_fuzz/inner_signature.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+extern crate afl;
+
+use canonical_serialization::{SimpleDeserializer, SimpleSerializer};
+use failure::prelude::Result;
+use types::transaction::SignedTransaction;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        let _: Result<SignedTransaction> = SimpleDeserializer::deserialize(&data);
+    });
+}


### PR DESCRIPTION
Summary: We are currently using libfuzzer as the main fuzzer. We also want to try experimenting with AFL as a fuzzer as it provides more exec/s

Test Plan: The fuzzer works

```
RUSTFLAGS='-C codegen-units=1'  cargo afl build --bin consensus_proposal
cargo afl fuzz -i fuzz/corpus/consensus_proposal -o out ../../target/debug/consensus_proposal
```
