### PR TITLE
[language] Ensure that AbstractMemorySize is always non-zero

### DIFF
--- a/language/functional_tests/tests/testsuite/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
@@ -1,6 +1,6 @@
-//! account: default, 10000, 0
+//! account: default, 100000, 0
 
-//! max-gas: 5000
+//! max-gas: 50000
 main() {
     return;
 }
@@ -11,8 +11,8 @@ import 0x0.LibraAccount;
 
 main() {
     // Ensures that the account was deducted for the gas fee.
-    assert(LibraAccount.balance(get_txn_sender()) < 10000, 42);
+    assert(LibraAccount.balance(get_txn_sender()) < 100000, 42);
     // Ensures that we are not just charging max_gas for the transaction.
-    assert(LibraAccount.balance(get_txn_sender()) >= 5000, 42);
+    assert(LibraAccount.balance(get_txn_sender()) >= 50000, 43);
     return;
 }

--- a/language/functional_tests/tests/testsuite/epilogue/recursion_out_of_gas_no_args.mvir
+++ b/language/functional_tests/tests/testsuite/epilogue/recursion_out_of_gas_no_args.mvir
@@ -1,0 +1,32 @@
+//! account: default, 50000
+
+module M {
+    public rec() {
+        Self.rec();
+        return;
+    }
+}
+
+//! new-transaction
+//! max-gas: 5000
+import {{default}}.M;
+
+main() {
+    M.rec();
+    return;
+}
+
+// check: gas_used
+// check: 5000
+// check: OUT_OF_GAS
+
+
+//! new-transaction
+import 0x0.LibraAccount;
+
+main() {
+    assert(LibraAccount.balance(get_txn_sender()) == 45000, 42);
+    return;
+}
+
+// check: EXECUTED

--- a/language/vm/vm_runtime/src/gas_meter.rs
+++ b/language/vm/vm_runtime/src/gas_meter.rs
@@ -248,8 +248,8 @@ impl GasMeter {
                     let size_difference = if new_val_size.app(&size, |new_vl_size, size| new_vl_size > size) {
                         new_val_size.sub(size)
                     } else {
-                        // The difference is always >= 0
-                        AbstractMemorySize::new(0)
+                        // The difference is always >= 1
+                        AbstractMemorySize::new(1)
                     };
                     default_gas.memory_gas = default_gas.memory_gas
                         // Charge for the iops on global memory
@@ -292,7 +292,9 @@ impl GasMeter {
                 let mem_size = if memory_size.get() > 1 {
                     memory_size.sub(AbstractMemorySize::new(1))
                 } else {
-                    AbstractMemorySize::new(0) // We already charged for size 1
+                    // We already charged, but we are restricted that we cannot have a memory size
+                    // of zero. So charge the minimal amount.
+                    AbstractMemorySize::new(1)
                 };
                 Self::gas_of(static_cost_instr(instr, mem_size))
             }


### PR DESCRIPTION
We add an invariant field to `define_gas_unit` to make sure that `AbstractMemorySizes` are always non-zero.

We will eventually also do this for the definition of `GasPrice`, but that is currently not the case since we allow zero gas prices in testnet.

GasUnits are allowed to be zero, since we count down the amount of gas used (as opposed to up).

Adds a test that would have failed previously. 
