### PR TITLE
[functional_tests] Add ability to send transactions from genesis addresses

### DIFF
--- a/language/e2e_tests/src/account.rs
+++ b/language/e2e_tests/src/account.rs
@@ -71,16 +71,24 @@ impl Account {
         }
     }
 
+    /// Creates a new account in memory representing an account created in the genesis transaction.
+    ///
+    /// The address will be [`address`], which should be an address for a genesis account and
+    /// the account will use [`GENESIS_KEYPAIR`][struct@GENESIS_KEYPAIR] as its keypair.
+    pub fn new_genesis_account(address: AccountAddress) -> Self {
+        Account {
+            addr: address,
+            pubkey: GENESIS_KEYPAIR.1.clone(),
+            privkey: GENESIS_KEYPAIR.0.clone(),
+        }
+    }
+
     /// Creates a new account representing the association in memory.
     ///
     /// The address will be [`association_address`][account_config::association_address], and
     /// the account will use [`GENESIS_KEYPAIR`][struct@GENESIS_KEYPAIR] as its keypair.
     pub fn new_association() -> Self {
-        Account {
-            addr: account_config::association_address(),
-            pubkey: GENESIS_KEYPAIR.1.clone(),
-            privkey: GENESIS_KEYPAIR.0.clone(),
-        }
+        Self::new_genesis_account(account_config::association_address())
     }
 
     /// Returns the address of the account. This is a hash of the public key the account was created

--- a/language/functional_tests/src/config/global.rs
+++ b/language/functional_tests/src/config/global.rs
@@ -5,7 +5,8 @@
 // A config entry starts with "//!", differentiating it from a directive.
 
 use crate::errors::*;
-use language_e2e_tests::account::AccountData;
+use crate::genesis_accounts::make_genesis_accounts;
+use language_e2e_tests::account::{Account, AccountData};
 use std::{
     collections::{btree_map, BTreeMap},
     str::FromStr,
@@ -71,6 +72,7 @@ impl FromStr for Entry {
 pub struct Config {
     /// A map from account names to account data
     pub accounts: BTreeMap<String, AccountData>,
+    pub genesis_accounts: BTreeMap<String, Account>,
 }
 
 impl Config {
@@ -104,6 +106,16 @@ impl Config {
         if let btree_map::Entry::Vacant(entry) = accounts.entry("default".to_string()) {
             entry.insert(AccountData::new(DEFAULT_BALANCE, 0));
         }
-        Ok(Config { accounts })
+        Ok(Config {
+            accounts,
+            genesis_accounts: make_genesis_accounts(),
+        })
+    }
+
+    pub fn get_account_for_name(&self, name: &str) -> Option<&Account> {
+        self.accounts
+            .get(name)
+            .map(|account_data| account_data.account())
+            .or_else(|| self.genesis_accounts.get(name))
     }
 }

--- a/language/functional_tests/src/config/transaction.rs
+++ b/language/functional_tests/src/config/transaction.rs
@@ -117,7 +117,9 @@ impl Config {
             match entry {
                 Entry::Sender(name) => match sender {
                     None => {
-                        if config.accounts.contains_key(name) {
+                        if config.accounts.contains_key(name)
+                            || config.genesis_accounts.contains_key(name)
+                        {
                             sender = Some(name.to_string())
                         } else {
                             return Err(ErrorKind::Other(format!(

--- a/language/functional_tests/src/genesis_accounts.rs
+++ b/language/functional_tests/src/genesis_accounts.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use language_e2e_tests::account::Account;
+use std::collections::BTreeMap;
+
+// These are special-cased since they are generated in genesis, and therefore we don't want
+// their account states to be generated.
+pub const ASSOCIATION_NAME: &str = "association";
+
+pub fn make_genesis_accounts() -> BTreeMap<String, Account> {
+    let mut m = BTreeMap::new();
+    m.insert(ASSOCIATION_NAME.to_string(), Account::new_association());
+    m
+}

--- a/language/functional_tests/src/lib.rs
+++ b/language/functional_tests/src/lib.rs
@@ -8,6 +8,7 @@ pub mod checker;
 pub mod config;
 pub mod errors;
 pub mod evaluator;
+mod genesis_accounts;
 pub mod utils;
 
 #[cfg(test)]

--- a/language/functional_tests/tests/testsuite/transactions/tx_assoc.mvir
+++ b/language/functional_tests/tests/testsuite/transactions/tx_assoc.mvir
@@ -1,0 +1,20 @@
+//! sender: association
+main() {
+    assert(get_txn_sender() == 0xA550C18, 0);
+    return;
+}
+
+//! new-transaction
+main() {
+    assert(get_txn_sender() != 0xA550C18, 1);
+    return;
+}
+
+//! new-transaction
+//! account: alice
+//! sender: alice
+main() {
+    assert(get_txn_sender() != 0xA550C18, 2);
+    assert({{alice}} != 0xA550C18, 3);
+    return;
+}


### PR DESCRIPTION
This only adds the association address at the moment, but this is easily
extensible to allow us to send transactions from other accounts created
in genesis as well.

This functionality is needed for testing out distribution of transaction fees, and probably a whole slew of other things that will eventually need to be restricted to only being sent from accounts defined in genesis. 


## Test Plan
Normal tests, additional test to make sure that we are sending from the association address when we specify it. 