### PR TITLE
[language] Split out interpreter entrypoint from function call impl

### DIFF
--- a/language/vm/vm_runtime/src/process_txn/execute.rs
+++ b/language/vm/vm_runtime/src/process_txn/execute.rs
@@ -112,7 +112,7 @@ where
             txn_executor.setup_main_args(args);
 
             // Run main.
-            match txn_executor.execute_function_impl(main) {
+            match txn_executor.interpeter_entrypoint(main) {
                 Ok(_) => txn_executor.transaction_cleanup(publish_modules),
                 Err(err) => match err.status_type() {
                     StatusType::InvariantViolation => {
@@ -189,7 +189,7 @@ where
 
             let (_, args) = script.into_inner();
             txn_executor.setup_main_args(args);
-            match txn_executor.execute_function_impl(main) {
+            match txn_executor.interpeter_entrypoint(main) {
                 Ok(_) => txn_executor.transaction_cleanup(vec![]),
                 Err(err) => match err.status_type() {
                     StatusType::InvariantViolation => {

--- a/language/vm/vm_runtime/src/txn_executor.rs
+++ b/language/vm/vm_runtime/src/txn_executor.rs
@@ -665,8 +665,9 @@ where
         }
     }
 
-    /// Execute a function given a FunctionRef.
-    pub(crate) fn execute_function_impl(&mut self, func: FunctionRef<'txn>) -> VMResult<()> {
+    /// Entrypoint into the interpreter. All external calls need to be routed through this
+    /// function.
+    pub(crate) fn interpeter_entrypoint(&mut self, func: FunctionRef<'txn>) -> VMResult<()> {
         // We charge an intrinsic amount of gas based upon the size of the transaction submitted
         // (in raw bytes).
         let txn_size = self.txn_data.transaction_size;
@@ -675,6 +676,11 @@ where
         assume!(txn_size.get() <= (MAX_TRANSACTION_SIZE_IN_BYTES as u64));
         self.gas_meter
             .charge_transaction_gas(txn_size, &self.execution_stack)?;
+        self.execute_function_impl(func)
+    }
+
+    /// Execute a function given a FunctionRef.
+    fn execute_function_impl(&mut self, func: FunctionRef<'txn>) -> VMResult<()> {
         let beginning_height = self.execution_stack.call_stack_height();
         self.execution_stack.push_call(func)?;
         // We always start execution from the first instruction.


### PR DESCRIPTION
Previously, the entrypoint into the interpreter loop was through
execute_function_impl. However, the entry into the interpreter is
special -- we need to charge an intrinsic amount of gas only once.

This separates these two out so that we only charge this once instead of
multiple times since this wound up being called internally from the VM as
well.