### PR TITLE
CanonicalSerializer support for ed25519 and x25519

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,7 @@ dependencies = [
  "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "canonical_serialization 0.1.0",
  "crypto_derive 0.1.0",
  "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -31,6 +31,7 @@ crypto_derive = { path = "../crypto_derive" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 nibble = { path = "../../common/nibble" }
 proto_conv = { path = "../../common/proto_conv" }
+canonical_serialization = { path = "../../common/canonical_serialization" }
 
 [dev-dependencies]
 bitvec = "0.10.1"

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -30,6 +30,9 @@
 //! testing purposes. Production code should find an alternate means for secure key generation.
 
 use crate::{traits::*, HashValue};
+use canonical_serialization::{
+    CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
+};
 use core::convert::TryFrom;
 use crypto_derive::{SilentDebug, SilentDisplay};
 use ed25519_dalek;
@@ -374,6 +377,19 @@ impl PartialEq for Ed25519Signature {
 
 impl Eq for Ed25519Signature {}
 
+/// Check if S < L to capture invalid signatures.
+fn check_s_lt_l(s: &[u8]) -> bool {
+    for i in (0..32).rev() {
+        if s[i] < L[i] {
+            return true;
+        } else if s[i] > L[i] {
+            return false;
+        }
+    }
+    // As this stage S == L which implies a non canonical S.
+    false
+}
+
 //////////////////////////
 // Compatibility Traits //
 //////////////////////////
@@ -452,6 +468,44 @@ pub mod compat {
 }
 
 //////////////////////////////
+// Canonical Serialization  //
+//////////////////////////////
+
+impl CanonicalSerialize for Ed25519PublicKey {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_bytes(&self.to_bytes())?;
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for Ed25519PublicKey {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let public_key_bytes = deserializer.decode_bytes()?;
+        Ok(Ed25519PublicKey::try_from(&public_key_bytes[..])?)
+    }
+}
+
+impl CanonicalSerialize for Ed25519Signature {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_bytes(&self.to_bytes())?;
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for Ed25519Signature {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let signature_bytes = deserializer.decode_bytes()?;
+        Ok(Ed25519Signature::try_from(&signature_bytes[..])?)
+    }
+}
+
+//////////////////////////////
 // Compact Serialization    //
 //////////////////////////////
 
@@ -483,9 +537,7 @@ impl ser::Serialize for Ed25519Signature {
 }
 
 struct Ed25519PrivateKeyVisitor;
-
 struct Ed25519PublicKeyVisitor;
-
 struct Ed25519SignatureVisitor;
 
 impl<'de> de::Visitor<'de> for Ed25519PrivateKeyVisitor {
@@ -558,17 +610,4 @@ impl<'de> de::Deserialize<'de> for Ed25519Signature {
     {
         deserializer.deserialize_bytes(Ed25519SignatureVisitor {})
     }
-}
-
-/// Check if S < L to capture invalid signatures.
-fn check_s_lt_l(s: &[u8]) -> bool {
-    for i in (0..32).rev() {
-        if s[i] < L[i] {
-            return true;
-        } else if s[i] > L[i] {
-            return false;
-        }
-    }
-    // As this stage S == L which implies a non canonical S.
-    false
 }

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -57,7 +57,11 @@
 //! ```
 
 use crate::{hkdf::Hkdf, traits::*};
+use canonical_serialization::{
+    CanonicalDeserialize, CanonicalDeserializer, CanonicalSerialize, CanonicalSerializer,
+};
 use crypto_derive::{Deref, SilentDebug, SilentDisplay};
+use failure::prelude::*;
 use rand::{rngs::EntropyRng, RngCore};
 use serde::{de, export, ser};
 use sha2::Sha256;
@@ -290,6 +294,27 @@ impl ValidKey for X25519StaticPublicKey {
 //////////////////////
 
 //////////////////////////////
+// Canonical Serialization  //
+//////////////////////////////
+
+impl CanonicalSerialize for X25519StaticPublicKey {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer.encode_bytes(&self.to_bytes())?;
+        Ok(())
+    }
+}
+
+impl CanonicalDeserialize for X25519StaticPublicKey {
+    fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let public_key_bytes = deserializer.decode_bytes()?;
+        Ok(X25519StaticPublicKey::try_from(&public_key_bytes[..])?)
+    }
+}
+
+//////////////////////////////
 // Compact Serialization    //
 //////////////////////////////
 
@@ -312,7 +337,6 @@ impl ser::Serialize for X25519StaticPublicKey {
 }
 
 struct X25519StaticPrivateKeyVisitor;
-
 struct X25519StaticPublicKeyVisitor;
 
 impl<'de> de::Visitor<'de> for X25519StaticPrivateKeyVisitor {

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -120,21 +120,19 @@ impl CanonicalSerialize for ValidatorPublicKeys {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer
             .encode_struct(&self.account_address)?
-            .encode_bytes(&self.consensus_public_key.to_bytes())?
-            .encode_bytes(&X25519StaticPublicKey::to_bytes(&self.network_identity_public_key)[..])?
-            .encode_bytes(&self.network_signing_public_key.to_bytes())?;
+            .encode_struct(&self.consensus_public_key)?
+            .encode_struct(&self.network_identity_public_key)?
+            .encode_struct(&self.network_signing_public_key)?;
         Ok(())
     }
 }
 
 impl CanonicalDeserialize for ValidatorPublicKeys {
     fn deserialize(deserializer: &mut impl CanonicalDeserializer) -> Result<Self> {
-        let account_address = deserializer.decode_struct::<AccountAddress>()?;
-        let consensus_public_key = Ed25519PublicKey::try_from(&deserializer.decode_bytes()?[..])?;
-        let network_identity_public_key =
-            X25519StaticPublicKey::try_from(&deserializer.decode_bytes()?[..])?;
-        let network_signing_public_key =
-            Ed25519PublicKey::try_from(&deserializer.decode_bytes()?[..])?;
+        let account_address: AccountAddress = deserializer.decode_struct()?;
+        let consensus_public_key: Ed25519PublicKey = deserializer.decode_struct()?;
+        let network_identity_public_key: X25519StaticPublicKey = deserializer.decode_struct()?;
+        let network_signing_public_key: Ed25519PublicKey = deserializer.decode_struct()?;
         Ok(ValidatorPublicKeys::new(
             account_address,
             consensus_public_key,


### PR DESCRIPTION
## Motivation

Adding support for canonical serialization in `ed25519` (public key and signature) and `x25519` (static public key). Also some function reordering to maintain function order (to match trait's functions order).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

Existing
