### PR TITLE
[bug] Add missing ByteArrayPool entry in IndexKind::variants()

### DIFF
--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -59,6 +59,7 @@ impl IndexKind {
 
         // XXX ensure this list stays up to date!
         &[
+            ByteArrayPool,
             ModuleHandle,
             StructHandle,
             FunctionHandle,


### PR DESCRIPTION
Fixes #785 
