### PR TITLE
[Consensus] Persist the last sent vote

### DIFF
--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -80,8 +80,9 @@ impl ChainedBftProvider {
         let config = ChainedBftSMRConfig::from_node_config(&node_config.consensus);
         let (storage, initial_data) = StorageWriteProxy::start(node_config);
         info!(
-            "Starting up the consensus state machine with recovery data - {:?}, {}",
+            "Starting up the consensus state machine with recovery data - [consensus state {:?}], [last_vote {}], [highest timeout certificates: {}]",
             initial_data.state(),
+            initial_data.last_vote().map_or("None".to_string(), |v| format!("{}", v)),
             initial_data.highest_timeout_certificates()
         );
         let smr = ChainedBftSMR::new(

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -213,6 +213,7 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
             .expect("already started, initial data is None");
         let consensus_state = initial_data.state();
         let highest_timeout_certificates = initial_data.highest_timeout_certificates().clone();
+        let last_vote = initial_data.last_vote();
         if initial_data.need_sync() {
             // make sure we sync to the root state in case we're not
             state_computer.sync_to_or_bail(initial_data.root_ledger_info());
@@ -257,8 +258,8 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
 
         let proposer_election = self.create_proposer_election();
         let event_processor = EventProcessor::new(
-            self.author,
             Arc::clone(&block_store),
+            last_vote,
             pacemaker,
             proposer_election,
             proposal_generator,

--- a/consensus/src/chained_bft/consensus_types/vote_msg.rs
+++ b/consensus/src/chained_bft/consensus_types/vote_msg.rs
@@ -37,9 +37,10 @@ impl Display for VoteMsg {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Vote: [vote data: {}, author: {}, {}]",
+            "Vote: [vote data: {}, author: {}, is_timeout: {}, {}]",
             self.vote_data,
             self.author.short_str(),
+            self.round_signature().is_some(),
             self.ledger_info
         )
     }

--- a/consensus/src/chained_bft/consensusdb/consensusdb_test.rs
+++ b/consensus/src/chained_bft/consensusdb/consensusdb_test.rs
@@ -17,7 +17,10 @@ fn test_put_get() {
     assert_eq!(old_blocks.len(), 0);
     assert_eq!(db.get_quorum_certificates().unwrap().len(), 0);
 
-    db.save_state(vec![0x01, 0x02, 0x03]).unwrap();
+    // The second parameter here is a serialization of the last vote message, which is hard to
+    // construct in this test, so it remains bogus (cannot be properly deserialized).
+    db.save_state(vec![0x01, 0x02, 0x03], vec![0x01, 0x02, 0x03])
+        .unwrap();
 
     let qcs = vec![QuorumCert::certificate_for_genesis()];
 

--- a/consensus/src/chained_bft/consensusdb/schema/single_entry/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/schema/single_entry/mod.rs
@@ -35,6 +35,8 @@ pub enum SingleEntryKey {
     ConsensusState = 0,
     // Used to store the highest timeout certificates
     HighestTimeoutCertificates = 1,
+    // Used to store the last vote
+    LastVoteMsg = 2,
 }
 
 impl KeyCodec<SingleEntrySchema> for SingleEntryKey {

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -147,8 +147,8 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
 
     // event processor
     EventProcessor::new(
-        signer.author(),
         Arc::clone(&block_store),
+        None,
         pacemaker,
         proposer_election,
         proposal_generator,

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -150,7 +150,7 @@ impl NodeSetup {
             Arc::clone(&epoch_mgr),
         );
         let consensus_state = initial_data.state();
-
+        let last_vote_sent = initial_data.last_vote();
         let (commit_cb_sender, _commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
         let state_computer = Arc::new(MockStateComputer::new(
             commit_cb_sender,
@@ -177,8 +177,8 @@ impl NodeSetup {
 
         let proposer_election = Self::create_proposer_election(proposer_author);
         let mut event_processor = EventProcessor::new(
-            author,
             Arc::clone(&block_store),
+            last_vote_sent,
             pacemaker,
             proposer_election,
             proposal_generator,

--- a/consensus/src/chained_bft/safety/safety_rules.rs
+++ b/consensus/src/chained_bft/safety/safety_rules.rs
@@ -218,13 +218,6 @@ impl SafetyRules {
         None
     }
 
-    /// Return the new state if the voting round was increased, otherwise ignore.  Increasing the
-    /// last vote round is always safe, but can affect liveness and must be increasing
-    /// to protect safety.
-    pub fn increase_last_vote_round(&mut self, round: Round) -> Option<ConsensusState> {
-        self.state.set_last_vote_round(round)
-    }
-
     /// Clones the up-to-date state of consensus (for monitoring / debugging purposes)
     pub fn consensus_state(&self) -> ConsensusState {
         self.state.clone()


### PR DESCRIPTION
## Summary:
We used to keep the last sent vote information in memory to be able to send the same vote upon timeout.
It means that if a node restarts it might lose the last sent vote and might not be able to send it again upon timeout, which is unacceptable if we want to use vote messages for timeouts.
This commit updates the logic to make sure that we persist the last sent vote in the consensus DB together with the consensus state.
As a result, we could move the persistency of the last sent vote to the function `EventProcessor::execute_and_vote()`. The processing of local timeout is then going to fail if no vote was generated
(there is no legitimate reason to fail to generate "some" vote anymore).

## Testing:
Existing unit test coverage is already covering the restartability of the nodes.

## Issues:
ref #1048 