### PR TITLE
[network] Fix flaky test in connectivity_manager

### DIFF
--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -662,7 +662,6 @@ fn backoff_on_failure() {
             let elapsed = Instant::now().duration_since(start);
             info!("Duration elapsed: {:?}", elapsed);
             assert!(elapsed.as_millis() >= 100);
-            assert!(elapsed.as_millis() <= 150);
         }
     };
     rt.block_on(events_f.boxed().unit_error().compat()).unwrap();


### PR DESCRIPTION
## Motivation

This PR fixes #1045 by removing an unnecessary upper bound on linear backoff in
connectivity_manager test. The upper-bound was randomly chosen and in
reality makes the test flaky. It also does not add much value.

![image](https://user-images.githubusercontent.com/877038/65727460-a4f32a00-e06c-11e9-873c-9d888ef3590b.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y