### PR TITLE
Prepend libra to mempool packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,10 @@ dependencies = [
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-mempool 0.1.0",
+ "libra-mempool-shared-proto 0.1.0",
  "libra-types 0.1.0",
  "logger 0.1.0",
- "mempool 0.1.0",
- "mempool-shared-proto 0.1.0",
  "metrics 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest_helpers 0.1.0",
@@ -57,9 +57,9 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-mempool-shared-proto 0.1.0",
  "libra-types 0.1.0",
  "logger 0.1.0",
- "mempool-shared-proto 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -732,9 +732,9 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-mempool 0.1.0",
  "libra-types 0.1.0",
  "logger 0.1.0",
- "mempool 0.1.0",
  "metrics 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
@@ -2052,6 +2052,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-mempool"
+version = "0.1.0"
+dependencies = [
+ "bounded-executor 0.1.0",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "channel 0.1.0",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "config 0.1.0",
+ "crypto 0.1.0",
+ "failure_ext 0.1.0",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpc_helpers 0.1.0",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-mempool-shared-proto 0.1.0",
+ "libra-types 0.1.0",
+ "logger 0.1.0",
+ "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics 0.1.0",
+ "network 0.1.0",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-service 0.1.0",
+ "storage_client 0.1.0",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ttl_cache 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm_validator 0.1.0",
+]
+
+[[package]]
+name = "libra-mempool-shared-proto"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_ext 0.1.0",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-node"
 version = "0.1.0"
 dependencies = [
@@ -2069,9 +2112,9 @@ dependencies = [
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-mempool 0.1.0",
  "libra-types 0.1.0",
  "logger 0.1.0",
- "mempool 0.1.0",
  "metrics 0.1.0",
  "network 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2316,49 +2359,6 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mempool"
-version = "0.1.0"
-dependencies = [
- "bounded-executor 0.1.0",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.1.0",
- "crypto 0.1.0",
- "failure_ext 0.1.0",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpc_helpers 0.1.0",
- "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-types 0.1.0",
- "logger 0.1.0",
- "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mempool-shared-proto 0.1.0",
- "metrics 0.1.0",
- "network 0.1.0",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-service 0.1.0",
- "storage_client 0.1.0",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "ttl_cache 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "vm_validator 0.1.0",
-]
-
-[[package]]
-name = "mempool-shared-proto"
-version = "0.1.0"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_ext 0.1.0",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -26,8 +26,8 @@ failure = { package = "failure_ext", path = "../../common/failure_ext" }
 executable-helpers = { path = "../../common/executable-helpers" }
 grpc_helpers = { path = "../../common/grpc_helpers" }
 logger = { path = "../../common/logger" }
-mempool = { path = "../../mempool" }
-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
+libra-mempool = { path = "../../mempool" }
+libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
 metrics = { path = "../../common/metrics" }
 storage_client = { path = "../../storage/storage_client" }
 libra-types = { path = "../../types" }

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -17,19 +17,19 @@ use failure::prelude::*;
 use futures::future::Future;
 use futures03::executor::block_on;
 use grpc_helpers::provide_grpc_response;
+use libra_mempool::proto::{
+    mempool::{AddTransactionWithValidationRequest, HealthCheckRequest},
+    mempool_client::MempoolClientTrait,
+};
+use libra_mempool_shared_proto::proto::mempool_status::{
+    MempoolAddTransactionStatus,
+    MempoolAddTransactionStatusCode::{self, MempoolIsFull},
+};
 use libra_types::{
     proto::types::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse},
     transaction::SignedTransaction,
 };
 use logger::prelude::*;
-use mempool::proto::{
-    mempool::{AddTransactionWithValidationRequest, HealthCheckRequest},
-    mempool_client::MempoolClientTrait,
-};
-use mempool_shared_proto::proto::mempool_status::{
-    MempoolAddTransactionStatus,
-    MempoolAddTransactionStatusCode::{self, MempoolIsFull},
-};
 use metrics::counters::SVC_COUNTERS;
 use std::convert::TryFrom;
 use std::sync::Arc;

--- a/admission_control/admission-control-service/src/mocks/local_mock_mempool.rs
+++ b/admission_control/admission-control-service/src/mocks/local_mock_mempool.rs
@@ -1,17 +1,17 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::{account_address::ADDRESS_LENGTH, transaction::SignedTransaction};
-use mempool::proto::{
+use libra_mempool::proto::{
     mempool::{
         AddTransactionWithValidationRequest, AddTransactionWithValidationResponse,
         HealthCheckRequest, HealthCheckResponse,
     },
     mempool_client::MempoolClientTrait,
 };
-use mempool_shared_proto::proto::mempool_status::{
+use libra_mempool_shared_proto::proto::mempool_status::{
     MempoolAddTransactionStatus, MempoolAddTransactionStatusCode,
 };
+use libra_types::{account_address::ADDRESS_LENGTH, transaction::SignedTransaction};
 use std::convert::TryFrom;
 use std::time::SystemTime;
 

--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -11,12 +11,12 @@ use crate::{
 use admission_control_proto::{AdmissionControlStatus, SubmitTransactionResponse};
 
 use crypto::{ed25519::*, test_utils::TEST_SEED};
+use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     vm_error::{StatusCode, VMStatus},
 };
-use mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use rand::SeedableRng;
 use std::convert::TryFrom;
 use std::sync::Arc;

--- a/admission_control/admission_control_proto/Cargo.toml
+++ b/admission_control/admission_control_proto/Cargo.toml
@@ -17,7 +17,7 @@ prost = "0.5.0"
 
 failure = { package = "failure_ext", path = "../../common/failure_ext" }
 logger = { path = "../../common/logger" }
-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
+libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]

--- a/admission_control/admission_control_proto/src/lib.rs
+++ b/admission_control/admission_control_proto/src/lib.rs
@@ -4,9 +4,9 @@
 pub mod proto;
 
 use failure::prelude::*;
+use libra_mempool_shared_proto::MempoolAddTransactionStatus;
 use libra_types::vm_error::VMStatus;
 use logger::prelude::*;
-use mempool_shared_proto::MempoolAddTransactionStatus;
 use std::convert::TryFrom;
 
 /// AC response status of submit_transaction to clients.

--- a/admission_control/admission_control_proto/src/proto/mod.rs
+++ b/admission_control/admission_control_proto/src/proto/mod.rs
@@ -4,7 +4,7 @@
 #![allow(bare_trait_objects)]
 
 use ::libra_types::proto::*;
-use mempool_shared_proto::proto::mempool_status;
+use libra_mempool_shared_proto::proto::mempool_status;
 
 pub mod admission_control {
     include!(concat!(env!("OUT_DIR"), "/admission_control.rs"));

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -38,7 +38,7 @@ debug_interface = { path = "../common/debug_interface" }
 executor = { path = "../execution/executor" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 logger = { path = "../common/logger" }
-mempool = { path = "../mempool" }
+libra-mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
 network = { path = "../network" }
 prost-ext = { path = "../common/prost-ext" }

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -18,13 +18,13 @@ use crate::{
 use config::config::{ConsensusProposerType::FixedProposer, NodeConfig};
 use executor::Executor;
 use failure::prelude::*;
+use libra_mempool::proto::mempool::MempoolClient;
 use libra_types::{
     account_address::AccountAddress,
     crypto_proxies::{ValidatorSigner, ValidatorVerifier},
     transaction::SignedTransaction,
 };
 use logger::prelude::*;
-use mempool::proto::mempool::MempoolClient;
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};
 use state_synchronizer::StateSyncClient;
 use std::{convert::TryFrom, sync::Arc};

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -8,7 +8,7 @@ use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender}
 use crate::chained_bft::chained_bft_consensus_provider::ChainedBftProvider;
 use executor::Executor;
 use grpcio::{ChannelBuilder, EnvBuilder};
-use mempool::proto::mempool::MempoolClient;
+use libra_mempool::proto::mempool::MempoolClient;
 use state_synchronizer::StateSyncClient;
 use std::sync::Arc;
 use storage_client::{StorageRead, StorageReadServiceClient};

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -5,12 +5,12 @@ use crate::{counters, state_replication::TxnManager};
 use executor::StateComputeResult;
 use failure::Result;
 use futures::{compat::Future01CompatExt, future, Future, FutureExt};
-use libra_types::transaction::{SignedTransaction, TransactionStatus};
-use logger::prelude::*;
-use mempool::proto::mempool::{
+use libra_mempool::proto::mempool::{
     CommitTransactionsRequest, CommittedTransaction, GetBlockRequest, MempoolClient,
     TransactionExclusion,
 };
+use libra_types::transaction::{SignedTransaction, TransactionStatus};
+use logger::prelude::*;
 use std::{convert::TryFrom, pin::Pin, sync::Arc};
 
 /// Proxy interface to mempool

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -30,7 +30,7 @@ executor = { path = "../execution/executor" }
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["async-await", "io-compat", "compat"] }
 grpc_helpers = { path = "../common/grpc_helpers" }
 logger = { path = "../common/logger" }
-mempool = { path = "../mempool" }
+libra-mempool = { path = "../mempool" }
 metrics = { path = "../common/metrics" }
 crypto = { path = "../crypto/crypto" }
 network = { path = "../network" }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -13,9 +13,9 @@ use executor::Executor;
 use futures::future::{FutureExt, TryFutureExt};
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder, ServerBuilder};
+use libra_mempool::{proto::mempool::MempoolClient, MempoolRuntime};
 use libra_types::account_address::AccountAddress as PeerId;
 use logger::prelude::*;
-use mempool::{proto::mempool::MempoolClient, MempoolRuntime};
 use metrics::metric_server;
 use network::{
     validator_network::{

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mempool"
+name = "libra-mempool"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 description = "Libra mempool"
@@ -22,7 +22,7 @@ prost = "0.5.0"
 tokio = "0.1.22"
 ttl_cache = "0.4.2"
 
-mempool-shared-proto = { path = "mempool-shared-proto" }
+libra-mempool-shared-proto = { path = "mempool-shared-proto" }
 bounded-executor = { path = "../common/bounded-executor" }
 config = { path = "../config" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }

--- a/mempool/mempool-shared-proto/Cargo.toml
+++ b/mempool/mempool-shared-proto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mempool-shared-proto"
+name = "libra-mempool-shared-proto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 license = "Apache-2.0"

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -15,12 +15,12 @@ use crate::{
 };
 use chrono::Utc;
 use config::config::NodeConfig;
+use libra_mempool_shared_proto::{
+    proto::mempool_status::MempoolAddTransactionStatusCode, MempoolAddTransactionStatus,
+};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use logger::prelude::*;
 use lru_cache::LruCache;
-use mempool_shared_proto::{
-    proto::mempool_status::MempoolAddTransactionStatusCode, MempoolAddTransactionStatus,
-};
 use std::{cmp::max, collections::HashSet, convert::TryFrom};
 use ttl_cache::TtlCache;
 

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -13,11 +13,11 @@ use crate::{
 };
 use config::config::MempoolConfig;
 use failure::prelude::*;
-use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
-use logger::prelude::*;
-use mempool_shared_proto::{
+use libra_mempool_shared_proto::{
     proto::mempool_status::MempoolAddTransactionStatusCode, MempoolAddTransactionStatus,
 };
+use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
+use logger::prelude::*;
 use std::{
     collections::HashMap,
     ops::Bound,

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -6,11 +6,11 @@ use config::config::NodeConfigHelpers;
 use crypto::ed25519::*;
 use failure::prelude::*;
 use lazy_static::lazy_static;
+use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{
     account_address::AccountAddress,
     transaction::{RawTransaction, Script, SignedTransaction},
 };
-use mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{collections::HashSet, iter::FromIterator};
 

--- a/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
@@ -9,8 +9,8 @@ use crate::core_mempool::{
     CoreMempool, TimelineState,
 };
 use config::config::NodeConfigHelpers;
+use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::transaction::SignedTransaction;
-use mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use std::{collections::HashSet, time::Duration};
 
 #[test]

--- a/mempool/src/proto/mod.rs
+++ b/mempool/src/proto/mod.rs
@@ -5,7 +5,7 @@
 #![allow(missing_docs)]
 
 use ::libra_types::proto::*;
-use mempool_shared_proto::proto::mempool_status;
+use libra_mempool_shared_proto::proto::mempool_status;
 
 pub mod mempool {
     include!(concat!(env!("OUT_DIR"), "/mempool.rs"));

--- a/mempool/src/unit_tests/service_test.rs
+++ b/mempool/src/unit_tests/service_test.rs
@@ -6,12 +6,12 @@ use config::config::NodeConfigHelpers;
 use crypto::ed25519::compat::generate_keypair;
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder};
+use libra_mempool_shared_proto::proto::mempool_status::*;
 use libra_types::{
     account_address::AccountAddress,
     test_helpers::transaction_test_helpers::get_test_signed_transaction,
     transaction::SignedTransaction,
 };
-use mempool_shared_proto::proto::mempool_status::*;
 use std::{
     convert::TryFrom,
     sync::{Arc, Mutex},


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `mempool` and `mempool-shared-proto` packages. Depends on #1226

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
