### PR TITLE
[config] Do not print public keys on startup

### DIFF
--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -19,6 +19,7 @@ use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializ
 use std::{
     collections::{BTreeMap, HashMap},
     convert::TryFrom,
+    fmt,
     hash::BuildHasher,
     str::FromStr,
 };
@@ -44,11 +45,17 @@ pub struct NetworkPrivateKeys {
     pub network_identity_private_key: X25519StaticPrivateKey,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct NetworkPeersConfig {
     #[serde(flatten)]
     #[serde(serialize_with = "serialize_ordered_map")]
     pub peers: HashMap<String, NetworkPeerInfo>,
+}
+
+impl fmt::Debug for NetworkPeersConfig {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "<{} keys>", self.peers.len())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
When node in 100-node cluster starts it spits out large amount of unreadable mess, that makes it hard to see actual problem if node spins in crash loop.

```
X: FieldElement51([1210454533490542, 1526802931897751, 1603226314870015, 899155920206535, 48869592638111]),
Y: FieldElement51([2100187077138447, 1319111961239893, 1362277274387823, 722046902069563, 1583204453722319]),
Z: FieldElement51([1, 0, 0, 0, 0]),
T: FieldElement51([1252372312680701, 1573889424469068, 1387183404206070, 1427688854983464, 832020595177248])
(...goes on forever...)
```

This diff removes this information from debug output as useless.
