### PR TITLE
[functional_tests] Check the correct capability flag in test

### DIFF
--- a/language/functional_tests/tests/testsuite/libra_account/remove_then_replace_rotation_capability.mvir
+++ b/language/functional_tests/tests/testsuite/libra_account/remove_then_replace_rotation_capability.mvir
@@ -16,7 +16,7 @@ main() {
 
   // restoring the capability should flip the flag back
   LibraAccount.restore_key_rotation_capability(move(cap));
-  assert(!LibraAccount.delegated_withdrawal_capability(copy(sender)), 52);
+  assert(!LibraAccount.delegated_key_rotation_capability(copy(sender)), 52);
 
   // and the sender should be able to rotate once again
   LibraAccount.rotate_authentication_key(AddressUtil.address_to_bytes(move(sender)));


### PR DESCRIPTION
Fixes what is presumably a copy-paste error.

Updates the `remove_then_replace_rotation_capability` test to check that the rotation capability is no longer delegated when restored rather than checking if the withdrawal capability is delegated.

## Motivation
Make sure the tests reflect what should be tested. Could potentially avoid the problem of having the test pass when something is broken.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes