### PR TITLE
[Client] Update option name and comment of 'faucet_account_file'

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -22,11 +22,8 @@ struct Args {
     #[structopt(short = "a", long)]
     pub host: String,
     /// Path to the generated keypair for the faucet account. The faucet account can be used to
-    /// mint coins. If not passed, a new keypair will be generated for
-    /// you and placed in a temporary directory.
-    /// To manually generate a keypair, use generate-keypair:
-    /// `cargo run -p generate-keypair -- -o <output_file_path>`
-    #[structopt(short = "m", long = "faucet-key-file-path")]
+    /// mint coins. If not passed, faucet_server will be used.
+    #[structopt(short = "m", long)]
     pub faucet_account_file: Option<String>,
     /// Host that operates a faucet service
     /// If not passed, will be derived from host parameter


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The comment of  'faucet_account_file' is outdated. if not passed, NO new keypair will be generated for you. The old name "faucet-key-file-path" is inconsistent with 'faucet_account_file', while other option names are consistent.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
