### PR TITLE
[config] Streamline how genesis file/storage dir get accessed

### DIFF
--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -24,9 +24,10 @@ pub fn load_config_from_path(config: Option<&Path>) -> NodeConfig {
 }
 
 pub fn setup_metrics(peer_id: &str, node_config: &NodeConfig) {
-    if !node_config.metrics.dir.as_os_str().is_empty() {
+    let metrics_dir = node_config.get_metrics_dir();
+    if !metrics_dir.as_os_str().is_empty() {
         metrics::dump_all_metrics_to_file_periodically(
-            &node_config.metrics.dir,
+            &metrics_dir,
             &format!("{}.metrics", peer_id),
             node_config.metrics.collection_interval_ms,
         );

--- a/config/config-builder/src/util.rs
+++ b/config/config-builder/src/util.rs
@@ -52,7 +52,7 @@ pub fn get_test_config() -> (NodeConfig, KeyPair<Ed25519PrivateKey, Ed25519Publi
     let (_, test_consensus_peers, test_network_peers) = ConfigHelpers::gen_validator_nodes(1, None);
     let genesis_transaction =
         gen_genesis_transaction_bytes(&keypair, &test_consensus_peers, &test_network_peers);
-    let mut genesis_transaction_file = File::create(&config.execution.genesis_file_location)
+    let mut genesis_transaction_file = File::create(config.get_genesis_transaction_file())
         .expect("[config] Failed to create file for storing genesis transaction");
     genesis_transaction_file
         .write_all(&genesis_transaction)

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -329,7 +329,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
     fn start(config: &NodeConfig) -> (Arc<Self>, RecoveryData<T>) {
         info!("Start consensus recovery.");
         let read_client = create_storage_read_client(config);
-        let db = Arc::new(ConsensusDB::new(config.storage.dir.clone()));
+        let db = Arc::new(ConsensusDB::new(config.get_storage_dir()));
         let proxy = Arc::new(Self::new(Arc::clone(&db)));
         let initial_data = db.get_data().expect("unable to recover consensus data");
         let consensus_state = initial_data.0.map_or_else(ConsensusState::default, |s| {

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -37,14 +37,13 @@ fn get_config() -> NodeConfig {
     // XXX Should this logic live in NodeConfigHelpers?
     let genesis_txn: types::proto::types::SignedTransaction =
         encode_genesis_transaction(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1.clone()).into();
-    let mut file = File::create(&config.execution.genesis_file_location).unwrap();
+    let mut file = File::create(config.get_genesis_transaction_file()).unwrap();
     file.write_all(&genesis_txn.to_vec().unwrap()).unwrap();
-
     config
 }
 
 fn create_storage_server(config: &mut NodeConfig) -> (grpcio::Server, mpsc::Receiver<()>) {
-    let (service, shutdown_receiver) = StorageService::new(&config.storage.get_dir());
+    let (service, shutdown_receiver) = StorageService::new(&config.get_storage_dir());
     let mut server = ServerBuilder::new(Arc::new(EnvBuilder::new().build()))
         .register_service(create_storage(service))
         .bind("localhost", 0)

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -197,7 +197,6 @@ where
 
         if committed_block_id == *PRE_GENESIS_BLOCK_ID {
             let genesis_transaction = config
-                .execution
                 .get_genesis_transaction()
                 .expect("failed to load genesis transaction!");
             executor.init_genesis(genesis_transaction);

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -32,7 +32,7 @@ use types::proto::types::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerRespo
 
 /// Starts storage service according to config.
 pub fn start_storage_service(config: &NodeConfig) -> ServerHandle {
-    let (storage_service, shutdown_receiver) = StorageService::new(&config.storage.get_dir());
+    let (storage_service, shutdown_receiver) = StorageService::new(&config.get_storage_dir());
     spawn_service_thread_with_drop_closure(
         create_storage(storage_service),
         config.storage.address.clone(),

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -351,11 +351,7 @@ fn test_startup_sync_state() {
     )
     .unwrap();
     // TODO Remove hardcoded path to state db
-    let state_db_path = node_config
-        .base
-        .data_dir_path
-        .join(node_config.storage.get_dir())
-        .join("libradb");
+    let state_db_path = node_config.get_storage_dir().join("libradb");
     // Verify that state_db_path exists and
     // we are not deleting a non-existent directory
     assert!(state_db_path.as_path().exists());


### PR DESCRIPTION
## Motivation
Genesis file location in config relative to base directory was inconsistently used in various parts of the code. This PR simplifies that and ensures that the genesis file location and storage dir location are always relative to the base directory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `cargo t`
- Ran libra swarm locally with both validators and full nodes
- Generated configs using `libra-config` binary and ensured config generation was successful