### PR TITLE
[language][functional tests] allow overiding sequence number per transaction & migrate some epilogue tests

### DIFF
--- a/language/functional_tests/_old_move_ir_tests/src/tests/epilogue.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/epilogue.rs
@@ -136,55 +136,6 @@ fn charge_more_gas_on_tx_script_failure2() {
     );
 }
 
-#[test]
-fn dont_increment_sequence_number_on_sequence_number_too_new() {
-    let mut test_env = TestEnvironment::default();
-
-    let sequence_number = 7;
-    assert_error_type!(
-        test_env.run_with_sequence_number(
-            sequence_number,
-            to_script(
-                b"
-main() {
-  assert(false, 77);
-  return;
-}
-",
-                vec![]
-            )
-        ),
-        ErrorKind::AssertError(ESEQUENCE_NUMBER_TOO_NEW, _)
-    );
-
-    // running with 0 should succeed because sequence number wasn't bumped
-    let sequence_number = 0;
-    assert_no_error!(test_env
-        .run_with_sequence_number(sequence_number, to_script(b"main() { return; }", vec![]),))
-}
-
-#[test]
-fn dont_increment_sequence_number_on_sequence_number_too_old() {
-    let mut test_env = TestEnvironment::default();
-
-    let sequence_number = 0;
-    assert_no_error!(test_env
-        .run_with_sequence_number(sequence_number, to_script(b"main() { return; }", vec![]),));
-
-    // running with 0 should fail
-    let sequence_number = 0;
-    assert_error_type!(
-        test_env
-            .run_with_sequence_number(sequence_number, to_script(b"main() { return; }", vec![])),
-        ErrorKind::AssertError(ESEQUENCE_NUMBER_TOO_OLD, _)
-    );
-
-    // but running with 1 should succeed
-    let sequence_number = 1;
-    assert_no_error!(test_env
-        .run_with_sequence_number(sequence_number, to_script(b"main() { return; }", vec![]),))
-}
-
 // You can call your own epilogue if you want to, but your sequence number will only be bumped once
 #[test]
 fn calling_own_epilogue_bumps_sequence_number_once() {

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -198,7 +198,9 @@ fn make_script_transaction(
     let account_resource = exec.read_account_resource(&account).unwrap();
     Ok(RawTransaction::new_script(
         *account.address(),
-        account_resource.sequence_number(),
+        config
+            .sequence_number
+            .unwrap_or_else(|| account_resource.sequence_number()),
         script,
         config.max_gas.unwrap_or_else(|| {
             std::cmp::min(
@@ -227,7 +229,9 @@ fn make_module_transaction(
     let account_resource = exec.read_account_resource(&account).unwrap();
     Ok(RawTransaction::new_module(
         *account.address(),
-        account_resource.sequence_number(),
+        config
+            .sequence_number
+            .unwrap_or_else(|| account_resource.sequence_number()),
         module,
         config.max_gas.unwrap_or_else(|| {
             std::cmp::min(

--- a/language/functional_tests/src/tests/transaction_config_tests.rs
+++ b/language/functional_tests/src/tests/transaction_config_tests.rs
@@ -73,6 +73,29 @@ fn parse_max_gas() {
 }
 
 #[test]
+fn parse_sequence_number() {
+    for s in &[
+        "//! sequence-number:77",
+        "//!sequence-number:0",
+        "//! sequence-number:  123",
+    ] {
+        s.parse::<Entry>().unwrap();
+    }
+
+    for s in &[
+        "//!sequence-number:",
+        "//!sequence-number:abc",
+        "//!sequence-number: 123, 45",
+    ] {
+        s.parse::<Entry>().unwrap_err();
+    }
+
+    // TODO: "//!sequence-number: 123 45" is currently parsed as 12345.
+    // This is because we remove all the spaces before parsing.
+    // Rewrite the parser to handle this case properly.
+}
+
+#[test]
 fn parse_new_transaction() {
     assert!(is_new_transaction("//! new-transaction"));
     assert!(is_new_transaction("//!new-transaction "));

--- a/language/functional_tests/tests/testsuite/epilogue/dont_increment_sequence_number_on_sequence_number_too_new.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/dont_increment_sequence_number_on_sequence_number_too_new.mvir
@@ -1,0 +1,16 @@
+//! account: default, 1000000, 0
+
+//! sequence-number: 5
+main() {
+    return;
+}
+// check: SEQUENCE_NUMBER_TOO_NEW
+
+
+// Running with 0 should succeed because sequence number wasn't bumped.
+//! new-transaction
+//! sequence-number: 0
+main() {
+    return;
+}
+// check: EXECUTED

--- a/language/functional_tests/tests/testsuite/epilogue/dont_increment_sequence_number_on_sequence_number_too_old.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/dont_increment_sequence_number_on_sequence_number_too_old.mvir
@@ -1,0 +1,17 @@
+// Set initial sequence number to 10.
+//! account: default, 1000000, 10
+
+
+//! sequence-number: 9
+main() {
+    return;
+}
+// check: SEQUENCE_NUMBER_TOO_OLD
+
+
+//! new-transaction
+//! sequence-number: 10
+main() {
+    return;
+}
+// check: EXECUTED


### PR DESCRIPTION
## Summary
This adds an option to override the sequence number in tests per transaction. (By default, the current sequence number will be used.) Two old tests that require this feature are also migrated.

## Test Plan
cargo test

## Related Issues
#789