### PR TITLE
[full-node] Add AC runtime and grpc to send transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "libra-types 0.1.0",
  "logger 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,13 +54,17 @@ dependencies = [
  "libra-types 0.1.0",
  "logger 0.1.0",
  "metrics 0.1.0",
+ "network 0.1.0",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest_helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-ext 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-service 0.1.0",
  "storage_client 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm_validator 0.1.0",
 ]
 
@@ -1652,6 +1656,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/admission_control/admission-control-proto/Cargo.toml
+++ b/admission_control/admission-control-proto/Cargo.toml
@@ -25,3 +25,4 @@ libra-types = { path = "../../types", features = ["testing"]}
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
+prost-build = "0.5.0"

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -11,12 +11,15 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
-futures = "0.1.28"
-futures03 = { version = "=0.3.0-alpha.19", package = "futures-preview" }
-grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 prost = "0.5.0"
+futures_01 = {version = "0.1.28", package = "futures"}
+futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["compat"] }
+grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["protobuf-codec"] }
+num_cpus = "1.10.1"
 lazy_static = "1.3.0"
 structopt = "0.3.2"
+rand = "0.6.5"
+tokio = "0.1.22"
 
 admission-control-proto = { path = "../admission-control-proto" }
 config = { path = "../../config" }
@@ -32,6 +35,8 @@ metrics = { path = "../../common/metrics" }
 storage_client = { path = "../../storage/storage_client" }
 libra-types = { path = "../../types" }
 vm_validator = { path = "../../vm_validator" }
+prost-ext = { path = "../../common/prost-ext" }
+network = { path = "../../network" }
 
 storage-service = { path = "../../storage/storage-service", optional = true }
 proptest_helpers = { path = "../../common/proptest_helpers", optional = true }
@@ -39,7 +44,6 @@ proptest = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-rand = "0.6.5"
 storage-service = { path = "../../storage/storage-service" }
 libra-types = { path = "../../types", features = ["testing"] }
 proptest_helpers = { path = "../../common/proptest_helpers" }

--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -6,6 +6,7 @@ use crate::{
     admission_control_service::SubmitTransactionRequest,
     mocks::local_mock_mempool::LocalMockMempool,
 };
+use futures::channel::mpsc;
 use libra_types::transaction::SignedTransaction;
 use proptest;
 use proptest_helpers::ValueGenerator;
@@ -47,6 +48,7 @@ pub fn fuzzer(data: &[u8]) {
             return;
         }
     };
+    let (upstream_proxy_sender, _) = mpsc::unbounded();
 
     // create service to receive it
     let ac_service = AdmissionControlService::new(
@@ -54,6 +56,7 @@ pub fn fuzzer(data: &[u8]) {
         Arc::new(MockStorageReadClient),
         Arc::new(MockVMValidator),
         false,
+        upstream_proxy_sender,
     );
 
     // process the request

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -14,8 +14,12 @@ use admission_control_proto::{
     AdmissionControlStatus,
 };
 use failure::prelude::*;
-use futures::future::Future;
-use futures03::executor::block_on;
+use futures::{
+    channel::{mpsc, oneshot},
+    executor::block_on,
+    SinkExt,
+};
+use futures_01::future::Future;
 use grpc_helpers::provide_grpc_response;
 use libra_mempool::proto::{
     mempool::{AddTransactionWithValidationRequest, HealthCheckRequest},
@@ -31,6 +35,7 @@ use libra_types::{
 };
 use logger::prelude::*;
 use metrics::counters::SVC_COUNTERS;
+use network::validator_network::RpcError;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use storage_client::StorageRead;
@@ -57,6 +62,9 @@ pub struct AdmissionControlService<M, V> {
     /// Flag indicating whether we need to check mempool before validation, drop txn if check
     /// fails.
     need_to_check_mempool_before_validation: bool,
+    /// mpsc sender connection to send transaction message to upstream proxy
+    //    upstream_proxy_sender: mpsc::UnboundedSender<(SubmitTransactionRequest, oneshot::Sender<Result<SubmitTransactionRequest>>)>,
+    upstream_proxy_sender: mpsc::UnboundedSender<SubmitTransactionRequest>,
 }
 
 impl<M: 'static, V> AdmissionControlService<M, V>
@@ -70,12 +78,14 @@ where
         storage_read_client: Arc<dyn StorageRead>,
         vm_validator: Arc<V>,
         need_to_check_mempool_before_validation: bool,
+        upstream_proxy_sender: mpsc::UnboundedSender<SubmitTransactionRequest>,
     ) -> Self {
         AdmissionControlService {
             mempool_client,
             storage_read_client,
             vm_validator,
             need_to_check_mempool_before_validation,
+            upstream_proxy_sender,
         }
     }
 
@@ -235,8 +245,27 @@ where
     ) {
         debug!("[GRPC] AdmissionControl::submit_transaction");
         let _timer = SVC_COUNTERS.req(&ctx);
-        let resp = match self.mempool_client {
-            None => Err(format_err!("Node doesn't accept write requests")),
+        let resp: Result<SubmitTransactionResponse> = match self.mempool_client {
+            None => {
+                //                println!("FINAL RESULT-------------{:?}", result);
+                //                let (req_sender, res_receiver) = oneshot::channel();
+                //                if let Err(e) = self.upstream_proxy_sender.unbounded_send((req, req_sender)) {
+                //                    Err(e)
+                //                }
+                //                let result = futures::executor::block_on(res_receiver);
+                //
+                //                let submit_txn_result = match result {
+                //                    Ok(res) => res,
+                //                    _ => Err(format_err!("Node doesn't accept write requests")),
+                //                };
+                //                submit_txn_result
+                //                Err(format_err!("Node doesn't accept write requests"))
+
+                let result = self.upstream_proxy_sender.unbounded_send(req);
+                let mut response = SubmitTransactionResponse::default();
+                response.status = Some(Status::AcStatus(AdmissionControlStatus::Accepted.into()));
+                Ok(response)
+            }
             Some(_) => self.submit_transaction_inner(req),
         };
         provide_grpc_response(resp, ctx, sink);

--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(missing_docs)]
+#![recursion_limit = "1024"]
 
 //! Admission Control
 //!
@@ -15,8 +16,15 @@ pub mod admission_control_service;
 #[cfg(any(test, feature = "fuzzing"))]
 /// Useful Mocks
 pub mod mocks;
+/// AC runtime to launch gRPC and network service
+pub mod runtime;
+/// Handler for sending transaction write requests upstream if needed
+mod upstream_proxy;
 use lazy_static::lazy_static;
 use metrics::OpMetrics;
+
+use libra_types::account_address::AccountAddress;
+type PeerId = AccountAddress;
 
 lazy_static! {
     static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("admission_control");

--- a/admission_control/admission-control-service/src/runtime.rs
+++ b/admission_control/admission-control-service/src/runtime.rs
@@ -1,0 +1,118 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{admission_control_service::AdmissionControlService, upstream_proxy::UpstreamProxy};
+use admission_control_proto::proto::admission_control::{
+    create_admission_control, AdmissionControlClient, SubmitTransactionRequest,
+};
+use config::config::NodeConfig;
+use futures::{
+    channel::mpsc,
+    future::{FutureExt, TryFutureExt},
+};
+use grpc_helpers::ServerHandle;
+use grpcio::{ChannelBuilder, EnvBuilder, ServerBuilder};
+use libra_mempool::proto::mempool::MempoolClient;
+use network::validator_network::{AdmissionControlNetworkEvents, AdmissionControlNetworkSender};
+use std::{cmp::min, sync::Arc};
+use storage_client::{StorageRead, StorageReadServiceClient};
+use tokio::runtime::{Builder, Runtime};
+use vm_validator::vm_validator::VMValidator;
+
+/// Handle for AdmissionControl Runtime
+pub struct AdmissionControlRuntime {
+    /// gRPC server to serve request between client and AC
+    _grpc_server: ServerHandle,
+    /// separate AC runtime
+    _upstream_proxy: Runtime,
+}
+
+impl AdmissionControlRuntime {
+    /// setup Admission Control runtime
+    pub fn bootstrap(
+        config: &NodeConfig,
+        network_sender: AdmissionControlNetworkSender,
+        network_events: Vec<AdmissionControlNetworkEvents>,
+    ) -> Self {
+        let (upstream_proxy_sender, upstream_proxy_receiver) = mpsc::unbounded();
+
+        let (grpc_server, client) = Self::setup_ac(&config, upstream_proxy_sender);
+
+        let upstream_proxy_runtime = Builder::new()
+            .name_prefix("ac-upstream-proxy-")
+            .build()
+            .expect("[admission control] failed to create runtime");
+
+        let executor = upstream_proxy_runtime.executor();
+
+        let upstream_proxy =
+            UpstreamProxy::new(config, network_sender, upstream_proxy_receiver, client);
+
+        executor.spawn(
+            upstream_proxy
+                .process_network_messages(network_events)
+                .boxed()
+                .unit_error()
+                .compat(),
+        );
+
+        Self {
+            _grpc_server: ServerHandle::setup(grpc_server),
+            _upstream_proxy: upstream_proxy_runtime,
+        }
+    }
+
+    /// setup Admission Control gRPC service
+    pub fn setup_ac(
+        config: &NodeConfig,
+        upstream_proxy_sender: mpsc::UnboundedSender<SubmitTransactionRequest>,
+    ) -> (::grpcio::Server, AdmissionControlClient) {
+        let env = Arc::new(
+            EnvBuilder::new()
+                .name_prefix("grpc-ac-")
+                .cq_count(min(num_cpus::get() * 2, 32))
+                .build(),
+        );
+        let port = config.admission_control.admission_control_service_port;
+
+        // Create mempool client if the node is validator.
+        let connection_str = format!("localhost:{}", config.mempool.mempool_service_port);
+        let env2 = Arc::new(EnvBuilder::new().name_prefix("grpc-ac-mem-").build());
+        let mempool_client = if config.is_validator() {
+            Some(Arc::new(MempoolClient::new(
+                ChannelBuilder::new(env2).connect(&connection_str),
+            )))
+        } else {
+            None
+        };
+
+        // Create storage read client
+        let storage_client: Arc<dyn StorageRead> = Arc::new(StorageReadServiceClient::new(
+            Arc::new(EnvBuilder::new().name_prefix("grpc-ac-sto-").build()),
+            "localhost",
+            config.storage.port,
+        ));
+
+        let vm_validator = Arc::new(VMValidator::new(&config, Arc::clone(&storage_client)));
+
+        let handle = AdmissionControlService::new(
+            mempool_client,
+            storage_client,
+            vm_validator,
+            config
+                .admission_control
+                .need_to_check_mempool_before_validation,
+            upstream_proxy_sender,
+        );
+        let service = create_admission_control(handle);
+        let server = ServerBuilder::new(Arc::clone(&env))
+            .register_service(service)
+            .bind(config.admission_control.address.clone(), port)
+            .build()
+            .expect("Unable to create grpc server");
+
+        let connection_str = format!("localhost:{}", port);
+        let client = AdmissionControlClient::new(ChannelBuilder::new(env).connect(&connection_str));
+        (server, client)
+    }
+}

--- a/admission_control/admission-control-service/src/runtime.rs
+++ b/admission_control/admission-control-service/src/runtime.rs
@@ -4,10 +4,11 @@
 use crate::{admission_control_service::AdmissionControlService, upstream_proxy::UpstreamProxy};
 use admission_control_proto::proto::admission_control::{
     create_admission_control, AdmissionControlClient, SubmitTransactionRequest,
+    SubmitTransactionResponse,
 };
 use config::config::NodeConfig;
 use futures::{
-    channel::mpsc,
+    channel::{mpsc, oneshot},
     future::{FutureExt, TryFutureExt},
 };
 use grpc_helpers::ServerHandle;
@@ -65,7 +66,10 @@ impl AdmissionControlRuntime {
     /// setup Admission Control gRPC service
     pub fn setup_ac(
         config: &NodeConfig,
-        upstream_proxy_sender: mpsc::UnboundedSender<SubmitTransactionRequest>,
+        upstream_proxy_sender: mpsc::UnboundedSender<(
+            SubmitTransactionRequest,
+            oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
+        )>,
     ) -> (::grpcio::Server, AdmissionControlClient) {
         let env = Arc::new(
             EnvBuilder::new()

--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -9,8 +9,8 @@ use crate::{
     mocks::local_mock_mempool::LocalMockMempool,
 };
 use admission_control_proto::{AdmissionControlStatus, SubmitTransactionResponse};
-
 use crypto::{ed25519::*, test_utils::TEST_SEED};
+use futures::channel::mpsc;
 use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
@@ -24,11 +24,13 @@ use storage_service::mocks::mock_storage_client::MockStorageReadClient;
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 pub fn create_ac_service_for_ut() -> AdmissionControlService<LocalMockMempool, MockVMValidator> {
+    let (upstream_proxy_sender, _) = mpsc::unbounded();
     AdmissionControlService::new(
         Some(Arc::new(LocalMockMempool::new())),
         Arc::new(MockStorageReadClient),
         Arc::new(MockVMValidator),
         false,
+        upstream_proxy_sender,
     )
 }
 

--- a/admission_control/admission-control-service/src/upstream_proxy.rs
+++ b/admission_control/admission-control-service/src/upstream_proxy.rs
@@ -21,16 +21,22 @@ use prost_ext::MessageExt;
 use rand::seq::SliceRandom;
 use std::collections::HashMap;
 
-/// Struct that owns all dependencies required by upstream proxy routine
+/// Full nodes use UpstreamProxy to send transaction write requests to their upstream validator,
+/// and is essentially the networking layer of AC.
+/// UpstreamProxy is instantiated in AC Runtime to communicate with the gRPC layer.
+/// The requests and responses are represented with AdmissionControlNetworkSender and AdmissionControlNetworkEvents.
 pub(crate) struct UpstreamProxy {
     ac_config: AdmissionControlConfig,
     network_sender: AdmissionControlNetworkSender,
     peer_info: HashMap<PeerId, bool>,
     /// used to process client requests
-    client_events: mpsc::UnboundedReceiver<(SubmitTransactionRequest)>,
+    client_events: mpsc::UnboundedReceiver<(
+        SubmitTransactionRequest,
+        oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
+    )>,
     role: RoleType,
     /// AC Client
-    pub client: AdmissionControlClient,
+    pub client: AdmissionControlClient, // TODO remove client
 }
 
 impl UpstreamProxy {
@@ -38,7 +44,10 @@ impl UpstreamProxy {
     pub fn new(
         config: &NodeConfig,
         network_sender: AdmissionControlNetworkSender,
-        client_events: mpsc::UnboundedReceiver<SubmitTransactionRequest>,
+        client_events: mpsc::UnboundedReceiver<(
+            SubmitTransactionRequest,
+            oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
+        )>,
         client: AdmissionControlClient,
     ) -> Self {
         let upstream_peer_ids = config.get_upstream_peer_ids();
@@ -66,41 +75,38 @@ impl UpstreamProxy {
 
         loop {
             ::futures::select! {
-            //                (mut msg, mut callback) = self.client_events.select_next_some() => {
-                            mut msg = self.client_events.select_next_some() => {
-                                self.submit_transaction_upstream(msg).await;
-            //                    let result = match self.submit_transaction_upstream(msg).await {
-            //                        Ok(res) => Ok(res),
-            //                        Err(e) => Err(e),
-            //                    };
-            //                    callback.send(result).await;
-                            },
-                            network_event = events.select_next_some() => {
-                                match network_event {
-                                    Ok(event) => {
-                                        match event {
-                                            Event::NewPeer(peer_id) => {
-                                                debug!("[admission control] new peer {}", peer_id);
-                                                self.new_peer(peer_id);
-                                            }
-                                            Event::LostPeer(peer_id) => {
-                                                debug!("[admission control] lost peer {}", peer_id);
-                                                self.lost_peer(peer_id);
-                                            }
-                                            Event::RpcRequest((peer_id, mut message, callback)) => {
-                                                if let Some(AdmissionControlMsg_oneof::SubmitTransactionRequest(request)) = message.message {
-                                                    if let Err(err) = self.process_submit_transaction_request(request, callback).await {
-                                                        error!("[admission control] failed to process transaction request, peer: {}, error: {:?}", peer_id, err);
-                                                    }
-                                                }
-                                            }
-                                            _ => {},
-                                        }
-                                    },
-                                    Err(err) => { error!("[admission control] network error {:?}", err); },
+                (mut msg, mut callback) = self.client_events.select_next_some() => {
+                    let result = self.submit_transaction_upstream(msg).await;
+                    if let Err(e) = callback.send(result) {
+                        error!("[admission control] failed to send back transaction result with error: {:?}", e);
+                    }
+                },
+                network_event = events.select_next_some() => {
+                    match network_event {
+                        Ok(event) => {
+                            match event {
+                                Event::NewPeer(peer_id) => {
+                                    debug!("[admission control] new peer {}", peer_id);
+                                    self.new_peer(peer_id);
                                 }
+                                Event::LostPeer(peer_id) => {
+                                    debug!("[admission control] lost peer {}", peer_id);
+                                    self.lost_peer(peer_id);
+                                }
+                                Event::RpcRequest((peer_id, mut message, callback)) => {
+                                    if let Some(AdmissionControlMsg_oneof::SubmitTransactionRequest(request)) = message.message {
+                                        if let Err(err) = self.process_submit_transaction_request(request, callback).await {
+                                            error!("[admission control] failed to process transaction request, peer: {}, error: {:?}", peer_id, err);
+                                        }
+                                    }
+                                }
+                                _ => {},
                             }
-                        }
+                        },
+                        Err(err) => { error!("[admission control] network error {:?}", err); },
+                    }
+                }
+            }
         }
     }
 
@@ -122,23 +128,23 @@ impl UpstreamProxy {
     async fn submit_transaction_upstream(
         &mut self,
         request: SubmitTransactionRequest,
-    ) -> Result<SubmitTransactionResponse, RpcError> {
+    ) -> failure::Result<SubmitTransactionResponse> {
         let active_peer_ids = self.get_active_upstream_peers();
-
         if !active_peer_ids.is_empty() {
             let peer_id = { active_peer_ids.choose(&mut rand::thread_rng()) };
             if let Some(peer_id) = peer_id {
-                let sender = self
+                let result = self
                     .network_sender
                     .send_transaction_upstream(
                         peer_id.clone(),
                         request,
                         self.ac_config.upstream_proxy_timeout,
                     )
-                    .await;
+                    .await?;
+                return Ok(result);
             }
         }
-        Err(RpcError::InvalidRpcResponse)
+        Err(format_err!("[admission-control] No active upstream peers"))
     }
 
     async fn process_submit_transaction_request(
@@ -147,10 +153,26 @@ impl UpstreamProxy {
         callback: oneshot::Sender<Result<Bytes, RpcError>>,
     ) -> failure::Result<()> {
         let mut response_msg = None;
-        if self.role == RoleType::Validator {
-            let result = self.client.submit_transaction(&request);
-            match result {
-                Ok(response) => {
+        match self.role {
+            RoleType::Validator => {
+                let result = self.client.submit_transaction(&request);
+                match result {
+                    Ok(response) => {
+                        let ac_control_msg = AdmissionControlMsg {
+                            message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
+                                response,
+                            )),
+                        };
+                        response_msg = Some(ac_control_msg);
+                    }
+                    Err(e) => {
+                        return Err(format_err!("{:?}", e.to_string()));
+                    }
+                }
+            }
+            RoleType::FullNode => {
+                // node is not a validator, so send the transaction to upstream AC via networking stack
+                if let Ok(response) = self.submit_transaction_upstream(request).await {
                     let ac_control_msg = AdmissionControlMsg {
                         message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
                             response,
@@ -158,40 +180,24 @@ impl UpstreamProxy {
                     };
                     response_msg = Some(ac_control_msg);
                 }
-                Err(e) => {
-                    return Err(format_err!("{:?}", e.to_string()));
-                }
-            }
-        } else {
-            // node is not a validator, so send the transaction to upstream AC via networking stack
-            if let Ok(response) = self.submit_transaction_upstream(request).await {
-                let ac_control_msg = AdmissionControlMsg {
-                    message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
-                        response,
-                    )),
-                };
-                response_msg = Some(ac_control_msg);
             }
         };
         if let Some(response_msg) = response_msg {
-            let response_data =
-                Bytes::from(response_msg.to_bytes().expect("fail to serialize proto"));
-            return callback
-                .send(Ok(response_data))
-                .map_err(|_| format_err!("handling inbound rpc call timed out"));
+            let response_data = response_msg.to_bytes().expect("fail to serialize proto");
+            return callback.send(Ok(response_data)).map_err(|_| {
+                format_err!("[admission-control] handling inbound rpc call timed out")
+            });
         };
-        Err(format_err!("handling inbound rpc call timed out"))
+        Err(format_err!(
+            "[admission-control] handling inbound rpc call timed out"
+        ))
     }
 
     fn get_active_upstream_peers(&self) -> Vec<PeerId> {
         self.peer_info
             .iter()
-            .filter_map(|(peer_id, is_alive)| {
-                if *is_alive {
-                    return Some(*peer_id);
-                }
-                None
-            })
+            .filter(|(_, &is_alive)| is_alive)
+            .map(|(&peer_id, _)| peer_id)
             .collect()
     }
 }

--- a/admission_control/admission-control-service/src/upstream_proxy.rs
+++ b/admission_control/admission-control-service/src/upstream_proxy.rs
@@ -1,0 +1,197 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::PeerId;
+use admission_control_proto::proto::admission_control::{
+    admission_control_msg::Message as AdmissionControlMsg_oneof, AdmissionControlClient,
+    AdmissionControlMsg, SubmitTransactionRequest, SubmitTransactionResponse,
+};
+use bytes::Bytes;
+use config::config::{AdmissionControlConfig, NodeConfig, RoleType};
+use failure::format_err;
+use futures::{
+    channel::{mpsc, oneshot},
+    stream::{select_all, StreamExt},
+};
+use logger::prelude::*;
+use network::validator_network::{
+    AdmissionControlNetworkEvents, AdmissionControlNetworkSender, Event, RpcError,
+};
+use prost_ext::MessageExt;
+use rand::seq::SliceRandom;
+use std::collections::HashMap;
+
+/// Struct that owns all dependencies required by upstream proxy routine
+pub(crate) struct UpstreamProxy {
+    ac_config: AdmissionControlConfig,
+    network_sender: AdmissionControlNetworkSender,
+    peer_info: HashMap<PeerId, bool>,
+    /// used to process client requests
+    client_events: mpsc::UnboundedReceiver<(SubmitTransactionRequest)>,
+    role: RoleType,
+    /// AC Client
+    pub client: AdmissionControlClient,
+}
+
+impl UpstreamProxy {
+    /// bootstrap of UpstreamProxy
+    pub fn new(
+        config: &NodeConfig,
+        network_sender: AdmissionControlNetworkSender,
+        client_events: mpsc::UnboundedReceiver<SubmitTransactionRequest>,
+        client: AdmissionControlClient,
+    ) -> Self {
+        let upstream_peer_ids = config.get_upstream_peer_ids();
+        let peer_info: HashMap<_, _> = upstream_peer_ids
+            .iter()
+            .map(|peer_id| (*peer_id, true))
+            .collect();
+
+        Self {
+            ac_config: config.admission_control.clone(),
+            network_sender,
+            peer_info,
+            client_events,
+            role: config.get_role(),
+            client,
+        }
+    }
+
+    /// main routine. starts sync coordinator that listens for CoordinatorMsg
+    pub async fn process_network_messages(
+        mut self,
+        network_events: Vec<AdmissionControlNetworkEvents>,
+    ) {
+        let mut events = select_all(network_events).fuse();
+
+        loop {
+            ::futures::select! {
+            //                (mut msg, mut callback) = self.client_events.select_next_some() => {
+                            mut msg = self.client_events.select_next_some() => {
+                                self.submit_transaction_upstream(msg).await;
+            //                    let result = match self.submit_transaction_upstream(msg).await {
+            //                        Ok(res) => Ok(res),
+            //                        Err(e) => Err(e),
+            //                    };
+            //                    callback.send(result).await;
+                            },
+                            network_event = events.select_next_some() => {
+                                match network_event {
+                                    Ok(event) => {
+                                        match event {
+                                            Event::NewPeer(peer_id) => {
+                                                debug!("[admission control] new peer {}", peer_id);
+                                                self.new_peer(peer_id);
+                                            }
+                                            Event::LostPeer(peer_id) => {
+                                                debug!("[admission control] lost peer {}", peer_id);
+                                                self.lost_peer(peer_id);
+                                            }
+                                            Event::RpcRequest((peer_id, mut message, callback)) => {
+                                                if let Some(AdmissionControlMsg_oneof::SubmitTransactionRequest(request)) = message.message {
+                                                    if let Err(err) = self.process_submit_transaction_request(request, callback).await {
+                                                        error!("[admission control] failed to process transaction request, peer: {}, error: {:?}", peer_id, err);
+                                                    }
+                                                }
+                                            }
+                                            _ => {},
+                                        }
+                                    },
+                                    Err(err) => { error!("[admission control] network error {:?}", err); },
+                                }
+                            }
+                        }
+        }
+    }
+
+    /// new peer discovery handler
+    /// adds new entry to `peer_info`
+    fn new_peer(&mut self, peer_id: PeerId) {
+        if let Some(state) = self.peer_info.get_mut(&peer_id) {
+            *state = true;
+        }
+    }
+
+    /// lost peer handler. Marks connection as dead
+    fn lost_peer(&mut self, peer_id: PeerId) {
+        if let Some(state) = self.peer_info.get_mut(&peer_id) {
+            *state = false;
+        }
+    }
+
+    async fn submit_transaction_upstream(
+        &mut self,
+        request: SubmitTransactionRequest,
+    ) -> Result<SubmitTransactionResponse, RpcError> {
+        let active_peer_ids = self.get_active_upstream_peers();
+
+        if !active_peer_ids.is_empty() {
+            let peer_id = { active_peer_ids.choose(&mut rand::thread_rng()) };
+            if let Some(peer_id) = peer_id {
+                let sender = self
+                    .network_sender
+                    .send_transaction_upstream(
+                        peer_id.clone(),
+                        request,
+                        self.ac_config.upstream_proxy_timeout,
+                    )
+                    .await;
+            }
+        }
+        Err(RpcError::InvalidRpcResponse)
+    }
+
+    async fn process_submit_transaction_request(
+        &mut self,
+        request: SubmitTransactionRequest,
+        callback: oneshot::Sender<Result<Bytes, RpcError>>,
+    ) -> failure::Result<()> {
+        let mut response_msg = None;
+        if self.role == RoleType::Validator {
+            let result = self.client.submit_transaction(&request);
+            match result {
+                Ok(response) => {
+                    let ac_control_msg = AdmissionControlMsg {
+                        message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
+                            response,
+                        )),
+                    };
+                    response_msg = Some(ac_control_msg);
+                }
+                Err(e) => {
+                    return Err(format_err!("{:?}", e.to_string()));
+                }
+            }
+        } else {
+            // node is not a validator, so send the transaction to upstream AC via networking stack
+            if let Ok(response) = self.submit_transaction_upstream(request).await {
+                let ac_control_msg = AdmissionControlMsg {
+                    message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
+                        response,
+                    )),
+                };
+                response_msg = Some(ac_control_msg);
+            }
+        };
+        if let Some(response_msg) = response_msg {
+            let response_data =
+                Bytes::from(response_msg.to_bytes().expect("fail to serialize proto"));
+            return callback
+                .send(Ok(response_data))
+                .map_err(|_| format_err!("handling inbound rpc call timed out"));
+        };
+        Err(format_err!("handling inbound rpc call timed out"))
+    }
+
+    fn get_active_upstream_peers(&self) -> Vec<PeerId> {
+        self.peer_info
+            .iter()
+            .filter_map(|(peer_id, is_alive)| {
+                if *is_alive {
+                    return Some(*peer_id);
+                }
+                None
+            })
+            .collect()
+    }
+}

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -268,6 +268,12 @@ impl ClientProxy {
             false
         };
         if reset_sequence_number {
+            if let Some(faucet_account) = &mut self.faucet_account {
+                if faucet_account.address == address {
+                    faucet_account.sequence_number = sequence_number;
+                    return Ok(sequence_number);
+                }
+            }
             let mut account = self.mut_account_from_parameter(space_delim_strings[1])?;
             // Set sequence_number to latest one.
             account.sequence_number = sequence_number;

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
     let (mut config, _logger) =
         setup_executable(args.config.as_ref().map(PathBuf::as_path), args.no_logging);
 
-    let (_ac_handle, _node_handle) = libra_node::main_node::setup_environment(&mut config);
+    let _node_handle = libra_node::main_node::setup_environment(&mut config);
 
     let term = Arc::new(AtomicBool::new(false));
     register_signals(Arc::clone(&term));

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -67,8 +67,11 @@ lazy_static::lazy_static! {
     /// Counter of pending network events to Consensus
     pub static ref PENDING_CONSENSUS_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_consensus_network_events");
 
-    /// Counter of pending network events to Consensus
+    /// Counter of pending network events to State Synchronizer
     pub static ref PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_state_sync_network_events");
+
+    /// Counter of pending network events to Admission Control
+    pub static ref PENDING_ADMISSION_CONTROL_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_admission_control_network_events");
 
     /// Counter of pending requests in Peer Manager
     pub static ref PENDING_PEER_MANAGER_REQUESTS: IntGauge = OP_COUNTERS.gauge("pending_peer_manager_requests");

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -558,7 +558,10 @@ fn test_full_node_basic_flow() {
         );
     }
 
-    // writes through full node AC are disabled for now
-    let mint_result = full_node_client.mint_coins(&["mintb", "0", "1"], true);
-    assert!(mint_result.is_err());
+    let mint_result = full_node_client.mint_coins(&["mintb", "0", "10"], true);
+    assert!(mint_result.is_ok());
+    assert_eq!(
+        Decimal::from_f64(17.0),
+        Decimal::from_str(&full_node_client.get_balance(&["b", "0"]).unwrap()).ok()
+    );
 }


### PR DESCRIPTION
## Motivation

This PR adds the bulk of the skeleton needed for AC to send write transactions to an upstream validator node if it is a full node. 

1. UpstreamProxy:  The networking layer of AC. ACs of nodes can send transaction requests and responses using AdmissionControlNetworkSender and AdmissionControlNetworkEvents
2. Added Runtime: Combines UpstreamProxy and gRPC server layers of AC. When it gets bootstrapped, it creates a mpsc connection between the two server layers as well. 
3. Network API: add_admission_control added in network/src/interface/module to expose AC interface in network API
4. main_node.rs: AC is now instantiated with network sender and events in setup_environment()
5. AC client is added to the node to process the transaction sent upstream (i.e. submit to mempool, send to consensus, etc)

## Test Plan

test_full_node_basic_flow in smoke_test.rs has been edited to submit transactions via full node and check for updated value. 

## Related PRs

https://github.com/libra/libra/pull/1024