### PR TITLE
[language] Test the e2e test on the testnet genesis.

### DIFF
--- a/language/e2e_tests/src/account_universe.rs
+++ b/language/e2e_tests/src/account_universe.rs
@@ -27,7 +27,7 @@ use crate::{
 use crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use lazy_static::lazy_static;
 use proptest::{prelude::*, strategy::Union};
-use std::fmt;
+use std::{fmt, sync::Arc};
 use types::{
     transaction::{SignedTransaction, TransactionStatus},
     vm_error::{StatusCode, VMStatus},
@@ -82,16 +82,16 @@ pub trait AUTransactionGen: fmt::Debug {
     /// necessary. Returns a signed transaction that can be run on the VM and the expected output.
     fn apply(&self, universe: &mut AccountUniverse) -> (SignedTransaction, TransactionStatus);
 
-    /// Creates a boxed version of this transaction, suitable for dynamic dispatch.
-    fn boxed(self) -> Box<dyn AUTransactionGen>
+    /// Creates an arced version of this transaction, suitable for dynamic dispatch.
+    fn arced(self) -> Arc<dyn AUTransactionGen>
     where
         Self: 'static + Sized,
     {
-        Box::new(self)
+        Arc::new(self)
     }
 }
 
-impl AUTransactionGen for Box<dyn AUTransactionGen> {
+impl AUTransactionGen for Arc<dyn AUTransactionGen> {
     fn apply(&self, universe: &mut AccountUniverse) -> (SignedTransaction, TransactionStatus) {
         (**self).apply(universe)
     }

--- a/language/e2e_tests/src/data_store.rs
+++ b/language/e2e_tests/src/data_store.rs
@@ -26,15 +26,33 @@ lazy_static! {
         path.pop();
         path.push("vm/vm_genesis/genesis/genesis.blob");
 
-        let mut f = File::open(&path).unwrap();
-        let mut bytes = vec![];
-        f.read_to_end(&mut bytes).unwrap();
-        let txn = SignedTransaction::from_proto(parse_from_bytes(&bytes).unwrap()).unwrap();
-        match txn.payload() {
-            TransactionPayload::WriteSet(ws) => ws.clone(),
-            _ => panic!("Expected writeset txn in genesis txn"),
-        }
+        load_genesis(path)
     };
+
+    pub static ref TESTNET_GENESIS: Vec<WriteSet> = {
+        let mut base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        base_path.pop();
+        base_path.pop();
+        base_path.push("terraform/validator-sets/");
+
+        let files = std::fs::read_dir(base_path).unwrap();
+        files
+            .filter_map(std::io::Result::ok)
+            .filter(|f| f.path().ends_with("genesis.blob"))
+            .map(|f| load_genesis(f.path()))
+            .collect()
+    };
+}
+
+fn load_genesis(path: PathBuf) -> WriteSet {
+    let mut f = File::open(&path).unwrap();
+    let mut bytes = vec![];
+    f.read_to_end(&mut bytes).unwrap();
+    let txn = SignedTransaction::from_proto(parse_from_bytes(&bytes).unwrap()).unwrap();
+    match txn.payload() {
+        TransactionPayload::WriteSet(ws) => ws.clone(),
+        _ => panic!("Expected writeset txn in genesis txn"),
+    }
 }
 
 /// An in-memory implementation of [`StateView`] and [`RemoteCache`] for the VM.

--- a/language/e2e_tests/src/tests/account_universe/create_account.rs
+++ b/language/e2e_tests/src/tests/account_universe/create_account.rs
@@ -10,6 +10,7 @@ use crate::{
     tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
 };
 use proptest::{collection::vec, prelude::*};
+use std::sync::Arc;
 
 proptest! {
     // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
@@ -86,11 +87,11 @@ proptest! {
 pub(super) fn create_account_strategy(
     min: u64,
     max: u64,
-) -> impl Strategy<Value = Box<dyn AUTransactionGen + 'static>> {
+) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
     prop_oneof![
-        3 => any_with::<CreateAccountGen>((min, max)).prop_map(CreateAccountGen::boxed),
+        3 => any_with::<CreateAccountGen>((min, max)).prop_map(CreateAccountGen::arced),
         1 => any_with::<CreateExistingAccountGen>((min, max)).prop_map(
-            CreateExistingAccountGen::boxed,
+            CreateExistingAccountGen::arced,
         ),
     ]
 }

--- a/language/e2e_tests/src/tests/account_universe/peer_to_peer.rs
+++ b/language/e2e_tests/src/tests/account_universe/peer_to_peer.rs
@@ -10,6 +10,7 @@ use crate::{
     tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
 };
 use proptest::{collection::vec, prelude::*};
+use std::sync::Arc;
 
 proptest! {
     // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
@@ -97,9 +98,9 @@ proptest! {
 pub(super) fn p2p_strategy(
     min: u64,
     max: u64,
-) -> impl Strategy<Value = Box<dyn AUTransactionGen + 'static>> {
+) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
     prop_oneof![
-        3 => any_with::<P2PTransferGen>((min, max)).prop_map(P2PTransferGen::boxed),
-        1 => any_with::<P2PNewReceiverGen>((min, max)).prop_map(P2PNewReceiverGen::boxed),
+        3 => any_with::<P2PTransferGen>((min, max)).prop_map(P2PTransferGen::arced),
+        1 => any_with::<P2PNewReceiverGen>((min, max)).prop_map(P2PNewReceiverGen::arced),
     ]
 }

--- a/language/e2e_tests/src/tests/create_account.rs
+++ b/language/e2e_tests/src/tests/create_account.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::create_account_txn,
-    executor::FakeExecutor,
+    executor::test_all_genesis,
 };
 use types::{
     transaction::{SignedTransaction, TransactionStatus},
@@ -14,75 +14,75 @@ use types::{
 #[test]
 fn create_account() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish a sender with 1_000_000 coins
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+        let new_account = Account::new();
+        let initial_amount = 1_000;
+        let txn = create_account_txn(sender.account(), &new_account, 10, initial_amount);
 
-    // create and publish a sender with 1_000_000 coins
-    let sender = AccountData::new(1_000_000, 10);
-    executor.add_account_data(&sender);
-    let new_account = Account::new();
-    let initial_amount = 1_000;
-    let txn = create_account_txn(sender.account(), &new_account, 10, initial_amount);
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
+        let txn_output = output.get(0).expect("must have a transaction output");
+        assert_eq!(
+            output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        );
+        println!("write set {:?}", txn_output.write_set());
+        executor.apply_write_set(txn_output.write_set());
 
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
-    let txn_output = output.get(0).expect("must have a transaction output");
-    assert_eq!(
-        output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-    );
-    println!("write set {:?}", txn_output.write_set());
-    executor.apply_write_set(txn_output.write_set());
-
-    // check that numbers in stored DB are correct
-    let gas = txn_output.gas_used();
-    let sender_balance = 1_000_000 - initial_amount - gas;
-    let updated_sender = executor
-        .read_account_resource(sender.account())
-        .expect("sender must exist");
-    let updated_receiver = executor
-        .read_account_resource(&new_account)
-        .expect("receiver must exist");
-    assert_eq!(initial_amount, updated_receiver.balance(),);
-    assert_eq!(sender_balance, updated_sender.balance(),);
-    assert_eq!(11, updated_sender.sequence_number());
+        // check that numbers in stored DB are correct
+        let gas = txn_output.gas_used();
+        let sender_balance = 1_000_000 - initial_amount - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        let updated_receiver = executor
+            .read_account_resource(&new_account)
+            .expect("receiver must exist");
+        assert_eq!(initial_amount, updated_receiver.balance(),);
+        assert_eq!(sender_balance, updated_sender.balance(),);
+        assert_eq!(11, updated_sender.sequence_number());
+    });
 }
 
 #[test]
 fn create_account_zero_balance() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish a sender with 1_000_000 coins
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+        let new_account = Account::new();
 
-    // create and publish a sender with 1_000_000 coins
-    let sender = AccountData::new(1_000_000, 10);
-    executor.add_account_data(&sender);
-    let new_account = Account::new();
+        // define the arguments to the create account transaction
+        let initial_amount = 0;
+        let txn = create_account_txn(sender.account(), &new_account, 10, initial_amount);
 
-    // define the arguments to the create account transaction
-    let initial_amount = 0;
-    let txn = create_account_txn(sender.account(), &new_account, 10, initial_amount);
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
+        let txn_output = output.get(0).expect("must have a transaction output");
+        assert_eq!(
+            output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        );
+        println!("write set {:?}", txn_output.write_set());
+        executor.apply_write_set(txn_output.write_set());
 
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
-    let txn_output = output.get(0).expect("must have a transaction output");
-    assert_eq!(
-        output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-    );
-    println!("write set {:?}", txn_output.write_set());
-    executor.apply_write_set(txn_output.write_set());
-
-    // check that numbers in stored DB are correct
-    let gas = txn_output.gas_used();
-    let sender_balance = 1_000_000 - initial_amount - gas;
-    let updated_sender = executor
-        .read_account_resource(sender.account())
-        .expect("sender must exist");
-    let updated_receiver = executor
-        .read_account_resource(&new_account)
-        .expect("receiver must exist");
-    assert_eq!(initial_amount, updated_receiver.balance());
-    assert_eq!(sender_balance, updated_sender.balance());
-    assert_eq!(11, updated_sender.sequence_number());
+        // check that numbers in stored DB are correct
+        let gas = txn_output.gas_used();
+        let sender_balance = 1_000_000 - initial_amount - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        let updated_receiver = executor
+            .read_account_resource(&new_account)
+            .expect("receiver must exist");
+        assert_eq!(initial_amount, updated_receiver.balance());
+        assert_eq!(sender_balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+    });
 }

--- a/language/e2e_tests/src/tests/mint.rs
+++ b/language/e2e_tests/src/tests/mint.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::mint_txn,
-    executor::FakeExecutor,
+    executor::test_all_genesis,
     gas_costs::TXN_RESERVED,
     transaction_status_eq,
 };
@@ -16,89 +16,91 @@ use types::{
 #[test]
 fn mint_to_existing() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
-    let genesis_account = Account::new_association();
+    test_all_genesis(|mut executor| {
+        let genesis_account = Account::new_association();
 
-    // create and publish a sender with 1_000_000 coins
-    let receiver = AccountData::new(1_000_000, 10);
-    executor.add_account_data(&receiver);
+        // create and publish a sender with 1_000_000 coins
+        let receiver = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&receiver);
 
-    let mint_amount = 1_000;
-    let txn = mint_txn(&genesis_account, receiver.account(), 1, mint_amount);
+        let mint_amount = 1_000;
+        let txn = mint_txn(&genesis_account, receiver.account(), 1, mint_amount);
 
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
-    let txn_output = output.get(0).expect("must have a transaction output");
-    assert_eq!(
-        output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-    );
-    println!("write set {:?}", txn_output.write_set());
-    executor.apply_write_set(txn_output.write_set());
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
+        let txn_output = output.get(0).expect("must have a transaction output");
+        assert_eq!(
+            output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        );
+        println!("write set {:?}", txn_output.write_set());
+        executor.apply_write_set(txn_output.write_set());
 
-    // check that numbers in stored DB are correct
-    let gas = txn_output.gas_used();
-    let sender_balance = 1_000_000_000 - gas;
-    let receiver_balance = 1_000_000 + mint_amount;
+        // check that numbers in stored DB are correct
+        let gas = txn_output.gas_used();
+        let sender_balance = 1_000_000_000 - gas;
+        let receiver_balance = 1_000_000 + mint_amount;
 
-    let updated_sender = executor
-        .read_account_resource(&genesis_account)
-        .expect("sender must exist");
-    let updated_receiver = executor
-        .read_account_resource(receiver.account())
-        .expect("receiver must exist");
-    assert_eq!(sender_balance, updated_sender.balance());
-    assert_eq!(receiver_balance, updated_receiver.balance());
-    assert_eq!(2, updated_sender.sequence_number());
-    assert_eq!(10, updated_receiver.sequence_number());
+        let updated_sender = executor
+            .read_account_resource(&genesis_account)
+            .expect("sender must exist");
+        let updated_receiver = executor
+            .read_account_resource(receiver.account())
+            .expect("receiver must exist");
+        assert_eq!(sender_balance, updated_sender.balance());
+        assert_eq!(receiver_balance, updated_receiver.balance());
+        assert_eq!(2, updated_sender.sequence_number());
+        assert_eq!(10, updated_receiver.sequence_number());
+    });
 }
 
 #[test]
 fn mint_to_new_account() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
-    let genesis_account = Account::new_association();
+    test_all_genesis(|mut executor| {
+        let genesis_account = Account::new_association();
 
-    // create and publish a sender with TXN_RESERVED coins
-    let new_account = Account::new();
+        // create and publish a sender with TXN_RESERVED coins
+        let new_account = Account::new();
 
-    let mint_amount = TXN_RESERVED;
-    let txn = mint_txn(&genesis_account, &new_account, 1, mint_amount);
+        let mint_amount = TXN_RESERVED;
+        let txn = mint_txn(&genesis_account, &new_account, 1, mint_amount);
 
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
-    let txn_output = output.get(0).expect("must have a transaction output");
-    assert!(transaction_status_eq(
-        &output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-    ));
-    executor.apply_write_set(txn_output.write_set());
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
+        let txn_output = output.get(0).expect("must have a transaction output");
+        assert!(transaction_status_eq(
+            &output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        ));
+        executor.apply_write_set(txn_output.write_set());
 
-    // check that numbers in stored DB are correct
-    let gas = txn_output.gas_used();
-    let sender_balance = 1_000_000_000 - gas;
-    let receiver_balance = mint_amount;
+        // check that numbers in stored DB are correct
+        let gas = txn_output.gas_used();
+        let sender_balance = 1_000_000_000 - gas;
+        let receiver_balance = mint_amount;
 
-    let updated_sender = executor
-        .read_account_resource(&genesis_account)
-        .expect("sender must exist");
-    let updated_receiver = executor
-        .read_account_resource(&new_account)
-        .expect("receiver must exist");
-    assert_eq!(sender_balance, updated_sender.balance());
-    assert_eq!(receiver_balance, updated_receiver.balance());
-    assert_eq!(2, updated_sender.sequence_number());
-    assert_eq!(0, updated_receiver.sequence_number());
+        let updated_sender = executor
+            .read_account_resource(&genesis_account)
+            .expect("sender must exist");
+        let updated_receiver = executor
+            .read_account_resource(&new_account)
+            .expect("receiver must exist");
+        assert_eq!(sender_balance, updated_sender.balance());
+        assert_eq!(receiver_balance, updated_receiver.balance());
+        assert_eq!(2, updated_sender.sequence_number());
+        assert_eq!(0, updated_receiver.sequence_number());
 
-    // Mint can only be called from genesis address;
-    let txn = mint_txn(&new_account, &new_account, 0, mint_amount);
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
+        // Mint can only be called from genesis address;
+        let txn = mint_txn(&new_account, &new_account, 0, mint_amount);
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
 
-    assert!(transaction_status_eq(
-        &output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::MISSING_DATA))
-    ));
+        assert!(transaction_status_eq(
+            &output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::MISSING_DATA))
+        ));
+    });
 }

--- a/language/e2e_tests/src/tests/peer_to_peer.rs
+++ b/language/e2e_tests/src/tests/peer_to_peer.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::peer_to_peer_txn,
-    executor::FakeExecutor,
+    executor::{test_all_genesis, FakeExecutor},
     gas_costs, transaction_status_eq,
 };
 use config::config::VMPublishingOption;
@@ -19,54 +19,54 @@ use types::{
 fn single_peer_to_peer_with_event() {
     ::logger::try_init_for_testing();
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
+        let sender = AccountData::new(1_000_000, 10);
+        let receiver = AccountData::new(100_000, 10);
+        executor.add_account_data(&sender);
+        executor.add_account_data(&receiver);
 
-    // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
-    let sender = AccountData::new(1_000_000, 10);
-    let receiver = AccountData::new(100_000, 10);
-    executor.add_account_data(&sender);
-    executor.add_account_data(&receiver);
+        let transfer_amount = 1_000;
+        let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount);
 
-    let transfer_amount = 1_000;
-    let txn = peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount);
-
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
-    let txn_output = output.get(0).expect("must have a transaction output");
-    assert_eq!(
-        output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-    );
-
-    executor.apply_write_set(txn_output.write_set());
-
-    // check that numbers in stored DB are correct
-    let gas = txn_output.gas_used();
-    let sender_balance = 1_000_000 - transfer_amount - gas;
-    let receiver_balance = 100_000 + transfer_amount;
-    let updated_sender = executor
-        .read_account_resource(sender.account())
-        .expect("sender must exist");
-    let updated_receiver = executor
-        .read_account_resource(receiver.account())
-        .expect("receiver must exist");
-    assert_eq!(receiver_balance, updated_receiver.balance());
-    assert_eq!(sender_balance, updated_sender.balance());
-    assert_eq!(11, updated_sender.sequence_number());
-    assert_eq!(0, updated_sender.received_events().count(),);
-    assert_eq!(1, updated_sender.sent_events().count());
-    assert_eq!(1, updated_receiver.received_events().count());
-    assert_eq!(0, updated_receiver.sent_events().count());
-
-    let rec_ev_path = receiver.received_events_key().to_vec();
-    let sent_ev_path = sender.sent_events_key().to_vec();
-    for event in txn_output.events() {
-        assert!(
-            rec_ev_path.as_slice() == event.key().as_bytes()
-                || sent_ev_path.as_slice() == event.key().as_bytes()
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
+        let txn_output = output.get(0).expect("must have a transaction output");
+        assert_eq!(
+            output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
         );
-    }
+
+        executor.apply_write_set(txn_output.write_set());
+
+        // check that numbers in stored DB are correct
+        let gas = txn_output.gas_used();
+        let sender_balance = 1_000_000 - transfer_amount - gas;
+        let receiver_balance = 100_000 + transfer_amount;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        let updated_receiver = executor
+            .read_account_resource(receiver.account())
+            .expect("receiver must exist");
+        assert_eq!(receiver_balance, updated_receiver.balance());
+        assert_eq!(sender_balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+        assert_eq!(0, updated_sender.received_events().count(),);
+        assert_eq!(1, updated_sender.sent_events().count());
+        assert_eq!(1, updated_receiver.received_events().count());
+        assert_eq!(0, updated_receiver.sent_events().count());
+
+        let rec_ev_path = receiver.received_events_key().to_vec();
+        let sent_ev_path = sender.sent_events_key().to_vec();
+        for event in txn_output.events() {
+            assert!(
+                rec_ev_path.as_slice() == event.key().as_bytes()
+                    || sent_ev_path.as_slice() == event.key().as_bytes()
+            );
+        }
+    });
 }
 
 #[test]
@@ -124,132 +124,133 @@ fn single_peer_to_peer_with_padding() {
 #[test]
 fn few_peer_to_peer_with_event() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
+        let sender = AccountData::new(1_000_000, 10);
+        let receiver = AccountData::new(100_000, 10);
+        executor.add_account_data(&sender);
+        executor.add_account_data(&receiver);
 
-    // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
-    let sender = AccountData::new(1_000_000, 10);
-    let receiver = AccountData::new(100_000, 10);
-    executor.add_account_data(&sender);
-    executor.add_account_data(&receiver);
+        let transfer_amount = 1_000;
 
-    let transfer_amount = 1_000;
-
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![
-        peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount),
-        peer_to_peer_txn(sender.account(), receiver.account(), 11, transfer_amount),
-        peer_to_peer_txn(sender.account(), receiver.account(), 12, transfer_amount),
-        peer_to_peer_txn(sender.account(), receiver.account(), 13, transfer_amount),
-    ];
-    let output = executor.execute_block(txns);
-    for (idx, txn_output) in output.iter().enumerate() {
-        assert_eq!(
-            txn_output.status(),
-            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-        );
-
-        // check events
-        for event in txn_output.events() {
-            let account_event: AccountEvent =
-                AccountEvent::try_from(event.event_data()).expect("event data must parse");
-            assert_eq!(transfer_amount, account_event.amount());
-            assert!(
-                &account_event.account() == sender.address()
-                    || &account_event.account() == receiver.address()
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![
+            peer_to_peer_txn(sender.account(), receiver.account(), 10, transfer_amount),
+            peer_to_peer_txn(sender.account(), receiver.account(), 11, transfer_amount),
+            peer_to_peer_txn(sender.account(), receiver.account(), 12, transfer_amount),
+            peer_to_peer_txn(sender.account(), receiver.account(), 13, transfer_amount),
+        ];
+        let output = executor.execute_block(txns);
+        for (idx, txn_output) in output.iter().enumerate() {
+            assert_eq!(
+                txn_output.status(),
+                &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
             );
+
+            // check events
+            for event in txn_output.events() {
+                let account_event: AccountEvent =
+                    AccountEvent::try_from(event.event_data()).expect("event data must parse");
+                assert_eq!(transfer_amount, account_event.amount());
+                assert!(
+                    &account_event.account() == sender.address()
+                        || &account_event.account() == receiver.address()
+                );
+            }
+
+            let original_sender = executor
+                .read_account_resource(sender.account())
+                .expect("sender must exist");
+            let original_receiver = executor
+                .read_account_resource(receiver.account())
+                .expect("receiver must exist");
+            executor.apply_write_set(txn_output.write_set());
+
+            // check that numbers in stored DB are correct
+            let gas = txn_output.gas_used();
+            let sender_balance = original_sender.balance() - transfer_amount - gas;
+            let receiver_balance = original_receiver.balance() + transfer_amount;
+            let updated_sender = executor
+                .read_account_resource(sender.account())
+                .expect("sender must exist");
+            let updated_receiver = executor
+                .read_account_resource(receiver.account())
+                .expect("receiver must exist");
+            assert_eq!(receiver_balance, updated_receiver.balance());
+            assert_eq!(sender_balance, updated_sender.balance());
+            assert_eq!(11 + idx as u64, updated_sender.sequence_number());
+            assert_eq!(0, updated_sender.received_events().count());
+            assert_eq!(idx as u64 + 1, updated_sender.sent_events().count());
+            assert_eq!(idx as u64 + 1, updated_receiver.received_events().count());
+            assert_eq!(0, updated_receiver.sent_events().count());
         }
-
-        let original_sender = executor
-            .read_account_resource(sender.account())
-            .expect("sender must exist");
-        let original_receiver = executor
-            .read_account_resource(receiver.account())
-            .expect("receiver must exist");
-        executor.apply_write_set(txn_output.write_set());
-
-        // check that numbers in stored DB are correct
-        let gas = txn_output.gas_used();
-        let sender_balance = original_sender.balance() - transfer_amount - gas;
-        let receiver_balance = original_receiver.balance() + transfer_amount;
-        let updated_sender = executor
-            .read_account_resource(sender.account())
-            .expect("sender must exist");
-        let updated_receiver = executor
-            .read_account_resource(receiver.account())
-            .expect("receiver must exist");
-        assert_eq!(receiver_balance, updated_receiver.balance());
-        assert_eq!(sender_balance, updated_sender.balance());
-        assert_eq!(11 + idx as u64, updated_sender.sequence_number());
-        assert_eq!(0, updated_sender.received_events().count());
-        assert_eq!(idx as u64 + 1, updated_sender.sent_events().count());
-        assert_eq!(idx as u64 + 1, updated_receiver.received_events().count());
-        assert_eq!(0, updated_receiver.sent_events().count());
-    }
+    });
 }
 
 /// Test that a zero-amount transaction fails, per policy.
 #[test]
 fn zero_amount_peer_to_peer() {
-    let mut executor = FakeExecutor::from_genesis_file();
-    let sequence_number = 10;
-    let sender = AccountData::new(1_000_000, sequence_number);
-    let receiver = AccountData::new(100_000, sequence_number);
-    executor.add_account_data(&sender);
-    executor.add_account_data(&receiver);
+    test_all_genesis(|mut executor| {
+        let sequence_number = 10;
+        let sender = AccountData::new(1_000_000, sequence_number);
+        let receiver = AccountData::new(100_000, sequence_number);
+        executor.add_account_data(&sender);
+        executor.add_account_data(&receiver);
 
-    let transfer_amount = 0;
-    let txn = peer_to_peer_txn(
-        sender.account(),
-        receiver.account(),
-        sequence_number,
-        transfer_amount,
-    );
+        let transfer_amount = 0;
+        let txn = peer_to_peer_txn(
+            sender.account(),
+            receiver.account(),
+            sequence_number,
+            transfer_amount,
+        );
 
-    let output = &executor.execute_block(vec![txn])[0];
-    // Error code 7 means that the transaction was a zero-amount one.
-    assert!(transaction_status_eq(
-        &output.status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED).with_sub_status(7))
-    ));
+        let output = &executor.execute_block(vec![txn])[0];
+        // Error code 7 means that the transaction was a zero-amount one.
+        assert!(transaction_status_eq(
+            &output.status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::ABORTED).with_sub_status(7))
+        ));
+    });
 }
 
 #[test]
 fn peer_to_peer_create_account() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish a sender with 1_000_000 coins
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+        let new_account = Account::new();
 
-    // create and publish a sender with 1_000_000 coins
-    let sender = AccountData::new(1_000_000, 10);
-    executor.add_account_data(&sender);
-    let new_account = Account::new();
+        // define the arguments to the peer to peer transaction
+        let transfer_amount = 1_000;
+        let txn = peer_to_peer_txn(sender.account(), &new_account, 10, transfer_amount);
 
-    // define the arguments to the peer to peer transaction
-    let transfer_amount = 1_000;
-    let txn = peer_to_peer_txn(sender.account(), &new_account, 10, transfer_amount);
+        // execute transaction
+        let txns: Vec<SignedTransaction> = vec![txn];
+        let output = executor.execute_block(txns);
+        let txn_output = output.get(0).expect("must have a transaction output");
+        assert_eq!(
+            output[0].status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        );
+        executor.apply_write_set(txn_output.write_set());
 
-    // execute transaction
-    let txns: Vec<SignedTransaction> = vec![txn];
-    let output = executor.execute_block(txns);
-    let txn_output = output.get(0).expect("must have a transaction output");
-    assert_eq!(
-        output[0].status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-    );
-    executor.apply_write_set(txn_output.write_set());
-
-    // check that numbers in stored DB are correct
-    let gas = txn_output.gas_used();
-    let sender_balance = 1_000_000 - transfer_amount - gas;
-    let receiver_balance = transfer_amount;
-    let updated_sender = executor
-        .read_account_resource(sender.account())
-        .expect("sender must exist");
-    let updated_receiver = executor
-        .read_account_resource(&new_account)
-        .expect("receiver must exist");
-    assert_eq!(receiver_balance, updated_receiver.balance());
-    assert_eq!(sender_balance, updated_sender.balance());
-    assert_eq!(11, updated_sender.sequence_number());
+        // check that numbers in stored DB are correct
+        let gas = txn_output.gas_used();
+        let sender_balance = 1_000_000 - transfer_amount - gas;
+        let receiver_balance = transfer_amount;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        let updated_receiver = executor
+            .read_account_resource(&new_account)
+            .expect("receiver must exist");
+        assert_eq!(receiver_balance, updated_receiver.balance());
+        assert_eq!(sender_balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+    });
 }
 
 // Holder for transaction data; arguments to transactions.
@@ -408,173 +409,173 @@ fn print_accounts(executor: &FakeExecutor, accounts: &[Account]) {
 #[test]
 fn cycle_peer_to_peer() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish accounts with 2_000_000 coins
+        let account_size = 100usize;
+        let initial_balance = 2_000_000u64;
+        let initial_seq_num = 10u64;
+        let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
 
-    // create and publish accounts with 2_000_000 coins
-    let account_size = 100usize;
-    let initial_balance = 2_000_000u64;
-    let initial_seq_num = 10u64;
-    let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
+        // set up the transactions
+        let transfer_amount = 1_000;
+        let (txns_info, txns) = create_cyclic_transfers(&executor, &accounts, transfer_amount);
 
-    // set up the transactions
-    let transfer_amount = 1_000;
-    let (txns_info, txns) = create_cyclic_transfers(&executor, &accounts, transfer_amount);
+        // execute transaction
+        let mut execution_time = 0u128;
+        let now = Instant::now();
+        let output = executor.execute_block(txns);
+        execution_time += now.elapsed().as_nanos();
+        println!("EXECUTION TIME: {}", execution_time);
+        for txn_output in &output {
+            assert_eq!(
+                txn_output.status(),
+                &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+            );
+        }
+        assert_eq!(accounts.len(), output.len());
 
-    // execute transaction
-    let mut execution_time = 0u128;
-    let now = Instant::now();
-    let output = executor.execute_block(txns);
-    execution_time += now.elapsed().as_nanos();
-    println!("EXECUTION TIME: {}", execution_time);
-    for txn_output in &output {
-        assert_eq!(
-            txn_output.status(),
-            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-        );
-    }
-    assert_eq!(accounts.len(), output.len());
-
-    check_and_apply_transfer_output(&mut executor, &txns_info, &output);
-    print_accounts(&executor, &accounts);
+        check_and_apply_transfer_output(&mut executor, &txns_info, &output);
+        print_accounts(&executor, &accounts);
+    });
 }
 
 #[test]
 fn cycle_peer_to_peer_multi_block() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish accounts with 1_000_000 coins
+        let account_size = 100usize;
+        let initial_balance = 1_000_000u64;
+        let initial_seq_num = 10u64;
+        let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
 
-    // create and publish accounts with 1_000_000 coins
-    let account_size = 100usize;
-    let initial_balance = 1_000_000u64;
-    let initial_seq_num = 10u64;
-    let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
-
-    // set up the transactions
-    let transfer_amount = 1_000;
-    let block_count = 5u64;
-    let cycle = account_size / (block_count as usize);
-    let mut range_left = 0usize;
-    let mut execution_time = 0u128;
-    for _i in 0..block_count {
-        range_left = if range_left + cycle >= account_size {
-            account_size - cycle
-        } else {
-            range_left
-        };
-        let (txns_info, txns) = create_cyclic_transfers(
-            &executor,
-            &accounts[range_left..range_left + cycle],
-            transfer_amount,
-        );
-
-        // execute transaction
-        let now = Instant::now();
-        let output = executor.execute_block(txns);
-        execution_time += now.elapsed().as_nanos();
-        for txn_output in &output {
-            assert_eq!(
-                txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        // set up the transactions
+        let transfer_amount = 1_000;
+        let block_count = 5u64;
+        let cycle = account_size / (block_count as usize);
+        let mut range_left = 0usize;
+        let mut execution_time = 0u128;
+        for _i in 0..block_count {
+            range_left = if range_left + cycle >= account_size {
+                account_size - cycle
+            } else {
+                range_left
+            };
+            let (txns_info, txns) = create_cyclic_transfers(
+                &executor,
+                &accounts[range_left..range_left + cycle],
+                transfer_amount,
             );
+
+            // execute transaction
+            let now = Instant::now();
+            let output = executor.execute_block(txns);
+            execution_time += now.elapsed().as_nanos();
+            for txn_output in &output {
+                assert_eq!(
+                    txn_output.status(),
+                    &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+                );
+            }
+            assert_eq!(cycle, output.len());
+            check_and_apply_transfer_output(&mut executor, &txns_info, &output);
+            range_left = (range_left + cycle) % account_size;
         }
-        assert_eq!(cycle, output.len());
-        check_and_apply_transfer_output(&mut executor, &txns_info, &output);
-        range_left = (range_left + cycle) % account_size;
-    }
-    println!("EXECUTION TIME: {}", execution_time);
-    print_accounts(&executor, &accounts);
+        println!("EXECUTION TIME: {}", execution_time);
+        print_accounts(&executor, &accounts);
+    });
 }
 
 #[test]
 fn one_to_many_peer_to_peer() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish accounts with 4_000_000 coins
+        let account_size = 100usize;
+        let initial_balance = 4_000_000u64;
+        let initial_seq_num = 10u64;
+        let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
 
-    // create and publish accounts with 4_000_000 coins
-    let account_size = 100usize;
-    let initial_balance = 4_000_000u64;
-    let initial_seq_num = 10u64;
-    let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
-
-    // set up the transactions
-    let transfer_amount = 1_000;
-    let block_count = 2u64;
-    let cycle = account_size / (block_count as usize);
-    let mut range_left = 0usize;
-    let mut execution_time = 0u128;
-    for _i in 0..block_count {
-        range_left = if range_left + cycle >= account_size {
-            account_size - cycle
-        } else {
-            range_left
-        };
-        let (txns_info, txns) = create_one_to_many_transfers(
-            &executor,
-            &accounts[range_left..range_left + cycle],
-            transfer_amount,
-        );
-
-        // execute transaction
-        let now = Instant::now();
-        let output = executor.execute_block(txns);
-        execution_time += now.elapsed().as_nanos();
-        for txn_output in &output {
-            assert_eq!(
-                txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        // set up the transactions
+        let transfer_amount = 1_000;
+        let block_count = 2u64;
+        let cycle = account_size / (block_count as usize);
+        let mut range_left = 0usize;
+        let mut execution_time = 0u128;
+        for _i in 0..block_count {
+            range_left = if range_left + cycle >= account_size {
+                account_size - cycle
+            } else {
+                range_left
+            };
+            let (txns_info, txns) = create_one_to_many_transfers(
+                &executor,
+                &accounts[range_left..range_left + cycle],
+                transfer_amount,
             );
+
+            // execute transaction
+            let now = Instant::now();
+            let output = executor.execute_block(txns);
+            execution_time += now.elapsed().as_nanos();
+            for txn_output in &output {
+                assert_eq!(
+                    txn_output.status(),
+                    &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+                );
+            }
+            assert_eq!(cycle - 1, output.len());
+            check_and_apply_transfer_output(&mut executor, &txns_info, &output);
+            range_left = (range_left + cycle) % account_size;
         }
-        assert_eq!(cycle - 1, output.len());
-        check_and_apply_transfer_output(&mut executor, &txns_info, &output);
-        range_left = (range_left + cycle) % account_size;
-    }
-    println!("EXECUTION TIME: {}", execution_time);
-    print_accounts(&executor, &accounts);
+        println!("EXECUTION TIME: {}", execution_time);
+        print_accounts(&executor, &accounts);
+    });
 }
 
 #[test]
 fn many_to_one_peer_to_peer() {
     // create a FakeExecutor with a genesis from file
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish accounts with 1_000_000 coins
+        let account_size = 100usize;
+        let initial_balance = 1_000_000u64;
+        let initial_seq_num = 10u64;
+        let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
 
-    // create and publish accounts with 1_000_000 coins
-    let account_size = 100usize;
-    let initial_balance = 1_000_000u64;
-    let initial_seq_num = 10u64;
-    let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
-
-    // set up the transactions
-    let transfer_amount = 1_000;
-    let block_count = 2u64;
-    let cycle = account_size / (block_count as usize);
-    let mut range_left = 0usize;
-    let mut execution_time = 0u128;
-    for _i in 0..block_count {
-        range_left = if range_left + cycle >= account_size {
-            account_size - cycle
-        } else {
-            range_left
-        };
-        let (txns_info, txns) = create_many_to_one_transfers(
-            &executor,
-            &accounts[range_left..range_left + cycle],
-            transfer_amount,
-        );
-
-        // execute transaction
-        let now = Instant::now();
-        let output = executor.execute_block(txns);
-        execution_time += now.elapsed().as_nanos();
-        for txn_output in &output {
-            assert_eq!(
-                txn_output.status(),
-                &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+        // set up the transactions
+        let transfer_amount = 1_000;
+        let block_count = 2u64;
+        let cycle = account_size / (block_count as usize);
+        let mut range_left = 0usize;
+        let mut execution_time = 0u128;
+        for _i in 0..block_count {
+            range_left = if range_left + cycle >= account_size {
+                account_size - cycle
+            } else {
+                range_left
+            };
+            let (txns_info, txns) = create_many_to_one_transfers(
+                &executor,
+                &accounts[range_left..range_left + cycle],
+                transfer_amount,
             );
+
+            // execute transaction
+            let now = Instant::now();
+            let output = executor.execute_block(txns);
+            execution_time += now.elapsed().as_nanos();
+            for txn_output in &output {
+                assert_eq!(
+                    txn_output.status(),
+                    &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+                );
+            }
+            assert_eq!(cycle - 1, output.len());
+            check_and_apply_transfer_output(&mut executor, &txns_info, &output);
+            range_left = (range_left + cycle) % account_size;
         }
-        assert_eq!(cycle - 1, output.len());
-        check_and_apply_transfer_output(&mut executor, &txns_info, &output);
-        range_left = (range_left + cycle) % account_size;
-    }
-    println!("EXECUTION TIME: {}", execution_time);
-    print_accounts(&executor, &accounts);
+        println!("EXECUTION TIME: {}", execution_time);
+        print_accounts(&executor, &accounts);
+    });
 }

--- a/language/e2e_tests/src/tests/rotate_key.rs
+++ b/language/e2e_tests/src/tests/rotate_key.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::{create_account_txn, rotate_key_txn},
-    executor::FakeExecutor,
+    executor::test_all_genesis,
 };
 use crypto::ed25519::compat;
 use types::{
@@ -15,52 +15,52 @@ use types::{
 
 #[test]
 fn rotate_key() {
-    let mut executor = FakeExecutor::from_genesis_file();
+    test_all_genesis(|mut executor| {
+        // create and publish sender
+        let mut sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
 
-    // create and publish sender
-    let mut sender = AccountData::new(1_000_000, 10);
-    executor.add_account_data(&sender);
+        let (privkey, pubkey) = compat::generate_keypair(None);
+        let new_key_hash = AccountAddress::from_public_key(&pubkey);
+        let txn = rotate_key_txn(sender.account(), new_key_hash, 10);
 
-    let (privkey, pubkey) = compat::generate_keypair(None);
-    let new_key_hash = AccountAddress::from_public_key(&pubkey);
-    let txn = rotate_key_txn(sender.account(), new_key_hash, 10);
+        // execute transaction
+        let output = &executor.execute_block(vec![txn])[0];
+        assert_eq!(
+            output.status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
+        );
+        executor.apply_write_set(output.write_set());
 
-    // execute transaction
-    let output = &executor.execute_block(vec![txn])[0];
-    assert_eq!(
-        output.status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
-    );
-    executor.apply_write_set(output.write_set());
+        // Check that numbers in store are correct.
+        let gas = output.gas_used();
+        let balance = 1_000_000 - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        assert_eq!(
+            new_key_hash.as_ref(),
+            updated_sender.authentication_key().as_bytes(),
+        );
+        assert_eq!(balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
 
-    // Check that numbers in store are correct.
-    let gas = output.gas_used();
-    let balance = 1_000_000 - gas;
-    let updated_sender = executor
-        .read_account_resource(sender.account())
-        .expect("sender must exist");
-    assert_eq!(
-        new_key_hash.as_ref(),
-        updated_sender.authentication_key().as_bytes(),
-    );
-    assert_eq!(balance, updated_sender.balance());
-    assert_eq!(11, updated_sender.sequence_number());
+        // Check that transactions cannot be sent with the old key any more.
+        let new_account = Account::new();
+        let old_key_txn = create_account_txn(sender.account(), &new_account, 11, 100_000);
+        let old_key_output = &executor.execute_block(vec![old_key_txn])[0];
+        assert_eq!(
+            old_key_output.status(),
+            &TransactionStatus::Discard(VMStatus::new(StatusCode::INVALID_AUTH_KEY)),
+        );
 
-    // Check that transactions cannot be sent with the old key any more.
-    let new_account = Account::new();
-    let old_key_txn = create_account_txn(sender.account(), &new_account, 11, 100_000);
-    let old_key_output = &executor.execute_block(vec![old_key_txn])[0];
-    assert_eq!(
-        old_key_output.status(),
-        &TransactionStatus::Discard(VMStatus::new(StatusCode::INVALID_AUTH_KEY)),
-    );
-
-    // Check that transactions can be sent with the new key.
-    sender.rotate_key(privkey, pubkey);
-    let new_key_txn = create_account_txn(sender.account(), &new_account, 11, 100_000);
-    let new_key_output = &executor.execute_block(vec![new_key_txn])[0];
-    assert_eq!(
-        new_key_output.status(),
-        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
-    );
+        // Check that transactions can be sent with the new key.
+        sender.rotate_key(privkey, pubkey);
+        let new_key_txn = create_account_txn(sender.account(), &new_account, 11, 100_000);
+        let new_key_output = &executor.execute_block(vec![new_key_txn])[0];
+        assert_eq!(
+            new_key_output.status(),
+            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
+        );
+    });
 }

--- a/scripts/circle_validate_configs.sh
+++ b/scripts/circle_validate_configs.sh
@@ -23,7 +23,7 @@ git checkout -- '**/seed_peers.config.toml'
 git update-index --refresh
 
 echo "--- Compare configs ---"
-changes=$(git diff-index HEAD -- '**/genesis.blob' '**/consensus_peers.config.toml' '**/node.consensus.keys.toml' '**/network_peers.config.toml' '**/node.network.keys.toml')
+changes=$(git diff-index HEAD -- '**/consensus_peers.config.toml' '**/node.consensus.keys.toml' '**/network_peers.config.toml' '**/node.network.keys.toml')
 if [ -z "$changes" ];
 then
 	# nothing to do


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Previously we've been testing genesis against the freshly built genesis blob. This wasn't ideal as we are developing on genesis (std libraries) pretty intensively recently, which was causing the testnet db to be wiped every week. In this PR I'm going to change the testing strategy to be following:

Instead of testing the genesis on a fresh genesis blob and override the old genesis in terraform, the e2e tests are going to be run against all the genesis blob used for this week's testnet genesis. By doing that, we can minimize the change to reset the genesis as the test suite is going to guarantee that the new VM code will be compatible with the old genesis. And in case there has to be a breaking change, we shall overwrite the terraform testnet genesis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
