### PR TITLE
[language][bytecode verifier] remove unreachable code/file unit_tests.rs

### DIFF
--- a/language/bytecode_verifier/src/unit_tests.rs
+++ b/language/bytecode_verifier/src/unit_tests.rs
@@ -1,4 +1,0 @@
-// Copyright (c) The Libra Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-mod signature_tests;


### PR DESCRIPTION
## Summary
All verifier tests have been moved into the separate crate `bytecode_verifier_tests`. The file of concern is no longer reachable from `lib.rs`, which I forgot to delete last time. This PR gets it deleted.

## Test Plan
```
cargo test
```