### PR TITLE
[cluster_test] Use thread pool to run ssh commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "rusoto_logs 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction_builder 0.1.0",
  "types 0.1.0",
 ]
@@ -4423,6 +4424,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "threshold_crypto"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,6 +5565,7 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95be1032c63011f20b01c5edb64930e2b51512782b43b458b1e3449613d70f87"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -34,3 +34,5 @@ transaction_builder = { path = "../../language/transaction_builder" }
 proto_conv = { path = "../../common/proto_conv" }
 crypto = { path = "../../crypto/crypto" }
 generate_keypair = { path = "../../config/generate_keypair" }
+
+threadpool = "1.7.1"

--- a/testsuite/cluster_test/src/effects/mod.rs
+++ b/testsuite/cluster_test/src/effects/mod.rs
@@ -6,12 +6,12 @@ pub use reboot::Reboot;
 use std::fmt::Display;
 pub use stop_container::StopContainer;
 
-pub trait Action: Display {
+pub trait Action: Display + Sync {
     fn apply(&self) -> failure::Result<()>;
     fn is_complete(&self) -> bool;
 }
 
-pub trait Effect: Display {
+pub trait Effect: Display + Sync {
     fn activate(&self) -> failure::Result<()>;
     fn deactivate(&self) -> failure::Result<()>;
 }


### PR DESCRIPTION
This diff uses thread pool to run ssh commands, to allow certain parallelism and make things faster.
Time of restarting 100 validator is reduced from 3:44 min to 0:24:
```bash
#Before:
[~]$ time ./cluster_test2 --workplace cluster-test --restart
Discovered 100 peers
...
real	3m44.687s

#After:
[~]$ time ./cluster_test --workplace cluster-test --restart
Discovered 100 peers
[...]
real	0m24.804s
```

To do this we introduce thread pool in cluster_test runner, and function `execute_jobs(Vec<Fn()>)` that executes vector of arbitrary functions on this thread pool.
`execute_jobs` has `unsafe` block that fakes lifetime of job, since we control this runtime ourselves by waiting for all jobs before returning - there is no good workaround without unsafe for this problem, since rust requires everything passed between threads to have `'static` lifetime.
