### PR TITLE
Macro for `ensure_max_length` in canonical serialization

### DIFF
--- a/common/canonical_serialization/src/lib.rs
+++ b/common/canonical_serialization/src/lib.rs
@@ -17,3 +17,17 @@ pub use simple_serializer::SimpleSerializer;
 
 #[cfg(test)]
 mod canonical_serialization_test;
+
+/// Commonly used function to ensure some length is <= ARRAY_MAX_LENGTH
+#[macro_export]
+macro_rules! ensure_max_length {
+    ($len:expr) => {
+        failure::ensure!(
+            $len <= crate::ARRAY_MAX_LENGTH,
+            "collection/array length exceeded the maximum length limit. \
+             length: {}, Max length limit: {}",
+            $len,
+            crate::ARRAY_MAX_LENGTH,
+        );
+    };
+}

--- a/common/canonical_serialization/src/simple_deserializer.rs
+++ b/common/canonical_serialization/src/simple_deserializer.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     canonical_deserialize::{CanonicalDeserialize, CanonicalDeserializer},
-    Endianness, ARRAY_MAX_LENGTH,
+    ensure_max_length, Endianness,
 };
 use byteorder::ReadBytesExt;
 use failure::prelude::*;
@@ -61,12 +61,7 @@ impl<'a> CanonicalDeserializer for SimpleDeserializer<'a> {
 
     fn decode_bytes(&mut self) -> Result<Vec<u8>> {
         let len = self.decode_u32()?;
-        ensure!(
-            len as usize <= ARRAY_MAX_LENGTH,
-            "array length longer than max allowed length. len: {}, max: {}",
-            len,
-            ARRAY_MAX_LENGTH
-        );
+        ensure_max_length!(len as usize);
 
         // make sure there is enough bytes left in the buffer
         let remain = self.raw_bytes.get_ref().len() - self.raw_bytes.position() as usize;
@@ -122,12 +117,7 @@ impl<'a> CanonicalDeserializer for SimpleDeserializer<'a> {
         &mut self,
     ) -> Result<BTreeMap<K, V>> {
         let len = self.decode_u32()?;
-        ensure!(
-            len as usize <= ARRAY_MAX_LENGTH,
-            "array length longer than max allowed. size: {}, max: {}",
-            len,
-            ARRAY_MAX_LENGTH
-        );
+        ensure_max_length!(len as usize);
 
         let mut map = BTreeMap::new();
         for _i in 0..len {
@@ -148,12 +138,7 @@ impl<'a> CanonicalDeserializer for SimpleDeserializer<'a> {
 
     fn decode_vec<T: CanonicalDeserialize>(&mut self) -> Result<Vec<T>> {
         let len = self.decode_u32()?;
-        ensure!(
-            len as usize <= ARRAY_MAX_LENGTH,
-            "array length longer than max allowed. size: {}, max: {}",
-            len,
-            ARRAY_MAX_LENGTH
-        );
+        ensure_max_length!(len as usize);
 
         let mut vec = Vec::new();
         for _i in 0..len {

--- a/common/canonical_serialization/src/simple_serializer.rs
+++ b/common/canonical_serialization/src/simple_serializer.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     canonical_serialize::{CanonicalSerialize, CanonicalSerializer},
-    Endianness, ARRAY_MAX_LENGTH,
+    ensure_max_length, Endianness,
 };
 use byteorder::WriteBytesExt;
 use failure::prelude::*;
@@ -59,13 +59,7 @@ where
     }
 
     fn encode_bytes(&mut self, v: &[u8]) -> Result<&mut Self> {
-        ensure!(
-            v.len() <= ARRAY_MAX_LENGTH,
-            "array length exceeded the maximum length limit. \
-             length: {}, Max length limit: {}",
-            v.len(),
-            ARRAY_MAX_LENGTH,
-        );
+        ensure_max_length!(v.len());
 
         // first add the length as a 4-byte integer
         self.encode_u32(v.len() as u32)?;
@@ -135,13 +129,7 @@ where
                 SimpleSerializer::<Vec<u8>>::serialize(&value)?,
             );
         }
-
-        ensure!(
-            map.len() <= ARRAY_MAX_LENGTH,
-            "array length exceeded the maximum limit. length: {}, max length limit: {}",
-            map.len(),
-            ARRAY_MAX_LENGTH,
-        );
+        ensure_max_length!(map.len());
 
         // add the number of pairs in the map
         self.encode_u32(map.len() as u32)?;
@@ -167,12 +155,7 @@ where
     }
 
     fn encode_vec<T: CanonicalSerialize>(&mut self, v: &[T]) -> Result<&mut Self> {
-        ensure!(
-            v.len() <= ARRAY_MAX_LENGTH,
-            "array length exceeded the maximum limit. length: {}, max length limit: {}",
-            v.len(),
-            ARRAY_MAX_LENGTH,
-        );
+        ensure_max_length!(v.len());
 
         // add the number of items in the vec
         self.encode_u32(v.len() as u32)?;


### PR DESCRIPTION
## Motivation

I realized in a previous PR that we're extensively reusing the ensure length function in our serialization engine, so I extracted it a new method.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

-
