### PR TITLE
[CI] enable build and test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ commands:
             echo 'export IMAGE_NAME=myapp' >> $BASH_ENV
             echo 'export LIBRA_DUMP_LOGS=1' >> $BASH_ENV
             echo 'export CARGO_INCREMENTAL=0' >> $BASH_ENV
+            echo 'export CI_TIMEOUT="timeout 40m"' >> $BASH_ENV
   install_deps:
     steps:
       - run:
@@ -96,15 +97,15 @@ jobs:
       - run:
           name: Run All Unit Tests
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo x test --unit
+            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --unit
       - run:
           name: Run Cryptography Unit Tests with the formally verified backend
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || ( RUST_BACKTRACE=1 cd crypto/crypto && cargo test --features='std fiat_u64_backend fuzzing' --no-default-features )
+            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || ( RUST_BACKTRACE=1 cd crypto/crypto && $CI_TIMEOUT cargo test --features='std fiat_u64_backend fuzzing' --no-default-features )
       - run:
           name: Run All End to End Tests
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo x test --package testsuite -- --test-threads 1
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --package testsuite -- --test-threads 1
       - build_teardown
   validate-config:
     description: Validate that committed docker configs are up to date


### PR DESCRIPTION
## Motivation
Kill stuck smoke tests to get signal early and free up CI resource.
The timeout is set to 40min (~2X current test time on CI). When the
text process is killed due to timeout, it will exit with code 124.

Recent ex https://app.circleci.com/jobs/github/libra/libra/16436/parallel-runs/3?filterBy=ALL

### Have you read the [Contributing Guidelines on pull requests]
Yes

## Test Plan
Tested locally with the updated cmds in Circle config.