### PR TITLE
[CI] create docker base builder

### DIFF
--- a/docker/base/base.Dockerfile
+++ b/docker/base/base.Dockerfile
@@ -1,0 +1,18 @@
+# Create a base image for mint, validator, client
+FROM debian:stretch as builder
+
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update \
+    && apt-get install -y protobuf-compiler/stretch-backports cmake curl clang \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+COPY . /libra
+RUN cargo build --release -p libra-node -p client -p benchmark

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+PROXY=""
+if [ "$https_proxy" ]; then
+	PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+fi
+
+docker build -f $DIR/base.Dockerfile $DIR/../.. --tag libra_base --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY

--- a/docker/bench/bench.Dockerfile
+++ b/docker/bench/bench.Dockerfile
@@ -1,21 +1,5 @@
-FROM debian:stretch as builder
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl clang \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-COPY . /libra
-RUN cargo build --release -p libra-node -p client -p benchmark
+### Base Builder Image ##
+FROM libra_base as builder
 
 ### Production Image ###
 FROM debian:stretch

--- a/docker/bench/build.sh
+++ b/docker/bench/build.sh
@@ -5,7 +5,7 @@ DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 PROXY=""
 if [ -z ${https_proxy+x} ]; then
-  PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+  PROXY="--build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
 echo "Building base..."
@@ -14,9 +14,9 @@ cd $BASE_BUILDER_DIR && pwd && ./build.sh
 
 echo "Building client..."
 docker build \
-  -f $DIR/validator.Dockerfile \
+  -f $DIR/bench.Dockerfile \
   $DIR/../.. \
-  --tag libra_e2e \
+  --tag libra_bench \
   --build-arg GIT_REV="$(git rev-parse HEAD)" \
   --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
   --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \

--- a/docker/client/build.sh
+++ b/docker/client/build.sh
@@ -4,8 +4,20 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 PROXY=""
-if [ "$https_proxy" ]; then
-    PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+if [ -z ${https_proxy+x} ]; then
+  PROXY="--build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/client.Dockerfile $DIR/../.. --tag libra_client --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+echo "Building base..."
+BASE_BUILDER_DIR=$DIR/../base
+cd $BASE_BUILDER_DIR && pwd && ./build.sh
+
+echo "Building client.."
+docker build \
+  -f $DIR/client.Dockerfile \
+  $DIR/../.. \
+  --tag libra_client \
+  --build-arg GIT_REV="$(git rev-parse HEAD)" \
+  --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY

--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -1,19 +1,5 @@
-### Build Image ###
-FROM debian:stretch as builder
-
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl clang \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-COPY . /libra
-RUN cargo build --release -p libra-node -p client -p benchmark
+### Base Builder Image ###
+FROM libra_base as builder
 RUN strip target/release/client
 
 ### Production Image ###

--- a/docker/mint/build.sh
+++ b/docker/mint/build.sh
@@ -4,8 +4,20 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 PROXY=""
-if [ "$https_proxy" ]; then
-    PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+if [ -z ${https_proxy+x} ]; then
+  PROXY="--build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/mint.Dockerfile $DIR/../.. --tag libra_mint  --build-arg GIT_REV=$(git rev-parse HEAD) --build-arg GIT_UPSTREAM=$(git merge-base --fork-point origin/master) --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+echo "Building base..."
+BASE_BUILDER_DIR=$DIR/../base
+cd $BASE_BUILDER_DIR && pwd && ./build.sh
+
+echo "Building mint..."
+docker build \
+  -f $DIR/mint.Dockerfile \
+  $DIR/../.. \
+  --tag libra_mint \
+  --build-arg GIT_REV=$(git rev-parse HEAD) \
+  --build-arg GIT_UPSTREAM=$(git merge-base --fork-point origin/master) \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -1,23 +1,5 @@
-FROM debian:stretch as builder
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl clang \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-COPY . /libra
-RUN cargo build --release -p libra-node -p client -p benchmark
-
 ### Production Image ###
+FROM libra_base as builder
 FROM debian:stretch
 
 # TODO: Unsure which of these are needed exactly for client

--- a/docker/validator/validator.Dockerfile
+++ b/docker/validator/validator.Dockerfile
@@ -1,21 +1,5 @@
-FROM debian:stretch as builder
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/stretch-backports cmake curl clang \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-COPY . /libra
-RUN cargo build --release -p libra-node -p client -p benchmark
+### Base Builder Image ###
+FROM libra_base as builder
 
 ### Production Image ###
 FROM debian:stretch
@@ -35,7 +19,12 @@ EXPOSE 9101
 ENV RUST_BACKTRACE 1
 
 # Define SEED_PEERS, NODE_CONFIG, NETWORK_KEYPAIRS, CONSENSUS_KEYPAIR, GENESIS_BLOB and PEER_ID environment variables when running
-CMD cd /opt/libra/etc && echo "$NODE_CONFIG" > node.config.toml && echo "$SEED_PEERS" > seed_peers.config.toml && echo "$NETWORK_KEYPAIRS" > network_keypairs.config.toml && echo "$CONSENSUS_KEYPAIR" > consensus_keypair.config.toml && exec /opt/libra/bin/libra-node -f node.config.toml
+CMD cd /opt/libra/etc \
+    && echo "$NODE_CONFIG" > node.config.toml \
+    && echo "$SEED_PEERS" > seed_peers.config.toml \
+    && echo "$NETWORK_KEYPAIRS" > network_keypairs.config.toml \
+    && echo "$CONSENSUS_KEYPAIR" > consensus_keypair.config.toml \
+    && exec /opt/libra/bin/libra-node -f node.config.toml
 
 ARG BUILD_DATE
 ARG GIT_REV


### PR DESCRIPTION
## Motivation
Docker layer caching is not consistent in nightly builds. Create a base builder to improve caching.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)
Yes

## Test Plan
Canary result (based off of cba3730, where Docker build step is added to the commit workflow):
- https://app.circleci.com/jobs/github/libra/libra/9375
- All four docker images completed in ~1 hr, compared 3+ hrs previously.
- The subsequent 3 docker images all took advantage of DLC