### PR TITLE
[e2e_test] Get rid of the CI diff compare check for genesis blob change.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "vm_genesis 0.1.0",
  "vm_runtime 0.1.0",
  "vm_runtime_types 0.1.0",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -29,6 +29,7 @@ proto_conv = { path = "../../common/proto_conv", features = ["derive"] }
 config =  { path = "../../config" }
 logger = { path = "../../common/logger" }
 stdlib = { path = "../stdlib" }
+walkdir = "2.2.9"
 
 [dev-dependencies]
 types = { path = "../../types", features = ["testing"] }

--- a/language/e2e_tests/src/data_store.rs
+++ b/language/e2e_tests/src/data_store.rs
@@ -18,6 +18,7 @@ use types::{
 };
 use vm::{errors::*, CompiledModule};
 use vm_runtime::data_cache::RemoteCache;
+use walkdir::WalkDir;
 
 lazy_static! {
     /// The write set encoded in the genesis transaction.
@@ -35,12 +36,15 @@ lazy_static! {
         base_path.pop();
         base_path.push("terraform/validator-sets/");
 
-        let files = std::fs::read_dir(base_path).unwrap();
-        files
-            .filter_map(std::io::Result::ok)
+        let files = WalkDir::new(base_path)
+            .into_iter()
+            .filter_map(|f| f.ok())
             .filter(|f| f.path().ends_with("genesis.blob"))
-            .map(|f| load_genesis(f.path()))
-            .collect()
+            .map(|f| load_genesis(f.path().to_path_buf()))
+            .collect::<Vec<_>>();
+
+        assert!(!files.is_empty());
+        files
     };
 }
 

--- a/language/e2e_tests/src/tests/mint.rs
+++ b/language/e2e_tests/src/tests/mint.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::executor::FakeExecutor;
 use crate::{
     account::{Account, AccountData},
     common_transactions::mint_txn,
-    executor::test_all_genesis,
     gas_costs::TXN_RESERVED,
     transaction_status_eq,
 };
@@ -16,91 +16,94 @@ use types::{
 #[test]
 fn mint_to_existing() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
-        let genesis_account = Account::new_association();
+    // We can't run mint test on terraform genesis as we don't have the private key to sign the
+    // mint transaction.
+    let mut executor = FakeExecutor::from_genesis_file();
+    let genesis_account = Account::new_association();
 
-        // create and publish a sender with 1_000_000 coins
-        let receiver = AccountData::new(1_000_000, 10);
-        executor.add_account_data(&receiver);
+    // create and publish a sender with 1_000_000 coins
+    let receiver = AccountData::new(1_000_000, 10);
+    executor.add_account_data(&receiver);
 
-        let mint_amount = 1_000;
-        let txn = mint_txn(&genesis_account, receiver.account(), 1, mint_amount);
+    let mint_amount = 1_000;
+    let txn = mint_txn(&genesis_account, receiver.account(), 1, mint_amount);
 
-        // execute transaction
-        let txns: Vec<SignedTransaction> = vec![txn];
-        let output = executor.execute_block(txns);
-        let txn_output = output.get(0).expect("must have a transaction output");
-        assert_eq!(
-            output[0].status(),
-            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-        );
-        println!("write set {:?}", txn_output.write_set());
-        executor.apply_write_set(txn_output.write_set());
+    // execute transaction
+    let txns: Vec<SignedTransaction> = vec![txn];
+    let output = executor.execute_block(txns);
+    let txn_output = output.get(0).expect("must have a transaction output");
+    assert_eq!(
+        output[0].status(),
+        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+    );
+    println!("write set {:?}", txn_output.write_set());
+    executor.apply_write_set(txn_output.write_set());
 
-        // check that numbers in stored DB are correct
-        let gas = txn_output.gas_used();
-        let sender_balance = 1_000_000_000 - gas;
-        let receiver_balance = 1_000_000 + mint_amount;
+    // check that numbers in stored DB are correct
+    let gas = txn_output.gas_used();
+    let sender_balance = 1_000_000_000 - gas;
+    let receiver_balance = 1_000_000 + mint_amount;
 
-        let updated_sender = executor
-            .read_account_resource(&genesis_account)
-            .expect("sender must exist");
-        let updated_receiver = executor
-            .read_account_resource(receiver.account())
-            .expect("receiver must exist");
-        assert_eq!(sender_balance, updated_sender.balance());
-        assert_eq!(receiver_balance, updated_receiver.balance());
-        assert_eq!(2, updated_sender.sequence_number());
-        assert_eq!(10, updated_receiver.sequence_number());
-    });
+    let updated_sender = executor
+        .read_account_resource(&genesis_account)
+        .expect("sender must exist");
+    let updated_receiver = executor
+        .read_account_resource(receiver.account())
+        .expect("receiver must exist");
+    assert_eq!(sender_balance, updated_sender.balance());
+    assert_eq!(receiver_balance, updated_receiver.balance());
+    assert_eq!(2, updated_sender.sequence_number());
+    assert_eq!(10, updated_receiver.sequence_number());
 }
 
 #[test]
 fn mint_to_new_account() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
-        let genesis_account = Account::new_association();
+    // We can't run mint test on terraform genesis as we don't have the private key to sign the
+    // mint transaction.
 
-        // create and publish a sender with TXN_RESERVED coins
-        let new_account = Account::new();
+    let mut executor = FakeExecutor::from_genesis_file();
+    let genesis_account = Account::new_association();
 
-        let mint_amount = TXN_RESERVED;
-        let txn = mint_txn(&genesis_account, &new_account, 1, mint_amount);
+    // create and publish a sender with TXN_RESERVED coins
+    let new_account = Account::new();
 
-        // execute transaction
-        let txns: Vec<SignedTransaction> = vec![txn];
-        let output = executor.execute_block(txns);
-        let txn_output = output.get(0).expect("must have a transaction output");
-        assert!(transaction_status_eq(
-            &output[0].status(),
-            &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
-        ));
-        executor.apply_write_set(txn_output.write_set());
+    let mint_amount = TXN_RESERVED;
+    let txn = mint_txn(&genesis_account, &new_account, 1, mint_amount);
 
-        // check that numbers in stored DB are correct
-        let gas = txn_output.gas_used();
-        let sender_balance = 1_000_000_000 - gas;
-        let receiver_balance = mint_amount;
+    // execute transaction
+    let txns: Vec<SignedTransaction> = vec![txn];
+    let output = executor.execute_block(txns);
+    let txn_output = output.get(0).expect("must have a transaction output");
+    assert!(transaction_status_eq(
+        &output[0].status(),
+        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+    ));
+    executor.apply_write_set(txn_output.write_set());
 
-        let updated_sender = executor
-            .read_account_resource(&genesis_account)
-            .expect("sender must exist");
-        let updated_receiver = executor
-            .read_account_resource(&new_account)
-            .expect("receiver must exist");
-        assert_eq!(sender_balance, updated_sender.balance());
-        assert_eq!(receiver_balance, updated_receiver.balance());
-        assert_eq!(2, updated_sender.sequence_number());
-        assert_eq!(0, updated_receiver.sequence_number());
+    // check that numbers in stored DB are correct
+    let gas = txn_output.gas_used();
+    let sender_balance = 1_000_000_000 - gas;
+    let receiver_balance = mint_amount;
 
-        // Mint can only be called from genesis address;
-        let txn = mint_txn(&new_account, &new_account, 0, mint_amount);
-        let txns: Vec<SignedTransaction> = vec![txn];
-        let output = executor.execute_block(txns);
+    let updated_sender = executor
+        .read_account_resource(&genesis_account)
+        .expect("sender must exist");
+    let updated_receiver = executor
+        .read_account_resource(&new_account)
+        .expect("receiver must exist");
+    assert_eq!(sender_balance, updated_sender.balance());
+    assert_eq!(receiver_balance, updated_receiver.balance());
+    assert_eq!(2, updated_sender.sequence_number());
+    assert_eq!(0, updated_receiver.sequence_number());
 
-        assert!(transaction_status_eq(
-            &output[0].status(),
-            &TransactionStatus::Keep(VMStatus::new(StatusCode::MISSING_DATA))
-        ));
-    });
+    // Mint can only be called from genesis address;
+    let txn = mint_txn(&new_account, &new_account, 0, mint_amount);
+    let txns: Vec<SignedTransaction> = vec![txn];
+    let output = executor.execute_block(txns);
+
+    assert!(transaction_status_eq(
+        &output[0].status(),
+        &TransactionStatus::Keep(VMStatus::new(StatusCode::MISSING_DATA))
+    ));
 }

--- a/scripts/circle_validate_configs.sh
+++ b/scripts/circle_validate_configs.sh
@@ -19,7 +19,7 @@ cd terraform/validator-sets
 # Notice: This is not comparing all configs yet.
 
 # Cleanup files we do compare yet
-git checkout -- '**/seed_peers.config.toml'
+git checkout -- '**/seed_peers.config.toml' '**/genesis.blob'
 git update-index --refresh
 
 echo "--- Compare configs ---"


### PR DESCRIPTION
## Motivation

This is a followup for #1056. Currently the CI is still comparing the genesis with the freshly generated ones. This PR should get rid of the check. One extra assertion is added to make sure the testsuite indeed finds the genesis that it needs to be tested against.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

#1056 
