### PR TITLE
[Storage] Return ledger consistency proof in update_to_latest_ledger

### DIFF
--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -201,13 +201,19 @@ where
         req: UpdateToLatestLedgerRequest,
     ) -> Result<UpdateToLatestLedgerResponse> {
         let rust_req = types::get_with_proof::UpdateToLatestLedgerRequest::from_proto(req)?;
-        let (response_items, ledger_info_with_sigs, validator_change_events) = self
+        let (
+            response_items,
+            ledger_info_with_sigs,
+            validator_change_events,
+            ledger_consistency_proof,
+        ) = self
             .storage_read_client
             .update_to_latest_ledger(rust_req.client_known_version, rust_req.requested_items)?;
         let rust_resp = types::get_with_proof::UpdateToLatestLedgerResponse::new(
             response_items,
             ledger_info_with_sigs,
             validator_change_events,
+            ledger_consistency_proof,
         );
         Ok(rust_resp.into_proto())
     }

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -366,7 +366,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
         );
 
         // find the block corresponding to storage latest ledger info
-        let (_, ledger_info, _) = read_client
+        let (_, ledger_info, _, _) = read_client
             .update_to_latest_ledger(0, vec![])
             .expect("unable to read ledger info from storage");
         let mut initial_data = RecoveryData::new(

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -375,7 +375,7 @@ fn test_executor_execute_chunk() {
     block_on(executor.execute_chunk(chunks[0].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
-    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
@@ -383,7 +383,7 @@ fn test_executor_execute_chunk() {
     block_on(executor.execute_chunk(chunks[1].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
-    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
@@ -391,7 +391,7 @@ fn test_executor_execute_chunk() {
     block_on(executor.execute_chunk(TransactionListWithProof::new_empty(), ledger_info.clone()))
         .unwrap()
         .unwrap();
-    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
@@ -399,7 +399,7 @@ fn test_executor_execute_chunk() {
     block_on(executor.execute_chunk(chunks[1].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
-    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
 
@@ -407,7 +407,7 @@ fn test_executor_execute_chunk() {
     block_on(executor.execute_chunk(chunks[2].clone(), ledger_info.clone()))
         .unwrap()
         .unwrap();
-    let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+    let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
     assert_eq!(li, ledger_info);
 
     drop(storage_server);
@@ -443,7 +443,7 @@ fn test_executor_execute_chunk_restart() {
         block_on(executor.execute_chunk(chunks[0].clone(), ledger_info.clone()))
             .unwrap()
             .unwrap();
-        let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+        let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
         assert_eq!(li.ledger_info().version(), 0);
         assert_eq!(li.ledger_info().consensus_block_id(), *GENESIS_BLOCK_ID);
     }
@@ -460,7 +460,7 @@ fn test_executor_execute_chunk_restart() {
         block_on(executor.execute_chunk(chunks[1].clone(), ledger_info.clone()))
             .unwrap()
             .unwrap();
-        let (_, li, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
+        let (_, li, _, _) = storage_client.update_to_latest_ledger(0, vec![]).unwrap();
         assert_eq!(li, ledger_info);
     }
 

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -284,7 +284,12 @@ fn test_execution_with_storage() {
         },
     ];
 
-    let (mut response_items, ledger_info_with_sigs, _validator_change_events) = storage_read_client
+    let (
+        mut response_items,
+        ledger_info_with_sigs,
+        _validator_change_events,
+        _ledger_consistency_proof,
+    ) = storage_read_client
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
@@ -477,7 +482,12 @@ fn test_execution_with_storage() {
             limit: 10,
         },
     ];
-    let (mut response_items, ledger_info_with_sigs, _validator_change_events) = storage_read_client
+    let (
+        mut response_items,
+        ledger_info_with_sigs,
+        _validator_change_events,
+        _ledger_consistency_proof,
+    ) = storage_read_client
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -24,7 +24,7 @@ use schemadb::{ReadOptions, DB};
 use std::{ops::Deref, sync::Arc};
 use types::{
     crypto_proxies::LedgerInfoWithSignatures,
-    proof::{position::Position, AccumulatorProof},
+    proof::{position::Position, AccumulatorConsistencyProof, AccumulatorProof},
     transaction::{TransactionInfo, Version},
 };
 
@@ -127,6 +127,16 @@ impl LedgerStore {
         ledger_version: Version,
     ) -> Result<AccumulatorProof> {
         Accumulator::get_proof(self, ledger_version + 1 /* num_leaves */, version)
+    }
+
+    /// Gets proof that shows the ledger at `ledger_version` is consistent with the ledger at
+    /// `client_known_version`.
+    pub fn get_consistency_proof(
+        &self,
+        client_known_version: Version,
+        ledger_version: Version,
+    ) -> Result<AccumulatorConsistencyProof> {
+        Accumulator::get_consistency_proof(self, ledger_version + 1, client_known_version + 1)
     }
 
     /// Write `txn_infos` to `batch`. Assigned `first_version` to the the version number of the

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -144,7 +144,12 @@ impl StorageService {
     ) -> Result<UpdateToLatestLedgerResponse> {
         let rust_req = types::get_with_proof::UpdateToLatestLedgerRequest::from_proto(req)?;
 
-        let (response_items, ledger_info_with_sigs, validator_change_events) = self
+        let (
+            response_items,
+            ledger_info_with_sigs,
+            validator_change_events,
+            ledger_consistency_proof,
+        ) = self
             .db
             .update_to_latest_ledger(rust_req.client_known_version, rust_req.requested_items)?;
 
@@ -152,6 +157,7 @@ impl StorageService {
             response_items,
             ledger_info_with_sigs,
             validator_change_events,
+            ledger_consistency_proof,
         };
 
         Ok(rust_resp.into_proto())

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -21,6 +21,7 @@ use types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof},
     event::EventHandle,
     get_with_proof::{RequestItem, ResponseItem},
+    proof::AccumulatorConsistencyProof,
     proof::SparseMerkleProof,
     proto::{
         account_state_blob::AccountStateWithProof,
@@ -55,6 +56,7 @@ impl StorageRead for MockStorageReadClient {
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
         Vec<ValidatorChangeEventWithProof>,
+        AccumulatorConsistencyProof,
     )> {
         let request = types::get_with_proof::UpdateToLatestLedgerRequest::new(
             client_known_version,
@@ -68,6 +70,7 @@ impl StorageRead for MockStorageReadClient {
             response.response_items,
             response.ledger_info_with_sigs,
             response.validator_change_events,
+            response.ledger_consistency_proof,
         ))
     }
 
@@ -82,6 +85,7 @@ impl StorageRead for MockStorageReadClient {
                         Vec<ResponseItem>,
                         LedgerInfoWithSignatures,
                         Vec<ValidatorChangeEventWithProof>,
+                        AccumulatorConsistencyProof,
                     )>,
                 > + Send,
         >,

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -83,7 +83,8 @@ proptest! {
             let (
                 response_items,
                 response_ledger_info_with_sigs,
-                _validator_change_events
+                _validator_change_events,
+                _ledger_consistency_proof,
             ) = read_client
                 .update_to_latest_ledger(0, account_state_request_items).unwrap();
             for ((address, blob), response_item) in zip_eq(account_states, response_items) {

--- a/storage/storage_client/src/lib.rs
+++ b/storage/storage_client/src/lib.rs
@@ -32,6 +32,7 @@ use types::{
     get_with_proof::{
         RequestItem, ResponseItem, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,
     },
+    proof::AccumulatorConsistencyProof,
     proof::SparseMerkleProof,
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
@@ -106,6 +107,7 @@ impl StorageRead for StorageReadServiceClient {
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
         Vec<ValidatorChangeEventWithProof>,
+        AccumulatorConsistencyProof,
     )> {
         block_on(self.update_to_latest_ledger_async(client_known_version, requested_items))
     }
@@ -121,6 +123,7 @@ impl StorageRead for StorageReadServiceClient {
                         Vec<ResponseItem>,
                         LedgerInfoWithSignatures,
                         Vec<ValidatorChangeEventWithProof>,
+                        AccumulatorConsistencyProof,
                     )>,
                 > + Send,
         >,
@@ -139,6 +142,7 @@ impl StorageRead for StorageReadServiceClient {
                 rust_resp.response_items,
                 rust_resp.ledger_info_with_sigs,
                 rust_resp.validator_change_events,
+                rust_resp.ledger_consistency_proof,
             ))
         })
         .boxed()
@@ -307,6 +311,7 @@ pub trait StorageRead: Send + Sync {
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
         Vec<ValidatorChangeEventWithProof>,
+        AccumulatorConsistencyProof,
     )>;
 
     /// See [`LibraDB::update_to_latest_ledger`].
@@ -324,6 +329,7 @@ pub trait StorageRead: Send + Sync {
                         Vec<ResponseItem>,
                         LedgerInfoWithSignatures,
                         Vec<ValidatorChangeEventWithProof>,
+                        AccumulatorConsistencyProof,
                     )>,
                 > + Send,
         >,

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -8,6 +8,7 @@ use crate::{
     account_state_blob::AccountStateWithProof,
     contract_event::EventWithProof,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    proof::AccumulatorConsistencyProof,
     proto::get_with_proof::{
         GetAccountStateRequest, GetAccountStateResponse,
         GetAccountTransactionBySequenceNumberRequest,
@@ -47,6 +48,7 @@ pub struct UpdateToLatestLedgerResponse<Sig> {
     pub response_items: Vec<ResponseItem>,
     pub ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
     pub validator_change_events: Vec<ValidatorChangeEventWithProof<Sig>>,
+    pub ledger_consistency_proof: AccumulatorConsistencyProof,
 }
 
 impl<Sig: Signature> IntoProto for UpdateToLatestLedgerResponse<Sig> {
@@ -57,6 +59,7 @@ impl<Sig: Signature> IntoProto for UpdateToLatestLedgerResponse<Sig> {
         out.set_response_items(self.response_items.into_proto());
         out.set_ledger_info_with_sigs(self.ledger_info_with_sigs.into_proto());
         out.set_validator_change_events(self.validator_change_events.into_proto());
+        out.set_ledger_consistency_proof(self.ledger_consistency_proof.into_proto());
         out
     }
 }
@@ -76,6 +79,9 @@ impl<Sig: Signature> FromProto for UpdateToLatestLedgerResponse<Sig> {
                 <Vec<ValidatorChangeEventWithProof<Sig>> as FromProto>::from_proto(
                     object.take_validator_change_events(),
                 )?,
+            ledger_consistency_proof: AccumulatorConsistencyProof::from_proto(
+                object.take_ledger_consistency_proof(),
+            )?,
         })
     }
 }
@@ -86,11 +92,13 @@ impl<Sig: Signature> UpdateToLatestLedgerResponse<Sig> {
         response_items: Vec<ResponseItem>,
         ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
         validator_change_events: Vec<ValidatorChangeEventWithProof<Sig>>,
+        ledger_consistency_proof: AccumulatorConsistencyProof,
     ) -> Self {
         UpdateToLatestLedgerResponse {
             response_items,
             ledger_info_with_sigs,
             validator_change_events,
+            ledger_consistency_proof,
         }
     }
 

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -12,7 +12,7 @@ use crate::{
     event::{EventHandle, EventKey},
     get_with_proof::{ResponseItem, UpdateToLatestLedgerResponse},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    proof::AccumulatorProof,
+    proof::{AccumulatorConsistencyProof, AccumulatorProof},
     transaction::{
         Module, Program, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction,
         TransactionArgument, TransactionInfo, TransactionListWithProof, TransactionPayload,
@@ -557,9 +557,14 @@ prop_compose! {
         response_items in vec(any::<ResponseItem>(), 0..10),
         ledger_info_with_sigs in any::<LedgerInfoWithSignatures<Ed25519Signature>>(),
         validator_change_events in vec(any::<ValidatorChangeEventWithProof<Ed25519Signature>>(), 0..10),
+        ledger_consistency_proof in any::<AccumulatorConsistencyProof>(),
     ) -> UpdateToLatestLedgerResponse<Ed25519Signature> {
         UpdateToLatestLedgerResponse::new(
-            response_items, ledger_info_with_sigs, validator_change_events)
+            response_items,
+            ledger_info_with_sigs,
+            validator_change_events,
+            ledger_consistency_proof,
+        )
     }
 }
 

--- a/types/src/proto/get_with_proof.proto
+++ b/types/src/proto/get_with_proof.proto
@@ -114,6 +114,7 @@ import "access_path.proto";
 import "account_state_blob.proto";
 import "events.proto";
 import "ledger_info.proto";
+import "proof.proto";
 import "transaction.proto";
 import "validator_change.proto";
 
@@ -171,6 +172,10 @@ message UpdateToLatestLedgerResponse {
     // inform the client of validator changes from the client's last known version
     // until the current version
     repeated ValidatorChangeEventWithProof validator_change_events = 3;
+
+    // A proof that shows the latest ledger accumulator is consistent with the
+    // old accumulator at "client_known_version".
+    AccumulatorConsistencyProof ledger_consistency_proof = 4;
 }
 
 // Individual response items to the queries posed by the requests

--- a/vm_validator/src/vm_validator.rs
+++ b/vm_validator/src/vm_validator.rs
@@ -71,7 +71,7 @@ impl TransactionValidation for VMValidator {
             .storage_read_client
             .update_to_latest_ledger(/* client_known_version = */ 0, vec![item])
         {
-            Ok((mut items, ledger_info_with_sigs, _)) => {
+            Ok((mut items, ledger_info_with_sigs, _, _)) => {
                 if items.len() != 1 {
                     return Box::new(err(format_err!(
                         "Unexpected number of items ({}).",
@@ -111,7 +111,7 @@ pub async fn get_account_state(
     address: AccountAddress,
 ) -> Result<(u64, u64)> {
     let req_item = RequestItem::GetAccountState { address };
-    let (response_items, _, _) = storage_read_client
+    let (response_items, _, _, _) = storage_read_client
         .update_to_latest_ledger_async(0 /* client_known_version */, vec![req_item])
         .await?;
     let account_state = match &response_items[0] {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since the client passes in `client_known_version`, we will return a proof that shows the latest ledger is derived from the ledger at that version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

.

## Test Plan

Not much logic change in this diff.

## Related PRs

None.
