### PR TITLE
[executor] Change the API for VMExecutor to include an Optional block metadata

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -319,7 +319,7 @@ where
         );
         let vm_outputs = {
             let _timer = OP_COUNTERS.timer("vm_execute_chunk_time_s");
-            V::execute_block(transactions.clone(), &self.vm_config, &state_view)
+            V::execute_block(transactions.clone(), &self.vm_config, &state_view, None)
         };
 
         // Since other validators have committed these transactions, their status should all be
@@ -609,6 +609,7 @@ where
                 block_to_execute.transactions().to_vec(),
                 &self.vm_config,
                 &state_view,
+                None,
             )
         };
 

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -44,6 +44,7 @@ fn test_mock_vm_different_senders() {
         txns.clone(),
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
+        None,
     );
 
     for (output, txn) in itertools::zip_eq(outputs.iter(), txns.iter()) {
@@ -77,6 +78,7 @@ fn test_mock_vm_same_sender() {
         txns,
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
+        None,
     );
 
     for (i, output) in outputs.iter().enumerate() {
@@ -111,6 +113,7 @@ fn test_mock_vm_payment() {
         txns,
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
+        None,
     );
 
     let mut output_iter = output.iter();

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
+    block_metadata::BlockMetaData,
     contract_event::ContractEvent,
     event::EventKey,
     transaction::{
@@ -52,6 +53,7 @@ impl VMExecutor for MockVM {
         transactions: Vec<SignedTransaction>,
         _config: &VMConfig,
         state_view: &dyn StateView,
+        _block_data: Option<BlockMetaData>,
     ) -> Vec<TransactionOutput> {
         if state_view.is_genesis() {
             assert_eq!(

--- a/language/e2e_tests/src/executor.rs
+++ b/language/e2e_tests/src/executor.rs
@@ -133,7 +133,7 @@ impl FakeExecutor {
     /// Typical tests will call this method and check that the output matches what was expected.
     /// However, this doesn't apply the results of successful transactions to the data store.
     pub fn execute_block(&self, txn_block: Vec<SignedTransaction>) -> Vec<TransactionOutput> {
-        MoveVM::execute_block(txn_block, &self.config.vm_config, &self.data_store)
+        MoveVM::execute_block(txn_block, &self.config.vm_config, &self.data_store, None)
     }
 
     pub fn execute_transaction(&self, txn: SignedTransaction) -> TransactionOutput {

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -139,6 +139,7 @@ pub use txn_executor::execute_function;
 use config::config::VMConfig;
 use state_view::StateView;
 use types::{
+    block_metadata::BlockMetaData,
     transaction::{SignedTransaction, TransactionOutput},
     vm_error::VMStatus,
 };
@@ -168,5 +169,6 @@ pub trait VMExecutor {
         transactions: Vec<SignedTransaction>,
         config: &VMConfig,
         state_view: &dyn StateView,
+        block_data: Option<BlockMetaData>,
     ) -> Vec<TransactionOutput>;
 }

--- a/language/vm/vm_runtime/src/move_vm.rs
+++ b/language/vm/vm_runtime/src/move_vm.rs
@@ -8,6 +8,7 @@ use crate::{
 use state_view::StateView;
 use std::sync::Arc;
 use types::{
+    block_metadata::BlockMetaData,
     transaction::{SignedTransaction, TransactionOutput},
     vm_error::VMStatus,
 };
@@ -65,6 +66,7 @@ impl VMExecutor for MoveVM {
         transactions: Vec<SignedTransaction>,
         config: &VMConfig,
         state_view: &dyn StateView,
+        _block_data: Option<BlockMetaData>,
     ) -> Vec<TransactionOutput> {
         let vm = MoveVMImpl::new(Box::new(Arena::new()), |arena| {
             // XXX This means that scripts and modules are NOT tested against the whitelist! This


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is the second step for #1083. We change the API for VMExecutor to include a `Option<BlockMetaData>` so that the executor can pass the consensus info to VM in the future.
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

