### PR TITLE
[terraform] Allow to overwrite ami id with variable

### DIFF
--- a/terraform/faucet.tf
+++ b/terraform/faucet.tf
@@ -14,7 +14,7 @@ resource "aws_secretsmanager_secret_version" "faucet" {
 }
 
 resource "aws_instance" "faucet" {
-  ami                         = data.aws_ami.ecs.id
+  ami                         = local.aws_ecs_ami
   instance_type               = "t3.medium"
   subnet_id                   = element(aws_subnet.testnet.*.id, 0)
   depends_on                  = [aws_main_route_table_association.testnet]

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -29,7 +29,7 @@ data "template_file" "alertmanager_yml" {
 }
 
 resource "aws_instance" "monitoring" {
-  ami                         = data.aws_ami.ecs.id
+  ami                         = local.aws_ecs_ami
   instance_type               = "t3.medium"
   subnet_id                   = element(aws_subnet.testnet.*.id, 0)
   depends_on                  = [aws_main_route_table_association.testnet]

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -14,6 +14,15 @@ data "aws_ami" "ecs" {
   owners = ["amazon"]
 }
 
+variable "aws_ecs_ami_override" {
+   default = ""
+   description = "Machine image to use for ec2 instances"
+}
+
+locals {
+    aws_ecs_ami = var.aws_ecs_ami_override == "" ? data.aws_ami.ecs.id : var.aws_ecs_ami_override
+}
+
 locals {
   ebs_types = ["t2", "t3", "m5", "c5"]
 
@@ -146,7 +155,7 @@ locals {
 
 resource "aws_instance" "validator" {
   count         = length(var.peer_ids)
-  ami           = data.aws_ami.ecs.id
+  ami           = local.aws_ecs_ami
   instance_type = var.validator_type
   subnet_id = element(
     aws_subnet.testnet.*.id,


### PR DESCRIPTION
We encountered a problem recently with cluster_test when test runner and validator nodes are crashing with kernel panic with recent AWS ami.
This diff allows to overwrite ami id with variable aws_ecs_ami_override - this allows to use previous ami, without upgrading to last one
