### PR TITLE
[protobuf] convert network specific protos to be generated using prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,11 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "multimap"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,6 +2457,8 @@ dependencies = [
  "noise 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2952,6 +2959,54 @@ dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5084,6 +5139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5387,6 +5451,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04d2c9c31e9c7fb10c69843da5a44c19f1e2b2896036e0ed3cb526829f53e529"
+"checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum new_debug_unreachable 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f40f005c60db6e03bae699e414c58bf9aa7ea02a2d0b9bfbcf19286cc4c82b30"
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
@@ -5440,6 +5505,10 @@ dependencies = [
 "checksum prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
 "checksum proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d31edb17edac73aeacc947bd61462dda15220584268896a58e12f053d767f15b"
+"checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
+"checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
+"checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
+"checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 "checksum protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f00e4a3cb64ecfeac2c0a73c74c68ae3439d7a6bead3870be56ad5dd2620a6f"
 "checksum protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2c6e555166cdb646306f599da020e01548e9f4d6ec2fd39802c6db2347cbd3e"
 "checksum protoc 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f26e88abedb402073b87981faecc3b973dd5b19b7002821ed47c457bc5b367a4"
@@ -5620,6 +5689,7 @@ dependencies = [
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum webpki 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4f7e1cd7900a3a6b65a3e8780c51a3e6b59c0e2c55c6dc69578c288d69f7d082"
 "checksum webpki-roots 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c10fa4212003ba19a564f25cd8ab572c6791f99a03cc219c13ed35ccab00de0e"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,6 +13,7 @@ futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features =
 lazy_static = "1.3.0"
 parity-multiaddr = "0.5.0"
 pin-utils = "=0.1.0-alpha.4"
+prost = "0.5.0"
 protobuf = { version = "~2.7", features = ["with-bytes"] }
 rand = "0.6.5"
 tokio = "0.1.22"
@@ -39,6 +40,7 @@ crypto = { path = "../crypto/crypto", features = ["testing"] }
 types = { path = "../types", features = ["testing"]}
 
 [build-dependencies]
+prost-build = "0.5.0"
 protoc-rust = "2.5.0"
 
 [[bench]]

--- a/network/build.rs
+++ b/network/build.rs
@@ -11,14 +11,22 @@ fn main() {
         "src/proto/admission_control.proto",
     ];
 
+    let proto_files_prost = ["src/proto/network.proto"];
+
+    let includes = ["../types/src/proto", "src/proto"];
+
     for file in &proto_files {
+        println!("cargo:rerun-if-changed={}", file);
+    }
+
+    for file in &proto_files_prost {
         println!("cargo:rerun-if-changed={}", file);
     }
 
     protoc_rust::run(protoc_rust::Args {
         out_dir: "src/proto",
         input: &proto_files,
-        includes: &["../types/src/proto", "src/proto"],
+        includes: &includes,
         customize: protoc_rust::Customize {
             carllerche_bytes_for_bytes: Some(true),
             carllerche_bytes_for_string: Some(true),
@@ -27,5 +35,5 @@ fn main() {
     })
     .expect("protoc");
 
-    prost_build::compile_protos(&["src/proto/network.proto"], &["src/"]).unwrap();
+    prost_build::compile_protos(&proto_files_prost, &includes).unwrap();
 }

--- a/network/build.rs
+++ b/network/build.rs
@@ -26,4 +26,6 @@ fn main() {
         },
     })
     .expect("protoc");
+
+    prost_build::compile_protos(&["src/proto/network.proto"], &["src/"]).unwrap();
 }

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -108,6 +108,18 @@ impl From<ProtobufError> for NetworkError {
     }
 }
 
+impl From<prost::EncodeError> for NetworkError {
+    fn from(err: prost::EncodeError) -> NetworkError {
+        err.context(NetworkErrorKind::ProtobufParseError).into()
+    }
+}
+
+impl From<prost::DecodeError> for NetworkError {
+    fn from(err: prost::DecodeError) -> NetworkError {
+        err.context(NetworkErrorKind::ProtobufParseError).into()
+    }
+}
+
 impl From<parity_multiaddr::Error> for NetworkError {
     fn from(err: parity_multiaddr::Error) -> NetworkError {
         err.context(NetworkErrorKind::MultiaddrError).into()

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -23,10 +23,10 @@ pub use self::{
         Proposal, QuorumCert, RequestBlock, RespondBlock, SyncInfo, TimeoutMsg, Vote, VoteData,
     },
     mempool::MempoolSyncMsg,
-    network::{
-        DiscoveryMsg, FullNodePayload, Note, PeerInfo, SignedFullNodePayload, SignedPeerInfo,
+    network_prost::{
+        identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,
+        PeerInfo, Ping, Pong, SignedFullNodePayload, SignedPeerInfo,
     },
-    network_prost::{identity_msg::Role as IdentityMsg_Role, IdentityMsg, Ping, Pong},
     state_synchronizer::{GetChunkRequest, GetChunkResponse, StateSynchronizerMsg},
 };
 pub use transaction::SignedTransaction;

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -4,11 +4,11 @@
 #![allow(bare_trait_objects)]
 
 //! Protobuf definitions for data structures sent over the network
+mod admission_control;
 mod consensus;
 mod mempool;
 mod network;
 mod state_synchronizer;
-mod admission_control;
 
 mod network_prost {
     include!(concat!(env!("OUT_DIR"), "/network.rs"));
@@ -24,10 +24,9 @@ pub use self::{
     },
     mempool::MempoolSyncMsg,
     network::{
-        DiscoveryMsg, FullNodePayload, IdentityMsg, IdentityMsg_Role, Note, PeerInfo,
-        SignedFullNodePayload, SignedPeerInfo,
+        DiscoveryMsg, FullNodePayload, Note, PeerInfo, SignedFullNodePayload, SignedPeerInfo,
     },
-    network_prost::{Ping, Pong},
+    network_prost::{identity_msg::Role as IdentityMsg_Role, IdentityMsg, Ping, Pong},
     state_synchronizer::{GetChunkRequest, GetChunkResponse, StateSynchronizerMsg},
 };
 pub use transaction::SignedTransaction;

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -7,10 +7,9 @@
 mod admission_control;
 mod consensus;
 mod mempool;
-mod network;
 mod state_synchronizer;
 
-mod network_prost {
+mod network {
     include!(concat!(env!("OUT_DIR"), "/network.rs"));
 }
 
@@ -23,7 +22,7 @@ pub use self::{
         Proposal, QuorumCert, RequestBlock, RespondBlock, SyncInfo, TimeoutMsg, Vote, VoteData,
     },
     mempool::MempoolSyncMsg,
-    network_prost::{
+    network::{
         identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,
         PeerInfo, Ping, Pong, SignedFullNodePayload, SignedPeerInfo,
     },

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -10,6 +10,10 @@ mod network;
 mod state_synchronizer;
 mod admission_control;
 
+mod network_prost {
+    include!(concat!(env!("OUT_DIR"), "/network.rs"));
+}
+
 use types::proto::{ledger_info, transaction};
 
 pub use self::{
@@ -20,9 +24,10 @@ pub use self::{
     },
     mempool::MempoolSyncMsg,
     network::{
-        DiscoveryMsg, FullNodePayload, IdentityMsg, IdentityMsg_Role, Note, PeerInfo, Ping, Pong,
+        DiscoveryMsg, FullNodePayload, IdentityMsg, IdentityMsg_Role, Note, PeerInfo,
         SignedFullNodePayload, SignedPeerInfo,
     },
+    network_prost::{Ping, Pong},
     state_synchronizer::{GetChunkRequest, GetChunkResponse, StateSynchronizerMsg},
 };
 pub use transaction::SignedTransaction;

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     error::NetworkError,
     peer_manager::{PeerManagerNotification, PeerManagerRequestSender},
     proto::{Ping, Pong},
-    utils::{read_proto_prost, MessageExt},
+    utils::{read_proto, MessageExt},
     ProtocolId,
 };
 use bytes::Bytes;
@@ -230,7 +230,7 @@ where
                 .await?;
             // Read Pong.
             debug!("Waiting for Pong from peer: {}", peer_id.short_str());
-            let _: Pong = read_proto_prost(&mut substream).await?;
+            let _: Pong = read_proto(&mut substream).await?;
             // Return success.
             Ok(())
         };
@@ -253,7 +253,7 @@ where
             Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
         // Read ping.
         trace!("Waiting for Ping on new substream");
-        let maybe_ping: Result<Ping, NetworkError> = read_proto_prost(&mut substream).await;
+        let maybe_ping: Result<Ping, NetworkError> = read_proto(&mut substream).await;
         if let Err(err) = maybe_ping {
             warn!(
                 "Failed to read ping from peer: {}. Error: {:?}",

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -63,14 +63,14 @@ async fn send_ping_expect_pong(substream: MemorySocket) {
         .await
         .unwrap();
     // Expect Pong.
-    let _: Pong = read_proto_prost(&mut substream).await.unwrap();
+    let _: Pong = read_proto(&mut substream).await.unwrap();
 }
 
 async fn expect_ping_send_ok(substream: MemorySocket) {
     // Messages are length-prefixed. Wrap in a framed stream.
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Read ping.
-    let _: Ping = read_proto_prost(&mut substream).await.unwrap();
+    let _: Ping = read_proto(&mut substream).await.unwrap();
     // Send Pong.
     substream
         .send(Pong::default().to_bytes().unwrap())
@@ -82,7 +82,7 @@ async fn expect_ping_send_notok(substream: MemorySocket) {
     // Messages are length-prefixed. Wrap in a framed stream.
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Read ping.
-    let _: Ping = read_proto_prost(&mut substream).await.unwrap();
+    let _: Ping = read_proto(&mut substream).await.unwrap();
     substream.close().await.unwrap();
 }
 
@@ -90,7 +90,7 @@ async fn expect_ping_timeout(substream: MemorySocket) {
     // Messages are length-prefixed. Wrap in a framed stream.
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Read ping.
-    let _: Ping = read_proto_prost(&mut substream).await.unwrap();
+    let _: Ping = read_proto(&mut substream).await.unwrap();
     // Sleep for ping timeout plus a little bit.
     std::thread::sleep(PING_TIMEOUT + Duration::from_millis(100));
 }

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -59,21 +59,21 @@ async fn send_ping_expect_pong(substream: MemorySocket) {
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Send ping.
     substream
-        .send(Bytes::from(Ping::new().write_to_bytes().unwrap()))
+        .send(Ping::default().to_bytes().unwrap())
         .await
         .unwrap();
     // Expect Pong.
-    let _: Pong = read_proto(&mut substream).await.unwrap();
+    let _: Pong = read_proto_prost(&mut substream).await.unwrap();
 }
 
 async fn expect_ping_send_ok(substream: MemorySocket) {
     // Messages are length-prefixed. Wrap in a framed stream.
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Read ping.
-    let _: Ping = read_proto(&mut substream).await.unwrap();
+    let _: Ping = read_proto_prost(&mut substream).await.unwrap();
     // Send Pong.
     substream
-        .send(Bytes::from(Pong::new().write_to_bytes().unwrap()))
+        .send(Pong::default().to_bytes().unwrap())
         .await
         .unwrap();
 }
@@ -82,7 +82,7 @@ async fn expect_ping_send_notok(substream: MemorySocket) {
     // Messages are length-prefixed. Wrap in a framed stream.
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Read ping.
-    let _: Ping = read_proto(&mut substream).await.unwrap();
+    let _: Ping = read_proto_prost(&mut substream).await.unwrap();
     substream.close().await.unwrap();
 }
 
@@ -90,7 +90,7 @@ async fn expect_ping_timeout(substream: MemorySocket) {
     // Messages are length-prefixed. Wrap in a framed stream.
     let mut substream = Framed::new(substream.compat(), UviBytes::<Bytes>::default()).sink_compat();
     // Read ping.
-    let _: Ping = read_proto(&mut substream).await.unwrap();
+    let _: Ping = read_proto_prost(&mut substream).await.unwrap();
     // Sleep for ping timeout plus a little bit.
     std::thread::sleep(PING_TIMEOUT + Duration::from_millis(100));
 }

--- a/network/src/utils.rs
+++ b/network/src/utils.rs
@@ -29,3 +29,33 @@ where
     let msg = protobuf::parse_from_bytes(data.as_ref())?;
     Ok(msg)
 }
+
+pub async fn read_proto_prost<T, TSubstream>(
+    substream: &mut Compat01As03Sink<Framed<Compat<TSubstream>, UviBytes<Bytes>>, Bytes>,
+) -> Result<T, NetworkError>
+where
+    T: prost::Message + Default,
+    TSubstream: AsyncRead + Unpin,
+{
+    // Read from stream.
+    let data: Bytes = substream.next().await.map_or_else(
+        || Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
+        |data| Ok(data?.freeze()),
+    )?;
+    // Parse to message.
+    let msg = T::decode(data)?;
+    Ok(msg)
+}
+
+impl<T: ?Sized> MessageExt for T where T: prost::Message {}
+
+pub trait MessageExt: prost::Message {
+    fn to_bytes(self) -> Result<Bytes, prost::EncodeError>
+    where
+        Self: Sized,
+    {
+        let mut bytes = bytes::BytesMut::with_capacity(self.encoded_len());
+        self.encode(&mut bytes)?;
+        Ok(bytes.freeze())
+    }
+}

--- a/network/src/utils.rs
+++ b/network/src/utils.rs
@@ -8,29 +8,11 @@ use futures::{
     io::AsyncRead,
     stream::StreamExt,
 };
-use protobuf::Message;
 use std::io;
 use tokio::codec::Framed;
 use unsigned_varint::codec::UviBytes;
 
 pub async fn read_proto<T, TSubstream>(
-    substream: &mut Compat01As03Sink<Framed<Compat<TSubstream>, UviBytes<Bytes>>, Bytes>,
-) -> Result<T, NetworkError>
-where
-    T: Message,
-    TSubstream: AsyncRead + Unpin,
-{
-    // Read from stream.
-    let data: Bytes = substream.next().await.map_or_else(
-        || Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
-        |data| Ok(data?.freeze()),
-    )?;
-    // Parse to message.
-    let msg = protobuf::parse_from_bytes(data.as_ref())?;
-    Ok(msg)
-}
-
-pub async fn read_proto_prost<T, TSubstream>(
     substream: &mut Compat01As03Sink<Framed<Compat<TSubstream>, UviBytes<Bytes>>, Bytes>,
 ) -> Result<T, NetworkError>
 where

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -173,14 +173,12 @@ impl NetworkBuilder {
         self.seed_peers = seed_peers
             .into_iter()
             .map(|(peer_id, seed_addrs)| {
-                let mut peer_info = PeerInfo::new();
-                peer_info.set_epoch(0);
-                peer_info.set_addrs(
-                    seed_addrs
-                        .into_iter()
-                        .map(|addr| addr.as_ref().into())
-                        .collect(),
-                );
+                let mut peer_info = PeerInfo::default();
+                peer_info.epoch = 0;
+                peer_info.addrs = seed_addrs
+                    .into_iter()
+                    .map(|addr| addr.as_ref().into())
+                    .collect();
                 (peer_id, peer_info)
             })
             .collect();


### PR DESCRIPTION
Eventually we want to be able to move to using a full rust implementation of grpc (like tower-grpc) to kick that off we first need to convert to using Prost for protobuf codegen instead of using rust-protobuf. This is going to be a longish effort but we can start by doing hopefully a piece at a time. This changes the network specific protos to be generated using Prost.

Ref: #221