### PR TITLE
[config] Make $PWD as data_dir_path in AWS

### DIFF
--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -500,9 +500,6 @@ impl SwarmConfigBuilder {
         template.base.data_dir_path = self.output_dir.clone();
         template.admission_control.address = listen_address.clone();
         template.debug_interface.address = listen_address;
-        template.execution.genesis_file_location = "genesis.blob".to_string();
-        template.consensus.consensus_peers_file =
-            PathBuf::from("consensus_peers.config.toml".to_string());
         // TODO:
         // [] Use rng instead of seed to prevent duplicate key generation in trusted_peers.rs.
         if self.role == RoleType::Validator {

--- a/config/data/configs/full_node.config.toml
+++ b/config/data/configs/full_node.config.toml
@@ -13,9 +13,6 @@ consensus_peers_file = ""  # For direct validation of this file
 [state_sync]
 upstream_peers = ["ae1b54220905fca36d046a6e093632ed1f219e0a35a4fd7ba82e6e0d515f0b8e"]
 
-[execution]
-genesis_file_location = "<USE_TEMP_DIR>"
-
 [vm_config]
   [vm_config.publishing_options]
   type = "Locked"

--- a/config/data/configs/node.config.toml
+++ b/config/data/configs/node.config.toml
@@ -9,9 +9,6 @@ role = "validator"
 consensus_keypair_file = "" # For direct validation of this file
 consensus_peers_file = ""  # For direct validation of this file
 
-[execution]
-genesis_file_location = "<USE_TEMP_DIR>"
-
 [vm_config]
   [vm_config.publishing_options]
   type = "Locked"

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -35,8 +35,6 @@ use types::{
 #[path = "unit_tests/config_test.rs"]
 mod config_test;
 
-pub const DISPOSABLE_DIR_MARKER: &str = "<USE_TEMP_DIR>";
-
 // path is relative to this file location
 static CONFIG_TEMPLATE: &[u8] = include_bytes!("../data/configs/node.config.toml");
 
@@ -96,7 +94,7 @@ pub struct BaseConfig {
 impl Default for BaseConfig {
     fn default() -> BaseConfig {
         BaseConfig {
-            data_dir_path: PathBuf::from("<USE_TEMP_DIR>"),
+            data_dir_path: PathBuf::from("."),
             temp_data_dir: None,
             node_sync_retries: 7,
             node_sync_channel_buffer_size: 10,
@@ -556,7 +554,6 @@ impl NodeConfig {
             }
         }
         config.consensus.load(path.as_ref())?;
-        NodeConfigHelpers::update_data_dir_path_if_needed(&mut config)?;
         Ok(config)
     }
 
@@ -638,6 +635,11 @@ impl NodeConfigHelpers {
         let config_string = String::from_utf8_lossy(CONFIG_TEMPLATE);
         let mut config =
             NodeConfig::parse(&config_string).expect("Error parsing single node test config");
+        // Create temporary directory for persisting configs.
+        let dir = TempPath::new();
+        dir.create_as_dir().expect("error creating tempdir");
+        config.base.data_dir_path = dir.path().to_owned();
+        config.base.temp_data_dir = Some(dir);
         if random_ports {
             NodeConfigHelpers::randomize_config_ports(&mut config);
         }
@@ -674,22 +676,7 @@ impl NodeConfigHelpers {
         network.advertised_address = network.listen_address.clone();
         network.seed_peers = seed_peers_config;
         network.network_peers = test_network_peers;
-        NodeConfigHelpers::update_data_dir_path_if_needed(&mut config).expect("creating tempdir");
         config
-    }
-
-    /// Replaces temp marker with the actual path and returns holder to the temp dir.
-    fn update_data_dir_path_if_needed(config: &mut NodeConfig) -> Result<()> {
-        if config.base.data_dir_path == Path::new(DISPOSABLE_DIR_MARKER) {
-            let dir = TempPath::new();
-            dir.create_as_dir().expect("error creating tempdir");
-            config.base.data_dir_path = dir.path().to_owned();
-            config.base.temp_data_dir = Some(dir);
-        }
-        if config.execution.genesis_file_location == DISPOSABLE_DIR_MARKER {
-            config.execution.genesis_file_location = "genesis.blob".to_string();
-        }
-        Ok(())
     }
 
     pub fn randomize_config_ports(config: &mut NodeConfig) {


### PR DESCRIPTION
## Motivation

In trying to streamline location of genesis transaction file to always be relative to `data_dir_path` (unless `config.execution.genesis_file_location` is an absolute path), #1228 broke the assumption that in prod (AWS), this file is located under `$PWD`.

This can be fixed by setting default `data_dir_path` to `.`. Only in tests or local swarms, we set `data_dir_path` to a temp directory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan
- Built a docker image locally and started cluster which uses the same configuration as terraform dev config.
- Run local libra swarm