### PR TITLE
[cluster_test] Add prometheus integration and print tps/latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "rusoto_ecs 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_kinesis 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_logs 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction_builder 0.1.0",

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -22,6 +22,7 @@ rusoto_kinesis = {version = "0.40.0", features=["rustls"], default_features = fa
 rusoto_logs = {version = "0.40.0", features=["rustls"], default_features = false}
 serde_json = "1.0"
 termion = "1.5.3"
+serde = { version = "1.0.89", features = ["derive"] }
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 debug_interface = { path = "../../common/debug_interface"}

--- a/testsuite/cluster_test/src/lib.rs
+++ b/testsuite/cluster_test/src/lib.rs
@@ -6,6 +6,7 @@ pub mod experiments;
 pub mod health;
 pub mod instance;
 pub mod log_prune;
+pub mod prometheus;
 pub mod slack;
 pub mod suite;
 pub mod tx_emitter;

--- a/testsuite/cluster_test/src/prometheus.rs
+++ b/testsuite/cluster_test/src/prometheus.rs
@@ -1,0 +1,180 @@
+use failure::{
+    self,
+    prelude::{bail, format_err},
+};
+use reqwest::Url;
+use serde::Deserialize;
+use std::{collections::HashMap, env, time::Duration};
+
+pub struct Prometheus {
+    url: Url,
+    client: reqwest::Client,
+}
+
+pub struct MatrixResponse {
+    inner: HashMap<String, TimeSeries>,
+}
+
+pub struct TimeSeries {
+    inner: Vec<(u64, f64)>,
+}
+
+impl Prometheus {
+    pub fn try_new_from_environment() -> Option<Self> {
+        match env::var("PROMETHEUS") {
+            Err(..) => None,
+            Ok(url) => {
+                let url = format!("http://{}:9091", url)
+                    .parse()
+                    .expect("Failed to parse PROMETHEUS");
+                let client = reqwest::Client::new();
+                Some(Self { url, client })
+            }
+        }
+    }
+
+    pub fn query_range(
+        &self,
+        query: String,
+        start: &Duration,
+        end: &Duration,
+        step: u64,
+    ) -> failure::Result<MatrixResponse> {
+        let url = self
+            .url
+            .join(&format!(
+                "api/datasources/proxy/1/api/v1/query_range?query={}&start={}&end={}&step={}",
+                query,
+                start.as_secs(),
+                end.as_secs(),
+                step
+            ))
+            .expect("Failed to make query_range url");
+
+        let mut response = self
+            .client
+            .get(url)
+            .send()
+            .map_err(|e| format_err!("Failed to query prometheus: {:?}", e))?;
+
+        // We don't check HTTP error code here
+        // Prometheus supplies error status in json response along with error text
+
+        let response: PrometheusResponse = response
+            .json()
+            .map_err(|e| format_err!("Failed to parse prometheus response: {:?}", e))?;
+
+        match response.data {
+            Some(data) => MatrixResponse::from_prometheus(data),
+            None => bail!(
+                "Prometheus query failed: {} {}",
+                response.error_type,
+                response.error
+            ),
+        }
+    }
+}
+
+impl MatrixResponse {
+    pub fn avg(&self) -> Option<f64> {
+        if self.inner.is_empty() {
+            return None;
+        }
+        let mut sum = 0.;
+        let mut count = 0usize;
+        for time_series in self.inner.values() {
+            if let Some(ts_avg) = time_series.avg() {
+                sum += ts_avg;
+                count += 1;
+            }
+        }
+        if count == 0 {
+            None
+        } else {
+            Some(sum / (count as f64))
+        }
+    }
+}
+
+impl TimeSeries {
+    pub fn get(&self) -> &[(u64, f64)] {
+        &self.inner
+    }
+
+    pub fn avg(&self) -> Option<f64> {
+        let mut sum = 0.;
+        let mut count = 0usize;
+        for (_, v) in self.inner.iter() {
+            if !v.is_normal() {
+                // Some time series can return NaN (for example, latency query that has division in
+                // it). If we include this NaN in sum, it will 'poison' it - if one
+                // of values is NaN, sum will be NaN too, and avg will be NaN
+                // Instead of poisoning, we simply ignore NaN values when calculating avg
+                continue;
+            }
+            sum += *v;
+            count += 1;
+        }
+        if count == 0 {
+            None
+        } else {
+            Some(sum / (count as f64))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusResponse {
+    data: Option<PrometheusData>,
+    #[serde(default)]
+    error: String,
+    #[serde(alias = "errorType")]
+    #[serde(default)]
+    error_type: String,
+    status: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusData {
+    result: Vec<PrometheusResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusResult {
+    metric: PrometheusMetric,
+    values: Vec<(u64, String)>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrometheusMetric {
+    op: String,
+    peer_id: String,
+}
+
+impl MatrixResponse {
+    fn from_prometheus(data: PrometheusData) -> failure::Result<Self> {
+        let mut inner = HashMap::new();
+        for entry in data.result {
+            let peer_id = entry.metric.peer_id;
+            if entry.values.is_empty() {
+                continue;
+            }
+            let time_series = TimeSeries::from_prometheus(entry.values)?;
+            inner.insert(peer_id, time_series);
+        }
+        Ok(Self { inner })
+    }
+}
+
+impl TimeSeries {
+    fn from_prometheus(values: Vec<(u64, String)>) -> failure::Result<Self> {
+        let mut inner = vec![];
+        for (ts, value) in values {
+            let value = value.parse().map_err(|e| {
+                format_err!("Failed to parse entry in prometheus time series: {:?}", e)
+            })?;
+            inner.push((ts, value));
+        }
+        Ok(TimeSeries { inner })
+    }
+}


### PR DESCRIPTION
This diff adds basic integration with prometheus to query statistics
It also adds simple use case in tx emitter - we print tps and avg e2e latency into console

Example output:
```
[achursin@ip-10-0-1-161 ~]$ PROMETHEUS=... ./cluster_test --workplace cluster-test --emit-tx
Discovered 100 peers
Minting accounts
Mint is done
Threads started
Tps: 555, latency: 776 ms
Tps: 633, latency: 866 ms
Tps: 710, latency: 862 ms
Tps: 710, latency: 849 ms
Tps: 708, latency: 844 ms
Tps: 708, latency: 843 ms
Tps: 710, latency: 843 ms
Tps: 712, latency: 843 ms
```
