### PR TITLE
[Storage] Move get_frozen_subtree_hashes to accumulator

### DIFF
--- a/storage/accumulator/src/tests/proof_test.rs
+++ b/storage/accumulator/src/tests/proof_test.rs
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::hash::TestOnlyHasher;
 use proptest::{collection::vec, prelude::*};
 use types::proof::verify_test_accumulator_element;
-
-type InMemoryAccumulator = types::proof::accumulator::Accumulator<TestOnlyHasher>;
 
 #[test]
 fn test_error_on_bad_parameters() {

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -24,10 +24,7 @@ use schemadb::{ReadOptions, DB};
 use std::{ops::Deref, sync::Arc};
 use types::{
     crypto_proxies::LedgerInfoWithSignatures,
-    proof::{
-        position::{FrozenSubTreeIterator, Position},
-        AccumulatorProof,
-    },
+    proof::{position::Position, AccumulatorProof},
     transaction::{TransactionInfo, Version},
 };
 
@@ -174,19 +171,7 @@ impl LedgerStore {
 
     /// From left to right, get frozen subtree root hashes of the transaction accumulator.
     pub fn get_ledger_frozen_subtree_hashes(&self, version: Version) -> Result<Vec<HashValue>> {
-        FrozenSubTreeIterator::new(version + 1)
-            .map(|pos| {
-                self.db
-                    .get::<TransactionAccumulatorSchema>(&pos)?
-                    .ok_or_else(|| {
-                        LibraDbError::NotFound(format!(
-                            "Txn Accumulator node at pos {}",
-                            pos.to_inorder_index()
-                        ))
-                        .into()
-                    })
-            })
-            .collect::<Result<Vec<_>>>()
+        Accumulator::get_frozen_subtree_hashes(self, version + 1)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

For consistency, I think this kind of logic can all go to the accumulator data structure. It is also easier to write tests this way.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.