### PR TITLE
[Consensus] VoteMsg to carry SyncInfo

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -11,8 +11,8 @@ use crate::chained_bft::{
         vote_msg::VoteMsg,
     },
     test_utils::{
-        build_empty_tree, build_empty_tree_with_custom_signing, placeholder_certificate_for_block,
-        placeholder_ledger_info, TreeInserter,
+        self, build_empty_tree, build_empty_tree_with_custom_signing,
+        placeholder_certificate_for_block, placeholder_ledger_info, TreeInserter,
     },
 };
 use crypto::{HashValue, PrivateKey};
@@ -82,6 +82,7 @@ fn test_block_store_create_block() {
         block_store.signer().author(),
         placeholder_ledger_info(),
         block_store.signer(),
+        test_utils::placeholder_sync_info(),
     );
     let validator_verifier = Arc::new(ValidatorVerifier::new_single(
         block_store.signer().author(),
@@ -353,6 +354,7 @@ fn test_insert_vote() {
             voter.author(),
             placeholder_ledger_info(),
             voter,
+            test_utils::placeholder_sync_info(),
         );
         let vote_res =
             block_store.insert_vote_and_qc(vote_msg.clone(), Arc::clone(&validator_verifier));
@@ -385,6 +387,7 @@ fn test_insert_vote() {
         final_voter.author(),
         placeholder_ledger_info(),
         final_voter,
+        test_utils::placeholder_sync_info(),
     );
     match block_store.insert_vote_and_qc(vote_msg, validator_verifier) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {

--- a/consensus/src/chained_bft/block_storage/pending_votes_test.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes_test.rs
@@ -6,6 +6,7 @@ use crate::chained_bft::common::Round;
 use crate::chained_bft::{
     block_storage::VoteReceptionResult,
     consensus_types::{vote_data::VoteData, vote_msg::VoteMsg},
+    test_utils,
 };
 use crypto::HashValue;
 use libra_types::crypto_proxies::random_validator_verifier;
@@ -50,6 +51,7 @@ fn test_qc_aggregation() {
         signers[0].author(),
         li1.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
 
     // first time a new vote is added the result is VoteAdded
@@ -71,6 +73,7 @@ fn test_qc_aggregation() {
         signers[0].author(),
         li2.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_data_2_author_0, Arc::clone(&validator_verifier)),
@@ -83,6 +86,7 @@ fn test_qc_aggregation() {
         signers[1].author(),
         li2.clone(),
         &signers[1],
+        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_data_2_author_1, Arc::clone(&validator_verifier)),
@@ -94,6 +98,7 @@ fn test_qc_aggregation() {
         signers[2].author(),
         li2.clone(),
         &signers[2],
+        test_utils::placeholder_sync_info(),
     );
     match pending_votes.insert_vote(&vote_data_2_author_2, Arc::clone(&validator_verifier)) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
@@ -123,6 +128,7 @@ fn test_qc_aggregation_keep_last_only() {
         signers[0].author(),
         li1.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
 
     // first time a new vote is added the result is VoteAdded
@@ -139,6 +145,7 @@ fn test_qc_aggregation_keep_last_only() {
         signers[0].author(),
         li2.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_round_2_author_0, Arc::clone(&validator_verifier)),
@@ -151,6 +158,7 @@ fn test_qc_aggregation_keep_last_only() {
         signers[1].author(),
         li1.clone(),
         &signers[1],
+        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_round_1_author_1, Arc::clone(&validator_verifier)),
@@ -163,6 +171,7 @@ fn test_qc_aggregation_keep_last_only() {
         signers[1].author(),
         li2.clone(),
         &signers[1],
+        test_utils::placeholder_sync_info(),
     );
     match pending_votes.insert_vote(&vote_round_2_author_1, Arc::clone(&validator_verifier)) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
@@ -192,6 +201,7 @@ fn test_tc_aggregation() {
         signers[0].author(),
         li1.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
     vote_round_1_author_0.add_round_signature(&signers[0]);
 
@@ -210,6 +220,7 @@ fn test_tc_aggregation() {
         signers[1].author(),
         li2.clone(),
         &signers[1],
+        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote2_round_1_author_1, Arc::clone(&validator_verifier)),
@@ -246,6 +257,7 @@ fn test_tc_aggregation_keep_last_only() {
         signers[0].author(),
         li1.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
     vote_round_1_author_0.add_round_signature(&signers[0]);
 
@@ -263,6 +275,7 @@ fn test_tc_aggregation_keep_last_only() {
         signers[0].author(),
         li2.clone(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
     vote_round_2_author_0.add_round_signature(&signers[0]);
     assert_eq!(
@@ -278,6 +291,7 @@ fn test_tc_aggregation_keep_last_only() {
         signers[1].author(),
         li3.clone(),
         &signers[1],
+        test_utils::placeholder_sync_info(),
     );
     vote3_round_1_author_1.add_round_signature(&signers[1]);
     assert_eq!(
@@ -293,6 +307,7 @@ fn test_tc_aggregation_keep_last_only() {
         signers[1].author(),
         li4.clone(),
         &signers[1],
+        test_utils::placeholder_sync_info(),
     );
     vote4_round_2_author_1.add_round_signature(&signers[1]);
     match pending_votes.insert_vote(&vote4_round_2_author_1, Arc::clone(&validator_verifier)) {

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -28,7 +28,7 @@ use crate::{
         persistent_storage::{PersistentStorage, RecoveryData},
         safety::safety_rules::{ConsensusState, SafetyRules},
         test_utils::{
-            consensus_runtime, placeholder_certificate_for_block, placeholder_ledger_info,
+            self, consensus_runtime, placeholder_certificate_for_block, placeholder_ledger_info,
             MockStateComputer, MockStorage, MockTransactionManager, TestPayload, TreeInserter,
         },
     },
@@ -280,6 +280,7 @@ fn basic_new_rank_event_test() {
             node.block_store.signer().author(),
             placeholder_ledger_info(),
             node.block_store.signer(),
+            test_utils::placeholder_sync_info(),
         );
         let validator_verifier = Arc::new(ValidatorVerifier::new_single(
             node.block_store.signer().author(),
@@ -695,6 +696,7 @@ fn process_votes_basic_test() {
         node.block_store.signer().author(),
         placeholder_ledger_info(),
         node.block_store.signer(),
+        test_utils::placeholder_sync_info(),
     );
     block_on(async move {
         node.event_processor.process_vote(vote_msg).await;

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -225,7 +225,14 @@ impl Pacemaker {
         let timeout = self
             .time_interval
             .get_round_duration(round_index_after_committed_round);
-        self.current_round_deadline = Instant::now() + timeout;
+        let now = Instant::now();
+        debug!(
+            "{:?} passed since the previous deadline.",
+            now.checked_duration_since(self.current_round_deadline)
+                .map_or("0 ms".to_string(), |v| format!("{:?}", v))
+        );
+        debug!("Set round deadline to {:?} from now", timeout);
+        self.current_round_deadline = now + timeout;
         timeout
     }
 

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -7,7 +7,7 @@ use crate::{
         consensus_types::{quorum_cert::QuorumCert, vote_data::VoteData, vote_msg::VoteMsg},
         liveness::proposal_generator::ProposalGenerator,
         test_utils::{
-            build_empty_tree, placeholder_ledger_info, MockTransactionManager, TreeInserter,
+            self, build_empty_tree, placeholder_ledger_info, MockTransactionManager, TreeInserter,
         },
     },
     util::mock_time_service::SimulatedTimeService,
@@ -86,6 +86,7 @@ fn test_proposal_generation_parent() {
         block_store.signer().author(),
         placeholder_ledger_info(),
         block_store.signer(),
+        test_utils::placeholder_sync_info(),
     );
     let validator_verifier = Arc::new(ValidatorVerifier::new_single(
         block_store.signer().author(),
@@ -114,6 +115,7 @@ fn test_proposal_generation_parent() {
         block_store.signer().author(),
         placeholder_ledger_info(),
         block_store.signer(),
+        test_utils::placeholder_sync_info(),
     );
     let validator_verifier = Arc::new(ValidatorVerifier::new_single(
         block_store.signer().author(),
@@ -155,6 +157,7 @@ fn test_old_proposal_generation() {
         block_store.signer().author(),
         placeholder_ledger_info(),
         block_store.signer(),
+        test_utils::placeholder_sync_info(),
     );
     let validator_verifier = Arc::new(ValidatorVerifier::new_single(
         block_store.signer().author(),

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -9,7 +9,7 @@ use crate::chained_bft::{
     },
     epoch_manager::EpochManager,
     network::{BlockRetrievalResponse, ConsensusNetworkImpl, NetworkReceivers},
-    test_utils::{consensus_runtime, placeholder_ledger_info},
+    test_utils::{self, consensus_runtime, placeholder_ledger_info},
 };
 use channel;
 use crypto::HashValue;
@@ -359,6 +359,7 @@ fn test_network_api() {
         peers[0],
         placeholder_ledger_info(),
         &signers[0],
+        test_utils::placeholder_sync_info(),
     );
     let previous_block = Block::make_genesis_block();
     let previous_qc = QuorumCert::certificate_for_genesis();

--- a/consensus/src/chained_bft/proto_test.rs
+++ b/consensus/src/chained_bft/proto_test.rs
@@ -10,7 +10,7 @@ use crate::chained_bft::{
         vote_data::VoteData,
         vote_msg::VoteMsg,
     },
-    test_utils::placeholder_ledger_info,
+    test_utils::{self, placeholder_ledger_info},
 };
 use crypto::HashValue;
 use executor::ExecutedState;
@@ -65,6 +65,7 @@ fn test_proto_convert_vote() {
         signer.author(),
         placeholder_ledger_info(),
         &signer,
+        test_utils::placeholder_sync_info(),
     );
     let vote_proto = network::proto::Vote::from(vote.clone());
     assert_eq!(vote, vote_proto.try_into().unwrap());

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -26,6 +26,7 @@ mod mock_state_computer;
 mod mock_storage;
 mod mock_txn_manager;
 
+use crate::chained_bft::consensus_types::sync_info::SyncInfo;
 pub use mock_state_computer::{EmptyStateComputer, MockStateComputer};
 pub use mock_storage::{EmptyStorage, MockStorage};
 pub use mock_txn_manager::MockTransactionManager;
@@ -190,6 +191,14 @@ pub fn placeholder_certificate_for_block(
             certified_parent_block_round,
         ),
         LedgerInfoWithSignatures::new(ledger_info_placeholder, signatures),
+    )
+}
+
+pub fn placeholder_sync_info() -> SyncInfo {
+    SyncInfo::new(
+        QuorumCert::certificate_for_genesis(),
+        QuorumCert::certificate_for_genesis(),
+        None,
     )
 }
 

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -124,6 +124,8 @@ message Vote {
   bytes signature = 4;
   // The round signatures can be aggregated into the timeout certificate.
   bytes round_signature = 5;
+  // Sync info for exchanging information about highest QC, TC and LedgerInfo
+  SyncInfo sync_info = 6;
 }
 
 message RequestBlock {


### PR DESCRIPTION
## Summary
We are adding SyncInfo field to the VoteMsg, similarly to the proposals / timeouts.
Note that SyncInfo field is currently not covered by any signature (we cannot use it for aggregation). We might need to have another signature covering
just the SyncInfo in future.

## Testing
existing unit test coverage

## Issues
ref #1048 