### PR TITLE
[smoke tests] test_basic_state_synchronization fix

### DIFF
--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -472,13 +472,8 @@ impl LibraSwarm {
 
     /// A specific public AC port of a validator or a full node.
     pub fn get_ac_port(&self, index: usize) -> u16 {
-        *self
-            .nodes
-            .values()
-            .map(|node| node.ac_port())
-            .collect::<Vec<u16>>()
-            .get(index)
-            .unwrap()
+        let node_id = format!("{}", index);
+        self.nodes.get(&node_id).map(|node| node.ac_port()).unwrap()
     }
 
     /// Vector with the peer ids of the validators in the swarm.


### PR DESCRIPTION
according to https://circleci.com/gh/libra/libra/7923#tests/containers/3
client fails to connect to validator after one of validators gets disabled
reason is LibraSwarm::get_ac_port function uses index in different way than LibraSwarm::kill_node
