### PR TITLE
[Storage] Small fix for MerkleAccumulatorView::get_consistency_proof

### DIFF
--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -343,7 +343,7 @@ where
         );
 
         let subtrees = FrozenSubtreeSiblingIterator::new(sub_acc_leaves, self.num_leaves)
-            .map(|p| self.get_hash(p))
+            .map(|p| self.reader.get(p))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(AccumulatorConsistencyProof::new(subtrees))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since the nodes we are reading are supposed to be frozen and exist in storage, we should just use `self.reader.get`, so it would return an error if the node doesn't exist.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.
