### PR TITLE
Fix bug in translation of call instruction

### DIFF
--- a/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
@@ -284,7 +284,9 @@ impl<'a> ModuleTranslator<'a> {
             Call(dests, callee_index, args) => {
                 let callee_name = self.function_name_from_handle_index(*callee_index);
                 let callee_function_handle = self.module.function_handle_at(*callee_index);
-                let callee_function_signature = self.module.function_signature_at(callee_function_handle.signature);
+                let callee_function_signature = self
+                    .module
+                    .function_signature_at(callee_function_handle.signature);
                 let mut dest_str = String::new();
                 let mut args_str = String::new();
                 let mut dest_type_assumptions = vec![];

--- a/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
+++ b/language/stackless_bytecode/bytecode_to_boogie/src/translator.rs
@@ -283,12 +283,14 @@ impl<'a> ModuleTranslator<'a> {
             FreezeRef(dest, src) => vec![format!("call t{} := FreezeRef(t{});", dest, src)],
             Call(dests, callee_index, args) => {
                 let callee_name = self.function_name_from_handle_index(*callee_index);
+                let callee_function_handle = self.module.function_handle_at(*callee_index);
+                let callee_function_signature = self.module.function_signature_at(callee_function_handle.signature);
                 let mut dest_str = String::new();
                 let mut args_str = String::new();
                 let mut dest_type_assumptions = vec![];
-                for arg in args.iter() {
+                for (i, arg) in args.iter().enumerate() {
                     args_str.push_str(&format!(", t{}", arg));
-                    if self.is_local_mutable_ref(*arg, func_idx) {
+                    if callee_function_signature.arg_types[i].is_mutable_reference() {
                         dest_str.push_str(&format!(", t{}", arg));
                         dest_type_assumptions.push(self.format_type_checking(
                             format!("t{}", arg),

--- a/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test3.bpl.expect
+++ b/language/stackless_bytecode/bytecode_to_boogie/test_mvir/test3.bpl.expect
@@ -1289,9 +1289,7 @@ procedure LibraCoin_mint_with_default_capability (c: CreationTime, addr_exists: 
     assume is#Global(rt#Reference(t3));
     assume is#Map(v#Reference(t3));
 
-    call addr_exists', t3, t4 := LibraCoin_mint(c', addr_exists', t1, t3);
-    assume is#Map(v#Reference(t3));
-
+    call addr_exists', t4 := LibraCoin_mint(c', addr_exists', t1, t3);
     assume is#Map(t4);
 
 
@@ -3845,9 +3843,7 @@ procedure LibraAccount_balance (c: CreationTime, addr_exists: [Address]bool, arg
     assume is#Global(rt#Reference(t2));
     assume is#Map(v#Reference(t2));
 
-    call addr_exists', t2, t3 := LibraAccount_balance_for_account(c', addr_exists', t2);
-    assume is#Map(v#Reference(t2));
-
+    call addr_exists', t3 := LibraAccount_balance_for_account(c', addr_exists', t2);
     assume is#Integer(t3);
 
 
@@ -3931,9 +3927,7 @@ procedure LibraAccount_sequence_number (c: CreationTime, addr_exists: [Address]b
     assume is#Global(rt#Reference(t2));
     assume is#Map(v#Reference(t2));
 
-    call addr_exists', t2, t3 := LibraAccount_sequence_number_for_account(c', addr_exists', t2);
-    assume is#Map(v#Reference(t2));
-
+    call addr_exists', t3 := LibraAccount_sequence_number_for_account(c', addr_exists', t2);
     assume is#Integer(t3);
 
 


### PR DESCRIPTION
Code was checking caller signature instead of callee signature, leading to improper numbers of arguments in some boogie calls.