### PR TITLE
[cluster_test] Change effect trait bound from Sync to Send

### DIFF
--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -6,12 +6,12 @@ pub use reboot::Reboot;
 use std::fmt::Display;
 pub use stop_container::StopContainer;
 
-pub trait Action: Display + Sync {
+pub trait Action: Display + Send {
     fn apply(&self) -> failure::Result<()>;
     fn is_complete(&self) -> bool;
 }
 
-pub trait Effect: Display + Sync {
+pub trait Effect: Display + Send {
     fn activate(&self) -> failure::Result<()>;
     fn deactivate(&self) -> failure::Result<()>;
 }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -601,11 +601,11 @@ impl ClusterTestRunner {
     }
 
     pub fn stop(&self) {
-        self.activate_all(&self.make_stop_effects())
+        self.activate_all(&mut self.make_stop_effects())
     }
 
     pub fn start(&self) {
-        self.deactivate_all(&self.make_stop_effects())
+        self.deactivate_all(&mut self.make_stop_effects())
     }
 
     fn make_stop_effects(&self) -> Vec<StopContainer> {
@@ -617,9 +617,9 @@ impl ClusterTestRunner {
             .collect()
     }
 
-    fn activate_all<T: Effect>(&self, effects: &[T]) {
+    fn activate_all<T: Effect>(&self, effects: &mut [T]) {
         let jobs = effects
-            .iter()
+            .iter_mut()
             .map(|effect| {
                 move || {
                     if let Err(e) = effect.activate() {
@@ -631,9 +631,9 @@ impl ClusterTestRunner {
         self.execute_jobs(jobs);
     }
 
-    fn deactivate_all<T: Effect>(&self, effects: &[T]) {
+    fn deactivate_all<T: Effect>(&self, effects: &mut [T]) {
         let jobs = effects
-            .iter()
+            .iter_mut()
             .map(|effect| {
                 move || {
                     if let Err(e) = effect.deactivate() {


### PR DESCRIPTION
Basically it means that Effect is safe to be send between thread, as long as one thread owns Effect at a time.

This means `Effect` can have mutable state, and does not have to wrap this state with Mutex, this will simplify writing effects with state.

In order to make this work with thread pool and execute_jobs, activate/deactivate job takes `&mut` ref, instead of `&`. `&mut T` can be send safely between threads(e.g. &mut T implements Send if T implements Send), while &T only implements Send if T implements Sync, which is much stricter marker.
