### PR TITLE
[consensus] remove parent_id from Block

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -415,7 +415,6 @@ fn test_illegal_timestamp() {
     let genesis = block_store.root();
     let block_with_illegal_timestamp = Block::<Vec<usize>>::new_internal(
         vec![],
-        genesis.id(),
         1,
         1,
         // This timestamp is illegal, it is the same as genesis

--- a/consensus/src/chained_bft/consensus_types/block_test.rs
+++ b/consensus/src/chained_bft/consensus_types/block_test.rs
@@ -32,13 +32,11 @@ prop_compose! {
     /// to generate it later on when adding to the tree.
     pub fn make_block(
         _ancestor_id: HashValue,
-        parent_id_strategy: impl Strategy<Value = HashValue>,
         round_strategy: impl Strategy<Value = Round>,
         height: Height,
         signer_strategy: impl Strategy<Value = ValidatorSigner>,
         parent_qc: QuorumCert,
     )(
-        parent_id in parent_id_strategy,
         round in round_strategy,
         payload in 0usize..10usize,
         height in Just(height),
@@ -47,7 +45,6 @@ prop_compose! {
     ) -> Block<Vec<usize>> {
         Block::new_internal(
             vec![payload],
-            parent_id,
             round,
             height,
             get_current_timestamp().as_micros() as u64,
@@ -69,7 +66,6 @@ prop_compose! {
     )(
         block in make_block(
             ancestor_id,
-            HashValue::arbitrary(),
             Round::arbitrary(),
             123,
             proptests::arb_signer(),
@@ -96,7 +92,6 @@ prop_compose! {
                 id: fake_id,
                 round: block.round(),
                 height: block.height(),
-                parent_id: block.parent_id(),
                 quorum_cert: block.quorum_cert().clone(),
                 block_type: BlockType::Proposal {
                     payload: block.payload().unwrap().clone(),
@@ -145,8 +140,6 @@ prop_compose! {
     )( block in make_block(
         // ancestor_id
         forest_vec[qc_idx].id(),
-        // parent_id
-        Just(forest_vec[parent_idx].id()),
         // round
         some_round(forest_vec[parent_idx].round()),
         // height,

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -133,7 +133,6 @@ impl TreeInserter {
 
         let new_block = Block::new_internal(
             block.payload().unwrap().clone(),
-            block.parent_id(),
             block.round(),
             block.height(),
             block.timestamp_usecs(),

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -72,26 +72,23 @@ message TimeoutCertificate {
 message Block {
   // This block's id as a hash value
   bytes id = 1;
-  // Parent block id of this block as a hash value (all zeros to indicate the
-  // genesis block)
-  bytes parent_id = 2;
   // Payload of the block (e.g. one or more transaction(s)
-  bytes payload = 3;
+  bytes payload = 2;
   // The round of the block (internal monotonically increasing counter).
-  uint64 round = 4;
+  uint64 round = 3;
   // The height of the block (position in the chain).
-  uint64 height = 5;
+  uint64 height = 4;
   // The approximate physical microseconds since the epoch when the block was proposed
-  uint64 timestamp_usecs = 6;
+  uint64 timestamp_usecs = 5;
   // Contains the quorum certified ancestor and whether the quorum certified
   // ancestor was voted on successfully
-  QuorumCert quorum_cert = 7;
+  QuorumCert quorum_cert = 6;
   // Author of the block that can be validated by the author's public key and
   // the signature
-  bytes author = 8;
+  bytes author = 7;
   // Signature that the hash of this block has been authored by the owner of the
   // private key
-  bytes signature = 9;
+  bytes signature = 8;
 }
 
 message QuorumCert {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The parent_id is derivable from the quorum cert.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
