### PR TITLE
[Small] Fix Swarm garbage collection

### DIFF
--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -535,7 +535,8 @@ impl Drop for LibraSwarm {
         // If panicking, we don't want to gc the swarm directory.
         if std::thread::panicking() {
             // let dir = self.dir;
-            if let LibraSwarmDir::Temporary(temp_dir) = &self.dir {
+            if let LibraSwarmDir::Temporary(temp_dir) = &mut self.dir {
+                temp_dir.persist();
                 let log_path = temp_dir.path();
                 println!("logs located at {:?}", log_path);
 


### PR DESCRIPTION
Summary:
The garbage collection of logs / DBs should not happen if a test fails. That logic was broken in one of the previous changes,
which changed tempdir::TempDir to a TempPath struct.
Fixing it here.

Testing: introduced an artificial failure in a smoke test and verified that the logs are there.