### PR TITLE
[language ☑, swarm ⍰, types ⍰][janitorial, easy] Unwrap removal + combinator patterns 

### DIFF
--- a/language/bytecode_verifier/src/type_memory_safety.rs
+++ b/language/bytecode_verifier/src/type_memory_safety.rs
@@ -57,7 +57,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
         let errors: Vec<VMStatus> = function_signature_view
             .arg_tokens()
             .enumerate()
-            .map(|(arg_idx, arg_type_view)| {
+            .flat_map(|(arg_idx, arg_type_view)| {
                 let arg_token = arg_type_view.as_inner();
                 let local_token = locals_signature_view
                     .token_at(arg_idx as LocalIndex)
@@ -73,7 +73,6 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                     ]
                 }
             })
-            .flatten()
             .collect();
         if !errors.is_empty() {
             return errors;

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -365,10 +365,7 @@ TypeFormal: (TypeVar, Kind) = {
 
 TypeActuals: Vec<Type> = {
     <tys: ("<" <Comma<Type>> ">")?> => {
-        match tys {
-            Some(tys) => tys,
-            None => vec![],
-        }
+        tys.unwrap_or(vec![])
     }
 }
 
@@ -474,10 +471,7 @@ Modules: Vec<ModuleDefinition> = {
 
 pub Program : Program = {
     <m: Modules?> <s: Script> => {
-        let modules = match m {
-            Some(modules) => modules,
-            None => vec![],
-        };
+        let modules = m.unwrap_or(vec![]);
         Program::new(modules, s)
     },
     <m: Module> => {

--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -77,13 +77,12 @@ impl<'a> BoundsChecker<'a> {
                 .locals_signatures
                 .iter()
                 .enumerate()
-                .map(|(idx, locals)| {
+                .flat_map(|(idx, locals)| {
                     locals
                         .check_struct_handles(&self.module.struct_handles)
                         .into_iter()
                         .map(move |err| append_err_info(err, IndexKind::LocalsSignature, idx))
                 })
-                .flatten()
                 .collect(),
         );
 
@@ -93,12 +92,11 @@ impl<'a> BoundsChecker<'a> {
                 .type_signatures
                 .iter()
                 .enumerate()
-                .map(|(idx, ty)| {
+                .flat_map(|(idx, ty)| {
                     ty.check_struct_handles(&self.module.struct_handles)
                         .into_iter()
                         .map(move |err| append_err_info(err, IndexKind::TypeSignature, idx))
                 })
-                .flatten()
                 .collect(),
         );
 
@@ -324,16 +322,14 @@ impl LocalsSignature {
     fn check_type_parameters(&self, type_formals_len: usize) -> Vec<VMStatus> {
         self.0
             .iter()
-            .map(|ty| ty.check_type_parameters(type_formals_len))
-            .flatten()
+            .flat_map(|ty| ty.check_type_parameters(type_formals_len))
             .collect()
     }
 
     fn check_struct_handles(&self, struct_handles: &[StructHandle]) -> Vec<VMStatus> {
         self.0
             .iter()
-            .map(|ty| ty.check_struct_handles(struct_handles))
-            .flatten()
+            .flat_map(|ty| ty.check_struct_handles(struct_handles))
             .collect()
     }
 }
@@ -352,8 +348,7 @@ impl SignatureToken {
         match self {
             SignatureToken::Struct(_, type_actuals) => type_actuals
                 .iter()
-                .map(|ty| ty.check_type_parameters(type_formals_len))
-                .flatten()
+                .flat_map(|ty| ty.check_type_parameters(type_formals_len))
                 .collect(),
             SignatureToken::Reference(ty) | SignatureToken::MutableReference(ty) => {
                 ty.check_type_parameters(type_formals_len)
@@ -380,8 +375,7 @@ impl SignatureToken {
             SignatureToken::Struct(idx, type_actuals) => {
                 let mut errors: Vec<_> = type_actuals
                     .iter()
-                    .map(|ty| ty.check_struct_handles(struct_handles))
-                    .flatten()
+                    .flat_map(|ty| ty.check_struct_handles(struct_handles))
                     .collect();
                 if let Some(err) = check_bounds_impl(struct_handles, *idx) {
                     errors.push(err);
@@ -445,7 +439,7 @@ impl BoundsCheck<(&CompiledModuleMut, &FunctionSignature)> for CodeUnit {
 
         code.iter()
             .enumerate()
-            .map(|(bytecode_offset, bytecode)| {
+            .flat_map(|(bytecode_offset, bytecode)| {
                 use self::Bytecode::*;
 
                 match bytecode {
@@ -531,7 +525,6 @@ impl BoundsCheck<(&CompiledModuleMut, &FunctionSignature)> for CodeUnit {
                     | GetTxnSequenceNumber | GetTxnPublicKey => vec![],
                 }
             })
-            .flatten()
             .collect()
     }
 }

--- a/libra_swarm/src/swarm.rs
+++ b/libra_swarm/src/swarm.rs
@@ -301,7 +301,7 @@ impl LibraSwarm {
             .with_faucet_keypair(faucet_account_keypair)
             .with_role(role)
             .with_upstream_config_dir(upstream_config_dir.clone());
-        let config = config_builder.build().unwrap();
+        let config = config_builder.build()?;
         Ok(Self {
             dir: swarm_config_dir,
             nodes: HashMap::new(),

--- a/testsuite/cluster_test/src/cluster.rs
+++ b/testsuite/cluster_test/src/cluster.rs
@@ -92,12 +92,9 @@ impl Cluster {
     }
 
     pub fn get_instance(&self, name: &str) -> Option<&Instance> {
-        for instance in &self.instances {
-            if instance.short_hash() == name {
-                return Some(instance);
-            }
-        }
-        None
+        self.instances
+            .iter()
+            .find(|instance| instance.short_hash() == name)
     }
 
     pub fn sub_cluster(&self, ids: Vec<String>) -> Cluster {

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -192,12 +192,14 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
     where
         T: Into<PublicKey::SignatureMaterial> + Clone,
     {
-        for author in aggregated_signature.keys() {
-            if self.author_to_public_keys.get(&author) == None {
-                return Err(VerifyError::UnknownAuthor);
-            }
+        if aggregated_signature
+            .keys()
+            .all(|author| self.author_to_public_keys.get(&author).is_some())
+        {
+            Ok(())
+        } else {
+            Err(VerifyError::UnknownAuthor)
         }
-        Ok(())
     }
 
     /// Return the public key for this address.


### PR DESCRIPTION
- cleans up a couple of unnecessary unwraps w/ try syntax
- cleans up Result / Option / iter combinator patterns