### PR TITLE
[fuzzing] adding merkle tree proto fuzzing

### DIFF
--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -55,12 +55,14 @@ macro_rules! proto_fuzz_target {
 }
 
 // List fuzz target modules here.
+mod accumulator_merkle_proof;
 mod admission_control;
 mod compiled_module;
 mod consensus_proposal;
 mod inbound_rpc_protocol;
 mod inner_signed_transaction;
 mod signed_transaction;
+mod sparse_merkle_proof;
 mod vm_value;
 
 lazy_static! {
@@ -70,6 +72,8 @@ lazy_static! {
             Box::new(compiled_module::CompiledModuleTarget::default()),
             Box::new(signed_transaction::SignedTransactionTarget::default()),
             Box::new(inner_signed_transaction::SignedTransactionTarget::default()),
+            Box::new(sparse_merkle_proof::SparseMerkleProofTarget::default()),
+            Box::new(accumulator_merkle_proof::AccumulatorProofTarget::default()),
             Box::new(vm_value::ValueTarget::default()),
             Box::new(consensus_proposal::ConsensusProposal::default()),
             Box::new(admission_control::AdmissionControlSubmitTransactionRequest::default()),

--- a/testsuite/libra-fuzzer/src/fuzz_targets/accumulator_merkle_proof.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/accumulator_merkle_proof.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_types::proof::TransactionAccumulatorProof;
+use libra_types::proto::types::AccumulatorProof as ProtoAccumulatorProof;
+
+proto_fuzz_target!(AccumulatorProofTarget => TransactionAccumulatorProof, ProtoAccumulatorProof);

--- a/testsuite/libra-fuzzer/src/fuzz_targets/sparse_merkle_proof.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/sparse_merkle_proof.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use libra_types::proof::SparseMerkleProof;
+use libra_types::proto::types::SparseMerkleProof as ProtoSparseMerkleProof;
+
+proto_fuzz_target!(SparseMerkleProofTarget => SparseMerkleProof, ProtoSparseMerkleProof);


### PR DESCRIPTION
## Motivation

Adding two fuzzers. When receiving sparse and non-sparse merkle tree proofs,
there is some involved proto decoding code that we can fuzz.

## Test Plan

The two fuzzers work (generation and fuzzing)