### PR TITLE
[consensus] make Genesis an explicit enum entry

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -121,8 +121,13 @@ impl<T: Payload> BlockStore<T> {
             .map(|qc| (qc.certified_block_id(), qc))
             .collect::<HashMap<_, _>>();
         for block in blocks {
+            assert!(!block.is_genesis_block());
             let compute_res = state_computer
-                .compute(block.parent_id(), block.id(), block.get_payload())
+                .compute(
+                    block.parent_id(),
+                    block.id(),
+                    block.payload().unwrap_or(&T::default()),
+                )
                 .await
                 .expect("fail to rebuild scratchpad");
             // if this block is certified, ensure we agree with the certified state.
@@ -198,7 +203,11 @@ impl<T: Payload> BlockStore<T> {
         };
         let compute_res = self
             .state_computer
-            .compute(parent_id, block.id(), block.get_payload())
+            .compute(
+                parent_id,
+                block.id(),
+                block.payload().unwrap_or(&T::default()),
+            )
             .await
             .with_context(|e| format!("Execution failure for block {}: {:?}", block, e))?;
 

--- a/consensus/src/chained_bft/consensus_types/block_test.rs
+++ b/consensus/src/chained_bft/consensus_types/block_test.rs
@@ -4,7 +4,7 @@
 use crate::chained_bft::{
     common::{Height, Round},
     consensus_types::{
-        block::{Block, BlockSource},
+        block::{Block, BlockType},
         quorum_cert::QuorumCert,
     },
     test_utils::placeholder_certificate_for_block,
@@ -94,12 +94,12 @@ prop_compose! {
             Block {
                 timestamp_usecs: get_current_timestamp().as_micros() as u64,
                 id: fake_id,
-                payload: block.get_payload().clone(),
                 round: block.round(),
                 height: block.height(),
                 parent_id: block.parent_id(),
                 quorum_cert: block.quorum_cert().clone(),
-                block_source: BlockSource::Proposal {
+                block_type: BlockType::Proposal {
+                    payload: block.payload().unwrap().clone(),
                     author: block.author().unwrap(),
                     signature: block.signature().unwrap().clone(),
                 },
@@ -272,7 +272,7 @@ fn test_block_relation() {
         next_block.quorum_cert().certified_block_id(),
         genesis_block.id()
     );
-    assert_eq!(next_block.get_payload(), &payload);
+    assert_eq!(next_block.payload(), Some(&payload));
 
     let cloned_block = next_block.clone();
     assert_eq!(cloned_block.round(), next_block.round());

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -802,20 +802,22 @@ impl<T: Payload> EventProcessor<T> {
             {
                 counters::CREATION_TO_COMMIT_S.observe_duration(time_to_commit);
             }
-            let compute_result = self
-                .block_store
-                .get_compute_result(committed.id())
-                .expect("Compute result of a pending block is unknown");
-            if let Err(e) = self
-                .txn_manager
-                .commit_txns(
-                    committed.get_payload(),
-                    compute_result.as_ref(),
-                    committed.timestamp_usecs(),
-                )
-                .await
-            {
-                error!("Failed to notify mempool: {:?}", e);
+            if let Some(payload) = committed.payload() {
+                let compute_result = self
+                    .block_store
+                    .get_compute_result(committed.id())
+                    .expect("Compute result of a pending block is unknown");
+                if let Err(e) = self
+                    .txn_manager
+                    .commit_txns(
+                        payload,
+                        compute_result.as_ref(),
+                        committed.timestamp_usecs(),
+                    )
+                    .await
+                {
+                    error!("Failed to notify mempool: {:?}", e);
+                }
             }
         }
         counters::LAST_COMMITTED_ROUND.set(block_to_commit.round() as i64);

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -130,7 +130,7 @@ impl<T: Payload> ProposalGenerator<T> {
         // parent (including) up to the root (excluding).
         let exclude_payload = pending_blocks
             .iter()
-            .map(|block| block.get_payload())
+            .flat_map(|block| block.payload())
             .collect();
 
         let block_timestamp = {

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -132,7 +132,7 @@ impl TreeInserter {
         };
 
         let new_block = Block::new_internal(
-            block.get_payload().clone(),
+            block.payload().unwrap().clone(),
             block.parent_id(),
             block.round(),
             block.height(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It's no-op in logics. Today we fake some fields in genesis, it'll get worse when we have reconfiguration genesis, so this is the first step to make it explicit what is a genesis block.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
