### PR TITLE
[full-node] Fix flaky smoke test test_full_node_basic_flow

### DIFF
--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -565,7 +565,10 @@ fn test_full_node_basic_flow() {
         validator_ac_client.faucet_account.clone().unwrap().address
     );
     // mint from full node and check both validator and full node have correct balance
-    validator_ac_client.create_next_account(false).unwrap();
+    let account3 = validator_ac_client
+        .create_next_account(false)
+        .unwrap()
+        .address;
     full_node_client.create_next_account(false).unwrap();
     full_node_client_2.create_next_account(false).unwrap();
 
@@ -631,6 +634,11 @@ fn test_full_node_basic_flow() {
         Decimal::from_f64(30.0),
         Decimal::from_str(&validator_ac_client.get_balance(&["b", "4"]).unwrap()).ok()
     );
+
+    let sequence = validator_ac_client
+        .get_sequence_number(&["sequence", &format!("{}", account3), "true"])
+        .unwrap();
+    full_node_client_2.wait_for_transaction(account3, sequence);
     assert_eq!(
         Decimal::from_f64(0.0),
         Decimal::from_str(&full_node_client_2.get_balance(&["b", "3"]).unwrap()).ok()


### PR DESCRIPTION
## Motivation

Fixing flaky test failure that happened in https://circleci.com/gh/libra/libra/10259#tests/containers/3

Test was failing because the second full node was not synced up with the most recent transaction. Adding an explicit wait until the sequence is synced up will remove this flakiness

## Test Plan

cargo test -- test_full_node_basic_flow