### PR TITLE
[consensus] better prepare chained bft smr for per-epoch structure

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -293,7 +293,7 @@ impl<T: Payload> BlockStore<T> {
     pub fn insert_vote(
         &self,
         vote_msg: VoteMsg,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         self.inner
             .write()
@@ -492,7 +492,7 @@ impl<T: Payload> BlockStore<T> {
     pub fn insert_vote_and_qc(
         &self,
         vote_msg: VoteMsg,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         let r = self.insert_vote(vote_msg, validator_verifier);
         if let VoteReceptionResult::NewQuorumCertificate(ref qc) = r {

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -84,11 +84,11 @@ fn test_block_store_create_block() {
         block_store.signer(),
         test_utils::placeholder_sync_info(),
     );
-    let validator_verifier = Arc::new(ValidatorVerifier::new_single(
+    let validator_verifier = ValidatorVerifier::new_single(
         block_store.signer().author(),
         block_store.signer().public_key(),
-    ));
-    block_store.insert_vote_and_qc(vote_msg, validator_verifier);
+    );
+    block_store.insert_vote_and_qc(vote_msg, &validator_verifier);
 
     let b1 = block_store.create_block(a1_ref.block(), vec![2], 2, 2);
     assert_eq!(b1.parent_id(), a1_ref.id());
@@ -330,7 +330,6 @@ fn test_insert_vote() {
     ::logger::try_init_for_testing();
     // Set up enough different authors to support different votes for the same block.
     let (signers, validator_verifier) = random_validator_verifier(11, Some(10), false);
-    let validator_verifier = Arc::new(validator_verifier);
     let my_signer = signers[10].clone();
     let block_store = build_empty_tree_with_custom_signing(my_signer);
     let genesis = block_store.root();
@@ -356,14 +355,13 @@ fn test_insert_vote() {
             voter,
             test_utils::placeholder_sync_info(),
         );
-        let vote_res =
-            block_store.insert_vote_and_qc(vote_msg.clone(), Arc::clone(&validator_verifier));
+        let vote_res = block_store.insert_vote_and_qc(vote_msg.clone(), &validator_verifier);
 
         // first vote of an author is accepted
         assert_eq!(vote_res, VoteReceptionResult::VoteAdded(i as u64));
         // filter out duplicates
         assert_eq!(
-            block_store.insert_vote_and_qc(vote_msg, Arc::clone(&validator_verifier)),
+            block_store.insert_vote_and_qc(vote_msg, &validator_verifier),
             VoteReceptionResult::DuplicateVote,
         );
         // qc is still not there
@@ -389,7 +387,7 @@ fn test_insert_vote() {
         final_voter,
         test_utils::placeholder_sync_info(),
     );
-    match block_store.insert_vote_and_qc(vote_msg, validator_verifier) {
+    match block_store.insert_vote_and_qc(vote_msg, &validator_verifier) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
             assert_eq!(qc.certified_block_id(), block.id());
         }

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -281,7 +281,7 @@ where
     pub(super) fn insert_vote(
         &mut self,
         vote_msg: &VoteMsg,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         let block_id = vote_msg.vote_data().block_id();
         if let Some(old_qc) = self.id_to_quorum_cert.get(&block_id) {

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -62,12 +62,12 @@ impl PendingVotes {
     pub fn insert_vote(
         &mut self,
         vote_msg: &VoteMsg,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         if let Err(e) = self.replace_prev_vote(vote_msg) {
             return e;
         }
-        let vote_aggr_res = self.aggregate_qc(vote_msg, &validator_verifier);
+        let vote_aggr_res = self.aggregate_qc(vote_msg, validator_verifier);
         if let VoteReceptionResult::NewQuorumCertificate(_) = vote_aggr_res {
             return vote_aggr_res;
         }
@@ -83,7 +83,7 @@ impl PendingVotes {
     fn aggregate_qc(
         &mut self,
         vote_msg: &VoteMsg,
-        validator_verifier: &Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         // Note that the digest covers the ledger info information, which is also indirectly
         // covering vote data hash (in its `consensus_data_hash` field).
@@ -115,7 +115,7 @@ impl PendingVotes {
     fn aggregate_tc(
         &mut self,
         vote_msg: &VoteMsg,
-        validator_verifier: &Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> Option<VoteReceptionResult> {
         let round_signature = vote_msg.round_signature().cloned()?;
         let round = vote_msg.vote_data().block_round();

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -8,12 +8,12 @@ use std::sync::{Arc, RwLock};
 /// verification.
 pub struct EpochManager {
     #[allow(dead_code)]
-    epoch: usize,
+    epoch: u64,
     validators: RwLock<Arc<ValidatorVerifier>>,
 }
 
 impl EpochManager {
-    pub fn new(epoch: usize, validators: ValidatorVerifier) -> Self {
+    pub fn new(epoch: u64, validators: ValidatorVerifier) -> Self {
         Self {
             epoch,
             validators: RwLock::new(Arc::new(validators)),

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -159,7 +159,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         storage.clone(),
         time_service,
         enforce_increasing_timestamps,
-        Arc::clone(&epoch_mgr),
+        epoch_mgr.validators(),
     )
 }
 

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -188,7 +188,7 @@ impl NodeSetup {
             storage.clone(),
             time_service,
             true,
-            Arc::clone(&epoch_mgr),
+            epoch_mgr.validators(),
         );
         block_on(event_processor.start());
         Self {
@@ -286,7 +286,7 @@ fn basic_new_rank_event_test() {
             node.block_store.signer().public_key(),
         ));
         node.block_store
-            .insert_vote_and_qc(vote_msg, validator_verifier);
+            .insert_vote_and_qc(vote_msg, validator_verifier.as_ref());
         node.event_processor
             .process_new_round_event(NewRoundEvent {
                 round: 2,

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -338,7 +338,7 @@ impl Pacemaker {
     pub fn process_remote_timeout(
         &mut self,
         pacemaker_timeout: PacemakerTimeout,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> Option<NewRoundEvent> {
         if self
             .pacemaker_timeout_manager

--- a/consensus/src/chained_bft/liveness/pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_test.rs
@@ -56,7 +56,6 @@ fn test_timeout_certificate() {
     let rounds: Round = 5;
     let (signers, validator_verifier) =
         random_validator_verifier((rounds - 1) as usize, None, false);
-    let validator_verifier = Arc::new(validator_verifier);
     let (mut pm, _) = make_pacemaker();
 
     // Send timeout for rounds 1..5, each from a different author, so that they can be
@@ -64,7 +63,7 @@ fn test_timeout_certificate() {
     for round in 1..rounds {
         let signer = &signers[(round - 1) as usize];
         let pacemaker_timeout = PacemakerTimeout::new(round, signer, None);
-        let result = pm.process_remote_timeout(pacemaker_timeout, Arc::clone(&validator_verifier));
+        let result = pm.process_remote_timeout(pacemaker_timeout, &validator_verifier);
         // quorum size is 3 in make_pacemaker
         if round >= 3 {
             // Then timeout quorum for previous round (1,2,3) generates new round event for

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager.rs
@@ -9,7 +9,7 @@ use consensus_types::{
 use libra_types::crypto_proxies::ValidatorVerifier;
 use logger::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, fmt};
 
 #[cfg(test)]
 #[path = "pacemaker_timeout_manager_test.rs"]
@@ -118,7 +118,7 @@ impl PacemakerTimeoutManager {
     /// PacemakerTimeoutCertificate with round=2.
     fn generate_timeout_certificate(
         author_to_received_timeouts: &HashMap<Author, PacemakerTimeout>,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> Option<PacemakerTimeoutCertificate> {
         // Sort the timeouts by round, highest to lowest and then, in order, aggregate
         // enough voting power to assemble a PacemakerTimeoutCertificate if possible.
@@ -155,7 +155,7 @@ impl PacemakerTimeoutManager {
     pub fn update_received_timeout(
         &mut self,
         pacemaker_timeout: PacemakerTimeout,
-        validator_verifier: Arc<ValidatorVerifier>,
+        validator_verifier: &ValidatorVerifier,
     ) -> bool {
         let author = pacemaker_timeout.author();
         let prev_timeout = self.author_to_received_timeouts.get(&author).cloned();

--- a/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_timeout_manager_test.rs
@@ -8,7 +8,6 @@ use crate::chained_bft::{
 };
 use consensus_types::timeout_msg::{PacemakerTimeout, PacemakerTimeoutCertificate};
 use libra_types::{crypto_proxies::random_validator_verifier, validator_signer::ValidatorSigner};
-use std::sync::Arc;
 
 #[test]
 fn test_basic() {
@@ -20,19 +19,16 @@ fn test_basic() {
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
     let (validator_signers, validator_verifier) = random_validator_verifier(2, None, false);
-    let validator_verifier = Arc::new(validator_verifier);
     // No timeout certificate generated on adding 2 timeouts from the same author
     let timeout_signer1_round1 = PacemakerTimeout::new(1, &validator_signers[0], None);
     assert_eq!(
-        timeout_manager
-            .update_received_timeout(timeout_signer1_round1, Arc::clone(&validator_verifier)),
+        timeout_manager.update_received_timeout(timeout_signer1_round1, &validator_verifier),
         false
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
     let timeout_signer1_round2 = PacemakerTimeout::new(2, &validator_signers[0], None);
     assert_eq!(
-        timeout_manager
-            .update_received_timeout(timeout_signer1_round2, Arc::clone(&validator_verifier)),
+        timeout_manager.update_received_timeout(timeout_signer1_round2, &validator_verifier),
         false
     );
     assert_eq!(timeout_manager.highest_timeout_certificate(), None);
@@ -40,8 +36,7 @@ fn test_basic() {
     // Timeout certificate generated on adding a timeout from signer2
     let timeout_signer2_round1 = PacemakerTimeout::new(1, &validator_signers[1], None);
     assert_eq!(
-        timeout_manager
-            .update_received_timeout(timeout_signer2_round1, Arc::clone(&validator_verifier)),
+        timeout_manager.update_received_timeout(timeout_signer2_round1, &validator_verifier),
         true
     );
     assert_eq!(
@@ -55,8 +50,7 @@ fn test_basic() {
     // Timeout certificate increased when incrementing the round from signer 2
     let timeout_signer2_round2 = PacemakerTimeout::new(2, &validator_signers[1], None);
     assert_eq!(
-        timeout_manager
-            .update_received_timeout(timeout_signer2_round2, Arc::clone(&validator_verifier)),
+        timeout_manager.update_received_timeout(timeout_signer2_round2, &validator_verifier),
         true
     );
     assert_eq!(
@@ -70,8 +64,7 @@ fn test_basic() {
     // No timeout certificate generated since signer 1 is still on round 2
     let timeout_signer2_round3 = PacemakerTimeout::new(3, &validator_signers[1], None);
     assert_eq!(
-        timeout_manager
-            .update_received_timeout(timeout_signer2_round3, Arc::clone(&validator_verifier)),
+        timeout_manager.update_received_timeout(timeout_signer2_round3, &validator_verifier),
         false
     );
     assert_eq!(

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -88,11 +88,11 @@ fn test_proposal_generation_parent() {
         block_store.signer(),
         test_utils::placeholder_sync_info(),
     );
-    let validator_verifier = Arc::new(ValidatorVerifier::new_single(
+    let validator_verifier = ValidatorVerifier::new_single(
         block_store.signer().author(),
         block_store.signer().public_key(),
-    ));
-    block_store.insert_vote_and_qc(vote_msg_a1, validator_verifier);
+    );
+    block_store.insert_vote_and_qc(vote_msg_a1, &validator_verifier);
     let a1_child_res =
         block_on(proposal_generator.generate_proposal(11, minute_from_now())).unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
@@ -121,7 +121,7 @@ fn test_proposal_generation_parent() {
         block_store.signer().author(),
         block_store.signer().public_key(),
     ));
-    block_store.insert_vote_and_qc(vote_msg_b1, validator_verifier);
+    block_store.insert_vote_and_qc(vote_msg_b1, &validator_verifier);
     let b1_child_res =
         block_on(proposal_generator.generate_proposal(12, minute_from_now())).unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
@@ -159,11 +159,11 @@ fn test_old_proposal_generation() {
         block_store.signer(),
         test_utils::placeholder_sync_info(),
     );
-    let validator_verifier = Arc::new(ValidatorVerifier::new_single(
+    let validator_verifier = ValidatorVerifier::new_single(
         block_store.signer().author(),
         block_store.signer().public_key(),
-    ));
-    block_store.insert_vote_and_qc(vote_msg_a1, validator_verifier);
+    );
+    block_store.insert_vote_and_qc(vote_msg_a1, &validator_verifier);
 
     let proposal_err = block_on(proposal_generator.generate_proposal(1, minute_from_now())).err();
     assert!(proposal_err.is_some());

--- a/consensus/src/chained_bft/liveness/rotating_proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/rotating_proposer_election.rs
@@ -18,6 +18,14 @@ pub struct RotatingProposer {
     contiguous_rounds: u32,
 }
 
+/// Choose a proposer that is going to be the single leader (relevant for a mock fixed proposer
+/// election only).
+pub fn choose_leader(peers: Vec<Author>) -> Author {
+    // As it is just a tmp hack function, pick the min PeerId to be a proposer.
+    // TODO: VRF will be integrated later.
+    peers.into_iter().min().expect("No trusted peers found!")
+}
+
 impl RotatingProposer {
     /// With only one proposer in the vector, it behaves the same as a fixed proposer strategy.
     pub fn new(proposers: Vec<Author>, contiguous_rounds: u32) -> Self {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I wrote down how the start up should work friendly with reconfiguration in the comment of `start` function.

We can potentially move Step 1 & 2 one layer higher to `chained_bft_consensus_provider` if we want.

- Reorganize how we start following the steps.
- Change some function to take &ValidatorVerifier instead of Arc.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
