### PR TITLE
[Consensus] Introduce a RoundData structure

### DIFF
--- a/consensus/src/chained_bft/consensus_types/mod.rs
+++ b/consensus/src/chained_bft/consensus_types/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod block;
 pub(crate) mod proposal_msg;
 pub(crate) mod quorum_cert;
+pub(crate) mod round_data;
 pub(crate) mod sync_info;
 pub(crate) mod timeout_msg;
 pub(crate) mod vote_data;

--- a/consensus/src/chained_bft/consensus_types/round_data.rs
+++ b/consensus/src/chained_bft/consensus_types/round_data.rs
@@ -1,0 +1,127 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::chained_bft::common::{Author, Round};
+use canonical_serialization::{CanonicalSerialize, CanonicalSerializer, SimpleSerializer};
+use crypto::{
+    hash::{CryptoHash, CryptoHasher, RoundDataHasher},
+    HashValue,
+};
+use failure::{Result as ProtoResult, ResultExt};
+use network::proto::RoundData as ProtoRoundData;
+use proto_conv::{FromProto, IntoProto};
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Formatter},
+};
+use types::crypto_proxies::{Signature, ValidatorSigner, ValidatorVerifier};
+
+// Internal use only, contains the fields of RoundData that contribute to its hash.
+struct RoundDataSerializer {
+    round: Round,
+}
+
+impl CanonicalSerialize for RoundDataSerializer {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> failure::Result<()> {
+        serializer.encode_u64(self.round)?;
+        Ok(())
+    }
+}
+
+impl CryptoHash for RoundDataSerializer {
+    type Hasher = RoundDataHasher;
+
+    fn hash(&self) -> HashValue {
+        let mut state = Self::Hasher::default();
+        state.write(
+            SimpleSerializer::<Vec<u8>>::serialize(self)
+                .expect("Should serialize.")
+                .as_ref(),
+        );
+        state.finish()
+    }
+}
+
+/// RoundData keeps the information about the round a validator has voted in.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct RoundData {
+    round: Round,
+    author: Author,
+    signature: Signature, // covers round and author
+}
+
+impl Display for RoundData {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "RoundData: [round: {:02}]", self.round,)
+    }
+}
+
+impl RoundData {
+    pub fn new(round: Round, author: Author, validator_signer: &ValidatorSigner) -> Self {
+        let signature = validator_signer
+            .sign_message(Self::digest(round))
+            .expect("Failed to sign LedgerInfo")
+            .into();
+        Self {
+            round,
+            author,
+            signature,
+        }
+    }
+
+    pub fn round(&self) -> Round {
+        self.round
+    }
+
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    pub fn hash(&self) -> HashValue {
+        Self::digest(self.round)
+    }
+
+    pub fn digest(round: Round) -> HashValue {
+        RoundDataSerializer { round }.hash()
+    }
+
+    /// Verifies the signature on the round data.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
+        self.signature()
+            .verify(validator, self.author(), self.hash())
+            .with_context(|e| format!("Fail to verify RoundData: {:?}", e))?;
+        Ok(())
+    }
+}
+
+impl IntoProto for RoundData {
+    type ProtoType = ProtoRoundData;
+
+    fn into_proto(self) -> Self::ProtoType {
+        let mut proto = Self::ProtoType::new();
+        proto.set_round(self.round);
+        proto.set_author(self.author.into());
+        proto.set_signature(bytes::Bytes::from(self.signature.to_bytes()));
+        proto
+    }
+}
+
+impl FromProto for RoundData {
+    type ProtoType = ProtoRoundData;
+
+    fn from_proto(mut object: Self::ProtoType) -> ProtoResult<Self> {
+        let round = object.get_round();
+        let author = Author::try_from(object.take_author())?;
+        let signature = Signature::try_from(object.get_signature())?;
+        Ok(RoundData {
+            round,
+            author,
+            signature,
+        })
+    }
+}

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -239,14 +239,7 @@ impl<T: Payload> EventProcessor<T> {
         }
 
         // pacemaker may catch up with the SyncInfo, check again
-        let current_round = self.pacemaker.current_round();
-        if proposal_msg.round() != current_round {
-            warn!(
-                "Proposal {} is ignored because its round {} != current round {}",
-                proposal_msg,
-                proposal_msg.round(),
-                current_round
-            );
+        if proposal_msg.round() != self.pacemaker.current_round() {
             return None;
         }
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -560,6 +560,11 @@ define_hasher! {
 }
 
 define_hasher! {
+    /// The hasher used to compute the hash of a RoundData object.
+    (RoundDataHasher, ROUND_DATA_HASHER, b"RoundData")
+}
+
+define_hasher! {
     /// The hasher used to compute the hash of a ContractEvent object.
     (ContractEventHasher, CONTRACT_EVENT_HASHER, b"ContractEvent")
 }

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -95,6 +95,15 @@ message QuorumCert {
   types.LedgerInfoWithSignatures signed_ledger_info = 2;
 }
 
+message RoundData {
+  // The round of the vote
+  uint64 round = 1;
+  // The author of the message
+  bytes author = 2;
+  // The signature over the round
+  bytes signature = 3;
+}
+
 message VoteData {
   // The id of the block being vote for.
   bytes block_id = 1;
@@ -122,6 +131,8 @@ message Vote {
   types.LedgerInfo ledger_info = 3;
   // Signature of the ledger info.
   bytes signature = 4;
+  // Information about the round that can be used in a standalone round certificate.
+  RoundData round_data = 5;
 }
 
 message RequestBlock {

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -16,7 +16,8 @@ pub use self::{
     admission_control::{AdmissionControlMsg, SubmitTransactionRequest, SubmitTransactionResponse},
     consensus::{
         Block, BlockRetrievalStatus, ConsensusMsg, PacemakerTimeout, PacemakerTimeoutCertificate,
-        Proposal, QuorumCert, RequestBlock, RespondBlock, SyncInfo, TimeoutMsg, Vote, VoteData,
+        Proposal, QuorumCert, RequestBlock, RespondBlock, RoundData, SyncInfo, TimeoutMsg, Vote,
+        VoteData,
     },
     mempool::MempoolSyncMsg,
     network::{


### PR DESCRIPTION
## Summary:
This change is a noop: it introduces a new structure `RoundData`, which keeps the round and is attached to the vote message.
The RoundData is going to be used for forming a TimeoutCertificate in the followup commits.

## Testing:
Existing unit test coverage

## Issues:
ref #1048