### PR TITLE
Set peer_id as macro in node.config.toml to be replaced by terraform

### DIFF
--- a/terraform/validator-sets/dev/node.config.toml
+++ b/terraform/validator-sets/dev/node.config.toml
@@ -1,5 +1,6 @@
 [[networks]]
 advertised_address = "/ip4/${self_ip}/tcp/6180"
+peer_id = "${self_peer_id}"
 
 [debug_interface]
 address = "0.0.0.0"

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -217,7 +217,7 @@ data "template_file" "node_config" {
 
   vars = {
     self_ip = var.validator_use_public_ip == true ? element(aws_instance.validator.*.public_ip, count.index) : element(aws_instance.validator.*.private_ip, count.index)
-
+    self_peer_id = var.peer_ids[count.index]
   }
 }
 


### PR DESCRIPTION
## Motivation

Fixes the issue that cluster fails to start when deploying with terraform because nodes no longer have their peer id (earlier passed as a command line flag)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

$ `terraform validate && terraform plan`

Output:
```
  # data.template_file.node_config[0] will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "node_config"  {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = "[[networks]]\nadvertised_address = \"/ip4/${self_ip}/tcp/6180\"\npeer_id = \"${self_peer_id}\"\n\n[debug_interface]\naddress = \"0.0.0.0\"\n\n[storage]\ndir = \"/opt/libra/data\"\n\n[metrics]\ndir = \"\"\n\n[vm_config]\n  [vm_config.publishing_options]\n    type = \"Locked\"\n    whitelist = [\n        \"1cf66b5f5c911e80dad222b8ee8dfe3ad4830f75bb412ba12ea8e429203d9c83\",\n        \"5ee07d4ac1ecf88f1b41c2c458f15699fe9d811c61563338253b3807b75c04c1\",\n        \"6aabc87f543f85e10216432d02b0251297d4c7723e906de481dfa04b057c2371\",\n        \"a2180395d1632a0793f34e8a8a6be20b3b03bdceee35affe8c751fc8467b73a4\",\n    ]\n"
      + vars     = {
          + "self_ip"      = (known after apply)
          + "self_peer_id" = "8deeeaed65f0cd7484a9e4e5ac51fbac548f2f71299a05e000156031ca78fb9f"
        }
    }

  # data.template_file.node_config[1] will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "node_config"  {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = "[[networks]]\nadvertised_address = \"/ip4/${self_ip}/tcp/6180\"\npeer_id = \"${self_peer_id}\"\n\n[debug_interface]\naddress = \"0.0.0.0\"\n\n[storage]\ndir = \"/opt/libra/data\"\n\n[metrics]\ndir = \"\"\n\n[vm_config]\n  [vm_config.publishing_options]\n    type = \"Locked\"\n    whitelist = [\n        \"1cf66b5f5c911e80dad222b8ee8dfe3ad4830f75bb412ba12ea8e429203d9c83\",\n        \"5ee07d4ac1ecf88f1b41c2c458f15699fe9d811c61563338253b3807b75c04c1\",\n        \"6aabc87f543f85e10216432d02b0251297d4c7723e906de481dfa04b057c2371\",\n        \"a2180395d1632a0793f34e8a8a6be20b3b03bdceee35affe8c751fc8467b73a4\",\n    ]\n"
      + vars     = {
          + "self_ip"      = (known after apply)
          + "self_peer_id" = "1e5d5a74b0fd09f601ac0fca2fe7d213704e02e51943d18cf25a546b8416e9e1"
        }
    }

  # data.template_file.node_config[2] will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "node_config"  {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = "[[networks]]\nadvertised_address = \"/ip4/${self_ip}/tcp/6180\"\npeer_id = \"${self_peer_id}\"\n\n[debug_interface]\naddress = \"0.0.0.0\"\n\n[storage]\ndir = \"/opt/libra/data\"\n\n[metrics]\ndir = \"\"\n\n[vm_config]\n  [vm_config.publishing_options]\n    type = \"Locked\"\n    whitelist = [\n        \"1cf66b5f5c911e80dad222b8ee8dfe3ad4830f75bb412ba12ea8e429203d9c83\",\n        \"5ee07d4ac1ecf88f1b41c2c458f15699fe9d811c61563338253b3807b75c04c1\",\n        \"6aabc87f543f85e10216432d02b0251297d4c7723e906de481dfa04b057c2371\",\n        \"a2180395d1632a0793f34e8a8a6be20b3b03bdceee35affe8c751fc8467b73a4\",\n    ]\n"
      + vars     = {
          + "self_ip"      = (known after apply)
          + "self_peer_id" = "ab0d6a54ce9d7fc79c061f95883a308f9bdfc987262b6a34a360fdd788fcd9cd"
        }
    }

  # data.template_file.node_config[3] will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "node_config"  {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = "[[networks]]\nadvertised_address = \"/ip4/${self_ip}/tcp/6180\"\npeer_id = \"${self_peer_id}\"\n\n[debug_interface]\naddress = \"0.0.0.0\"\n\n[storage]\ndir = \"/opt/libra/data\"\n\n[metrics]\ndir = \"\"\n\n[vm_config]\n  [vm_config.publishing_options]\n    type = \"Locked\"\n    whitelist = [\n        \"1cf66b5f5c911e80dad222b8ee8dfe3ad4830f75bb412ba12ea8e429203d9c83\",\n        \"5ee07d4ac1ecf88f1b41c2c458f15699fe9d811c61563338253b3807b75c04c1\",\n        \"6aabc87f543f85e10216432d02b0251297d4c7723e906de481dfa04b057c2371\",\n        \"a2180395d1632a0793f34e8a8a6be20b3b03bdceee35affe8c751fc8467b73a4\",\n    ]\n"
      + vars     = {
          + "self_ip"      = (known after apply)
          + "self_peer_id" = "57ff83747054695f2228042c26eb6a243ac73de1b9038aea103999480b076d45"
        }
    }
```