### PR TITLE
Improve CLI Help message

### DIFF
--- a/client/src/account_commands.rs
+++ b/client/src/account_commands.rs
@@ -3,8 +3,48 @@
 
 use crate::{client_proxy::ClientProxy, commands::*};
 
+use std::collections::HashMap;
+
 /// Major command for account related operations.
-pub struct AccountCommand {}
+pub struct AccountCommand {
+    pub sub_commands: Vec<Box<dyn Command>>,
+    pub command_map: HashMap<&'static str, usize>,
+}
+
+impl AccountCommand {
+    pub fn new() -> AccountCommand {
+        let commands: Vec<Box<dyn Command>> = vec![
+            Box::new(AccountCommandCreate {}),
+            Box::new(AccountCommandListAccounts {}),
+            Box::new(AccountCommandRecoverWallet {}),
+            Box::new(AccountCommandWriteRecovery {}),
+            Box::new(AccountCommandMint {}),
+        ];
+        let mut commands_map = HashMap::new();
+        for (i, cmd) in commands.iter().enumerate() {
+            for alias in cmd.get_aliases() {
+                if commands_map.insert(alias, i) != None {
+                    panic!("Duplicate alias {}", alias);
+                }
+            }
+        }
+        AccountCommand {
+            sub_commands: commands,
+            command_map: commands_map,
+        }
+    }
+    fn print_helper(&self) {
+        println!("usage: account <arg>\n\nUse the following sub-commands for this command:\n");
+        for cmd in &self.sub_commands {
+            println!(
+                "{:<35}{}",
+                cmd.get_aliases().join(" | "),
+                cmd.get_description()
+            );
+        }
+        println!("\n");
+    }
+}
 
 impl Command for AccountCommand {
     fn get_aliases(&self) -> Vec<&'static str> {
@@ -14,15 +54,20 @@ impl Command for AccountCommand {
         "Account operations"
     }
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
-        let commands: Vec<Box<dyn Command>> = vec![
-            Box::new(AccountCommandCreate {}),
-            Box::new(AccountCommandListAccounts {}),
-            Box::new(AccountCommandRecoverWallet {}),
-            Box::new(AccountCommandWriteRecovery {}),
-            Box::new(AccountCommandMint {}),
-        ];
-
-        subcommand_execute(&params[0], commands, client, &params[1..]);
+        match self.command_map.get(&params[1]) {
+            Some(&idx) => self.sub_commands[idx].execute(client, &params[1..]),
+            _ => self.print_usage(&params),
+        }
+    }
+    fn print_usage(&self, params: &[&str]) {
+        if params.len() > 1 {
+            match self.command_map.get(&params[1]) {
+                Some(&idx) => self.sub_commands[idx].print_usage(&params),
+                _ => self.print_helper(),
+            }
+        } else {
+            self.print_helper()
+        }
     }
 }
 
@@ -46,6 +91,9 @@ impl Command for AccountCommandCreate {
             ),
             Err(e) => report_error("Error creating account", e),
         }
+    }
+    fn print_usage(&self, _params: &[&str]) {
+        println!("usage: account create\n\n{}\n", self.get_description());
     }
 }
 
@@ -77,6 +125,13 @@ impl Command for AccountCommandRecoverWallet {
             Err(e) => report_error("Error recovering Libra wallet", e),
         }
     }
+    fn print_usage(&self, _params: &[&str]) {
+        println!(
+            "usage: account recover {}\n\n{}\n",
+            self.get_params_help(),
+            self.get_description()
+        );
+    }
 }
 
 /// Sub command to backup wallet to the file specified.
@@ -99,6 +154,13 @@ impl Command for AccountCommandWriteRecovery {
             Err(e) => report_error("Error writing mnemonic recovery seed to file", e),
         }
     }
+    fn print_usage(&self, _params: &[&str]) {
+        println!(
+            "usage: account write {}\n\n{}\n",
+            self.get_params_help(),
+            self.get_description()
+        );
+    }
 }
 
 /// Sub command to list all accounts information.
@@ -114,6 +176,9 @@ impl Command for AccountCommandListAccounts {
     fn execute(&self, client: &mut ClientProxy, _params: &[&str]) {
         client.print_all_accounts();
     }
+    fn print_usage(&self, _params: &[&str]) {
+        println!("usage: account list \n\n{}\n", self.get_description());
+    }
 }
 
 /// Sub command to mint account.
@@ -124,7 +189,7 @@ impl Command for AccountCommandMint {
         vec!["mint", "mintb", "m", "mb"]
     }
     fn get_params_help(&self) -> &'static str {
-        "<receiver_account_ref_id>|<receiver_account_address> <number_of_coins>"
+        "<receiver_account_ref_id>\n<receiver_account_address> <number_of_coins>"
     }
     fn get_description(&self) -> &'static str {
         "Mint coins to the account. Suffix 'b' is for blocking"
@@ -147,6 +212,21 @@ impl Command for AccountCommandMint {
                 }
             }
             Err(e) => report_error("Error minting coins", e),
+        }
+    }
+    fn print_usage(&self, params: &[&str]) {
+        if blocking_cmd(params[1]) {
+            print_sub_command_usage(
+                "account mintb",
+                self.get_description(),
+                self.get_params_help(),
+            );
+        } else {
+            print_sub_command_usage(
+                "account mint",
+                self.get_description(),
+                self.get_params_help(),
+            );
         }
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -111,7 +111,16 @@ fn main() -> std::io::Result<()> {
                     }
                     None => match params[0] {
                         "quit" | "q!" => break,
-                        "help" | "h" => print_help(&cli_info, &commands),
+                        "help" | "h" => {
+                            if params.len() > 1 {
+                                match alias_to_cmd.get(&params[1]) {
+                                    Some(cmd) => cmd.print_usage(&params[1..]),
+                                    None => print_help(&cli_info, &commands),
+                                }
+                            } else {
+                                print_help(&cli_info, &commands);
+                            }
+                        }
                         "" => continue,
                         x => println!("Unknown command: {:?}", x),
                     },
@@ -141,15 +150,13 @@ fn print_help(client_info: &str, commands: &[std::sync::Arc<dyn Command>]) {
     println!("usage: <command> <args>\n\nUse the following commands:\n");
     for cmd in commands {
         println!(
-            "{} {}\n\t{}",
+            "{:<35}{}",
             cmd.get_aliases().join(" | "),
-            cmd.get_params_help(),
             cmd.get_description()
         );
     }
-
-    println!("help | h \n\tPrints this help");
-    println!("quit | q! \n\tExit this client");
+    println!("{:<35}Prints this help", "help | h");
+    println!("{:<35}Exit this client", "quit | q!");
     println!("\n");
 }
 

--- a/client/src/transfer_commands.rs
+++ b/client/src/transfer_commands.rs
@@ -11,22 +11,17 @@ impl Command for TransferCommand {
         vec!["transfer", "transferb", "t", "tb"]
     }
     fn get_params_help(&self) -> &'static str {
-        "\n\t<sender_account_address>|<sender_account_ref_id> \
-         <receiver_account_address>|<receiver_account_ref_id> <number_of_coins> \
-         [gas_unit_price_in_micro_libras (default=0)] [max_gas_amount_in_micro_libras (default 140000)] \
-         Suffix 'b' is for blocking. "
+        "<sender_account_address>\n<sender_account_ref_id> \
+         <receiver_account_address>\n<receiver_account_ref_id> <number_of_coins> \
+         [gas_unit_price_in_micro_libras (default=0)] [max_gas_amount_in_micro_libras (default 140000)]"
     }
     fn get_description(&self) -> &'static str {
-        "Transfer coins (in libra) from account to another."
+        "Transfer coins (in libra) from account to another. Suffix 'b' is for blocking. "
     }
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
         if params.len() < 4 || params.len() > 6 {
-            println!("Invalid number of arguments for transfer");
-            println!(
-                "{} {}",
-                self.get_aliases().join(" | "),
-                self.get_params_help()
-            );
+            println!("Invalid number of arguments for transfer\n");
+            self.print_usage(&params);
             return;
         }
 
@@ -47,5 +42,8 @@ impl Command for TransferCommand {
             }
             Err(e) => report_error("Failed to perform transaction", e),
         }
+    }
+    fn print_usage(&self, _params: &[&str]) {
+        print_sub_command_usage("transfer", self.get_description(), self.get_params_help());
     }
 }


### PR DESCRIPTION
## Motivation

Address feature request issue #126

* Add `help` command.
* Add a `print_helper` to Command trait for dispatch call.

## Usage
To invoke help, prepend `help` or `h` to commands.

Examples:
```
libra% help
Connected to validator at: ac.testnet.libra.org:8000
usage: <command> <args>

Use the following commands:

account | a                        Account operations
query | q                          Query operations
transfer | transferb | t | tb      Transfer coins (in libra) from account to another. Suffix 'b' is for blocking.
help | h                           Prints this help
quit | q!                          Exit this client


libra% help account
usage: account <arg>

Use the following sub-commands for this command:

create | c                         Create an account. Returns reference ID to use in other operations
list | la                          Print all accounts that were created or loaded
recover | r                        Recover Libra wallet from the file path
write | w                          Save Libra wallet mnemonic recovery seed to disk
mint | mintb | m | mb              Mint coins to the account. Suffix 'b' is for blocking


libra% help account mintb
usage: account mintb <options>

Mint coins to the account. Suffix 'b' is for blocking

Use the following options for this command:

<receiver_account_ref_id>
<receiver_account_address> <number_of_coins>
```

Closes #140