### PR TITLE
[faucet] set delaybeforesend

### DIFF
--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -31,6 +31,7 @@ def create_client():
             "/opt/libra/etc/consensus_peers.config.toml")
 
         application.client = pexpect.spawn(cmd)
+        application.client.delaybeforesend = 0.1
         application.client.expect("Please, input commands")
 
 


### PR DESCRIPTION
we updated to newer version of peexpect
now this parameter needs to be set explicitly to reasonable value
