### PR TITLE
[Consensus][tiny] Fix a chained_bft_smr_test

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -396,12 +396,12 @@ fn basic_commit_and_restart() {
         // We cannot reliable wait for the event of "commit & prune": the only thing that we know is
         // that after receiving the vote for round 20, the root should be at least height 16.
         assert!(
-            nodes[0].smr.block_store().unwrap().root().round() >= 18,
+            nodes[0].smr.block_store().unwrap().root().round() >= 17,
             "round of node 0 is {}",
             nodes[0].smr.block_store().unwrap().root().round()
         );
         assert!(
-            nodes[1].smr.block_store().unwrap().root().round() >= 18,
+            nodes[1].smr.block_store().unwrap().root().round() >= 17,
             "round of node 1 is {}",
             nodes[1].smr.block_store().unwrap().root().round()
         );


### PR DESCRIPTION
## Summary:
basic_commit_and_restart test got flaky after https://github.com/libra/libra/pull/1245: we're counting the vote messages in the test, hence the vote message corresponding to round 20 may or may not update the root of the tree to round 18 as observed by the test (it is racing with the test check). We can only assert that it's at least 17.

## Testing:
the unit tests pass