### PR TITLE
Fix dependency name for fuzzer

### DIFF
--- a/testsuite/libra-fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra-fuzzer/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-libra_fuzzer = { path = ".." }
+libra-fuzzer = { path = ".." }
 lazy_static = { version = "1.3.0", default-features = false }
 
 # Prevent this from interfering with workspaces


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

@bmwill  updated the paths in 696825a43be70eba241b255a0f96f221c330e7a7 so making the corresponding change here.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Ran `cargo run fuzz` to make sure the fuzzer was getting compiled and run.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
