### PR TITLE
[cluster_test] Clear event log after deploy

### DIFF
--- a/testsuite/cluster_test/src/main.rs
+++ b/testsuite/cluster_test/src/main.rs
@@ -224,6 +224,7 @@ impl ClusterTestRunner {
         }
         self.deployment_manager.redeploy(hash)?;
         thread::sleep(Duration::from_secs(60));
+        self.logs.recv_all();
         self.health_check_runner.clear();
         self.start();
         info!("Waiting until all validators healthy after deployment");


### PR DESCRIPTION
We clear health_check data after deploy, to prevent spurious `validator produced contradicting commit` error.
However, we did not clear log event channel. Leftovers of logs can pollute commit health check with round-commit from previous db state, resulting in spurious failure
