### PR TITLE
[consensus][reconfig] enforcing reconfiguration suffix blocks must be empty rule

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -74,6 +74,10 @@ impl StateComputeResult {
     pub fn status(&self) -> &Vec<TransactionStatus> {
         &self.compute_status
     }
+
+    pub fn has_reconfiguration(&self) -> bool {
+        self.executed_state.validators.is_some()
+    }
 }
 
 /// Executed state derived from StateComputeResult that is maintained with every proposed block.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As our reconfiguration design, any child of reconfiguration block needs to be empty and not executed at all.

We flag the reconfiguration by the executed_state and roll over this flag for any child blocks.

This PR enforces this in two places
- block_store will reject non-empty blocks as reconfiguration child and roll over compute result for empty blocks.
- proposal generator will only generate empty blocks

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

Added unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
