### PR TITLE
[types] Delete this comment because 'encode_raw_bytes' no longer exsits

### DIFF
--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -129,9 +129,6 @@ impl fmt::Display for EventKey {
 
 impl CanonicalSerialize for EventKey {
     fn serialize(&self, serializer: &mut impl CanonicalSerializer) -> Result<()> {
-        // We cannot use encode_raw_bytes as this structure will represent how Move Value of type
-        // EventKey is serialized into. And since Move doesn't have fix length bytearray, values
-        // can't be encoded in the fix length fasion.
         serializer.encode_bytes(&self.0)?;
         Ok(())
     }


### PR DESCRIPTION
…nger exsits.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This comment is outdated because function 'encode_raw_bytes' no longer exists.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
