### PR TITLE
[consensus] weighted voting

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -11,18 +11,17 @@ use crate::{
     },
     utils::{deserialize_whitelist, get_available_port, get_local_ip, serialize_whitelist},
 };
-use crypto::{ed25519::Ed25519PublicKey, ValidKey};
+use crypto::ValidKey;
 use failure::prelude::*;
 use parity_multiaddr::Multiaddr;
 use proto_conv::FromProtoBytes;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     convert::TryFrom,
     fs::File,
     io::{Read, Write},
     path::{Path, PathBuf},
-    str::FromStr,
     string::ToString,
 };
 use toml;
@@ -483,24 +482,6 @@ impl ConsensusConfig {
 
     pub fn pacemaker_initial_timeout_ms(&self) -> &Option<u64> {
         &self.pacemaker_initial_timeout_ms
-    }
-
-    pub fn get_consensus_peers(&self) -> HashMap<PeerId, Ed25519PublicKey> {
-        self.consensus_peers
-            .peers
-            .iter()
-            .map(|(peer_id_str, peer_info)| {
-                (
-                    PeerId::from_str(peer_id_str).unwrap_or_else(|_| {
-                        panic!(
-                            "Failed to deserialize PeerId: {} from consensus peers config: ",
-                            peer_id_str
-                        )
-                    }),
-                    peer_info.consensus_pubkey.clone(),
-                )
-            })
-            .collect()
     }
 }
 

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -21,9 +21,9 @@ use executor::StateComputeResult;
 /// as the Error part of the result.
 #[derive(Debug, PartialEq)]
 pub enum VoteReceptionResult {
-    /// The vote has been added but QC has not been formed yet. Return the number of votes for
+    /// The vote has been added but QC has not been formed yet. Return the amount of voting power
     /// the given (proposal, execution) pair.
-    VoteAdded(usize),
+    VoteAdded(u64),
     /// The very same vote message has been processed in past.
     DuplicateVote,
     /// This block has been already certified.

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -123,12 +123,17 @@ impl ChainedBftProvider {
         let signer = ValidatorSigner::new(author, private_key);
         // Keeping the initial set of validators in a node config is embarrassing and we should
         // all feel bad about it.
-        let peers_with_public_keys = node_config.consensus.get_consensus_peers();
-        let validator = ValidatorVerifier::new(peers_with_public_keys);
+        let validator = node_config
+            .consensus
+            .consensus_peers
+            .get_validator_verifier();
         counters::EPOCH_NUM.set(0); // No reconfiguration yet, so it is always zero
         counters::CURRENT_EPOCH_NUM_VALIDATORS.set(validator.len() as i64);
-        counters::CURRENT_EPOCH_QUORUM_SIZE.set(validator.quorum_size() as i64);
-        debug!("[Consensus]: quorum_size = {:?}", validator.quorum_size());
+        counters::CURRENT_EPOCH_QUORUM_SIZE.set(validator.quorum_voting_power() as i64);
+        debug!(
+            "[Consensus]: quorum_size = {:?}",
+            validator.quorum_voting_power()
+        );
         InitialSetup {
             author,
             signer,

--- a/consensus/src/chained_bft/consensus_types/timeout_msg.rs
+++ b/consensus/src/chained_bft/consensus_types/timeout_msg.rs
@@ -312,10 +312,7 @@ impl PacemakerTimeoutCertificate {
             let timeout_round = timeout.round();
             min_round = Some(min_round.map_or(timeout_round, move |x| x.min(timeout_round)))
         }
-        ensure!(
-            unique_authors.len() >= validator.quorum_size(),
-            "TimeoutCert has no quorum"
-        );
+        validator.check_voting_power(unique_authors.iter())?;
         ensure!(
             min_round == Some(self.round),
             "TimeoutCert has inconsistent round {}, expected: {:?}",

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -20,10 +20,6 @@ impl EpochManager {
         }
     }
 
-    pub fn quorum_size(&self) -> usize {
-        self.validators.read().unwrap().quorum_size()
-    }
-
     pub fn validators(&self) -> Arc<ValidatorVerifier> {
         Arc::clone(&self.validators.read().unwrap())
     }

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -21,6 +21,7 @@ use std::{
     time::{Duration, Instant},
 };
 use termion::color::*;
+use types::crypto_proxies::ValidatorVerifier;
 
 /// A reason for starting a new round: introduced for monitoring / debug purposes.
 #[derive(Eq, Debug, PartialEq)]
@@ -328,11 +329,11 @@ impl Pacemaker {
     pub fn process_remote_timeout(
         &mut self,
         pacemaker_timeout: PacemakerTimeout,
-        quorum_size: usize,
+        validator_verifier: Arc<ValidatorVerifier>,
     ) -> Option<NewRoundEvent> {
         if self
             .pacemaker_timeout_manager
-            .update_received_timeout(pacemaker_timeout, quorum_size)
+            .update_received_timeout(pacemaker_timeout, validator_verifier)
         {
             self.update_current_round()
         } else {

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
@@ -7,11 +7,11 @@ use crate::chained_bft::{
     persistent_storage::PersistentStorage,
     test_utils::{MockStorage, TestPayload},
 };
-use types::validator_signer::ValidatorSigner;
+use std::sync::Arc;
+use types::{crypto_proxies::random_validator_verifier, validator_signer::ValidatorSigner};
 
 #[test]
 fn test_basic() {
-    let quorum_size = 2;
     let mut timeout_manager = PacemakerTimeoutManager::new(
         HighestTimeoutCertificates::new(None, None),
         MockStorage::<TestPayload>::start_for_testing()
@@ -19,27 +19,29 @@ fn test_basic() {
             .persistent_liveness_storage(),
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
-    let validator_signer1 = ValidatorSigner::random([0u8; 32]);
-    let validator_signer2 = ValidatorSigner::random([1u8; 32]);
-
+    let (validator_signers, validator_verifier) = random_validator_verifier(2, None, false);
+    let validator_verifier = Arc::new(validator_verifier);
     // No timeout certificate generated on adding 2 timeouts from the same author
-    let timeout_signer1_round1 = PacemakerTimeout::new(1, &validator_signer1, None);
+    let timeout_signer1_round1 = PacemakerTimeout::new(1, &validator_signers[0], None);
     assert_eq!(
-        timeout_manager.update_received_timeout(timeout_signer1_round1, quorum_size),
+        timeout_manager
+            .update_received_timeout(timeout_signer1_round1, Arc::clone(&validator_verifier)),
         false
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
-    let timeout_signer1_round2 = PacemakerTimeout::new(2, &validator_signer1, None);
+    let timeout_signer1_round2 = PacemakerTimeout::new(2, &validator_signers[0], None);
     assert_eq!(
-        timeout_manager.update_received_timeout(timeout_signer1_round2, quorum_size),
+        timeout_manager
+            .update_received_timeout(timeout_signer1_round2, Arc::clone(&validator_verifier)),
         false
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
 
     // Timeout certificate generated on adding a timeout from signer2
-    let timeout_signer2_round1 = PacemakerTimeout::new(1, &validator_signer2, None);
+    let timeout_signer2_round1 = PacemakerTimeout::new(1, &validator_signers[1], None);
     assert_eq!(
-        timeout_manager.update_received_timeout(timeout_signer2_round1, quorum_size),
+        timeout_manager
+            .update_received_timeout(timeout_signer2_round1, Arc::clone(&validator_verifier)),
         true
     );
     assert_eq!(
@@ -51,9 +53,10 @@ fn test_basic() {
     );
 
     // Timeout certificate increased when incrementing the round from signer 2
-    let timeout_signer2_round2 = PacemakerTimeout::new(2, &validator_signer2, None);
+    let timeout_signer2_round2 = PacemakerTimeout::new(2, &validator_signers[1], None);
     assert_eq!(
-        timeout_manager.update_received_timeout(timeout_signer2_round2, quorum_size),
+        timeout_manager
+            .update_received_timeout(timeout_signer2_round2, Arc::clone(&validator_verifier)),
         true
     );
     assert_eq!(
@@ -65,9 +68,10 @@ fn test_basic() {
     );
 
     // No timeout certificate generated since signer 1 is still on round 2
-    let timeout_signer2_round3 = PacemakerTimeout::new(3, &validator_signer2, None);
+    let timeout_signer2_round3 = PacemakerTimeout::new(3, &validator_signers[1], None);
     assert_eq!(
-        timeout_manager.update_received_timeout(timeout_signer2_round3, quorum_size),
+        timeout_manager
+            .update_received_timeout(timeout_signer2_round3, Arc::clone(&validator_verifier)),
         false
     );
     assert_eq!(
@@ -82,8 +86,8 @@ fn test_basic() {
     let received_timeout_certificate = PacemakerTimeoutCertificate::new(
         10,
         vec![
-            PacemakerTimeout::new(10, &validator_signer1, None),
-            PacemakerTimeout::new(11, &validator_signer2, None),
+            PacemakerTimeout::new(10, &validator_signers[0], None),
+            PacemakerTimeout::new(11, &validator_signers[1], None),
         ],
     );
     assert_eq!(

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use types::crypto_proxies::ValidatorVerifier;
 
 fn minute_from_now() -> Instant {
     Instant::now() + Duration::new(60, 0)
@@ -89,7 +90,11 @@ fn test_proposal_generation_parent() {
         placeholder_ledger_info(),
         block_store.signer(),
     );
-    block_store.insert_vote_and_qc(vote_msg_a1, 1);
+    let validator_verifier = Arc::new(ValidatorVerifier::new_single(
+        block_store.signer().author(),
+        block_store.signer().public_key(),
+    ));
+    block_store.insert_vote_and_qc(vote_msg_a1, validator_verifier);
     let a1_child_res =
         block_on(proposal_generator.generate_proposal(11, minute_from_now())).unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
@@ -116,8 +121,11 @@ fn test_proposal_generation_parent() {
         placeholder_ledger_info(),
         block_store.signer(),
     );
-
-    block_store.insert_vote_and_qc(vote_msg_b1, 1);
+    let validator_verifier = Arc::new(ValidatorVerifier::new_single(
+        block_store.signer().author(),
+        block_store.signer().public_key(),
+    ));
+    block_store.insert_vote_and_qc(vote_msg_b1, validator_verifier);
     let b1_child_res =
         block_on(proposal_generator.generate_proposal(12, minute_from_now())).unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
@@ -157,7 +165,11 @@ fn test_old_proposal_generation() {
         placeholder_ledger_info(),
         block_store.signer(),
     );
-    block_store.insert_vote_and_qc(vote_msg_a1, 1);
+    let validator_verifier = Arc::new(ValidatorVerifier::new_single(
+        block_store.signer().author(),
+        block_store.signer().public_key(),
+    ));
+    block_store.insert_vote_and_qc(vote_msg_a1, validator_verifier);
 
     let proposal_err = block_on(proposal_generator.generate_proposal(1, minute_from_now())).err();
     assert!(proposal_err.is_some());

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -71,6 +71,7 @@ use std::{
 use tokio::{codec::Framed, prelude::FutureExt as _};
 use types::{
     crypto_proxies::{ValidatorSigner as Signer, ValidatorVerifier as SignatureValidator},
+    validator_verifier::ValidatorInfo as SignatureInfo,
     PeerId,
 };
 use unsigned_varint::codec::UviBytes;
@@ -549,13 +550,16 @@ fn verify_signature(
     signature: &[u8],
     msg: &[u8],
 ) -> Result<(), NetworkError> {
-    let verifier = SignatureValidator::new_with_quorum_size(
+    let verifier = SignatureValidator::new_with_quorum_voting_power(
         trusted_peers
             .read()
             .unwrap()
             .iter()
             .map(|(peer_id, network_public_keys)| {
-                (*peer_id, network_public_keys.signing_public_key.clone())
+                (
+                    *peer_id,
+                    SignatureInfo::new(network_public_keys.signing_public_key.clone(), 1),
+                )
             })
             .collect(),
         1, /* quorum size */

--- a/state_synchronizer/src/executor_proxy.rs
+++ b/state_synchronizer/src/executor_proxy.rs
@@ -55,7 +55,7 @@ impl ExecutorProxy {
             &config.storage.address,
             config.storage.port,
         ));
-        let validator_verifier = ValidatorVerifier::new(config.consensus.get_consensus_peers());
+        let validator_verifier = config.consensus.consensus_peers.get_validator_verifier();
         Self {
             storage_read_client,
             executor,

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -24,7 +24,9 @@ use crate::{
     ledger_info::LedgerInfoWithSignatures as RawLedgerInfoWithSignatures,
     validator_change::ValidatorChangeEventWithProof as RawValidatorChangeEventWithProof,
     validator_signer::ValidatorSigner as RawValidatorSigner,
-    validator_verifier::{ValidatorVerifier as RawValidatorVerifier, VerifyError},
+    validator_verifier::{
+        ValidatorInfo as RawValidatorInfo, ValidatorVerifier as RawValidatorVerifier, VerifyError,
+    },
 };
 use crypto::{hash::HashValue, traits::Signature as RawSignature};
 use serde::{Deserialize, Serialize};
@@ -77,6 +79,7 @@ impl<Sig: RawSignature> From<Sig> for SignatureWrapper<Sig> {
 // below is banned.
 
 use crypto::ed25519::*;
+use std::collections::HashMap;
 
 // used in chained_bft::consensus_types::block_test
 #[cfg(any(test, feature = "testing"))]
@@ -84,6 +87,43 @@ pub type SecretKey = Ed25519PrivateKey;
 
 pub type Signature = SignatureWrapper<Ed25519Signature>;
 pub type LedgerInfoWithSignatures = RawLedgerInfoWithSignatures<Ed25519Signature>;
+pub type ValidatorInfo = RawValidatorInfo<Ed25519PublicKey>;
 pub type ValidatorVerifier = RawValidatorVerifier<Ed25519PublicKey>;
 pub type ValidatorSigner = RawValidatorSigner<Ed25519PrivateKey>;
 pub type ValidatorChangeEventWithProof = RawValidatorChangeEventWithProof<Ed25519Signature>;
+
+/// Helper function to get random validator signers and a corresponding validator verifier for
+/// testing.  If custom_voting_power_quorum is not None, set a custom voting power quorum amount.
+/// With pseudo_random_account_address enabled, logs show 0 -> [0000], 1 -> [1000]
+pub fn random_validator_verifier(
+    count: usize,
+    custom_voting_power_quorum: Option<u64>,
+    pseudo_random_account_address: bool,
+) -> (Vec<ValidatorSigner>, ValidatorVerifier) {
+    let mut signers = Vec::new();
+    let mut account_address_to_validator_info: HashMap<AccountAddress, ValidatorInfo> =
+        HashMap::new();
+    for i in 0..count {
+        let random_signer = if pseudo_random_account_address {
+            ValidatorSigner::from_int(i as u8)
+        } else {
+            ValidatorSigner::random([i as u8; 32])
+        };
+        account_address_to_validator_info.insert(
+            random_signer.author(),
+            ValidatorInfo::new(random_signer.public_key(), 1),
+        );
+        signers.push(random_signer);
+    }
+    (
+        signers,
+        match custom_voting_power_quorum {
+            Some(custom_voting_power_quorum) => ValidatorVerifier::new_with_quorum_voting_power(
+                account_address_to_validator_info,
+                custom_voting_power_quorum,
+            )
+            .expect("Unable to create testing validator verifier"),
+            None => ValidatorVerifier::new(account_address_to_validator_info),
+        },
+    )
+}

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -14,12 +14,12 @@ pub enum VerifyError {
     /// The author for this signature is unknown by this validator.
     UnknownAuthor,
     #[fail(
-        display = "The number of signatures ({}) is smaller than quorum size ({})",
-        num_of_signatures, quorum_size
+        display = "The voting power ({}) is less than quorum voting power ({})",
+        voting_power, quorum_voting_power
     )]
-    TooFewSignatures {
-        num_of_signatures: usize,
-        quorum_size: usize,
+    TooLittleVotingPower {
+        voting_power: u64,
+        quorum_voting_power: u64,
     },
     #[fail(
         display = "The number of signatures ({}) is greater than total number of authors ({})",
@@ -34,52 +34,91 @@ pub enum VerifyError {
     InvalidSignature,
 }
 
-/// Supports validation of signatures for known authors. This struct can be used for all signature
-/// verification operations including block and network signature verification, respectively.
+/// Helper struct to manage validator information for validation
 #[derive(Clone)]
-pub struct ValidatorVerifier<P> {
-    author_to_public_keys: HashMap<AccountAddress, P>,
-    quorum_size: usize,
+pub struct ValidatorInfo<PublicKey> {
+    public_key: PublicKey,
+    voting_power: u64,
 }
 
-impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
-    /// Initialize with a map of author to public key and set quorum size to default (`2f + 1`) or
-    /// zero if `author_to_public_keys` is empty.
-    pub fn new(author_to_public_keys: HashMap<AccountAddress, PublicKey>) -> Self {
-        let quorum_size = if author_to_public_keys.is_empty() {
-            0
-        } else {
-            author_to_public_keys.len() * 2 / 3 + 1
-        };
-        ValidatorVerifier {
-            author_to_public_keys,
-            quorum_size,
+impl<PublicKey: VerifyingKey> ValidatorInfo<PublicKey> {
+    pub fn new(public_key: PublicKey, voting_power: u64) -> Self {
+        ValidatorInfo {
+            public_key,
+            voting_power,
         }
     }
 
-    /// Initializes a validator verifier with specified quorum size.
-    pub fn new_with_quorum_size(
-        author_to_public_keys: HashMap<AccountAddress, PublicKey>,
-        quorum_size: usize,
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
+
+    pub fn voting_power(&self) -> u64 {
+        self.voting_power
+    }
+}
+
+/// Supports validation of signatures for known authors with individual voting powers. This struct
+/// can be used for all signature verification operations including block and network signature
+/// verification, respectively.
+#[derive(Clone)]
+pub struct ValidatorVerifier<PublicKey> {
+    address_to_validator_info: HashMap<AccountAddress, ValidatorInfo<PublicKey>>,
+    /// The minimum voting power required to achieve a quorum
+    quorum_voting_power: u64,
+    /// Total voting power of all validators (cached from address_to_validator_info)
+    total_voting_power: u64,
+}
+
+impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
+    /// Initialize with a map of account address to validator info and set quorum size to
+    /// default (`2f + 1`) or zero if `address_to_validator_info` is empty.
+    pub fn new(
+        address_to_validator_info: HashMap<AccountAddress, ValidatorInfo<PublicKey>>,
+    ) -> Self {
+        let total_voting_power = address_to_validator_info
+            .values()
+            .map(|x| x.voting_power)
+            .sum();
+        let quorum_voting_power = if address_to_validator_info.is_empty() {
+            0
+        } else {
+            total_voting_power * 2 / 3 + 1
+        };
+        ValidatorVerifier {
+            address_to_validator_info,
+            quorum_voting_power,
+            total_voting_power,
+        }
+    }
+
+    /// Initializes a validator verifier with a specified quorum voting power.
+    pub fn new_with_quorum_voting_power(
+        address_to_validator_info: HashMap<AccountAddress, ValidatorInfo<PublicKey>>,
+        quorum_voting_power: u64,
     ) -> Result<Self> {
+        let total_voting_power = address_to_validator_info
+            .values()
+            .fold(0, |sum, x| sum + x.voting_power);
         ensure!(
-            quorum_size <= author_to_public_keys.len(),
-            "Quorum size is greater than the number of authors: author_to_public_keys.len(): {}, \
+            quorum_voting_power <= total_voting_power,
+            "Quorum voting power is greater than the sum of all voting power of authors: {}, \
              quorum_size: {}.",
-            author_to_public_keys.len(),
-            quorum_size
+            quorum_voting_power,
+            total_voting_power
         );
         Ok(ValidatorVerifier {
-            author_to_public_keys,
-            quorum_size,
+            address_to_validator_info,
+            quorum_voting_power,
+            total_voting_power,
         })
     }
 
-    /// Helper method to initialize with a single author and public key.
+    /// Helper method to initialize with a single author and public key with quorum voting power 1.
     pub fn new_single(author: AccountAddress, public_key: PublicKey) -> Self {
-        let mut author_to_public_keys = HashMap::new();
-        author_to_public_keys.insert(author, public_key);
-        Self::new(author_to_public_keys)
+        let mut author_to_validator_info = HashMap::new();
+        author_to_validator_info.insert(author, ValidatorInfo::new(public_key, 1));
+        Self::new(author_to_validator_info)
     }
 
     /// Verify the correctness of a signature of a hash by a known author.
@@ -89,9 +128,7 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         hash: HashValue,
         signature: &PublicKey::SignatureMaterial,
     ) -> std::result::Result<(), VerifyError> {
-        let public_key = self.author_to_public_keys.get(&author);
-        match public_key {
-            None => Err(VerifyError::UnknownAuthor),
+        match self.get_public_key(&author) {
             Some(public_key) => {
                 if public_key.verify_signature(&hash, signature).is_err() {
                     Err(VerifyError::InvalidSignature)
@@ -99,6 +136,7 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
                     Ok(())
                 }
             }
+            None => Err(VerifyError::UnknownAuthor),
         }
     }
 
@@ -115,7 +153,8 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
     where
         T: Into<PublicKey::SignatureMaterial> + Clone,
     {
-        self.check_num_of_signatures(aggregated_signature)?;
+        self.check_num_of_signatures(&aggregated_signature)?;
+        self.check_voting_power(aggregated_signature.keys())?;
         for (author, signature) in aggregated_signature {
             self.verify_signature(*author, hash, &signature.clone().into())?;
         }
@@ -132,23 +171,20 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
     where
         T: Into<PublicKey::SignatureMaterial> + Clone,
     {
-        self.check_num_of_signatures(aggregated_signature)?;
-        self.check_keys(aggregated_signature)?;
+        self.check_num_of_signatures(&aggregated_signature)?;
+        self.check_voting_power(aggregated_signature.keys())?;
         let keys_and_signatures: Vec<(PublicKey, PublicKey::SignatureMaterial)> =
             aggregated_signature
                 .iter()
-                .flat_map(|(author, signature)| {
+                .flat_map(|(address, signature)| {
                     let sig: PublicKey::SignatureMaterial = signature.clone().into();
-                    self.author_to_public_keys
-                        .get(&author)
+                    self.get_public_key(&address)
                         .map(|pub_key| (pub_key.clone(), sig))
                 })
                 .collect();
         // Fallback is required to identify the source of the problem if batching fails.
         if PublicKey::batch_verify_signatures(&hash, keys_and_signatures).is_err() {
-            let iterated_verification =
-                self.verify_aggregated_signature(hash, aggregated_signature);
-            match iterated_verification {
+            match self.verify_aggregated_signature(hash, aggregated_signature) {
                 Ok(_) => warn!(
                     "Inconsistency between batch and iterative signature verification detected! \
                      Batch verification failed, while iterative passed."
@@ -159,7 +195,7 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         Ok(())
     }
 
-    /// Ensure there are at least quorum_size and not more than maximum expected signatures.
+    /// Ensure there are not more than the maximum expected signatures (all possible signatures).
     fn check_num_of_signatures<T>(
         &self,
         aggregated_signature: &HashMap<AccountAddress, T>,
@@ -168,12 +204,6 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         T: Into<PublicKey::SignatureMaterial> + Clone,
     {
         let num_of_signatures = aggregated_signature.len();
-        if num_of_signatures < self.quorum_size {
-            return Err(VerifyError::TooFewSignatures {
-                num_of_signatures,
-                quorum_size: self.quorum_size,
-            });
-        }
         if num_of_signatures > self.len() {
             return Err(VerifyError::TooManySignatures {
                 num_of_signatures,
@@ -182,42 +212,56 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         }
         Ok(())
     }
-
-    /// Ensure there are only known authors. According to the threshold verification policy,
+    /// Ensure there is at least quorum_voting_power in the provided signatures and there
+    /// are only known authors. According to the threshold verification policy,
     /// invalid public keys are not allowed.
-    fn check_keys<T>(
+    pub fn check_voting_power<'a>(
         &self,
-        aggregated_signature: &HashMap<AccountAddress, T>,
-    ) -> std::result::Result<(), VerifyError>
-    where
-        T: Into<PublicKey::SignatureMaterial> + Clone,
-    {
-        if aggregated_signature
-            .keys()
-            .all(|author| self.author_to_public_keys.get(&author).is_some())
-        {
-            Ok(())
-        } else {
-            Err(VerifyError::UnknownAuthor)
+        authors: impl Iterator<Item = &'a AccountAddress>,
+    ) -> std::result::Result<(), VerifyError> {
+        // Add voting power for valid accounts, exiting early for unknown authors
+        let mut aggregated_voting_power = 0;
+        for account_address in authors {
+            match self.get_voting_power(&account_address) {
+                Some(voting_power) => aggregated_voting_power += voting_power,
+                None => return Err(VerifyError::UnknownAuthor),
+            }
         }
+
+        if aggregated_voting_power < self.quorum_voting_power {
+            return Err(VerifyError::TooLittleVotingPower {
+                voting_power: aggregated_voting_power,
+                quorum_voting_power: self.quorum_voting_power,
+            });
+        }
+        Ok(())
     }
 
-    /// Return the public key for this address.
-    pub fn get_public_key(&self, author: AccountAddress) -> Option<PublicKey> {
-        self.author_to_public_keys.get(&author).cloned()
+    /// Returns the public key for this address.
+    pub fn get_public_key(&self, author: &AccountAddress) -> Option<PublicKey> {
+        self.address_to_validator_info
+            .get(&author)
+            .map(|validator_info| validator_info.public_key.clone())
+    }
+
+    /// Returns the voting power for this address.
+    pub fn get_voting_power(&self, author: &AccountAddress) -> Option<u64> {
+        self.address_to_validator_info
+            .get(&author)
+            .map(|validator_info| validator_info.voting_power)
     }
 
     /// Returns a ordered list of account addresses from smallest to largest.
     pub fn get_ordered_account_addresses(&self) -> Vec<AccountAddress> {
         let mut account_addresses: Vec<AccountAddress> =
-            self.author_to_public_keys.keys().cloned().collect();
+            self.address_to_validator_info.keys().cloned().collect();
         account_addresses.sort();
         account_addresses
     }
 
     /// Returns the number of authors to be validated.
     pub fn len(&self) -> usize {
-        self.author_to_public_keys.len()
+        self.address_to_validator_info.len()
     }
 
     /// Is there at least one author?
@@ -225,21 +269,52 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         self.len() == 0
     }
 
-    /// Returns quorum_size.
-    pub fn quorum_size(&self) -> usize {
-        self.quorum_size
+    /// Returns quorum voting power.
+    pub fn quorum_voting_power(&self) -> u64 {
+        self.quorum_voting_power
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::crypto_proxies::random_validator_verifier;
+    use crate::validator_verifier::VerifyError::TooLittleVotingPower;
     use crate::{
         account_address::AccountAddress,
         validator_signer::ValidatorSigner,
-        validator_verifier::{ValidatorVerifier, VerifyError},
+        validator_verifier::{ValidatorInfo, ValidatorVerifier, VerifyError},
     };
     use crypto::{ed25519::*, test_utils::TEST_SEED, HashValue};
     use std::collections::HashMap;
+
+    #[test]
+    fn test_check_voting_power() {
+        let (validator_signers, validator_verifier) = random_validator_verifier(2, None, false);
+        let mut author_to_signature_map: HashMap<AccountAddress, Ed25519Signature> = HashMap::new();
+
+        assert_eq!(
+            validator_verifier
+                .check_voting_power(author_to_signature_map.keys())
+                .unwrap_err(),
+            TooLittleVotingPower {
+                voting_power: 0,
+                quorum_voting_power: 2,
+            }
+        );
+
+        let random_hash = HashValue::random();
+        for validator in validator_signers.iter() {
+            author_to_signature_map.insert(
+                validator.author(),
+                validator.sign_message(random_hash).unwrap(),
+            );
+        }
+
+        assert_eq!(
+            validator_verifier.check_voting_power(author_to_signature_map.keys()),
+            Ok(())
+        );
+    }
 
     #[test]
     fn test_validator() {
@@ -269,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn test_quorum_validators() {
+    fn test_equal_vote_quorum_validators() {
         const NUM_SIGNERS: u8 = 7;
         // Generate NUM_SIGNERS random signers.
         let validator_signers: Vec<ValidatorSigner<Ed25519PrivateKey>> = (0..NUM_SIGNERS)
@@ -277,11 +352,14 @@ mod tests {
             .collect();
         let random_hash = HashValue::random();
 
-        // Create a map from authors to public keys.
-        let mut author_to_public_key_map: HashMap<AccountAddress, Ed25519PublicKey> =
+        // Create a map from authors to public keys with equal voting power.
+        let mut author_to_public_key_map: HashMap<AccountAddress, ValidatorInfo<Ed25519PublicKey>> =
             HashMap::new();
         for validator in validator_signers.iter() {
-            author_to_public_key_map.insert(validator.author(), validator.public_key());
+            author_to_public_key_map.insert(
+                validator.author(),
+                ValidatorInfo::new(validator.public_key(), 1),
+            );
         }
 
         // Create a map from author to signatures.
@@ -295,11 +373,12 @@ mod tests {
 
         // Let's assume our verifier needs to satisfy at least 5 signatures from the original
         // NUM_SIGNERS.
-        let validator_verifier = ValidatorVerifier::<Ed25519PublicKey>::new_with_quorum_size(
-            author_to_public_key_map,
-            5,
-        )
-        .expect("Incorrect quorum size.");
+        let validator_verifier =
+            ValidatorVerifier::<Ed25519PublicKey>::new_with_quorum_voting_power(
+                author_to_public_key_map,
+                5,
+            )
+            .expect("Incorrect quorum size.");
 
         // Check against signatures == N; this will pass.
         assert_eq!(
@@ -358,9 +437,114 @@ mod tests {
         assert_eq!(
             validator_verifier
                 .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
-            Err(VerifyError::TooFewSignatures {
-                num_of_signatures: 4,
-                quorum_size: 5
+            Err(VerifyError::TooLittleVotingPower {
+                voting_power: 4,
+                quorum_voting_power: 5
+            })
+        );
+
+        // Add an unknown signer, we have 5 signers, but one of them is invalid; this will fail.
+        author_to_signature_map.insert(unknown_validator_signer.author(), unknown_signature);
+        assert_eq!(
+            validator_verifier
+                .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
+            Err(VerifyError::UnknownAuthor)
+        );
+    }
+
+    #[test]
+    fn test_unequal_vote_quorum_validators() {
+        const NUM_SIGNERS: u8 = 4;
+        // Generate NUM_SIGNERS random signers.
+        let validator_signers: Vec<ValidatorSigner<Ed25519PrivateKey>> = (0..NUM_SIGNERS)
+            .map(|i| ValidatorSigner::random([i; 32]))
+            .collect();
+        let random_hash = HashValue::random();
+
+        // Create a map from authors to public keys with increasing weights (0, 1, 2, 3) and
+        // a map of author to signature.
+        let mut author_to_public_key_map: HashMap<AccountAddress, ValidatorInfo<Ed25519PublicKey>> =
+            HashMap::new();
+        let mut author_to_signature_map: HashMap<AccountAddress, Ed25519Signature> = HashMap::new();
+        for (i, validator_signer) in validator_signers.iter().enumerate() {
+            author_to_public_key_map.insert(
+                validator_signer.author(),
+                ValidatorInfo::new(validator_signer.public_key(), i as u64),
+            );
+            author_to_signature_map.insert(
+                validator_signer.author(),
+                validator_signer.sign_message(random_hash).unwrap(),
+            );
+        }
+
+        // Let's assume our verifier needs to satisfy at least 5 quorum voting power
+        let validator_verifier =
+            ValidatorVerifier::<Ed25519PublicKey>::new_with_quorum_voting_power(
+                author_to_public_key_map,
+                5,
+            )
+            .expect("Incorrect quorum size.");
+
+        // Check against all signatures (6 voting power); this will pass.
+        assert_eq!(
+            validator_verifier
+                .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
+            Ok(())
+        );
+
+        // Add an extra unknown signer, signatures > N; this will fail.
+        let unknown_validator_signer =
+            ValidatorSigner::<Ed25519PrivateKey>::random([NUM_SIGNERS + 1; 32]);
+        let unknown_signature = unknown_validator_signer.sign_message(random_hash).unwrap();
+        author_to_signature_map
+            .insert(unknown_validator_signer.author(), unknown_signature.clone());
+        assert_eq!(
+            validator_verifier
+                .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
+            Err(VerifyError::TooManySignatures {
+                num_of_signatures: 5,
+                num_of_authors: 4
+            })
+        );
+
+        // Add 5 voting power signers only (quorum threshold is met) with (2, 3) ; this will pass.
+        author_to_signature_map.clear();
+        for validator in validator_signers.iter().skip(2) {
+            author_to_signature_map.insert(
+                validator.author(),
+                validator.sign_message(random_hash).unwrap(),
+            );
+        }
+        assert_eq!(
+            validator_verifier
+                .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
+            Ok(())
+        );
+
+        // Add an unknown signer, but quorum is satisfied and signatures <= N; this will fail as we
+        // don't tolerate invalid signatures.
+        author_to_signature_map
+            .insert(unknown_validator_signer.author(), unknown_signature.clone());
+        assert_eq!(
+            validator_verifier
+                .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
+            Err(VerifyError::UnknownAuthor)
+        );
+
+        // Add first 3 valid signers only (quorum threshold is NOT met); this will fail.
+        author_to_signature_map.clear();
+        for validator in validator_signers.iter().take(3) {
+            author_to_signature_map.insert(
+                validator.author(),
+                validator.sign_message(random_hash).unwrap(),
+            );
+        }
+        assert_eq!(
+            validator_verifier
+                .batch_verify_aggregated_signature(random_hash, &author_to_signature_map),
+            Err(VerifyError::TooLittleVotingPower {
+                voting_power: 3,
+                quorum_voting_power: 5
             })
         );
 


### PR DESCRIPTION
Currently all validators have 1 vote in consensus. In order to support
systems that have weighted voting (e.g. proof-of-stake), Libra Core
must support weighted voting. The main change is to modify
ValidatorVerifier to support weighted voting quorums.

* Unified config access for ValidatorVerifier to get_validator_validator() from multiple locations to a single access point
* Consensus voting is handled directly by ValidatorVerifier rather than passing quorum sizes explicitly
* Added random_validator_verifier to simplify testing that requires ValidatorVerifier and reduce boilerplate
* Added weighted voting counting to BlockTree#insert_vote(), PacemakerTimeoutCertificate#verify(), PacemakerTimeoutManager#generate_timeout_certificate
* Added new tests in ValidatorVerifier#test_unequal_vote_quorum_validators() for weighted voting

Future work
* Add for support configuration that uses voting weights other than 1
* Add more support for weighted voting counting in ValidatorVerifier rather than directly counting in consensus

## Related issues

#1148
