### PR TITLE
[language][functional tests] allow overiding max gas amount per transaction & migrate some epilogue tests

### DIFF
--- a/language/functional_tests/src/tests/transaction_config_tests.rs
+++ b/language/functional_tests/src/tests/transaction_config_tests.rs
@@ -62,6 +62,17 @@ fn parse_args() {
 }
 
 #[test]
+fn parse_max_gas() {
+    for s in &["//! max-gas:77", "//!max-gas:0", "//! max-gas:  123"] {
+        s.parse::<Entry>().unwrap();
+    }
+
+    for s in &["//!max-gas:", "//!max-gas:abc", "//!max-gas: 123, 45"] {
+        s.parse::<Entry>().unwrap_err();
+    }
+}
+
+#[test]
 fn parse_new_transaction() {
     assert!(is_new_transaction("//! new-transaction"));
     assert!(is_new_transaction("//!new-transaction "));

--- a/language/functional_tests/tests/testsuite/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
@@ -1,0 +1,18 @@
+//! account: default, 10000, 0
+
+//! max-gas: 5000
+main() {
+    return;
+}
+
+
+//! new-transaction
+import 0x0.LibraAccount;
+
+main() {
+    // Ensures that the account was deducted for the gas fee.
+    assert(LibraAccount.balance(get_txn_sender()) < 10000, 42);
+    // Ensures that we are not just charging max_gas for the transaction.
+    assert(LibraAccount.balance(get_txn_sender()) >= 5000, 42);
+    return;
+}

--- a/language/functional_tests/tests/testsuite/epilogue/loop_out_of_gas.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/loop_out_of_gas.mvir
@@ -1,0 +1,22 @@
+//! account: default, 100000
+
+//! max-gas: 10000
+main() {
+    loop {}
+    return;
+}
+
+// check: gas_used
+// check: 10000
+// check: OUT_OF_GAS
+
+
+//! new-transaction
+import 0x0.LibraAccount;
+
+main() {
+    assert(LibraAccount.balance(get_txn_sender()) == 90000, 42);
+    return;
+}
+
+// check: EXECUTED

--- a/language/functional_tests/tests/testsuite/epilogue/recursion_out_of_gas.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/recursion_out_of_gas.mvir
@@ -1,0 +1,33 @@
+//! account: default, 50000
+
+module M {
+    public rec(x: u64) {
+        Self.rec(move(x));
+        return;
+    }
+}
+
+
+//! new-transaction
+//! max-gas: 5000
+import {{default}}.M;
+
+main() {
+    M.rec(3);
+    return;
+}
+
+// check: gas_used
+// check: 5000
+// check: OUT_OF_GAS
+
+
+//! new-transaction
+import 0x0.LibraAccount;
+
+main() {
+    assert(LibraAccount.balance(get_txn_sender()) == 45000, 42);
+    return;
+}
+
+// check: EXECUTED

--- a/language/functional_tests/tests/testsuite/epilogue/while_out_of_gas.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/while_out_of_gas.mvir
@@ -1,0 +1,22 @@
+//! account: default, 100000
+
+//! max-gas: 10000
+main() {
+    while(true) {}
+    return;
+}
+
+// check: gas_used
+// check: 10000
+// check: OUT_OF_GAS
+
+
+//! new-transaction
+import 0x0.LibraAccount;
+
+main() {
+    assert(LibraAccount.balance(get_txn_sender()) == 90000, 42);
+    return;
+}
+
+// check: EXECUTED


### PR DESCRIPTION
## Summary
This adds an option to override the max gas amount in tests per transaction. (By default it's the minimum of the current account balance and the maximum allowed amount.) Some related old tests were migrated/rewritten.

## Test Plan
cargo test

## Related Issues
#789