### PR TITLE
Move lalrpop generated code to `OUT_DIR`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,6 @@
 # Ignore wallet mnemonic files used for deterministic key derivation
 *.mnemonic
 
-# Generated Parser File by LALRPOP
-language/compiler/ir_to_bytecode/syntax/src/syntax.rs
-# Older locations for this file.
-language/compiler/ir_to_bytecode/src/parser/syntax.rs
-language/move_ir/
-
 # GDB related
 **/.gdb_history
 

--- a/language/compiler/ir_to_bytecode/syntax/build.rs
+++ b/language/compiler/ir_to_bytecode/syntax/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     lalrpop::Configuration::new()
-        .generate_in_source_tree()
+        .use_cargo_dir_conventions()
         .process()
         .unwrap();
 }

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/syntax.rs"));


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Crates that modify their source directories during builds cannot be published to [crates.io](https://crates.io), so stop `lalrpop` generating code into the `src` directory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Code has only changed location, so existing CI should suffice.
