### PR TITLE
[language] source code map for bytecode MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,21 +383,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecode_source_map"
-version = "0.1.0"
-dependencies = [
- "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_ext 0.1.0",
- "ir_to_bytecode_syntax 0.1.0",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "types 0.1.0",
- "vm 0.1.0",
-]
-
-[[package]]
-name = "bytecode_verifier"
+name = "bytecode-verifier"
 version = "0.1.0"
 dependencies = [
  "failure_ext 0.1.0",
@@ -407,6 +393,21 @@ dependencies = [
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
  "vm_runtime_types 0.1.0",
+]
+
+[[package]]
+name = "bytecode_source_map"
+version = "0.1.0"
+dependencies = [
+ "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_ext 0.1.0",
+ "ir_to_bytecode_syntax 0.1.0",
+ "libra-types 0.1.0",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm 0.1.0",
 ]
 
 [[package]]
@@ -684,8 +685,8 @@ dependencies = [
 name = "compiler"
 version = "0.1.0"
 dependencies = [
+ "bytecode-verifier 0.1.0",
  "bytecode_source_map 0.1.0",
- "bytecode_verifier 0.1.0",
  "failure_ext 0.1.0",
  "ir_to_bytecode 0.1.0",
  "libra-types 0.1.0",
@@ -4263,8 +4264,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stdlib"
 version = "0.1.0"
 dependencies = [
+ "bytecode-verifier 0.1.0",
  "bytecode_source_map 0.1.0",
- "bytecode_verifier 0.1.0",
  "ir_to_bytecode 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecode-verifier"
+name = "bytecode_source_map"
+version = "0.1.0"
+dependencies = [
+ "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_ext 0.1.0",
+ "ir_to_bytecode_syntax 0.1.0",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "types 0.1.0",
+ "vm 0.1.0",
+]
+
+[[package]]
+name = "bytecode_verifier"
 version = "0.1.0"
 dependencies = [
  "failure_ext 0.1.0",
@@ -653,6 +667,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -668,7 +684,8 @@ dependencies = [
 name = "compiler"
 version = "0.1.0"
 dependencies = [
- "bytecode-verifier 0.1.0",
+ "bytecode_source_map 0.1.0",
+ "bytecode_verifier 0.1.0",
  "failure_ext 0.1.0",
  "ir_to_bytecode 0.1.0",
  "libra-types 0.1.0",
@@ -1859,6 +1876,7 @@ dependencies = [
 name = "ir_to_bytecode"
 version = "0.1.0"
 dependencies = [
+ "bytecode_source_map 0.1.0",
  "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_ext 0.1.0",
@@ -4245,7 +4263,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stdlib"
 version = "0.1.0"
 dependencies = [
- "bytecode-verifier 0.1.0",
+ "bytecode_source_map 0.1.0",
+ "bytecode_verifier 0.1.0",
  "ir_to_bytecode 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "language/e2e_tests",
     "language/tools/cost-synthesis",
     "language/tools/test-generation",
+    "language/compiler/bytecode_source_map",
     "language/stackless_bytecode/bytecode-to-boogie",
     "language/stackless_bytecode/generator",
     "language/vm",

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 bytecode-verifier = { path = "../bytecode-verifier" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 ir_to_bytecode = { path = "ir_to_bytecode" }
+bytecode_source_map = { path = "bytecode_source_map" }
 stdlib = { path = "../stdlib" }
 libra-types = { path = "../../types" }
 vm = { path = "../vm" }

--- a/language/compiler/bytecode_source_map/Cargo.toml
+++ b/language/compiler/bytecode_source_map/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bytecode_source_map"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+failure = { path = "../../../common/failure_ext", package = "failure_ext" }
+ir_to_bytecode_syntax = { path = "../ir_to_bytecode/syntax" }
+types = { path = "../../../types" }
+vm = { path = "../../vm" }
+codespan = "0.2.1"
+codespan-reporting = "0.2.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+types = { path = "../../../types", features = ["testing"] }

--- a/language/compiler/bytecode_source_map/Cargo.toml
+++ b/language/compiler/bytecode_source_map/Cargo.toml
@@ -9,12 +9,13 @@ edition = "2018"
 [dependencies]
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 ir_to_bytecode_syntax = { path = "../ir_to_bytecode/syntax" }
-types = { path = "../../../types" }
+libra-types = { path = "../../../types" }
 vm = { path = "../../vm" }
 codespan = "0.2.1"
 codespan-reporting = "0.2.1"
+structopt = "0.3.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-types = { path = "../../../types", features = ["testing"] }
+libra-types = { path = "../../../types", features = ["testing"] }

--- a/language/compiler/bytecode_source_map/src/lib.rs
+++ b/language/compiler/bytecode_source_map/src/lib.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod mapping;
+pub mod marking;
 pub mod source_map;
 pub mod utils;

--- a/language/compiler/bytecode_source_map/src/lib.rs
+++ b/language/compiler/bytecode_source_map/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod mapping;
+pub mod source_map;
+pub mod utils;

--- a/language/compiler/bytecode_source_map/src/main.rs
+++ b/language/compiler/bytecode_source_map/src/main.rs
@@ -1,0 +1,98 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use bytecode_source_map::mapping::{SourceMapping, SourceMappingOptions};
+use bytecode_source_map::utils::module_source_map_from_file;
+use ir_to_bytecode_syntax::ast::Loc;
+use libra_types::transaction::Module;
+use serde_json;
+use std::fs;
+use std::path::Path;
+use structopt::StructOpt;
+use vm::file_format::{CompiledModule, CompiledScript};
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Move Bytecode Disassembler",
+    about = "Move IR bytecode disassembler."
+)]
+struct Args {
+    /// Shows only public functions.
+    #[structopt(short = "p", long = "public")]
+    pub only_public: bool,
+
+    /// Prints out the disassembled bytecodes for each function.
+    #[structopt(short = "c", long = "code")]
+    pub print_code: bool,
+
+    /// The path to the bytecode file to disassemble; let's call it file.mv. We assume that two
+    /// other files reside under the same directory: a source map file.mvsm (possibly) and the Move
+    /// IR source code file.mvir.
+    #[structopt(short = "s", long = "script")]
+    pub is_script: bool,
+
+    /// The path to the bytecode file.
+    #[structopt(short = "b", long = "bytecode")]
+    pub bytecode_file_path: String,
+}
+
+fn main() {
+    let args = Args::from_args();
+
+    let mvir_extension = "mvir";
+    let mv_bytecode_extension = "mv";
+    let source_map_extension = "mvsm";
+
+    let source_path = Path::new(&args.bytecode_file_path);
+    let extension = source_path
+        .extension()
+        .expect("Missing file extension for bytecode file");
+    if extension != mv_bytecode_extension {
+        println!(
+            "Bad source file extension {:?}; expected {}",
+            extension, mv_bytecode_extension
+        );
+        std::process::exit(1);
+    }
+
+    let bytecode_source =
+        fs::read_to_string(args.bytecode_file_path.clone()).expect("Unable to read bytecode file");
+    let module_bytes: Module = serde_json::from_str(bytecode_source.as_str())
+        .expect("Unable to deserialize bytecode file");
+
+    let ir_source =
+        fs::read_to_string(Path::new(&args.bytecode_file_path).with_extension(mvir_extension)).ok();
+    let source_map = module_source_map_from_file::<Loc>(
+        &Path::new(&args.bytecode_file_path).with_extension(source_map_extension),
+    );
+
+    let mut mapping_options = SourceMappingOptions::new();
+
+    if args.print_code {
+        mapping_options.print_code();
+    }
+
+    if args.only_public {
+        mapping_options.only_public();
+    }
+
+    let mut source_mapping = if args.is_script {
+        let compiled_script = CompiledScript::deserialize(module_bytes.code())
+            .expect("Script blob can't be deserialized");
+        SourceMapping::new_from_script(source_map, compiled_script, mapping_options)
+    } else {
+        let compiled_module = CompiledModule::deserialize(module_bytes.code())
+            .expect("Module blob can't be deserialized");
+        SourceMapping::new(source_map, compiled_module, mapping_options)
+    };
+
+    if let Some(source_code) = ir_source {
+        source_mapping.with_source_code(source_code);
+    }
+
+    let dissassemble_string = source_mapping
+        .disassemble()
+        .expect("Unable to dissassemble");
+
+    println!("{}", dissassemble_string);
+}

--- a/language/compiler/bytecode_source_map/src/mapping.rs
+++ b/language/compiler/bytecode_source_map/src/mapping.rs
@@ -1,0 +1,27 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::source_map::ModuleSourceMap;
+use vm::file_format::{CompiledModule, CompiledScript};
+
+// An object that associates source code with compiled bytecode and source map.
+struct SourceMapping<T> {
+    source_code: String,
+    source_map: ModuleSourceMap,
+    bytecode: T,
+}
+
+pub type MappedModule = SourceMapping<CompiledModule>;
+pub type MappedScript = SourceMapping<CompiledScript>;
+// TODO: Add source mapping for compiled programs
+//pub type MappedProgram = SourceMaping<CompiledProgram>;
+
+impl<T> SourceMapping<T> {
+    pub fn new(source_code: String, source_map: ModuleSourceMap, bytecode: T) -> Self {
+        Self {
+            source_code,
+            source_map,
+            bytecode,
+        }
+    }
+}

--- a/language/compiler/bytecode_source_map/src/mapping.rs
+++ b/language/compiler/bytecode_source_map/src/mapping.rs
@@ -1,27 +1,337 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::source_map::ModuleSourceMap;
-use vm::file_format::{CompiledModule, CompiledScript};
+use crate::marking::MarkedSourceMapping;
+use crate::source_map::{ModuleSourceMap, SourceName};
+use failure::prelude::*;
+use libra_types::identifier::IdentStr;
+use vm::access::ModuleAccess;
+use vm::file_format::{
+    CompiledModule, CompiledScript, FieldDefinitionIndex, FunctionDefinition,
+    FunctionDefinitionIndex, Kind, SignatureToken, StructDefinition, StructDefinitionIndex,
+    StructFieldInformation, TableIndex, TypeSignature,
+};
 
-// An object that associates source code with compiled bytecode and source map.
-struct SourceMapping<T> {
-    source_code: String,
-    source_map: ModuleSourceMap,
-    bytecode: T,
+/// Holds the various options that we support while disassembling code.
+#[derive(Debug, Default)]
+pub struct SourceMappingOptions {
+    /// Only print public functions
+    pub only_public: bool,
+
+    // TODO: Need to implement this.
+    /// Print the bytecode for the instructions within the function.
+    pub print_code: bool,
 }
 
-pub type MappedModule = SourceMapping<CompiledModule>;
-pub type MappedScript = SourceMapping<CompiledScript>;
-// TODO: Add source mapping for compiled programs
-//pub type MappedProgram = SourceMaping<CompiledProgram>;
+/// An object that associates source code with compiled bytecode and source map.
+#[derive(Debug)]
+pub struct SourceMapping<Location: Clone + Eq> {
+    // The various options that we can set for disassembly.
+    options: SourceMappingOptions,
 
-impl<T> SourceMapping<T> {
-    pub fn new(source_code: String, source_map: ModuleSourceMap, bytecode: T) -> Self {
+    // The resulting bytecode from compiling the source map
+    bytecode: CompiledModule,
+
+    // The source map for the bytecode made w.r.t. to the `source_code`
+    source_map: ModuleSourceMap<Location>,
+
+    // The source code for the bytecode. This is not required for disassembly, but it is required
+    // for being able to print out corresponding source code for marked functions and structs.
+    // Unused for now, this will be used when we start printing function/struct markings
+    _source_code: Option<String>,
+
+    // Function and struct markings. These are used to lift up annotations/messages on the bytecode
+    // into the disassembled program and/or IR source code.
+    marks: Option<MarkedSourceMapping>,
+}
+
+impl SourceMappingOptions {
+    pub fn new() -> Self {
         Self {
-            source_code,
+            only_public: false,
+            print_code: false,
+        }
+    }
+
+    pub fn only_public(&mut self) {
+        self.only_public = true;
+    }
+
+    pub fn print_code(&mut self) {
+        self.print_code = true;
+    }
+}
+
+impl<Location: Clone + Eq> SourceMapping<Location> {
+    pub fn new(
+        source_map: ModuleSourceMap<Location>,
+        bytecode: CompiledModule,
+        options: SourceMappingOptions,
+    ) -> Self {
+        Self {
+            options,
             source_map,
             bytecode,
+            _source_code: None,
+            marks: None,
         }
+    }
+
+    pub fn new_from_script(
+        source_map: ModuleSourceMap<Location>,
+        bytecode: CompiledScript,
+        options: SourceMappingOptions,
+    ) -> Self {
+        Self::new(source_map, bytecode.into_module(), options)
+    }
+
+    pub fn with_marks(&mut self, marks: MarkedSourceMapping) {
+        self.marks = Some(marks);
+    }
+
+    pub fn with_source_code(&mut self, source_code: String) {
+        self._source_code = Some(source_code);
+    }
+
+    //***************************************************************************
+    // Helpers
+    //***************************************************************************
+
+    fn get_function_def(
+        &self,
+        function_definition_index: FunctionDefinitionIndex,
+    ) -> Result<&FunctionDefinition> {
+        if function_definition_index.0 as usize >= self.bytecode.function_defs().len() {
+            bail!("Invalid function definition index supplied when marking function")
+        }
+        Ok(self.bytecode.function_def_at(function_definition_index))
+    }
+
+    fn get_struct_def(
+        &self,
+        struct_definition_index: StructDefinitionIndex,
+    ) -> Result<&StructDefinition> {
+        if struct_definition_index.0 as usize >= self.bytecode.struct_defs().len() {
+            bail!("Invalid struct definition index supplied when marking struct")
+        }
+        Ok(self.bytecode.struct_def_at(struct_definition_index))
+    }
+
+    // These need to be in the context of a function or a struct definition since type parameters
+    // can refer to function/struct type parameters.
+    fn disassemble_sig_tok(
+        &self,
+        sig_tok: SignatureToken,
+        type_param_context: &[SourceName<Location>],
+    ) -> Result<String> {
+        Ok(match sig_tok {
+            SignatureToken::Bool => "bool".to_string(),
+            SignatureToken::U64 => "u64".to_string(),
+            SignatureToken::String => "string".to_string(),
+            SignatureToken::ByteArray => "bytearray".to_string(),
+            SignatureToken::Address => "address".to_string(),
+            SignatureToken::Struct(struct_handle_idx, _) => self
+                .bytecode
+                .identifier_at(self.bytecode.struct_handle_at(struct_handle_idx).name)
+                .to_string(),
+            SignatureToken::Reference(sig_tok) => format!(
+                "&{}",
+                self.disassemble_sig_tok(*sig_tok, type_param_context)?
+            ),
+            SignatureToken::MutableReference(sig_tok) => format!(
+                "&mut {}",
+                self.disassemble_sig_tok(*sig_tok, type_param_context)?
+            ),
+            SignatureToken::TypeParameter(ty_param_index) => type_param_context
+                .get(ty_param_index as usize)
+                .ok_or_else(|| {
+                    format_err!(
+                        "Type parameter index out of bounds while disassembling type signature"
+                    )
+                })?
+                .0
+                .to_string(),
+        })
+    }
+
+    //***************************************************************************
+    // Disassemblers
+    //***************************************************************************
+
+    fn disassemble_type_formals(
+        source_map_ty_params: &[SourceName<Location>],
+        kinds: &[Kind],
+    ) -> String {
+        let ty_params: Vec<String> = source_map_ty_params
+            .iter()
+            .zip(kinds.iter())
+            .map(|((name, _), kind)| format!("{}: {:#?}", name.as_str(), kind))
+            .collect();
+        if ty_params.is_empty() {
+            "".to_string()
+        } else {
+            format!("<{}>", ty_params.join(", "))
+        }
+    }
+
+    pub fn disassemble_function_def(
+        &self,
+        function_definition_index: FunctionDefinitionIndex,
+    ) -> Result<String> {
+        let function_definition = self.get_function_def(function_definition_index)?;
+        let function_handle = self
+            .bytecode
+            .function_handle_at(function_definition.function);
+        let function_signature = self
+            .bytecode
+            .function_signature_at(function_handle.signature);
+
+        let function_source_map = self
+            .source_map
+            .get_function_source_map(function_definition_index)?;
+
+        if self.options.only_public && !function_definition.is_public() {
+            return Ok("".to_string());
+        }
+
+        let visibility_modifier = if function_definition.is_native() {
+            "native "
+        } else if function_definition.is_public() {
+            "public "
+        } else {
+            ""
+        };
+
+        let ty_params = Self::disassemble_type_formals(
+            &function_source_map.type_parameters,
+            &function_signature.type_formals,
+        );
+        let name = self
+            .bytecode
+            .identifier_at(function_handle.name)
+            .to_string();
+        let ret_type: Vec<String> = function_signature
+            .return_types
+            .iter()
+            .cloned()
+            .map(|sig_token| {
+                let sig_tok_str =
+                    self.disassemble_sig_tok(sig_token, &function_source_map.type_parameters)?;
+                Ok(sig_tok_str.to_string())
+            })
+            .collect::<Result<Vec<String>>>()?;
+        let args: Vec<String> = function_signature
+            .arg_types
+            .iter()
+            .zip(function_source_map.locals.iter())
+            .map(|(typ, (name, _))| {
+                let ty_str =
+                    self.disassemble_sig_tok(typ.clone(), &function_source_map.type_parameters)?;
+                Ok(format!("{}: {}", name.to_string(), ty_str))
+            })
+            .collect::<Result<Vec<String>>>()?;
+        Ok(format!(
+            "{visibility_modifier}{name}{ty_params}({args}):{ret_type}",
+            visibility_modifier = visibility_modifier,
+            name = name,
+            ty_params = ty_params,
+            args = &args.join(", "),
+            ret_type = &ret_type.join(" * "),
+        ))
+    }
+
+    // The struct defs will filter out the structs that we print to only be the ones that are
+    // defined in the module in question.
+    pub fn disassemble_struct_def(&self, struct_def_idx: StructDefinitionIndex) -> Result<String> {
+        let struct_definition = self.get_struct_def(struct_def_idx)?;
+        let struct_handle = self
+            .bytecode
+            .struct_handle_at(struct_definition.struct_handle);
+        let struct_source_map = self.source_map.get_struct_source_map(struct_def_idx)?;
+
+        let field_info: Option<Vec<(&IdentStr, &TypeSignature)>> = match struct_definition
+            .field_information
+        {
+            StructFieldInformation::Native => None,
+            StructFieldInformation::Declared {
+                field_count,
+                fields,
+            } => Some(
+                (fields.0..fields.0 + field_count)
+                    .map(|i| {
+                        let field_definition = self.bytecode.field_def_at(FieldDefinitionIndex(i));
+                        let type_sig = self.bytecode.type_signature_at(field_definition.signature);
+                        let field_name = self.bytecode.identifier_at(field_definition.name);
+                        (field_name, type_sig)
+                    })
+                    .collect(),
+            ),
+        };
+
+        let native = if field_info.is_none() { "native " } else { "" };
+
+        let nominal_name = if struct_handle.is_nominal_resource {
+            "resource"
+        } else {
+            "struct"
+        };
+
+        let name = self.bytecode.identifier_at(struct_handle.name).to_string();
+
+        let ty_params = Self::disassemble_type_formals(
+            &struct_source_map.type_parameters,
+            &struct_handle.type_formals,
+        );
+        let mut fields = match field_info {
+            None => vec![],
+            Some(field_info) => field_info
+                .iter()
+                .map(|(name, ty)| {
+                    let ty_str =
+                        self.disassemble_sig_tok(ty.0.clone(), &struct_source_map.type_parameters)?;
+                    Ok(format!("{}: {}", name.to_string(), ty_str))
+                })
+                .collect::<Result<Vec<String>>>()?,
+        };
+
+        if let Some(first_elem) = fields.first_mut() {
+            first_elem.insert_str(0, "{\n\t");
+        }
+
+        if let Some(last_elem) = fields.last_mut() {
+            last_elem.push_str("\n}");
+        }
+
+        Ok(format!(
+            "{native}{nominal_name} {name}{ty_params} {fields}",
+            native = native,
+            nominal_name = nominal_name,
+            name = name,
+            ty_params = ty_params,
+            fields = &fields.join(",\n\t"),
+        ))
+    }
+
+    pub fn disassemble(&self) -> Result<String> {
+        let name = format!(
+            "{}.{}",
+            self.source_map.module_name.0,
+            self.source_map.module_name.1.to_string()
+        );
+
+        let struct_defs: Vec<String> = (0..self.bytecode.struct_defs().len())
+            .map(|i| self.disassemble_struct_def(StructDefinitionIndex(i as TableIndex)))
+            .collect::<Result<Vec<String>>>()?;
+
+        let function_defs: Vec<String> = (0..self.bytecode.function_defs().len())
+            .map(|i| self.disassemble_function_def(FunctionDefinitionIndex(i as TableIndex)))
+            .collect::<Result<Vec<String>>>()?;
+
+        Ok(format!(
+            "module {name} {{\n{struct_defs}\n\n{function_defs}\n}}",
+            name = name,
+            struct_defs = &struct_defs.join("\n"),
+            function_defs = &function_defs.join("\n")
+        ))
     }
 }

--- a/language/compiler/bytecode_source_map/src/marking.rs
+++ b/language/compiler/bytecode_source_map/src/marking.rs
@@ -1,0 +1,143 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+use vm::file_format::{
+    CodeOffset, FieldDefinitionIndex, FunctionDefinitionIndex, StructDefinitionIndex, TableIndex,
+};
+
+/// A data structure used to track any markings or extra information that is desired to be exposed
+/// in the disassembled function definition. Every marking can have multiple messages associated with it.
+#[derive(Debug, Default)]
+pub struct FunctionMarking {
+    // Code offset markings
+    pub code_offsets: BTreeMap<CodeOffset, Vec<String>>,
+
+    // Type parameters markings
+    pub type_param_offsets: BTreeMap<usize, Vec<String>>,
+}
+
+/// A data structure used to track any markings or extra information that is desired to be exposed
+/// in the disassembled struct definition. Every marking can have multiple messages associated with it.
+#[derive(Debug, Default)]
+pub struct StructMarking {
+    // Field markings
+    pub fields: BTreeMap<FieldDefinitionIndex, Vec<String>>,
+
+    // Type parameter markings
+    pub type_param_offsets: BTreeMap<usize, Vec<String>>,
+}
+
+/// A data structure that contains markings for both functions and structs. This will be used for
+/// printing out error messages and the like.
+#[derive(Debug, Default)]
+pub struct MarkedSourceMapping {
+    // Any function markings
+    function_marks: HashMap<TableIndex, FunctionMarking>,
+
+    // Any struct marking
+    struct_marks: HashMap<TableIndex, StructMarking>,
+}
+
+impl FunctionMarking {
+    pub fn new() -> Self {
+        Self {
+            code_offsets: BTreeMap::new(),
+            type_param_offsets: BTreeMap::new(),
+        }
+    }
+
+    pub fn code_offset(&mut self, code_offset: CodeOffset, message: String) {
+        self.code_offsets
+            .entry(code_offset)
+            .or_insert_with(Vec::new)
+            .push(message)
+    }
+
+    pub fn type_param(&mut self, type_param_index: usize, message: String) {
+        self.type_param_offsets
+            .entry(type_param_index)
+            .or_insert_with(Vec::new)
+            .push(message)
+    }
+}
+
+impl StructMarking {
+    pub fn new() -> Self {
+        Self {
+            fields: BTreeMap::new(),
+            type_param_offsets: BTreeMap::new(),
+        }
+    }
+
+    pub fn field(&mut self, field_index: FieldDefinitionIndex, message: String) {
+        self.fields
+            .entry(field_index)
+            .or_insert_with(Vec::new)
+            .push(message)
+    }
+
+    pub fn type_param(&mut self, type_param_index: usize, message: String) {
+        self.type_param_offsets
+            .entry(type_param_index)
+            .or_insert_with(Vec::new)
+            .push(message)
+    }
+}
+
+impl MarkedSourceMapping {
+    pub fn new() -> Self {
+        Self {
+            function_marks: HashMap::new(),
+            struct_marks: HashMap::new(),
+        }
+    }
+
+    pub fn mark_code_offset(
+        &mut self,
+        function_definition_index: FunctionDefinitionIndex,
+        code_offset: CodeOffset,
+        message: String,
+    ) {
+        self.function_marks
+            .entry(function_definition_index.0)
+            .or_insert_with(FunctionMarking::new)
+            .code_offset(code_offset, message)
+    }
+
+    pub fn mark_function_type_param(
+        &mut self,
+        function_definition_index: FunctionDefinitionIndex,
+        type_param_offset: usize,
+        message: String,
+    ) {
+        self.function_marks
+            .entry(function_definition_index.0)
+            .or_insert_with(FunctionMarking::new)
+            .type_param(type_param_offset, message)
+    }
+
+    pub fn mark_struct_field(
+        &mut self,
+        struct_definition_index: StructDefinitionIndex,
+        field_def_index: FieldDefinitionIndex,
+        message: String,
+    ) {
+        self.struct_marks
+            .entry(struct_definition_index.0)
+            .or_insert_with(StructMarking::new)
+            .field(field_def_index, message)
+    }
+
+    pub fn mark_struct_type_param(
+        &mut self,
+        struct_definition_index: StructDefinitionIndex,
+        type_param_offset: usize,
+        message: String,
+    ) {
+        self.struct_marks
+            .entry(struct_definition_index.0)
+            .or_insert_with(StructMarking::new)
+            .type_param(type_param_offset, message)
+    }
+}

--- a/language/compiler/bytecode_source_map/src/source_map.rs
+++ b/language/compiler/bytecode_source_map/src/source_map.rs
@@ -1,0 +1,254 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use codespan::Span;
+use ir_to_bytecode_syntax::ast::{Loc, QualifiedModuleIdent, Var_};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::ops::Bound;
+use types::account_address::AccountAddress;
+use types::identifier::Identifier;
+use vm::file_format::{
+    CodeOffset, FieldDefinitionIndex, FunctionDefinitionIndex, StructDefinitionIndex, TableIndex,
+};
+use vm::internals::ModuleIndex;
+
+//***************************************************************************
+// Source location mapping
+//***************************************************************************
+
+pub type SourceMap = Vec<ModuleSourceMap>;
+pub type SourceName = (Identifier, Loc);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StructSourceMap {
+    // NB type parameters need to be added in the order of their declaration
+    type_parameters: Vec<SourceName>,
+
+    // NB that fields to a struct source map need to be added in the order of the fields.
+    fields: Vec<SourceName>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FunctionSourceMap {
+    // NB type parameters need to be added in the order of their declaration
+    type_parameters: Vec<SourceName>,
+
+    // The index into the vector is the locals index. The corresponding `(Identifier, Loc)` tuple
+    // is the name and location of the local.
+    locals: Vec<SourceName>,
+
+    // The source location map for the function body.
+    code_map: BTreeMap<CodeOffset, Loc>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModuleSourceMap {
+    // The name <address.module_name> for module that this source map is for
+    module_name: (AccountAddress, Identifier),
+
+    // A mapping of StructDefinitionIndex to source map for each struct/resource
+    struct_map: HashMap<TableIndex, StructSourceMap>,
+
+    // A mapping of FunctionDefinitionIndex to the soure map for that function.
+    function_map: HashMap<TableIndex, FunctionSourceMap>,
+}
+
+impl StructSourceMap {
+    pub fn new() -> Self {
+        Self {
+            type_parameters: Vec::new(),
+            fields: Vec::new(),
+        }
+    }
+
+    pub fn add_type_parameter(&mut self, type_name: SourceName) {
+        self.type_parameters.push(type_name)
+    }
+
+    pub fn get_type_parameter_name(&self, type_parameter_idx: usize) -> Option<SourceName> {
+        self.type_parameters.get(type_parameter_idx).cloned()
+    }
+
+    pub fn add_field(&mut self, field_name: SourceName) {
+        self.fields.push(field_name)
+    }
+
+    pub fn get_field_name(&self, field_index: FieldDefinitionIndex) -> Option<SourceName> {
+        self.fields.get(field_index.into_index()).cloned()
+    }
+}
+
+impl FunctionSourceMap {
+    pub fn new() -> Self {
+        Self {
+            type_parameters: Vec::new(),
+            locals: Vec::new(),
+            code_map: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_type_parameter(&mut self, type_name: SourceName) {
+        self.type_parameters.push(type_name)
+    }
+
+    pub fn get_type_parameter_name(&self, type_parameter_idx: usize) -> Option<SourceName> {
+        self.type_parameters.get(type_parameter_idx).cloned()
+    }
+
+    /// A single source-level instruction may possibly map to a number of bytecode instructions. In
+    /// order to not store a location for each instruction, we instead use a BTreeMap to represent
+    /// a segement map (holding the left-hand-sands of the segments).  Thus, an instruction
+    /// sequence is always marked from the starting point. To determine what part of the source
+    /// code corresponds to a given `CodeOffset` we query to find the element that is the largest
+    /// number less than or equal to the query. This will give us the location for that bytcode
+    /// range.
+    pub fn add_code_mapping(&mut self, start_offset: CodeOffset, location: Loc) {
+        self.code_map.insert(start_offset, location);
+    }
+
+    // NB that locations must be added in order.
+    pub fn add_local_mapping(&mut self, name: Var_) {
+        let loc = name.span;
+        let name = Identifier::from(name.value.name());
+        self.locals.push((name, loc));
+    }
+
+    /// Recall that we are using a segment tree. We therefore lookup the location for the code
+    /// offset by performing a range query for the largest number less than or equal to the code
+    /// offset passed in.
+    pub fn get_code_location(&self, code_offset: CodeOffset) -> Option<Loc> {
+        self.code_map
+            .range((Bound::Unbounded, Bound::Included(&code_offset)))
+            .next_back()
+            .and_then(|(_, vl)| Some(Span::from(vl.clone())))
+    }
+
+    pub fn get_local_name(&self, local_index: u64) -> Option<SourceName> {
+        self.locals.get(local_index as usize).cloned()
+    }
+}
+
+impl ModuleSourceMap {
+    pub fn new(module_name: QualifiedModuleIdent) -> Self {
+        Self {
+            module_name: (module_name.address, module_name.name.into_inner()),
+            struct_map: HashMap::new(),
+            function_map: HashMap::new(),
+        }
+    }
+
+    pub fn add_function_type_parameter_mapping(
+        &mut self,
+        fdef_idx: FunctionDefinitionIndex,
+        name: SourceName,
+    ) {
+        let func_entry = self
+            .function_map
+            .entry(fdef_idx.0)
+            .or_insert_with(|| FunctionSourceMap::new());
+        func_entry.add_type_parameter(name);
+    }
+
+    pub fn get_function_type_parameter_name(
+        &self,
+        fdef_idx: FunctionDefinitionIndex,
+        type_parameter_idx: usize,
+    ) -> Option<SourceName> {
+        self.function_map
+            .get(&fdef_idx.0)
+            .and_then(|function_source_map| {
+                function_source_map.get_type_parameter_name(type_parameter_idx)
+            })
+    }
+
+    pub fn add_code_mapping(
+        &mut self,
+        function_definition_index: FunctionDefinitionIndex,
+        start_offset: CodeOffset,
+        location: Loc,
+    ) {
+        let func_entry = self
+            .function_map
+            .entry(function_definition_index.0)
+            .or_insert_with(|| FunctionSourceMap::new());
+        func_entry.add_code_mapping(start_offset, location);
+    }
+
+    /// Given a function definition and a code offset within that function definition, this returns
+    /// the location in the source code associated with the instruction at that offset.
+    pub fn get_code_location(
+        &self,
+        function_definition_index: &FunctionDefinitionIndex,
+        offset: CodeOffset,
+    ) -> Option<Loc> {
+        self.function_map
+            .get(&function_definition_index.0)
+            .and_then(|function_source_map| function_source_map.get_code_location(offset))
+    }
+
+    pub fn add_local_mapping(&mut self, fdef_idx: FunctionDefinitionIndex, name: Var_) {
+        let func_entry = self
+            .function_map
+            .entry(fdef_idx.0)
+            .or_insert_with(|| FunctionSourceMap::new());
+        func_entry.add_local_mapping(name);
+    }
+
+    pub fn get_local_name(
+        &self,
+        fdef_idx: FunctionDefinitionIndex,
+        index: u64,
+    ) -> Option<SourceName> {
+        self.function_map
+            .get(&fdef_idx.0)
+            .and_then(|function_source_map| function_source_map.get_local_name(index))
+    }
+
+    pub fn add_struct_field_mapping(
+        &mut self,
+        struct_def_idx: StructDefinitionIndex,
+        name: SourceName,
+    ) {
+        let struct_entry = self
+            .struct_map
+            .entry(struct_def_idx.0)
+            .or_insert_with(|| StructSourceMap::new());
+        struct_entry.add_field(name);
+    }
+
+    pub fn get_struct_field_name(
+        &self,
+        struct_def_idx: StructDefinitionIndex,
+        field_idx: FieldDefinitionIndex,
+    ) -> Option<SourceName> {
+        self.struct_map
+            .get(&struct_def_idx.0)
+            .and_then(|struct_source_map| struct_source_map.get_field_name(field_idx))
+    }
+
+    pub fn add_struct_type_parameter_mapping(
+        &mut self,
+        fdef_idx: StructDefinitionIndex,
+        name: SourceName,
+    ) {
+        let struct_entry = self
+            .struct_map
+            .entry(fdef_idx.0)
+            .or_insert_with(|| StructSourceMap::new());
+        struct_entry.add_type_parameter(name);
+    }
+
+    pub fn get_struct_type_parameter_name(
+        &self,
+        fdef_idx: StructDefinitionIndex,
+        type_parameter_idx: usize,
+    ) -> Option<SourceName> {
+        self.struct_map
+            .get(&fdef_idx.0)
+            .and_then(|struct_source_map| {
+                struct_source_map.get_type_parameter_name(type_parameter_idx)
+            })
+    }
+}

--- a/language/compiler/bytecode_source_map/src/utils.rs
+++ b/language/compiler/bytecode_source_map/src/utils.rs
@@ -1,0 +1,20 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::source_map::{ModuleSourceMap, SourceMap};
+use std::fs::File;
+use std::path::Path;
+
+pub fn module_source_map_from_file(filename: &str) -> ModuleSourceMap {
+    let file_path = Path::new(filename);
+    let file = File::open(file_path).expect("Failed to open source map file");
+    serde_json::from_reader(file).expect("Error while reading in source map information")
+}
+
+pub fn source_map_from_file(filename: &str) -> SourceMap {
+    let file_path = Path::new(filename);
+    let file = File::open(file_path).expect("Failed to open source map file");
+    serde_json::from_reader(file).expect("Error while reading in source map information")
+}
+
+//fn display(source_str: &str, span: Loc) { }

--- a/language/compiler/bytecode_source_map/src/utils.rs
+++ b/language/compiler/bytecode_source_map/src/utils.rs
@@ -2,19 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::source_map::{ModuleSourceMap, SourceMap};
+use serde::de::DeserializeOwned;
 use std::fs::File;
 use std::path::Path;
 
-pub fn module_source_map_from_file(filename: &str) -> ModuleSourceMap {
-    let file_path = Path::new(filename);
+pub fn module_source_map_from_file<Location>(file_path: &Path) -> ModuleSourceMap<Location>
+where
+    Location: Clone + Eq + DeserializeOwned,
+{
     let file = File::open(file_path).expect("Failed to open source map file");
     serde_json::from_reader(file).expect("Error while reading in source map information")
 }
 
-pub fn source_map_from_file(filename: &str) -> SourceMap {
-    let file_path = Path::new(filename);
+pub fn source_map_from_file<Location>(file_path: &Path) -> SourceMap<Location>
+where
+    Location: Clone + Eq + DeserializeOwned,
+{
     let file = File::open(file_path).expect("Failed to open source map file");
     serde_json::from_reader(file).expect("Error while reading in source map information")
 }
-
-//fn display(source_str: &str, span: Loc) { }

--- a/language/compiler/ir_to_bytecode/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/Cargo.toml
@@ -14,6 +14,7 @@ failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 ir_to_bytecode_syntax = { path = "syntax" }
 libra-types = { path = "../../../types" }
 vm = { path = "../../vm" }
+bytecode_source_map = { path = "../bytecode_source_map" }
 lalrpop-util = "0.17.2"
 log = "0.4.7"
 codespan = "0.2.1"

--- a/language/compiler/ir_to_bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir_to_bytecode/syntax/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-codespan = "0.2.1"
+codespan = { version = "0.2.1", features = ["serialization"] }
 failure = { path = "../../../../common/failure_ext", package = "failure_ext" }
 hex = "0.3.2"
 lazy_static = "1.4.0"

--- a/language/compiler/ir_to_bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir_to_bytecode/syntax/src/ast.rs
@@ -391,9 +391,9 @@ pub struct IfElse {
     /// the if's condition
     pub cond: Exp_,
     /// the block taken if the condition is `true`
-    pub if_block: Block,
+    pub if_block: Block_,
     /// the block taken if the condition is `false`
-    pub else_block: Option<Block>,
+    pub else_block: Option<Block_>,
 }
 
 /// Struct defining a while statement
@@ -402,14 +402,14 @@ pub struct While {
     /// The condition for a while statement
     pub cond: Exp_,
     /// The block taken if the condition is `true`
-    pub block: Block,
+    pub block: Block_,
 }
 
 /// Struct defining a loop statement
 #[derive(Debug, PartialEq, Clone)]
 pub struct Loop {
     /// The body of the loop
-    pub block: Block,
+    pub block: Block_,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -433,6 +433,9 @@ pub struct Block {
     /// The statements that make up the block
     pub stmts: VecDeque<Statement>,
 }
+
+/// The type of a Block coupled with source location information.
+pub type Block_ = Spanned<Block>;
 
 //**************************************************************************************************
 // Expressions
@@ -926,7 +929,7 @@ impl Cmd {
 
 impl IfElse {
     /// Creates an if-statement with no else branch
-    pub fn if_block(cond: Exp_, if_block: Block) -> Self {
+    pub fn if_block(cond: Exp_, if_block: Block_) -> Self {
         IfElse {
             cond,
             if_block,
@@ -935,7 +938,7 @@ impl IfElse {
     }
 
     /// Creates an if-statement with an else branch
-    pub fn if_else(cond: Exp_, if_block: Block, else_block: Block) -> Self {
+    pub fn if_else(cond: Exp_, if_block: Block_, else_block: Block_) -> Self {
         IfElse {
             cond,
             if_block,
@@ -951,12 +954,12 @@ impl Statement {
     }
 
     /// Creates an `Statement::IfElseStatement` variant with no else branch
-    pub fn if_block(cond: Exp_, if_block: Block) -> Self {
+    pub fn if_block(cond: Exp_, if_block: Block_) -> Self {
         Statement::IfElseStatement(IfElse::if_block(cond, if_block))
     }
 
     /// Creates an `Statement::IfElseStatement` variant with an else branch
-    pub fn if_else(cond: Exp_, if_block: Block, else_block: Block) -> Self {
+    pub fn if_else(cond: Exp_, if_block: Block_, else_block: Block_) -> Self {
         Statement::IfElseStatement(IfElse::if_else(cond, if_block, else_block))
     }
 }

--- a/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
+++ b/language/compiler/ir_to_bytecode/syntax/src/syntax.lalrpop
@@ -296,14 +296,17 @@ Statement : Statement = {
                 span
             }
         };
+        let span = err.span;
         let stmt = {
-            let span = err.span;
             Statement::CommandStatement(Spanned {
                 value: Cmd::Abort(Some(Box::new(err))),
                 span,
             })
         };
-        Statement::IfElseStatement(IfElse::if_block(cond, Block::new(vec![stmt])))
+        Statement::IfElseStatement(IfElse::if_block(cond, Spanned {
+            value: Block::new(vec![stmt]),
+            span
+        }))
     },
     <IfStatement>,
     <WhileStatement>,
@@ -312,22 +315,22 @@ Statement : Statement = {
 }
 
 IfStatement : Statement = {
-    "if" "(" <cond: Sp<Exp>> ")" <block: Block> => {
+    "if" "(" <cond: Sp<Exp>> ")" <block: Sp<Block>> => {
         Statement::IfElseStatement(IfElse::if_block(cond, block))
     },
-    "if" "(" <cond: Sp<Exp>> ")" <if_block: Block> "else" <else_block: Block> => {
+    "if" "(" <cond: Sp<Exp>> ")" <if_block: Sp<Block>> "else" <else_block: Sp<Block>> => {
         Statement::IfElseStatement(IfElse::if_else(cond, if_block, else_block))
     },
 }
 
 WhileStatement : Statement = {
-    "while" "(" <cond: Sp<Exp>> ")" <block: Block> => {
+    "while" "(" <cond: Sp<Exp>> ")" <block: Sp<Block>> => {
         Statement::WhileStatement(While {cond, block})
     }
 }
 
 LoopStatement : Statement = {
-    "loop" <block: Block> => {
+    "loop" <block: Sp<Block>> => {
         Statement::LoopStatement(Loop {block})
     }
 }

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -6,6 +6,7 @@ pub mod util;
 #[cfg(test)]
 mod unit_tests;
 
+use bytecode_source_map::source_map::{ModuleSourceMap, SourceMap};
 use bytecode_verifier::VerifiedModule;
 use failure::prelude::*;
 use ir_to_bytecode::{
@@ -50,12 +51,28 @@ impl Compiler {
         Ok(self.compile_impl(code)?.0)
     }
 
+    pub fn into_compiled_program_and_source_maps(
+        mut self,
+        code: &str,
+    ) -> Result<(CompiledProgram, SourceMap)> {
+        let (compiled_program, source_maps, _) = self.compile_impl(code)?;
+        Ok((compiled_program, source_maps))
+    }
+
+    pub fn into_compiled_program_and_source_maps_deps(
+        mut self,
+        code: &str,
+    ) -> Result<(CompiledProgram, SourceMap, Vec<VerifiedModule>)> {
+        Ok(self.compile_impl(code)?)
+    }
+
     /// Compiles into a `CompiledProgram` and also returns the dependencies.
     pub fn into_compiled_program_and_deps(
         mut self,
         code: &str,
     ) -> Result<(CompiledProgram, Vec<VerifiedModule>)> {
-        self.compile_impl(code)
+        let (compiled_program, _, deps) = self.compile_impl(code)?;
+        Ok((compiled_program, deps))
     }
 
     /// Compiles into a `CompiledScript`.
@@ -92,21 +109,27 @@ impl Compiler {
         Ok(Script::new(self.into_script_blob(code)?, args))
     }
 
-    fn compile_impl(&mut self, code: &str) -> Result<(CompiledProgram, Vec<VerifiedModule>)> {
+    fn compile_impl(
+        &mut self,
+        code: &str,
+    ) -> Result<(CompiledProgram, SourceMap, Vec<VerifiedModule>)> {
         let parsed_program = parse_program(code)?;
         let deps = self.deps();
-        let compiled_program = compile_program(self.address, parsed_program, &deps)?;
-        Ok((compiled_program, deps))
+        let (compiled_program, source_maps) = compile_program(self.address, parsed_program, &deps)?;
+        Ok((compiled_program, source_maps, deps))
     }
 
-    fn compile_mod(&mut self, code: &str) -> Result<(CompiledModule, Vec<VerifiedModule>)> {
+    fn compile_mod(
+        &mut self,
+        code: &str,
+    ) -> Result<(CompiledModule, ModuleSourceMap, Vec<VerifiedModule>)> {
         let parsed_program = parse_program(code)?;
         let deps = self.deps();
         let mut modules = parsed_program.modules;
         assert_eq!(modules.len(), 1, "Must have single module");
         let module = modules.pop().expect("Module must exist");
-        let compiled_module = compile_module(self.address, module, &deps)?;
-        Ok((compiled_module, deps))
+        let (compiled_module, source_map) = compile_module(self.address, module, &deps)?;
+        Ok((compiled_module, source_map, deps))
     }
 
     fn deps(&mut self) -> Vec<VerifiedModule> {

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -11,7 +11,7 @@ use bytecode_verifier::VerifiedModule;
 use failure::prelude::*;
 use ir_to_bytecode::{
     compiler::{compile_module, compile_program},
-    parser::parse_program,
+    parser::{ast::Loc, parse_program},
 };
 use libra_types::{
     account_address::AccountAddress,
@@ -54,7 +54,7 @@ impl Compiler {
     pub fn into_compiled_program_and_source_maps(
         mut self,
         code: &str,
-    ) -> Result<(CompiledProgram, SourceMap)> {
+    ) -> Result<(CompiledProgram, SourceMap<Loc>)> {
         let (compiled_program, source_maps, _) = self.compile_impl(code)?;
         Ok((compiled_program, source_maps))
     }
@@ -62,7 +62,7 @@ impl Compiler {
     pub fn into_compiled_program_and_source_maps_deps(
         mut self,
         code: &str,
-    ) -> Result<(CompiledProgram, SourceMap, Vec<VerifiedModule>)> {
+    ) -> Result<(CompiledProgram, SourceMap<Loc>, Vec<VerifiedModule>)> {
         Ok(self.compile_impl(code)?)
     }
 
@@ -112,7 +112,7 @@ impl Compiler {
     fn compile_impl(
         &mut self,
         code: &str,
-    ) -> Result<(CompiledProgram, SourceMap, Vec<VerifiedModule>)> {
+    ) -> Result<(CompiledProgram, SourceMap<Loc>, Vec<VerifiedModule>)> {
         let parsed_program = parse_program(code)?;
         let deps = self.deps();
         let (compiled_program, source_maps) = compile_program(self.address, parsed_program, &deps)?;
@@ -122,7 +122,7 @@ impl Compiler {
     fn compile_mod(
         &mut self,
         code: &str,
-    ) -> Result<(CompiledModule, ModuleSourceMap, Vec<VerifiedModule>)> {
+    ) -> Result<(CompiledModule, ModuleSourceMap<Loc>, Vec<VerifiedModule>)> {
         let parsed_program = parse_program(code)?;
         let deps = self.deps();
         let mut modules = parsed_program.modules;

--- a/language/compiler/src/unit_tests/testutils.rs
+++ b/language/compiler/src/unit_tests/testutils.rs
@@ -36,7 +36,7 @@ fn compile_script_string_impl(
     deps: Vec<CompiledModule>,
 ) -> Result<(CompiledScript, Vec<VMStatus>)> {
     let parsed_program = parse_program(code).unwrap();
-    let compiled_program = compile_program(AccountAddress::default(), parsed_program, &deps)?;
+    let compiled_program = compile_program(AccountAddress::default(), parsed_program, &deps)?.0;
 
     let mut serialized_script = Vec::<u8>::new();
     compiled_program.script.serialize(&mut serialized_script)?;
@@ -89,7 +89,7 @@ fn compile_module_string_impl(
 ) -> Result<(CompiledModule, Vec<VMStatus>)> {
     let address = AccountAddress::default();
     let module = parse_module(code).unwrap();
-    let compiled_module = compile_module(address, module, &deps)?;
+    let compiled_module = compile_module(address, module, &deps)?.0;
 
     let mut serialized_module = Vec::<u8>::new();
     compiled_module.serialize(&mut serialized_module)?;

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use bytecode_source_map::source_map::ModuleSourceMap;
 use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
 use libra_types::account_address::AccountAddress;
 use std::{fs, path::Path};
@@ -10,7 +11,7 @@ pub fn do_compile_module<T: ModuleAccess>(
     source_path: &Path,
     address: AccountAddress,
     dependencies: &[T],
-) -> CompiledModule {
+) -> (CompiledModule, ModuleSourceMap) {
     let source = fs::read_to_string(source_path)
         .unwrap_or_else(|_| panic!("Unable to read file: {:?}", source_path));
     let parsed_module = parse_module(&source).unwrap();

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_source_map::source_map::ModuleSourceMap;
-use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
+use ir_to_bytecode::{
+    compiler::compile_module,
+    parser::{ast::Loc, parse_module},
+};
 use libra_types::account_address::AccountAddress;
 use std::{fs, path::Path};
 use vm::{access::ModuleAccess, file_format::CompiledModule};
@@ -11,7 +14,7 @@ pub fn do_compile_module<T: ModuleAccess>(
     source_path: &Path,
     address: AccountAddress,
     dependencies: &[T],
-) -> (CompiledModule, ModuleSourceMap) {
+) -> (CompiledModule, ModuleSourceMap<Loc>) {
     let source = fs::read_to_string(source_path)
         .unwrap_or_else(|_| panic!("Unable to read file: {:?}", source_path));
     let parsed_module = parse_module(&source).unwrap();

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -343,7 +343,7 @@ fn eval_transaction(
             log.append(EvaluationOutput::Stage(Stage::Compiler));
 
             let compiled_script =
-                unwrap_or_abort!(compile_script(*addr, parsed_script, &*deps), log);
+                unwrap_or_abort!(compile_script(*addr, parsed_script, &*deps), log).0;
             log.append(EvaluationOutput::Output(Box::new(
                 OutputType::CompiledScript(compiled_script.clone()),
             )));
@@ -386,7 +386,7 @@ fn eval_transaction(
             log.append(EvaluationOutput::Stage(Stage::Compiler));
 
             let compiled_module =
-                unwrap_or_abort!(compile_module(*addr, parsed_module, &*deps), log);
+                unwrap_or_abort!(compile_module(*addr, parsed_module, &*deps), log).0;
             log.append(EvaluationOutput::Output(Box::new(
                 OutputType::CompiledModule(compiled_module.clone()),
             )));

--- a/language/stackless_bytecode/bytecode-to-boogie/src/main.rs
+++ b/language/stackless_bytecode/bytecode-to-boogie/src/main.rs
@@ -21,8 +21,9 @@ fn compile_files(file_names: Vec<String>) -> Vec<VerifiedModule> {
     for file_name in dep_files {
         let code = fs::read_to_string(file_name).unwrap();
         let module = parse_module(&code).unwrap();
-        let compiled_module =
-            compile_module(address, module, &verified_modules).expect("module failed to compile");
+        let compiled_module = compile_module(address, module, &verified_modules)
+            .expect("module failed to compile")
+            .0;
         let verified_module_res = VerifiedModule::new(compiled_module);
 
         match verified_module_res {

--- a/language/stackless_bytecode/bytecode-to-boogie/tests/translator_tests.rs
+++ b/language/stackless_bytecode/bytecode-to-boogie/tests/translator_tests.rs
@@ -16,8 +16,9 @@ fn compile_files(file_names: Vec<String>) -> Vec<VerifiedModule> {
     for file_name in dep_files {
         let code = fs::read_to_string(file_name).unwrap();
         let module = parse_module(&code).unwrap();
-        let compiled_module =
-            compile_module(address, module, &verified_modules).expect("module failed to compile");
+        let compiled_module = compile_module(address, module, &verified_modules)
+            .expect("module failed to compile")
+            .0;
         let verified_module_res = VerifiedModule::new(compiled_module);
 
         match verified_module_res {

--- a/language/stackless_bytecode/generator/tests/stack_elim_tests.rs
+++ b/language/stackless_bytecode/generator/tests/stack_elim_tests.rs
@@ -556,7 +556,7 @@ fn generate_code_from_string(code: String) -> (Vec<StacklessBytecode>, Vec<Signa
     let address = AccountAddress::default();
     let program = parse_program(&code).unwrap();
     let deps = stdlib_modules();
-    let compiled_program = compile_program(address, program, deps).unwrap();
+    let compiled_program = compile_program(address, program, deps).unwrap().0;
     println!("{:?}", compiled_program);
     let res = StacklessProgramGenerator::new(compiled_program).generate_program();
     let code = res.module_functions[0][0].code.clone();

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 bytecode-verifier = { path = "../bytecode-verifier" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 libra-types = { path = "../../types" }
+bytecode_source_map = { path = "../compiler/bytecode_source_map" }
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -4,14 +4,15 @@
 pub mod stdlib;
 pub mod transaction_scripts;
 
+use bytecode_source_map::source_map::{ModuleSourceMap, SourceMap};
 use bytecode_verifier::{verify_module_dependencies, VerifiedModule};
 use ir_to_bytecode::compiler::compile_module;
+use ir_to_bytecode::parser::ast::Loc;
 use lazy_static::lazy_static;
 use libra_types::{account_address::AccountAddress, account_config};
-use bytecode_source_map::source_map::{SourceMap, ModuleSourceMap};
 
 lazy_static! {
-    static ref ANNOTATED_STDLIB: (Vec<VerifiedModule>, SourceMap) =
+    static ref ANNOTATED_STDLIB: (Vec<VerifiedModule>, SourceMap<Loc>) =
         { build_stdlib(account_config::core_code_address()) };
 }
 
@@ -27,7 +28,7 @@ pub fn stdlib_modules() -> &'static [VerifiedModule] {
 ///
 /// The order of the modules returned in this follows the same order as the modules returned in the
 /// stdlib_modules.
-pub fn stdlib_source_map() -> &'static [ModuleSourceMap] {
+pub fn stdlib_source_map() -> &'static [ModuleSourceMap<Loc>] {
     &*ANNOTATED_STDLIB.1
 }
 
@@ -35,13 +36,14 @@ pub fn stdlib_source_map() -> &'static [ModuleSourceMap] {
 ///
 /// A copy of the stdlib built with the [default address](account_config::core_code_address) is
 /// available through [`stdlib_modules`].
-pub fn build_stdlib(address: AccountAddress) -> (Vec<VerifiedModule>, SourceMap) {
+pub fn build_stdlib(address: AccountAddress) -> (Vec<VerifiedModule>, SourceMap<Loc>) {
     let mut stdlib_modules = vec![];
     let mut stdlib_source_maps = vec![];
 
     for module_def in stdlib::module_defs() {
-        let (compiled_module, source_map) = compile_module(address, (*module_def).clone(), &stdlib_modules)
-            .expect("stdlib module failed to compile");
+        let (compiled_module, source_map) =
+            compile_module(address, (*module_def).clone(), &stdlib_modules)
+                .expect("stdlib module failed to compile");
         let verified_module =
             VerifiedModule::new(compiled_module).expect("stdlib module failed to verify");
 

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -8,9 +8,10 @@ use bytecode_verifier::{verify_module_dependencies, VerifiedModule};
 use ir_to_bytecode::compiler::compile_module;
 use lazy_static::lazy_static;
 use libra_types::{account_address::AccountAddress, account_config};
+use bytecode_source_map::source_map::{SourceMap, ModuleSourceMap};
 
 lazy_static! {
-    static ref STDLIB_MODULES: Vec<VerifiedModule> =
+    static ref ANNOTATED_STDLIB: (Vec<VerifiedModule>, SourceMap) =
         { build_stdlib(account_config::core_code_address()) };
 }
 
@@ -19,18 +20,27 @@ lazy_static! {
 ///
 /// The order the modules are presented in is important: later modules depend on earlier ones.
 pub fn stdlib_modules() -> &'static [VerifiedModule] {
-    &*STDLIB_MODULES
+    &*ANNOTATED_STDLIB.0
+}
+
+/// Returns a reference to the source maps for the standard library.
+///
+/// The order of the modules returned in this follows the same order as the modules returned in the
+/// stdlib_modules.
+pub fn stdlib_source_map() -> &'static [ModuleSourceMap] {
+    &*ANNOTATED_STDLIB.1
 }
 
 /// Builds and returns a copy of the standard library with this address as the self address.
 ///
 /// A copy of the stdlib built with the [default address](account_config::core_code_address) is
 /// available through [`stdlib_modules`].
-pub fn build_stdlib(address: AccountAddress) -> Vec<VerifiedModule> {
+pub fn build_stdlib(address: AccountAddress) -> (Vec<VerifiedModule>, SourceMap) {
     let mut stdlib_modules = vec![];
+    let mut stdlib_source_maps = vec![];
 
     for module_def in stdlib::module_defs() {
-        let compiled_module = compile_module(address, (*module_def).clone(), &stdlib_modules)
+        let (compiled_module, source_map) = compile_module(address, (*module_def).clone(), &stdlib_modules)
             .expect("stdlib module failed to compile");
         let verified_module =
             VerifiedModule::new(compiled_module).expect("stdlib module failed to verify");
@@ -43,7 +53,8 @@ pub fn build_stdlib(address: AccountAddress) -> Vec<VerifiedModule> {
         assert!(verification_errors.is_empty());
 
         stdlib_modules.push(verified_module);
+        stdlib_source_maps.push(source_map)
     }
 
-    stdlib_modules
+    (stdlib_modules, stdlib_source_maps)
 }

--- a/language/transaction_builder/src/lib.rs
+++ b/language/transaction_builder/src/lib.rs
@@ -30,7 +30,9 @@ lazy_static! {
 
 fn compile_script(body: &ast::Program) -> Vec<u8> {
     let compiled_program =
-        compile_program(AccountAddress::default(), body.clone(), stdlib_modules()).unwrap();
+        compile_program(AccountAddress::default(), body.clone(), stdlib_modules())
+            .unwrap()
+            .0;
     let mut script_bytes = vec![];
     compiled_program
         .script
@@ -65,6 +67,7 @@ pub fn encode_transfer_script_with_padding(
         stdlib_modules(),
     )
     .unwrap()
+    .0
     .script
     .into_inner();
     script_mut


### PR DESCRIPTION
This PR adds a basic functionality for tracking IR source locations in the
bytecode. There is a lot of work left to do here, but this is an "mvp" for this.

# High level idea

### Functions

Every function definition in the module has a couple mappings and data associated with it:

1. a mapping for type parameters: `<type param offset> -> <type param name & source location>`
2. information on the location of the function: `<source location of the whole function>`
3. a mapping for each code offset: `<codeOffset> -> <sourceLocation>`; and for locals
4. a mapping: `localIndex -> (name, sourceLocation)`.

Since a single source location may lead to multiple bytecode instructions, we represent these offsets as a segment tree (using a btree and appropriate range queries). You can read more in the implementation.

Note that for native functions we only store 1, 2, and 3 (but only for the arguments to the function).

### Structs/Resources

Every also has a similar set of mappings:

1. a mapping for type parameters: `<type param offset> -> <type param name & source location>`
2. information on the location of the struct: `<source location of the whole struct>`
3. a mapping for each field of the struct: `<field offset> -> <name & sourceLocation>`

Note that for native structs that we only keep track of 1 and 2. 

### How to use

#### From Rust
There are two different ways that you can use this. The first, is from within Rust. You first need to create a `SourceMapping` which requires a compiled module (or script) and a source map. After this you can disassemble individual functions or structs, or the whole module. There are also functions for marking/annotating functions and structs with messages -- reporting of these markings is not yet implemented, but they will be shortly.

#### From the command line

If you compile a module or script (and _NOT_ a program) with the compiler, and pass the `--src-map` flag this will output two different files; a `.mv` (compiled binary), and `.mvsm` (source map). e.g. assume we have a module `foo.mvir` in `$HOME`. and we compile (under `language/compiler`) with:

```
cargo run -- --src-map -m $HOME/foo.mvir
```

Then we can disassemble this in a similar manner by running (under `language/compiler/bytecode_source_map`):

```
cargo run -- -b $HOME/foo.mv
```

### Future work

* Adding bytecode pretty printing that will e.g. will in location indices with the location name.
* Add printing of markings (both function and struct) along with their corresponding source code (if the source code is available).

### An Example

Let's say we have this module (ignore any semantic errors):

```
module Foo {
  resource A {
    a: u64,
    b: bool,
  }

  resource B<T> {
    c: T,
    d: bool,
  }

  struct T {
    foo: u64,
    bar: bool,
  }

  struct R<X> {
    ffoo: u64,
    bbar: bool,
  }

  native struct C<T>;
  native struct D;

  native resource E<T>;
  native resource F;

  public foo<T>(): u64 {
    let x: u64;
    let y: u64;
    x = 1;
    y = 2;
    return move(x) + move(y);
  }

  public bar(x: u64) {
    let t: &u64;
    let y: u64;
    y = move(x);
    t = &y;
    return;
  }

  native nat<T>(x: u64): T;

  public flip(b: bool): u64 {
    if (move(b)) {
      return 1;
    } else {
      return 0;
    }
  }
}
```

Then we produce a source map (internally) that looks like this: 

```
ModuleSourceMap {
    module_name: (
        0000000000000000000000000000000000000000000000000000000000000000,
        Identifier(
            "Foo",
        ),
    ),
    struct_map: {
        4: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(205),
                end: ByteIndex(224),
            },
            type_parameters: [
                (
                    Identifier(
                        "T",
                    ),
                    Span {
                        start: ByteIndex(0),
                        end: ByteIndex(0),
                    },
                ),
            ],
            fields: [],
        },
        0: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(15),
                end: ByteIndex(56),
            },
            type_parameters: [],
            fields: [
                (
                    Identifier(
                        "a",
                    ),
                    Span {
                        start: ByteIndex(32),
                        end: ByteIndex(33),
                    },
                ),
                (
                    Identifier(
                        "b",
                    ),
                    Span {
                        start: ByteIndex(44),
                        end: ByteIndex(45),
                    },
                ),
            ],
        },
        2: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(106),
                end: ByteIndex(149),
            },
            type_parameters: [],
            fields: [
                (
                    Identifier(
                        "foo",
                    ),
                    Span {
                        start: ByteIndex(121),
                        end: ByteIndex(124),
                    },
                ),
                (
                    Identifier(
                        "bar",
                    ),
                    Span {
                        start: ByteIndex(135),
                        end: ByteIndex(138),
                    },
                ),
            ],
        },
        6: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(247),
                end: ByteIndex(268),
            },
            type_parameters: [
                (
                    Identifier(
                        "T",
                    ),
                    Span {
                        start: ByteIndex(0),
                        end: ByteIndex(0),
                    },
                ),
            ],
            fields: [],
        },
        7: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(271),
                end: ByteIndex(289),
            },
            type_parameters: [],
            fields: [],
        },
        1: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(60),
                end: ByteIndex(102),
            },
            type_parameters: [
                (
                    Identifier(
                        "T",
                    ),
                    Span {
                        start: ByteIndex(0),
                        end: ByteIndex(0),
                    },
                ),
            ],
            fields: [
                (
                    Identifier(
                        "c",
                    ),
                    Span {
                        start: ByteIndex(80),
                        end: ByteIndex(81),
                    },
                ),
                (
                    Identifier(
                        "d",
                    ),
                    Span {
                        start: ByteIndex(90),
                        end: ByteIndex(91),
                    },
                ),
            ],
        },
        5: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(227),
                end: ByteIndex(243),
            },
            type_parameters: [],
            fields: [],
        },
        3: StructSourceMap {
            decl_location: Span {
                start: ByteIndex(153),
                end: ByteIndex(201),
            },
            type_parameters: [
                (
                    Identifier(
                        "X",
                    ),
                    Span {
                        start: ByteIndex(0),
                        end: ByteIndex(0),
                    },
                ),
            ],
            fields: [
                (
                    Identifier(
                        "ffoo",
                    ),
                    Span {
                        start: ByteIndex(171),
                        end: ByteIndex(175),
                    },
                ),
                (
                    Identifier(
                        "bbar",
                    ),
                    Span {
                        start: ByteIndex(186),
                        end: ByteIndex(190),
                    },
                ),
            ],
        },
    },
    function_map: {
        2: FunctionSourceMap {
            decl_location: Span {
                start: ByteIndex(509),
                end: ByteIndex(534),
            },
            type_parameters: [
                (
                    Identifier(
                        "T",
                    ),
                    Span {
                        start: ByteIndex(0),
                        end: ByteIndex(0),
                    },
                ),
            ],
            locals: [
                (
                    Identifier(
                        "x",
                    ),
                    Span {
                        start: ByteIndex(523),
                        end: ByteIndex(524),
                    },
                ),
            ],
            code_map: {},
        },
        3: FunctionSourceMap {
            decl_location: Span {
                start: ByteIndex(538),
                end: ByteIndex(639),
            },
            type_parameters: [],
            locals: [
                (
                    Identifier(
                        "b",
                    ),
                    Span {
                        start: ByteIndex(550),
                        end: ByteIndex(551),
                    },
                ),
            ],
            code_map: {
                0: Span {
                    start: ByteIndex(574),
                    end: ByteIndex(581),
                },
                2: Span {
                    start: ByteIndex(598),
                    end: ByteIndex(599),
                },
                3: Span {
                    start: ByteIndex(591),
                    end: ByteIndex(599),
                },
                4: Span {
                    start: ByteIndex(627),
                    end: ByteIndex(628),
                },
                5: Span {
                    start: ByteIndex(620),
                    end: ByteIndex(628),
                },
            },
        },
        0: FunctionSourceMap {
            decl_location: Span {
                start: ByteIndex(293),
                end: ByteIndex(403),
            },
            type_parameters: [
                (
                    Identifier(
                        "T",
                    ),
                    Span {
                        start: ByteIndex(0),
                        end: ByteIndex(0),
                    },
                ),
            ],
            locals: [
                (
                    Identifier(
                        "x",
                    ),
                    Span {
                        start: ByteIndex(324),
                        end: ByteIndex(325),
                    },
                ),
                (
                    Identifier(
                        "y",
                    ),
                    Span {
                        start: ByteIndex(340),
                        end: ByteIndex(341),
                    },
                ),
            ],
            code_map: {
                0: Span {
                    start: ByteIndex(356),
                    end: ByteIndex(357),
                },
                1: Span {
                    start: ByteIndex(352),
                    end: ByteIndex(353),
                },
                2: Span {
                    start: ByteIndex(367),
                    end: ByteIndex(368),
                },
                3: Span {
                    start: ByteIndex(363),
                    end: ByteIndex(364),
                },
                4: Span {
                    start: ByteIndex(381),
                    end: ByteIndex(388),
                },
                5: Span {
                    start: ByteIndex(391),
                    end: ByteIndex(398),
                },
                6: Span {
                    start: ByteIndex(381),
                    end: ByteIndex(398),
                },
                7: Span {
                    start: ByteIndex(374),
                    end: ByteIndex(398),
                },
            },
        },
        1: FunctionSourceMap {
            decl_location: Span {
                start: ByteIndex(407),
                end: ByteIndex(505),
            },
            type_parameters: [],
            locals: [
                (
                    Identifier(
                        "x",
                    ),
                    Span {
                        start: ByteIndex(418),
                        end: ByteIndex(419),
                    },
                ),
                (
                    Identifier(
                        "t",
                    ),
                    Span {
                        start: ByteIndex(436),
                        end: ByteIndex(437),
                    },
                ),
                (
                    Identifier(
                        "y",
                    ),
                    Span {
                        start: ByteIndex(453),
                        end: ByteIndex(454),
                    },
                ),
            ],
            code_map: {
                0: Span {
                    start: ByteIndex(469),
                    end: ByteIndex(476),
                },
                1: Span {
                    start: ByteIndex(465),
                    end: ByteIndex(466),
                },
                2: Span {
                    start: ByteIndex(486),
                    end: ByteIndex(488),
                },
                3: Span {
                    start: ByteIndex(482),
                    end: ByteIndex(483),
                },
                4: Span {
                    start: ByteIndex(494),
                    end: ByteIndex(500),
                },
            },
        },
    },
}
```

and will dissasemble through the CLI as:
```
module 0000000000000000000000000000000000000000000000000000000000000000.Foo {
resource A<> {
	a: u64,
	b: bool
}
resource B<T: All> {
	c: T,
	d: bool
}
struct T<> {
	foo: u64,
	bar: bool
}
struct R<X: All> {
	ffoo: u64,
	bbar: bool
}
native struct C<T: All> {

}
native struct D<> {

}
native resource E<T: All> {

}
native resource F<> {

}

public foo<T: All>():u64
public bar<>(x: u64):
native nat<T: All>(x: u64):T
public flip<>(b: bool):u64
}
```
