### PR TITLE
[vm] New API for VMExecutor

### DIFF
--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -319,7 +319,14 @@ where
         );
         let vm_outputs = {
             let _timer = OP_COUNTERS.timer("vm_execute_chunk_time_s");
-            V::execute_block(transactions.clone(), &self.vm_config, &state_view)
+            V::execute_block(
+                transactions
+                    .iter()
+                    .map(|txn| Transaction::UserTransaction(txn.clone()))
+                    .collect(),
+                &self.vm_config,
+                &state_view,
+            )
         };
 
         // Since other validators have committed these transactions, their status should all be
@@ -615,10 +622,12 @@ where
                     .transactions()
                     .iter()
                     .map(|txn| {
-                        txn.as_signed_user_txn()
-                            .expect("All should be user transactions for now.")
+                        Transaction::UserTransaction(
+                            txn.as_signed_user_txn()
+                                .expect("All should be user transactions for now.")
+                                .clone(),
+                        )
                     })
-                    .cloned()
                     .collect(),
                 &self.vm_config,
                 &state_view,

--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -618,7 +618,7 @@ where
         let vm_outputs = {
             let _timer = OP_COUNTERS.timer("vm_execute_block_time_s");
             V::execute_block(
-                block_to_execute.transactions().iter().cloned().collect(),
+                block_to_execute.transactions().to_vec(),
                 &self.vm_config,
                 &state_view,
             )

--- a/execution/executor/src/block_processor.rs
+++ b/execution/executor/src/block_processor.rs
@@ -618,17 +618,7 @@ where
         let vm_outputs = {
             let _timer = OP_COUNTERS.timer("vm_execute_block_time_s");
             V::execute_block(
-                block_to_execute
-                    .transactions()
-                    .iter()
-                    .map(|txn| {
-                        Transaction::UserTransaction(
-                            txn.as_signed_user_txn()
-                                .expect("All should be user transactions for now.")
-                                .clone(),
-                        )
-                    })
-                    .collect(),
+                block_to_execute.transactions().iter().cloned().collect(),
                 &self.vm_config,
                 &state_view,
             )

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -38,19 +38,20 @@ fn test_mock_vm_different_senders() {
     let amount = 100;
     let mut txns = vec![];
     for i in 0..10 {
-        txns.push(encode_mint_transaction(gen_address(i), amount));
+        txns.push(Transaction::UserTransaction(encode_mint_transaction(
+            gen_address(i),
+            amount,
+        )));
     }
 
     let outputs = MockVM::execute_block(
-        txns.iter()
-            .map(|txn| Transaction::UserTransaction(txn.clone()))
-            .collect(),
+        txns.clone(),
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
     );
 
     for (output, txn) in itertools::zip_eq(outputs.iter(), txns.iter()) {
-        let sender = txn.sender();
+        let sender = txn.as_signed_user_txn().unwrap().sender();
         assert_eq!(
             output.write_set().iter().cloned().collect::<Vec<_>>(),
             vec![

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -7,6 +7,7 @@ use failure::Result;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
+    transaction::Transaction,
     write_set::WriteOp,
 };
 use state_view::StateView;
@@ -41,7 +42,9 @@ fn test_mock_vm_different_senders() {
     }
 
     let outputs = MockVM::execute_block(
-        txns.clone(),
+        txns.iter()
+            .map(|txn| Transaction::UserTransaction(txn.clone()))
+            .collect(),
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
     );
@@ -70,7 +73,9 @@ fn test_mock_vm_same_sender() {
     let sender = gen_address(1);
     let mut txns = vec![];
     for _i in 0..10 {
-        txns.push(encode_mint_transaction(sender, amount));
+        txns.push(Transaction::UserTransaction(encode_mint_transaction(
+            sender, amount,
+        )));
     }
 
     let outputs = MockVM::execute_block(
@@ -108,7 +113,7 @@ fn test_mock_vm_payment() {
     ));
 
     let output = MockVM::execute_block(
-        txns,
+        txns.into_iter().map(Transaction::UserTransaction).collect(),
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
     );

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -13,8 +13,8 @@ use libra_types::{
     contract_event::ContractEvent,
     event::EventKey,
     transaction::{
-        RawTransaction, Script, SignedTransaction, Transaction as ExecutorTransaction,
-        TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
+        RawTransaction, Script, SignedTransaction, Transaction, TransactionArgument,
+        TransactionOutput, TransactionPayload, TransactionStatus,
     },
     vm_error::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use vm_runtime::VMExecutor;
 
 #[derive(Debug)]
-enum Transaction {
+enum MockVMTransaction {
     Mint {
         sender: AccountAddress,
         amount: u64,
@@ -49,7 +49,7 @@ pub struct MockVM;
 
 impl VMExecutor for MockVM {
     fn execute_block(
-        transactions: Vec<ExecutorTransaction>,
+        transactions: Vec<Transaction>,
         _config: &VMConfig,
         state_view: &dyn StateView,
     ) -> Vec<TransactionOutput> {
@@ -70,68 +70,65 @@ impl VMExecutor for MockVM {
         let mut outputs = vec![];
 
         for txn in transactions {
-            if let ExecutorTransaction::UserTransaction(user_txn) = txn {
-                match decode_transaction(&user_txn) {
-                    Transaction::Mint { sender, amount } => {
-                        let old_balance = read_balance(&output_cache, state_view, sender);
-                        let new_balance = old_balance + amount;
-                        let old_seqnum = read_seqnum(&output_cache, state_view, sender);
-                        let new_seqnum = old_seqnum + 1;
+            match decode_transaction(&txn.as_signed_user_txn().unwrap()) {
+                MockVMTransaction::Mint { sender, amount } => {
+                    let old_balance = read_balance(&output_cache, state_view, sender);
+                    let new_balance = old_balance + amount;
+                    let old_seqnum = read_seqnum(&output_cache, state_view, sender);
+                    let new_seqnum = old_seqnum + 1;
 
-                        output_cache.insert(balance_ap(sender), new_balance);
-                        output_cache.insert(seqnum_ap(sender), new_seqnum);
+                    output_cache.insert(balance_ap(sender), new_balance);
+                    output_cache.insert(seqnum_ap(sender), new_seqnum);
 
-                        let write_set = gen_mint_writeset(sender, new_balance, new_seqnum);
-                        let events = gen_events(sender);
+                    let write_set = gen_mint_writeset(sender, new_balance, new_seqnum);
+                    let events = gen_events(sender);
+                    outputs.push(TransactionOutput::new(
+                        write_set,
+                        events,
+                        0,
+                        KEEP_STATUS.clone(),
+                    ));
+                }
+                MockVMTransaction::Payment {
+                    sender,
+                    recipient,
+                    amount,
+                } => {
+                    let sender_old_balance = read_balance(&output_cache, state_view, sender);
+                    let recipient_old_balance = read_balance(&output_cache, state_view, recipient);
+                    if sender_old_balance < amount {
                         outputs.push(TransactionOutput::new(
-                            write_set,
-                            events,
+                            WriteSet::default(),
+                            vec![],
                             0,
-                            KEEP_STATUS.clone(),
+                            DISCARD_STATUS.clone(),
                         ));
+                        continue;
                     }
-                    Transaction::Payment {
+
+                    let sender_old_seqnum = read_seqnum(&output_cache, state_view, sender);
+                    let sender_new_seqnum = sender_old_seqnum + 1;
+                    let sender_new_balance = sender_old_balance - amount;
+                    let recipient_new_balance = recipient_old_balance + amount;
+
+                    output_cache.insert(balance_ap(sender), sender_new_balance);
+                    output_cache.insert(seqnum_ap(sender), sender_new_seqnum);
+                    output_cache.insert(balance_ap(recipient), recipient_new_balance);
+
+                    let write_set = gen_payment_writeset(
                         sender,
+                        sender_new_balance,
+                        sender_new_seqnum,
                         recipient,
-                        amount,
-                    } => {
-                        let sender_old_balance = read_balance(&output_cache, state_view, sender);
-                        let recipient_old_balance =
-                            read_balance(&output_cache, state_view, recipient);
-                        if sender_old_balance < amount {
-                            outputs.push(TransactionOutput::new(
-                                WriteSet::default(),
-                                vec![],
-                                0,
-                                DISCARD_STATUS.clone(),
-                            ));
-                            continue;
-                        }
-
-                        let sender_old_seqnum = read_seqnum(&output_cache, state_view, sender);
-                        let sender_new_seqnum = sender_old_seqnum + 1;
-                        let sender_new_balance = sender_old_balance - amount;
-                        let recipient_new_balance = recipient_old_balance + amount;
-
-                        output_cache.insert(balance_ap(sender), sender_new_balance);
-                        output_cache.insert(seqnum_ap(sender), sender_new_seqnum);
-                        output_cache.insert(balance_ap(recipient), recipient_new_balance);
-
-                        let write_set = gen_payment_writeset(
-                            sender,
-                            sender_new_balance,
-                            sender_new_seqnum,
-                            recipient,
-                            recipient_new_balance,
-                        );
-                        let events = gen_events(sender);
-                        outputs.push(TransactionOutput::new(
-                            write_set,
-                            events,
-                            0,
-                            TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
-                        ));
-                    }
+                        recipient_new_balance,
+                    );
+                    let events = gen_events(sender);
+                    outputs.push(TransactionOutput::new(
+                        write_set,
+                        events,
+                        0,
+                        TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
+                    ));
                 }
             }
         }
@@ -286,21 +283,21 @@ fn encode_transaction(sender: AccountAddress, program: Script) -> SignedTransact
         .into_inner()
 }
 
-fn decode_transaction(txn: &SignedTransaction) -> Transaction {
+fn decode_transaction(txn: &SignedTransaction) -> MockVMTransaction {
     let sender = txn.sender();
     match txn.payload() {
         TransactionPayload::Script(script) => {
             assert!(script.code().is_empty(), "Code should be empty.");
             match script.args().len() {
                 1 => match script.args()[0] {
-                    TransactionArgument::U64(amount) => Transaction::Mint { sender, amount },
+                    TransactionArgument::U64(amount) => MockVMTransaction::Mint { sender, amount },
                     _ => unimplemented!(
                         "Only one integer argument is allowed for mint transactions."
                     ),
                 },
                 2 => match (&script.args()[0], &script.args()[1]) {
                     (TransactionArgument::Address(recipient), TransactionArgument::U64(amount)) => {
-                        Transaction::Payment {
+                        MockVMTransaction::Payment {
                             sender,
                             recipient: *recipient,
                             amount: *amount,

--- a/language/e2e_tests/src/executor.rs
+++ b/language/e2e_tests/src/executor.rs
@@ -13,7 +13,7 @@ use libra_types::{
     access_path::AccessPath,
     account_config::AccountResource,
     language_storage::ModuleId,
-    transaction::{SignedTransaction, TransactionOutput},
+    transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
     write_set::WriteSet,
 };
@@ -133,7 +133,14 @@ impl FakeExecutor {
     /// Typical tests will call this method and check that the output matches what was expected.
     /// However, this doesn't apply the results of successful transactions to the data store.
     pub fn execute_block(&self, txn_block: Vec<SignedTransaction>) -> Vec<TransactionOutput> {
-        MoveVM::execute_block(txn_block, &self.config.vm_config, &self.data_store)
+        MoveVM::execute_block(
+            txn_block
+                .into_iter()
+                .map(Transaction::UserTransaction)
+                .collect(),
+            &self.config.vm_config,
+            &self.data_store,
+        )
     }
 
     pub fn execute_transaction(&self, txn: SignedTransaction) -> TransactionOutput {

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -138,7 +138,7 @@ pub use txn_executor::execute_function;
 
 use config::config::VMConfig;
 use libra_types::{
-    transaction::{SignedTransaction, TransactionOutput},
+    transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
 };
 use state_view::StateView;
@@ -165,7 +165,7 @@ pub trait VMExecutor {
 
     /// Executes a block of transactions and returns output for each one of them.
     fn execute_block(
-        transactions: Vec<SignedTransaction>,
+        transactions: Vec<Transaction>,
         config: &VMConfig,
         state_view: &dyn StateView,
     ) -> Vec<TransactionOutput>;

--- a/language/vm/vm_runtime/src/move_vm.rs
+++ b/language/vm/vm_runtime/src/move_vm.rs
@@ -6,7 +6,7 @@ use crate::{
     VMVerifier,
 };
 use libra_types::{
-    transaction::{SignedTransaction, TransactionOutput},
+    transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
 };
 use state_view::StateView;
@@ -62,7 +62,7 @@ impl VMVerifier for MoveVM {
 
 impl VMExecutor for MoveVM {
     fn execute_block(
-        transactions: Vec<SignedTransaction>,
+        transactions: Vec<Transaction>,
         config: &VMConfig,
         state_view: &dyn StateView,
     ) -> Vec<TransactionOutput> {

--- a/language/vm/vm_runtime/src/runtime.rs
+++ b/language/vm/vm_runtime/src/runtime.rs
@@ -117,7 +117,7 @@ impl<'alloc> VMRuntime<'alloc> {
             .into_iter()
             .map(|txn| {
                 SignedTransaction::try_from(txn)
-                    .expect("All transaction should be user transaction")
+                    .expect("All transactions should be user transaction")
             })
             .collect();
         execute_block(

--- a/language/vm/vm_runtime/src/runtime.rs
+++ b/language/vm/vm_runtime/src/runtime.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use config::config::{VMConfig, VMPublishingOption};
 use libra_types::{
-    transaction::{SignedTransaction, TransactionOutput},
+    transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::{StatusCode, VMStatus},
 };
 use logger::prelude::*;
@@ -109,11 +109,19 @@ impl<'alloc> VMRuntime<'alloc> {
     /// transaction output.
     pub fn execute_block_transactions(
         &self,
-        txn_block: Vec<SignedTransaction>,
+        txn_block: Vec<Transaction>,
         data_view: &dyn StateView,
     ) -> Vec<TransactionOutput> {
+        let mut txns = vec![];
+        for txn in txn_block {
+            match txn {
+                Transaction::UserTransaction(user_txn) => txns.push(user_txn),
+                // TODO: Refactor the logic for writeset transaction.
+                _ => return Vec::new(),
+            }
+        }
         execute_block(
-            txn_block,
+            txns,
             &self.code_cache,
             &self.script_cache,
             data_view,

--- a/types/src/transaction.rs
+++ b/types/src/transaction.rs
@@ -1282,3 +1282,14 @@ impl From<Transaction> for crate::proto::types::Transaction {
         Self { transaction: bytes }
     }
 }
+
+impl TryFrom<Transaction> for SignedTransaction {
+    type Error = Error;
+
+    fn try_from(txn: Transaction) -> Result<Self> {
+        match txn {
+            Transaction::UserTransaction(txn) => Ok(txn),
+            _ => Err(format_err!("Not a user transaction.")),
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a follow up for #1281. This PR will change the VM api to take a vector of Transaction.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

#1173 
