### PR TITLE
[prometheus] drop protobuf dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,7 +2955,6 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -12,14 +12,10 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 hyper = "0.12.34"
 lazy_static = "1.3.0"
 serde_json = "1.0.40"
+prometheus = { version = "0.7.0", default-features = false }
 
 failure = { path = "../failure_ext", package = "failure_ext" }
 logger = { path = "../logger" }
-
-[dependencies.prometheus]
-version  = "0.7.0"
-default-features = false
-features = ["protobuf"]
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 siphasher = { version = "0.3.0", default-features = false }
 termion = { version = "1.5.3", default-features = false }
 tokio = { version = "0.1.22", default-features = false }
+prometheus = { version = "0.7.0", default-features = false }
 
 canonical_serialization = { path = "../common/canonical_serialization" }
 channel = { path = "../common/channel" }
@@ -44,11 +45,6 @@ storage_client = { path = "../storage/storage_client" }
 tools = { path = "../common/tools" }
 types = { path = "../types" }
 vm_runtime = { path = "../language/vm/vm_runtime" }
-
-[dependencies.prometheus]
-version  = "0.7.0"
-default-features = false
-features = ["protobuf"]
 
 [dev-dependencies]
 cached = "0.9.0"

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -13,6 +13,7 @@ proptest = "0.9"
 rayon = "1.1"
 rental = "0.5.4"
 mirai-annotations = "1.4.0"
+prometheus = { version = "0.7.0", default-features = false }
 
 bytecode_verifier = { path = "../../bytecode_verifier" }
 canonical_serialization = { path = "../../../common/canonical_serialization" }
@@ -25,11 +26,6 @@ types = { path = "../../../types" }
 vm = { path = "../" }
 vm_cache_map = { path = "vm_cache_map" }
 vm_runtime_types = { path = "vm_runtime_types" }
-
-[dependencies.prometheus]
-version  = "0.7.0"
-default-features = false
-features = ["protobuf"]
 
 [dev-dependencies]
 compiler = { path = "../../compiler" }

--- a/state_synchronizer/Cargo.toml
+++ b/state_synchronizer/Cargo.toml
@@ -12,6 +12,7 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 rand = "0.6.5"
 tokio = { version = "0.1.22", default-features = false }
+prometheus = { version = "0.7.0", default-features = false }
 
 config = { path = "../config" }
 executor = { path = "../execution/executor" }
@@ -22,10 +23,6 @@ network = { path = "../network" }
 storage_client = { path = "../storage/storage_client" }
 types = { path = "../types" }
 vm_runtime = { path = "../language/vm/vm_runtime" }
-
-[dependencies.prometheus]
-version  = "0.7.0"
-default-features = false
 
 [dev-dependencies]
 bytes = "0.4.12"


### PR DESCRIPTION
Prometheus versions > 2.0 no longer support Protobuf and instead prefer
exporting metics via a text-based format. As such the rust prometheus
library we use for metrics has placed protobuf support behind a feature
and as it isn't required lets turn off the protobuf feature.
