### PR TITLE
[crypto] serialize/deserialize keypairs with LCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,6 @@ name = "client"
 version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.1.0",
  "crash-handler 0.1.0",
@@ -569,6 +568,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libra_wallet 0.1.0",
@@ -951,7 +951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "crypto"
 version = "0.1.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -963,6 +962,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "nibble 0.1.0",
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1538,9 +1538,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "generate-keypair"
 version = "0.1.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
+ "libra-canonical-serialization 0.1.0",
  "libra-tools 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.1"
 chrono = "0.4.7"
 futures = "0.1.28"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
@@ -30,6 +29,7 @@ config = { path = "../config" }
 crash-handler = { path = "../common/crash-handler" }
 crypto = { path = "../crypto/crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
+lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
 libra_wallet = { path = "./libra_wallet" }
 logger =  { path = "../common/logger" }
 metrics = { path = "../common/metrics" }

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -890,7 +890,7 @@ impl ClientProxy {
     ) -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
         match fs::read(faucet_account_file) {
             Ok(data) => {
-                bincode::deserialize(&data[..]).expect("Unable to deserialize faucet account file")
+                lcs::from_bytes(&data[..]).expect("Unable to deserialize faucet account file")
             }
             Err(e) => {
                 panic!(

--- a/common/lcs/src/ser.rs
+++ b/common/lcs/src/ser.rs
@@ -51,7 +51,7 @@ use std::collections::BTreeMap;
 /// ```
 pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
 where
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let mut serializer = Serializer::new();
     value.serialize(&mut serializer)?;

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bincode = { version = "1.1.4", default-features = false }
 structopt = "0.3.2"
 
+lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 crypto = { path = "../../crypto/crypto/"}
 libra-tools = { path = "../../common/tools" }

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use bincode::serialize;
 use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
 use libra_tools::tempdir::TempPath;
@@ -22,7 +21,7 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
     let keypair = KeyPair::from(private_key);
 
     // Write to disk
-    let encoded: Vec<u8> = serialize(&keypair).expect("Unable to serialize keys");
+    let encoded = lcs::to_bytes(&keypair).expect("Unable to serialize keys");
     let mut file =
         File::create(output_file_path).expect("Unable to create/truncate file at specified path");
     file.write_all(&encoded)
@@ -34,7 +33,7 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
 pub fn load_key_from_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>> {
-    bincode::deserialize(&fs::read(path)?[..]).map_err(|b| b.into())
+    lcs::from_bytes(&fs::read(path)?[..]).map_err(Into::into)
 }
 
 /// Returns the generated or loaded keypair, the path to the file where this keypair is saved,

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.1"
 byteorder = "1.3.2"
 bytes = "0.4.12"
 curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false }
@@ -32,6 +31,7 @@ x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "
 
 crypto_derive = { path = "../crypto_derive" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
+lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 nibble = { path = "../../common/nibble" }
 
 [dev-dependencies]

--- a/crypto/crypto/src/bls12381.rs
+++ b/crypto/crypto/src/bls12381.rs
@@ -31,7 +31,6 @@
 //! performance in consensus.
 
 use crate::{traits::*, HashValue};
-use bincode::{deserialize, serialize};
 use core::convert::TryFrom;
 use crypto_derive::{Deref, SilentDebug, SilentDisplay};
 use failure::prelude::*;
@@ -136,7 +135,7 @@ impl Uniform for BLS12381PrivateKey {
 
 impl std::cmp::PartialEq<Self> for BLS12381PrivateKey {
     fn eq(&self, other: &Self) -> bool {
-        serialize(self).unwrap() == serialize(other).unwrap()
+        lcs::to_bytes(self).unwrap() == lcs::to_bytes(other).unwrap()
     }
 }
 
@@ -150,7 +149,7 @@ impl TryFrom<&[u8]> for BLS12381PrivateKey {
             return Err(CryptoMaterialError::WrongLengthError);
         }
         // First we deserialize raw bytes, which may or may not work.
-        let key_res = deserialize::<BLS12381PrivateKey>(bytes);
+        let key_res = lcs::from_bytes(bytes);
         // Note that the underlying implementation of SerdeSecret checks for validation during
         // deserialization. Also, we don't need to check for validity of the derived PublicKey, as a
         // correct SerdeSecret (checked during deserialization that is in field) will always produce
@@ -161,7 +160,7 @@ impl TryFrom<&[u8]> for BLS12381PrivateKey {
 impl ValidKey for BLS12381PrivateKey {
     fn to_bytes(&self) -> Vec<u8> {
         // This is expected to succeed as we just return the bytes of an existing key.
-        bincode::serialize(&self.0).unwrap()
+        lcs::to_bytes(&self.0).unwrap()
     }
 }
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -644,7 +644,7 @@ pub trait TestOnlyHash {
 
 impl<T: ser::Serialize + ?Sized> TestOnlyHash for T {
     fn test_only_hash(&self) -> HashValue {
-        let bytes = ::bincode::serialize(self).expect("serialize failed during hash.");
+        let bytes = lcs::to_bytes(self).expect("serialize failed during hash.");
         let mut hasher = TestOnlyHasher::default();
         hasher.write(&bytes);
         hasher.finish()

--- a/crypto/crypto/src/test_utils.rs
+++ b/crypto/crypto/src/test_utils.rs
@@ -4,7 +4,6 @@
 //! Internal module containing convenience utility functions mainly for testing
 
 use crate::traits::Uniform;
-use bincode::serialize;
 use serde::{Deserialize, Serialize};
 
 /// A deterministic seed for PRNGs related to keys
@@ -71,8 +70,8 @@ where
     Pub: Serialize + for<'a> From<&'a Priv>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut v = serialize(&self.private_key).unwrap();
-        v.extend(&serialize(&self.public_key).unwrap());
+        let mut v = lcs::to_bytes(&self.private_key).unwrap();
+        v.extend(&lcs::to_bytes(&self.public_key).unwrap());
         write!(f, "{}", hex::encode(&v[..]))
     }
 }

--- a/crypto/crypto/src/unit_tests/bls12381_test.rs
+++ b/crypto/crypto/src/unit_tests/bls12381_test.rs
@@ -3,14 +3,13 @@
 
 use crate::{
     bls12381::{
-        BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature, BLS12381_PRIVATE_KEY_LENGTH,
+        BLS12381PrivateKey, BLS12381PublicKey, BLS12381_PRIVATE_KEY_LENGTH,
         BLS12381_PUBLIC_KEY_LENGTH, BLS12381_SIGNATURE_LENGTH,
     },
     hash::HashValue,
     traits::*,
     unit_tests::uniform_keypair_strategy,
 };
-use bincode::{deserialize, serialize};
 use proptest::prelude::*;
 use std::convert::TryFrom;
 
@@ -18,13 +17,13 @@ proptest! {
     #[test]
     fn test_keys_encode(keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()) {
         {
-            let serialized = serialize(&keypair.private_key).unwrap();
+            let serialized = lcs::to_bytes(&keypair.private_key).unwrap();
             let encoded = ::hex::encode(&serialized);
             let decoded = BLS12381PrivateKey::from_encoded_string(&encoded);
             prop_assert_eq!(Some(keypair.private_key), decoded.ok());
         }
         {
-            let serialized = serialize(&keypair.public_key).unwrap();
+            let serialized = lcs::to_bytes(&keypair.public_key).unwrap();
             let encoded = ::hex::encode(&serialized);
             let decoded = BLS12381PublicKey::from_encoded_string(&encoded);
             prop_assert_eq!(Some(keypair.public_key), decoded.ok());
@@ -34,12 +33,12 @@ proptest! {
     #[test]
     fn test_keys_serde(keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()) {
         {
-            let serialized: &[u8] = &serialize(&keypair.private_key).unwrap();
+            let serialized: &[u8] = &lcs::to_bytes(&keypair.private_key).unwrap();
             let deserialized = BLS12381PrivateKey::try_from(serialized);
             prop_assert_eq!(Some(keypair.private_key), deserialized.ok());
         }
         {
-            let serialized: &[u8] = &serialize(&keypair.public_key).unwrap();
+            let serialized: &[u8] = &lcs::to_bytes(&keypair.public_key).unwrap();
             let deserialized = BLS12381PublicKey::try_from(serialized);
             prop_assert_eq!(Some(keypair.public_key), deserialized.ok());
         }
@@ -73,9 +72,9 @@ proptest! {
         keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()
     ) {
         let signature = keypair.private_key.sign_message(&hash);
-        let serialized = serialize(&signature).unwrap();
+        let serialized = lcs::to_bytes(&signature).unwrap();
         prop_assert_eq!(serialized.len(), BLS12381_SIGNATURE_LENGTH);
-        let deserialized = deserialize::<BLS12381Signature>(&serialized).unwrap();
+        let deserialized = lcs::from_bytes(&serialized).unwrap();
         prop_assert!(keypair.public_key.verify_signature(&hash, &deserialized).is_ok());
     }
 
@@ -85,8 +84,8 @@ proptest! {
         keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()
     ) {
         let signature = keypair.private_key.sign_message(&hash);
-        let serialized = serialize(&signature).unwrap();
-        let deserialized = deserialize::<BLS12381Signature>(&serialized).unwrap();
+        let serialized = lcs::to_bytes(&signature).unwrap();
+        let deserialized = lcs::from_bytes(&serialized).unwrap();
         prop_assert!(keypair.public_key.verify_signature(&hash, &deserialized).is_ok());
     }
 }

--- a/crypto/crypto/src/unit_tests/hash_test.rs
+++ b/crypto/crypto/src/unit_tests/hash_test.rs
@@ -15,7 +15,7 @@ struct Foo(u32);
 fn test_default_hasher() {
     assert_eq!(
         Foo(3).test_only_hash(),
-        HashValue::from_iter_sha3(vec![::bincode::serialize(&Foo(3)).unwrap().as_slice()]),
+        HashValue::from_iter_sha3(vec![lcs::to_bytes(&Foo(3)).unwrap().as_slice()]),
     );
     assert_eq!(
         format!("{:x}", b"hello".test_only_hash()),

--- a/crypto/crypto/src/unit_tests/x25519_test.rs
+++ b/crypto/crypto/src/unit_tests/x25519_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{traits::*, x25519::*};
-use bincode::{deserialize, serialize};
 use rand::{rngs::StdRng, SeedableRng};
 
 #[test]
@@ -70,8 +69,8 @@ fn test_serialize_deserialize() {
     let private_key = X25519StaticPrivateKey::generate_for_testing(&mut rng);
     let public_key: X25519StaticPublicKey = (&private_key).into();
 
-    let serialized = serialize(&private_key).unwrap();
-    let deserialized = deserialize::<X25519StaticPrivateKey>(&serialized).unwrap();
+    let serialized = lcs::to_bytes(&private_key).unwrap();
+    let deserialized: X25519StaticPrivateKey = lcs::from_bytes(&serialized).unwrap();
 
     assert_eq!(public_key, (&deserialized).into());
 }


### PR DESCRIPTION
Convert from using bincode to LCS when serializing and deserializing
keypairs.

Fixes: #952