### PR TITLE
[consensus] Add type alias ValidatorSignature and remove SignatureWrapper

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -371,8 +371,8 @@ where
             LedgerInfoWithSignatures::new(vote_msg.ledger_info().clone(), HashMap::new())
         });
 
-        vote_msg.signature().clone().add_to_li(author, li_with_sig);
-        match validator_verifier.check_voting_power(li_with_sig.signatures().keys())
+        li_with_sig.add_signature(author, vote_msg.signature().clone());
+        match validator_verifier.batch_verify_aggregated_signature(li_with_sig.ledger_info().hash(), li_with_sig.signatures())
         {
             Ok(_) => {
                 let quorum_cert =

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -25,47 +25,9 @@ use crate::{
     validator_change::ValidatorChangeEventWithProof as RawValidatorChangeEventWithProof,
     validator_signer::ValidatorSigner as RawValidatorSigner,
     validator_verifier::{
-        ValidatorInfo as RawValidatorInfo, ValidatorVerifier as RawValidatorVerifier, VerifyError,
+        ValidatorInfo as RawValidatorInfo, ValidatorVerifier as RawValidatorVerifier,
     },
 };
-use crypto::{hash::HashValue, traits::Signature as RawSignature};
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-pub struct SignatureWrapper<Sig: RawSignature>(Sig);
-
-impl<Sig: RawSignature> SignatureWrapper<Sig> {
-    pub fn verify(
-        &self,
-        validator_verifier: &RawValidatorVerifier<Sig::VerifyingKeyMaterial>,
-        author: AccountAddress,
-        message: HashValue,
-    ) -> std::result::Result<(), VerifyError> {
-        validator_verifier.verify_signature(author, message, &self.0)
-    }
-
-    pub fn try_from(bytes: &[u8]) -> Result<Self, crypto::traits::CryptoMaterialError> {
-        Sig::try_from(bytes).map(SignatureWrapper)
-    }
-
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.to_bytes()
-    }
-
-    pub fn add_to_li(
-        self,
-        author: AccountAddress,
-        li_with_sig: &mut RawLedgerInfoWithSignatures<Sig>,
-    ) {
-        li_with_sig.add_signature(author, self.0)
-    }
-}
-
-impl<Sig: RawSignature> From<Sig> for SignatureWrapper<Sig> {
-    fn from(s: Sig) -> Self {
-        SignatureWrapper(s)
-    }
-}
 
 // This sets the types containing cryptographic materials used in the
 // consensus crate. It is intended as a one-stop shop for changing the
@@ -85,7 +47,7 @@ use std::collections::HashMap;
 #[cfg(any(test, feature = "testing"))]
 pub type SecretKey = Ed25519PrivateKey;
 
-pub type Signature = SignatureWrapper<Ed25519Signature>;
+pub type ValidatorSignature = Ed25519Signature;
 pub type LedgerInfoWithSignatures = RawLedgerInfoWithSignatures<Ed25519Signature>;
 pub type ValidatorInfo = RawValidatorInfo<Ed25519PublicKey>;
 pub type ValidatorVerifier = RawValidatorVerifier<Ed25519PublicKey>;


### PR DESCRIPTION
* Remove additional layers of abstraction for SignatureWrapper and simplify the code
* Allow easier access to ValidatorVerifier methods that require
  &HashMap<AccountAddress, T> that are made more difficult with SignatureWrapper.
  This will allow us to eventually get rid of publically exposing check_voting_power().

## Related PRs

#1149 

## Related Issues

#1148 