### PR TITLE
[easy] Rewrite to interrogation operator patterns

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -388,10 +388,9 @@ impl<T: Payload> BlockStore<T> {
             "Block with old round"
         );
 
-        let parent = match self.get_block(block.parent_id()) {
-            None => bail!("Block with missing parent {}", block.parent_id()),
-            Some(parent) => parent,
-        };
+        let parent = self
+            .get_block(block.parent_id())
+            .ok_or_else(|| format_err!("Block with missing parent {}", block.parent_id()))?;
         ensure!(parent.round() < block.round(), "Block with invalid round");
         ensure!(
             !self.enforce_increasing_timestamps

--- a/language/compiler/ir_to_bytecode/src/compiler.rs
+++ b/language/compiler/ir_to_bytecode/src/compiler.rs
@@ -1050,10 +1050,8 @@ fn compile_expression(
             field,
         } => {
             let loc_type_opt = compile_expression(context, function_frame, code, *exp)?.pop_front();
-            let loc_type = match loc_type_opt {
-                Some(t) => t,
-                None => bail!("Impossible no expression to borrow"),
-            };
+            let loc_type =
+                loc_type_opt.ok_or_else(|| format_err!("Impossible no expression to borrow"))?;
             let sh_idx = loc_type.get_struct_handle()?;
             let (fd_idx, field_type, _) = context.field(sh_idx, field)?;
             function_frame.pop()?;

--- a/language/compiler/ir_to_bytecode/src/context.rs
+++ b/language/compiler/ir_to_bytecode/src/context.rs
@@ -576,10 +576,9 @@ impl<'a> Context<'a> {
             }
             SignatureToken::Struct(orig_sh_idx, inners) => {
                 let dep_info = self.dependency(&dep)?;
-                let (mident, sname) = match dep_info.source_struct_info(orig_sh_idx) {
-                    None => bail!("Malformed dependency"),
-                    Some(res) => res,
-                };
+                let (mident, sname) = dep_info
+                    .source_struct_info(orig_sh_idx)
+                    .ok_or_else(|| format_err!("Malformed dependency"))?;
                 let module_name = self.module_alias(&mident)?.clone();
                 let sident = QualifiedStructIdent {
                     module: module_name,

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -164,10 +164,8 @@ impl fmt::Display for EvaluationLog {
 
 /// Verifies a script & its dependencies.
 fn do_verify_script(script: CompiledScript, deps: &[VerifiedModule]) -> Result<VerifiedScript> {
-    let verified_script = match VerifiedScript::new(script) {
-        Ok(verified_script) => verified_script,
-        Err((_, errs)) => return Err(ErrorKind::VerificationFailure(errs).into()),
-    };
+    let verified_script =
+        VerifiedScript::new(script).map_err(|(_, errs)| ErrorKind::VerificationFailure(errs))?;
     let errs = verify_script_dependencies(&verified_script, deps);
     if !errs.is_empty() {
         return Err(ErrorKind::VerificationFailure(errs).into());
@@ -177,10 +175,8 @@ fn do_verify_script(script: CompiledScript, deps: &[VerifiedModule]) -> Result<V
 
 /// Verifies a module & its dependencies.
 fn do_verify_module(module: CompiledModule, deps: &[VerifiedModule]) -> Result<VerifiedModule> {
-    let verified_module = match VerifiedModule::new(module) {
-        Ok(verified_module) => verified_module,
-        Err((_, errs)) => return Err(ErrorKind::VerificationFailure(errs).into()),
-    };
+    let verified_module =
+        VerifiedModule::new(module).map_err(|(_, errs)| ErrorKind::VerificationFailure(errs))?;
     let errs = verify_module_dependencies(&verified_module, deps);
     if !errs.is_empty() {
         return Err(ErrorKind::VerificationFailure(errs).into());

--- a/language/vm/src/deserializer.rs
+++ b/language/vm/src/deserializer.rs
@@ -543,10 +543,8 @@ fn load_identifiers(
             if count != size {
                 return Err(VMStatus::new(StatusCode::MALFORMED));
             }
-            let s = match Identifier::from_utf8(buffer) {
-                Ok(bytes) => bytes,
-                Err(_) => return Err(VMStatus::new(StatusCode::MALFORMED)),
-            };
+            let s =
+                Identifier::from_utf8(buffer).map_err(|_| VMStatus::new(StatusCode::MALFORMED))?;
 
             identifiers.push(s);
         }
@@ -573,10 +571,8 @@ fn load_user_strings(
             if count != size {
                 return Err(VMStatus::new(StatusCode::MALFORMED));
             }
-            let us = match VMString::from_utf8(buffer) {
-                Ok(bytes) => bytes,
-                Err(_) => return Err(VMStatus::new(StatusCode::MALFORMED)),
-            };
+            let us =
+                VMString::from_utf8(buffer).map_err(|_| VMStatus::new(StatusCode::MALFORMED))?;
 
             user_strings.push(us);
         }

--- a/language/vm/vm_runtime/src/process_txn/verify.rs
+++ b/language/vm/vm_runtime/src/process_txn/verify.rs
@@ -101,10 +101,7 @@ where
         script_cache: &'txn ScriptCache<'alloc>,
     ) -> VMResult<(FunctionRef<'alloc>, Vec<VerifiedModule>)> {
         // Ensure the script can correctly be resolved into main.
-        let main = match script_cache.cache_script(&program.code()) {
-            Ok(main) => main,
-            Err(err) => return Err(err),
-        };
+        let main = script_cache.cache_script(&program.code())?;
 
         if !verify_actuals(main.signature(), program.args()) {
             return Err(VMStatus::new(StatusCode::TYPE_MISMATCH)

--- a/storage/jellyfish_merkle/src/lib.rs
+++ b/storage/jellyfish_merkle/src/lib.rs
@@ -495,11 +495,9 @@ where
             let next_node = self.reader.get_node(&next_node_key)?;
             match next_node {
                 Node::Internal(internal_node) => {
-                    let queried_child_index = match nibble_iter.next() {
-                        Some(nibble) => nibble,
-                        // Shouldn't happen
-                        None => bail!("ran out of nibbles"),
-                    };
+                    let queried_child_index = nibble_iter
+                        .next()
+                        .ok_or_else(|| format_err!("ran out of nibbles"))?;
                     let (child_node_key, mut siblings_in_internal) =
                         internal_node.get_child_with_siblings(&next_node_key, queried_child_index);
                     siblings.append(&mut siblings_in_internal);

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -82,10 +82,8 @@ impl Cluster {
             !instances.is_empty(),
             "No instances were discovered for cluster"
         );
-        let prometheus_ip = match prometheus_ip {
-            Some(ip) => ip,
-            None => bail!("Prometheus was not found in workplace"),
-        };
+        let prometheus_ip =
+            prometheus_ip.ok_or_else(|| format_err!("Prometheus was not found in workplace"))?;
         Ok(Self {
             instances,
             prometheus_ip,

--- a/testsuite/cluster-test/src/health/aws_log_tail.rs
+++ b/testsuite/cluster-test/src/health/aws_log_tail.rs
@@ -314,17 +314,11 @@ impl AwsLogThread {
     }
 
     fn parse_commit_log_entry(&self, e: &LogEntry) -> Option<Commit> {
-        let cap = match self.re_commit.captures(e.message) {
-            Some(cap) => cap,
-            None => return None,
-        };
+        let cap = self.re_commit.captures(e.message)?;
         let commit = &cap[1];
         let round = &cap[2];
         let parent = &cap[3];
-        let round = match round.parse::<u64>() {
-            Ok(round) => round,
-            Err(..) => return None,
-        };
+        let round = round.parse::<u64>().ok()?;
         Some(Commit {
             commit: commit.into(),
             round,

--- a/testsuite/libra-fuzzer/src/commands.rs
+++ b/testsuite/libra-fuzzer/src/commands.rs
@@ -87,10 +87,9 @@ pub fn fuzz_target(
 
     // Pass the target name in as an environment variable.
     // Use the manifest directory as the current one.
-    let manifest_dir = match env::var_os("CARGO_MANIFEST_DIR") {
-        Some(dir) => dir,
-        None => bail!("Fuzzing requires CARGO_MANIFEST_DIR to be set (are you using `cargo run`?)"),
-    };
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").ok_or_else(|| {
+        format_err!("Fuzzing requires CARGO_MANIFEST_DIR to be set (are you using `cargo run`?)")
+    })?;
 
     let status = Command::new("cargo")
         .arg("fuzz")


### PR DESCRIPTION
The '?' operator can make for a simple short-circuiting `unwrap`, but it's also available on `Option` since rust 1.22.

This rewrites a few return statements to use it.