### PR TITLE
Prost conversion: Impl From/To conversions for types crate

### DIFF
--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -57,7 +57,11 @@ use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use radix_trie::TrieKey;
 use serde::{Deserialize, Serialize};
-use std::{fmt, slice::Iter};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt,
+    slice::Iter,
+};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
 pub struct Field(Identifier);
@@ -352,5 +356,22 @@ impl CanonicalDeserialize for AccessPath {
         let path = deserializer.decode_bytes()?;
 
         Ok(Self { address, path })
+    }
+}
+
+impl TryFrom<crate::proto::types::AccessPath> for AccessPath {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::AccessPath) -> Result<Self> {
+        Ok(AccessPath::new(proto.address.try_into()?, proto.path))
+    }
+}
+
+impl From<AccessPath> for crate::proto::types::AccessPath {
+    fn from(path: AccessPath) -> Self {
+        Self {
+            address: path.address.to_vec(),
+            path: path.path,
+        }
     }
 }

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -77,6 +77,20 @@ impl TryFrom<&BTreeMap<Vec<u8>, Vec<u8>>> for AccountStateBlob {
     }
 }
 
+impl TryFrom<crate::proto::types::AccountStateBlob> for AccountStateBlob {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::AccountStateBlob) -> Result<Self> {
+        Ok(proto.blob.into())
+    }
+}
+
+impl From<AccountStateBlob> for crate::proto::types::AccountStateBlob {
+    fn from(blob: AccountStateBlob) -> Self {
+        Self { blob: blob.blob }
+    }
+}
+
 #[cfg(any(test, feature = "testing"))]
 impl From<AccountResource> for AccountStateBlob {
     fn from(account_resource: AccountResource) -> Self {

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -119,6 +119,66 @@ impl<Sig: Signature> FromProto for UpdateToLatestLedgerResponse<Sig> {
     }
 }
 
+impl<Sig: Signature> TryFrom<crate::proto::types::UpdateToLatestLedgerResponse>
+    for UpdateToLatestLedgerResponse<Sig>
+{
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::UpdateToLatestLedgerResponse) -> Result<Self> {
+        let response_items = proto
+            .response_items
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>>>()?;
+        let ledger_info_with_sigs = proto
+            .ledger_info_with_sigs
+            .ok_or_else(|| format_err!("Missing ledger_info_with_sigs"))?
+            .try_into()?;
+        let validator_change_events = proto
+            .validator_change_events
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>>>()?;
+        let ledger_consistency_proof = proto
+            .ledger_consistency_proof
+            .ok_or_else(|| format_err!("Missing ledger_consistency_proof"))?
+            .try_into()?;
+
+        Ok(Self {
+            response_items,
+            ledger_info_with_sigs,
+            validator_change_events,
+            ledger_consistency_proof,
+        })
+    }
+}
+
+impl<Sig: Signature> From<UpdateToLatestLedgerResponse<Sig>>
+    for crate::proto::types::UpdateToLatestLedgerResponse
+{
+    fn from(response: UpdateToLatestLedgerResponse<Sig>) -> Self {
+        let response_items = response
+            .response_items
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let ledger_info_with_sigs = Some(response.ledger_info_with_sigs.into());
+        let validator_change_events = response
+            .validator_change_events
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let ledger_consistency_proof = Some(response.ledger_consistency_proof.into());
+
+        Self {
+            response_items,
+            ledger_info_with_sigs,
+            validator_change_events,
+            ledger_consistency_proof,
+        }
+    }
+}
+
 impl<Sig: Signature> UpdateToLatestLedgerResponse<Sig> {
     /// Constructor.
     pub fn new(

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -48,6 +48,34 @@ impl UpdateToLatestLedgerRequest {
     }
 }
 
+impl TryFrom<crate::proto::types::UpdateToLatestLedgerRequest> for UpdateToLatestLedgerRequest {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::UpdateToLatestLedgerRequest) -> Result<Self> {
+        Ok(Self {
+            client_known_version: proto.client_known_version,
+            requested_items: proto
+                .requested_items
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+impl From<UpdateToLatestLedgerRequest> for crate::proto::types::UpdateToLatestLedgerRequest {
+    fn from(request: UpdateToLatestLedgerRequest) -> Self {
+        Self {
+            client_known_version: request.client_known_version,
+            requested_items: request
+                .requested_items
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpdateToLatestLedgerResponse<Sig> {
     pub response_items: Vec<ResponseItem>,

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -17,6 +17,7 @@ use failure::Result;
 use proptest_derive::Arbitrary;
 use proto_conv::{FromProto, IntoProto};
 use serde::{Deserialize, Serialize};
+use std::convert::{TryFrom, TryInto};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub struct StructTag {
@@ -74,6 +75,26 @@ impl ModuleId {
 
     pub fn address(&self) -> &AccountAddress {
         &self.address
+    }
+}
+
+impl TryFrom<crate::proto::types::ModuleId> for ModuleId {
+    type Error = failure::Error;
+
+    fn try_from(proto: crate::proto::types::ModuleId) -> Result<Self> {
+        Ok(Self {
+            address: proto.address.try_into()?,
+            name: Identifier::new(proto.name)?,
+        })
+    }
+}
+
+impl From<ModuleId> for crate::proto::types::ModuleId {
+    fn from(txn: ModuleId) -> Self {
+        Self {
+            address: txn.address.into(),
+            name: txn.name.into_string(),
+        }
     }
 }
 

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -587,6 +587,43 @@ impl AccountStateProof {
     }
 }
 
+impl TryFrom<crate::proto::types::AccountStateProof> for AccountStateProof {
+    type Error = Error;
+
+    fn try_from(proto_proof: crate::proto::types::AccountStateProof) -> Result<Self> {
+        let ledger_info_to_transaction_info_proof = proto_proof
+            .ledger_info_to_transaction_info_proof
+            .ok_or_else(|| format_err!("Missing ledger_info_to_transaction_info_proof"))?
+            .try_into()?;
+        let transaction_info = proto_proof
+            .transaction_info
+            .ok_or_else(|| format_err!("Missing transaction_info"))?
+            .try_into()?;
+        let transaction_info_to_account_proof = proto_proof
+            .transaction_info_to_account_proof
+            .ok_or_else(|| format_err!("Missing transaction_info_to_account_proof"))?
+            .try_into()?;
+
+        Ok(AccountStateProof::new(
+            ledger_info_to_transaction_info_proof,
+            transaction_info,
+            transaction_info_to_account_proof,
+        ))
+    }
+}
+
+impl From<AccountStateProof> for crate::proto::types::AccountStateProof {
+    fn from(proof: AccountStateProof) -> Self {
+        Self {
+            ledger_info_to_transaction_info_proof: Some(
+                proof.ledger_info_to_transaction_info_proof.into(),
+            ),
+            transaction_info: Some(proof.transaction_info.into()),
+            transaction_info_to_account_proof: Some(proof.transaction_info_to_account_proof.into()),
+        }
+    }
+}
+
 /// The complete proof used to authenticate a contract event. This structure consists of the
 /// `AccumulatorProof` from `LedgerInfo` to `TransactionInfo`, the `TransactionInfo` object and the
 /// `AccumulatorProof` from event accumulator root to the event.

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -673,6 +673,43 @@ impl EventProof {
     }
 }
 
+impl TryFrom<crate::proto::types::EventProof> for EventProof {
+    type Error = Error;
+
+    fn try_from(proto_proof: crate::proto::types::EventProof) -> Result<Self> {
+        let ledger_info_to_transaction_info_proof = proto_proof
+            .ledger_info_to_transaction_info_proof
+            .ok_or_else(|| format_err!("Missing ledger_info_to_transaction_info_proof"))?
+            .try_into()?;
+        let transaction_info = proto_proof
+            .transaction_info
+            .ok_or_else(|| format_err!("Missing transaction_info"))?
+            .try_into()?;
+        let transaction_info_to_event_proof = proto_proof
+            .transaction_info_to_event_proof
+            .ok_or_else(|| format_err!("Missing transaction_info_to_account_proof"))?
+            .try_into()?;
+
+        Ok(EventProof::new(
+            ledger_info_to_transaction_info_proof,
+            transaction_info,
+            transaction_info_to_event_proof,
+        ))
+    }
+}
+
+impl From<EventProof> for crate::proto::types::EventProof {
+    fn from(proof: EventProof) -> Self {
+        Self {
+            ledger_info_to_transaction_info_proof: Some(
+                proof.ledger_info_to_transaction_info_proof.into(),
+            ),
+            transaction_info: Some(proof.transaction_info.into()),
+            transaction_info_to_event_proof: Some(proof.transaction_info_to_event_proof.into()),
+        }
+    }
+}
+
 mod bitmap {
     /// The bitmap indicating which siblings are default in a compressed accumulator proof. 1 means
     /// non-default and 0 means default.  The LSB corresponds to the sibling at the bottom of the

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -445,6 +445,28 @@ impl IntoProto for AccumulatorConsistencyProof {
     }
 }
 
+impl TryFrom<crate::proto::types::AccumulatorConsistencyProof> for AccumulatorConsistencyProof {
+    type Error = Error;
+
+    fn try_from(proto_proof: crate::proto::types::AccumulatorConsistencyProof) -> Result<Self> {
+        let subtrees = proto_proof
+            .subtrees
+            .into_iter()
+            .map(|hash_bytes| HashValue::from_slice(&hash_bytes))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self::new(subtrees))
+    }
+}
+
+impl From<AccumulatorConsistencyProof> for crate::proto::types::AccumulatorConsistencyProof {
+    fn from(proof: AccumulatorConsistencyProof) -> Self {
+        Self {
+            subtrees: proof.subtrees.iter().map(HashValue::to_vec).collect(),
+        }
+    }
+}
+
 /// The complete proof used to authenticate a `SignedTransaction` object.  This structure consists
 /// of an `AccumulatorProof` from `LedgerInfo` to `TransactionInfo` the verifier needs to verify
 /// the correctness of the `TransactionInfo` object, and the `TransactionInfo` object that is

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -534,12 +534,11 @@ impl TryFrom<crate::proto::types::SignedTransaction> for SignedTransaction {
     }
 }
 
-impl TryFrom<SignedTransaction> for crate::proto::types::SignedTransaction {
-    type Error = Error;
-
-    fn try_from(txn: SignedTransaction) -> Result<Self> {
-        let signed_txn = SimpleSerializer::<Vec<u8>>::serialize(&txn)?;
-        Ok(Self { signed_txn })
+impl From<SignedTransaction> for crate::proto::types::SignedTransaction {
+    fn from(txn: SignedTransaction) -> Self {
+        let signed_txn = SimpleSerializer::<Vec<u8>>::serialize(&txn)
+            .expect("Unable to serialize SignedTransaction");
+        Self { signed_txn }
     }
 }
 

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -797,6 +797,38 @@ impl FromProto for TransactionInfo {
     }
 }
 
+impl TryFrom<crate::proto::types::TransactionInfo> for TransactionInfo {
+    type Error = Error;
+
+    fn try_from(proto_txn_info: crate::proto::types::TransactionInfo) -> Result<Self> {
+        let signed_txn_hash = HashValue::from_slice(&proto_txn_info.signed_transaction_hash)?;
+        let state_root_hash = HashValue::from_slice(&proto_txn_info.state_root_hash)?;
+        let event_root_hash = HashValue::from_slice(&proto_txn_info.event_root_hash)?;
+        let gas_used = proto_txn_info.gas_used;
+        let major_status =
+            StatusCode::try_from(proto_txn_info.major_status).unwrap_or(StatusCode::UNKNOWN_STATUS);
+        Ok(TransactionInfo::new(
+            signed_txn_hash,
+            state_root_hash,
+            event_root_hash,
+            gas_used,
+            major_status,
+        ))
+    }
+}
+
+impl From<TransactionInfo> for crate::proto::types::TransactionInfo {
+    fn from(txn_info: TransactionInfo) -> Self {
+        Self {
+            signed_transaction_hash: txn_info.signed_transaction_hash.to_vec(),
+            state_root_hash: txn_info.state_root_hash.to_vec(),
+            event_root_hash: txn_info.event_root_hash.to_vec(),
+            gas_used: txn_info.gas_used,
+            major_status: txn_info.major_status.into(),
+        }
+    }
+}
+
 /// `TransactionInfo` is the object we store in the transaction accumulator. It consists of the
 /// transaction as well as the execution result of this transaction.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, IntoProto)]

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -3,7 +3,9 @@
 
 use crate::{contract_event::EventWithProof, ledger_info::LedgerInfoWithSignatures};
 use crypto::*;
+use failure::*;
 use proto_conv::{FromProto, IntoProto};
+use std::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValidatorChangeEventWithProof<Sig> {
@@ -32,6 +34,38 @@ impl<Sig: Signature> FromProto for ValidatorChangeEventWithProof<Sig> {
             )?,
             event_with_proof: EventWithProof::from_proto(object.take_event_with_proof())?,
         })
+    }
+}
+
+impl<Sig: Signature> TryFrom<crate::proto::types::ValidatorChangeEventWithProof>
+    for ValidatorChangeEventWithProof<Sig>
+{
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::ValidatorChangeEventWithProof) -> Result<Self> {
+        let ledger_info_with_sigs = proto
+            .ledger_info_with_sigs
+            .ok_or_else(|| format_err!("Missing ledger_info_with_sigs"))?
+            .try_into()?;
+        let event_with_proof = proto
+            .event_with_proof
+            .ok_or_else(|| format_err!("Missing event_with_proof"))?
+            .try_into()?;
+        Ok(ValidatorChangeEventWithProof {
+            ledger_info_with_sigs,
+            event_with_proof,
+        })
+    }
+}
+
+impl<Sig: Signature> From<ValidatorChangeEventWithProof<Sig>>
+    for crate::proto::types::ValidatorChangeEventWithProof
+{
+    fn from(change: ValidatorChangeEventWithProof<Sig>) -> Self {
+        Self {
+            ledger_info_with_sigs: Some(change.ledger_info_with_sigs.into()),
+            event_with_proof: Some(change.event_with_proof.into()),
+        }
     }
 }
 

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -116,6 +116,36 @@ impl IntoProto for ValidatorPublicKeys {
     }
 }
 
+impl TryFrom<crate::proto::types::ValidatorPublicKeys> for ValidatorPublicKeys {
+    type Error = failure::Error;
+
+    fn try_from(proto: crate::proto::types::ValidatorPublicKeys) -> Result<Self> {
+        let account_address = AccountAddress::try_from(proto.account_address)?;
+        let consensus_public_key = Ed25519PublicKey::try_from(&proto.consensus_public_key[..])?;
+        let network_signing_public_key =
+            Ed25519PublicKey::try_from(&proto.network_signing_public_key[..])?;
+        let network_identity_public_key =
+            X25519StaticPublicKey::try_from(&proto.network_identity_public_key[..])?;
+        Ok(Self::new(
+            account_address,
+            consensus_public_key,
+            network_signing_public_key,
+            network_identity_public_key,
+        ))
+    }
+}
+
+impl From<ValidatorPublicKeys> for crate::proto::types::ValidatorPublicKeys {
+    fn from(keys: ValidatorPublicKeys) -> Self {
+        Self {
+            account_address: keys.account_address.to_vec(),
+            consensus_public_key: keys.consensus_public_key.to_bytes().to_vec(),
+            network_signing_public_key: keys.network_signing_public_key.to_bytes().to_vec(),
+            network_identity_public_key: keys.network_identity_public_key.to_bytes().to_vec(),
+        }
+    }
+}
+
 impl CanonicalSerialize for ValidatorPublicKeys {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
         serializer

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -249,6 +249,52 @@ impl FromProto for VMStatus {
     }
 }
 
+impl TryFrom<crate::proto::types::VmStatus> for VMStatus {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::VmStatus) -> Result<Self> {
+        let mut status = VMStatus::new(
+            StatusCode::try_from(proto.major_status).unwrap_or(StatusCode::UNKNOWN_STATUS),
+        );
+
+        if proto.has_sub_status {
+            status.set_sub_status(proto.sub_status);
+        }
+
+        if proto.has_message {
+            status.set_message(proto.message);
+        }
+
+        Ok(status)
+    }
+}
+
+impl From<VMStatus> for crate::proto::types::VmStatus {
+    fn from(status: VMStatus) -> Self {
+        let mut proto_status = Self::default();
+
+        proto_status.has_sub_status = false;
+        proto_status.has_message = false;
+
+        // Set major status
+        proto_status.major_status = status.major_status.into();
+
+        // Set minor status if there is one
+        if let Some(sub_status) = status.sub_status {
+            proto_status.has_sub_status = true;
+            proto_status.sub_status = sub_status;
+        }
+
+        // Set info string
+        if let Some(string) = status.message {
+            proto_status.has_message = true;
+            proto_status.message = string;
+        }
+
+        proto_status
+    }
+}
+
 impl IntoProto for StatusCode {
     type ProtoType = u64;
     fn into_proto(self) -> Self::ProtoType {


### PR DESCRIPTION
We make heavy use of FromProto/ToProto convenience traits for conversion between rust structs and protobufs structs. In order to help facilitate converting to using prost for protobuf code generation lets begin adding From/To conversions impls for these types to their prost equivalents.