### PR TITLE
[libra_swarm] modify interface for full node support in libra_swarm binary

### DIFF
--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -88,9 +88,7 @@ mod tests {
         );
         let mut args = BenchOpt {
             validator_addresses: Vec::new(),
-            swarm_config_dir: Some(String::from(
-                swarm.dir.as_ref().unwrap().as_ref().to_str().unwrap(),
-            )),
+            swarm_config_dir: Some(String::from(swarm.dir.as_ref().to_str().unwrap())),
             // Don't start metrics server as we are not testing with prometheus.
             metrics_server_address: None,
             faucet_key_file_path,

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -38,8 +38,6 @@ fn setup_env(
     let validator_set_file = swarm
         .dir
         .as_ref()
-        .expect("fail to access output dir")
-        .as_ref()
         .join("0")
         .join(&config.consensus.consensus_peers_file);
     let client_proxy = ClientProxy::new(
@@ -300,8 +298,6 @@ fn test_basic_state_synchronization() {
     let config = NodeConfig::load(&swarm.config.configs[0]).unwrap();;
     let validator_set_file = swarm
         .dir
-        .as_ref()
-        .expect("fail to access output dir")
         .as_ref()
         .join("0")
         .join(&config.consensus.consensus_peers_file);

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -46,7 +46,7 @@ rusty_fork_test! {
             None,   /* template_path */
             None, /* upstream_path */
         );
-        let swarm_config_dir = String::from(swarm.dir.as_ref().unwrap().as_ref().to_str().unwrap());
+        let swarm_config_dir = String::from(swarm.dir.as_ref().to_str().unwrap());
         let validator_addresses = parse_swarm_config_from_dir(&swarm_config_dir).unwrap();
         let clients = create_ac_clients(num_clients, &validator_addresses);
         let mut bm = Benchmarker::new(clients, stagger_ms, submit_rate);


### PR DESCRIPTION
* renamed cli option to `f`/`num_full_nodes`
* retired old `f` option for faucet key [unused mostly]
* split swarm launch into 2-step process: configure swarm and launch it.
This way we can configure and start full node cluster without need to reconfigure and restart parent validator

Example: to run local cluster of 4 validators and 2 full nodes use
`cargo run --bin libra_swarm -- -n 4 -f 2 -s`
