### PR TITLE
add type parameter to stackless bytecode

### DIFF
--- a/language/stackless_bytecode/bytecode-to-boogie/src/translator.rs
+++ b/language/stackless_bytecode/bytecode-to-boogie/src/translator.rs
@@ -281,7 +281,7 @@ impl<'a> ModuleTranslator<'a> {
                 vec![format!("call t{} := WriteRef(t{}, t{});", dest, dest, src)]
             }
             FreezeRef(dest, src) => vec![format!("call t{} := FreezeRef(t{});", dest, src)],
-            Call(dests, callee_index, args) => {
+            Call(dests, callee_index, _, args) => {
                 let callee_name = self.function_name_from_handle_index(*callee_index);
                 let callee_function_handle = self.module.function_handle_at(*callee_index);
                 let callee_function_signature = self
@@ -314,7 +314,7 @@ impl<'a> ModuleTranslator<'a> {
                 res_vec.extend(dest_type_assumptions);
                 res_vec
             }
-            Pack(dest, struct_def_index, fields) => {
+            Pack(dest, struct_def_index, _, fields) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 let mut fields_str = String::new();
                 let mut res_vec = vec![];
@@ -334,7 +334,7 @@ impl<'a> ModuleTranslator<'a> {
                 ));
                 res_vec
             }
-            Unpack(dests, struct_def_index, src) => {
+            Unpack(dests, struct_def_index, _, src) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 let mut dests_str = String::new();
                 let mut dest_type_assumptions = vec![];
@@ -363,14 +363,14 @@ impl<'a> ModuleTranslator<'a> {
                     self.format_type_checking(format!("t{}", dest), &field_sig),
                 ]
             }
-            Exists(dest, addr, struct_def_index) => {
+            Exists(dest, addr, struct_def_index, _) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 vec![format!(
                     "call t{} := Exists(t{}, rs_{});",
                     dest, addr, struct_str
                 )]
             }
-            BorrowGlobal(dest, addr, struct_def_index) => {
+            BorrowGlobal(dest, addr, struct_def_index, _) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 vec![
                     format!(
@@ -381,14 +381,14 @@ impl<'a> ModuleTranslator<'a> {
                     format!("assume is#Map(v#Reference(t{}));", dest),
                 ]
             }
-            MoveToSender(src, struct_def_index) => {
+            MoveToSender(src, struct_def_index, _) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 vec![format!(
                     "call rs_{} := MoveToSender(rs_{}, t{});",
                     struct_str, struct_str, src,
                 )]
             }
-            MoveFrom(dest, src, struct_def_index) => {
+            MoveFrom(dest, src, struct_def_index, _) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 vec![
                     format!(
@@ -646,7 +646,7 @@ impl<'a> ModuleTranslator<'a> {
                 }
                 res.push_str("\n");
             }
-            if let Call(_, _, args) = bytecode {
+            if let Call(_, _, _, args) = bytecode {
                 // update everything that might be related to the updated reference
                 for dest in args {
                     if !self.is_local_mutable_ref(*dest, idx) {

--- a/language/stackless_bytecode/generator/src/stackless_bytecode.rs
+++ b/language/stackless_bytecode/generator/src/stackless_bytecode.rs
@@ -1,6 +1,6 @@
 use vm::file_format::{
     AddressPoolIndex, ByteArrayPoolIndex, CodeOffset, FieldDefinitionIndex, FunctionHandleIndex,
-    LocalIndex, StructDefinitionIndex, UserStringIndex,
+    LocalIndex, LocalsSignatureIndex, StructDefinitionIndex, UserStringIndex,
 };
 
 type TempIndex = usize;
@@ -16,18 +16,48 @@ pub enum StacklessBytecode {
     WriteRef(TempIndex, TempIndex),  // *t1 = t2
     FreezeRef(TempIndex, TempIndex), // t1 = immutable(t2)
 
-    Call(Vec<TempIndex>, FunctionHandleIndex, Vec<TempIndex>), /* t1_vec = call(index) with
-                                                                * t2_vec as parameters */
+    Call(
+        Vec<TempIndex>,
+        FunctionHandleIndex,
+        LocalsSignatureIndex,
+        Vec<TempIndex>,
+    ), /* t1_vec = call(index) with
+        * t2_vec as parameters */
     Ret(Vec<TempIndex>),
 
-    Pack(TempIndex, StructDefinitionIndex, Vec<TempIndex>), /* t1 = struct(index) with t2_vec
-                                                             * as fields */
-    Unpack(Vec<TempIndex>, StructDefinitionIndex, TempIndex), // t1_vec = t2's fields
-    BorrowField(TempIndex, TempIndex, FieldDefinitionIndex),  // t1 = t2.field
-    MoveToSender(TempIndex, StructDefinitionIndex),           // move_to_sender<struct_index>(t)
-    MoveFrom(TempIndex, TempIndex, StructDefinitionIndex),    // t1 = move_from<struct_index>(t2)
-    BorrowGlobal(TempIndex, TempIndex, StructDefinitionIndex), /* t1 = borrow_global<struct_index>(t2) */
-    Exists(TempIndex, TempIndex, StructDefinitionIndex),       // t1 = exists<struct_index>(t2)
+    Pack(
+        TempIndex,
+        StructDefinitionIndex,
+        LocalsSignatureIndex,
+        Vec<TempIndex>,
+    ), /* t1 = struct(index) with t2_vec
+        * as fields */
+    Unpack(
+        Vec<TempIndex>,
+        StructDefinitionIndex,
+        LocalsSignatureIndex,
+        TempIndex,
+    ), // t1_vec = t2's fields
+    BorrowField(TempIndex, TempIndex, FieldDefinitionIndex), // t1 = t2.field
+    MoveToSender(TempIndex, StructDefinitionIndex, LocalsSignatureIndex), /* move_to_sender<struct_index>(t) */
+    MoveFrom(
+        TempIndex,
+        TempIndex,
+        StructDefinitionIndex,
+        LocalsSignatureIndex,
+    ), /* t1 = move_from<struct_index>(t2) */
+    BorrowGlobal(
+        TempIndex,
+        TempIndex,
+        StructDefinitionIndex,
+        LocalsSignatureIndex,
+    ), /* t1 = borrow_global<struct_index>(t2) */
+    Exists(
+        TempIndex,
+        TempIndex,
+        StructDefinitionIndex,
+        LocalsSignatureIndex,
+    ), /* t1 = exists<struct_index>(t2) */
 
     GetGasRemaining(TempIndex),
     GetTxnSequenceNumber(TempIndex),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I modified `stackless_bytecode` generator and `bytecode_to_boogie` translator to support generics.
This includes adding one more parameter of type `LocalsSignatureIndex` to some `stackless_bytecode` instructions, adding lookups for the type parameter in the generator, etc.
I have also added a test case in tests for the generator.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
