### PR TITLE
[cli] Add a verbose flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,7 @@ version = "0.1.0"
 dependencies = [
  "admission_control_proto 0.1.0",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.1.0",
  "crash_handler 0.1.0",
  "crypto 0.1.0",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.1.1"
+chrono = "0.4.7"
 futures = "0.1.28"
 grpcio = { version = "0.4.4", default-features = false, features = ["protobuf-codec"] }
 hex = "0.3.2"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use chrono::prelude::{SecondsFormat, Utc};
 use client::{client_proxy::ClientProxy, commands::*};
 use logger::set_default_global_logger;
 use rustyline::{config::CompletionType, error::ReadlineError, Config, Editor};
@@ -48,6 +49,9 @@ struct Args {
     /// If set, client will sync with validator during wallet recovery.
     #[structopt(short = "r", long = "sync")]
     pub sync: bool,
+    /// Verbose output.
+    #[structopt(short = "v", long = "verbose")]
+    pub verbose: bool,
 }
 
 fn main() -> std::io::Result<()> {
@@ -99,7 +103,12 @@ fn main() -> std::io::Result<()> {
                     continue;
                 }
                 match alias_to_cmd.get(&params[0]) {
-                    Some(cmd) => cmd.execute(&mut client_proxy, &params),
+                    Some(cmd) => {
+                        if args.verbose {
+                            println!("{}", Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true));
+                        }
+                        cmd.execute(&mut client_proxy, &params);
+                    }
                     None => match params[0] {
                         "quit" | "q!" => break,
                         "help" | "h" => print_help(&cli_info, &commands),

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -12,17 +12,28 @@ source "$HOME/.cargo/env"
 SCRIPT_PATH="$(dirname $0)"
 
 RUN_PARAMS="--host ac.testnet.libra.org --port 8000 -s $SCRIPT_PATH/consensus_peers.config.toml"
+RELEASE=""
 
-case $1 in
-    -h | --help)
-        print_help;exit 0;;
-    -r | --release)
-        echo "Building and running client in release mode."
-        cargo run -p client --release -- $RUN_PARAMS
-        ;;
-    '')
-        echo "Building and running client in debug mode."
-        cargo run -p client -- $RUN_PARAMS
-        ;;
-    *) echo "Invalid option"; print_help; exit 0;
-esac
+while [[ ! -z "$1" ]]; do
+	case "$1" in
+		-h | --help)
+			print_help;exit 0;;
+		-r | --release)
+			RELEASE="--release"
+			;;
+		--)
+			shift
+			break
+			;;
+		*) echo "Invalid option"; print_help; exit 0;
+	esac
+	shift
+done
+
+if [ -z "$RELEASE" ]; then
+	echo "Building and running client in debug mode."
+else
+	echo "Building and running client in release mode."
+fi
+
+cargo run -p client $RELEASE -- $RUN_PARAMS "$@"


### PR DESCRIPTION
## Motivation

Debugging CLI interaction with the testnet service can be complicated by a lack of output to help associate CLI and server activity.  This PR adds a `--verbose | -v` CLI flag to print a UTC timestamp for every CLI command.

The verbose flag (and additional CLI flags) may be passed through
`start_cli_testnet.sh` by passing them after `--`. (See example in the test plan.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

:+1:

## Test Plan

Manual testing without adding flags:
```
$ ./scripts/cli/start_cli_testnet.sh
(snip)
libra% a c
>> Creating/retrieving next account from wallet
Created/retrieved account #0 address 657c04130b1c03d910f5b211548066fb9c2266da9d69e1224662487312c3a679
libra% a m 0 100
>> Minting coins
Mint request submitted
```

With the verbose flag:
```
$ ./scripts/cli/start_cli_testnet.sh -- -v
(snip)
libra% a c
2019-10-02T18:41:31Z
>> Creating/retrieving next account from wallet
Created/retrieved account #0 address 657c04130b1c03d910f5b211548066fb9c2266da9d69e1224662487312c3a679
libra% a m 0 100
2019-10-02T18:41:34Z
>> Minting coins
Mint request submitted
```