### PR TITLE
Proof janitorial work / accumulator improvement

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -181,7 +181,7 @@ where
                             committed_timestamp_usecs,
                             state_root_hash,
                             frozen_subtrees_in_accumulator,
-                            num_leaves_in_accumulator,
+                            num_leaves_in_accumulator as usize,
                             committed_block_id,
                             storage_read_client,
                             storage_write_client,
@@ -396,7 +396,7 @@ impl ExecutedTrees {
     }
 
     pub fn version_and_state_root(&self) -> (Option<Version>, HashValue) {
-        let num_elements = self.txn_accumulator().num_leaves();
+        let num_elements = self.txn_accumulator().num_leaves() as u64;
         let version = if num_elements > 0 {
             Some(num_elements - 1)
         } else {

--- a/storage/accumulator/src/tests/mod.rs
+++ b/storage/accumulator/src/tests/mod.rs
@@ -163,9 +163,9 @@ proptest! {
         store.put_many(&writes);
 
         let frozen_subtree_hashes =
-            TestAccumulator::get_frozen_subtree_hashes(&store, leaves.len() as u64).unwrap();
+            TestAccumulator::get_frozen_subtree_hashes(&store, leaves.len()).unwrap();
         let in_mem_acc =
-            InMemoryAccumulator::new(frozen_subtree_hashes, leaves.len() as u64).unwrap();
+            InMemoryAccumulator::new(frozen_subtree_hashes, leaves.len()).unwrap();
         prop_assert_eq!(root_hash, in_mem_acc.root_hash());
     }
 }

--- a/storage/accumulator/src/tests/write_test.rs
+++ b/storage/accumulator/src/tests/write_test.rs
@@ -22,8 +22,7 @@ fn test_append_one() {
     let mut leaves = Vec::new();
     for _ in 0..100 {
         let hash = HashValue::random();
-        let (root_hash, writes) =
-            TestAccumulator::append(&store, leaves.len() as u64, &[hash]).unwrap();
+        let (root_hash, writes) = TestAccumulator::append(&store, leaves.len(), &[hash]).unwrap();
         store.put_many(&writes);
 
         leaves.push(hash);
@@ -47,7 +46,7 @@ proptest! {
                 TestAccumulator::append(&store, num_leaves, &hashes).unwrap();
             store.put_many(&writes);
 
-            num_leaves += hashes.len() as u64;
+            num_leaves += hashes.len();
             leaves.extend(hashes.iter());
             let expected_root_hash = store.verify(&leaves).unwrap();
             assert_eq!(root_hash, expected_root_hash)
@@ -62,7 +61,7 @@ proptest! {
         store.put_many(&writes);
 
         let (root_hash2, writes2) =
-            TestAccumulator::append(&store, leaves.len() as u64, &[]).unwrap();
+            TestAccumulator::append(&store, leaves.len(), &[]).unwrap();
 
         assert_eq!(root_hash, root_hash2);
         assert!(writes2.is_empty());

--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -75,7 +75,7 @@ impl EventStore {
         let mut iter = self.db.iter::<EventSchema>(ReadOptions::default())?;
         iter.seek_for_prev(&(version + 1))?;
         let num_events = match iter.next().transpose()? {
-            Some(((ver, index), _)) if ver == version => index + 1,
+            Some(((ver, index), _)) if ver == version => (index + 1) as usize,
             _ => unreachable!(), // since we've already got at least one event above
         };
 

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -126,7 +126,11 @@ impl LedgerStore {
         version: Version,
         ledger_version: Version,
     ) -> Result<AccumulatorProof> {
-        Accumulator::get_proof(self, ledger_version + 1 /* num_leaves */, version)
+        Accumulator::get_proof(
+            self,
+            (ledger_version + 1) as usize, /* num_leaves */
+            version,
+        )
     }
 
     /// Write `txn_infos` to `batch`. Assigned `first_version` to the the version number of the
@@ -147,7 +151,7 @@ impl LedgerStore {
         let txn_hashes: Vec<HashValue> = txn_infos.iter().map(TransactionInfo::hash).collect();
         let (root_hash, writes) = Accumulator::append(
             self,
-            first_version, /* num_existing_leaves */
+            first_version as usize, /* num_existing_leaves */
             &txn_hashes,
         )?;
         writes
@@ -171,7 +175,7 @@ impl LedgerStore {
 
     /// From left to right, get frozen subtree root hashes of the transaction accumulator.
     pub fn get_ledger_frozen_subtree_hashes(&self, version: Version) -> Result<Vec<HashValue>> {
-        Accumulator::get_frozen_subtree_hashes(self, version + 1)
+        Accumulator::get_frozen_subtree_hashes(self, version as usize + 1)
     }
 }
 

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -123,7 +123,7 @@ proptest! {
         let position_to_hash = compute_hashes_for_all_positions(&all_hashes);
 
         let subtree_hashes: Vec<_> =
-            FrozenSubtreeSiblingIterator::new(hashes1.len() as u64, all_hashes.len() as u64)
+            FrozenSubtreeSiblingIterator::new(hashes1.len(), all_hashes.len())
                 .filter_map(|pos| position_to_hash.get(&pos).cloned())
                 .collect();
         let new_accumulator = accumulator

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -102,7 +102,7 @@ fn test_accumulator_append() {
         itertools::zip_eq(leaves.into_iter(), expected_root_hashes.into_iter()).enumerate()
     {
         assert_eq!(accumulator.root_hash(), expected_root_hash);
-        assert_eq!(accumulator.num_leaves(), i as u64);
+        assert_eq!(accumulator.num_leaves(), i);
         accumulator = accumulator.append(vec![leaf]);
     }
 }
@@ -127,7 +127,7 @@ proptest! {
                 .filter_map(|pos| position_to_hash.get(&pos).cloned())
                 .collect();
         let new_accumulator = accumulator
-            .append_subtrees(&subtree_hashes, hashes2.len() as u64)
+            .append_subtrees(&subtree_hashes, hashes2.len())
             .unwrap();
         prop_assert_eq!(
             new_accumulator.root_hash(),

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -14,6 +14,7 @@
 mod accumulator_test;
 
 use super::MerkleTreeInternalNode;
+use crate::proof::definition::MAX_ACCUMULATOR_LEAVES;
 use crypto::{
     hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
@@ -41,7 +42,7 @@ pub struct Accumulator<H> {
     frozen_subtree_roots: Vec<HashValue>,
 
     /// The total number of leaves in this accumulator.
-    num_leaves: u64,
+    num_leaves: usize,
 
     /// The root hash of this accumulator.
     root_hash: HashValue,
@@ -55,7 +56,7 @@ where
 {
     /// Constructs a new accumulator with roots of existing frozen subtrees. Returns error if the
     /// number of frozen subtree roots does not match the number of leaves.
-    pub fn new(frozen_subtree_roots: Vec<HashValue>, num_leaves: u64) -> Result<Self> {
+    pub fn new(frozen_subtree_roots: Vec<HashValue>, num_leaves: usize) -> Result<Self> {
         ensure!(
             frozen_subtree_roots.len() == num_leaves.count_ones() as usize,
             "The number of frozen subtrees does not match the number of leaves. \
@@ -94,7 +95,7 @@ where
     /// and remove old nodes if they are now part of a larger frozen subtree.
     fn append_one(
         frozen_subtree_roots: &mut Vec<HashValue>,
-        num_existing_leaves: u64,
+        num_existing_leaves: usize,
         leaf: HashValue,
     ) {
         // For example, this accumulator originally had N = 7 leaves. Appending a leaf is like
@@ -166,9 +167,9 @@ where
     ///               / \ / \ / \ / \                         / \           / \   / \ / \      / \ / \                / \
     ///               o o o o o o o o                         o o           A B   C D E F      G H I J  K (subtrees[3]) placeholder
     /// ```
-    pub fn append_subtrees(&self, subtrees: &[HashValue], num_new_leaves: u64) -> Result<Self> {
+    pub fn append_subtrees(&self, subtrees: &[HashValue], num_new_leaves: usize) -> Result<Self> {
         ensure!(
-            num_new_leaves <= (1 << 63) - self.num_leaves,
+            num_new_leaves <= MAX_ACCUMULATOR_LEAVES - self.num_leaves,
             "Too many new leaves. self.num_leaves: {}. num_new_leaves: {}.",
             self.num_leaves,
             num_new_leaves,
@@ -225,7 +226,7 @@ where
 
     /// Computes the root hash of an accumulator given the frozen subtree roots and the number of
     /// leaves in this accumulator.
-    fn compute_root_hash(frozen_subtree_roots: &[HashValue], num_leaves: u64) -> HashValue {
+    fn compute_root_hash(frozen_subtree_roots: &[HashValue], num_leaves: usize) -> HashValue {
         match frozen_subtree_roots.len() {
             0 => return *ACCUMULATOR_PLACEHOLDER_HASH,
             1 => return frozen_subtree_roots[0],
@@ -257,7 +258,7 @@ where
     }
 
     /// Returns the total number of leaves in this accumulator.
-    pub fn num_leaves(&self) -> u64 {
+    pub fn num_leaves(&self) -> usize {
         self.num_leaves
     }
 }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -14,9 +14,9 @@ use crypto::{
     HashValue,
 };
 use failure::prelude::*;
+#[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
-#[cfg(any(test, feature = "testing"))]
 use std::mem;
 
 /// A proof that can be used authenticate an element in an accumulator given trusted root hash. For

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -32,6 +32,7 @@ pub struct AccumulatorProof {
 /// must not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm
 /// proof depth is limited to 63.
 pub const MAX_ACCUMULATOR_PROOF_DEPTH: usize = 63;
+pub const MAX_ACCUMULATOR_LEAVES: usize = 1 << MAX_ACCUMULATOR_PROOF_DEPTH;
 
 impl AccumulatorProof {
     /// Constructs a new `AccumulatorProof` using a list of siblings.

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -14,9 +14,10 @@ use crypto::{
     HashValue,
 };
 use failure::prelude::*;
-#[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
+#[cfg(any(test, feature = "testing"))]
+use std::mem;
 
 /// A proof that can be used authenticate an element in an accumulator given trusted root hash. For
 /// example, both `LedgerInfoToTransactionInfoProof` and `TransactionInfoToEventProof` can be
@@ -28,9 +29,11 @@ pub struct AccumulatorProof {
     siblings: Vec<HashValue>,
 }
 
-/// Because leaves can only take half the space in the tree, any numbering of the tree leaves
-/// must not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm
-/// proof depth is limited to 63.
+/// Because leaves can only take half the space in the tree, any numbering of the tree leaves must
+/// not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm proof
+/// depth is limited to 63.  We rely on usize to provide full 64-bit width, and assert for this.
+#[allow(dead_code)]
+const USIZE_STATIC_ASSERT: usize = mem::size_of::<usize>() - mem::size_of::<u64>();
 pub const MAX_ACCUMULATOR_PROOF_DEPTH: usize = 63;
 pub const MAX_ACCUMULATOR_LEAVES: usize = 1 << MAX_ACCUMULATOR_PROOF_DEPTH;
 

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -23,6 +23,7 @@
 //! Note2: The level of tree counts from leaf level, start from 0
 //! Note3: The leaf index starting from left-most leaf, starts from 0
 
+use crate::proof::definition::{MAX_ACCUMULATOR_LEAVES, MAX_ACCUMULATOR_PROOF_DEPTH};
 use std::fmt;
 
 #[cfg(test)]
@@ -371,8 +372,9 @@ impl FrozenSubtreeSiblingIterator {
     /// the size of the bigger accumulator.
     pub fn new(current_num_leaves: u64, new_num_leaves: u64) -> Self {
         assert!(
-            new_num_leaves <= 1 << 63,
-            "An accumulator can have at most 2^63 leaves. Provided num_leaves: {}.",
+            new_num_leaves <= MAX_ACCUMULATOR_LEAVES as u64,
+            "An accumulator can have at most 2^{} leaves. Provided num_leaves: {}.",
+            MAX_ACCUMULATOR_PROOF_DEPTH,
             new_num_leaves,
         );
         assert!(

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -149,9 +149,15 @@ impl Position {
         Self(smear_ones_for_u64(leaf.0) >> 1)
     }
 
-    pub fn root_from_leaf_count(leaf_count: u64) -> Self {
-        let leaf = Self::from_leaf_index(leaf_count - 1);
-        Self(smear_ones_for_u64(leaf.0) >> 1)
+    pub fn root_from_leaf_count(leaf_count: usize) -> Self {
+        assert!(leaf_count > 0);
+        Self::root_from_leaf_index((leaf_count - 1) as u64)
+    }
+
+    pub fn root_level_from_leaf_count(leaf_count: usize) -> usize {
+        assert!(leaf_count > 0);
+        let index = (leaf_count - 1) as u64;
+        MAX_ACCUMULATOR_PROOF_DEPTH + 1 - index.leading_zeros() as usize
     }
 
     /// Given a node, find its right most child in its subtree.
@@ -321,9 +327,9 @@ pub struct FrozenSubTreeIterator {
 }
 
 impl FrozenSubTreeIterator {
-    pub fn new(num_leaves: u64) -> Self {
+    pub fn new(num_leaves: usize) -> Self {
         Self {
-            bitmap: num_leaves,
+            bitmap: num_leaves as u64,
             seen_leaves: 0,
         }
     }

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -112,6 +112,20 @@ fn test_position_root_from_leaf_index() {
 }
 
 #[test]
+fn test_root_level_from_leaf_count() {
+    assert_eq!(Position::root_level_from_leaf_count(1), 0);
+    assert_eq!(Position::root_level_from_leaf_count(2), 1);
+    assert_eq!(Position::root_level_from_leaf_count(3), 2);
+    assert_eq!(Position::root_level_from_leaf_count(4), 2);
+    for i in 1..100usize {
+        assert_eq!(
+            Position::root_level_from_leaf_count(i),
+            Position::root_from_leaf_count(i).level() as usize
+        );
+    }
+}
+
+#[test]
 fn test_is_freezable() {
     let mut position = Position::from_inorder_index(5);
     assert_eq!(position.is_freezable(2), false);
@@ -245,11 +259,11 @@ fn slow_get_frozen_subtree_roots_impl(root: Position, max_leaf_index: u64) -> Ve
     }
 }
 
-fn slow_get_frozen_subtree_roots(num_leaves: u64) -> Vec<Position> {
+fn slow_get_frozen_subtree_roots(num_leaves: usize) -> Vec<Position> {
     if num_leaves == 0 {
         Vec::new()
     } else {
-        let max_leaf_index = num_leaves - 1;
+        let max_leaf_index = num_leaves as u64 - 1;
         let root = Position::root_from_leaf_count(num_leaves);
         slow_get_frozen_subtree_roots_impl(root, max_leaf_index)
     }
@@ -257,7 +271,7 @@ fn slow_get_frozen_subtree_roots(num_leaves: u64) -> Vec<Position> {
 
 #[test]
 fn test_frozen_subtree_iterator() {
-    for n in 0..10000 {
+    for n in 0..10000usize {
         assert_eq!(
             FrozenSubTreeIterator::new(n).collect::<Vec<_>>(),
             slow_get_frozen_subtree_roots(n),

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -265,7 +265,7 @@ fn test_frozen_subtree_iterator() {
     }
 }
 
-fn collect_all_positions(num_leaves: u64, num_new_leaves: u64) -> Vec<u64> {
+fn collect_all_positions(num_leaves: usize, num_new_leaves: usize) -> Vec<u64> {
     FrozenSubtreeSiblingIterator::new(num_leaves, num_new_leaves)
         .map(Position::to_inorder_index)
         .collect()

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -4,7 +4,10 @@
 //! All proofs generated in this module are not valid proofs. They are only for the purpose of
 //! testing conversion between Rust and Protobuf.
 
-use crate::proof::{AccumulatorConsistencyProof, AccumulatorProof, SparseMerkleProof};
+use crate::proof::{
+    definition::MAX_ACCUMULATOR_PROOF_DEPTH, AccumulatorConsistencyProof, AccumulatorProof,
+    SparseMerkleProof,
+};
 use crypto::{
     hash::{ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
@@ -14,8 +17,8 @@ use rand::{seq::SliceRandom, thread_rng};
 
 prop_compose! {
     fn arb_accumulator_proof()(
-        non_default_siblings in vec(any::<HashValue>(), 0..63usize),
-        total_num_siblings in 0..64usize,
+        non_default_siblings in vec(any::<HashValue>(), 0..MAX_ACCUMULATOR_PROOF_DEPTH),
+        total_num_siblings in 0..=MAX_ACCUMULATOR_PROOF_DEPTH,
     ) -> AccumulatorProof {
         let mut siblings = non_default_siblings;
         if !siblings.is_empty() {
@@ -51,7 +54,7 @@ prop_compose! {
 
 prop_compose! {
     fn arb_accumulator_consistency_proof()(
-        subtrees in vec(any::<HashValue>(), 0..64),
+        subtrees in vec(any::<HashValue>(), 0..=MAX_ACCUMULATOR_PROOF_DEPTH),
     ) -> AccumulatorConsistencyProof {
         AccumulatorConsistencyProof::new(subtrees)
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make usize consistent internally in proof; infiltration of u64 is because of protobuf types.  Clean up some terminology with respect to leaf count vs. subtree size which makes some of the iterator logic confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

我没看

## Test Plan

CI / cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
