### PR TITLE
[block_tree] Adopt delegation instead of Deref for block types

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -419,7 +419,7 @@ impl<T: Payload> BlockReader for BlockStore<T> {
     }
 
     fn get_block(&self, block_id: HashValue) -> Option<Arc<ExecutedBlock<T>>> {
-        self.inner.read().unwrap().try_get_block(&block_id)
+        self.inner.read().unwrap().get_block(&block_id)
     }
 
     fn get_compute_result(&self, block_id: HashValue) -> Option<Arc<StateComputeResult>> {

--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -25,7 +25,6 @@ use std::{
     collections::HashMap,
     convert::TryFrom,
     fmt::{Display, Formatter},
-    ops::Deref,
     sync::Arc,
 };
 use types::{
@@ -118,14 +117,6 @@ pub struct ExecutedBlock<T> {
     /// committed). The execution results are not persisted: they're recalculated again for the
     /// pending blocks upon restart.
     compute_result: Arc<StateComputeResult>,
-}
-
-impl<T> Deref for ExecutedBlock<T> {
-    type Target = Block<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.block
-    }
 }
 
 impl<T> Display for Block<T> {
@@ -436,6 +427,43 @@ impl<T> ExecutedBlock<T> {
 
     pub fn compute_result(&self) -> &Arc<StateComputeResult> {
         &self.compute_result
+    }
+}
+
+impl<T> ExecutedBlock<T>
+where
+    T: Serialize + Default + CanonicalSerialize + PartialEq,
+{
+    pub fn get_payload(&self) -> &T {
+        self.block().get_payload()
+    }
+
+    pub fn id(&self) -> HashValue {
+        self.block().id()
+    }
+
+    pub fn parent_id(&self) -> HashValue {
+        self.block().parent_id()
+    }
+
+    pub fn height(&self) -> Height {
+        self.block().height()
+    }
+
+    pub fn round(&self) -> Round {
+        self.block().round()
+    }
+
+    pub fn timestamp_usecs(&self) -> u64 {
+        self.block().timestamp_usecs()
+    }
+
+    pub fn quorum_cert(&self) -> &QuorumCert {
+        self.block().quorum_cert()
+    }
+
+    pub fn is_nil_block(&self) -> bool {
+        self.block().is_nil_block()
     }
 }
 

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -223,8 +223,7 @@ fn basic_new_rank_event_test() {
     let node = &nodes[0];
     let genesis = node.block_store.root();
     let mut inserter = TreeInserter::new(node.block_store.clone());
-    let a1 =
-        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
     block_on(async move {
         let new_round = 1;
         node.event_processor
@@ -325,7 +324,7 @@ fn process_successful_proposal_test() {
     let genesis_qc = QuorumCert::certificate_for_genesis();
     block_on(async move {
         let proposal = Block::make_block(
-            genesis.as_ref(),
+            genesis.block(),
             vec![1],
             1,
             1,
@@ -365,7 +364,7 @@ fn process_old_proposal_test() {
     let genesis = node.block_store.root();
     let genesis_qc = QuorumCert::certificate_for_genesis();
     let new_block = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         1,
@@ -374,7 +373,7 @@ fn process_old_proposal_test() {
     );
     let new_block_id = new_block.id();
     let old_block = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         2,
@@ -416,7 +415,7 @@ fn process_round_mismatch_test() {
     let genesis = node.block_store.root();
     let genesis_qc = QuorumCert::certificate_for_genesis();
     let correct_block = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         1,
@@ -424,7 +423,7 @@ fn process_round_mismatch_test() {
         node.block_store.signer(),
     );
     let block_skip_round = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         2,
         2,
@@ -468,7 +467,7 @@ fn process_new_round_msg_test() {
     let genesis = non_proposer.block_store.root();
     let block_0 = non_proposer
         .block_store
-        .create_block(&genesis, vec![1], 1, 1);
+        .create_block(genesis.block(), vec![1], 1, 1);
     let block_0_id = block_0.id();
     block_on(
         non_proposer
@@ -549,7 +548,7 @@ fn process_proposer_mismatch_test() {
     let genesis = node.block_store.root();
     let genesis_qc = QuorumCert::certificate_for_genesis();
     let correct_block = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         1,
@@ -557,7 +556,7 @@ fn process_proposer_mismatch_test() {
         node.block_store.signer(),
     );
     let block_incorrect_proposer = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         1,
@@ -602,7 +601,7 @@ fn process_timeout_certificate_test() {
     let genesis = node.block_store.root();
     let genesis_qc = QuorumCert::certificate_for_genesis();
     let correct_block = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         1,
@@ -610,7 +609,7 @@ fn process_timeout_certificate_test() {
         node.block_store.signer(),
     );
     let block_skip_round = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         2,
         2,
@@ -654,8 +653,7 @@ fn process_votes_basic_test() {
         .unwrap();
     let genesis = node.block_store.root();
     let mut inserter = TreeInserter::new(node.block_store.clone());
-    let a1 =
-        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
     let vote_data = VoteData::new(
         a1.id(),
         node.block_store
@@ -698,7 +696,7 @@ fn process_block_retrieval() {
     let genesis_qc = QuorumCert::certificate_for_genesis();
 
     let block = Block::make_block(
-        genesis.as_ref(),
+        genesis.block(),
         vec![1],
         1,
         1,
@@ -785,12 +783,11 @@ fn basic_restart_test() {
     let mut proposals = Vec::new();
     let num_proposals = 100;
     // insert a few successful proposals
-    let a1 =
-        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
     proposals.push(a1);
     for i in 2..=num_proposals {
         let parent = proposals.last().unwrap();
-        let proposal = inserter.insert_block(parent, i);
+        let proposal = inserter.insert_block(&parent, i);
         proposals.push(proposal);
     }
     for proposal in &proposals {
@@ -802,7 +799,7 @@ fn basic_restart_test() {
         block_on(
             node_mut
                 .event_processor
-                .process_proposed_block(Block::clone(proposal)),
+                .process_proposed_block(proposal.block().clone()),
         );
     }
     // verify after restart we recover the data

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -95,7 +95,7 @@ impl<T: Payload> ProposalGenerator<T> {
             .get_quorum_cert_for_block(hqc_block.id())
             .ok_or_else(|| ProposalGenerationError::GivenRoundTooLow(hqc_block.round()))?;
         Ok(Block::make_nil_block(
-            hqc_block.as_ref(),
+            hqc_block.block(),
             round,
             hqc_block_qc.as_ref().clone(),
         ))
@@ -226,7 +226,7 @@ impl<T: Payload> ProposalGenerator<T> {
             .await
         {
             Ok(txns) => Ok(block_store.create_block(
-                &hqc_block,
+                hqc_block.block(),
                 txns,
                 round,
                 block_timestamp.as_micros() as u64,

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -61,10 +61,8 @@ fn test_proposal_generation_parent() {
         true,
     );
     let genesis = block_store.root();
-    let a1 =
-        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
-    let b1 =
-        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 2);
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
+    let b1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 2);
 
     // With no certifications the parent is genesis
     // generate proposals for an empty tree.
@@ -143,8 +141,7 @@ fn test_old_proposal_generation() {
         true,
     );
     let genesis = block_store.root();
-    let a1 =
-        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), genesis.as_ref(), 1);
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
     let vote_msg_a1 = VoteMsg::new(
         VoteData::new(
             a1.id(),

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -70,7 +70,7 @@ impl TreeInserter {
     /// `insert_block_with_qc`.
     pub fn insert_block(
         &mut self,
-        parent: &Block<Vec<usize>>,
+        parent: &ExecutedBlock<Vec<usize>>,
         round: Round,
     ) -> Arc<ExecutedBlock<Vec<usize>>> {
         // Node must carry a QC to its parent
@@ -90,12 +90,12 @@ impl TreeInserter {
     pub fn insert_block_with_qc(
         &mut self,
         parent_qc: QuorumCert,
-        parent: &Block<Vec<usize>>,
+        parent: &ExecutedBlock<Vec<usize>>,
         round: Round,
     ) -> Arc<ExecutedBlock<Vec<usize>>> {
         self.payload_val += 1;
         block_on(self.block_store.insert_block_with_qc(Block::make_block(
-            parent,
+            parent.block(),
             vec![self.payload_val],
             round,
             parent.timestamp_usecs() + 1,


### PR DESCRIPTION
## Motivation

Per https://github.com/libra/libra/pull/1026#discussion_r327382004

Using `Deref` is not recommended in such cases. `Deref` should be only implemented for smart pointers in the official Rust documentation. So we use delegation instead though it is more verbose.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI
## Related PRs

#1026
