### PR TITLE
[cluster-test] Allow basic cluster-test against libra-swarm

### DIFF
--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -98,6 +98,24 @@ fn main() {
         validator_set_file,
         faucet_key_file_path,
     );
+    let node_address_list = validator_swarm
+        .config
+        .configs
+        .iter()
+        .map(|config| {
+            let port = NodeConfig::load(config)
+                .unwrap()
+                .admission_control
+                .admission_control_service_port;
+            format!("localhost:{}", port)
+        })
+        .collect::<Vec<String>>()
+        .join(",");
+    println!("To run transaction generator run:");
+    println!(
+        "\tcargo run --bin cluster-test -- --mint-file {:?} --swarm --peers {:?}  --emit-tx",
+        faucet_key_file_path, node_address_list,
+    );
     if let Some(ref swarm) = full_node_swarm {
         let full_node_config = NodeConfig::load(&swarm.config.configs[0]).unwrap();
         println!("To connect to the full nodes you just spawned, use this command:");

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -9,11 +9,16 @@ use std::{
 pub struct Instance {
     short_hash: String,
     ip: String,
+    ac_port: u32,
 }
 
 impl Instance {
-    pub fn new(short_hash: String, ip: String) -> Instance {
-        Instance { short_hash, ip }
+    pub fn new(short_hash: String, ip: String, ac_port: u32) -> Instance {
+        Instance {
+            short_hash,
+            ip,
+            ac_port,
+        }
     }
 
     pub fn run_cmd_tee_err<I, S>(&self, args: I) -> failure::Result<()>
@@ -64,6 +69,10 @@ impl Instance {
 
     pub fn ip(&self) -> &String {
         &self.ip
+    }
+
+    pub fn ac_port(&self) -> u32 {
+        self.ac_port
     }
 }
 

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -81,7 +81,7 @@ pub struct EmitJobRequest {
 impl TxEmitter {
     pub fn new(cluster: &Cluster) -> Self {
         let mint_client = Self::make_client(&cluster.instances()[0]);
-        let faucet_account = load_faucet_account(&mint_client, "mint.key");
+        let faucet_account = load_faucet_account(&mint_client, cluster.mint_file());
         Self {
             accounts: vec![],
             mint_client,
@@ -147,7 +147,7 @@ impl TxEmitter {
     }
 
     fn make_client(instance: &Instance) -> AdmissionControlClient {
-        let address = format!("{}:8000", instance.ip());
+        let address = format!("{}:{}", instance.ip(), instance.ac_port());
         let env_builder = Arc::new(EnvBuilder::new().name_prefix("ac-grpc-").build());
         let ch = ChannelBuilder::new(env_builder).connect(&address);
         AdmissionControlClient::new(ch)


### PR DESCRIPTION
# Summary

This diff will allow us to point cluster-test to a local libra-swarm

libra-swarm changes:
* Print cluster-test command when we start libra-swarm

cluster-test changes:
* Add "mint-file" flag to cluster-test binary
* Update struct Cluster: make prometheus_ip an Option<String> and add mint_file: String
* Add from_host_port method to struct Cluster
* Add port: u32 field to struct Instance
* During ClusterUtil::setup check if all peers are of format host:port, in that case don't use AWS

## Test Plan

### Created a swarm

```
% cargo run -p libra-swarm -- -n 4
   Compiling libra-swarm v0.1.0 (/Users/kush/git/libra/libra-swarm)
    Finished dev [unoptimized + debuginfo] target(s) in 9.49s
     Running `target/debug/libra-swarm -n 4`
Faucet account created in (loaded from) file "/var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/42d246ecba8cdbf6126c8db7a0015181/temp_faucet_keys"
Base directory containing logs and configs: Temporary(TempPath { path_buf: "/var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/78126c6f0ae98e423ea76d9c62983c35", persist: false })
To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:
	cargo run --bin client -- -a localhost -p 60575 -s "/var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/78126c6f0ae98e423ea76d9c62983c35/0/consensus_peers.config.toml" -m "/var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/42d246ecba8cdbf6126c8db7a0015181/temp_faucet_keys"
To run transaction generator run:
	cargo run --bin cluster-test -- --mint-file "/var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/42d246ecba8cdbf6126c8db7a0015181/temp_faucet_keys" --peers localhost:60575  --emit-tx --workplace <workplace-name>
CTRL-C to exit.
```

### Ran cluster-test binary against this swarm
```
% cargo run --bin cluster-test -- --mint-file "/var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/42d246ecba8cdbf6126c8db7a0015181/temp_faucet_keys" --peers localhost:60575  --emit-tx --workplace kush                           (130)
    Finished dev [unoptimized + debuginfo] target(s) in 0.76s
     Running `target/debug/cluster-test --mint-file /var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/42d246ecba8cdbf6126c8db7a0015181/temp_faucet_keys --peers 'localhost:60575' --emit-tx --workplace kush`
Oct 10 11:09:18.576 INFO Minting accounts
Oct 10 11:09:23.228 INFO Mint is done
```

Closes #1219