### PR TITLE
[language][bytecode_verifier] Fix to ensure that types of locals and parameters of of a function match up

### DIFF
--- a/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode_verifier/bytecode_verifier_tests/src/unit_tests/signature_tests.rs
@@ -1,19 +1,21 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use bytecode_verifier::SignatureChecker;
+use bytecode_verifier::{SignatureChecker, VerifiedModule};
 use invalid_mutations::signature::{
     ApplySignatureDoubleRefContext, ApplySignatureFieldRefContext, DoubleRefMutation,
     FieldRefMutation,
 };
 use proptest::{collection::vec, prelude::*};
-use types::vm_error::StatusCode;
-use vm::file_format::*;
+use types::{
+    account_address::{AccountAddress, ADDRESS_LENGTH},
+    identifier::Identifier,
+    vm_error::StatusCode,
+};
+use vm::file_format::{Bytecode::*, CompiledModule, SignatureToken::*, *};
 
 #[test]
 fn test_reference_of_reference() {
-    use SignatureToken::*;
-
     let mut m = basic_test_module();
     m.locals_signatures[0] = LocalsSignature(vec![Reference(Box::new(Reference(Box::new(
         SignatureToken::Bool,
@@ -91,4 +93,261 @@ proptest! {
         }
         prop_assert_eq!(expected_violations, actual_violations);
     }
+}
+
+#[test]
+fn no_verify_locals_good() {
+    let compiled_module_good = CompiledModuleMut {
+        module_handles: vec![ModuleHandle {
+            address: AddressPoolIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![],
+        function_handles: vec![
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                signature: FunctionSignatureIndex(0),
+            },
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(2),
+                signature: FunctionSignatureIndex(1),
+            },
+        ],
+        type_signatures: vec![],
+        function_signatures: vec![
+            FunctionSignature {
+                return_types: vec![],
+                arg_types: vec![Address],
+                type_formals: vec![],
+            },
+            FunctionSignature {
+                return_types: vec![],
+                arg_types: vec![U64],
+                type_formals: vec![],
+            },
+        ],
+        locals_signatures: vec![LocalsSignature(vec![Address]), LocalsSignature(vec![U64])],
+        identifiers: vec![
+            Identifier::new("Bad").unwrap(),
+            Identifier::new("blah").unwrap(),
+            Identifier::new("foo").unwrap(),
+        ],
+        user_strings: vec![],
+        byte_array_pool: vec![],
+        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        struct_defs: vec![],
+        field_defs: vec![],
+        function_defs: vec![
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                flags: 1,
+                acquires_global_resources: vec![],
+                code: CodeUnit {
+                    max_stack_size: 0,
+                    locals: LocalsSignatureIndex(0),
+                    code: vec![Ret],
+                },
+            },
+            FunctionDefinition {
+                function: FunctionHandleIndex(1),
+                flags: 0,
+                acquires_global_resources: vec![],
+                code: CodeUnit {
+                    max_stack_size: 0,
+                    locals: LocalsSignatureIndex(1),
+                    code: vec![Ret],
+                },
+            },
+        ],
+    };
+    assert!(VerifiedModule::new(compiled_module_good.freeze().unwrap()).is_ok());
+}
+
+#[test]
+fn no_verify_locals_bad1() {
+    // This test creates a function with one argument of type Address and
+    // a vector of locals containing a single entry of type U64. The function
+    // must fail verification since the argument type at position 0 is different
+    // from the local type at position 0.
+    let compiled_module_bad1 = CompiledModuleMut {
+        module_handles: vec![ModuleHandle {
+            address: AddressPoolIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            signature: FunctionSignatureIndex(0),
+        }],
+        type_signatures: vec![],
+        function_signatures: vec![FunctionSignature {
+            return_types: vec![],
+            arg_types: vec![Address],
+            type_formals: vec![],
+        }],
+        locals_signatures: vec![LocalsSignature(vec![U64])],
+        identifiers: vec![
+            Identifier::new("Bad").unwrap(),
+            Identifier::new("blah").unwrap(),
+        ],
+        user_strings: vec![],
+        byte_array_pool: vec![],
+        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        struct_defs: vec![],
+        field_defs: vec![],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            flags: 1,
+            acquires_global_resources: vec![],
+            code: CodeUnit {
+                max_stack_size: 0,
+                locals: LocalsSignatureIndex(0),
+                code: vec![Ret],
+            },
+        }],
+    };
+    assert!(VerifiedModule::new(compiled_module_bad1.freeze().unwrap()).is_err());
+}
+
+#[test]
+fn no_verify_locals_bad2() {
+    // This test creates a function with one argument of type Address and
+    // an empty vector of locals. The function must fail verification since
+    // number of arguments is greater than the number of locals.
+    let compiled_module_bad2 = CompiledModuleMut {
+        module_handles: vec![ModuleHandle {
+            address: AddressPoolIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            signature: FunctionSignatureIndex(0),
+        }],
+        type_signatures: vec![],
+        function_signatures: vec![FunctionSignature {
+            return_types: vec![],
+            arg_types: vec![Address],
+            type_formals: vec![],
+        }],
+        locals_signatures: vec![LocalsSignature(vec![])],
+        identifiers: vec![
+            Identifier::new("Bad").unwrap(),
+            Identifier::new("blah").unwrap(),
+        ],
+        user_strings: vec![],
+        byte_array_pool: vec![],
+        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        struct_defs: vec![],
+        field_defs: vec![],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            flags: 1,
+            acquires_global_resources: vec![],
+            code: CodeUnit {
+                max_stack_size: 0,
+                locals: LocalsSignatureIndex(0),
+                code: vec![Ret],
+            },
+        }],
+    };
+    assert!(VerifiedModule::new(compiled_module_bad2.freeze().unwrap()).is_err());
+}
+
+#[test]
+fn no_verify_locals_bad3() {
+    // This test creates a function with one argument of type Address and
+    // a vector of locals containing two types, U64 and Address. The function
+    // must fail verification since the argument type at position 0 is different
+    // from the local type at position 0.
+    let compiled_module_bad1 = CompiledModuleMut {
+        module_handles: vec![ModuleHandle {
+            address: AddressPoolIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            signature: FunctionSignatureIndex(0),
+        }],
+        type_signatures: vec![],
+        function_signatures: vec![FunctionSignature {
+            return_types: vec![],
+            arg_types: vec![Address],
+            type_formals: vec![],
+        }],
+        locals_signatures: vec![LocalsSignature(vec![U64, Address])],
+        identifiers: vec![
+            Identifier::new("Bad").unwrap(),
+            Identifier::new("blah").unwrap(),
+        ],
+        user_strings: vec![],
+        byte_array_pool: vec![],
+        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        struct_defs: vec![],
+        field_defs: vec![],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            flags: 1,
+            acquires_global_resources: vec![],
+            code: CodeUnit {
+                max_stack_size: 0,
+                locals: LocalsSignatureIndex(0),
+                code: vec![Ret],
+            },
+        }],
+    };
+    assert!(VerifiedModule::new(compiled_module_bad1.freeze().unwrap()).is_err());
+}
+
+#[test]
+fn no_verify_locals_bad4() {
+    // This test creates a function with two arguments of type U64 and Address and
+    // a vector of locals containing three types, U64, U64 and Address. The function
+    // must fail verification since the argument type at position 0 is different
+    // from the local type at position 0.
+    let compiled_module_bad1 = CompiledModuleMut {
+        module_handles: vec![ModuleHandle {
+            address: AddressPoolIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            signature: FunctionSignatureIndex(0),
+        }],
+        type_signatures: vec![],
+        function_signatures: vec![FunctionSignature {
+            return_types: vec![],
+            arg_types: vec![U64, Address],
+            type_formals: vec![],
+        }],
+        locals_signatures: vec![LocalsSignature(vec![U64, U64, Address])],
+        identifiers: vec![
+            Identifier::new("Bad").unwrap(),
+            Identifier::new("blah").unwrap(),
+        ],
+        user_strings: vec![],
+        byte_array_pool: vec![],
+        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        struct_defs: vec![],
+        field_defs: vec![],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            flags: 1,
+            acquires_global_resources: vec![],
+            code: CodeUnit {
+                max_stack_size: 0,
+                locals: LocalsSignatureIndex(0),
+                code: vec![Ret],
+            },
+        }],
+    };
+    assert!(VerifiedModule::new(compiled_module_bad1.freeze().unwrap()).is_err());
 }

--- a/language/vm/vm_runtime/src/loaded_data/function.rs
+++ b/language/vm/vm_runtime/src/loaded_data/function.rs
@@ -16,19 +16,19 @@ pub trait FunctionReference<'txn>: Sized + Clone {
     /// Create a new function reference to a module
     fn new(module: &'txn LoadedModule, idx: FunctionDefinitionIndex) -> Self;
 
-    /// Fetch the reference to the module where the function is defined.
+    /// Fetch the reference to the module where the function is defined
     fn module(&self) -> &'txn LoadedModule;
 
-    /// Fetch the code of the function definition.
+    /// Fetch the code of the function definition
     fn code_definition(&self) -> &'txn [Bytecode];
 
-    /// Return the signature vector for the function's local value
+    /// Return the number of locals for the function
     fn local_count(&self) -> usize;
 
-    /// Return function's argument type
+    /// Return the number of input parameters for the function
     fn arg_count(&self) -> usize;
 
-    /// Return function's return type.
+    /// Return the number of output parameters for the function
     fn return_count(&self) -> usize;
 
     /// Return whether the function is native or not
@@ -37,7 +37,7 @@ pub trait FunctionReference<'txn>: Sized + Clone {
     /// Return the name of the function
     fn name(&self) -> &'txn IdentStr;
 
-    /// Returns the signature of the function.
+    /// Returns the signature of the function
     fn signature(&self) -> &'txn FunctionSignature;
 }
 
@@ -78,7 +78,7 @@ impl<'txn> FunctionReference<'txn> for FunctionRef<'txn> {
     }
 
     fn return_count(&self) -> usize {
-        self.def.local_count
+        self.def.return_count
     }
 
     fn is_native(&self) -> bool {

--- a/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/module_cache_tests.rs
@@ -68,7 +68,7 @@ fn test_module(name: &'static str) -> VerifiedModule {
                 acquires_global_resources: vec![],
                 code: CodeUnit {
                     max_stack_size: 10,
-                    locals: LocalsSignatureIndex::new(0),
+                    locals: LocalsSignatureIndex::new(1),
                     code: vec![Bytecode::Ret],
                 },
             },
@@ -86,7 +86,10 @@ fn test_module(name: &'static str) -> VerifiedModule {
                 type_formals: vec![],
             },
         ],
-        locals_signatures: vec![LocalsSignature(vec![])],
+        locals_signatures: vec![
+            LocalsSignature(vec![]),
+            LocalsSignature(vec![SignatureToken::U64]),
+        ],
         identifiers: idents(vec![name, "func1", "func2"]),
         user_strings: vec![],
         byte_array_pool: vec![],


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

An error should be reported when the input signature of a function does not match its local signature.  This error was not being reported but will now be reported as a result of this commit,
thus fixing this [issue](https://github.com/libra/libra/issues/1011).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
