### PR TITLE
Removing a bunch of unneeded internal dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "client 0.1.0",
  "config 0.1.0",
- "config_builder 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -584,7 +583,6 @@ version = "0.1.0"
 dependencies = [
  "admission_control_proto 0.1.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "client 0.1.0",
  "crypto 0.1.0",
  "debug_interface 0.1.0",
  "failure_ext 0.1.0",
@@ -1381,7 +1379,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
- "transaction_builder 0.1.0",
  "types 0.1.0",
  "vm 0.1.0",
 ]
@@ -3708,7 +3705,6 @@ name = "scratchpad"
 version = "0.1.0"
 dependencies = [
  "crypto 0.1.0",
- "failure_ext 0.1.0",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "types 0.1.0",
@@ -4047,7 +4043,6 @@ dependencies = [
  "executor 0.1.0",
  "failure_ext 0.1.0",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpc_helpers 0.1.0",
  "grpcio 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
@@ -4744,7 +4739,6 @@ version = "0.1.0"
 dependencies = [
  "config 0.1.0",
  "crypto 0.1.0",
- "failure_ext 0.1.0",
  "ir_to_bytecode 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -4956,7 +4950,6 @@ dependencies = [
  "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
- "ir_to_bytecode 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -20,7 +20,6 @@ walkdir = "2.2.9"
 admission_control_proto = { path = "../admission_control/admission_control_proto" }
 client = { path = "../client" }
 config = { path = "../config" }
-config_builder = { path = "../config/config_builder" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 generate_keypair = { path = "../config/generate_keypair" }
 libra_wallet = { path = "../client/libra_wallet" }

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -15,7 +15,6 @@ vm = { path = "../vm" }
 bytecode_verifier = { path = "../bytecode_verifier" }
 language_e2e_tests = { path = "../e2e_tests" }
 config = { path = "../../config" }
-transaction_builder = { path = "../transaction_builder" }
 filecheck = "0.4.0"
 lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }

--- a/language/transaction_builder/Cargo.toml
+++ b/language/transaction_builder/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [dependencies]
 config = { path = "../../config" }
 crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 lazy_static = "1.3.0"
 stdlib = { path = "../stdlib" }

--- a/language/vm/vm_genesis/Cargo.toml
+++ b/language/vm/vm_genesis/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 config = { path = "../../../config" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 transaction_builder = { path = "../../transaction_builder"}
-ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
 crypto = { path = "../../../crypto/crypto" }
 stdlib = { path = "../../stdlib" }
 proto_conv = { path = "../../../common/proto_conv", features = ["derive"] }

--- a/state_synchronizer/Cargo.toml
+++ b/state_synchronizer/Cargo.toml
@@ -16,11 +16,9 @@ tokio = { version = "0.1.22", default-features = false }
 config = { path = "../config" }
 executor = { path = "../execution/executor" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
-grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 network = { path = "../network" }
-crypto = { path = "../crypto/crypto" }
 proto_conv = { path = "../common/proto_conv" }
 storage_client = { path = "../storage/storage_client" }
 types = { path = "../types" }

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 itertools = "0.8.0"
 
 crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure_ext", package = "failure_ext" }
 types = { path = "../../types" }
 
 [dev-dependencies]

--- a/testsuite/cluster_test/Cargo.toml
+++ b/testsuite/cluster_test/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1.0.89", features = ["derive"] }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 debug_interface = { path = "../../common/debug_interface"}
 admission_control_proto = { path = "../../admission_control/admission_control_proto" }
-client = { path = "../../client" }
 logger = { path = "../../common/logger" }
 
 types = { path = "../../types" }


### PR DESCRIPTION
[don't 'r+' until @andll has had a look, 'delegate+' instead]
Removing failure from scratchpad

Removing config_builder from benchmark

Removing client from cluster_test

Removing grpc_helpers from state_synchronizer

Removing crypto from state_synchronizer

Removing types from config_builder

Removing ir_to_bytecode from vm_genesis

Removing failure from transaction_builder

Removing transaction_builder from functional_tests
[don't 'r+' until @andll has had a look, 'delegate+' instead]
