### PR TITLE
[config] Change terraform build script to be platform independent

### DIFF
--- a/terraform/validator-sets/build.sh
+++ b/terraform/validator-sets/build.sh
@@ -20,7 +20,7 @@ cd $OUTDIR
 # Remove all generated node.config.toml files.
 find . -mindepth 2 -iname node.config.toml | xargs rm
 # Move all keys files to single top-level directory.
-find . -mindepth 2 -iname '*.keys.toml' -exec mv -f -t . {} +
+find . -mindepth 2 -iname '*.keys.toml' | xargs -I '{}' mv '{}' ./
 # Move all seed peers files to top-level directory.
 find . -mindepth 2 -iname '*.seed_peers.config.toml' | xargs rm
 # Move all network peers files to top-level directory.


### PR DESCRIPTION
## Motivation

Previous version of this script was using the `-t` flag to the `mv`
command which does not exist on all (older) platforms, e.g. macOS.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
`./scripts/circle_validate_configs.sh` from top-level libra directory