### PR TITLE
[consensusu][reconfig] carry reconfiguration info in vote

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -435,6 +435,10 @@ where
         self.block().round()
     }
 
+    pub fn epoch(&self) -> u64 {
+        self.block().epoch()
+    }
+
     pub fn timestamp_usecs(&self) -> u64 {
         self.block().timestamp_usecs()
     }

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -36,8 +36,8 @@ impl<T> Payload for T where
 {
 }
 
-pub fn round_hash(round: Round) -> HashValue {
-    let digest = lcs::to_bytes(&round).expect("Should serialize");
+pub fn timeout_hash(round: Round, epoch: u64) -> HashValue {
+    let digest = lcs::to_bytes(&(round, epoch)).expect("Should serialize");
     let mut state = RoundHasher::default();
     state.write(digest.as_ref());
     state.finish()

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -300,10 +300,7 @@ impl<T: Payload> BlockStore<T> {
                     assert_eq!(
                         executed_block.compute_result().executed_state.state_id,
                         qc.certified_block().executed_state_id(),
-                        "We have inconsistent executed state with the executed state from the quorum \
-                     certificate for block {}, will kill this validator and rely on state \
-                     synchronization to try to achieve consistent state with the quorum \
-                     certificate.",
+                        "QC for block {} has a different execution result than the local computation. Restart and try again.",
                         qc.certified_block().id(),
                     );
                 }

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -34,10 +34,7 @@ fn test_block_store_create_block() {
     assert_eq!(a1.quorum_cert().certified_block().id(), genesis.id());
 
     let a1_ref = block_on(block_store.execute_and_insert_block(a1)).unwrap();
-    let executed_state = &block_store
-        .get_compute_result(a1_ref.id())
-        .unwrap()
-        .executed_state;
+    let executed_state = &a1_ref.compute_result().executed_state;
 
     // certify a1
     let vote = Vote::new(
@@ -307,10 +304,7 @@ fn test_insert_vote() {
 
     assert!(block_store.get_quorum_cert_for_block(block.id()).is_none());
     for (i, voter) in signers.iter().enumerate().take(10).skip(1) {
-        let executed_state = &block_store
-            .get_compute_result(block.id())
-            .unwrap()
-            .executed_state;
+        let executed_state = &block.compute_result().executed_state;
 
         let vote = Vote::new(
             VoteData::new(
@@ -339,10 +333,7 @@ fn test_insert_vote() {
     }
 
     // Add the final vote to form a QC
-    let executed_state = &block_store
-        .get_compute_result(block.id())
-        .unwrap()
-        .executed_state;
+    let executed_state = &block.compute_result().executed_state;
     let final_voter = &signers[0];
     let vote = Vote::new(
         VoteData::new(

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -11,7 +11,6 @@ use consensus_types::{
     vote::Vote,
 };
 use crypto::HashValue;
-use executor::StateComputeResult;
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use mirai_annotations::{checked_verify_eq, precondition};
@@ -170,17 +169,6 @@ where
     pub(super) fn get_block(&self, block_id: &HashValue) -> Option<Arc<ExecutedBlock<T>>> {
         self.get_linkable_block(block_id)
             .map(|lb| Arc::clone(lb.executed_block()))
-    }
-
-    pub(super) fn get_compute_result(
-        &self,
-        block_id: &HashValue,
-    ) -> Option<Arc<StateComputeResult>> {
-        if self.root_id == *block_id {
-            None
-        } else {
-            self.get_block(block_id).map(|b| b.compute_result().clone())
-        }
     }
 
     pub(super) fn root(&self) -> Arc<ExecutedBlock<T>> {

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -15,7 +15,6 @@ mod block_tree;
 mod pending_votes;
 
 pub use block_store::{BlockStore, NeedFetchResult};
-use executor::StateComputeResult;
 
 /// Result of the vote processing. The failure case (Verification error) is returned
 /// as the Error part of the result.
@@ -44,12 +43,6 @@ pub trait BlockReader: Send + Sync {
 
     /// Try to get a block with the block_id, return an Arc of it if found.
     fn get_block(&self, block_id: HashValue) -> Option<Arc<ExecutedBlock<Self::Payload>>>;
-
-    /// Try to get a compute result given the specified block id.
-    ///
-    /// Returns an option since all blocks should have a compute result or None for root block
-    /// since it has already been committed.
-    fn get_compute_result(&self, block_id: HashValue) -> Option<Arc<StateComputeResult>>;
 
     /// Get the current root block of the BlockTree.
     fn root(&self) -> Arc<ExecutedBlock<Self::Payload>>;

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -116,13 +116,12 @@ impl PendingVotes {
         vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> Option<VoteReceptionResult> {
-        let round_signature = vote.round_signature().cloned()?;
+        let timeout_signature = vote.timeout_signature().cloned()?;
         let round = vote.vote_data().proposed().round();
-        let tc = self
-            .round_to_tc
-            .entry(round)
-            .or_insert_with(|| TimeoutCertificate::new(round, HashMap::new()));
-        tc.add_signature(vote.author(), round_signature);
+        let tc = self.round_to_tc.entry(round).or_insert_with(|| {
+            TimeoutCertificate::new(vote.vote_data().proposed().epoch(), round, HashMap::new())
+        });
+        tc.add_signature(vote.author(), timeout_signature);
         match validator_verifier.check_voting_power(tc.signatures().keys()) {
             Ok(_) => Some(VoteReceptionResult::NewTimeoutCertificate(Arc::new(
                 tc.clone(),

--- a/consensus/src/chained_bft/block_storage/pending_votes_test.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes_test.rs
@@ -180,7 +180,7 @@ fn test_tc_aggregation() {
         li1.clone(),
         &signers[0],
     );
-    vote_round_1_author_0.add_round_signature(&signers[0]);
+    vote_round_1_author_0.add_timeout_signature(&signers[0]);
 
     // first time a new vote is added the result is VoteAdded
     assert_eq!(
@@ -204,7 +204,7 @@ fn test_tc_aggregation() {
     );
 
     // if that vote is now enhanced with a round signature, it can form a TC
-    vote2_round_1_author_1.add_round_signature(&signers[1]);
+    vote2_round_1_author_1.add_timeout_signature(&signers[1]);
     match pending_votes.insert_vote(&vote2_round_1_author_1, &validator) {
         VoteReceptionResult::NewTimeoutCertificate(tc) => {
             assert!(validator.check_voting_power(tc.signatures().keys()).is_ok());
@@ -231,7 +231,7 @@ fn test_tc_aggregation_keep_last_only() {
         li1.clone(),
         &signers[0],
     );
-    vote_round_1_author_0.add_round_signature(&signers[0]);
+    vote_round_1_author_0.add_timeout_signature(&signers[0]);
 
     // first time a new vote is added the result is VoteAdded
     assert_eq!(
@@ -248,7 +248,7 @@ fn test_tc_aggregation_keep_last_only() {
         li2.clone(),
         &signers[0],
     );
-    vote_round_2_author_0.add_round_signature(&signers[0]);
+    vote_round_2_author_0.add_timeout_signature(&signers[0]);
     assert_eq!(
         pending_votes.insert_vote(&vote_round_2_author_0, &validator),
         VoteReceptionResult::VoteAdded(1)
@@ -263,7 +263,7 @@ fn test_tc_aggregation_keep_last_only() {
         li3.clone(),
         &signers[1],
     );
-    vote3_round_1_author_1.add_round_signature(&signers[1]);
+    vote3_round_1_author_1.add_timeout_signature(&signers[1]);
     assert_eq!(
         pending_votes.insert_vote(&vote3_round_1_author_1, &validator),
         VoteReceptionResult::VoteAdded(1)
@@ -278,7 +278,7 @@ fn test_tc_aggregation_keep_last_only() {
         li4.clone(),
         &signers[1],
     );
-    vote4_round_2_author_1.add_round_signature(&signers[1]);
+    vote4_round_2_author_1.add_timeout_signature(&signers[1]);
     match pending_votes.insert_vote(&vote4_round_2_author_1, &validator) {
         VoteReceptionResult::NewTimeoutCertificate(tc) => {
             assert!(validator.check_voting_power(tc.signatures().keys()).is_ok());

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -379,7 +379,7 @@ impl<T: Payload> EventProcessor<T> {
         };
 
         if !timeout_vote.is_timeout() {
-            timeout_vote.add_round_signature(self.block_store.signer());
+            timeout_vote.add_timeout_signature(self.block_store.signer());
         }
         let timeout_vote_msg = VoteMsg::new(timeout_vote, self.gen_sync_info());
         self.network.broadcast_vote(timeout_vote_msg).await

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -259,11 +259,7 @@ fn basic_new_rank_event_test() {
         );
         assert_eq!(pending_proposals[0].proposer(), node.author);
 
-        let executed_state = &node
-            .block_store
-            .get_compute_result(a1.id())
-            .unwrap()
-            .executed_state;
+        let executed_state = &a1.compute_result().executed_state;
 
         // Simulate a case with a1 receiving enough votes for a QC: a new proposal
         // should be a child of a1 and carry its QC.
@@ -705,11 +701,7 @@ fn process_votes_basic_test() {
     let genesis = node.block_store.root();
     let mut inserter = TreeInserter::new(node.block_store.clone());
     let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
-    let executed_state = &node
-        .block_store
-        .get_compute_result(a1.id())
-        .unwrap()
-        .executed_state;
+    let executed_state = &a1.compute_result().executed_state;
 
     let vote_data = VoteData::new(
         BlockInfo::new(

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -555,7 +555,7 @@ fn process_vote_timeout_msg_test() {
         &non_proposer.signer,
     );
 
-    vote_on_timeout.add_round_signature(&non_proposer.signer);
+    vote_on_timeout.add_timeout_signature(&non_proposer.signer);
 
     let vote_msg_on_timeout = VoteMsg::new(
         vote_on_timeout,
@@ -565,7 +565,6 @@ fn process_vote_timeout_msg_test() {
             None,
         ),
     );
-
     block_on(
         static_proposer
             .event_processor
@@ -663,7 +662,7 @@ fn process_timeout_certificate_test() {
         genesis_qc.clone(),
         node.block_store.signer(),
     );
-    let tc = TimeoutCertificate::new(1, HashMap::new());
+    let tc = TimeoutCertificate::new(1, 1, HashMap::new());
 
     block_on(async move {
         let skip_round_proposal = ProposalMsg::<TestPayload>::new(

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -260,7 +260,7 @@ impl NetworkPlayground {
     pub fn timeout_votes_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
         // Timeout votes carry non-empty round signatures.
         if let Some(ConsensusMsg_oneof::VoteMsg(vote_msg)) = &msg_copy.1.message {
-            !vote_msg.vote.as_ref().unwrap().round_signature.is_empty()
+            !vote_msg.vote.as_ref().unwrap().timeout_signature.is_empty()
         } else {
             false
         }

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -35,10 +35,11 @@ message SyncInfo {
 }
 
 message TimeoutCertificate {
+  uint64 epoch = 1;
   // Round certified by this timeout certificate.
-  uint64 round = 1;
+  uint64 round = 2;
   // List of signatures certifying the timeout.
-  repeated types.ValidatorSignature signatures = 2;
+  repeated types.ValidatorSignature signatures = 3;
 }
 
 message Block {
@@ -118,7 +119,7 @@ message Vote {
   // Signature of the ledger info.
   bytes signature = 4;
   // The round signatures can be aggregated into the timeout certificate.
-  bytes round_signature = 5;
+  bytes timeout_signature = 5;
 }
 
 message VoteMsg {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We now populate the epoch num and validator set from execution to vote
and ledger info.

Also removed `get_compute_result` since we already have `ExecutedBlock`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
