### PR TITLE
[docker] Add --release flag for docker builds in validator

### DIFF
--- a/docker/validator/build.sh
+++ b/docker/validator/build.sh
@@ -21,7 +21,7 @@ else
   docker run --name libra-node-builder-container -d -i -t -v $DIR/../..:/libra libra-node-builder bash
 fi
 
-docker exec -i -t libra-node-builder-container bash -c 'source /root/.cargo/env; cargo build -p libra-node --target-dir /target && /bin/cp /target/debug/libra-node target/libra-node-builder/'
+docker exec -i -t libra-node-builder-container bash -c 'source /root/.cargo/env; cargo build --release -p libra-node --target-dir /target && /bin/cp /target/release/libra-node target/libra-node-builder/'
 
 ln target/libra-node-builder/libra-node libra-node-from-docker
 docker build -f $DIR/validator.Dockerfile $DIR/../.. --tag libra_e2e --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY


### PR DESCRIPTION
## Motivation

After adding the incremental build for the validator docker image #1296, libra-node was missing the --release flag.  Without --release, performance will suffer quite a bit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Noted a large performance regression in test clusters.
