### PR TITLE
[language] Add counters to track execution time and gas usage stats

### DIFF
--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -106,12 +106,13 @@ extern crate lazy_static;
 extern crate rental;
 #[macro_use]
 extern crate mirai_annotations;
+#[macro_use]
+mod counters;
 
 #[cfg(feature = "mirai-contracts")]
 pub mod foreign_contracts;
 
 mod block_processor;
-mod counters;
 mod frame;
 mod gas_meter;
 mod move_vm;

--- a/language/vm/vm_runtime/src/move_vm.rs
+++ b/language/vm/vm_runtime/src/move_vm.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{loaded_data::loaded_module::LoadedModule, runtime::VMRuntime, VMExecutor, VMVerifier};
+use crate::{
+    counters::*, loaded_data::loaded_module::LoadedModule, runtime::VMRuntime, VMExecutor,
+    VMVerifier,
+};
 use state_view::StateView;
 use std::sync::Arc;
 use types::{
@@ -49,8 +52,11 @@ impl VMVerifier for MoveVM {
         state_view: &dyn StateView,
     ) -> Option<VMStatus> {
         // TODO: This should be implemented as an async function.
-        self.inner
-            .rent(move |runtime| runtime.verify_transaction(transaction, state_view))
+        record_stats! {TXN_VALIDATION_TIME_TAKEN_HISTOGRAM, {
+            self.inner
+                .rent(move |runtime| runtime.verify_transaction(transaction, state_view))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Add a number of different timers in order to track how much time is
being spent in various parts of the transaction flow. In particular, in:
* The bytecode verifier
* Transaction validation (aka prologue)
* Transaction execution
* Transaction epilogue

We also add histograms to track gas for these sections as well:
* Total gas usage for the transaction
* Gas usage for transaction execution

The primary purpose for these statistics is to start collecting data to
measure how "good" the gas metering is -- in particular correlation
between the gas used and the time spent processing the transaction.

The dimensions of data should eventually be expanded to track such things as the number of bytes read/written, but that will have to wait.

I also need to plumb these variables in to graphana, and set up some light alarms possibly (e.g. if the computation time exceeds some multiplier of the gas used). 