### PR TITLE
[libra-swarm] dump logs on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ commands:
           command: |
             echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> $BASH_ENV
             echo 'export IMAGE_NAME=myapp' >> $BASH_ENV
+            echo 'export LIBRA_DUMP_LOGS=1' >> $BASH_ENV
             echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
   install_deps:
     steps:


### PR DESCRIPTION
Teach LibraSwarm to dump logs for each validator in the swarm when
panicking and `LIBRA_DUMP_LOGS` environment variable is set. This
enables us to gain more insight into test failures in CircleCi since we
don't have any way to grab the logs of a failed run off the build
machines.

Closes: #1049