### PR TITLE
[types] Fix verify_get_txns_resp when zero txns returned

### DIFF
--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -448,16 +448,15 @@ fn verify_get_txns_resp(
     req_fetch_events: bool,
     txn_list_with_proof: &TransactionListWithProof,
 ) -> Result<()> {
-    ensure!(
-        req_fetch_events == txn_list_with_proof.events.is_some(),
-        "Bad GetTransactions response. Events requested: {}, events returned: {}.",
-        req_fetch_events,
-        txn_list_with_proof.events.is_some(),
-    );
-
     if req_limit == 0 || req_start_version > ledger_info.version() {
         txn_list_with_proof.verify(ledger_info, None)
     } else {
+        ensure!(
+            req_fetch_events == txn_list_with_proof.events.is_some(),
+            "Bad GetTransactions response. Events requested: {}, events returned: {}.",
+            req_fetch_events,
+            txn_list_with_proof.events.is_some(),
+        );
         let num_txns = txn_list_with_proof.transaction_and_infos.len();
         ensure!(
             cmp::min(req_limit, ledger_info.version() - req_start_version + 1)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Function `verify_get_txns_resp`  has bug when zero txns returned. For example:

>     libra% q tr 1 0 true
>     >> Getting committed transaction by range
>     [ERROR] Error getting committed transactions by range: Bad GetTransactions response. Events requested: true, events returned: false.
> 
>     libra% q tr 123456789 1 true
>     >> Getting committed transaction by range
>     [ERROR] Error getting committed transactions by range: Bad GetTransactions response. Events requested: true, events returned: false.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run 'cargo run -p libra-swarm -- -s',  then input 'q tr 1 0 true' in libra shell,

> libra% q tr 1 0 true

There should be no error.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
