### PR TITLE
[swarm][config] Enable config generation for full node swarm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "tools 0.1.0",
  "transaction_builder 0.1.0",
  "types 0.1.0",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -677,6 +678,8 @@ dependencies = [
  "failure_ext 0.1.0",
  "generate_keypair 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logger 0.1.0",
+ "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proto_conv 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "types 0.1.0",

--- a/admission_control/admission_control_service/src/main.rs
+++ b/admission_control/admission_control_service/src/main.rs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use admission_control_service::admission_control_node;
-use executable_helpers::helpers::{
-    setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
-};
+use executable_helpers::helpers::{setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING};
 
 /// Run a Admission Control service in its own process.
 /// It will also setup global logger and initialize config.
 fn main() {
     let (config, _logger, _args) = setup_executable(
         "Libra AdmissionControl node".to_string(),
-        vec![ARG_PEER_ID, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
+        vec![ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
     );
 
     let admission_control_node = admission_control_node::AdmissionControlNode::new(config);

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -15,6 +15,7 @@ rand = "0.6.5"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 structopt = "0.2.15"
 num_cpus = "1.10.1"
+walkdir = "2.2.9"
 
 admission_control_proto = { path = "../admission_control/admission_control_proto" }
 client = { path = "../client" }

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -1,6 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use benchmark::{
+    bin_utils::{create_benchmarker_from_opt, measure_throughput, try_start_metrics_server},
+    cli_opt::{RubenOpt, TransactionPattern},
+    load_generator::{LoadGenerator, PairwiseTransferTxnGenerator, RingTransferTxnGenerator},
+};
 /// To run benchmarking experiment, RuBen creates two key required components:
 /// * An object that implements LoadGenerator trait, which generates accounts and offline
 ///   requests that to be submitted during both setup stage and testing stage.
@@ -24,11 +29,6 @@
 ///
 /// By conforming to the LoadGenerator APIs,
 /// this flow is basically the same for different LoadGenerators/experiments.
-use benchmark::{
-    bin_utils::{create_benchmarker_from_opt, measure_throughput, try_start_metrics_server},
-    cli_opt::{RubenOpt, TransactionPattern},
-    load_generator::{LoadGenerator, PairwiseTransferTxnGenerator, RingTransferTxnGenerator},
-};
 use logger::{self, prelude::*};
 use std::ops::DerefMut;
 
@@ -66,6 +66,7 @@ mod tests {
         OP_COUNTER,
     };
     use client::AccountData;
+    use config::config::RoleType;
     use libra_swarm::swarm::LibraSwarm;
     use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
     use std::ops::Range;
@@ -77,11 +78,13 @@ mod tests {
         let (faucet_account_keypair, faucet_key_file_path, temp_dir) =
             generate_keypair::load_faucet_key_or_create_default(None);
         let swarm = LibraSwarm::launch_swarm(
-            4,    /* num_nodes */
+            4, /* num_nodes */
+            RoleType::Validator,
             true, /* disable_logging */
             faucet_account_keypair,
             None, /* config_dir */
             None, /* template_path */
+            None, /* upstream_path */
         );
         let mut args = BenchOpt {
             validator_addresses: Vec::new(),

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -1104,7 +1104,7 @@ mod tests {
         let mnemonic_path = file.path().to_str().unwrap().to_string();
         let consensus_peer_file = TempPath::new();
         let consensus_peers_path = consensus_peer_file.path();
-        let (_, consensus_peers_config) = ConfigHelpers::get_test_consensus_config(1, None);
+        let (_, consensus_peers_config, _) = ConfigHelpers::gen_validator_nodes(1, None);
         consensus_peers_config.save_config(&consensus_peers_path);
         let val_set_file = consensus_peers_path.to_str().unwrap().to_string();
 

--- a/common/executable_helpers/src/helpers.rs
+++ b/common/executable_helpers/src/helpers.rs
@@ -7,7 +7,6 @@ use logger::prelude::*;
 use slog_scope::GlobalLoggerGuard;
 
 // General args
-pub const ARG_PEER_ID: &str = "--peer_id";
 pub const ARG_DISABLE_LOGGING: &str = "--no_logging";
 pub const ARG_CONFIG_PATH: &str = "--config_path";
 
@@ -17,15 +16,11 @@ pub const ARG_PAYLOAD_SIZE: &str = "--payload_size";
 
 pub fn load_configs_from_args(args: &ArgMatches<'_>) -> NodeConfig {
     let node_config = if args.is_present(ARG_CONFIG_PATH) {
-        // Allow peer id over-ride via command line
-        let peer_id = value_t!(args, ARG_PEER_ID, String).ok();
-
         let config_path =
             value_t!(args, ARG_CONFIG_PATH, String).expect("Path to config file must be specified");
         info!("Loading node config from: {}", &config_path);
-        NodeConfig::load(peer_id, &config_path).expect("NodeConfig")
+        NodeConfig::load(&config_path).expect("NodeConfig")
     } else {
-        // Note we will silently ignore --peer_id arg here
         info!("Loading test configs");
         NodeConfigHelpers::get_single_node_test_config(false /* random ports */)
     };
@@ -102,11 +97,6 @@ fn get_arg_matches(app_name: String, arg_names: Vec<&str>) -> ArgMatches<'_> {
         let takes_value;
         let help;
         match arg {
-            ARG_PEER_ID => {
-                short = "-p";
-                takes_value = true;
-                help = "Specify peer id for this node";
-            }
             ARG_CONFIG_PATH => {
                 short = "-f";
                 takes_value = true;
@@ -137,6 +127,5 @@ fn get_arg_matches(app_name: String, arg_names: Vec<&str>) -> ArgMatches<'_> {
                 .help(help),
         );
     }
-
     app.get_matches()
 }

--- a/config/config_builder/Cargo.toml
+++ b/config/config_builder/Cargo.toml
@@ -9,12 +9,14 @@ edition = "2018"
 [dependencies]
 clap = { version = "2.33.0", default-features = false }
 hex = { version = "0.3.2", default-features = false }
+parity-multiaddr = { version = "0.5.0", default-features = false }
 rand = "0.6.5"
 
 config = { path = ".." }
 crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 generate_keypair = { path = "../generate_keypair" }
+logger = { path = "../../common/logger" }
 proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 types = { path = "../../types" }
 vm_genesis = { path = "../../language/vm/vm_genesis" }

--- a/config/config_builder/src/swarm_config.rs
+++ b/config/config_builder/src/swarm_config.rs
@@ -11,95 +11,129 @@ use config::{
     keys::{ConsensusKeyPair, NetworkKeyPairs},
     seed_peers::{SeedPeersConfig, SeedPeersConfigHelpers},
     trusted_peers::{
-        ConfigHelpers, ConsensusPeersConfig, NetworkPeerPrivateKeys, NetworkPeersConfig,
+        ConfigHelpers, ConsensusPeersConfig, ConsensusPrivateKey, NetworkPeersConfig,
+        NetworkPrivateKeys, UpstreamPeersConfig,
     },
+    utils::get_available_port,
 };
 use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
-use std::path::{Path, PathBuf};
+use logger::prelude::*;
+use parity_multiaddr::{Multiaddr, Protocol};
+use proto_conv::IntoProtoBytes;
+use std::{
+    collections::BTreeMap,
+    fs::{self, File},
+    io::prelude::*,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use types::PeerId;
 
 pub struct SwarmConfig {
-    pub configs: Vec<(PathBuf, NodeConfig)>,
-    pub seed_peers: (PathBuf, SeedPeersConfig),
-    pub network_peers: (PathBuf, NetworkPeersConfig),
-    pub consensus_peers: (PathBuf, ConsensusPeersConfig),
+    pub configs: Vec<PathBuf>,
 }
 
 impl SwarmConfig {
-    //TODO convert this to use the Builder paradigm
-    pub fn new(
+    pub fn new_full_node_swarm(
         mut template: NodeConfig,
         num_nodes: usize,
-        role: RoleType,
-        faucet_key: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         prune_seed_peers_for_discovery: bool,
         is_ipv4: bool,
         key_seed: Option<[u8; 32]>,
         output_dir: &Path,
+        is_permissioned: bool,
+        upstream_config_dir: PathBuf,
     ) -> Result<Self> {
-        // Generate trusted peer configs + their private keys.
-        template.base.data_dir_path = output_dir.into();
-
-        // Setup consensus keys and peers config file.
-        let consensus_peers_file = template.consensus.consensus_peers_file.clone();
-        let (mut consensus_private_keys, consensus_peers_config) =
-            ConfigHelpers::get_test_consensus_config(num_nodes, key_seed);
-        consensus_peers_config.save_config(&output_dir.join(&consensus_peers_file));
-
-        // Setup network keys and file.
-        let network_peers_file = template.networks.get(0).unwrap().network_peers_file.clone();
-        let (mut network_private_keys, network_peers_config) =
-            ConfigHelpers::get_test_network_peers_config(&consensus_peers_config, key_seed);
-        network_peers_config.save_config(&output_dir.join(&network_peers_file));
-
-        // Setup seed peers and file.
-        let seed_peers_file = template.networks.get(0).unwrap().seed_peers_file.clone();
+        // Load upstream peer config from file.
+        let mut upstream_peer_config =
+            NodeConfig::load(&upstream_config_dir.join("node.config.toml"))?;
+        // Generate new network config for upstream peer (permissioned if so).
+        let (mut upstream_private_keys, upstream_network_peers_config) =
+            ConfigHelpers::gen_full_nodes(1, Some([2u8; 32]));
+        let upstream_peer_id = *upstream_private_keys.keys().nth(0).unwrap();
+        let upstream_private_keys = upstream_private_keys
+            .remove_entry(&upstream_peer_id)
+            .unwrap()
+            .1;
+        let upstream_network_keypairs = NetworkKeyPairs::load(
+            upstream_private_keys.network_signing_private_key,
+            upstream_private_keys.network_identity_private_key,
+        );
+        let template_network = template.networks.get(0).unwrap();
+        // Generate upstream peer address.
+        let upstream_full_node_address = {
+            let mut addr = Multiaddr::empty();
+            if is_ipv4 {
+                addr.push(Protocol::Ip4("0.0.0.0".parse().unwrap()));
+            } else {
+                addr.push(Protocol::Ip6("::1".parse().unwrap()));
+            }
+            addr.push(Protocol::Tcp(get_available_port()));
+            addr
+        };
+        // Save new network keys for upstream peer.
+        let upstream_network_keys_file_name =
+            format!("{}.network.keys.toml", upstream_peer_id.to_string());
+        upstream_network_keypairs
+            .save_config(&upstream_config_dir.join(&upstream_network_keys_file_name));
+        // Create network config for upstream node.
+        let mut upstream_full_node_config = NetworkConfig {
+            peer_id: upstream_peer_id.to_string(),
+            role: "full_node".to_string(),
+            network_keypairs_file: upstream_network_keys_file_name.into(),
+            network_peers_file: template_network.network_peers_file.clone(),
+            seed_peers_file: template_network.seed_peers_file.clone(),
+            listen_address: upstream_full_node_address.clone(),
+            advertised_address: upstream_full_node_address.clone(),
+            discovery_interval_ms: template_network.discovery_interval_ms,
+            connectivity_check_interval_ms: template_network.connectivity_check_interval_ms,
+            enable_encryption_and_authentication: template_network
+                .enable_encryption_and_authentication,
+            is_permissioned,
+            // Dummy values - will be loaded from corresponding files.
+            network_keypairs: NetworkKeyPairs::default(),
+            network_peers: template_network.network_peers.clone(),
+            seed_peers: template_network.seed_peers.clone(),
+        };
+        let (mut private_keys, mut network_peers_config) =
+            ConfigHelpers::gen_full_nodes(num_nodes, key_seed);
+        // Add upstream peer to NetworkPeersConfig.
+        network_peers_config
+            .peers
+            .extend(upstream_network_peers_config.peers.into_iter());
+        // Update network peers config in upstream peer config if permissioned.
+        if is_permissioned {
+            let upstream_network_peers_file_name =
+                format!("{}.network_peers.config.toml", upstream_peer_id.to_string());
+            network_peers_config
+                .save_config(&upstream_config_dir.join(&upstream_network_peers_file_name));
+            upstream_full_node_config.network_peers_file = upstream_network_peers_file_name.into();
+        }
+        // Modify upstream peer config to add the new network config.
+        upstream_peer_config
+            .networks
+            .push(upstream_full_node_config);
+        // Write contents of upstream config to file.
+        upstream_peer_config.save_config(&upstream_config_dir.join("node.config.toml"));
+        // Add upstream peer to StateSync::UpstreamPeersConfig.
+        template.state_sync.upstream_peers = UpstreamPeersConfig {
+            upstream_peers: vec![upstream_peer_id.to_string()],
+        };
+        // Setup seed peers config.
         let mut seed_peers_config = SeedPeersConfigHelpers::get_test_config_with_ipver(
             &network_peers_config,
             None,
             is_ipv4,
         );
-
-        gen_genesis_transaction(
-            &output_dir.join(&template.execution.genesis_file_location),
-            &faucet_key,
-            &consensus_peers_config,
-            &network_peers_config,
-        )?;
-
-        let mut configs = Vec::new();
-        // Generate configs for all nodes.
-        for (node_id, addrs) in &seed_peers_config.seed_peers {
-            // Serialize keypairs on independent {node}.node.keys.toml file. This is because the
-            // network_keypairs and consensus_keypair fields are skipped during
-            // (de)serialization.
-            let consensus_private_key = consensus_private_keys.remove_entry(node_id).unwrap().1;
-            let consensus_keypair = ConsensusKeyPair::load(Some(consensus_private_key));
-            let NetworkPeerPrivateKeys {
-                network_signing_private_key,
-                network_identity_private_key,
-            } = network_private_keys.remove_entry(node_id).unwrap().1;
-            let network_keypairs =
-                NetworkKeyPairs::load(network_signing_private_key, network_identity_private_key);
-            let mut validator_config = Self::get_config_by_role(
-                &template,
-                role,
-                &node_id,
-                &network_keypairs,
-                &consensus_keypair,
-                &output_dir,
-                &template.storage.dir,
-            );
-            // If listen address is different from advertised address, we need to set it
-            // appropriately below.
-            validator_config.networks.get_mut(0).unwrap().listen_address = addrs[0].clone();
-            validator_config
-                .networks
-                .get_mut(0)
-                .unwrap()
-                .advertised_address = addrs[0].clone();
-            configs.push(validator_config);
-        }
+        // Extract peer addresses for full nodes from seed peer config.
+        let peer_addresses: BTreeMap<_, _> = seed_peers_config
+            .seed_peers
+            .clone()
+            .into_iter()
+            .filter(|(peer_id, _)| *peer_id != upstream_peer_id.to_string())
+            .collect();
+        // Prune seed peers config to a single node if needed.
         if prune_seed_peers_for_discovery {
             seed_peers_config.seed_peers = seed_peers_config
                 .seed_peers
@@ -108,29 +142,130 @@ impl SwarmConfig {
                 .take(1)
                 .collect();
         }
-        seed_peers_config.save_config(&output_dir.join(&seed_peers_file));
-        let configs = configs
-            .into_iter()
-            .map(|config| {
-                let file_name = format!("{}.node.config.toml", Self::get_alias(&config));
-                let config_file = output_dir.join(file_name);
-                (config_file, config)
-            })
-            .collect::<Vec<(PathBuf, NodeConfig)>>();
-
-        for (path, node_config) in &configs {
-            node_config.save_config(&path);
+        // Add upstream peer to SeedPeersConfig of full nodes.
+        seed_peers_config.seed_peers.insert(
+            upstream_peer_id.to_string(),
+            vec![upstream_full_node_address.clone()],
+        );
+        // Load contents of consensus peers file from upstream node.
+        let consensus_peers_config = ConsensusPeersConfig::load_config(
+            &upstream_config_dir.join(&upstream_peer_config.consensus.consensus_peers_file),
+        );
+        // NOTE: Need to restart upstream node with new configuration.
+        let mut configs = Vec::new();
+        // Generate configs for all nodes.
+        for (index, (node_id, addrs)) in peer_addresses.iter().enumerate() {
+            let node_dir = output_dir.join(format!("{}", index));
+            std::fs::create_dir_all(&node_dir).expect("unable to create config dir");
+            // Copy contents of genesis file from upstream node.
+            let genesis_transaction_file = node_dir.join(&template.execution.genesis_file_location);
+            fs::copy(
+                upstream_config_dir
+                    .with_file_name(&upstream_peer_config.execution.genesis_file_location),
+                genesis_transaction_file,
+            )?;
+            // Remove network private keys for this peer.
+            let peer_id = PeerId::from_str(&node_id).unwrap();
+            warn!("Looking for peer id for peer: {}", node_id);
+            let NetworkPrivateKeys {
+                network_signing_private_key,
+                network_identity_private_key,
+            } = private_keys
+                .remove_entry(&peer_id)
+                .unwrap_or_else(|| panic!("Key not found for peer: {}", node_id))
+                .1;
+            let network_keypairs =
+                NetworkKeyPairs::load(network_signing_private_key, network_identity_private_key);
+            let full_node_config = Self::get_config_by_role(
+                &template,
+                RoleType::FullNode,
+                &node_id,
+                &network_keypairs,
+                &ConsensusKeyPair::load(None),
+                &seed_peers_config,
+                &network_peers_config,
+                &consensus_peers_config,
+                &node_dir,
+                &addrs,
+            );
+            let config_file = node_dir.join("node.config.toml");
+            full_node_config.save_config(&config_file);
+            configs.push(config_file);
         }
+        Ok(Self { configs })
+    }
 
-        Ok(Self {
-            configs,
-            seed_peers: (output_dir.join(seed_peers_file), seed_peers_config),
-            network_peers: (output_dir.join(network_peers_file), network_peers_config),
-            consensus_peers: (
-                output_dir.join(consensus_peers_file),
-                consensus_peers_config,
-            ),
-        })
+    pub fn new_validator_swarm(
+        template: NodeConfig,
+        num_nodes: usize,
+        faucet_key: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+        prune_seed_peers_for_discovery: bool,
+        is_ipv4: bool,
+        key_seed: Option<[u8; 32]>,
+        output_dir: &Path,
+    ) -> Result<Self> {
+        let (mut private_keys, consensus_peers_config, network_peers_config) =
+            ConfigHelpers::gen_validator_nodes(num_nodes, key_seed);
+        let mut seed_peers_config = SeedPeersConfigHelpers::get_test_config_with_ipver(
+            &network_peers_config,
+            None,
+            is_ipv4,
+        );
+        let raw_genesis_transaction =
+            gen_genesis_transaction(&faucet_key, &consensus_peers_config, &network_peers_config)
+                .into_proto_bytes()?;
+        // Extract peer addresses from seed peer config.
+        let peer_addresses: BTreeMap<_, _> =
+            seed_peers_config.seed_peers.clone().into_iter().collect();
+        // Prune seed peers config if needed.
+        if prune_seed_peers_for_discovery {
+            seed_peers_config.seed_peers = seed_peers_config
+                .seed_peers
+                .clone()
+                .into_iter()
+                .take(1)
+                .collect();
+        }
+        let mut configs = Vec::new();
+        // Generate configs for all nodes.
+        for (index, (node_id, addrs)) in peer_addresses.iter().enumerate() {
+            let node_dir = output_dir.join(format!("{}", index));
+            std::fs::create_dir_all(&node_dir).expect("unable to create config dir");
+            debug!("Directory for node {}: {:?}", index, node_dir);
+            // Save genesis transaction in file.
+            let mut genesis_transaction_file =
+                File::create(&node_dir.join(&template.execution.genesis_file_location))?;
+            genesis_transaction_file.write_all(&raw_genesis_transaction)?;
+            let peer_id = PeerId::from_str(&node_id).unwrap();
+            let (
+                ConsensusPrivateKey {
+                    consensus_private_key,
+                },
+                NetworkPrivateKeys {
+                    network_signing_private_key,
+                    network_identity_private_key,
+                },
+            ) = private_keys.remove_entry(&peer_id).unwrap().1;
+            let consensus_keypair = ConsensusKeyPair::load(Some(consensus_private_key));
+            let network_keypairs =
+                NetworkKeyPairs::load(network_signing_private_key, network_identity_private_key);
+            let validator_config = Self::get_config_by_role(
+                &template,
+                RoleType::Validator,
+                &node_id,
+                &network_keypairs,
+                &consensus_keypair,
+                &seed_peers_config,
+                &network_peers_config,
+                &consensus_peers_config,
+                &node_dir,
+                &addrs,
+            );
+            let config_file = node_dir.join("node.config.toml");
+            validator_config.save_config(&config_file);
+            configs.push(config_file);
+        }
+        Ok(Self { configs })
     }
 
     fn get_config_by_role(
@@ -138,21 +273,35 @@ impl SwarmConfig {
         role: RoleType,
         node_id: &str,
         network_keypairs: &NetworkKeyPairs,
-        // TODO(abhayb): make Optional.
         consenus_keypair: &ConsensusKeyPair,
+        seed_peers_config: &SeedPeersConfig,
+        network_peers_config: &NetworkPeersConfig,
+        consensus_peers_config: &ConsensusPeersConfig,
         output_dir: &Path,
-        dir: &PathBuf,
+        addrs: &[Multiaddr],
     ) -> NodeConfig {
+        // Save consensus keys if present.
+        let mut consensus_keys_file_name = "".to_string();
+        if consenus_keypair.is_present() {
+            consensus_keys_file_name = format!("{}.node.consensus.keys.toml", node_id.to_string());
+            consenus_keypair.save_config(&output_dir.join(&consensus_keys_file_name));
+        }
+        // Save network keys.
         let network_keys_file_name = format!("{}.node.network.keys.toml", node_id.to_string());
         network_keypairs.save_config(&output_dir.join(&network_keys_file_name));
-        let consensus_keys_file_name = format!("{}.node.consensus.keys.toml", node_id.to_string());
-        consenus_keypair.save_config(&output_dir.join(&consensus_keys_file_name));
-
+        // Save seed peers file.
+        let seed_peers_file_name = format!("{}.seed_peers.config.toml", node_id);
+        seed_peers_config.save_config(&output_dir.join(&seed_peers_file_name));
+        // Save network peers file.
+        let network_peers_file_name = format!("{}.network_peers.config.toml", node_id);
+        network_peers_config.save_config(&output_dir.join(&network_peers_file_name));
+        // Save consensus peers file.
+        let consensus_peers_file_name = "consensus_peers.config.toml".to_string();
+        consensus_peers_config.save_config(&output_dir.join(&consensus_peers_file_name));
         let role_string = match role {
             RoleType::Validator => "validator".to_string(),
             RoleType::FullNode => "full_node".to_string(),
         };
-
         let base_config = BaseConfig::new(
             template.base.data_dir_path.clone(),
             template.base.node_sync_retries,
@@ -163,19 +312,20 @@ impl SwarmConfig {
         let network_config = NetworkConfig {
             peer_id: node_id.to_string(),
             role: role_string,
-            network_keypairs: NetworkKeyPairs::default(),
             network_keypairs_file: network_keys_file_name.into(),
-            network_peers: template_network.network_peers.clone(),
-            network_peers_file: template_network.network_peers_file.clone(),
-            seed_peers: template_network.seed_peers.clone(),
-            seed_peers_file: template_network.seed_peers_file.clone(),
-            listen_address: template_network.listen_address.clone(),
-            advertised_address: template_network.advertised_address.clone(),
+            network_peers_file: network_peers_file_name.into(),
+            seed_peers_file: seed_peers_file_name.into(),
+            listen_address: addrs[0].clone(),
+            advertised_address: addrs[0].clone(),
             discovery_interval_ms: template_network.discovery_interval_ms,
             connectivity_check_interval_ms: template_network.connectivity_check_interval_ms,
             enable_encryption_and_authentication: template_network
                 .enable_encryption_and_authentication,
             is_permissioned: template_network.is_permissioned,
+            // Dummy values - will be loaded from corresponding files.
+            network_keypairs: NetworkKeyPairs::default(),
+            network_peers: template_network.network_peers.clone(),
+            seed_peers: template_network.seed_peers.clone(),
         };
         let consensus_config = ConsensusConfig {
             max_block_size: template.consensus.max_block_size,
@@ -183,10 +333,11 @@ impl SwarmConfig {
             contiguous_rounds: template.consensus.contiguous_rounds,
             max_pruned_blocks_in_mem: template.consensus.max_pruned_blocks_in_mem,
             pacemaker_initial_timeout_ms: template.consensus.pacemaker_initial_timeout_ms,
-            consensus_keypair: ConsensusKeyPair::default(),
             consensus_keypair_file: consensus_keys_file_name.into(),
+            consensus_peers_file: consensus_peers_file_name.into(),
+            // Dummy values - will be loaded from corresponding files.
+            consensus_keypair: ConsensusKeyPair::default(),
             consensus_peers: template.consensus.consensus_peers.clone(),
-            consensus_peers_file: template.consensus.consensus_peers_file.clone(),
         };
         let mut config = NodeConfig {
             base: base_config,
@@ -204,21 +355,9 @@ impl SwarmConfig {
             secret_service: template.secret_service.clone(),
         };
         NodeConfigHelpers::randomize_config_ports(&mut config);
-        let alias = Self::get_alias(&config);
-        config.storage.dir = dir.join(alias).join("db");
+        config.storage.dir = output_dir.join(&template.storage.dir).join("db");
         config.vm_config.publishing_options = VMPublishingOption::Open;
         config
-    }
-
-    pub fn get_alias(config: &NodeConfig) -> String {
-        let network = config.networks.get(0).unwrap();
-        match (&network.role).into() {
-            RoleType::Validator => format!("validator_{}", network.peer_id),
-            RoleType::FullNode => format!(
-                "full_node_{}_{}",
-                network.peer_id, config.admission_control.admission_control_service_port
-            ),
-        }
     }
 }
 
@@ -232,7 +371,10 @@ pub struct SwarmConfigBuilder {
     faucet_account_keypair_filepath: Option<PathBuf>,
     faucet_account_keypair: Option<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
     role: RoleType,
+    upstream_config_dir: Option<String>,
+    is_permissioned: bool,
 }
+
 impl Default for SwarmConfigBuilder {
     fn default() -> Self {
         SwarmConfigBuilder {
@@ -245,6 +387,8 @@ impl Default for SwarmConfigBuilder {
             faucet_account_keypair_filepath: None,
             faucet_account_keypair: None,
             role: RoleType::Validator,
+            upstream_config_dir: None,
+            is_permissioned: true,
         }
     }
 }
@@ -307,7 +451,17 @@ impl SwarmConfigBuilder {
         self
     }
 
-    pub fn build(&mut self) -> Result<SwarmConfig> {
+    pub fn with_upstream_config_dir(&mut self, upstream_config_dir: Option<String>) -> &mut Self {
+        self.upstream_config_dir = upstream_config_dir;
+        self
+    }
+
+    pub fn with_is_permissioned(&mut self, is_permissioned: bool) -> &mut Self {
+        self.is_permissioned = is_permissioned;
+        self
+    }
+
+    pub fn build(mut self) -> Result<SwarmConfig> {
         // verify required fields
         let faucet_key_path = self.faucet_account_keypair_filepath.clone();
         let faucet_key = self.faucet_account_keypair.take().unwrap_or_else(|| {
@@ -334,54 +488,38 @@ impl SwarmConfigBuilder {
         // update everything in the template and then generate swarm config
         let listen_address = if self.is_ipv4 { "0.0.0.0" } else { "::1" };
         let listen_address = listen_address.to_string();
+        template.base.data_dir_path = self.output_dir.clone();
         template.admission_control.address = listen_address.clone();
         template.debug_interface.address = listen_address;
         template.execution.genesis_file_location = "genesis.blob".to_string();
-        // Set and generate network peers config file
-        if template
-            .networks
-            .get(0)
-            .unwrap()
-            .network_peers_file
-            .as_os_str()
-            .is_empty()
-        {
-            template.networks.get_mut(0).unwrap().network_peers_file =
-                PathBuf::from("network_peers.config.toml");
-        };
-
-        // Set and generate network peers config file
-        if template
-            .consensus
-            .consensus_peers_file
-            .as_os_str()
-            .is_empty()
-        {
-            template.consensus.consensus_peers_file = PathBuf::from("consensus_peers.config.toml");
-        };
-
-        // Set seed peers file and config. Config is populated in the loop below
-        if template
-            .networks
-            .get(0)
-            .unwrap()
-            .seed_peers_file
-            .as_os_str()
-            .is_empty()
-        {
-            template.networks.get_mut(0).unwrap().seed_peers_file =
-                PathBuf::from("seed_peers.config.toml");
-        };
-
-        SwarmConfig::new(
-            template,
-            self.num_nodes,
-            self.role,
-            faucet_key,
-            self.force_discovery,
-            self.is_ipv4,
-            self.key_seed,
-            &self.output_dir,
-        )
+        template.consensus.consensus_peers_file =
+            PathBuf::from("consensus_peers.config.toml".to_string());
+        // TODO:
+        // [] Use rng instead of seed to prevent duplicate key generation in trusted_peers.rs.
+        if self.role == RoleType::Validator {
+            SwarmConfig::new_validator_swarm(
+                template,
+                self.num_nodes,
+                faucet_key,
+                self.force_discovery,
+                self.is_ipv4,
+                self.key_seed,
+                &self.output_dir,
+            )
+        } else {
+            SwarmConfig::new_full_node_swarm(
+                template,
+                self.num_nodes,
+                self.force_discovery,
+                self.is_ipv4,
+                self.key_seed,
+                &self.output_dir,
+                self.is_permissioned,
+                PathBuf::from(
+                    self.upstream_config_dir
+                        .expect("Upstream config path not set"),
+                ),
+            )
+        }
     }
 }

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -183,6 +183,13 @@ impl ConsensusKeyPair {
     pub fn take_consensus_private(&mut self) -> Option<Ed25519PrivateKey> {
         self.consensus_private_key.take()
     }
+
+    pub fn is_present(&self) -> bool {
+        match self.consensus_private_key {
+            PrivateKeyContainer::Present(_) => true,
+            _ => false,
+        }
+    }
 }
 
 pub fn serialize_opt_key<S, K>(opt_key: &Option<K>, serializer: S) -> Result<S::Ok, S::Error>

--- a/config/src/seed_peers.rs
+++ b/config/src/seed_peers.rs
@@ -37,12 +37,7 @@ impl SeedPeersConfigHelpers {
     ) -> SeedPeersConfig {
         let mut seed_peers = HashMap::new();
         // sort to have same repeatable order
-        let mut peers: Vec<String> = network_peers
-            .peers
-            .clone()
-            .into_iter()
-            .map(|(peer_id, _)| peer_id)
-            .collect();
+        let mut peers: Vec<String> = network_peers.peers.keys().cloned().collect();
         peers.sort_unstable_by_key(std::clone::Clone::clone);
         // If a port is supplied, we should have only 1 peer.
         if port.is_some() {

--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -3,13 +3,15 @@
 
 use crypto::{
     ed25519::{compat, *},
-    traits::ValidKeyStringExt,
+    traits::{ValidKey, ValidKeyStringExt},
     x25519::{self, X25519StaticPrivateKey, X25519StaticPublicKey},
 };
+use mirai_annotations::postcondition;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::{BTreeMap, HashMap},
+    convert::TryFrom,
     hash::BuildHasher,
     str::FromStr,
 };
@@ -34,7 +36,7 @@ pub struct NetworkPeerInfo {
     pub network_identity_pubkey: X25519StaticPublicKey,
 }
 
-pub struct NetworkPeerPrivateKeys {
+pub struct NetworkPrivateKeys {
     pub network_signing_private_key: Ed25519PrivateKey,
     pub network_identity_private_key: X25519StaticPrivateKey,
 }
@@ -52,6 +54,10 @@ pub struct ConsensusPeerInfo {
     #[serde(deserialize_with = "deserialize_key")]
     #[serde(rename = "c")]
     pub consensus_pubkey: Ed25519PublicKey,
+}
+
+pub struct ConsensusPrivateKey {
+    pub consensus_private_key: Ed25519PrivateKey,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -106,87 +112,116 @@ pub struct ConfigHelpers {}
 /// Creates a new TrustedPeersConfig with the given number of peers,
 /// as well as a hashmap of all the test validator nodes' private keys.
 impl ConfigHelpers {
-    pub fn get_test_consensus_config(
-        number_of_peers: usize,
+    pub fn gen_validator_nodes(
+        num_peers: usize,
         seed: Option<[u8; 32]>,
-    ) -> (HashMap<String, Ed25519PrivateKey>, ConsensusPeersConfig) {
+    ) -> (
+        HashMap<AccountAddress, (ConsensusPrivateKey, NetworkPrivateKeys)>,
+        ConsensusPeersConfig,
+        NetworkPeersConfig,
+    ) {
         let mut consensus_peers = HashMap::new();
+        let mut network_peers = HashMap::new();
+        let mut consensus_private_keys = BTreeMap::new();
         let mut peers_private_keys = HashMap::new();
-        // deterministically derive keypairs from a seeded-rng
-        let seed = if let Some(seed) = seed {
-            seed
-        } else {
-            [0u8; 32]
-        };
+        // Deterministically derive keypairs from a seeded-rng
+        let seed = seed.unwrap_or([0u8; 32]);
         let mut fast_rng = StdRng::from_seed(seed);
-        for _ in 0..number_of_peers {
-            // Generate extra keypairs to preserve peer ids.
+        for _ in 0..num_peers {
             let _ = compat::generate_keypair(&mut fast_rng);
             let _ = x25519::compat::generate_keypair(&mut fast_rng);
-            let (private0, public0) = compat::generate_keypair(&mut fast_rng);
-            let peer_id = AccountAddress::from_public_key(&public0);
+            let (private2, public2) = compat::generate_keypair(&mut fast_rng);
+            // Generate peer id from consensus public key.
+            let peer_id = AccountAddress::from_public_key(&public2);
             consensus_peers.insert(
                 peer_id.to_string(),
                 ConsensusPeerInfo {
-                    consensus_pubkey: public0,
+                    consensus_pubkey: public2,
+                },
+            );
+            consensus_private_keys.insert(
+                peer_id,
+                ConsensusPrivateKey {
+                    consensus_private_key: private2,
+                },
+            );
+        }
+        let mut fast_rng = StdRng::from_seed(seed);
+        for (peer_id, consensus_private_key) in consensus_private_keys.into_iter() {
+            let (private0, public0) = compat::generate_keypair(&mut fast_rng);
+            let (private1, public1) = x25519::compat::generate_keypair(&mut fast_rng);
+            let _ = compat::generate_keypair(&mut fast_rng);
+            network_peers.insert(
+                peer_id.to_string(),
+                NetworkPeerInfo {
+                    network_signing_pubkey: public0,
+                    network_identity_pubkey: public1,
                 },
             );
             // save the private keys in a different hashmap
-            peers_private_keys.insert(peer_id.to_string(), private0);
+            peers_private_keys.insert(
+                peer_id,
+                (
+                    consensus_private_key,
+                    NetworkPrivateKeys {
+                        network_identity_private_key: private1,
+                        network_signing_private_key: private0,
+                    },
+                ),
+            );
         }
+        postcondition!(peers_private_keys.len() == num_peers);
         (
             peers_private_keys,
             ConsensusPeersConfig {
                 peers: consensus_peers,
             },
-        )
-    }
-
-    pub fn get_test_network_peers_config(
-        consensus_peers: &ConsensusPeersConfig,
-        seed: Option<[u8; 32]>,
-    ) -> (HashMap<String, NetworkPeerPrivateKeys>, NetworkPeersConfig) {
-        let mut network_peers = HashMap::new();
-        let mut peers_private_keys = HashMap::new();
-        // deterministically derive keypairs from a seeded-rng
-        let seed = if let Some(seed) = seed {
-            seed
-        } else {
-            [0u8; 32]
-        };
-        let peers_ordered: BTreeMap<_, _> = consensus_peers.peers.iter().collect();
-        let mut fast_rng = StdRng::from_seed(seed);
-        for peer_id in peers_ordered.keys().cloned() {
-            let (private0, public0) = compat::generate_keypair(&mut fast_rng);
-            let (private1, public1) = x25519::compat::generate_keypair(&mut fast_rng);
-            // Generate extra keypairs to preserve peer ids.
-            let _ = compat::generate_keypair(&mut fast_rng);
-            // save the public_key in peers hashmap
-            let peer = NetworkPeerInfo {
-                network_signing_pubkey: public0,
-                network_identity_pubkey: public1,
-            };
-            network_peers.insert(peer_id.clone(), peer);
-            // save the private keys in a different hashmap
-            let private_keys = NetworkPeerPrivateKeys {
-                network_signing_private_key: private0,
-                network_identity_private_key: private1,
-            };
-            peers_private_keys.insert(peer_id.clone(), private_keys);
-        }
-        (
-            peers_private_keys,
             NetworkPeersConfig {
                 peers: network_peers,
             },
         )
     }
 
-    pub fn get_test_upstream_peers_config(
-        network_peers: &NetworkPeersConfig,
-    ) -> UpstreamPeersConfig {
-        let upstream_peers = network_peers.peers.keys().cloned().collect();
-        UpstreamPeersConfig { upstream_peers }
+    pub fn gen_full_nodes(
+        num_peers: usize,
+        seed: Option<[u8; 32]>,
+    ) -> (
+        HashMap<AccountAddress, NetworkPrivateKeys>,
+        NetworkPeersConfig,
+    ) {
+        let mut network_peers = HashMap::new();
+        let mut peers_private_keys = HashMap::new();
+        // Deterministically derive keypairs from a seeded-rng
+        let seed = seed.unwrap_or([1u8; 32]);
+        let mut fast_rng = StdRng::from_seed(seed);
+        for _ in 0..num_peers {
+            let (private0, public0) = compat::generate_keypair(&mut fast_rng);
+            let (private1, public1) = x25519::compat::generate_keypair(&mut fast_rng);
+            // Generate peer id from network identity key.
+            let peer_id = AccountAddress::try_from(public1.to_bytes()).unwrap();
+            network_peers.insert(
+                peer_id.to_string(),
+                NetworkPeerInfo {
+                    network_signing_pubkey: public0,
+                    network_identity_pubkey: public1,
+                },
+            );
+            // save the private keys in a different hashmap
+            peers_private_keys.insert(
+                peer_id,
+                NetworkPrivateKeys {
+                    network_identity_private_key: private1,
+                    network_signing_private_key: private0,
+                },
+            );
+        }
+        postcondition!(peers_private_keys.len() == num_peers);
+        (
+            peers_private_keys,
+            NetworkPeersConfig {
+                peers: network_peers,
+            },
+        )
     }
 }
 

--- a/config/src/unit_tests/config_test.rs
+++ b/config/src/unit_tests/config_test.rs
@@ -18,10 +18,9 @@ fn verify_all_configs() {
     for path in paths {
         let config_path = path.unwrap().path();
         let config_path_str = config_path.to_str().unwrap();
-        let peer_id = PeerId::random();
         if config_path_str.ends_with(".toml") {
             println!("Loading {}", config_path_str);
-            let _ = NodeConfig::load(Some((&peer_id).into()), config_path_str).expect("NodeConfig");
+            let _ = NodeConfig::load(config_path_str).expect("NodeConfig");
         } else {
             println!("Invalid file {} for verifying", config_path_str);
         }

--- a/config/src/unit_tests/seed_peers_test.rs
+++ b/config/src/unit_tests/seed_peers_test.rs
@@ -6,8 +6,6 @@ use crate::trusted_peers::ConfigHelpers;
 
 #[test]
 fn generate_test_config() {
-    let (_, consensus_peers_config) = ConfigHelpers::get_test_consensus_config(10, None);
-    let (_, network_peers_config) =
-        ConfigHelpers::get_test_network_peers_config(&consensus_peers_config, None);
+    let (_, _, network_peers_config) = ConfigHelpers::gen_validator_nodes(10, None);
     let _ = SeedPeersConfigHelpers::get_test_config(&network_peers_config, None);
 }

--- a/config/src/unit_tests/trusted_peers_test.rs
+++ b/config/src/unit_tests/trusted_peers_test.rs
@@ -5,6 +5,7 @@ use super::ConfigHelpers;
 
 #[test]
 fn generate_test_config() {
-    let (_, consensus_peers_config) = ConfigHelpers::get_test_consensus_config(10, None);
-    let (_, _) = ConfigHelpers::get_test_network_peers_config(&consensus_peers_config, None);
+    let (_keys, _consensus_peers_config, _network_peers_config) =
+        ConfigHelpers::gen_validator_nodes(10, None);
+    let (_keys, _network_peers_config) = ConfigHelpers::gen_full_nodes(10, None);
 }

--- a/crypto/secret_service/src/main.rs
+++ b/crypto/secret_service/src/main.rs
@@ -1,16 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use executable_helpers::helpers::{
-    setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
-};
+use executable_helpers::helpers::{setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING};
 use secret_service::secret_service_node;
 
 /// Run a SecretService in its own process.
 fn main() {
     let (config, _logger, _args) = setup_executable(
         "Libra Secret Service".to_string(),
-        vec![ARG_PEER_ID, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
+        vec![ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
     );
 
     let secret_service_node = secret_service_node::SecretServiceNode::new(config);

--- a/language/vm/vm_genesis/src/main.rs
+++ b/language/vm/vm_genesis/src/main.rs
@@ -14,8 +14,7 @@ use proto_conv::IntoProtoBytes;
 
 /// Generate the genesis blob used by the Libra blockchain
 fn generate_genesis_blob() -> Vec<u8> {
-    let (_, consensus_config) = ConfigHelpers::get_test_consensus_config(10, None);
-    let (_, network_config) = ConfigHelpers::get_test_network_peers_config(&consensus_config, None);
+    let (_, consensus_config, network_config) = ConfigHelpers::gen_validator_nodes(10, None);
     encode_genesis_transaction_with_validator(
         &GENESIS_KEYPAIR.0,
         GENESIS_KEYPAIR.1.clone(),

--- a/libra_node/src/main.rs
+++ b/libra_node/src/main.rs
@@ -1,9 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use executable_helpers::helpers::{
-    setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
-};
+use executable_helpers::helpers::{setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING};
 use signal_hook;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -34,7 +32,7 @@ fn register_signals(term: Arc<AtomicBool>) {
 fn main() {
     let (mut config, _logger, _args) = setup_executable(
         "Libra single node".to_string(),
-        vec![ARG_PEER_ID, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
+        vec![ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
     );
     let (_ac_handle, _node_handle) = libra_node::main_node::setup_environment(&mut config);
 

--- a/libra_swarm/src/main.rs
+++ b/libra_swarm/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::RoleType;
+use config::config::{NodeConfig, RoleType};
 use libra_swarm::{client, swarm::LibraSwarm};
 use std::path::Path;
 use structopt::StructOpt;
@@ -31,12 +31,14 @@ struct Args {
     /// If specified, load faucet key from this file. Otherwise generate new keypair file.
     #[structopt(short = "f", long = "faucet_key_path")]
     pub faucet_key_path: Option<String>,
+    /// If set, starts a full node swarm connected to the first node in the validator swarm..
+    #[structopt(short = "w", long = "with_full_node_swarm")]
+    pub with_full_nodes: bool,
 }
 
 fn main() {
     let args = Args::from_args();
     let num_nodes = args.num_nodes.unwrap_or(1);
-
     let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(args.faucet_key_path);
 
@@ -45,37 +47,81 @@ fn main() {
         faucet_key_file_path
     );
 
-    let swarm = LibraSwarm::launch_swarm(
+    let mut validator_swarm = LibraSwarm::launch_swarm(
         num_nodes,
+        RoleType::Validator,
         !args.enable_logging,
-        faucet_account_keypair,
+        faucet_account_keypair.clone(),
         args.config_dir.clone(),
         None, /* template_path */
+        None, /* upstream_config_dir */
     );
+    let full_node_swarm = if args.with_full_nodes {
+        let swarm = LibraSwarm::launch_swarm(
+            num_nodes,
+            RoleType::FullNode,
+            !args.enable_logging,
+            faucet_account_keypair,
+            None, /* config dir */
+            None, /* template_path */
+            Some(String::from(
+                validator_swarm
+                    .dir
+                    .as_ref()
+                    .expect("Validator swarm config directory not set")
+                    .as_ref()
+                    .join("0")
+                    .to_str()
+                    .expect("Failed to convert std::fs::Path to String"),
+            )),
+        );
+        validator_swarm.kill_node(0);
+        validator_swarm
+            .add_node(0, !args.enable_logging)
+            .expect("Failed to restart upstream validator node");
+        Some(swarm)
+    } else {
+        None
+    };
 
-    let config = &swarm.config.configs[0].1;
-    let validator_set_file = &config.consensus.consensus_peers_file;
-    println!("To run the Libra CLI client in a separate process and connect to the local cluster of nodes you just spawned, use this command:");
+    let validator_config = NodeConfig::load(&validator_swarm.config.configs[0]).unwrap();;
+    let validator_set_file = validator_swarm
+        .dir
+        .as_ref()
+        .expect("fail to access output dir")
+        .as_ref()
+        .join("0")
+        .join(&validator_config.consensus.consensus_peers_file);
+    println!("To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:");
     println!(
         "\tcargo run --bin client -- -a localhost -p {} -s {:?} -m {:?}",
-        config.admission_control.admission_control_service_port,
-        swarm
-            .dir
-            .as_ref()
-            .expect("fail to access output dir")
-            .as_ref()
-            .join(validator_set_file),
+        validator_config
+            .admission_control
+            .admission_control_service_port,
+        validator_set_file,
         faucet_key_file_path,
     );
+    if let Some(ref swarm) = full_node_swarm {
+        let full_node_config = NodeConfig::load(&swarm.config.configs[0]).unwrap();;
+        println!("To connect to the full nodes you just spawned, use this command:");
+        println!(
+            "\tcargo run --bin client -- -a localhost -p {} -s {:?} -m {:?}",
+            full_node_config
+                .admission_control
+                .admission_control_service_port,
+            validator_set_file,
+            faucet_key_file_path,
+        );
+    }
 
     let tmp_mnemonic_file = TempPath::new();
     tmp_mnemonic_file.create_as_file().unwrap();
     if args.start_client {
         let client = client::InteractiveClient::new_with_inherit_io(
-            swarm.get_ac_port(0, RoleType::Validator),
+            validator_swarm.get_ac_port(0),
             Path::new(&faucet_key_file_path),
             &tmp_mnemonic_file.path(),
-            swarm.get_trusted_peers_config_path(),
+            validator_set_file.into_os_string().into_string().unwrap(),
         );
         println!("Loading client...");
         let _output = client.output().expect("Failed to wait on child");

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -12,7 +12,7 @@ use std::{
     collections::HashMap,
     env,
     fs::File,
-    io::Read,
+    io::{self, Read},
     path::{Path, PathBuf},
     process::{Child, Command},
     str::FromStr,
@@ -23,9 +23,9 @@ const LIBRA_NODE_BIN: &str = "libra_node";
 
 pub struct LibraNode {
     node: Child,
+    node_id: String,
     debug_client: NodeDebugClient,
     ac_port: u16,
-    peer_id: String,
     log: PathBuf,
 }
 
@@ -49,22 +49,19 @@ impl Drop for LibraNode {
 
 impl LibraNode {
     pub fn launch(
-        config: &NodeConfig,
+        node_id: String,
         config_path: &Path,
-        logdir: &Path,
+        log_path: PathBuf,
         disable_logging: bool,
     ) -> Result<Self> {
-        // For now, We consider the peer id on the first network config as the node's peer id.
-        // TODO: Create a peer id independent node identifier.
-        let peer_id = config.networks.get(0).unwrap().peer_id.clone();
-        let log = logdir.join(format!("{}.log", SwarmConfig::get_alias(&config)));
-        let log_file = File::create(&log)?;
+        let config = NodeConfig::load(&config_path)
+            .unwrap_or_else(|_| panic!("Failed to load NodeConfig from file: {:?}", config_path));
+        let log_file = File::create(&log_path)?;
         let mut node_command = Command::new(utils::get_bin(LIBRA_NODE_BIN));
         node_command
             .current_dir(utils::workspace_root())
             .arg("-f")
-            .arg(config_path)
-            .args(&["-p", &peer_id]);
+            .arg(config_path);
         if env::var("RUST_LOG").is_err() {
             // Only set our RUST_LOG if its not present in environment
             node_command.env("RUST_LOG", "debug");
@@ -72,30 +69,23 @@ impl LibraNode {
         if disable_logging {
             node_command.arg("-d");
         }
-
         node_command
             .stdout(log_file.try_clone()?)
             .stderr(log_file.try_clone()?);
-
         let node = node_command
             .spawn()
             .context("Error launching node process")?;
-
         let debug_client = NodeDebugClient::new(
             "localhost",
             config.debug_interface.admission_control_node_debug_port,
         );
         Ok(Self {
             node,
+            node_id,
             debug_client,
             ac_port: config.admission_control.admission_control_service_port,
-            peer_id,
-            log,
+            log: log_path,
         })
-    }
-
-    pub fn peer_id(&self) -> String {
-        self.peer_id.clone()
     }
 
     pub fn ac_port(&self) -> u16 {
@@ -106,7 +96,6 @@ impl LibraNode {
         let mut log = File::open(&self.log)?;
         let mut contents = String::new();
         log.read_to_string(&mut contents)?;
-
         Ok(contents)
     }
 
@@ -115,13 +104,13 @@ impl LibraNode {
             Err(e) => {
                 debug!(
                     "error getting {} for node: {}; error: {}",
-                    metric_name, self.peer_id, e
+                    metric_name, self.node_id, e
                 );
                 None
             }
             Ok(maybeval) => {
                 if maybeval.is_none() {
-                    debug!("Node: {} did not report {}", self.peer_id, metric_name);
+                    debug!("Node: {} did not report {}", self.node_id, metric_name);
                 }
                 maybeval
             }
@@ -133,7 +122,7 @@ impl LibraNode {
             if num_connected_peers != expected_peers {
                 debug!(
                     "Node '{}' Expected peers: {}, found peers: {}",
-                    self.peer_id, expected_peers, num_connected_peers
+                    self.node_id, expected_peers, num_connected_peers
                 );
                 return false;
             } else {
@@ -144,13 +133,13 @@ impl LibraNode {
     }
 
     pub fn health_check(&mut self) -> HealthStatus {
-        debug!("Health check on node '{}'", self.peer_id);
+        debug!("Health check on node '{}'", self.node_id);
 
         // check if the process has terminated
         match self.node.try_wait() {
             // This would mean the child process has crashed
             Ok(Some(status)) => {
-                debug!("Node '{}' crashed with: {}", self.peer_id, status);
+                debug!("Node '{}' crashed with: {}", self.node_id, status);
                 return HealthStatus::Crashed(status);
             }
 
@@ -165,11 +154,11 @@ impl LibraNode {
 
         match self.debug_client.get_node_metrics() {
             Ok(_) => {
-                debug!("Node '{}' is healthy", self.peer_id);
+                debug!("Node '{}' is healthy", self.node_id);
                 HealthStatus::Healthy
             }
             Err(e) => {
-                debug!("Error querying metrics for node '{}'", self.peer_id);
+                debug!("Error querying metrics for node '{}'", self.node_id);
                 HealthStatus::RpcFailure(e)
             }
         }
@@ -202,9 +191,8 @@ impl AsRef<Path> for LibraSwarmDir {
 pub struct LibraSwarm {
     // Output log, LibraNodes' config file, libradb etc, into this dir.
     pub dir: Option<LibraSwarmDir>,
-    // Maps the peer id of a node to the LibraNode struct
-    pub validator_nodes: HashMap<String, LibraNode>,
-    pub full_nodes: Vec<LibraNode>,
+    // Maps the node id of a node to the LibraNode struct
+    pub nodes: HashMap<String, LibraNode>,
     pub config: SwarmConfig,
 }
 
@@ -219,31 +207,44 @@ pub enum SwarmLaunchFailure {
     /// Timeout while waiting for the nodes to report that they're all interconnected
     #[fail(display = "Node connectivity check timeout")]
     ConnectivityTimeout,
+    #[fail(display = "IO Error")]
+    IoError(#[cause] io::Error),
+}
+
+impl From<io::Error> for SwarmLaunchFailure {
+    fn from(err: io::Error) -> Self {
+        SwarmLaunchFailure::IoError(err)
+    }
 }
 
 impl LibraSwarm {
     pub fn launch_swarm(
         num_nodes: usize,
+        role: RoleType,
         disable_logging: bool,
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
         config_dir: Option<String>,
         template_path: Option<String>,
+        upstream_config_dir: Option<String>,
     ) -> Self {
         let num_launch_attempts = 5;
         for i in 0..num_launch_attempts {
-            let swarm_config_dir = Self::setup_config_dir(&config_dir);
             info!("Launch swarm attempt: {} of {}", i, num_launch_attempts);
             match Self::launch_swarm_attempt(
                 num_nodes,
+                role,
                 disable_logging,
                 faucet_account_keypair.clone(),
-                swarm_config_dir,
+                config_dir.clone(),
                 &template_path,
+                &upstream_config_dir,
             ) {
                 Ok(swarm) => {
                     return swarm;
                 }
-                Err(e) => error!("Error launching swarm: {}", e),
+                Err(e) => {
+                    error!("Error launching swarm: {}", e);
+                }
             }
         }
         panic!("Max out {} attempts to launch swarm", num_launch_attempts);
@@ -277,56 +278,58 @@ impl LibraSwarm {
 
     fn launch_swarm_attempt(
         num_nodes: usize,
+        role: RoleType,
         disable_logging: bool,
         faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
-        dir: LibraSwarmDir,
+        config_dir: Option<String>,
         template_path: &Option<String>,
-    ) -> std::result::Result<Self, SwarmLaunchFailure> {
-        let logs_dir_path = dir.as_ref().join("logs");
-        std::fs::create_dir(&logs_dir_path).unwrap();
+        upstream_config_dir: &Option<String>,
+    ) -> std::result::Result<LibraSwarm, SwarmLaunchFailure> {
+        let swarm_config_dir = Self::setup_config_dir(&config_dir);
+        let logs_dir_path = swarm_config_dir.as_ref().join("logs");
+        std::fs::create_dir(&logs_dir_path)?;
         let base = utils::workspace_root().join(
             template_path
                 .as_ref()
                 .unwrap_or(&"config/data/configs/node.config.toml".to_string()),
         );
         let mut config_builder = SwarmConfigBuilder::new();
-
         config_builder
             .with_ipv4()
             .with_num_nodes(num_nodes)
             .with_base(base)
-            .with_output_dir(&dir)
-            .with_faucet_keypair(faucet_account_keypair);
+            .with_output_dir(&swarm_config_dir)
+            .with_faucet_keypair(faucet_account_keypair)
+            .with_role(role)
+            .with_upstream_config_dir(upstream_config_dir.clone());
         let config = config_builder.build().unwrap();
-
         let mut swarm = Self {
-            dir: Some(dir),
-            validator_nodes: HashMap::new(),
-            full_nodes: vec![],
+            dir: Some(swarm_config_dir),
+            nodes: HashMap::new(),
             config,
         };
         // For each config launch a node
-        for (path, node_config) in &swarm.config.configs {
-            let node =
-                LibraNode::launch(&node_config, &path, &logs_dir_path, disable_logging).unwrap();
-            if node_config.is_validator() {
-                swarm.validator_nodes.insert(node.peer_id(), node);
-            } else {
-                swarm.full_nodes.push(node);
-            }
+        for (index, path) in swarm.config.configs.iter().enumerate() {
+            // Use index as node id.
+            let node_id = format!("{}", index);
+            let node = LibraNode::launch(
+                node_id.clone(),
+                &path,
+                logs_dir_path.join(format!("{}.log", index)),
+                disable_logging,
+            )
+            .unwrap();
+            swarm.nodes.insert(node_id, node);
         }
-
         swarm.wait_for_startup()?;
         swarm.wait_for_connectivity()?;
-
         info!("Successfully launched Swarm");
-
         Ok(swarm)
     }
 
     fn wait_for_connectivity(&self) -> std::result::Result<(), SwarmLaunchFailure> {
         // Early return if we're only launching a single node
-        if self.validator_nodes.len() == 1 {
+        if self.nodes.len() == 1 {
             return Ok(());
         }
 
@@ -336,9 +339,9 @@ impl LibraSwarm {
             debug!("Wait for connectivity attempt: {}", i);
 
             if self
-                .validator_nodes
+                .nodes
                 .values()
-                .all(|node| node.check_connectivity(self.validator_nodes.len() as i64 - 1))
+                .all(|node| node.check_connectivity(self.nodes.len() as i64 - 1))
             {
                 return Ok(());
             }
@@ -352,26 +355,20 @@ impl LibraSwarm {
 
     fn wait_for_startup(&mut self) -> std::result::Result<(), SwarmLaunchFailure> {
         let num_attempts = 120;
-        let mut done = vec![false; self.validator_nodes.len() + self.full_nodes.len()];
+        let mut done = vec![false; self.nodes.len()];
         for i in 0..num_attempts {
             debug!("Wait for startup attempt: {} of {}", i, num_attempts);
-            for (node, done) in self
-                .validator_nodes
-                .values_mut()
-                .chain(self.full_nodes.iter_mut())
-                .zip(done.iter_mut())
-            {
+            for (node, done) in self.nodes.values_mut().zip(done.iter_mut()) {
                 if *done {
                     continue;
                 }
-
                 match node.health_check() {
                     HealthStatus::Healthy => *done = true,
                     HealthStatus::RpcFailure(_) => continue,
                     HealthStatus::Crashed(status) => {
                         error!(
                             "Libra node '{}' has crashed with status '{}'. Log output: '''{}'''",
-                            node.peer_id,
+                            node.node_id,
                             status,
                             node.get_log_contents().unwrap()
                         );
@@ -398,21 +395,21 @@ impl LibraSwarm {
     pub fn wait_for_all_nodes_to_catchup(&mut self) -> bool {
         let num_attempts = 60;
         let last_committed_round_str = "consensus{op=committed_blocks_count}";
-        let mut done = vec![false; self.validator_nodes.len()];
+        let mut done = vec![false; self.nodes.len()];
 
         let mut last_committed_round = 0;
         // First, try to retrieve the max value across all the committed rounds
         debug!("Calculating max committed round across the validators.");
-        for node in self.validator_nodes.values() {
+        for node in self.nodes.values() {
             match node.get_metric(last_committed_round_str) {
                 Some(val) => {
-                    debug!("\tNode {} last committed round = {}", node.peer_id, val);
+                    debug!("\tNode {} last committed round = {}", node.node_id, val);
                     last_committed_round = last_committed_round.max(val);
                 }
                 None => {
                     debug!(
                         "\tNode {} last committed round unknown, assuming 0.",
-                        node.peer_id
+                        node.node_id
                     );
                 }
             }
@@ -426,7 +423,7 @@ impl LibraSwarm {
                 i + 1,
                 num_attempts
             );
-            for (node, done) in self.validator_nodes.values_mut().zip(done.iter_mut()) {
+            for (node, done) in self.nodes.values_mut().zip(done.iter_mut()) {
                 if *done {
                     continue;
                 }
@@ -436,20 +433,20 @@ impl LibraSwarm {
                         if val >= last_committed_round {
                             debug!(
                                 "\tNode {} is caught up with last committed round {}",
-                                node.peer_id, val
+                                node.node_id, val
                             );
                             *done = true;
                         } else {
                             debug!(
                                 "\tNode {} is not caught up yet with last committed round {}",
-                                node.peer_id, val
+                                node.node_id, val
                             );
                         }
                     }
                     None => {
                         debug!(
                             "\tNode {} last committed round unknown, assuming 0.",
-                            node.peer_id
+                            node.node_id
                         );
                     }
                 }
@@ -467,28 +464,19 @@ impl LibraSwarm {
     }
 
     /// A specific public AC port of a validator or a full node.
-    pub fn get_ac_port(&self, index: usize, role: RoleType) -> u16 {
-        match role {
-            RoleType::Validator => *self
-                .validator_nodes
-                .values()
-                .map(|node| node.ac_port())
-                .collect::<Vec<u16>>()
-                .get(index)
-                .unwrap(),
-            RoleType::FullNode => *self
-                .full_nodes
-                .iter()
-                .map(|node| node.ac_port())
-                .collect::<Vec<u16>>()
-                .get(index)
-                .unwrap(),
-        }
+    pub fn get_ac_port(&self, index: usize) -> u16 {
+        *self
+            .nodes
+            .values()
+            .map(|node| node.ac_port())
+            .collect::<Vec<u16>>()
+            .get(index)
+            .unwrap()
     }
 
     /// Vector with the peer ids of the validators in the swarm.
     pub fn get_validators_ids(&self) -> Vec<String> {
-        self.validator_nodes.keys().cloned().collect()
+        self.nodes.keys().cloned().collect()
     }
 
     /// Vector with the debug ports of all the validators in the swarm.
@@ -496,63 +484,53 @@ impl LibraSwarm {
         self.config
             .configs
             .iter()
-            .map(|(_, c)| c.debug_interface.admission_control_node_debug_port)
+            .map(|path| {
+                let config = NodeConfig::load(&path).unwrap();
+                config.debug_interface.admission_control_node_debug_port
+            })
             .collect()
     }
 
-    pub fn get_validator(&self, peer_id: &str) -> Option<&LibraNode> {
-        self.validator_nodes.get(peer_id)
+    pub fn get_validator(&self, idx: usize) -> Option<&LibraNode> {
+        let node_id = format!("{}", idx);
+        self.nodes.get(&node_id)
     }
 
-    pub fn kill_node(&mut self, peer_id: &str) {
-        self.validator_nodes.remove(peer_id);
+    pub fn kill_node(&mut self, idx: usize) {
+        let node_id = format!("{}", idx);
+        self.nodes.remove(&node_id);
     }
 
     pub fn add_node(
         &mut self,
-        peer_id: String,
+        idx: usize,
         disable_logging: bool,
     ) -> std::result::Result<(), SwarmLaunchFailure> {
         // First take the configs out to not keep immutable borrow on self when calling
         // `launch_node`.
-        self.launch_node(peer_id, disable_logging)
-    }
-
-    fn launch_node(
-        &mut self,
-        peer_id: String,
-        disable_logging: bool,
-    ) -> std::result::Result<(), SwarmLaunchFailure> {
-        let (path, config) = self
+        let path = self
             .config
             .configs
-            .iter()
-            .find(|(_path, config)| config.networks.get(0).unwrap().peer_id == peer_id)
-            .expect(
-                &format!(
-                    "PeerId {} not found in any of the admission control service ports.",
-                    peer_id
-                )[..],
-            );
-        let logs_dir_path = self.dir.as_ref().map(|x| x.as_ref().join("logs")).unwrap();
-        let mut node = LibraNode::launch(config, path, &logs_dir_path, disable_logging).unwrap();
+            .get(idx)
+            .unwrap_or_else(|| panic!("Node at index {} not found", idx));
+        let log_file_path = self
+            .dir
+            .as_ref()
+            .unwrap()
+            .as_ref()
+            .join("logs")
+            .join(format!("{}.log", idx));
+        let node_id = format!("{}", idx);
+        let mut node =
+            LibraNode::launch(node_id.clone(), path, log_file_path, disable_logging).unwrap();
         for _ in 0..60 {
             if let HealthStatus::Healthy = node.health_check() {
-                self.validator_nodes.insert(peer_id, node);
+                self.nodes.insert(node_id, node);
                 return self.wait_for_connectivity();
             }
             ::std::thread::sleep(::std::time::Duration::from_millis(1000));
         }
         Err(SwarmLaunchFailure::LaunchTimeout)
-    }
-
-    pub fn get_trusted_peers_config_path(&self) -> String {
-        let (path, _) = &self.config.consensus_peers;
-        path.canonicalize()
-            .expect("Unable to get canonical path of trusted peers config file")
-            .to_str()
-            .unwrap()
-            .to_string()
     }
 }
 
@@ -568,7 +546,7 @@ impl Drop for LibraSwarm {
                     // Dump logs for each validator to stdout when `LIBRA_DUMP_LOGS`
                     // environment variable is set
                     if env::var_os("LIBRA_DUMP_LOGS").is_some() {
-                        for (peer_id, node) in &mut self.validator_nodes {
+                        for (peer_id, node) in &mut self.nodes {
                             // Skip dumping logs for healthy nodes
                             if let HealthStatus::Healthy = node.health_check() {
                                 continue;

--- a/storage/storage_service/src/main.rs
+++ b/storage/storage_service/src/main.rs
@@ -1,9 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use executable_helpers::helpers::{
-    setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING, ARG_PEER_ID,
-};
+use executable_helpers::helpers::{setup_executable, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING};
 use std::thread;
 
 use config::config::NodeConfig;
@@ -52,7 +50,7 @@ impl StorageNode {
 fn main() {
     let (config, _logger, _args) = setup_executable(
         "Libra Storage node".to_string(),
-        vec![ARG_PEER_ID, ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
+        vec![ARG_CONFIG_PATH, ARG_DISABLE_LOGGING],
     );
 
     let storage_node = StorageNode::new(config);

--- a/terraform/validator-sets/build.sh
+++ b/terraform/validator-sets/build.sh
@@ -15,4 +15,21 @@ fi
 cargo run --bin libra-config -- -b config/data/configs/node.config.toml -m "terraform/validator-sets/$OUTDIR/mint.key" -o "terraform/validator-sets/$OUTDIR" -d "$@"
 
 cd -
-rm $OUTDIR/*.node.config.toml
+cd $OUTDIR
+
+# Remove all generated node.config.toml files.
+find . -mindepth 2 -iname node.config.toml | xargs rm
+# Move all keys files to single top-level directory.
+find . -mindepth 2 -iname '*.keys.toml' -exec mv -f -t . {} +
+# Move all seed peers files to top-level directory.
+find . -mindepth 2 -iname '*.seed_peers.config.toml' | xargs rm
+# Move all network peers files to top-level directory.
+find . -mindepth 2 -iname '*.network_peers.config.toml' -exec mv -f {} ./network_peers.config.toml \;
+# Move all consensus peers files to top-level directory.
+find . -mindepth 2 -iname 'consensus_peers.config.toml' -exec mv -f {} ./consensus_peers.config.toml \;
+# Move all genesis.blob files to top-level directory.
+find . -mindepth 2 -iname 'genesis.blob' -exec mv -f {} ./genesis.blob \;
+# Delete all directories.
+find . -mindepth 1 -type d | xargs rmdir
+
+cd -

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -4,7 +4,7 @@
 use cli::{
     client_proxy::ClientProxy, AccountAddress, CryptoHash, TransactionArgument, TransactionPayload,
 };
-use config::config::RoleType;
+use config::config::{NodeConfig, RoleType};
 use crypto::{ed25519::*, SigningKey};
 use libra_swarm::{swarm::LibraSwarm, utils};
 use num_traits::cast::FromPrimitive;
@@ -18,26 +18,34 @@ fn setup_env(
     role: RoleType,
 ) -> (LibraSwarm, ClientProxy) {
     ::logger::init_for_e2e_testing();
-
     let (faucet_account_keypair, faucet_key_file_path, _temp_dir) =
         generate_keypair::load_faucet_key_or_create_default(None);
-
     let swarm = LibraSwarm::launch_swarm(
         num_nodes, /* num nodes */
-        false,     /* disable_logging */
+        role,
+        false, /* disable_logging */
         faucet_account_keypair,
         None, /* config_dir */
         template_path,
+        None, /* upstream_path */
     );
-    let port = swarm.get_ac_port(client_port_index, role);
+    let port = swarm.get_ac_port(client_port_index);
     let tmp_mnemonic_file = tools::tempdir::TempPath::new();
     tmp_mnemonic_file
         .create_as_file()
         .expect("could not create temporary mnemonic_file_path");
+    let config = NodeConfig::load(&swarm.config.configs[0]).unwrap();;
+    let validator_set_file = swarm
+        .dir
+        .as_ref()
+        .expect("fail to access output dir")
+        .as_ref()
+        .join("0")
+        .join(&config.consensus.consensus_peers_file);
     let client_proxy = ClientProxy::new(
         "localhost",
         port.to_string().as_str(),
-        &swarm.get_trusted_peers_config_path(),
+        validator_set_file.to_str().unwrap(),
         &faucet_key_file_path,
         false,
         /* faucet server */ None,
@@ -189,10 +197,8 @@ fn test_concurrent_transfers_single_node() {
 fn test_basic_fault_tolerance() {
     // A configuration with 4 validators should tolerate single node failure.
     let (mut swarm, mut client_proxy) = setup_swarm_and_client_proxy(4, 1);
-    let validators = swarm.get_validators_ids();
     // kill the first validator
-    swarm.kill_node(validators.get(0).unwrap());
-
+    swarm.kill_node(0);
     // run the script for the smoke test by submitting requests to the second validator
     test_smoke_script(client_proxy);
 }
@@ -214,9 +220,9 @@ fn test_basic_restartability() {
         Decimal::from_f64(10.0),
         Decimal::from_str(&client_proxy.get_balance(&["b", "1"]).unwrap()).ok()
     );
-    let peer_to_restart = swarm.get_validators_ids()[0].clone();
+    let peer_to_restart = 0;
     // restart node
-    swarm.kill_node(&peer_to_restart);
+    swarm.kill_node(peer_to_restart);
     assert!(swarm.add_node(peer_to_restart, false).is_ok());
     assert_eq!(
         Decimal::from_f64(90.0),
@@ -262,9 +268,8 @@ fn test_basic_state_synchronization() {
         Decimal::from_f64(10.0),
         Decimal::from_str(&client_proxy.get_balance(&["b", "1"]).unwrap()).ok()
     );
-    let node_to_restart = swarm.get_validators_ids().get(0).unwrap().clone();
-
-    swarm.kill_node(&node_to_restart);
+    let node_to_restart = 0;
+    swarm.kill_node(node_to_restart);
     // All these are executed while one node is down
     assert_eq!(
         Decimal::from_f64(90.0),
@@ -281,7 +286,7 @@ fn test_basic_state_synchronization() {
     }
 
     // Reconnect and synchronize the state
-    assert!(swarm.add_node(node_to_restart.clone(), false).is_ok());
+    assert!(swarm.add_node(node_to_restart, false).is_ok());
 
     // Wait for all the nodes to catch up
     assert!(swarm.wait_for_all_nodes_to_catchup());
@@ -291,11 +296,19 @@ fn test_basic_state_synchronization() {
     tmp_mnemonic_file
         .create_as_file()
         .expect("could not create temporary mnemonic_file_path");
-    let ac_port = swarm.get_validator(&node_to_restart).unwrap().ac_port();
+    let ac_port = swarm.get_validator(node_to_restart).unwrap().ac_port();
+    let config = NodeConfig::load(&swarm.config.configs[0]).unwrap();;
+    let validator_set_file = swarm
+        .dir
+        .as_ref()
+        .expect("fail to access output dir")
+        .as_ref()
+        .join("0")
+        .join(&config.consensus.consensus_peers_file);
     let mut client_proxy2 = ClientProxy::new(
         "localhost",
         ac_port.to_string().as_str(),
-        &swarm.get_trusted_peers_config_path(),
+        &validator_set_file.to_str().unwrap(),
         "",
         false,
         /* faucet server */ None,

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -7,6 +7,7 @@ use benchmark::{
     load_generator::PairwiseTransferTxnGenerator,
     Benchmarker,
 };
+use config::config::RoleType;
 use libra_swarm::swarm::LibraSwarm;
 use num::traits::Float;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
@@ -38,10 +39,12 @@ rusty_fork_test! {
             generate_keypair::load_faucet_key_or_create_default(None);
         let swarm = LibraSwarm::launch_swarm(
             num_nodes,
+            RoleType::Validator,
             true,   /* disable_logging */
             faucet_account_keypair,
             None,   /* config_dir */
             None,   /* template_path */
+            None, /* upstream_path */
         );
         let swarm_config_dir = String::from(swarm.dir.as_ref().unwrap().as_ref().to_str().unwrap());
         let validator_addresses = parse_swarm_config_from_dir(&swarm_config_dir).unwrap();


### PR DESCRIPTION
## Motivation

Changes are made to swarm config generation (`config/config_builder/src/swarm_config.rs`) to enable generation of configuration for nodes in a full node swarm.

Currently, full node config generation also requires a `Path` to the directory storing configuration of the upstream validator node. This is needed since the upstream node config also needs to be updated to allow the created full nodes to connect to it. If this config generation is done "manually", the upstream node will also need to be restarted to start accepting connections from the full nodes since we do not yet have the ability to dynamically update a node's configuration.

The `libra_swarm` binary is also augmented (with a `-w` flag) to allow creation of a full node swarm in addition to a validator swarm. `libra_swarm` takes care of restarting the appropriate validator node once full node configs have been generated.

To start a full node swarm, users can run:
`./target/debug/libra_swarm -n <NUM_NODES>  -w`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Run local validator and full node swarms
2. Commit txns through client connected to AC on validator swarm
3. Confirm that txns can be read through client connected to AC on full node swarm.

## Related PRs
#825 