### PR TITLE
[consensus] expand test coverage for restartability

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -105,7 +105,10 @@ impl SMRNode {
         let mempool = Arc::new(mp);
         smr.start(
             mempool.clone(),
-            Arc::new(MockStateComputer::new(commit_cb_sender.clone())),
+            Arc::new(MockStateComputer::new(
+                commit_cb_sender.clone(),
+                Arc::clone(&storage),
+            )),
         )
         .expect("Failed to start SMR!");
         Self {

--- a/consensus/src/chained_bft/consensus_types/quorum_cert.rs
+++ b/consensus/src/chained_bft/consensus_types/quorum_cert.rs
@@ -34,7 +34,7 @@ impl Display for QuorumCert {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "QuorumCert: [Vote data: {}, {}]",
+            "QuorumCert: [{}, {}]",
             self.vote_data, self.signed_ledger_info
         )
     }

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -12,7 +12,7 @@ use crate::chained_bft::{
 };
 use crypto::{hash::CryptoHash, HashValue};
 use executor::ExecutedState;
-use futures::{channel::mpsc, executor::block_on};
+use futures::executor::block_on;
 use logger::{set_simple_logger, set_simple_logger_prefix};
 use std::{collections::HashMap, sync::Arc};
 use termion::color::*;
@@ -40,13 +40,12 @@ pub fn build_empty_tree() -> Arc<BlockStore<Vec<usize>>> {
 pub fn build_empty_tree_with_custom_signing(
     my_signer: ValidatorSigner,
 ) -> Arc<BlockStore<Vec<usize>>> {
-    let (commit_cb_sender, _commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
     let (storage, initial_data) = EmptyStorage::start_for_testing();
     Arc::new(block_on(BlockStore::new(
         storage,
         initial_data,
         my_signer,
-        Arc::new(MockStateComputer::new(commit_cb_sender)),
+        Arc::new(EmptyStateComputer),
         true,
         10, // max pruned blocks in mem
     )))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To prevent https://github.com/libra/libra/issues/1054 happens again.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

- Added new invariant LI(S).timestamp <= root.timestamp
- expand the `verify_consistency` to commit/sync so that we cover all db writes in unit tests

The original bug would fail many tests and the output looks like this(revert https://github.com/libra/libra/pull/1058 to produce)
```
thread 'tokio-runtime-worker-0' panicked at 'invalid db after commit: Blocks in db:
	[id: a0614bb4 (NIL), round: 01, parent_id: 47454e45]
	[id: 9b440cc9, round: 01, parent_id: 47454e45]
	[id: 4ef99fe8, round: 02, parent_id: 9b440cc9]
	[id: 112214f8 (NIL), round: 03, parent_id: 4ef99fe8]
	[id: 154a7e3a (NIL), round: 04, parent_id: 4ef99fe8]
	[id: 30aec1d0 (NIL), round: 05, parent_id: 154a7e3a]
	[id: d0f69751 (NIL), round: 06, parent_id: 30aec1d0]
Quorum Certs in db:
	QuorumCert: [VoteData: [block id: 47454e45, round: 00, parent_block_id: 47454e45, parent_block_round: 00, grandparent_block_id: 47454e45, grandparent_block_round: 00], LedgerInfo: [committed_block_id: 47454e45, version: 0, epoch_num: 0, timestamp (us): 0, next_validator_set: None]]
	QuorumCert: [VoteData: [block id: 9b440cc9, round: 01, parent_block_id: 47454e45, parent_block_round: 00, grandparent_block_id: 47454e45, grandparent_block_round: 00], LedgerInfo: [committed_block_id: 00000000, version: 0, epoch_num: 0, timestamp (us): 0, next_validator_set: None]]
	QuorumCert: [VoteData: [block id: 4ef99fe8, round: 02, parent_block_id: 9b440cc9, parent_block_round: 01, grandparent_block_id: 47454e45, grandparent_block_round: 00], LedgerInfo: [committed_block_id: 00000000, version: 0, epoch_num: 0, timestamp (us): 0, next_validator_set: None]]
	QuorumCert: [VoteData: [block id: 154a7e3a, round: 04, parent_block_id: 4ef99fe8, parent_block_round: 02, grandparent_block_id: 9b440cc9, grandparent_block_round: 01], LedgerInfo: [committed_block_id: 00000000, version: 0, epoch_num: 0, timestamp (us): 0, next_validator_set: None]]
	QuorumCert: [VoteData: [block id: 30aec1d0, round: 05, parent_block_id: 154a7e3a, parent_block_round: 04, grandparent_block_id: 4ef99fe8, grandparent_block_round: 02], LedgerInfo: [committed_block_id: 00000000, version: 0, epoch_num: 0, timestamp (us): 0, next_validator_set: None]]
	QuorumCert: [VoteData: [block id: d0f69751, round: 06, parent_block_id: 30aec1d0, parent_block_round: 05, grandparent_block_id: 154a7e3a, grandparent_block_round: 04], LedgerInfo: [committed_block_id: 154a7e3a, version: 0, epoch_num: 0, timestamp (us): 1569384413953108, next_validator_set: None]]
error: Storage LedgerInfo: [committed_block_id: 154a7e3a, version: 0, epoch_num: 0, timestamp (us): 1569384413953108, next_validator_set: None] is ahead of root LedgerInfo: [committed_block_id: 47454e45, version: 0, epoch_num: 0, timestamp (us): 0, next_validator_set: None]'
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
