### PR TITLE
[Proof] Make verify a method of AccumulatorProof

### DIFF
--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -150,7 +150,7 @@ where
         reader: &R,
         num_leaves: LeafCount,
         leaf_index: u64,
-    ) -> Result<AccumulatorProof> {
+    ) -> Result<AccumulatorProof<H>> {
         MerkleAccumulatorView::<R, H>::new(reader, num_leaves).get_proof(leaf_index)
     }
 
@@ -310,7 +310,7 @@ where
     }
 
     /// implementation for pub interface `MerkleAccumulator::get_proof`
-    fn get_proof(&self, leaf_index: u64) -> Result<AccumulatorProof> {
+    fn get_proof(&self, leaf_index: u64) -> Result<AccumulatorProof<H>> {
         ensure!(
             leaf_index < self.num_leaves as u64,
             "invalid leaf_index {}, num_leaves {}",

--- a/storage/accumulator/src/tests/proof_test.rs
+++ b/storage/accumulator/src/tests/proof_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use libra_types::proof::verify_test_accumulator_element;
 use proptest::{collection::vec, prelude::*};
 
 #[test]
@@ -90,6 +89,6 @@ fn verify(
     leaves.iter().enumerate().for_each(|(i, hash)| {
         let leaf_index = first_leaf_idx + i as u64;
         let proof = TestAccumulator::get_proof(store, num_leaves, leaf_index).unwrap();
-        verify_test_accumulator_element(root_hash, *hash, leaf_index, &proof).unwrap();
+        proof.verify(root_hash, *hash, leaf_index).unwrap();
     });
 }

--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -25,7 +25,7 @@ use libra_types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,
     event::EventKey,
-    proof::{position::Position, AccumulatorProof, EventProof},
+    proof::{position::Position, EventAccumulatorProof, EventProof},
     transaction::Version,
 };
 use schemadb::{schema::ValueCodec, ReadOptions, DB};
@@ -64,7 +64,7 @@ impl EventStore {
         &self,
         version: Version,
         index: u64,
-    ) -> Result<(ContractEvent, AccumulatorProof)> {
+    ) -> Result<(ContractEvent, EventAccumulatorProof)> {
         // Get event content.
         let event = self
             .db

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -9,7 +9,6 @@ use libra_types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,
     event::EventKey,
-    proof::verify_event_accumulator_element,
     proptest_types::{AccountInfoUniverse, ContractEventGen},
 };
 use proptest::{
@@ -74,7 +73,7 @@ proptest! {
                 .get_event_with_proof_by_version_and_index(100, idx as u64)
                 .unwrap();
             prop_assert_eq!(&event, expected_event);
-            verify_event_accumulator_element(root_hash, event.hash(),  idx as u64, &proof).unwrap();
+            proof.verify(root_hash, event.hash(), idx as u64).unwrap();
         }
         // error on index >= num_events
         prop_assert!(store

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -22,7 +22,7 @@ use failure::prelude::*;
 use itertools::Itertools;
 use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
-    proof::{position::Position, AccumulatorConsistencyProof, AccumulatorProof},
+    proof::{position::Position, AccumulatorConsistencyProof, TransactionAccumulatorProof},
     transaction::{TransactionInfo, Version},
 };
 use schemadb::{ReadOptions, DB};
@@ -113,7 +113,7 @@ impl LedgerStore {
         &self,
         version: Version,
         ledger_version: Version,
-    ) -> Result<(TransactionInfo, AccumulatorProof)> {
+    ) -> Result<(TransactionInfo, TransactionAccumulatorProof)> {
         Ok((
             self.get_transaction_info(version)?,
             self.get_transaction_proof(version, ledger_version)?,
@@ -125,7 +125,7 @@ impl LedgerStore {
         &self,
         version: Version,
         ledger_version: Version,
-    ) -> Result<AccumulatorProof> {
+    ) -> Result<TransactionAccumulatorProof> {
         Accumulator::get_proof(self, ledger_version + 1 /* num_leaves */, version)
     }
 

--- a/storage/libradb/src/ledger_store/transaction_info_test.rs
+++ b/storage/libradb/src/ledger_store/transaction_info_test.rs
@@ -3,7 +3,6 @@
 
 use super::*;
 use crate::LibraDB;
-use libra_types::proof::verify_transaction_accumulator_element;
 use proptest::{collection::vec, prelude::*};
 use tools::tempdir::TempPath;
 
@@ -25,8 +24,7 @@ fn verify(
                 .unwrap();
 
             assert_eq!(&txn_info, expected_txn_info);
-            verify_transaction_accumulator_element(root_hash, txn_info.hash(), version, &proof)
-                .unwrap();
+            proof.verify(root_hash, txn_info.hash(), version).unwrap();
         })
 }
 

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -280,7 +280,7 @@ fn get_mock_txn_data(
 }
 
 fn get_accumulator_proof() -> AccumulatorProof {
-    libra_types::proof::AccumulatorProof::new(vec![]).into()
+    libra_types::proof::TransactionAccumulatorProof::new(vec![]).into()
 }
 
 fn get_transaction_info() -> libra_types::transaction::TransactionInfo {

--- a/types/src/proof/unit_tests/proof_proto_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_proto_conversion_test.rs
@@ -3,8 +3,8 @@
 
 use crate::proof::{
     definition::bitmap::{AccumulatorBitmap, SparseMerkleBitmap},
-    AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, EventProof,
-    SignedTransactionProof, SparseMerkleProof,
+    AccountStateProof, AccumulatorConsistencyProof, EventProof, SignedTransactionProof,
+    SparseMerkleProof, TestAccumulatorProof,
 };
 use crypto::{
     hash::{TestOnlyHash, ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -69,14 +69,14 @@ fn accumulator_proof_protobuf_conversion_test(
     expected_bitmap: u64,
     expected_num_non_default_siblings: usize,
 ) {
-    let proof = AccumulatorProof::new(siblings);
+    let proof = TestAccumulatorProof::new(siblings);
     let compressed_proof: crate::proto::types::AccumulatorProof = proof.clone().into();
     assert_eq!(compressed_proof.bitmap, expected_bitmap);
     assert_eq!(
         compressed_proof.non_default_siblings.len(),
         expected_num_non_default_siblings
     );
-    let decompressed_proof = AccumulatorProof::try_from(compressed_proof).unwrap();
+    let decompressed_proof = TestAccumulatorProof::try_from(compressed_proof).unwrap();
     assert_eq!(decompressed_proof, proof);
 }
 
@@ -126,7 +126,7 @@ fn test_convert_accumulator_proof_wrong_number_of_siblings() {
     compressed_proof
         .non_default_siblings
         .push(sibling1.to_vec());
-    assert!(AccumulatorProof::try_from(compressed_proof).is_err());
+    assert!(TestAccumulatorProof::try_from(compressed_proof).is_err());
 }
 
 #[test]
@@ -137,7 +137,7 @@ fn test_convert_accumulator_proof_malformed_hashes() {
     let mut compressed_proof = crate::proto::types::AccumulatorProof::default();
     compressed_proof.bitmap = 0b100;
     compressed_proof.non_default_siblings.push(sibling0);
-    assert!(AccumulatorProof::try_from(compressed_proof).is_err());
+    assert!(TestAccumulatorProof::try_from(compressed_proof).is_err());
 }
 
 fn sparse_merkle_proof_protobuf_conversion_test(
@@ -306,8 +306,8 @@ proptest! {
     }
 
     #[test]
-    fn test_accumulator_protobuf_conversion_roundtrip(proof in any::<AccumulatorProof>()) {
-        assert_protobuf_encode_decode::<crate::proto::types::AccumulatorProof, AccumulatorProof>(&proof);
+    fn test_accumulator_protobuf_conversion_roundtrip(proof in any::<TestAccumulatorProof>()) {
+        assert_protobuf_encode_decode::<crate::proto::types::AccumulatorProof, TestAccumulatorProof>(&proof);
     }
 
     #[test]

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -7,11 +7,11 @@ use crate::{
     ledger_info::LedgerInfo,
     proof::{
         definition::MAX_ACCUMULATOR_PROOF_DEPTH, verify_account_state, verify_event,
-        verify_signed_transaction, verify_sparse_merkle_element, verify_test_accumulator_element,
-        AccountStateProof, AccumulatorProof, EventAccumulatorInternalNode, EventProof,
-        MerkleTreeInternalNode, SignedTransactionProof, SparseMerkleInternalNode,
-        SparseMerkleLeafNode, SparseMerkleProof, TestAccumulatorInternalNode,
-        TransactionAccumulatorInternalNode,
+        verify_signed_transaction, verify_sparse_merkle_element, AccountStateProof,
+        EventAccumulatorInternalNode, EventAccumulatorProof, EventProof, MerkleTreeInternalNode,
+        SignedTransactionProof, SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleProof,
+        TestAccumulatorInternalNode, TestAccumulatorProof, TransactionAccumulatorInternalNode,
+        TransactionAccumulatorProof,
     },
     transaction::{
         RawTransaction, Script, SignedTransaction, TransactionInfo, TransactionListWithProof,
@@ -32,16 +32,16 @@ use proptest::{collection::vec, prelude::*};
 fn test_verify_empty_accumulator() {
     let element_hash = b"hello".test_only_hash();
     let root_hash = *ACCUMULATOR_PLACEHOLDER_HASH;
-    let proof = AccumulatorProof::new(vec![]);
-    assert!(verify_test_accumulator_element(root_hash, element_hash, 0, &proof).is_err());
+    let proof = TestAccumulatorProof::new(vec![]);
+    assert!(proof.verify(root_hash, element_hash, 0).is_err());
 }
 
 #[test]
 fn test_verify_single_element_accumulator() {
     let element_hash = b"hello".test_only_hash();
     let root_hash = element_hash;
-    let proof = AccumulatorProof::new(vec![]);
-    assert!(verify_test_accumulator_element(root_hash, element_hash, 0, &proof).is_ok());
+    let proof = TestAccumulatorProof::new(vec![]);
+    assert!(proof.verify(root_hash, element_hash, 0).is_ok());
 }
 
 #[test]
@@ -50,20 +50,12 @@ fn test_verify_two_element_accumulator() {
     let element1_hash = b"world".test_only_hash();
     let root_hash = TestAccumulatorInternalNode::new(element0_hash, element1_hash).hash();
 
-    assert!(verify_test_accumulator_element(
-        root_hash,
-        element0_hash,
-        0,
-        &AccumulatorProof::new(vec![element1_hash]),
-    )
-    .is_ok());
-    assert!(verify_test_accumulator_element(
-        root_hash,
-        element1_hash,
-        1,
-        &AccumulatorProof::new(vec![element0_hash]),
-    )
-    .is_ok());
+    assert!(TestAccumulatorProof::new(vec![element1_hash])
+        .verify(root_hash, element0_hash, 0)
+        .is_ok());
+    assert!(TestAccumulatorProof::new(vec![element0_hash])
+        .verify(root_hash, element1_hash, 1)
+        .is_ok());
 }
 
 #[test]
@@ -76,27 +68,21 @@ fn test_verify_three_element_accumulator() {
         TestAccumulatorInternalNode::new(element2_hash, *ACCUMULATOR_PLACEHOLDER_HASH).hash();
     let root_hash = TestAccumulatorInternalNode::new(internal0_hash, internal1_hash).hash();
 
-    assert!(verify_test_accumulator_element(
-        root_hash,
-        element0_hash,
-        0,
-        &AccumulatorProof::new(vec![internal1_hash, element1_hash]),
-    )
-    .is_ok());
-    assert!(verify_test_accumulator_element(
-        root_hash,
-        element1_hash,
-        1,
-        &AccumulatorProof::new(vec![internal1_hash, element0_hash]),
-    )
-    .is_ok());
-    assert!(verify_test_accumulator_element(
-        root_hash,
-        element2_hash,
-        2,
-        &AccumulatorProof::new(vec![internal0_hash, *ACCUMULATOR_PLACEHOLDER_HASH]),
-    )
-    .is_ok());
+    assert!(
+        TestAccumulatorProof::new(vec![internal1_hash, element1_hash])
+            .verify(root_hash, element0_hash, 0)
+            .is_ok()
+    );
+    assert!(
+        TestAccumulatorProof::new(vec![internal1_hash, element0_hash])
+            .verify(root_hash, element1_hash, 1)
+            .is_ok()
+    );
+    assert!(
+        TestAccumulatorProof::new(vec![internal0_hash, *ACCUMULATOR_PLACEHOLDER_HASH])
+            .verify(root_hash, element2_hash, 2)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -112,9 +98,9 @@ fn test_accumulator_proof_max_siblings_leftmost() {
         .fold(element_hash, |hash, sibling_hash| {
             TestAccumulatorInternalNode::new(hash, *sibling_hash).hash()
         });
-    let proof = AccumulatorProof::new(siblings);
+    let proof = TestAccumulatorProof::new(siblings);
 
-    assert!(verify_test_accumulator_element(root_hash, element_hash, 0, &proof).is_ok());
+    assert!(proof.verify(root_hash, element_hash, 0).is_ok());
 }
 
 #[test]
@@ -131,9 +117,9 @@ fn test_accumulator_proof_max_siblings_rightmost() {
             TestAccumulatorInternalNode::new(*sibling_hash, hash).hash()
         });
     let leaf_index = (std::u64::MAX - 1) / 2;
-    let proof = AccumulatorProof::new(siblings);
+    let proof = TestAccumulatorProof::new(siblings);
 
-    assert!(verify_test_accumulator_element(root_hash, element_hash, leaf_index, &proof).is_ok());
+    assert!(proof.verify(root_hash, element_hash, leaf_index).is_ok());
 }
 
 #[test]
@@ -150,9 +136,9 @@ fn test_accumulator_proof_sibling_overflow() {
         .fold(element_hash, |hash, sibling_hash| {
             TestAccumulatorInternalNode::new(hash, *sibling_hash).hash()
         });
-    let proof = AccumulatorProof::new(siblings);
+    let proof = TestAccumulatorProof::new(siblings);
 
-    assert!(verify_test_accumulator_element(root_hash, element_hash, 0, &proof).is_err());
+    assert!(proof.verify(root_hash, element_hash, 0).is_err());
 }
 
 #[test]
@@ -305,7 +291,7 @@ fn test_verify_signed_transaction() {
     );
 
     let ledger_info_to_transaction_info_proof =
-        AccumulatorProof::new(vec![internal_b_hash, txn_info0_hash]);
+        TransactionAccumulatorProof::new(vec![internal_b_hash, txn_info0_hash]);
     let proof = SignedTransactionProof::new(ledger_info_to_transaction_info_proof, txn_info1);
 
     // The proof can be used to verify txn1.
@@ -407,7 +393,7 @@ fn test_verify_account_state_and_event() {
     );
 
     let ledger_info_to_transaction_info_proof =
-        AccumulatorProof::new(vec![internal_a_hash, *ACCUMULATOR_PLACEHOLDER_HASH]);
+        TransactionAccumulatorProof::new(vec![internal_a_hash, *ACCUMULATOR_PLACEHOLDER_HASH]);
     let transaction_info_to_account_proof = SparseMerkleProof::new(
         Some((key2, blob2.hash())),
         vec![*SPARSE_MERKLE_PLACEHOLDER_HASH, leaf1_hash, leaf3_hash],
@@ -447,7 +433,7 @@ fn test_verify_account_state_and_event() {
     )
     .is_err());
 
-    let transaction_info_to_event_proof = AccumulatorProof::new(vec![event1_hash]);
+    let transaction_info_to_event_proof = EventAccumulatorProof::new(vec![event1_hash]);
     let event_proof = EventProof::new(
         ledger_info_to_transaction_info_proof.clone(),
         txn_info2.clone(),
@@ -574,11 +560,11 @@ proptest! {
                    last_index /= 2;
                }
                let first_proof =
-                   Some(AccumulatorProof::new(first_siblings.into_iter().rev().collect::<Vec<_>>()));
+                   Some(TransactionAccumulatorProof::new(first_siblings.into_iter().rev().collect::<Vec<_>>()));
                let last_proof = if first_version == last_version {
                    None
                } else {
-                   Some(AccumulatorProof::new(last_siblings.into_iter().rev().collect::<Vec<_>>()))
+                   Some(TransactionAccumulatorProof::new(last_siblings.into_iter().rev().collect::<Vec<_>>()))
                };
 
                TransactionListWithProof::new(

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -13,7 +13,7 @@ use crate::{
     event::{EventHandle, EventKey},
     get_with_proof::{ResponseItem, UpdateToLatestLedgerResponse},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    proof::{AccumulatorConsistencyProof, AccumulatorProof},
+    proof::{AccumulatorConsistencyProof, TransactionAccumulatorProof},
     transaction::{
         Module, Program, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction,
         TransactionArgument, TransactionInfo, TransactionListWithProof, TransactionPayload,
@@ -831,8 +831,8 @@ fn arb_transaction_list_with_proof() -> impl Strategy<Value = TransactionListWit
             Just(transaction_and_infos),
             option::of(Just(events)),
             any::<Version>(),
-            any::<AccumulatorProof>(),
-            any::<AccumulatorProof>(),
+            any::<TransactionAccumulatorProof>(),
+            any::<TransactionAccumulatorProof>(),
         )
     })
     .prop_map(

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -9,7 +9,7 @@ use crate::{
     ledger_info::LedgerInfo,
     proof::{
         get_accumulator_root_hash, verify_signed_transaction, verify_transaction_list,
-        AccumulatorProof, SignedTransactionProof,
+        SignedTransactionProof, TransactionAccumulatorProof,
     },
     vm_error::{StatusCode, StatusType, VMStatus},
     write_set::WriteSet,
@@ -1012,8 +1012,8 @@ pub struct TransactionListWithProof {
     pub transaction_and_infos: Vec<(SignedTransaction, TransactionInfo)>,
     pub events: Option<Vec<Vec<ContractEvent>>>,
     pub first_transaction_version: Option<Version>,
-    pub proof_of_first_transaction: Option<AccumulatorProof>,
-    pub proof_of_last_transaction: Option<AccumulatorProof>,
+    pub proof_of_first_transaction: Option<TransactionAccumulatorProof>,
+    pub proof_of_last_transaction: Option<TransactionAccumulatorProof>,
 }
 
 impl TransactionListWithProof {
@@ -1022,8 +1022,8 @@ impl TransactionListWithProof {
         transaction_and_infos: Vec<(SignedTransaction, TransactionInfo)>,
         events: Option<Vec<Vec<ContractEvent>>>,
         first_transaction_version: Option<Version>,
-        proof_of_first_transaction: Option<AccumulatorProof>,
-        proof_of_last_transaction: Option<AccumulatorProof>,
+        proof_of_first_transaction: Option<TransactionAccumulatorProof>,
+        proof_of_last_transaction: Option<TransactionAccumulatorProof>,
     ) -> Self {
         Self {
             transaction_and_infos,
@@ -1144,12 +1144,12 @@ impl TryFrom<crate::proto::types::TransactionListWithProof> for TransactionListW
             proof_of_first_transaction: proto
                 .proof_of_first_transaction
                 .take()
-                .map(AccumulatorProof::try_from)
+                .map(TransactionAccumulatorProof::try_from)
                 .transpose()?,
             proof_of_last_transaction: proto
                 .proof_of_last_transaction
                 .take()
-                .map(AccumulatorProof::try_from)
+                .map(TransactionAccumulatorProof::try_from)
                 .transpose()?,
             first_transaction_version: proto.first_transaction_version,
         })


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Right now there are too many `verify_xxx` functions in `proof/mod.rs`. I think making a `verify` method would be nicer. Some existing structs like `EventWithProof` already has it.

Note that we are making the hasher as a generic parameter of the proof, instead of having a generic parameter on the function.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.
