### PR TITLE
[consensus] direct export fuzzing module to save CLion

### DIFF
--- a/consensus/src/chained_bft/mod.rs
+++ b/consensus/src/chained_bft/mod.rs
@@ -24,14 +24,11 @@ mod network_tests;
 mod proto_test;
 
 #[cfg(any(test, feature = "fuzzing"))]
-pub mod test_utils;
+mod test_utils;
 
-#[cfg(not(any(test, feature = "fuzzing")))]
 mod liveness;
-#[cfg(any(test, feature = "fuzzing"))]
-pub mod liveness;
 
-#[cfg(not(feature = "fuzzing"))]
 mod event_processor;
+
 #[cfg(feature = "fuzzing")]
-pub mod event_processor;
+pub use event_processor::event_processor_fuzzing;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -8,6 +8,7 @@
 //! [HotStuff](https://arxiv.org/pdf/1803.05069.pdf)).
 
 #![cfg_attr(not(feature = "fuzzing"), deny(missing_docs))]
+#![cfg_attr(feature = "fuzzing", allow(dead_code))]
 #![feature(async_await)]
 #![recursion_limit = "512"]
 extern crate failure;
@@ -16,15 +17,12 @@ extern crate failure;
 #[macro_use]
 extern crate debug_interface;
 
-#[cfg(not(feature = "fuzzing"))]
 mod chained_bft;
-#[cfg(feature = "fuzzing")]
-pub mod chained_bft;
 
-#[cfg(not(any(test, feature = "fuzzing")))]
 mod util;
-#[cfg(any(test, feature = "fuzzing"))]
-pub mod util;
+
+#[cfg(feature = "fuzzing")]
+pub use chained_bft::event_processor_fuzzing;
 
 /// Defines the public consensus provider traits to implement for
 /// use in the Libra Core blockchain.

--- a/testsuite/libra_fuzzer/src/fuzz_targets/consensus_proposal.rs
+++ b/testsuite/libra_fuzzer/src/fuzz_targets/consensus_proposal.rs
@@ -1,7 +1,5 @@
 use crate::FuzzTargetImpl;
-use consensus::chained_bft::event_processor::event_processor_fuzzing::{
-    fuzz_proposal, generate_corpus_proposal,
-};
+use consensus::event_processor_fuzzing::{fuzz_proposal, generate_corpus_proposal};
 use proptest_helpers::ValueGenerator;
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The double definition confused the IDE and makes the jump to declaration unusable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo run generate consensus_proposal

confirm CLion back to normal

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
