### PR TITLE
[state sync] reduce # of get_chunk requests

### DIFF
--- a/state_synchronizer/src/peer_manager.rs
+++ b/state_synchronizer/src/peer_manager.rs
@@ -10,7 +10,7 @@ use rand::{
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    time::{Duration, SystemTime},
+    time::SystemTime,
 };
 
 const MAX_SCORE: f64 = 100.0;
@@ -181,6 +181,10 @@ impl PeerManager {
         self.requests.insert(version, (peer_id, SystemTime::now()));
     }
 
+    pub fn get_request_time(&self, version: u64) -> Option<SystemTime> {
+        self.requests.get(&version).map(|(_, tst)| tst).cloned()
+    }
+
     pub fn process_response(&mut self, version: u64, peer_id: PeerId) {
         if let Some((id, _)) = self.requests.get(&version) {
             if *id == peer_id {
@@ -200,16 +204,10 @@ impl PeerManager {
         self.requests = self.requests.split_off(&(version + 1));
     }
 
-    pub fn process_timeout(&mut self, current_requested_version: u64, timeout: u64) {
-        let request = self.requests.get(&current_requested_version).cloned();
-        if let Some((peer_id, request_time)) = request {
-            if let Some(timeout_threshold) =
-                request_time.checked_add(Duration::from_millis(timeout))
-            {
-                if SystemTime::now().duration_since(timeout_threshold).is_ok() {
-                    self.update_score(&peer_id, PeerScoreUpdateType::TimeOut);
-                    self.requests.remove(&current_requested_version);
-                }
+    pub fn process_timeout(&mut self, version: u64, penalize: bool) {
+        if let Some((peer_id, _)) = self.requests.remove(&version) {
+            if penalize {
+                self.update_score(&peer_id, PeerScoreUpdateType::TimeOut);
             }
         }
     }


### PR DESCRIPTION
currently progress is ensured based on last committed timestamp, which works correctly
But if node doesn't get data before `last_commit + timeout` it will start issuing sync requests to upstream peers on each interval tick, which leads to DDoS behavior
It's specially common for Full Nodes
This diff changes `check_progress` routine to check last request timestamp instead
Also we shouldn't penalize upstream node if there's no new data available in the system
