### PR TITLE
[storage] `TransactionToCommit` carries `enum Transaction`

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -20,8 +20,8 @@ use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
     proof::{accumulator::Accumulator, definition::LeafCount, SparseMerkleProof},
     transaction::{
-        SignedTransaction, TransactionInfo, TransactionListWithProof, TransactionOutput,
-        TransactionPayload, TransactionStatus, TransactionToCommit, Version,
+        SignedTransaction, Transaction, TransactionInfo, TransactionListWithProof,
+        TransactionOutput, TransactionPayload, TransactionStatus, TransactionToCommit, Version,
     },
     write_set::{WriteOp, WriteSet},
 };
@@ -362,7 +362,7 @@ where
                 i,
             );
             txns_to_commit.push(TransactionToCommit::new(
-                txn,
+                Transaction::UserTransaction(txn),
                 txn_data.account_blobs().clone(),
                 txn_data.events().to_vec(),
                 txn_data.gas_used(),
@@ -499,7 +499,7 @@ where
             ) {
                 if let TransactionStatus::Keep(_) = txn_data.status() {
                     txns_to_commit.push(TransactionToCommit::new(
-                        txn.clone(),
+                        Transaction::UserTransaction(txn.clone()),
                         txn_data.account_blobs().clone(),
                         txn_data.events().to_vec(),
                         txn_data.gas_used(),

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -307,11 +307,11 @@ fn verify_committed_transactions(
         // Verify transaction hash.
         assert_eq!(
             txn_info.signed_transaction_hash(),
-            txn_to_commit.signed_txn().hash()
+            txn_to_commit.as_signed_user_txn()?.hash()
         );
 
         // Fetch and verify transaction itself.
-        let txn = txn_to_commit.signed_txn();
+        let txn = txn_to_commit.as_signed_user_txn()?;
         let txn_with_proof = db.get_transaction_with_proof(cur_ver, ledger_version, true)?;
         txn_with_proof.verify(ledger_info, cur_ver, txn.sender(), txn.sequence_number())?;
 

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -17,7 +17,7 @@ use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
     ledger_info::LedgerInfo,
     proof::SparseMerkleLeafNode,
-    transaction::{RawTransaction, Script, TransactionInfo, TransactionToCommit},
+    transaction::{RawTransaction, Script, Transaction, TransactionInfo, TransactionToCommit},
     vm_error::StatusCode,
 };
 use rand::{
@@ -56,7 +56,7 @@ fn gen_mock_genesis() -> (
         .collect::<HashMap<_, _>>();
 
     let txn_to_commit = TransactionToCommit::new(
-        signed_txn,
+        Transaction::UserTransaction(signed_txn),
         account_states.clone(),
         vec![], /* events */
         0,      /* gas_used */

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -33,7 +33,7 @@ fn to_blocks_to_commit(
                 cur_ver += 1;
                 let mut cs = ChangeSet::new();
 
-                let txn_hash = txn_to_commit.signed_txn().hash();
+                let txn_hash = txn_to_commit.as_signed_user_txn()?.hash();
                 let state_root_hash = db.state_store.put_account_state_sets(
                     vec![txn_to_commit.account_states().clone()],
                     cur_ver,

--- a/storage/libradb/src/transaction_store/mod.rs
+++ b/storage/libradb/src/transaction_store/mod.rs
@@ -62,20 +62,16 @@ impl TransactionStore {
     pub fn put_transaction(
         &self,
         version: Version,
-        signed_transaction: &SignedTransaction,
+        transaction: &Transaction,
         cs: &mut ChangeSet,
     ) -> Result<()> {
-        cs.batch.put::<TransactionByAccountSchema>(
-            &(
-                signed_transaction.sender(),
-                signed_transaction.sequence_number(),
-            ),
-            &version,
-        )?;
-        cs.batch.put::<TransactionSchema>(
-            &version,
-            &Transaction::UserTransaction(signed_transaction.clone()),
-        )?;
+        if let Transaction::UserTransaction(txn) = transaction {
+            cs.batch.put::<TransactionByAccountSchema>(
+                &(txn.sender(), txn.sequence_number()),
+                &version,
+            )?;
+        }
+        cs.batch.put::<TransactionSchema>(&version, &transaction)?;
 
         Ok(())
     }

--- a/storage/libradb/src/transaction_store/test.rs
+++ b/storage/libradb/src/transaction_store/test.rs
@@ -33,7 +33,7 @@ proptest! {
         let mut cs = ChangeSet::new();
         for (ver, txn) in txns.iter().enumerate() {
             store
-                .put_transaction(ver as Version, &txn, &mut cs)
+                .put_transaction(ver as Version, &Transaction::UserTransaction(txn.clone()), &mut cs)
                 .unwrap();
         }
         store.db.write_schemas(cs.batch).unwrap();

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 /// 3. Once that special resource is modified, the other user transactions can read the consensus
 ///    info by calling into the read method of that resource, which would thus give users the
 ///    information such as the current leader.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockMetadata {
     id: HashValue,
     timestamp_usec: u64,

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::transaction::Transaction;
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -747,7 +748,7 @@ impl TransactionToCommitGen {
             .collect();
 
         TransactionToCommit::new(
-            signed_txn,
+            Transaction::UserTransaction(signed_txn),
             account_states,
             events,
             self.gas_used,

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -72,7 +72,7 @@ message AccountState {
 // Transaction struct to commit to storage
 message TransactionToCommit {
     // The signed transaction which was executed
-    SignedTransaction signed_txn = 1;
+    Transaction transaction = 1;
     // State db updates
     repeated AccountState account_states = 2;
     // Events yielded by the transaction.

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -27,9 +27,8 @@ message SignedTransaction {
     bytes signed_txn = 5;
 }
 
-// A generic structure that represents a transaction, covering all three
-// possible variants: a signed user transaction, a write set transaction, or a
-// block metadata transaction.
+// A generic structure that represents a transaction, covering all possible
+// variants.
 message Transaction {
     bytes transaction = 1;
 }

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -27,6 +27,13 @@ message SignedTransaction {
     bytes signed_txn = 5;
 }
 
+// A generic structure that represents a transaction, covering all three
+// possible variants: a signed user transaction, a write set transaction, or a
+// block metadata transaction.
+message Transaction {
+    bytes transaction = 1;
+}
+
 message SignedTransactionWithProof {
     // The version of the returned signed transaction.
     uint64 version = 1;

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -1194,7 +1194,7 @@ impl From<TransactionListWithProof> for crate::proto::types::TransactionListWith
 /// transaction.
 #[allow(clippy::large_enum_variant)]
 #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Transaction {
     /// Transaction submitted by the user. e.g: P2P payment transaction, publishing module
     /// transaction, etc.
@@ -1252,5 +1252,21 @@ impl CanonicalDeserialize for Transaction {
             }
         };
         Ok(transaction)
+    }
+}
+
+impl TryFrom<crate::proto::types::Transaction> for Transaction {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::types::Transaction) -> Result<Self> {
+        SimpleDeserializer::deserialize(&proto.transaction)
+    }
+}
+
+impl From<Transaction> for crate::proto::types::Transaction {
+    fn from(txn: Transaction) -> Self {
+        let bytes =
+            SimpleSerializer::<Vec<u8>>::serialize(&txn).expect("Serialization should not fail.");
+        Self { transaction: bytes }
     }
 }

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -1272,8 +1272,7 @@ impl TryFrom<crate::proto::types::Transaction> for Transaction {
 
 impl From<Transaction> for crate::proto::types::Transaction {
     fn from(txn: Transaction) -> Self {
-        let bytes =
-            SimpleSerializer::<Vec<u8>>::serialize(&txn).expect("Serialization should not fail.");
+        let bytes = SimpleSerializer::serialize(&txn).expect("Serialization should not fail.");
         Self { transaction: bytes }
     }
 }

--- a/types/src/unit_tests/transaction_proto_conversion_test.rs
+++ b/types/src/unit_tests/transaction_proto_conversion_test.rs
@@ -12,6 +12,11 @@ proptest! {
     }
 
     #[test]
+    fn test_txn(txn in any::<Transaction>()) {
+        assert_protobuf_encode_decode::<crate::proto::types::Transaction, Transaction>(&txn);
+    }
+
+    #[test]
     fn test_signed_txn_with_proof(signed_txn_with_proof in any::<SignedTransactionWithProof>()) {
         assert_protobuf_encode_decode::<crate::proto::types::SignedTransactionWithProof, SignedTransactionWithProof>(&signed_txn_with_proof);
     }


### PR DESCRIPTION

## Motivation
Another step towards using `enum Transaction` everywhere instead of `SignedTransaction`. 

part of the effort around #1173

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing coverage.
## Related PRs
based on #1229
