### PR TITLE
Break circular dependency in crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,6 @@ dependencies = [
 name = "crypto_derive"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/crypto_derive/Cargo.toml
+++ b/crypto/crypto_derive/Cargo.toml
@@ -16,5 +16,4 @@ quote = "1.0.0"
 proc-macro2 = "1.0.1"
 
 [dev-dependencies]
-crypto = { path = "../crypto"}
 failure = { path = "../../common/failure_ext", package = "failure_ext"}

--- a/crypto/crypto_derive/src/lib.rs
+++ b/crypto/crypto_derive/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```ignore
 //! # #[macro_use] extern crate crypto_derive;
 //! use crypto::{
 //!     hash::HashValue,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The `crypto` and `crypto_derive` packages have a circular dependency, which makes it impossible to publish either crate. This PR disables a doc-test to remove the circular dependency. The test appears redundant, as it only checks that the procedural macros successfully build, which also occurs in any build of the crypto crate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only change is to ignore a doc test that appears redundant.
