### PR TITLE
[cost_synthesis] Eliminate unnecessary guard on `.entry()` usage

### DIFF
--- a/language/tools/cost_synthesis/src/global_state/inhabitor.rs
+++ b/language/tools/cost_synthesis/src/global_state/inhabitor.rs
@@ -115,33 +115,26 @@ where
             .get_loaded_module(&module_id)
             .expect("[Module Lookup] Runtime error while looking up module")
             .expect("[Module Lookup] Unable to find module");
-        let struct_def_idx = if self.struct_handle_table.contains_key(&module_id) {
-            self.struct_handle_table
-                .get(&module_id)
-                .expect("[Struct Definition Lookup] Unable to get struct handles for module")
-                .get(struct_name)
-        } else {
-            let entry = self
-                .struct_handle_table
-                .entry(module_id)
-                .or_insert_with(|| {
-                    module
-                        .struct_defs()
-                        .iter()
-                        .enumerate()
-                        .map(|(struct_def_index, struct_def)| {
-                            let handle = module.struct_handle_at(struct_def.struct_handle);
-                            let name = module.identifier_at(handle.name).to_owned();
-                            (
-                                name,
-                                StructDefinitionIndex::new(struct_def_index as TableIndex),
-                            )
-                        })
-                        .collect()
-                });
-            entry.get(struct_name)
-        }
-        .expect("[Struct Definition Lookup] Unable to get struct definition for struct handle");
+        let struct_def_idx = self
+            .struct_handle_table
+            .entry(module_id)
+            .or_insert_with(|| {
+                module
+                    .struct_defs()
+                    .iter()
+                    .enumerate()
+                    .map(|(struct_def_index, struct_def)| {
+                        let handle = module.struct_handle_at(struct_def.struct_handle);
+                        let name = module.identifier_at(handle.name).to_owned();
+                        (
+                            name,
+                            StructDefinitionIndex::new(struct_def_index as TableIndex),
+                        )
+                    })
+                    .collect()
+            })
+            .get(struct_name)
+            .expect("[Struct Definition Lookup] Unable to get struct definition for struct handle");
         let struct_def = module.struct_def_at(*struct_def_idx);
         (module, struct_def, *struct_def_idx)
     }

--- a/language/tools/cost_synthesis/src/stack_generator.rs
+++ b/language/tools/cost_synthesis/src/stack_generator.rs
@@ -419,33 +419,26 @@ where
             .get_loaded_module(&module_id)
             .expect("[Module Lookup] Runtime error while looking up module")
             .expect("[Module Lookup] Unable to find module");
-        let struct_def_idx = if self.struct_handle_table.contains_key(&module_id) {
-            self.struct_handle_table
-                .get(&module_id)
-                .expect("[Struct Definition Lookup] Unable to get struct handles for module")
-                .get(struct_name)
-        } else {
-            let entry = self
-                .struct_handle_table
-                .entry(module_id)
-                .or_insert_with(|| {
-                    module
-                        .struct_defs()
-                        .iter()
-                        .enumerate()
-                        .map(|(struct_def_index, struct_def)| {
-                            let handle = module.struct_handle_at(struct_def.struct_handle);
-                            let name = module.identifier_at(handle.name).to_owned();
-                            (
-                                name,
-                                StructDefinitionIndex::new(struct_def_index as TableIndex),
-                            )
-                        })
-                        .collect()
-                });
-            entry.get(struct_name)
-        }
-        .expect("[Struct Definition Lookup] Unable to get struct definition for struct handle");
+        let struct_def_idx = self
+            .struct_handle_table
+            .entry(module_id)
+            .or_insert_with(|| {
+                module
+                    .struct_defs()
+                    .iter()
+                    .enumerate()
+                    .map(|(struct_def_index, struct_def)| {
+                        let handle = module.struct_handle_at(struct_def.struct_handle);
+                        let name = module.identifier_at(handle.name).to_owned();
+                        (
+                            name,
+                            StructDefinitionIndex::new(struct_def_index as TableIndex),
+                        )
+                    })
+                    .collect()
+            })
+            .get(struct_name)
+            .expect("[Struct Definition Lookup] Unable to get struct definition for struct handle");
 
         let struct_def = module.struct_def_at(*struct_def_idx);
         (module, struct_def, *struct_def_idx)
@@ -472,36 +465,26 @@ where
             .get_loaded_module(&module_id)
             .expect("[Module Lookup] Runtime error while looking up module")
             .expect("[Module Lookup] Unable to find module");
-        let function_def_idx = if self.function_handle_table.contains_key(&module_id) {
-            *self
-                .function_handle_table
-                .get(&module_id)
-                .expect("[Function Definition Lookup] Unable to get function handles for module")
-                .get(function_name)
-                .expect(
-                    "[Function Definition Lookup] Unable to get function definition for struct handle",
-                )
-        } else {
-            let entry = self
-                .function_handle_table
-                .entry(module_id)
-                .or_insert_with(|| {
-                    module
-                        .function_defs()
-                        .iter()
-                        .enumerate()
-                        .map(|(function_def_index, function_def)| {
-                            let handle = module.function_handle_at(function_def.function);
-                            let name = module.identifier_at(handle.name).to_owned();
-                            (
-                                name,
-                                FunctionDefinitionIndex::new(function_def_index as TableIndex),
-                            )
-                        })
-                        .collect()
-                });
-            *entry.get(function_name).unwrap()
-        };
+        let function_def_idx = *self
+            .function_handle_table
+            .entry(module_id)
+            .or_insert_with(|| {
+                module
+                    .function_defs()
+                    .iter()
+                    .enumerate()
+                    .map(|(function_def_index, function_def)| {
+                        let handle = module.function_handle_at(function_def.function);
+                        let name = module.identifier_at(handle.name).to_owned();
+                        (
+                            name,
+                            FunctionDefinitionIndex::new(function_def_index as TableIndex),
+                        )
+                    })
+                    .collect()
+            })
+            .get(function_name)
+            .unwrap();
 
         let function_def = module.function_def_at(function_def_idx);
         (module, function_def, function_def_idx, function_signature)


### PR DESCRIPTION
Cost synthesis makes great use of `map.entry(key).or_insert_with(||
{...})` but sometimes guards it with a redundant `if
map.contains_key(key)`, which leads to `.unwrap()` / `.expect`. This
removes it.