### PR TITLE
[types] Format code to hex str

### DIFF
--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -29,10 +29,8 @@ impl Module {
 
 impl fmt::Debug for Module {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // XXX note that "code" will eventually be encoded bytecode and will no longer be a
-        // UTF8-ish string -- at that point the from_utf8_lossy will stop making sense.
         f.debug_struct("Module")
-            .field("code", &String::from_utf8_lossy(&self.code))
+            .field("code", &hex::encode(&self.code))
             .finish()
     }
 }

--- a/types/src/transaction/program.rs
+++ b/types/src/transaction/program.rs
@@ -44,10 +44,8 @@ impl Program {
 
 impl fmt::Debug for Program {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // XXX note that "code" will eventually be encoded bytecode and will no longer be a
-        // UTF8-ish string -- at that point the from_utf8_lossy will stop making sense.
         f.debug_struct("Program")
-            .field("code", &String::from_utf8_lossy(&self.code))
+            .field("code", &hex::encode(&self.code))
             .field("args", &self.args)
             .finish()
     }

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -38,10 +38,8 @@ impl Script {
 
 impl fmt::Debug for Script {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // XXX note that "code" will eventually be encoded bytecode and will no longer be a
-        // UTF8-ish string -- at that point the from_utf8_lossy will stop making sense.
         f.debug_struct("Script")
-            .field("code", &String::from_utf8_lossy(&self.code))
+            .field("code", &hex::encode(&self.code))
             .field("args", &self.args)
             .finish()
     }

--- a/types/src/unit_tests/code_debug_fmt_test.rs
+++ b/types/src/unit_tests/code_debug_fmt_test.rs
@@ -1,0 +1,19 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction::Script;
+use std::fmt;
+
+#[test]
+fn test_code_fmt() {
+    let expect_output = r#"Script {
+    code: "6d6f7665",
+    args: [],
+}"#;
+    let script = Script::new(b"move".to_vec(), vec![]);
+    let mut output = String::new();
+    fmt::write(&mut output, format_args!("{:#?}", script))
+        .expect("Error occurred while trying to format Script.");
+    assert_eq!(output, expect_output);
+    println!("{:#?}", script);
+}

--- a/types/src/unit_tests/mod.rs
+++ b/types/src/unit_tests/mod.rs
@@ -4,6 +4,7 @@
 mod access_path_test;
 mod address_test;
 mod canonical_serialization_examples;
+mod code_debug_fmt_test;
 mod contract_event_proto_conversion_test;
 mod get_with_proof_proto_conversion_test;
 mod identifier_test;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Bytecode no longer be a UTF8-ish string, so we format bytecode to hex str in debug fmt.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Add test case file under types/unit_tests/code_debug_fmt_test.py

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
