### PR TITLE
Prepend libra to tools package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-swarm 0.1.0",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libra_wallet 0.1.0",
  "logger 0.1.0",
@@ -213,7 +214,6 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
  "transaction_builder 0.1.0",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -586,6 +586,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libra_wallet 0.1.0",
  "logger 0.1.0",
@@ -598,7 +599,6 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
  "transaction_builder 0.1.0",
 ]
 
@@ -697,6 +697,7 @@ dependencies = [
  "failure_ext 0.1.0",
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -704,7 +705,6 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -743,6 +743,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-mempool 0.1.0",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "logger 0.1.0",
  "metrics 0.1.0",
@@ -767,7 +768,6 @@ dependencies = [
  "storage-client 0.1.0",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
  "vm_genesis 0.1.0",
  "vm_runtime 0.1.0",
  "vm_validator 0.1.0",
@@ -1578,8 +1578,8 @@ dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
+ "libra-tools 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -2180,9 +2180,17 @@ dependencies = [
  "failure_ext 0.1.0",
  "generate-keypair 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-tools 0.1.0",
  "logger 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
+]
+
+[[package]]
+name = "libra-tools"
+version = "0.1.0"
+dependencies = [
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2223,6 +2231,7 @@ dependencies = [
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2230,7 +2239,6 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -2246,6 +2254,7 @@ dependencies = [
  "jellyfish-merkle 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "logger 0.1.0",
  "metrics 0.1.0",
@@ -2263,7 +2272,6 @@ dependencies = [
  "storage_proto 0.1.0",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -3871,11 +3879,11 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-tools 0.1.0",
  "metrics 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -4316,6 +4324,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libradb 0.1.0",
  "logger 0.1.0",
@@ -4325,7 +4334,6 @@ dependencies = [
  "storage-client 0.1.0",
  "storage_proto 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -4550,13 +4558,13 @@ dependencies = [
  "generate-keypair 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-swarm 0.1.0",
+ "libra-tools 0.1.0",
  "logger 0.1.0",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tools 0.1.0",
 ]
 
 [[package]]
@@ -5013,14 +5021,6 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tools"
-version = "0.1.0"
-dependencies = [
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -31,7 +31,7 @@ logger = { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 crypto = { path = "../crypto/crypto" }
 rusty-fork = "0.2.1"
-tools = { path = "../common/tools" }
+libra-tools = { path = "../common/tools" }
 libra-types = { path = "../types" }
 transaction_builder = { path = "../language/transaction_builder" }
 

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -68,9 +68,9 @@ mod tests {
     use client::AccountData;
     use config::config::RoleType;
     use libra_swarm::swarm::LibraSwarm;
+    use libra_tools::tempdir::TempPath;
     use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
     use std::ops::Range;
-    use tools::tempdir::TempPath;
 
     /// Start libra-swarm and create a BenchOpt struct for testing.
     /// Must return the TempPath otherwise it will be freed somehow.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -34,7 +34,7 @@ libra_wallet = { path = "./libra_wallet" }
 logger =  { path = "../common/logger" }
 metrics = { path = "../common/metrics" }
 libra-types = { path = "../types" }
-tools = { path = "../common/tools/" }
+libra-tools = { path = "../common/tools/" }
 transaction_builder = { path = "../language/transaction_builder" }
 
 [dev-dependencies]

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -25,4 +25,4 @@ libra-types = { path = "../../types" }
 
 [dev-dependencies]
 libra-types = { path = "../../types", features = ["testing"]}
-tools = { path = "../../common/tools"}
+libra-tools = { path = "../../common/tools"}

--- a/client/libra_wallet/src/mnemonic.rs
+++ b/client/libra_wallet/src/mnemonic.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 #[cfg(test)]
-use tools::tempdir::TempPath;
+use libra_tools::tempdir::TempPath;
 
 /// Mnemonic seed for deterministic key derivation based on [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki).
 /// The mnemonic must encode entropy in a multiple of 32 bits. With more entropy, security is

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -6,6 +6,7 @@ use admission_control_proto::proto::admission_control::SubmitTransactionRequest;
 use config::{config::PersistableConfig, trusted_peers::ConsensusPeersConfig};
 use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
@@ -41,7 +42,6 @@ use std::{
     sync::Arc,
     thread, time,
 };
-use tools::tempdir::TempPath;
 
 const CLIENT_WALLET_MNEMONIC_FILE: &str = "client.mnemonic";
 const GAS_UNIT_PRICE: u64 = 0;
@@ -1086,9 +1086,9 @@ impl fmt::Display for AccountEntry {
 mod tests {
     use crate::client_proxy::{parse_bool, AddressAndIndex, ClientProxy};
     use config::{config::PersistableConfig, trusted_peers::ConfigHelpers};
+    use libra_tools::tempdir::TempPath;
     use libra_wallet::io_utils;
     use proptest::prelude::*;
-    use tools::tempdir::TempPath;
 
     fn generate_accounts_from_wallet(count: usize) -> (ClientProxy, Vec<AddressAndIndex>) {
         let mut accounts = Vec::new();

--- a/common/tools/Cargo.toml
+++ b/common/tools/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "tools"
+name = "libra-tools"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
-description = "Libra tools"
+description = "Libra libra-tools"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -21,7 +21,7 @@ prost = "0.5.0"
 
 crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
-tools = { path = "../common/tools" }
+libra-tools = { path = "../common/tools" }
 libra-types = { path = "../types" }
 
 [dev-dependencies]

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -15,4 +15,4 @@ structopt = "0.3.2"
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 crypto = { path = "../../crypto/crypto/"}
-tools = { path = "../../common/tools" }
+libra-tools = { path = "../../common/tools" }

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -4,12 +4,12 @@
 use bincode::serialize;
 use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
+use libra_tools::tempdir::TempPath;
 use std::{
     fs::{self, File},
     io::Write,
     path::Path,
 };
-use tools::tempdir::TempPath;
 
 pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
     let output_file_path = Path::new(&output_file);

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use crypto::ValidKey;
 use failure::prelude::*;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, SCRIPT_HASH_LENGTH},
     PeerId,
@@ -31,7 +32,6 @@ use std::{
     time::Duration,
 };
 use toml;
-use tools::tempdir::TempPath;
 
 #[cfg(test)]
 #[path = "unit_tests/config_test.rs"]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -46,7 +46,7 @@ safety-rules = { path = "safety-rules" }
 state-synchronizer = { path = "../state-synchronizer" }
 schemadb = { path = "../storage/schemadb" }
 storage-client = { path = "../storage/storage-client" }
-tools = { path = "../common/tools" }
+libra-tools = { path = "../common/tools" }
 libra-types = { path = "../types" }
 vm_runtime = { path = "../language/vm/vm_runtime" }
 

--- a/consensus/src/chained_bft/consensusdb/consensusdb_test.rs
+++ b/consensus/src/chained_bft/consensusdb/consensusdb_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use tools::tempdir::TempPath;
+use libra_tools::tempdir::TempPath;
 
 #[test]
 fn test_put_get() {

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -22,7 +22,7 @@ failure = { path = "../common/failure_ext", package = "failure_ext" }
 generate-keypair = { path = "../config/generate-keypair" }
 logger = { path = "../common/logger" }
 crypto = { path = "../crypto/crypto" }
-tools = { path = "../common/tools" }
+libra-tools = { path = "../common/tools" }
 
 [dev-dependencies]
 crypto = { path = "../crypto/crypto", features = ["testing"]}

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -3,9 +3,9 @@
 
 use config::config::{NodeConfig, RoleType};
 use libra_swarm::{client, swarm::LibraSwarm};
+use libra_tools::tempdir::TempPath;
 use std::path::Path;
 use structopt::StructOpt;
-use tools::tempdir::TempPath;
 
 #[derive(Debug, StructOpt)]
 #[structopt(about = "Libra swarm to start local nodes")]

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -7,6 +7,7 @@ use config_builder::swarm_config::{SwarmConfig, SwarmConfigBuilder};
 use crypto::{ed25519::*, test_utils::KeyPair};
 use debug_interface::NodeDebugClient;
 use failure::prelude::*;
+use libra_tools::tempdir::TempPath;
 use logger::prelude::*;
 use std::{
     collections::HashMap,
@@ -17,7 +18,6 @@ use std::{
     process::{Child, Command},
     str::FromStr,
 };
-use tools::tempdir::TempPath;
 
 const LIBRA_NODE_BIN: &str = "libra-node";
 

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -35,7 +35,7 @@ metrics = { path = "../../common/metrics" }
 prost-ext = { path = "../../common/prost-ext" }
 schemadb = { path = "../schemadb" }
 storage_proto = { path = "../storage_proto" }
-tools = { path = "../../common/tools" }
+libra-tools = { path = "../../common/tools" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::LibraDB;
 use crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use itertools::Itertools;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,
@@ -19,7 +20,6 @@ use proptest::{
 use proptest_helpers::Index;
 use rand::Rng;
 use std::collections::HashMap;
-use tools::tempdir::TempPath;
 
 fn save(store: &EventStore, version: Version, events: &[ContractEvent]) -> HashValue {
     let mut cs = ChangeSet::new();

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -3,9 +3,9 @@
 
 use super::*;
 use crate::{change_set::ChangeSet, LibraDB};
+use libra_tools::tempdir::TempPath;
 use libra_types::ledger_info::LedgerInfo;
 use proptest::{collection::vec, prelude::*};
-use tools::tempdir::TempPath;
 
 prop_compose! {
     fn arb_partial_ledger_info()(accu_hash in any::<HashValue>(),

--- a/storage/libradb/src/ledger_store/transaction_info_test.rs
+++ b/storage/libradb/src/ledger_store/transaction_info_test.rs
@@ -3,8 +3,8 @@
 
 use super::*;
 use crate::LibraDB;
+use libra_tools::tempdir::TempPath;
 use proptest::{collection::vec, prelude::*};
-use tools::tempdir::TempPath;
 
 fn verify(
     store: &LedgerStore,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -7,6 +7,7 @@ use crate::{
     test_helper::arb_blocks_to_commit,
 };
 use crypto::hash::CryptoHash;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_config::get_account_resource_or_default, contract_event::ContractEvent,
     ledger_info::LedgerInfo,
@@ -14,7 +15,6 @@ use libra_types::{
 use proptest::prelude::*;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::collections::HashMap;
-use tools::tempdir::TempPath;
 
 fn test_save_blocks_impl(
     input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,

--- a/storage/libradb/src/pruner/test.rs
+++ b/storage/libradb/src/pruner/test.rs
@@ -4,12 +4,12 @@
 use super::*;
 use crate::{change_set::ChangeSet, state_store::StateStore, LibraDB};
 use crypto::HashValue;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_state_blob::AccountStateBlob,
 };
 use std::collections::HashMap;
-use tools::tempdir::TempPath;
 
 fn put_account_state_set(
     db: &DB,

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -4,11 +4,11 @@
 use super::*;
 use crate::{pruner, LibraDB};
 use crypto::hash::CryptoHash;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_state_blob::AccountStateBlob,
 };
-use tools::tempdir::TempPath;
 
 fn put_account_state_set(
     store: &StateStore,

--- a/storage/libradb/src/system_store/test.rs
+++ b/storage/libradb/src/system_store/test.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{ledger_counters::LedgerCounter, LibraDB};
-use tools::tempdir::TempPath;
+use libra_tools::tempdir::TempPath;
 
 fn bump_ledger_counters(
     store: &SystemStore,

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -6,13 +6,13 @@
 use super::*;
 use crate::mock_genesis::{db_with_mock_genesis, GENESIS_INFO};
 use crypto::hash::CryptoHash;
+use libra_tools::tempdir::TempPath;
 use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
     ledger_info::LedgerInfo,
     proptest_types::{AccountInfoUniverse, TransactionToCommitGen},
 };
 use proptest::{collection::vec, prelude::*};
-use tools::tempdir::TempPath;
 
 fn to_blocks_to_commit(
     partial_blocks: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>,

--- a/storage/libradb/src/transaction_store/test.rs
+++ b/storage/libradb/src/transaction_store/test.rs
@@ -3,10 +3,10 @@
 
 use super::*;
 use crate::LibraDB;
+use libra_tools::tempdir::TempPath;
 use libra_types::proptest_types::{AccountInfoUniverse, SignatureCheckedTransactionGen};
 use proptest::{collection::vec, prelude::*};
 use proptest_helpers::Index;
-use tools::tempdir::TempPath;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -23,4 +23,4 @@ rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 byteorder = "1.3.2"
 proptest = "0.9.4"
 tempfile = "3.1.0"
-tools = { path = "../../common/tools" }
+libra-tools = { path = "../../common/tools" }

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -71,7 +71,7 @@ impl ValueCodec<TestSchema2> for TestField {
     }
 }
 
-fn open_db(dir: &tools::tempdir::TempPath) -> DB {
+fn open_db(dir: &libra_tools::tempdir::TempPath) -> DB {
     let cf_opts_map: ColumnFamilyOptionsMap = [
         (DEFAULT_CF_NAME, ColumnFamilyOptions::default()),
         (
@@ -90,13 +90,13 @@ fn open_db(dir: &tools::tempdir::TempPath) -> DB {
 }
 
 struct TestDB {
-    _tmpdir: tools::tempdir::TempPath,
+    _tmpdir: libra_tools::tempdir::TempPath,
     db: DB,
 }
 
 impl TestDB {
     fn new() -> Self {
-        let tmpdir = tools::tempdir::TempPath::new();
+        let tmpdir = libra_tools::tempdir::TempPath::new();
         let db = open_db(&tmpdir);
 
         TestDB {
@@ -283,7 +283,7 @@ fn test_two_schema_batches() {
 
 #[test]
 fn test_reopen() {
-    let tmpdir = tools::tempdir::TempPath::new();
+    let tmpdir = libra_tools::tempdir::TempPath::new();
     {
         let db = open_db(&tmpdir);
         db.put::<TestSchema1>(&TestField(0), &TestField(0)).unwrap();

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -71,13 +71,13 @@ fn collect_values(iter: SchemaIterator<TestSchema>) -> Vec<u32> {
 }
 
 struct TestDB {
-    _tmpdir: tools::tempdir::TempPath,
+    _tmpdir: libra_tools::tempdir::TempPath,
     db: DB,
 }
 
 impl TestDB {
     fn new() -> Self {
-        let tmpdir = tools::tempdir::TempPath::new();
+        let tmpdir = libra_tools::tempdir::TempPath::new();
         let cf_opts_map: ColumnFamilyOptionsMap = [
             (DEFAULT_CF_NAME, ColumnFamilyOptions::default()),
             (

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.6.5"
 [dev-dependencies]
 itertools = "0.8.0"
 proptest = "0.9.2"
-tools = { path = "../../common/tools" }
+libra-tools = { path = "../../common/tools" }
 libradb = { path = "../libradb", features = ["testing"] }
 libra-types = { path = "../../types", features = ["testing"] }
 

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -18,13 +18,13 @@ use storage_client::{
 fn start_test_storage_with_read_write_client(
     need_to_use_genesis: bool,
 ) -> (
-    tools::tempdir::TempPath,
+    libra_tools::tempdir::TempPath,
     ServerHandle,
     StorageReadServiceClient,
     StorageWriteServiceClient,
 ) {
     let mut config = NodeConfigHelpers::get_single_node_test_config(/* random_ports = */ true);
-    let tmp_dir = tools::tempdir::TempPath::new();
+    let tmp_dir = libra_tools::tempdir::TempPath::new();
     config.storage.dir = tmp_dir.path().to_path_buf();
 
     // initialize db with genesis info.

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -26,5 +26,5 @@ generate-keypair = { path = "../config/generate-keypair" }
 libra-swarm = { path = "../libra-swarm", features = ["testing"]}
 logger = { path = "../common/logger" }
 config = { path = "../config" }
-tools = { path = "../common/tools" }
+libra-tools = { path = "../common/tools" }
 crypto = { path = "../crypto/crypto" }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -7,12 +7,12 @@ use cli::{
 use config::config::{NodeConfig, RoleType};
 use crypto::{ed25519::*, test_utils::KeyPair, SigningKey};
 use libra_swarm::{swarm::LibraSwarm, utils};
+use libra_tools::tempdir::TempPath;
 use logger::prelude::*;
 use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
 use std::fs;
 use std::str::FromStr;
-use tools::tempdir::TempPath;
 
 struct TestEnvironment {
     validator_swarm: LibraSwarm,
@@ -39,7 +39,7 @@ impl TestEnvironment {
         )
         .unwrap();
 
-        let mnemonic_file = tools::tempdir::TempPath::new();
+        let mnemonic_file = libra_tools::tempdir::TempPath::new();
         mnemonic_file
             .create_as_file()
             .expect("could not create temporary mnemonic_file_path");


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `tools` package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235