### PR TITLE
[canonical_serialzier] Implement a more generic api for serializing maps

### DIFF
--- a/common/canonical_serialization/src/canonical_serialize.rs
+++ b/common/canonical_serialization/src/canonical_serialize.rs
@@ -64,7 +64,16 @@ pub trait CanonicalSerializer {
     fn encode_btreemap<K: CanonicalSerialize, V: CanonicalSerialize>(
         &mut self,
         v: &BTreeMap<K, V>,
-    ) -> Result<&mut Self>;
+    ) -> Result<&mut Self> {
+        self.encode_tuple_iterator(v.iter())
+    }
+
+    fn encode_tuple_iterator<K: CanonicalSerialize, V: CanonicalSerialize, I>(
+        &mut self,
+        iter: I,
+    ) -> Result<&mut Self>
+    where
+        I: Iterator<Item = (K, V)>;
 
     fn encode_optional<T: CanonicalSerialize>(&mut self, v: &Option<T>) -> Result<&mut Self>;
 
@@ -128,6 +137,16 @@ impl_canonical_serialize_for_primitive!(encode_u8, u8);
 impl_canonical_serialize_for_primitive!(encode_u16, u16);
 impl_canonical_serialize_for_primitive!(encode_u32, u32);
 impl_canonical_serialize_for_primitive!(encode_u64, u64);
+
+impl<T> CanonicalSerialize for &T
+where
+    T: CanonicalSerialize,
+{
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_struct(*self)?;
+        Ok(())
+    }
+}
 
 impl<T> CanonicalSerialize for Option<T>
 where

--- a/common/canonical_serialization/src/simple_serializer.rs
+++ b/common/canonical_serialization/src/simple_serializer.rs
@@ -66,6 +66,9 @@ where
         I: Iterator<Item = (K, V)>,
     {
         let mut map = BTreeMap::new();
+        
+        // Regardless of the order defined for K of the map, write in the order of the lexicographic
+        // order of the canonical serialized bytes of K
         for (key, value) in iter {
             map.insert(
                 SimpleSerializer::<Vec<u8>>::serialize(&key)?,
@@ -82,9 +85,6 @@ where
 
         // add the number of pairs in the map
         self.encode_u32(map.len() as u32)?;
-
-        // Regardless of the order defined for K of the map, write in the order of the lexicographic
-        // order of the canonical serialized bytes of K
 
         for (key, value) in map {
             self.output.write_all(key.as_ref())?;

--- a/common/canonical_serialization/src/simple_serializer.rs
+++ b/common/canonical_serialization/src/simple_serializer.rs
@@ -66,7 +66,7 @@ where
         I: Iterator<Item = (K, V)>,
     {
         let mut map = BTreeMap::new();
-        
+
         // Regardless of the order defined for K of the map, write in the order of the lexicographic
         // order of the canonical serialized bytes of K
         for (key, value) in iter {


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation


Currently when serializing a BTreeMap, we are just sorting on the serialized result of the key. This means that we really don't rely on the fact that the key is sorted. As a result, we can relax the api a bit so that it will just take a iterator of key-value tuples and serialize them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

cargo test

The test suite is going to make sure that we have exactly the same semantics as before.