### PR TITLE
[TF] fix generate-keypair in config

### DIFF
--- a/terraform/validator-sets/build.sh
+++ b/terraform/validator-sets/build.sh
@@ -9,7 +9,7 @@ mkdir -p "$OUTDIR"
 cd ../..
 
 if [ ! -e "terraform/validator-sets/$OUTDIR/mint.key" ]; then
-	cargo run --bin generate_keypair -- -o "terraform/validator-sets/$OUTDIR/mint.key"
+	cargo run --bin generate-keypair -- -o "terraform/validator-sets/$OUTDIR/mint.key"
 fi
 
 cargo run --bin libra-config -- -b config/data/configs/node.config.toml -m "terraform/validator-sets/$OUTDIR/mint.key" -o "terraform/validator-sets/$OUTDIR" -d "$@"


### PR DESCRIPTION
## Motivation
Update Terraform config to be in sync with standardization in `generate-keypair` so it generates the config for nightly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
Tested locally. 
```
[youngyl@youngyl-mbp:libra ncr_tf_validator_set_fix_std]$ cd terraform/validator-sets/ && ./build.sh nightly
   Compiling libc v0.2.62
   Compiling cfg-if v0.1.9
   Compiling autocfg v0.1.6
   Compiling log v0.4.8
   Compiling rand_core v0.4.2
...
...
   Compiling transaction_builder v0.1.0 (/Users/youngyl/workp/libra/language/transaction_builder)
   Compiling vm_genesis v0.1.0 (/Users/youngyl/workp/libra/language/vm/vm_genesis)
   Compiling config-builder v0.1.0 (/Users/youngyl/workp/libra/config/config-builder)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 19s
     Running `target/debug/libra-config -b config/data/configs/node.config.toml -m terraform/validator-sets/nightly/mint.key -o terraform/validator-sets/nightly -d`
```
## Related PRs
#1236 