### PR TITLE
Let clippy complain if the # of arguments grows out of hand

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,4 +3,4 @@ cognitive-complexity-threshold = 100
 # types are used for safety encoding
 type-complexity-threshold = 10000
 # manipulating complex states machines in consensus
-too-many-arguments-threshold = 15
+too-many-arguments-threshold = 13


### PR DESCRIPTION
The # of fns with large > of arguments is growing fast\
(record is 9 in `linear_search_max_throughput` in benchmark)

Calls with >7 arguments in consensus:
https://gist.github.com/huitseeker/ec8d79f88cbcbacde5e3a21a6b207358