### PR TITLE
[consensus] Remove hash from block protos

### DIFF
--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -584,7 +584,13 @@ lazy_static! {
 
     /// Genesis block id is used as a parent of the very first block executed by the executor.
     pub static ref GENESIS_BLOCK_ID: HashValue =
-        create_literal_hash("GENESIS_BLOCK_ID");
+        // This maintains the invariant that block.id() == block.hash(), for
+        // the genesis block and allows us to (de/)serialize it consistently
+        HashValue::new(
+            [0x10, 0x78, 0xfa, 0x2e, 0x6d, 0x13, 0x81, 0x95,
+             0x4c, 0x98, 0x63, 0xf9, 0xaa, 0xf0, 0x94, 0xbe,
+             0xf5, 0x19, 0x7f, 0x01, 0x9e, 0xe3, 0xc6, 0x6d,
+             0xd9, 0xa6, 0x9f, 0x61, 0x39, 0x1c, 0xa6, 0xba]);
 }
 
 /// Provides a test_only_hash() method that can be used in tests on types that implement

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -70,25 +70,23 @@ message TimeoutCertificate {
 }
 
 message Block {
-  // This block's id as a hash value
-  bytes id = 1;
   // Payload of the block (e.g. one or more transaction(s)
-  bytes payload = 2;
+  bytes payload = 1;
   // Epoch number corresponds to the set of validators that are active for this block.
-  uint64 epoch = 3;
+  uint64 epoch = 2;
   // The round of the block (internal monotonically increasing counter).
-  uint64 round = 4;
+  uint64 round = 3;
   // The approximate physical microseconds since the epoch when the block was proposed
-  uint64 timestamp_usecs = 5;
+  uint64 timestamp_usecs = 4;
   // Contains the quorum certified ancestor and whether the quorum certified
   // ancestor was voted on successfully
-  QuorumCert quorum_cert = 6;
+  QuorumCert quorum_cert = 5;
   // Author of the block that can be validated by the author's public key and
   // the signature
-  bytes author = 7;
+  bytes author = 6;
   // Signature that the hash of this block has been authored by the owner of the
   // private key
-  bytes signature = 8;
+  bytes signature = 7;
 }
 
 message QuorumCert {


### PR DESCRIPTION
*This PR modifies the following behavior:*
- removes the id field from proto for Blocks,
- reconstructs the hash at deserialization to create a `Block<T>`,
- changes the corresponding test in verify_well_formed to a MIRAI `debug_checked_verify_eq` annotation,
- adjusts the value of `GENESIS_BLOCK_ID` to maintain the invariant (genesis hashes to its id)

*Why this is better:*
- avoids the temptation of trusting the hash transmitted over the network by removing its existence,
- thereby protects other compatible implementation from making that possible mistake,

*Why this is worse:*
- n/a: as long as we're going to compute the block's hash to check it, we can just use that computation to populate the hash instead
