### PR TITLE
[cluster_test] Fix printing of health-check results

### DIFF
--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -141,17 +141,19 @@ impl HealthCheckRunner {
         }
 
         let mut failed = vec![];
+        let mut validators_message = "".to_string();
         for (i, (node, healthy)) in node_health.into_iter().sorted().enumerate() {
             if healthy {
-                messages.push(format!("{}* {}{}   ", Fg(Green), node, Fg(Reset)));
+                validators_message.push_str(&format!("{}* {}{}   ", Fg(Green), node, Fg(Reset)));
             } else {
-                messages.push(format!("{}* {}{}   ", Fg(Red), node, Fg(Reset)));
+                validators_message.push_str(&format!("{}* {}{}   ", Fg(Red), node, Fg(Reset)));
                 failed.push(node);
             }
             if (i + 1) % 15 == 0 {
-                messages.push(format!(""));
+                validators_message.push_str("\n");
             }
         }
+        messages.push(validators_message);
         messages.push(format!(""));
         messages.push(format!(""));
 


### PR DESCRIPTION
## Summary

After #1305 the health-check printing was printing one validator per line as seen below. This PR fixes it to old behaviour

![image](https://user-images.githubusercontent.com/796949/66965953-654aad00-f030-11e9-8f87-0b80e904f87b.png)

## Test Plan

Ran --health-check on my workspace and verified the expected behaviour

![image](https://user-images.githubusercontent.com/796949/66965924-46e4b180-f030-11e9-9c8c-5818749943ab.png)

Related to #1244

Bug introduced by #1305