### PR TITLE
[Client] Change port type to NonZeroU16 so as to avoid invalid port number

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -107,7 +107,7 @@ impl ClientProxy {
     /// Construct a new TestClient.
     pub fn new(
         host: &str,
-        ac_port: &str,
+        ac_port: u16,
         validator_set_file: &str,
         faucet_account_file: &str,
         sync_on_wallet_recovery: bool,
@@ -1112,7 +1112,7 @@ mod tests {
         // generate random accounts
         let mut client_proxy = ClientProxy::new(
             "", /* host */
-            "", /* port */
+            0,  /* port */
             &val_set_file,
             &"",
             false,

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -42,7 +42,7 @@ pub struct GRPCClient {
 
 impl GRPCClient {
     /// Construct a new Client instance.
-    pub fn new(host: &str, port: &str, validator_verifier: Arc<ValidatorVerifier>) -> Result<Self> {
+    pub fn new(host: &str, port: u16, validator_verifier: Arc<ValidatorVerifier>) -> Result<Self> {
         let conn_addr = format!("{}:{}", host, port);
 
         // Create a GRPC client

--- a/libra_swarm/src/client.rs
+++ b/libra_swarm/src/client.rs
@@ -158,7 +158,7 @@ impl InProcessTestClient {
         Self {
             client: ClientProxy::new(
                 "localhost",
-                port.to_string().as_str(),
+                port,
                 &validator_set_file,
                 faucet_key_file_path
                     .canonicalize()

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -42,7 +42,7 @@ fn setup_env(
         .join(&config.consensus.consensus_peers_file);
     let client_proxy = ClientProxy::new(
         "localhost",
-        port.to_string().as_str(),
+        port,
         validator_set_file.to_str().unwrap(),
         &faucet_key_file_path,
         false,
@@ -303,7 +303,7 @@ fn test_basic_state_synchronization() {
         .join(&config.consensus.consensus_peers_file);
     let mut client_proxy2 = ClientProxy::new(
         "localhost",
-        ac_port.to_string().as_str(),
+        ac_port,
         &validator_set_file.to_str().unwrap(),
         "",
         false,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The ip port type in Client module is str, so invalid port such as 'abc' or 65536 can be accepted.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Add test cases in client/src/main.rs with four case:

1. default port
2. valid port
3. too large int port
4. invalid str port

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
