### PR TITLE
[Client] Change port type to u16 so as to avoid invalid port number

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -107,7 +107,7 @@ impl ClientProxy {
     /// Construct a new TestClient.
     pub fn new(
         host: &str,
-        ac_port: &str,
+        ac_port: u16,
         validator_set_file: &str,
         faucet_account_file: &str,
         sync_on_wallet_recovery: bool,
@@ -1112,7 +1112,7 @@ mod tests {
         // generate random accounts
         let mut client_proxy = ClientProxy::new(
             "", /* host */
-            "", /* port */
+            0, /* port */
             &val_set_file,
             &"",
             false,

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -42,7 +42,7 @@ pub struct GRPCClient {
 
 impl GRPCClient {
     /// Construct a new Client instance.
-    pub fn new(host: &str, port: &str, validator_verifier: Arc<ValidatorVerifier>) -> Result<Self> {
+    pub fn new(host: &str, port: u16, validator_verifier: Arc<ValidatorVerifier>) -> Result<Self> {
         let conn_addr = format!("{}:{}", host, port);
 
         // Create a GRPC client

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -15,7 +15,7 @@ use structopt::StructOpt;
 struct Args {
     /// Admission Control port to connect to.
     #[structopt(short = "p", long = "port", default_value = "8000")]
-    pub port: String,
+    pub port: u16,
     /// Host address/name to connect to.
     #[structopt(short = "a", long = "host")]
     pub host: String,
@@ -54,13 +54,18 @@ fn main() -> std::io::Result<()> {
     crash_handler::setup_panic_handler();
     let args = Args::from_args();
 
+    if args.port == 0 {
+        println!("Port number cannot be zero, zero is reserved for random port.");
+        return Ok(());
+    }
+
     let (commands, alias_to_cmd) = get_commands(args.faucet_account_file.is_some());
 
     let faucet_account_file = args.faucet_account_file.unwrap_or_else(|| "".to_string());
 
     let mut client_proxy = ClientProxy::new(
         &args.host,
-        &args.port,
+        args.port,
         &args.validator_set_file,
         &faucet_account_file,
         args.sync,
@@ -141,4 +146,31 @@ fn print_help(client_info: &str, commands: &[std::sync::Arc<dyn Command>]) {
     println!("help | h \n\tPrints this help");
     println!("quit | q! \n\tExit this client");
     println!("\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_args_port() {
+        let args = Args::from_iter(&["test", "--host=h", "--validator_set_file=vsf"]);
+        assert_eq!(args.port, 8000);
+	assert_eq!(format!("{}:{}", args.host, args.port), "h:8000");
+        let args = Args::from_iter(&["test", "--port=65535", "--host=h", "--validator_set_file=vsf"]);
+        assert_eq!(args.port, 65535);
+    }
+
+    #[test]
+    fn test_args_port_too_large() {
+        let result = Args::from_iter_safe(&["test", "--port=65536", "--host=h", "--validator_set_file=vsf"]);
+        assert_eq!(result.is_ok(), false);
+    }
+
+    #[test]
+    fn test_args_port_invalid() {
+        let result = Args::from_iter_safe(&["test", "--port=abc", "--host=h", "--validator_set_file=vsf"]);
+        assert_eq!(result.is_ok(), false);
+    }
+
 }

--- a/libra_swarm/src/client.rs
+++ b/libra_swarm/src/client.rs
@@ -158,7 +158,7 @@ impl InProcessTestClient {
         Self {
             client: ClientProxy::new(
                 "localhost",
-                port.to_string().as_str(),
+                port,
                 &validator_set_file,
                 faucet_key_file_path
                     .canonicalize()

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -36,7 +36,7 @@ fn setup_env(
         .expect("could not create temporary mnemonic_file_path");
     let client_proxy = ClientProxy::new(
         "localhost",
-        port.to_string().as_str(),
+        port,
         &swarm.get_trusted_peers_config_path(),
         &faucet_key_file_path,
         false,
@@ -294,7 +294,7 @@ fn test_basic_state_synchronization() {
     let ac_port = swarm.get_validator(&node_to_restart).unwrap().ac_port();
     let mut client_proxy2 = ClientProxy::new(
         "localhost",
-        ac_port.to_string().as_str(),
+        ac_port,
         &swarm.get_trusted_peers_config_path(),
         "",
         false,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The ip port type in Client module is str, so invalid port such as 'abc' or 65536 can be accepted.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES.

## Test Plan

Add test cases in client/src/main.rs with four case:

1. default port
2. valid port
3. too large int port
4. invalid str port

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
