### PR TITLE
[terraform] Disable container logs in CloudWatch by default

### DIFF
--- a/terraform/faucet.tf
+++ b/terraform/faucet.tf
@@ -40,7 +40,7 @@ data "template_file" "ecs_faucet_definition" {
     ac_hosts             = join(",", aws_instance.validator.*.private_ip)
     secret               = aws_secretsmanager_secret.faucet.arn
     log_level            = var.faucet_log_level
-    log_group            = aws_cloudwatch_log_group.testnet.name
+    log_group            = var.cloudwatch_logs ? aws_cloudwatch_log_group.testnet.name : ""
     log_region           = var.region
     log_prefix           = "faucet"
   }

--- a/terraform/templates/faucet.json
+++ b/terraform/templates/faucet.json
@@ -16,16 +16,18 @@
             {"name": "AC_HOST", "value": "${ac_hosts}"},
             {"name": "LOG_LEVEL", "value": "${log_level}"}
         ],
-        "secrets": [
-            {"name": "MINT_KEY", "valueFrom": "${secret}"}
-        ],
+%{ if log_group != "" }
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
-            "awslogs-group": "${log_group}",
-            "awslogs-region": "${log_region}",
-            "awslogs-stream-prefix": "${log_prefix}"
+                "awslogs-group": "${log_group}",
+                "awslogs-region": "${log_region}",
+                "awslogs-stream-prefix": "${log_prefix}"
             }
-        }
+        },
+%{ endif }
+        "secrets": [
+            {"name": "MINT_KEY", "valueFrom": "${secret}"}
+        ]
     }
 ]

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -31,10 +31,7 @@
         "ulimits": [
             {"name": "nofile", "softLimit": 131072, "hardLimit": 131072}
         ],
-        "secrets": [
-            {"name": "NETWORK_KEYPAIRS", "valueFrom": "${network_secret}"},
-            {"name": "CONSENSUS_KEYPAIR", "valueFrom": "${consensus_secret}"}
-        ],
+%{ if log_group != "" }
         "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
@@ -42,6 +39,11 @@
                 "awslogs-region": "${log_region}",
                 "awslogs-stream-prefix": "${log_prefix}"
             }
-        }
+        },
+%{ endif }
+        "secrets": [
+            {"name": "NETWORK_KEYPAIRS", "valueFrom": "${network_secret}"},
+            {"name": "CONSENSUS_KEYPAIR", "valueFrom": "${consensus_secret}"}
+        ]
     }
 ]

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -74,6 +74,7 @@ resource "aws_cloudwatch_log_group" "testnet" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "log_metric_filter" {
+  count          = var.cloudwatch_logs ? 1 : 0
   name           = "critical_log"
   pattern        = "[code=C*, time, x, file, ...]"
   log_group_name = "${aws_cloudwatch_log_group.testnet.name}"
@@ -243,7 +244,7 @@ data "template_file" "ecs_task_definition" {
     network_secret   = element(aws_secretsmanager_secret.validator_network.*.arn, count.index)
     consensus_secret = element(aws_secretsmanager_secret.validator_consensus.*.arn, count.index)
     log_level        = var.validator_log_level
-    log_group        = aws_cloudwatch_log_group.testnet.name
+    log_group        = var.cloudwatch_logs ? aws_cloudwatch_log_group.testnet.name : ""
     log_region       = var.region
     log_prefix       = "validator-${substr(var.peer_ids[count.index], 0, 8)}"
     capabilities     = jsonencode(var.validator_linux_capabilities)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -106,3 +106,8 @@ variable "monitoring_snapshot" {
   default     = ""
   description = "EBS snapshot ID to initialise monitoring data with"
 }
+
+variable "cloudwatch_logs" {
+  description = "Send container logs to CloudWatch"
+  default     = false
+}


### PR DESCRIPTION
People are finding it difficult to work with logs in CloudWatch, and
they don't seem to provide that much value. Make this configurable and
default to off.

Test Plan: Created mgorven workspace with cloudwatch_logs both on and
off.