### PR TITLE
[consensus] Signatures encoded into consensus blockchain

### DIFF
--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -14,6 +14,7 @@ use libra_types::{
     validator_verifier::VerifyError,
 };
 use logger::prelude::*;
+use std::collections::BTreeMap;
 use std::{collections::HashMap, sync::Arc};
 
 #[cfg(test)]
@@ -88,7 +89,7 @@ impl PendingVotes {
         // covering vote data hash (in its `consensus_data_hash` field).
         let li_digest = vote_msg.ledger_info().hash();
         let li_with_sig = self.li_digest_to_votes.entry(li_digest).or_insert_with(|| {
-            LedgerInfoWithSignatures::new(vote_msg.ledger_info().clone(), HashMap::new())
+            LedgerInfoWithSignatures::new(vote_msg.ledger_info().clone(), BTreeMap::new())
         });
         // TODO: we'd prefer to use LedgerInfoWithSignatures::add_signature instead, but the
         // CryptoProxy types should be properly updated first.

--- a/consensus/src/chained_bft/consensus_types/block.rs
+++ b/consensus/src/chained_bft/consensus_types/block.rs
@@ -22,7 +22,7 @@ use mirai_annotations::{assumed_postcondition, checked_precondition, checked_pre
 use rmp_serde::{from_slice, to_vec_named};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     convert::{TryFrom, TryInto},
     fmt::{Display, Formatter},
     sync::Arc,
@@ -197,7 +197,7 @@ where
                     0,
                     None,
                 ),
-                HashMap::new(),
+                BTreeMap::new(),
             ),
         );
 
@@ -444,7 +444,7 @@ where
             .encode_u64(self.timestamp_usecs)?
             .encode_u64(self.round)?
             .encode_optional(&self.payload)?
-            .encode_bytes(self.quorum_cert.certified_block_id().as_ref())?
+            .encode_struct(self.quorum_cert)?
             .encode_optional(&self.author)?;
         Ok(())
     }

--- a/consensus/src/chained_bft/consensus_types/vote_data.rs
+++ b/consensus/src/chained_bft/consensus_types/vote_data.rs
@@ -7,6 +7,7 @@ use crypto::{
     hash::{CryptoHash, CryptoHasher, VoteDataHasher},
     HashValue,
 };
+use failure::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
@@ -175,5 +176,17 @@ impl From<VoteData> for network::proto::VoteData {
             parent_block_id: vote.parent_block_id.to_vec(),
             parent_block_round: vote.parent_block_round,
         }
+    }
+}
+
+impl CanonicalSerialize for VoteData {
+    fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
+        serializer
+            .encode_bytes(self.block_id.as_ref())?
+            .encode_bytes(self.executed_state_id.as_ref())?
+            .encode_u64(self.round)?
+            .encode_bytes(self.parent_block_id.as_ref())?
+            .encode_u64(self.parent_block_round)?;
+        Ok(())
     }
 }

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -18,7 +18,7 @@ use libra_types::{
     ledger_info::LedgerInfo,
 };
 use logger::{set_simple_logger, set_simple_logger_prefix};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 use termion::color::*;
 use tokio::runtime;
 
@@ -172,7 +172,7 @@ pub fn placeholder_certificate_for_block(
     let mut ledger_info_placeholder = placeholder_ledger_info();
     ledger_info_placeholder.set_consensus_data_hash(consensus_data_hash);
 
-    let mut signatures = HashMap::new();
+    let mut signatures = BTreeMap::new();
     for signer in signers {
         let li_sig = signer
             .sign_message(ledger_info_placeholder.hash())

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -21,7 +21,7 @@ use proptest::prelude::*;
 use prost_ext::MessageExt;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fs::File,
     io::Write,
     sync::{mpsc, Arc},
@@ -172,7 +172,7 @@ fn gen_ledger_info(
         timestamp_usecs,
         None,
     );
-    LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new())
+    LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
 }
 
 #[test]

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -33,8 +33,8 @@ use libra_types::{
 use logger::prelude::*;
 use scratchpad::SparseMerkleTree;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::{
-    collections::HashMap,
     marker::PhantomData,
     rc::Rc,
     sync::{mpsc, Arc, Mutex},
@@ -229,8 +229,7 @@ where
             /* timestamp_usecs = */ 0,
             None,
         );
-        let ledger_info_with_sigs =
-            LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new());
+        let ledger_info_with_sigs = LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new());
         block_on(self.commit_block(ledger_info_with_sigs))
             .expect("Response sender was unexpectedly dropped.")
             .expect("Failed to commit genesis block.");

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -23,7 +23,7 @@ use libra_types::{
     },
 };
 use rand::SeedableRng;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::start_storage_service;
 use transaction_builder::{encode_create_account_script, encode_transfer_script};
@@ -47,7 +47,7 @@ fn gen_ledger_info_with_sigs(
         /* timestamp = */ 0,
         None,
     );
-    LedgerInfoWithSignatures::new(ledger_info, /* signatures = */ HashMap::new())
+    LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
 }
 
 fn create_storage_service_and_executor(config: &NodeConfig) -> (ServerHandle, Executor<MoveVM>) {
@@ -285,7 +285,7 @@ fn test_execution_with_storage() {
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
-        Arc::new(ValidatorVerifier::new(HashMap::new())),
+        Arc::new(ValidatorVerifier::new(BTreeMap::new())),
         0,
         &request_items,
         &response_items,
@@ -483,7 +483,7 @@ fn test_execution_with_storage() {
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
-        Arc::new(ValidatorVerifier::new(HashMap::new())),
+        Arc::new(ValidatorVerifier::new(BTreeMap::new())),
         0,
         &request_items,
         &response_items,

--- a/state_synchronizer/src/tests/integration_tests.rs
+++ b/state_synchronizer/src/tests/integration_tests.rs
@@ -33,7 +33,7 @@ use network::{
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     pin::Pin,
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -72,7 +72,7 @@ impl MockExecutorProxy {
             0,
             None,
         );
-        let mut signatures = HashMap::new();
+        let mut signatures = BTreeMap::new();
         let private_key = Ed25519PrivateKey::genesis();
         let signature = private_key.sign_message(&HashValue::zero());
         signatures.insert(peer_id, signature);

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -24,7 +24,7 @@ use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 fn gen_mock_genesis() -> (
     TransactionInfo,
@@ -83,7 +83,7 @@ fn gen_mock_genesis() -> (
         None,
     );
     let ledger_info_with_sigs =
-        LedgerInfoWithSignatures::new(ledger_info, HashMap::new() /* signatures */);
+        LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new() /* signatures */);
 
     (txn_info, ledger_info_with_sigs, txn_to_commit)
 }

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -79,7 +79,7 @@ impl<Sig: RawSignature> From<Sig> for SignatureWrapper<Sig> {
 // below is banned.
 
 use crypto::ed25519::*;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // used in chained_bft::consensus_types::block_test
 #[cfg(any(test, feature = "testing"))]
@@ -101,8 +101,7 @@ pub fn random_validator_verifier(
     pseudo_random_account_address: bool,
 ) -> (Vec<ValidatorSigner>, ValidatorVerifier) {
     let mut signers = Vec::new();
-    let mut account_address_to_validator_info: HashMap<AccountAddress, ValidatorInfo> =
-        HashMap::new();
+    let mut account_address_to_validator_info = BTreeMap::new();
     for i in 0..count {
         let random_signer = if pseudo_random_account_address {
             ValidatorSigner::from_int(i as u8)


### PR DESCRIPTION
Currently, when serializing blocks (used for hashing), only the block
id of the QuorumCertificate is hashed, but not the signatures of the
QuorumCertificate.  This means that the consensus blockchain can
disagree on the signatures validating the consensus blockchain between
validators.  This also makes it hard to assign rewards to validators
that participate in consensus since there isn't agreement on the
signatures.

This PR adds support for encoding all the QuorumCertificate
information into the canonical hashing method (serialize()), so that
the consensus blockchain agrees on the QuorumCertificates and Blocks
that have been committed.  There is also a test to ensure this
behavior and verified it was failed before this change and now passes.
LedgerInfoWithSignatures now has a BTreeMap of signatures to make it
easier to do canonical serialization.
