### PR TITLE
[terraform] Reduce c5.2xlarge mem limit

### DIFF
--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -57,8 +57,8 @@ locals {
     "c5d.large"    = 3704
     "c5.xlarge"    = 7624
     "c5d.xlarge"   = 7624
-    "c5.2xlarge"   = 15464
-    "c5d.2xlarge"  = 15464
+    "c5.2xlarge"   = 15463
+    "c5d.2xlarge"  = 15463
     "c5.4xlarge"   = 31142
     "c5d.4xlarge"  = 31142
     "c5.9xlarge"   = 70341


### PR DESCRIPTION
Otherwise cluster-test refused to start on c5d.2xlarge, because available mem was 15463:
```
service cluster-test-validator-2cc0e46f was unable to place a task because no container instance met all of its requirements. The closest matching container-instance 23442007570c4f25964925a1b22aca20 has insufficient memory available. For more information, see the Troubleshooting section.
```
