### PR TITLE
[mempool] retire sequence_cache_capacity setting

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -514,7 +514,6 @@ pub struct MempoolConfig {
     pub capacity: usize,
     // max number of transactions per user in Mempool
     pub capacity_per_user: usize,
-    pub sequence_cache_capacity: usize,
     pub system_transaction_timeout_secs: u64,
     pub system_transaction_gc_interval_ms: u64,
     pub mempool_service_port: u16,
@@ -528,9 +527,8 @@ impl Default for MempoolConfig {
             shared_mempool_tick_interval_ms: 50,
             shared_mempool_batch_size: 100,
             shared_mempool_max_concurrent_inbound_syncs: 100,
-            capacity: 10_000_000,
+            capacity: 1_000_000,
             capacity_per_user: 100,
-            sequence_cache_capacity: 1000,
             system_transaction_timeout_secs: 86400,
             address: "localhost".to_string(),
             mempool_service_port: 6182,

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -39,7 +39,7 @@ impl Mempool {
     pub(crate) fn new(config: &NodeConfig) -> Self {
         Mempool {
             transactions: TransactionStore::new(&config.mempool),
-            sequence_number_cache: LruCache::new(config.mempool.sequence_cache_capacity),
+            sequence_number_cache: LruCache::new(config.mempool.capacity),
             metrics_cache: TtlCache::new(config.mempool.capacity),
             system_transaction_timeout: Duration::from_secs(
                 config.mempool.system_transaction_timeout_secs,


### PR DESCRIPTION
in worst case scenario number of unique accounts equals to number of all transactions in mempool
so it should be equal to capacity
