### PR TITLE
[executor] use `enum Transaction` instead of `SignedTransaction`

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -592,6 +592,7 @@ impl NodeConfig {
         });
         let mut buffer = vec![];
         file.read_to_end(&mut buffer)?;
+        // TODO: update to use `Transaction::WriteSet` variant when ready.
         Ok(Transaction::UserTransaction(SignedTransaction::try_from(
             libra_types::proto::types::SignedTransaction::decode(&buffer)?,
         )?))

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -14,7 +14,7 @@ use crate::{
 use crypto::ValidKey;
 use failure::prelude::*;
 use libra_types::{
-    transaction::{SignedTransaction, SCRIPT_HASH_LENGTH},
+    transaction::{SignedTransaction, Transaction, SCRIPT_HASH_LENGTH},
     PeerId,
 };
 use parity_multiaddr::Multiaddr;
@@ -581,7 +581,7 @@ impl NodeConfig {
         }
     }
 
-    pub fn get_genesis_transaction(&self) -> Result<SignedTransaction> {
+    pub fn get_genesis_transaction(&self) -> Result<Transaction> {
         let file_path = self.get_genesis_transaction_file();
         let mut file: File = File::open(&file_path).unwrap_or_else(|err| {
             panic!(
@@ -592,9 +592,9 @@ impl NodeConfig {
         });
         let mut buffer = vec![];
         file.read_to_end(&mut buffer)?;
-        SignedTransaction::try_from(libra_types::proto::types::SignedTransaction::decode(
-            &buffer,
-        )?)
+        Ok(Transaction::UserTransaction(SignedTransaction::try_from(
+            libra_types::proto::types::SignedTransaction::decode(&buffer)?,
+        )?))
     }
 
     pub fn get_storage_dir(&self) -> PathBuf {

--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -20,8 +20,8 @@ use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
     proof::{accumulator::Accumulator, definition::LeafCount, SparseMerkleProof},
     transaction::{
-        SignedTransaction, Transaction, TransactionInfo, TransactionListWithProof,
-        TransactionOutput, TransactionPayload, TransactionStatus, TransactionToCommit, Version,
+        Transaction, TransactionInfo, TransactionListWithProof, TransactionOutput,
+        TransactionPayload, TransactionStatus, TransactionToCommit, Version,
     },
     write_set::{WriteOp, WriteSet},
 };
@@ -331,6 +331,11 @@ where
         }
 
         let (account_to_btree, account_to_proof) = state_view.into();
+        // TODO: Remove once `TransactionListWithProof` carries `enum Transaction`
+        let transactions = transactions
+            .into_iter()
+            .map(Transaction::UserTransaction)
+            .collect::<Vec<_>>();
         let output = Self::process_vm_outputs(
             account_to_btree,
             account_to_proof,
@@ -362,7 +367,7 @@ where
                 i,
             );
             txns_to_commit.push(TransactionToCommit::new(
-                Transaction::UserTransaction(txn),
+                txn,
                 txn_data.account_blobs().clone(),
                 txn_data.events().to_vec(),
                 txn_data.gas_used(),
@@ -499,7 +504,7 @@ where
             ) {
                 if let TransactionStatus::Keep(_) = txn_data.status() {
                     txns_to_commit.push(TransactionToCommit::new(
-                        Transaction::UserTransaction(txn.clone()),
+                        txn.clone(),
                         txn_data.account_blobs().clone(),
                         txn_data.events().to_vec(),
                         txn_data.gas_used(),
@@ -606,7 +611,15 @@ where
         let vm_outputs = {
             let _timer = OP_COUNTERS.timer("vm_execute_block_time_s");
             V::execute_block(
-                block_to_execute.transactions().to_vec(),
+                block_to_execute
+                    .transactions()
+                    .iter()
+                    .map(|txn| {
+                        txn.as_signed_user_txn()
+                            .expect("All should be user transactions for now.")
+                    })
+                    .cloned()
+                    .collect(),
                 &self.vm_config,
                 &state_view,
             )
@@ -679,7 +692,7 @@ where
     fn process_vm_outputs(
         mut account_to_btree: HashMap<AccountAddress, BTreeMap<Vec<u8>, Vec<u8>>>,
         account_to_proof: HashMap<HashValue, SparseMerkleProof>,
-        transactions: &[SignedTransaction],
+        transactions: &[Transaction],
         vm_outputs: Vec<TransactionOutput>,
         parent_trees: &ExecutedTrees,
     ) -> Result<ProcessedVMOutput> {
@@ -694,11 +707,9 @@ where
         let mut txn_info_hashes = vec![];
 
         let proof_reader = ProofReader::new(account_to_proof);
-        for (vm_output, signed_txn) in
-            itertools::zip_eq(vm_outputs.into_iter(), transactions.iter())
-        {
+        for (vm_output, txn) in itertools::zip_eq(vm_outputs.into_iter(), transactions.iter()) {
             let (blobs, state_tree, num_accounts_created) = Self::process_write_set(
-                signed_txn,
+                txn,
                 &mut account_to_btree,
                 &proof_reader,
                 vm_output.write_set().clone(),
@@ -717,7 +728,7 @@ where
                     // Compute hash for the TransactionInfo object. We need the hash of the
                     // transaction itself, the state root hash as well as the event root hash.
                     let txn_info = TransactionInfo::new(
-                        signed_txn.hash(),
+                        txn.as_signed_user_txn()?.hash(),
                         state_tree.root_hash(),
                         event_tree.root_hash(),
                         vm_output.gas_used(),
@@ -764,7 +775,7 @@ where
     /// on the write set. Returns the blob value of all these accounts as well as the newly
     /// constructed state tree.
     fn process_write_set(
-        transaction: &SignedTransaction,
+        transaction: &Transaction,
         account_to_btree: &mut HashMap<AccountAddress, BTreeMap<Vec<u8>, Vec<u8>>>,
         proof_reader: &ProofReader,
         write_set: WriteSet,
@@ -796,7 +807,7 @@ where
                     // Before writing to an account, VM should always read that account. So we
                     // should not reach this code path. The exception is genesis transaction (and
                     // maybe other FTVM transactions).
-                    match transaction.payload() {
+                    match transaction.as_signed_user_txn()?.payload() {
                         TransactionPayload::Program(_)
                         | TransactionPayload::Module(_)
                         | TransactionPayload::Script(_) => {

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -27,7 +27,7 @@ use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
     ledger_info::LedgerInfo,
     proof::accumulator::Accumulator,
-    transaction::{SignedTransaction, TransactionListWithProof, TransactionStatus, Version},
+    transaction::{Transaction, TransactionListWithProof, TransactionStatus, Version},
     validator_set::ValidatorSet,
 };
 use logger::prelude::*;
@@ -207,7 +207,7 @@ where
 
     /// This is used when we start for the first time and the DB is completely empty. It will write
     /// necessary information to DB by committing the genesis transaction.
-    fn init_genesis(&self, genesis_txn: SignedTransaction) {
+    fn init_genesis(&self, genesis_txn: Transaction) {
         // Create a block with genesis_txn being the only transaction. Execute it then commit it
         // immediately.
         // We create `PRE_GENESIS_BLOCK_ID` as the parent of the genesis block.
@@ -239,7 +239,7 @@ where
     /// Executes a block.
     pub fn execute_block(
         &self,
-        transactions: Vec<SignedTransaction>,
+        transactions: Vec<Transaction>,
         parent_id: HashValue,
         id: HashValue,
     ) -> oneshot::Receiver<Result<StateComputeResult>> {
@@ -355,7 +355,7 @@ impl<V> Drop for Executor<V> {
 #[derive(Debug)]
 enum Command {
     ExecuteBlock {
-        transactions: Vec<SignedTransaction>,
+        transactions: Vec<Transaction>,
         parent_id: HashValue,
         id: HashValue,
         resp_sender: oneshot::Sender<Result<StateComputeResult>>,

--- a/execution/executor/src/transaction_block.rs
+++ b/execution/executor/src/transaction_block.rs
@@ -11,7 +11,7 @@ use libra_types::{
     contract_event::ContractEvent,
     crypto_proxies::LedgerInfoWithSignatures,
     proof::accumulator::Accumulator,
-    transaction::{SignedTransaction, TransactionStatus},
+    transaction::{Transaction, TransactionStatus},
 };
 use logger::prelude::*;
 use scratchpad::SparseMerkleTree;
@@ -36,7 +36,7 @@ pub struct TransactionBlock {
     children: HashSet<HashValue>,
 
     /// The transactions themselves.
-    transactions: Vec<SignedTransaction>,
+    transactions: Vec<Transaction>,
 
     /// The result of processing VM's output.
     output: Option<ProcessedVMOutput>,
@@ -59,7 +59,7 @@ impl TransactionBlock {
     /// Constructs a new block. A `TransactionBlock` is constructed as soon as consensus gives us a
     /// new block. It has not been executed yet so output is `None`.
     pub fn new(
-        transactions: Vec<SignedTransaction>,
+        transactions: Vec<Transaction>,
         parent_id: HashValue,
         id: HashValue,
         execute_response_sender: oneshot::Sender<Result<StateComputeResult>>,
@@ -79,7 +79,7 @@ impl TransactionBlock {
     }
 
     /// Returns the list of transactions.
-    pub fn transactions(&self) -> &[SignedTransaction] {
+    pub fn transactions(&self) -> &[Transaction] {
         &self.transactions
     }
 

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -269,9 +269,8 @@ fn get_mock_txn_data(
     let mut txns = vec![];
     let mut infos = vec![];
     for i in start_seq..=end_seq {
-        let signed_txn =
-            get_test_signed_txn(address, i, priv_key.clone(), pub_key.clone(), None).into();
-        txns.push(signed_txn);
+        let txn = get_test_signed_txn(address, i, priv_key.clone(), pub_key.clone(), None);
+        txns.push(txn.into());
 
         let info = get_transaction_info().into();
         infos.push(info);

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -918,10 +918,7 @@ impl TransactionToCommit {
     }
 
     pub fn as_signed_user_txn(&self) -> Result<&SignedTransaction> {
-        match &self.transaction {
-            Transaction::UserTransaction(txn) => Ok(txn),
-            _ => Err(format_err!("Not a user transaction.")),
-        }
+        self.transaction.as_signed_user_txn()
     }
 
     pub fn account_states(&self) -> &HashMap<AccountAddress, AccountStateBlob> {
@@ -1215,6 +1212,15 @@ pub enum Transaction {
 
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),
+}
+
+impl Transaction {
+    pub fn as_signed_user_txn(&self) -> Result<&SignedTransaction> {
+        match self {
+            Transaction::UserTransaction(txn) => Ok(txn),
+            _ => Err(format_err!("Not a user transaction.")),
+        }
+    }
 }
 
 #[derive(IntoPrimitive, TryFromPrimitive)]


### PR DESCRIPTION
## Motivation
Another step towards using `enum Transaction` everywhere instead of `SignedTransaction`. 

part of the effort around #1173

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing coverage.
## Related PRs
based on #1271
