### PR TITLE
[Consensus] Pacemaker implementation based on external TC aggregation

### DIFF
--- a/consensus/src/chained_bft/liveness/mod.rs
+++ b/consensus/src/chained_bft/liveness/mod.rs
@@ -3,6 +3,7 @@
 
 pub(crate) mod multi_proposer_election;
 pub(crate) mod pacemaker;
+pub(crate) mod pacemaker_new;
 pub(crate) mod pacemaker_timeout_manager;
 pub(crate) mod proposal_generator;
 pub(crate) mod proposer_election;
@@ -10,6 +11,8 @@ pub(crate) mod rotating_proposer_election;
 
 #[cfg(test)]
 mod multi_proposer_test;
+#[cfg(test)]
+mod pacemaker_new_test;
 #[cfg(test)]
 mod pacemaker_test;
 #[cfg(test)]

--- a/consensus/src/chained_bft/liveness/pacemaker_new.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_new.rs
@@ -1,0 +1,285 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    chained_bft::{
+        common::Round,
+        consensus_types::{quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate},
+    },
+    counters,
+    util::time_service::{SendTask, TimeService},
+};
+use channel;
+use logger::prelude::*;
+use std::{
+    fmt,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// A reason for starting a new round: introduced for monitoring / debug purposes.
+#[derive(Eq, Debug, PartialEq)]
+pub enum NewRoundReason {
+    QCReady { cert: Arc<QuorumCert> },
+    Timeout { cert: Arc<TimeoutCertificate> },
+}
+
+impl fmt::Display for NewRoundReason {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NewRoundReason::QCReady { cert } => {
+                write!(f, "QCReady (round={})", cert.certified_block_round())
+            }
+            NewRoundReason::Timeout { cert } => write!(f, "TCReady (round={})", cert.round()),
+        }
+    }
+}
+
+/// NewRoundEvents produced by Pacemaker are guaranteed to be monotonically increasing.
+/// NewRoundEvents are consumed by the rest of the system: they can cause sending new proposals
+/// or voting for some proposals that wouldn't have been voted otherwise.
+/// The duration is populated for debugging and testing
+#[derive(Debug, PartialEq, Eq)]
+pub struct NewRoundEvent {
+    pub round: Round,
+    pub reason: NewRoundReason,
+    pub timeout: Duration,
+}
+
+impl fmt::Display for NewRoundEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "NewRoundEvent: [round: {}, reason: {}, timeout: {:?}]",
+            self.round, self.reason, self.timeout
+        )
+    }
+}
+
+/// Determines the maximum round duration based on the round difference between the current
+/// round and the committed round
+pub trait PacemakerTimeInterval: Send + Sync + 'static {
+    /// Use the index of the round after the highest quorum certificate to commit a block and
+    /// return the duration for this round
+    ///
+    /// Round indices start at 0 (round index = 0 is the first round after the round that led
+    /// to the highest committed round).  Given that round r is the highest round to commit a
+    /// block, then round index 0 is round r+1.  Note that for genesis does not follow the
+    /// 3-chain rule for commits, so round 1 has round index 0.  For example, if one wants
+    /// to calculate the round duration of round 6 and the highest committed round is 3 (meaning
+    /// the highest round to commit a block is round 5, then the round index is 0.
+    fn get_round_duration(&self, round_index_after_committed_qc: usize) -> Duration;
+}
+
+/// Round durations increase exponentially
+/// Basically time interval is base * mul^power
+/// Where power=max(rounds_since_qc, max_exponent)
+#[derive(Clone)]
+pub struct ExponentialTimeInterval {
+    // Initial time interval duration after a successful quorum commit.
+    base_ms: u64,
+    // By how much we increase interval every time
+    exponent_base: f64,
+    // Maximum time interval won't exceed base * mul^max_pow.
+    // Theoretically, setting it means
+    // that we rely on synchrony assumptions when the known max messaging delay is
+    // max_interval.  Alternatively, we can consider using max_interval to meet partial synchrony
+    // assumptions where while delta is unknown, it is <= max_interval.
+    max_exponent: usize,
+}
+
+#[allow(dead_code)]
+impl ExponentialTimeInterval {
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn fixed(duration: Duration) -> Self {
+        Self::new(duration, 1.0, 0)
+    }
+
+    pub fn new(base: Duration, exponent_base: f64, max_exponent: usize) -> Self {
+        assert!(
+            max_exponent < 32,
+            "max_exponent for PacemakerTimeInterval should be <32"
+        );
+        assert!(
+            exponent_base.powf(max_exponent as f64).ceil() < f64::from(std::u32::MAX),
+            "Maximum interval multiplier should be less then u32::Max"
+        );
+        ExponentialTimeInterval {
+            base_ms: base.as_millis() as u64, // any reasonable ms timeout fits u64 perfectly
+            exponent_base,
+            max_exponent,
+        }
+    }
+}
+
+impl PacemakerTimeInterval for ExponentialTimeInterval {
+    fn get_round_duration(&self, round_index_after_committed_qc: usize) -> Duration {
+        let pow = round_index_after_committed_qc.min(self.max_exponent) as u32;
+        let base_multiplier = self.exponent_base.powf(f64::from(pow));
+        let duration_ms = ((self.base_ms as f64) * base_multiplier).ceil() as u64;
+        Duration::from_millis(duration_ms)
+    }
+}
+
+/// `Pacemaker` is a Pacemaker implementation that is responsible for generating the new round
+/// and local timeout events.
+///
+/// A round `r` starts in the following cases:
+/// * there is a QuorumCert for round `r-1`,
+/// * there is a TimeoutCertificate for round `r-1`.
+///
+/// Round interval calculation is the responsibility of the PacemakerTimeoutInterval trait. It
+/// depends on the delta between the current round and the highest committed round (the intuition is
+/// that we want to exponentially grow the interval the further the current round is from the last
+/// committed round).
+///
+/// Whenever a new round starts a local timeout is set following the round interval. This local
+/// timeout is going to send the timeout events once in interval until the new round starts.
+pub struct Pacemaker {
+    // Determines the time interval for a round given the number of non-committed rounds since
+    // last commit.
+    time_interval: Box<dyn PacemakerTimeInterval>,
+    // Highest known committed round as reported by the caller. The caller might choose not to
+    // inform the Pacemaker about certain committed rounds (e.g., NIL blocks): in this case the
+    // committed round in Pacemaker might lag behind the committed round of a block tree.
+    highest_committed_round: Round,
+    // Current round is max{highest_qc, highest_tc} + 1.
+    current_round: Round,
+    // The deadline for the next local timeout event. It is reset every time a new round start, or
+    // a previous deadline expires.
+    current_round_deadline: Instant,
+    // Service for timer
+    time_service: Arc<dyn TimeService>,
+    // To send local timeout events to the subscriber (e.g., SMR)
+    timeout_sender: channel::Sender<Round>,
+}
+
+#[allow(dead_code)]
+impl Pacemaker {
+    pub fn new(
+        time_interval: Box<dyn PacemakerTimeInterval>,
+        time_service: Arc<dyn TimeService>,
+        timeout_sender: channel::Sender<Round>,
+    ) -> Self {
+        // Our counters are initialized via lazy_static, so they're not going to appear in
+        // Prometheus if some conditions never happen. Invoking get() function enforces creation.
+        counters::QC_ROUNDS_COUNT.get();
+        counters::TIMEOUT_ROUNDS_COUNT.get();
+        counters::TIMEOUT_COUNT.get();
+
+        Self {
+            time_interval,
+            highest_committed_round: 0,
+            current_round: 0,
+            current_round_deadline: Instant::now(),
+            time_service,
+            timeout_sender,
+        }
+    }
+
+    /// Return the current round.
+    pub fn current_round(&self) -> Round {
+        self.current_round
+    }
+
+    /// Returns deadline for current round
+    pub fn current_round_deadline(&self) -> Instant {
+        self.current_round_deadline
+    }
+
+    /// In case the local timeout corresponds to the current round, reset the timeout and
+    /// return true. Otherwise ignore and return false.
+    pub fn process_local_timeout(&mut self, round: Round) -> bool {
+        if round != self.current_round {
+            return false;
+        }
+        warn!("Local timeout for round {}", round);
+        counters::TIMEOUT_COUNT.inc();
+        self.setup_timeout();
+        true
+    }
+
+    /// Notify the Pacemaker about the potentially new QC, TC, and highest committed round.
+    /// Note that some of these values might not be available by the caller.
+    pub fn process_certificates(
+        &mut self,
+        highest_qc: Option<Arc<QuorumCert>>,
+        highest_tc: Option<Arc<TimeoutCertificate>>,
+        highest_committed_round: Option<Round>,
+    ) -> Option<NewRoundEvent> {
+        let qc_round = highest_qc
+            .as_ref()
+            .map_or(0, |qc| qc.certified_block_round());
+        let tc_round = highest_tc.as_ref().map_or(0, |tc| tc.round());
+        if let Some(committed_round) = highest_committed_round {
+            if committed_round > self.highest_committed_round {
+                self.highest_committed_round = committed_round;
+            }
+        }
+        let new_round = std::cmp::max(qc_round, tc_round) + 1;
+        if new_round > self.current_round {
+            // Start a new round.
+            self.current_round = new_round;
+            let timeout = self.setup_timeout();
+            // The new round reason is QCReady in case both QC and TC are equal
+            let new_round_reason = if qc_round >= tc_round {
+                NewRoundReason::QCReady {
+                    cert: highest_qc.expect("None QC generated a new round"),
+                }
+            } else {
+                NewRoundReason::Timeout {
+                    cert: highest_tc.expect("None TC generated a new round"),
+                }
+            };
+            let new_round_event = NewRoundEvent {
+                round: self.current_round,
+                reason: new_round_reason,
+                timeout,
+            };
+            debug!("Starting new round: {}", new_round_event);
+            return Some(new_round_event);
+        }
+        None
+    }
+
+    /// Setup the timeout task and return the duration of the current timeout
+    fn setup_timeout(&mut self) -> Duration {
+        let timeout_sender = self.timeout_sender.clone();
+        let timeout = self.setup_deadline();
+        trace!(
+            "Scheduling timeout of {} ms for round {}",
+            timeout.as_millis(),
+            self.current_round
+        );
+        self.time_service
+            .run_after(timeout, SendTask::make(timeout_sender, self.current_round));
+        timeout
+    }
+
+    /// Setup the current round deadline and return the duration of the current round
+    fn setup_deadline(&mut self) -> Duration {
+        let round_index_after_committed_round = {
+            if self.highest_committed_round == 0 {
+                // Genesis doesn't require the 3-chain rule for commit, hence start the index at
+                // the round after genesis.
+                self.current_round - 1
+            } else if self.current_round < self.highest_committed_round + 3 {
+                0
+            } else {
+                self.current_round - self.highest_committed_round - 3
+            }
+        } as usize;
+        let timeout = self
+            .time_interval
+            .get_round_duration(round_index_after_committed_round);
+        let now = Instant::now();
+        debug!(
+            "{:?} passed since the previous deadline.",
+            now.checked_duration_since(self.current_round_deadline)
+                .map_or("0 ms".to_string(), |v| format!("{:?}", v))
+        );
+        debug!("Set round deadline to {:?} from now", timeout);
+        self.current_round_deadline = now + timeout;
+        timeout
+    }
+}

--- a/consensus/src/chained_bft/liveness/pacemaker_new_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_new_test.rs
@@ -1,0 +1,130 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    chained_bft::{
+        common::Round,
+        consensus_types::quorum_cert::QuorumCert,
+        liveness::pacemaker_new::{
+            ExponentialTimeInterval, NewRoundEvent, NewRoundReason, Pacemaker,
+            PacemakerTimeInterval,
+        },
+        test_utils,
+    },
+    util::mock_time_service::SimulatedTimeService,
+};
+use channel;
+use consensus_types::timeout_certificate::TimeoutCertificate;
+use consensus_types::vote_data::VoteData;
+use crypto::HashValue;
+use futures::{executor::block_on, StreamExt};
+use libra_types::crypto_proxies::LedgerInfoWithSignatures;
+use std::collections::{BTreeMap, HashMap};
+use std::{sync::Arc, time::Duration};
+
+#[test]
+fn test_pacemaker_time_interval() {
+    let interval = ExponentialTimeInterval::new(Duration::from_millis(3000), 1.5, 2);
+    assert_eq!(3000, interval.get_round_duration(0).as_millis());
+    assert_eq!(4500, interval.get_round_duration(1).as_millis());
+    assert_eq!(
+        6750, /* 4500*1.5 */
+        interval.get_round_duration(2).as_millis()
+    );
+    // Test that there is no integer overflow
+    assert_eq!(6750, interval.get_round_duration(1000).as_millis());
+}
+
+#[test]
+/// Verify that Pacemaker properly outputs local timeout events upon timeout
+fn test_basic_timeout() {
+    let (mut pm, mut timeout_rx) = make_pacemaker();
+
+    // jump start the pacemaker
+    pm.process_certificates(
+        Some(Arc::new(QuorumCert::certificate_for_genesis())),
+        None,
+        None,
+    );
+    for _ in 0..2 {
+        let round = block_on(timeout_rx.next()).unwrap();
+        // Here we just test timeout send retry,
+        // round for timeout is not changed as no timeout certificate was gathered at this point
+        assert_eq!(1, round);
+        pm.process_local_timeout(round);
+    }
+}
+
+#[test]
+fn test_round_event_generation() {
+    let (mut pm, _) = make_pacemaker();
+    // Happy path with new QC
+    expect_qc(
+        2,
+        pm.process_certificates(Some(qc_for_round(1)), None, None),
+    );
+    // Old QC does not generate anything
+    assert!(pm
+        .process_certificates(Some(qc_for_round(1)), None, None)
+        .is_none());
+    // A TC for a higher round
+    expect_timeout(
+        3,
+        pm.process_certificates(None, Some(tc_for_round(2)), None),
+    );
+    // In case both QC and TC are present choose the one with the higher value
+    expect_timeout(
+        4,
+        pm.process_certificates(Some(qc_for_round(2)), Some(tc_for_round(3)), None),
+    );
+    // In case both QC and TC are present with the same value, choose QC
+    expect_qc(
+        5,
+        pm.process_certificates(Some(qc_for_round(4)), Some(tc_for_round(4)), None),
+    );
+}
+
+fn make_pacemaker() -> (Pacemaker, channel::Receiver<Round>) {
+    let time_interval = Box::new(ExponentialTimeInterval::fixed(Duration::from_millis(2)));
+    let simulated_time = SimulatedTimeService::auto_advance_until(Duration::from_millis(4));
+    let (timeout_tx, timeout_rx) = channel::new_test(1_024);
+    (
+        Pacemaker::new(time_interval, Arc::new(simulated_time.clone()), timeout_tx),
+        timeout_rx,
+    )
+}
+
+fn qc_for_round(round: Round) -> Arc<QuorumCert> {
+    Arc::new(QuorumCert::new(
+        VoteData::new(
+            HashValue::random(),
+            HashValue::random(),
+            round,
+            HashValue::random(),
+            0,
+        ),
+        LedgerInfoWithSignatures::new(test_utils::placeholder_ledger_info(), BTreeMap::new()),
+    ))
+}
+
+fn tc_for_round(round: Round) -> Arc<TimeoutCertificate> {
+    Arc::new(TimeoutCertificate::new(round, HashMap::new()))
+}
+
+fn expect_qc(round: Round, event: Option<NewRoundEvent>) {
+    let event = event.unwrap();
+    assert_eq!(round, event.round);
+    match event.reason {
+        NewRoundReason::QCReady { .. } => (),
+        x => panic!("Expected QCReady reason for round {}, got {:?}", round, x),
+    }
+}
+
+fn expect_timeout(round: Round, event: Option<NewRoundEvent>) {
+    let event = event.unwrap();
+    assert_eq!(round, event.round);
+    match event.reason {
+        NewRoundReason::Timeout { .. } => (),
+        x => panic!("Expected Timeout reason for round {}, got {:?}", round, x),
+    };
+}


### PR DESCRIPTION
## Summary: 
Note: this is an intermediate step towards further refactoring.
As we're moving towards the solution, in which the TC is aggregated and managed by the block store, we can significantly simplify the Pacemaker.
This change introduces a new implementation that is not handling timeout certificates, instead it just takes the round being max{tc,qc} + 1.
The only real piece of logic in the pacemaker is the interval calculation and the generation of the local timeouts.

In order to have reasonably sized changes this diff introduces a separate "pacemaker_new" module with the new implementation, which is not used yet.
We're going to start using it in the followup change and will cleanup the old Pacemaker after that.

## Testing:
added unit tests for the new implementation

## Issues
ref #1048