### PR TITLE
[terraform] Limit container log size

### DIFF
--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -31,16 +31,23 @@
         "ulimits": [
             {"name": "nofile", "softLimit": 131072, "hardLimit": 131072}
         ],
-%{ if log_group != "" }
         "logConfiguration": {
+%{ if log_group != "" }
             "logDriver": "awslogs",
             "options": {
                 "awslogs-group": "${log_group}",
                 "awslogs-region": "${log_region}",
                 "awslogs-stream-prefix": "${log_prefix}"
             }
-        },
+%{ else }
+            "logDriver": "json-file",
+            "options": {
+                "max-size": "1g",
+                "max-file": "20",
+                "compress": "true"
+            }
 %{ endif }
+        },
         "secrets": [
             {"name": "NETWORK_KEYPAIRS", "valueFrom": "${network_secret}"},
             {"name": "CONSENSUS_KEYPAIR", "valueFrom": "${consensus_secret}"}


### PR DESCRIPTION
The default `json-file` log driver has no size limit. Set some.

Test Plan: Deployed to mgorven workspace, inspected containers to check that log config was present.