### PR TITLE
[admission-control] Make AC runtime multi-threaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
@@ -63,7 +64,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-validator 0.1.0",
 ]
 

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -18,7 +18,7 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["pr
 num_cpus = "1.10.1"
 lazy_static = "1.3.0"
 rand = "0.6.5"
-tokio = "0.1.22"
+tokio = "=0.2.0-alpha.6"
 
 admission-control-proto = { path = "../admission-control-proto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
@@ -36,6 +36,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
 network = { path = "../../network", version = "0.1.0" }
+bounded-executor = { path = "../../common/bounded-executor", version = "0.1.0" }
 
 storage-service = { path = "../../storage/storage-service", version = "0.1.0", optional = true }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }

--- a/admission_control/admission-control-service/src/runtime.rs
+++ b/admission_control/admission-control-service/src/runtime.rs
@@ -1,21 +1,21 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{admission_control_service::AdmissionControlService, upstream_proxy::UpstreamProxy};
+use crate::{
+    admission_control_service::AdmissionControlService,
+    upstream_proxy::{process_network_messages, UpstreamProxyData},
+};
 use admission_control_proto::proto::admission_control::{
     create_admission_control, AdmissionControlClient, SubmitTransactionRequest,
     SubmitTransactionResponse,
 };
-use futures::{
-    channel::{mpsc, oneshot},
-    future::{FutureExt, TryFutureExt},
-};
+use futures::channel::{mpsc, oneshot};
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder, ServerBuilder};
 use libra_config::config::NodeConfig;
 use libra_mempool::proto::mempool::MempoolClient;
 use network::validator_network::{AdmissionControlNetworkEvents, AdmissionControlNetworkSender};
-use std::{cmp::min, sync::Arc};
+use std::{cmp::min, collections::HashMap, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient};
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::vm_validator::VMValidator;
@@ -46,16 +46,25 @@ impl AdmissionControlRuntime {
 
         let executor = upstream_proxy_runtime.executor();
 
-        let upstream_proxy =
-            UpstreamProxy::new(config, network_sender, upstream_proxy_receiver, client);
+        let upstream_peer_ids = config.get_upstream_peer_ids();
+        let peer_info: HashMap<_, _> = upstream_peer_ids
+            .iter()
+            .map(|peer_id| (*peer_id, true))
+            .collect();
 
-        executor.spawn(
-            upstream_proxy
-                .process_network_messages(network_events)
-                .boxed()
-                .unit_error()
-                .compat(),
+        let upstream_proxy_data = UpstreamProxyData::new(
+            config.admission_control.clone(),
+            network_sender,
+            config.get_role(),
+            client,
         );
+        executor.spawn(process_network_messages(
+            upstream_proxy_data,
+            network_events,
+            peer_info,
+            executor.clone(),
+            upstream_proxy_receiver,
+        ));
 
         Self {
             _grpc_server: ServerHandle::setup(grpc_server),

--- a/admission_control/admission-control-service/src/upstream_proxy.rs
+++ b/admission_control/admission-control-service/src/upstream_proxy.rs
@@ -6,13 +6,14 @@ use admission_control_proto::proto::admission_control::{
     admission_control_msg::Message as AdmissionControlMsg_oneof, AdmissionControlClient,
     AdmissionControlMsg, SubmitTransactionRequest, SubmitTransactionResponse,
 };
+use bounded_executor::BoundedExecutor;
 use bytes::Bytes;
 use failure::format_err;
 use futures::{
     channel::{mpsc, oneshot},
     stream::{select_all, StreamExt},
 };
-use libra_config::config::{AdmissionControlConfig, NodeConfig, RoleType};
+use libra_config::config::{AdmissionControlConfig, RoleType};
 use libra_logger::prelude::*;
 use libra_prost_ext::MessageExt;
 use network::validator_network::{
@@ -20,184 +21,219 @@ use network::validator_network::{
 };
 use rand::seq::SliceRandom;
 use std::collections::HashMap;
+use tokio::runtime::TaskExecutor;
 
-/// Full nodes use UpstreamProxy to send transaction write requests to their upstream validator,
-/// and is essentially the networking layer of AC.
-/// UpstreamProxy is instantiated in AC Runtime to communicate with the gRPC layer.
-/// The requests and responses are represented with AdmissionControlNetworkSender and AdmissionControlNetworkEvents.
-pub(crate) struct UpstreamProxy {
+/// UpstreamProxyData is the set of data needed for a full node to send transaction write
+/// requests to their upstream validator.
+/// UpstreamProxyData is instantiated in AC Runtime.
+#[derive(Clone)]
+pub struct UpstreamProxyData {
     ac_config: AdmissionControlConfig,
     network_sender: AdmissionControlNetworkSender,
-    peer_info: HashMap<PeerId, bool>,
-    /// used to process client requests
-    client_events: mpsc::UnboundedReceiver<(
-        SubmitTransactionRequest,
-        oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
-    )>,
     role: RoleType,
     /// AC Client
     pub client: AdmissionControlClient, // TODO remove client
 }
 
-impl UpstreamProxy {
-    /// bootstrap of UpstreamProxy
+impl UpstreamProxyData {
     pub fn new(
-        config: &NodeConfig,
+        ac_config: AdmissionControlConfig,
         network_sender: AdmissionControlNetworkSender,
-        client_events: mpsc::UnboundedReceiver<(
-            SubmitTransactionRequest,
-            oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
-        )>,
-        client: AdmissionControlClient,
+        role: RoleType,
+        client: AdmissionControlClient, // TODO remove client
     ) -> Self {
-        let upstream_peer_ids = config.get_upstream_peer_ids();
-        let peer_info: HashMap<_, _> = upstream_peer_ids
-            .iter()
-            .map(|peer_id| (*peer_id, true))
-            .collect();
-
         Self {
-            ac_config: config.admission_control.clone(),
+            ac_config,
             network_sender,
-            peer_info,
-            client_events,
-            role: config.get_role(),
+            role,
             client,
         }
     }
+}
 
-    /// main routine. starts sync coordinator that listens for CoordinatorMsg
-    pub async fn process_network_messages(
-        mut self,
-        network_events: Vec<AdmissionControlNetworkEvents>,
-    ) {
-        let mut events = select_all(network_events).fuse();
+/// Main routine for proxying write request. Starts a coordinator that listens for AdmissionControlMsg
+pub async fn process_network_messages(
+    upstream_proxy_data: UpstreamProxyData,
+    network_events: Vec<AdmissionControlNetworkEvents>,
+    mut peer_info: HashMap<PeerId, bool>,
+    executor: TaskExecutor,
+    mut client_events: mpsc::UnboundedReceiver<(
+        SubmitTransactionRequest,
+        oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
+    )>,
+) {
+    let mut events = select_all(network_events).fuse();
+    let workers_available = upstream_proxy_data.ac_config.max_concurrent_inbound_syncs;
+    let bounded_executor = BoundedExecutor::new(workers_available, executor);
 
-        loop {
-            ::futures::select! {
-                (mut msg, mut callback) = self.client_events.select_next_some() => {
-                    let result = self.submit_transaction_upstream(msg).await;
-                    if let Err(e) = callback.send(result) {
-                        error!("[admission control] failed to send back transaction result with error: {:?}", e);
-                    }
-                },
-                network_event = events.select_next_some() => {
-                    match network_event {
-                        Ok(event) => {
-                            match event {
-                                Event::NewPeer(peer_id) => {
-                                    debug!("[admission control] new peer {}", peer_id);
-                                    self.new_peer(peer_id);
-                                }
-                                Event::LostPeer(peer_id) => {
-                                    debug!("[admission control] lost peer {}", peer_id);
-                                    self.lost_peer(peer_id);
-                                }
-                                Event::RpcRequest((peer_id, mut message, callback)) => {
-                                    if let Some(AdmissionControlMsg_oneof::SubmitTransactionRequest(request)) = message.message {
-                                        if let Err(err) = self.process_submit_transaction_request(request, callback).await {
-                                            error!("[admission control] failed to process transaction request, peer: {}, error: {:?}", peer_id, err);
-                                        }
-                                    }
-                                }
-                                _ => {},
+    loop {
+        ::futures::select! {
+            (mut msg, callback) = client_events.select_next_some() => {
+                let peer_id = pick_peer(&peer_info);
+                bounded_executor
+                    .spawn(start_submit_transaction_upstream(msg, upstream_proxy_data.clone(), peer_id, callback))
+                    .await;
+            },
+            network_event = events.select_next_some() => {
+                match network_event {
+                    Ok(event) => {
+                        match event {
+                            Event::NewPeer(peer_id) => {
+                                debug!("[admission control] new peer {}", peer_id);
+                                new_peer(&mut peer_info, peer_id);
                             }
-                        },
-                        Err(err) => { error!("[admission control] network error {:?}", err); },
-                    }
+                            Event::LostPeer(peer_id) => {
+                                debug!("[admission control] lost peer {}", peer_id);
+                                lost_peer(&mut peer_info, peer_id);
+                            }
+                            Event::RpcRequest((peer_id, mut message, callback)) => {
+                                if let Some(AdmissionControlMsg_oneof::SubmitTransactionRequest(request)) = message.message {
+                                    let peer_id = pick_peer(&peer_info);
+                                    bounded_executor
+                                        .spawn(process_submit_transaction_request(upstream_proxy_data.clone(), peer_id, request, callback))
+                                        .await;
+                                }
+                            }
+                            _ => {},
+                        }
+                    },
+                    Err(err) => { error!("[admission control] network error {:?}", err); },
                 }
             }
         }
     }
+}
 
-    /// new peer discovery handler
-    /// adds new entry to `peer_info`
-    fn new_peer(&mut self, peer_id: PeerId) {
-        if let Some(state) = self.peer_info.get_mut(&peer_id) {
-            *state = true;
-        }
+/// new peer discovery handler
+/// adds new entry to `peer_info`
+fn new_peer(peer_info: &mut HashMap<PeerId, bool>, peer_id: PeerId) {
+    if let Some(state) = peer_info.get_mut(&peer_id) {
+        *state = true;
     }
+}
 
-    /// lost peer handler. Marks connection as dead
-    fn lost_peer(&mut self, peer_id: PeerId) {
-        if let Some(state) = self.peer_info.get_mut(&peer_id) {
-            *state = false;
-        }
+/// lost peer handler. Marks connection as dead
+fn lost_peer(peer_info: &mut HashMap<PeerId, bool>, peer_id: PeerId) {
+    if let Some(state) = peer_info.get_mut(&peer_id) {
+        *state = false;
     }
+}
 
-    async fn submit_transaction_upstream(
-        &mut self,
-        request: SubmitTransactionRequest,
-    ) -> failure::Result<SubmitTransactionResponse> {
-        let active_peer_ids = self.get_active_upstream_peers();
-        if !active_peer_ids.is_empty() {
-            let peer_id = { active_peer_ids.choose(&mut rand::thread_rng()) };
-            if let Some(peer_id) = peer_id {
-                let result = self
-                    .network_sender
-                    .send_transaction_upstream(
-                        peer_id.clone(),
-                        request,
-                        self.ac_config.upstream_proxy_timeout,
-                    )
-                    .await?;
-                return Ok(result);
+fn pick_peer(peer_info: &HashMap<PeerId, bool>) -> Option<PeerId> {
+    let active_peer_ids: Vec<PeerId> = peer_info
+        .iter()
+        .filter(|(_, &is_alive)| is_alive)
+        .map(|(&peer_id, _)| peer_id)
+        .collect();
+    if !active_peer_ids.is_empty() {
+        return active_peer_ids.choose(&mut rand::thread_rng()).cloned();
+    }
+    None
+}
+
+async fn start_submit_transaction_upstream(
+    request: SubmitTransactionRequest,
+    upstream_proxy_data: UpstreamProxyData,
+    peer_id: Option<PeerId>,
+    callback: oneshot::Sender<failure::Result<SubmitTransactionResponse>>,
+) {
+    let mut response = None;
+    if let Some(peer_id) = peer_id {
+        let result = upstream_proxy_data
+            .network_sender
+            .send_transaction_upstream(
+                peer_id.clone(),
+                request,
+                upstream_proxy_data.ac_config.upstream_proxy_timeout,
+            )
+            .await;
+        match result {
+            Ok(res) => {
+                response = Some(Ok(res));
+            }
+            Err(e) => {
+                response = Some(Err(format_err!(
+                    "[admission-control] Sending transaction upstream returned an error: {:?}",
+                    e
+                )));
             }
         }
-        Err(format_err!("[admission-control] No active upstream peers"))
     }
+    let res = response
+        .unwrap_or_else(|| Err(format_err!("[admission-control] No active upstream peers")));
+    if let Err(e) = callback.send(res) {
+        error!(
+            "[admission control] failed to send back transaction result with error: {:?}",
+            e
+        );
+    };
+}
 
-    async fn process_submit_transaction_request(
-        &mut self,
-        request: SubmitTransactionRequest,
-        callback: oneshot::Sender<Result<Bytes, RpcError>>,
-    ) -> failure::Result<()> {
-        let mut response_msg = None;
-        match self.role {
-            RoleType::Validator => {
-                let result = self.client.submit_transaction(&request);
-                match result {
-                    Ok(response) => {
-                        let ac_control_msg = AdmissionControlMsg {
-                            message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
-                                response,
-                            )),
-                        };
-                        response_msg = Some(ac_control_msg);
-                    }
-                    Err(e) => {
-                        return Err(format_err!("{:?}", e.to_string()));
-                    }
-                }
-            }
-            RoleType::FullNode => {
-                // node is not a validator, so send the transaction to upstream AC via networking stack
-                if let Ok(response) = self.submit_transaction_upstream(request).await {
-                    let ac_control_msg = AdmissionControlMsg {
-                        message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
-                            response,
-                        )),
-                    };
-                    response_msg = Some(ac_control_msg);
-                }
-            }
-        };
-        if let Some(response_msg) = response_msg {
-            let response_data = response_msg.to_bytes().expect("fail to serialize proto");
-            return callback.send(Ok(response_data)).map_err(|_| {
-                format_err!("[admission-control] handling inbound rpc call timed out")
-            });
-        };
-        Err(format_err!(
-            "[admission-control] handling inbound rpc call timed out"
-        ))
+async fn submit_transaction_upstream(
+    request: SubmitTransactionRequest,
+    upstream_proxy_data: &UpstreamProxyData,
+    peer_id: Option<PeerId>,
+) -> failure::Result<SubmitTransactionResponse> {
+    if let Some(peer_id) = peer_id {
+        let result = upstream_proxy_data
+            .network_sender
+            .send_transaction_upstream(
+                peer_id.clone(),
+                request,
+                upstream_proxy_data.ac_config.upstream_proxy_timeout,
+            )
+            .await?;
+        return Ok(result);
     }
+    Err(format_err!("[admission-control] No active upstream peers"))
+}
 
-    fn get_active_upstream_peers(&self) -> Vec<PeerId> {
-        self.peer_info
-            .iter()
-            .filter(|(_, &is_alive)| is_alive)
-            .map(|(&peer_id, _)| peer_id)
-            .collect()
+async fn process_submit_transaction_request(
+    upstream_proxy_data: UpstreamProxyData,
+    peer_id: Option<PeerId>,
+    request: SubmitTransactionRequest,
+    callback: oneshot::Sender<Result<Bytes, RpcError>>,
+) {
+    let mut response_msg = None;
+    match upstream_proxy_data.role {
+        RoleType::Validator => {
+            if let Ok(response) = upstream_proxy_data.client.submit_transaction(&request) {
+                let ac_control_msg = AdmissionControlMsg {
+                    message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
+                        response,
+                    )),
+                };
+                response_msg = Some(ac_control_msg);
+            }
+        }
+        RoleType::FullNode => {
+            // node is not a validator, so send the transaction to upstream AC via networking stack
+            if let Ok(response) =
+                submit_transaction_upstream(request, &upstream_proxy_data, peer_id).await
+            {
+                let ac_control_msg = AdmissionControlMsg {
+                    message: Some(AdmissionControlMsg_oneof::SubmitTransactionResponse(
+                        response,
+                    )),
+                };
+                response_msg = Some(ac_control_msg);
+            }
+        }
+    };
+    if let Some(response_msg) = response_msg {
+        let response_data = response_msg.to_bytes().expect("fail to serialize proto");
+        if let Err(err) = callback
+            .send(Ok(response_data))
+            .map_err(|_| format_err!("[admission-control] handling inbound rpc call timed out"))
+        {
+            error!(
+                "[admission control] failed to process transaction request, error: {:?}",
+                err
+            );
+        }
+    } else {
+        error!(
+            "[admission control] Did not get a response msg back from submit transaction upstream request",
+        );
     }
 }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -244,6 +244,7 @@ pub struct AdmissionControlConfig {
     pub address: String,
     pub admission_control_service_port: u16,
     pub need_to_check_mempool_before_validation: bool,
+    pub max_concurrent_inbound_syncs: usize,
     pub upstream_proxy_timeout: Duration,
 }
 
@@ -253,6 +254,7 @@ impl Default for AdmissionControlConfig {
             address: "0.0.0.0".to_string(),
             admission_control_service_port: 8000,
             need_to_check_mempool_before_validation: false,
+            max_concurrent_inbound_syncs: 100,
             upstream_proxy_timeout: Duration::from_secs(1),
         }
     }

--- a/network/src/validator_network/admission_control.rs
+++ b/network/src/validator_network/admission_control.rs
@@ -94,7 +94,7 @@ impl AdmissionControlNetworkSender {
     /// The rpc request can be canceled at any point by dropping the returned
     /// future.
     pub async fn send_transaction_upstream(
-        &mut self,
+        &self,
         recipient: PeerId,
         req_msg: SubmitTransactionRequest,
         timeout: Duration,
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_admission_control_outbound_rpc() {
         let (network_reqs_tx, mut network_reqs_rx) = channel::new_test(8);
-        let mut sender = AdmissionControlNetworkSender::new(network_reqs_tx);
+        let sender = AdmissionControlNetworkSender::new(network_reqs_tx);
 
         // make submit_transaction_request rpc request
         let peer_id = PeerId::random();


### PR DESCRIPTION
## Motivation

Currently the AC proxy setup is single-threaded, which is not ideal for performance. This PR makes this process multi-threaded by using bounded executor to process the upstream requests. 

In order to support this, I had to refactor UpstreamProxy to not share data such as ac_config, network_sender, peer_info, etc across the whole process, since different threads would each need access to their own data. UpstreamProxyData is the struct that will hold all the information that can be cloned and passed to each thread when process_submit_transaction_request is called.

## Test Plan

cargo test -- test_full_node_basic_flow --nocapture
