### PR TITLE
[CI] Add unit test run using the verified backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,10 @@ jobs:
           command: |
             [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo test -j 16 --all --exclude testsuite
       - run:
+          name: Run Cryptography Unit Tests with the formally verified backend
+          command: |
+            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo test -j 16 -p crypto -p secret-service --features='std fiat_u64_backend' --no-default-features
+      - run:
           name: Run All End to End Tests
           command: |
             [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo test -j 16 --package testsuite -- --test-threads 1


### PR DESCRIPTION
- the formally verified backend was introduced in #739 
- it requires building under a slightly different set of flags
- This uses them to runs tests for the cryptography packages
