### PR TITLE
[proof] Make LeafCount type alias

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -181,7 +181,7 @@ where
                             committed_timestamp_usecs,
                             state_root_hash,
                             frozen_subtrees_in_accumulator,
-                            num_leaves_in_accumulator as usize,
+                            num_leaves_in_accumulator,
                             committed_block_id,
                             storage_read_client,
                             storage_write_client,

--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -146,7 +146,11 @@ where
     /// if they are non-frozen).
     ///
     /// See [`types::proof::AccumulatorProof`] for proof format.
-    pub fn get_proof(reader: &R, num_leaves: LeafCount, leaf_index: u64) -> Result<AccumulatorProof> {
+    pub fn get_proof(
+        reader: &R,
+        num_leaves: LeafCount,
+        leaf_index: u64,
+    ) -> Result<AccumulatorProof> {
         MerkleAccumulatorView::<R, H>::new(reader, num_leaves).get_proof(leaf_index)
     }
 
@@ -330,7 +334,10 @@ where
     }
 
     /// Implementation for public interface `MerkleAccumulator::get_consistency_proof`.
-    fn get_consistency_proof(&self, sub_acc_leaves: LeafCount) -> Result<AccumulatorConsistencyProof> {
+    fn get_consistency_proof(
+        &self,
+        sub_acc_leaves: LeafCount,
+    ) -> Result<AccumulatorConsistencyProof> {
         ensure!(
             sub_acc_leaves <= self.num_leaves,
             "The other accumulator is bigger than this one. self.num_leaves: {}. \

--- a/storage/accumulator/src/tests/mod.rs
+++ b/storage/accumulator/src/tests/mod.rs
@@ -105,7 +105,8 @@ impl MockHashStore {
             let max_position = right.max_position;
             let hash = Self::hash_internal(left.hash, right.hash);
             let frozen = left.frozen && right.frozen;
-            let num_frozen_nodes = left.num_frozen_nodes + right.num_frozen_nodes + frozen as LeafCount;
+            let num_frozen_nodes =
+                left.num_frozen_nodes + right.num_frozen_nodes + frozen as LeafCount;
 
             Subtree {
                 root_position,

--- a/storage/accumulator/src/tests/proof_test.rs
+++ b/storage/accumulator/src/tests/proof_test.rs
@@ -36,15 +36,15 @@ proptest! {
         // insert all leaves in two batches
         let (root_hash1, writes1) = TestAccumulator::append(&store, 0, &batch1).unwrap();
         store.put_many(&writes1);
-        let (root_hash2, writes2) = TestAccumulator::append(&store, batch1.len(), &batch2).unwrap();
+        let (root_hash2, writes2) = TestAccumulator::append(&store, batch1.len() as LeafCount, &batch2).unwrap();
         store.put_many(&writes2);
 
         // verify proofs for all leaves towards current root
-        verify(&store, total_leaves, root_hash2, &batch1, 0);
-        verify(&store, total_leaves, root_hash2, &batch2, batch1.len() as u64);
+        verify(&store, total_leaves as u64, root_hash2, &batch1, 0);
+        verify(&store, total_leaves as u64, root_hash2, &batch2, batch1.len() as u64);
 
         // verify proofs for all leaves of a subtree towards subtree root
-        verify(&store, batch1.len(), root_hash1, &batch1, 0);
+        verify(&store, batch1.len() as u64, root_hash1, &batch1, 0);
     }
 
     #[test]
@@ -58,23 +58,23 @@ proptest! {
         let (root_hash1, writes1) = TestAccumulator::append(&store, 0, &batch1).unwrap();
         store.put_many(&writes1);
         let proof1 =
-            TestAccumulator::get_consistency_proof(&store, batch1.len(), 0).unwrap();
+            TestAccumulator::get_consistency_proof(&store, batch1.len() as LeafCount, 0).unwrap();
         let in_mem_acc1 = empty_in_mem_acc
-            .append_subtrees(proof1.subtrees(), batch1.len())
+            .append_subtrees(proof1.subtrees(), batch1.len() as LeafCount)
             .unwrap();
         prop_assert_eq!(root_hash1, in_mem_acc1.root_hash());
 
         let (root_hash2, writes2) =
-            TestAccumulator::append(&store, batch1.len(), &batch2).unwrap();
+            TestAccumulator::append(&store, batch1.len() as LeafCount, &batch2).unwrap();
         store.put_many(&writes2);
         let proof2 = TestAccumulator::get_consistency_proof(
             &store,
-            batch1.len() + batch2.len(),
-            batch1.len()
+            (batch1.len() + batch2.len()) as LeafCount,
+            batch1.len() as LeafCount
         )
         .unwrap();
         let in_mem_acc2 = in_mem_acc1
-            .append_subtrees(proof2.subtrees(), batch2.len())
+            .append_subtrees(proof2.subtrees(), batch2.len() as LeafCount)
             .unwrap();
         prop_assert_eq!(root_hash2, in_mem_acc2.root_hash());
     }
@@ -82,7 +82,7 @@ proptest! {
 
 fn verify(
     store: &MockHashStore,
-    num_leaves: usize,
+    num_leaves: u64,
     root_hash: HashValue,
     leaves: &[HashValue],
     first_leaf_idx: u64,

--- a/storage/accumulator/src/tests/write_test.rs
+++ b/storage/accumulator/src/tests/write_test.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use proptest::{collection::vec, prelude::*};
+use types::proof::definition::LeafCount;
 
 #[test]
 fn test_append_empty_on_empty() {
@@ -22,7 +23,7 @@ fn test_append_one() {
     let mut leaves = Vec::new();
     for _ in 0..100 {
         let hash = HashValue::random();
-        let (root_hash, writes) = TestAccumulator::append(&store, leaves.len(), &[hash]).unwrap();
+        let (root_hash, writes) = TestAccumulator::append(&store, leaves.len() as LeafCount, &[hash]).unwrap();
         store.put_many(&writes);
 
         leaves.push(hash);
@@ -46,7 +47,7 @@ proptest! {
                 TestAccumulator::append(&store, num_leaves, &hashes).unwrap();
             store.put_many(&writes);
 
-            num_leaves += hashes.len();
+            num_leaves += hashes.len() as LeafCount;
             leaves.extend(hashes.iter());
             let expected_root_hash = store.verify(&leaves).unwrap();
             assert_eq!(root_hash, expected_root_hash)
@@ -61,7 +62,7 @@ proptest! {
         store.put_many(&writes);
 
         let (root_hash2, writes2) =
-            TestAccumulator::append(&store, leaves.len(), &[]).unwrap();
+            TestAccumulator::append(&store, leaves.len() as LeafCount, &[]).unwrap();
 
         assert_eq!(root_hash, root_hash2);
         assert!(writes2.is_empty());

--- a/storage/accumulator/src/tests/write_test.rs
+++ b/storage/accumulator/src/tests/write_test.rs
@@ -23,7 +23,8 @@ fn test_append_one() {
     let mut leaves = Vec::new();
     for _ in 0..100 {
         let hash = HashValue::random();
-        let (root_hash, writes) = TestAccumulator::append(&store, leaves.len() as LeafCount, &[hash]).unwrap();
+        let (root_hash, writes) =
+            TestAccumulator::append(&store, leaves.len() as LeafCount, &[hash]).unwrap();
         store.put_many(&writes);
 
         leaves.push(hash);

--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -75,7 +75,7 @@ impl EventStore {
         let mut iter = self.db.iter::<EventSchema>(ReadOptions::default())?;
         iter.seek_for_prev(&(version + 1))?;
         let num_events = match iter.next().transpose()? {
-            Some(((ver, index), _)) if ver == version => (index + 1) as usize,
+            Some(((ver, index), _)) if ver == version => (index + 1),
             _ => unreachable!(), // since we've already got at least one event above
         };
 

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -128,7 +128,7 @@ impl LedgerStore {
     ) -> Result<AccumulatorProof> {
         Accumulator::get_proof(
             self,
-            (ledger_version + 1) as usize, /* num_leaves */
+            ledger_version + 1, /* num_leaves */
             version,
         )
     }
@@ -151,7 +151,7 @@ impl LedgerStore {
         let txn_hashes: Vec<HashValue> = txn_infos.iter().map(TransactionInfo::hash).collect();
         let (root_hash, writes) = Accumulator::append(
             self,
-            first_version as usize, /* num_existing_leaves */
+            first_version, /* num_existing_leaves */
             &txn_hashes,
         )?;
         writes
@@ -175,7 +175,7 @@ impl LedgerStore {
 
     /// From left to right, get frozen subtree root hashes of the transaction accumulator.
     pub fn get_ledger_frozen_subtree_hashes(&self, version: Version) -> Result<Vec<HashValue>> {
-        Accumulator::get_frozen_subtree_hashes(self, version as usize + 1)
+        Accumulator::get_frozen_subtree_hashes(self, version + 1)
     }
 }
 

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -126,11 +126,7 @@ impl LedgerStore {
         version: Version,
         ledger_version: Version,
     ) -> Result<AccumulatorProof> {
-        Accumulator::get_proof(
-            self,
-            ledger_version + 1, /* num_leaves */
-            version,
-        )
+        Accumulator::get_proof(self, ledger_version + 1 /* num_leaves */, version)
     }
 
     /// Write `txn_infos` to `batch`. Assigned `first_version` to the the version number of the

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -3,6 +3,7 @@
 
 use super::Accumulator;
 use crate::proof::{
+    definition::LeafCount,
     position::{FrozenSubtreeSiblingIterator, Position},
     TestAccumulatorInternalNode,
 };
@@ -102,7 +103,7 @@ fn test_accumulator_append() {
         itertools::zip_eq(leaves.into_iter(), expected_root_hashes.into_iter()).enumerate()
     {
         assert_eq!(accumulator.root_hash(), expected_root_hash);
-        assert_eq!(accumulator.num_leaves(), i);
+        assert_eq!(accumulator.num_leaves(), i as LeafCount);
         accumulator = accumulator.append(vec![leaf]);
     }
 }
@@ -123,11 +124,11 @@ proptest! {
         let position_to_hash = compute_hashes_for_all_positions(&all_hashes);
 
         let subtree_hashes: Vec<_> =
-            FrozenSubtreeSiblingIterator::new(hashes1.len(), all_hashes.len())
+            FrozenSubtreeSiblingIterator::new(hashes1.len() as LeafCount, all_hashes.len() as LeafCount)
                 .filter_map(|pos| position_to_hash.get(&pos).cloned())
                 .collect();
         let new_accumulator = accumulator
-            .append_subtrees(&subtree_hashes, hashes2.len())
+            .append_subtrees(&subtree_hashes, hashes2.len() as LeafCount)
             .unwrap();
         prop_assert_eq!(
             new_accumulator.root_hash(),

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -14,7 +14,7 @@
 mod accumulator_test;
 
 use super::MerkleTreeInternalNode;
-use crate::proof::definition::MAX_ACCUMULATOR_LEAVES;
+use crate::proof::definition::{LeafCount, MAX_ACCUMULATOR_LEAVES};
 use crypto::{
     hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
@@ -42,7 +42,7 @@ pub struct Accumulator<H> {
     frozen_subtree_roots: Vec<HashValue>,
 
     /// The total number of leaves in this accumulator.
-    num_leaves: usize,
+    num_leaves: LeafCount,
 
     /// The root hash of this accumulator.
     root_hash: HashValue,
@@ -56,7 +56,7 @@ where
 {
     /// Constructs a new accumulator with roots of existing frozen subtrees. Returns error if the
     /// number of frozen subtree roots does not match the number of leaves.
-    pub fn new(frozen_subtree_roots: Vec<HashValue>, num_leaves: usize) -> Result<Self> {
+    pub fn new(frozen_subtree_roots: Vec<HashValue>, num_leaves: LeafCount) -> Result<Self> {
         ensure!(
             frozen_subtree_roots.len() == num_leaves.count_ones() as usize,
             "The number of frozen subtrees does not match the number of leaves. \
@@ -95,7 +95,7 @@ where
     /// and remove old nodes if they are now part of a larger frozen subtree.
     fn append_one(
         frozen_subtree_roots: &mut Vec<HashValue>,
-        num_existing_leaves: usize,
+        num_existing_leaves: LeafCount,
         leaf: HashValue,
     ) {
         // For example, this accumulator originally had N = 7 leaves. Appending a leaf is like
@@ -167,7 +167,7 @@ where
     ///               / \ / \ / \ / \                         / \           / \   / \ / \      / \ / \                / \
     ///               o o o o o o o o                         o o           A B   C D E F      G H I J  K (subtrees[3]) placeholder
     /// ```
-    pub fn append_subtrees(&self, subtrees: &[HashValue], num_new_leaves: usize) -> Result<Self> {
+    pub fn append_subtrees(&self, subtrees: &[HashValue], num_new_leaves: LeafCount) -> Result<Self> {
         ensure!(
             num_new_leaves <= MAX_ACCUMULATOR_LEAVES - self.num_leaves,
             "Too many new leaves. self.num_leaves: {}. num_new_leaves: {}.",
@@ -226,7 +226,7 @@ where
 
     /// Computes the root hash of an accumulator given the frozen subtree roots and the number of
     /// leaves in this accumulator.
-    fn compute_root_hash(frozen_subtree_roots: &[HashValue], num_leaves: usize) -> HashValue {
+    fn compute_root_hash(frozen_subtree_roots: &[HashValue], num_leaves: LeafCount) -> HashValue {
         match frozen_subtree_roots.len() {
             0 => return *ACCUMULATOR_PLACEHOLDER_HASH,
             1 => return frozen_subtree_roots[0],
@@ -258,7 +258,7 @@ where
     }
 
     /// Returns the total number of leaves in this accumulator.
-    pub fn num_leaves(&self) -> usize {
+    pub fn num_leaves(&self) -> LeafCount {
         self.num_leaves
     }
 }

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -167,7 +167,11 @@ where
     ///               / \ / \ / \ / \                         / \           / \   / \ / \      / \ / \                / \
     ///               o o o o o o o o                         o o           A B   C D E F      G H I J  K (subtrees[3]) placeholder
     /// ```
-    pub fn append_subtrees(&self, subtrees: &[HashValue], num_new_leaves: LeafCount) -> Result<Self> {
+    pub fn append_subtrees(
+        &self,
+        subtrees: &[HashValue],
+        num_new_leaves: LeafCount,
+    ) -> Result<Self> {
         ensure!(
             num_new_leaves <= MAX_ACCUMULATOR_LEAVES - self.num_leaves,
             "Too many new leaves. self.num_leaves: {}. num_new_leaves: {}.",

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -17,7 +17,6 @@ use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
-use std::mem;
 
 /// A proof that can be used authenticate an element in an accumulator given trusted root hash. For
 /// example, both `LedgerInfoToTransactionInfoProof` and `TransactionInfoToEventProof` can be
@@ -31,11 +30,10 @@ pub struct AccumulatorProof {
 
 /// Because leaves can only take half the space in the tree, any numbering of the tree leaves must
 /// not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm proof
-/// depth is limited to 63.  We rely on usize to provide full 64-bit width, and assert for this.
-#[allow(dead_code)]
-const USIZE_STATIC_ASSERT: usize = mem::size_of::<usize>() - mem::size_of::<u64>();
+/// depth is limited to 63.
+pub type LeafCount = u64;
 pub const MAX_ACCUMULATOR_PROOF_DEPTH: usize = 63;
-pub const MAX_ACCUMULATOR_LEAVES: usize = 1 << MAX_ACCUMULATOR_PROOF_DEPTH;
+pub const MAX_ACCUMULATOR_LEAVES: LeafCount = 1 << MAX_ACCUMULATOR_PROOF_DEPTH;
 
 impl AccumulatorProof {
     /// Constructs a new `AccumulatorProof` using a list of siblings.

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod accumulator;
+pub mod definition;
 pub mod position;
 #[cfg(any(test, feature = "testing"))]
 pub mod proptest_proof;
 
-mod definition;
 #[cfg(test)]
 #[path = "unit_tests/proof_test.rs"]
 mod proof_test;

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -117,10 +117,10 @@ fn test_root_level_from_leaf_count() {
     assert_eq!(Position::root_level_from_leaf_count(2), 1);
     assert_eq!(Position::root_level_from_leaf_count(3), 2);
     assert_eq!(Position::root_level_from_leaf_count(4), 2);
-    for i in 1..100usize {
+    for i in 1..100 {
         assert_eq!(
             Position::root_level_from_leaf_count(i),
-            Position::root_from_leaf_count(i).level() as usize
+            Position::root_from_leaf_count(i).level()
         );
     }
 }
@@ -259,11 +259,11 @@ fn slow_get_frozen_subtree_roots_impl(root: Position, max_leaf_index: u64) -> Ve
     }
 }
 
-fn slow_get_frozen_subtree_roots(num_leaves: usize) -> Vec<Position> {
+fn slow_get_frozen_subtree_roots(num_leaves: u64) -> Vec<Position> {
     if num_leaves == 0 {
         Vec::new()
     } else {
-        let max_leaf_index = num_leaves as u64 - 1;
+        let max_leaf_index = num_leaves - 1;
         let root = Position::root_from_leaf_count(num_leaves);
         slow_get_frozen_subtree_roots_impl(root, max_leaf_index)
     }
@@ -271,7 +271,7 @@ fn slow_get_frozen_subtree_roots(num_leaves: usize) -> Vec<Position> {
 
 #[test]
 fn test_frozen_subtree_iterator() {
-    for n in 0..10000usize {
+    for n in 0..10000 {
         assert_eq!(
             FrozenSubTreeIterator::new(n).collect::<Vec<_>>(),
             slow_get_frozen_subtree_roots(n),
@@ -279,7 +279,7 @@ fn test_frozen_subtree_iterator() {
     }
 }
 
-fn collect_all_positions(num_leaves: usize, num_new_leaves: usize) -> Vec<u64> {
+fn collect_all_positions(num_leaves: u64, num_new_leaves: u64) -> Vec<u64> {
     FrozenSubtreeSiblingIterator::new(num_leaves, num_new_leaves)
         .map(Position::to_inorder_index)
         .collect()

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -259,7 +259,7 @@ fn slow_get_frozen_subtree_roots_impl(root: Position, max_leaf_index: u64) -> Ve
     }
 }
 
-fn slow_get_frozen_subtree_roots(num_leaves: u64) -> Vec<Position> {
+fn slow_get_frozen_subtree_roots(num_leaves: LeafCount) -> Vec<Position> {
     if num_leaves == 0 {
         Vec::new()
     } else {
@@ -279,7 +279,7 @@ fn test_frozen_subtree_iterator() {
     }
 }
 
-fn collect_all_positions(num_leaves: u64, num_new_leaves: u64) -> Vec<u64> {
+fn collect_all_positions(num_leaves: LeafCount, num_new_leaves: LeafCount) -> Vec<u64> {
     FrozenSubtreeSiblingIterator::new(num_leaves, num_new_leaves)
         .map(Position::to_inorder_index)
         .collect()


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add a type alias for LeafCount as u64 so that 32-bit builds will
continue to work.  This is required for external HSM code that
needs to include types crate.  We lose some type checking but
gain readability and consistency on what is a Version versus
what is a LeafCount.

### Have you read the [Contributing Guidelines on pull requests]

Ja, ek het dit gelees.

## Test Plan

CI

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
