### PR TITLE
[Consensus] Decrease the load of the broadcasting timeout messages

### DIFF
--- a/consensus/consensus-types/src/timeout_msg.rs
+++ b/consensus/consensus-types/src/timeout_msg.rs
@@ -95,6 +95,10 @@ impl PacemakerTimeout {
         self.vote.as_ref()
     }
 
+    fn drop_vote_msg(&mut self) {
+        self.vote.take();
+    }
+
     /// Verifies that this message has valid signature
     pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
         self.signature
@@ -310,7 +314,11 @@ impl fmt::Display for PacemakerTimeoutCertificate {
 
 impl PacemakerTimeoutCertificate {
     /// Creates new PacemakerTimeoutCertificate
-    pub fn new(round: Round, timeouts: Vec<PacemakerTimeout>) -> PacemakerTimeoutCertificate {
+    pub fn new(round: Round, mut timeouts: Vec<PacemakerTimeout>) -> PacemakerTimeoutCertificate {
+        // The timeouts aggregated by the TC don't need to carry the vote messages: they're not used
+        for t in &mut timeouts {
+            t.drop_vote_msg();
+        }
         PacemakerTimeoutCertificate { round, timeouts }
     }
 

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -609,10 +609,16 @@ impl<T: Payload> EventProcessor<T> {
 
     /// Generate sync info that can be attached to an outgoing message
     fn gen_sync_info(&self) -> SyncInfo {
+        let hqc = self.block_store.highest_quorum_cert().as_ref().clone();
+        // No need to include HTC if it's lower than HQC
+        let htc = self
+            .pacemaker
+            .highest_timeout_certificate()
+            .filter(|tc| tc.round() > hqc.certified_block_round());
         SyncInfo::new(
-            self.block_store.highest_quorum_cert().as_ref().clone(),
+            hqc,
             self.block_store.highest_ledger_info().as_ref().clone(),
-            self.pacemaker.highest_timeout_certificate(),
+            htc,
         )
     }
 

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -223,6 +223,7 @@ impl ConsensusNetworkImpl {
     }
 
     async fn broadcast(&mut self, msg: ConsensusMsg) {
+        let msg_raw = msg.to_bytes().unwrap();
         for peer in self.epoch_mgr.validators().get_ordered_account_addresses() {
             if self.author == peer {
                 let self_msg = Event::Message((self.author, msg.clone()));
@@ -231,7 +232,7 @@ impl ConsensusNetworkImpl {
                 }
                 continue;
             }
-            if let Err(err) = self.network_sender.send_to(peer, msg.clone()).await {
+            if let Err(err) = self.network_sender.send_bytes(peer, msg_raw.clone()).await {
                 error!(
                     "Error broadcasting proposal to peer: {:?}, error: {:?}, msg: {:?}",
                     peer, err, msg

--- a/network/src/validator_network/consensus.rs
+++ b/network/src/validator_network/consensus.rs
@@ -15,6 +15,7 @@ use crate::{
     validator_network::Event,
     NetworkPublicKeys, ProtocolId,
 };
+use bytes::Bytes;
 use channel;
 use futures::{
     stream::Map,
@@ -101,12 +102,21 @@ impl ConsensusNetworkSender {
         recipient: PeerId,
         message: ConsensusMsg,
     ) -> Result<(), NetworkError> {
+        self.send_bytes(recipient, message.to_bytes().unwrap())
+            .await
+    }
+
+    pub async fn send_bytes(
+        &mut self,
+        recipient: PeerId,
+        message_bytes: Bytes,
+    ) -> Result<(), NetworkError> {
         self.inner
             .send(NetworkRequest::SendMessage(
                 recipient,
                 Message {
                     protocol: ProtocolId::from_static(CONSENSUS_DIRECT_SEND_PROTOCOL),
-                    mdata: message.to_bytes().unwrap(),
+                    mdata: message_bytes,
                 },
             ))
             .await?;


### PR DESCRIPTION
## Summary:
This change fixes several levels of inefficiency that caused the system to stall when running at 100 validators network.
1. When broadcasting a message the serialization of a message was done for each recipient separately.
2. The SyncInfo attached to the messages includes TimeoutCertificate even if it is not required because it's lower than the highest QC.
3. The TimeoutCertificate includes 2f+1 PacemakerTimeouts: these timeouts don't need to keep the optional VoteMsgs because these vote messages are not needed for TC anyway. Note that with each VoteMsg carrying a SyncInfo (with O(n) signatures) we used to have TimeoutCertificate message carrying O(n^2) signatures.

## Testing:
Running to perf to detect the problem on the serialization happening during the broadcast. Verified that the problem is gone.
