### PR TITLE
[state-sync] Fixing flaky peer manager test

### DIFF
--- a/state_synchronizer/src/tests/unit_tests.rs
+++ b/state_synchronizer/src/tests/unit_tests.rs
@@ -35,9 +35,11 @@ fn test_peer_manager() {
         *counter += 1;
     }
 
-    assert!(pick_counts.get(&peers[0]).unwrap() < pick_counts.get(&peers[1]).unwrap());
-    assert!(pick_counts.get(&peers[0]).unwrap() < pick_counts.get(&peers[2]).unwrap());
-    assert!(pick_counts.get(&peers[0]).unwrap() < pick_counts.get(&peers[3]).unwrap());
+    // unwrap_or needed because the peer with bad score may never be picked, and may be
+    // missing from pick_counts
+    assert!(pick_counts.get(&peers[0]).unwrap_or(&0) < pick_counts.get(&peers[1]).unwrap());
+    assert!(pick_counts.get(&peers[0]).unwrap_or(&0) < pick_counts.get(&peers[2]).unwrap());
+    assert!(pick_counts.get(&peers[0]).unwrap_or(&0) < pick_counts.get(&peers[3]).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

test_peer_manager was flaky because the bad actor could never be picked, and panic at pick_counts.get(&peers[0]).unwrap(). Fixing to unwrap_or() if the peer is never picked.

Some instances of this flakiness:
#1007 (comment)
https://circleci.com/gh/libra/libra/7309#tests/containers/2

Check issue at: https://github.com/libra/libra/issues/1034#event-2655935600

## Test Plan

unit test
