### PR TITLE
[language][functional tests] code cleanup & refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
  "config 0.1.0",
+ "crypto 0.1.0",
  "datatest-stable 0.1.0",
  "failure_ext 0.1.0",
  "filecheck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -18,6 +18,7 @@ vm = { path = "../vm" }
 bytecode-verifier = { path = "../bytecode-verifier" }
 language_e2e_tests = { path = "../e2e_tests" }
 config = { path = "../../config" }
+crypto = { path = "../../crypto/crypto" }
 filecheck = "0.4.0"
 lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
@@ -25,6 +26,7 @@ regex = { version = "1.3.0", default-features = false, features = ["std", "perf"
 [dev-dependencies]
 libra-types = { path = "../../types", features = ["testing"] }
 datatest-stable = { path = "../../common/datatest-stable" }
+crypto = { path = "../../crypto/crypto", features = ["testing"] }
 
 [[test]]
 name = "testsuite"

--- a/language/functional_tests/src/config/mod.rs
+++ b/language/functional_tests/src/config/mod.rs
@@ -3,3 +3,11 @@
 
 pub mod global;
 pub mod transaction;
+
+fn strip<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.starts_with(prefix) {
+        Some(&s[prefix.len()..])
+    } else {
+        None
+    }
+}

--- a/language/functional_tests/src/config/transaction.rs
+++ b/language/functional_tests/src/config/transaction.rs
@@ -1,7 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::global::Config as GlobalConfig, errors::*, evaluator::Stage};
+use crate::{
+    config::{global::Config as GlobalConfig, strip},
+    errors::*,
+    evaluator::Stage,
+};
+use language_e2e_tests::account::Account;
 use libra_types::transaction::{parse_as_transaction_argument, TransactionArgument};
 use std::{collections::BTreeSet, str::FromStr};
 
@@ -41,21 +46,18 @@ impl FromStr for Entry {
 
     fn from_str(s: &str) -> Result<Self> {
         let s = s.split_whitespace().collect::<String>();
-        if !s.starts_with("//!") {
-            return Err(
-                ErrorKind::Other("txn config entry must start with //!".to_string()).into(),
-            );
-        }
-        let s = s[3..].trim_start();
-        if s.starts_with("sender:") {
-            let s = s[7..].trim_start().trim_end();
+        let s = strip(&s, "//!")
+            .ok_or_else(|| ErrorKind::Other("txn config entry must start with //!".to_string()))?
+            .trim_start();
+
+        if let Some(s) = strip(s, "sender:") {
             if s.is_empty() {
                 return Err(ErrorKind::Other("sender cannot be empty".to_string()).into());
             }
             return Ok(Entry::Sender(s.to_ascii_lowercase()));
         }
-        if s.starts_with("args:") {
-            let res: Result<Vec<_>> = s[5..]
+        if let Some(s) = strip(s, "args:") {
+            let res: Result<Vec<_>> = s
                 .split(',')
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
@@ -63,8 +65,8 @@ impl FromStr for Entry {
                 .collect();
             return Ok(Entry::Arguments(res?));
         }
-        if s.starts_with("no-run:") {
-            let res: Result<Vec<_>> = s[7..]
+        if let Some(s) = strip(s, "no-run:") {
+            let res: Result<Vec<_>> = s
                 .split(',')
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
@@ -72,11 +74,11 @@ impl FromStr for Entry {
                 .collect();
             return Ok(Entry::DisableStages(res?));
         }
-        if s.starts_with("max-gas:") {
-            return Ok(Entry::MaxGas(s[8..].parse::<u64>()?));
+        if let Some(s) = strip(s, "max-gas:") {
+            return Ok(Entry::MaxGas(s.parse::<u64>()?));
         }
-        if s.starts_with("sequence-number:") {
-            return Ok(Entry::SequenceNumber(s[16..].parse::<u64>()?));
+        if let Some(s) = strip(s, "sequence-number:") {
+            return Ok(Entry::SequenceNumber(s.parse::<u64>()?));
         }
         Err(ErrorKind::Other(format!(
             "failed to parse '{}' as transaction config entry",
@@ -108,17 +110,17 @@ impl Entry {
 /// A table of options specific to one transaction, fine tweaking how the transaction
 /// is handled by the testing infra.
 #[derive(Debug)]
-pub struct Config {
+pub struct Config<'a> {
     pub disabled_stages: BTreeSet<Stage>,
-    pub sender: String,
+    pub sender: &'a Account,
     pub args: Vec<TransactionArgument>,
     pub max_gas: Option<u64>,
     pub sequence_number: Option<u64>,
 }
 
-impl Config {
+impl<'a> Config<'a> {
     /// Builds a transaction config table from raw entries.
-    pub fn build(config: &GlobalConfig, entries: &[Entry]) -> Result<Self> {
+    pub fn build(config: &'a GlobalConfig, entries: &[Entry]) -> Result<Self> {
         let mut disabled_stages = BTreeSet::new();
         let mut sender = None;
         let mut args = None;
@@ -128,19 +130,7 @@ impl Config {
         for entry in entries {
             match entry {
                 Entry::Sender(name) => match sender {
-                    None => {
-                        if config.accounts.contains_key(name)
-                            || config.genesis_accounts.contains_key(name)
-                        {
-                            sender = Some(name.to_string())
-                        } else {
-                            return Err(ErrorKind::Other(format!(
-                                "account '{}' does not exist",
-                                name
-                            ))
-                            .into());
-                        }
-                    }
+                    None => sender = Some(config.get_account_for_name(name)?),
                     _ => return Err(ErrorKind::Other("sender already set".to_string()).into()),
                 },
                 Entry::Arguments(raw_args) => match args {
@@ -149,16 +139,9 @@ impl Config {
                             raw_args
                                 .iter()
                                 .map(|arg| match arg {
-                                    Argument::AddressOf(name) => match config.accounts.get(name) {
-                                        Some(data) => {
-                                            Ok(TransactionArgument::Address(*data.address()))
-                                        }
-                                        None => Err(ErrorKind::Other(format!(
-                                            "account '{}' does not exist",
-                                            name
-                                        ))
-                                        .into()),
-                                    },
+                                    Argument::AddressOf(name) => Ok(TransactionArgument::Address(
+                                        *config.get_account_for_name(name)?.address(),
+                                    )),
                                     Argument::SelfContained(arg) => Ok(arg.clone()),
                                 })
                                 .collect::<Result<Vec<_>>>()?,
@@ -201,9 +184,9 @@ impl Config {
             }
         }
 
-        Ok(Config {
+        Ok(Self {
             disabled_stages,
-            sender: sender.unwrap_or_else(|| "default".to_string()),
+            sender: sender.unwrap_or_else(|| config.accounts.get("default").unwrap().account()),
             args: args.unwrap_or_else(|| vec![]),
             max_gas,
             sequence_number,

--- a/language/functional_tests/src/errors.rs
+++ b/language/functional_tests/src/errors.rs
@@ -9,7 +9,7 @@ pub use failure::Error;
 /// Defines all errors in this crate.
 #[derive(Clone, Debug, Fail)]
 pub enum ErrorKind {
-    #[fail(display = "an error occurred when executing the program")]
+    #[fail(display = "an error occurred when executing the transaction")]
     VMExecutionFailure(TransactionOutput),
     #[fail(display = "the transaction was discarded")]
     DiscardedTransaction(TransactionOutput),

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -9,13 +9,15 @@ use bytecode_verifier::verifier::{
     verify_module_dependencies, verify_script_dependencies, VerifiedModule, VerifiedScript,
 };
 use config::config::VMPublishingOption;
+use crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use ir_to_bytecode::{
     compiler::{compile_module, compile_script},
     parser::parse_script_or_module,
 };
 use ir_to_bytecode_syntax::ast::ScriptOrModule;
-use language_e2e_tests::{account::Account, executor::FakeExecutor};
+use language_e2e_tests::executor::FakeExecutor;
 use libra_types::{
+    account_address::AccountAddress,
     transaction::{
         Module as TransactionModule, RawTransaction, Script as TransactionScript,
         SignedTransaction, TransactionOutput, TransactionStatus,
@@ -30,8 +32,8 @@ use vm::gas_schedule::{GasAlgebra, MAXIMUM_NUMBER_OF_GAS_UNITS};
 /// A transaction to be evaluated by the testing infra.
 /// Contains code and a transaction config.
 #[derive(Debug)]
-pub struct Transaction {
-    pub config: TransactionConfig,
+pub struct Transaction<'a> {
+    pub config: TransactionConfig<'a>,
     pub input: String,
 }
 
@@ -184,10 +186,45 @@ fn do_verify_module(module: CompiledModule, deps: &[VerifiedModule]) -> Result<V
     Ok(verified_module)
 }
 
+/// A set of common parameters required to create transactions.
+struct TransactionParameters<'a> {
+    pub sender_addr: AccountAddress,
+    pub pubkey: &'a Ed25519PublicKey,
+    pub privkey: &'a Ed25519PrivateKey,
+    pub sequence_number: u64,
+    pub max_gas_amount: u64,
+    pub gas_unit_price: u64,
+    pub expiration_time: Duration,
+}
+
+/// Gets the transaction parameters from the current execution environment and the config.
+fn get_transaction_parameters<'a>(
+    exec: &'a FakeExecutor,
+    config: &'a TransactionConfig,
+) -> TransactionParameters<'a> {
+    let account_resource = exec.read_account_resource(config.sender).unwrap();
+
+    TransactionParameters {
+        sender_addr: *config.sender.address(),
+        pubkey: &config.sender.pubkey,
+        privkey: &config.sender.privkey,
+        sequence_number: config
+            .sequence_number
+            .unwrap_or_else(|| account_resource.sequence_number()),
+        max_gas_amount: config.max_gas.unwrap_or_else(|| {
+            std::cmp::min(
+                MAXIMUM_NUMBER_OF_GAS_UNITS.get(),
+                account_resource.balance(),
+            )
+        }),
+        gas_unit_price: 1,
+        expiration_time: Duration::from_secs(u64::max_value()),
+    }
+}
+
 /// Creates and signs a script transaction.
 fn make_script_transaction(
     exec: &FakeExecutor,
-    account: &Account,
     config: &TransactionConfig,
     script: CompiledScript,
 ) -> Result<SignedTransaction> {
@@ -195,30 +232,22 @@ fn make_script_transaction(
     script.serialize(&mut blob)?;
     let script = TransactionScript::new(blob, config.args.clone());
 
-    let account_resource = exec.read_account_resource(&account).unwrap();
+    let params = get_transaction_parameters(exec, config);
     Ok(RawTransaction::new_script(
-        *account.address(),
-        config
-            .sequence_number
-            .unwrap_or_else(|| account_resource.sequence_number()),
+        params.sender_addr,
+        params.sequence_number,
         script,
-        config.max_gas.unwrap_or_else(|| {
-            std::cmp::min(
-                MAXIMUM_NUMBER_OF_GAS_UNITS.get(),
-                account_resource.balance(),
-            )
-        }),
-        1,
-        Duration::from_secs(u64::max_value()),
+        params.max_gas_amount,
+        params.gas_unit_price,
+        params.expiration_time,
     )
-    .sign(&account.privkey, account.pubkey.clone())?
+    .sign(params.privkey, params.pubkey.clone())?
     .into_inner())
 }
 
 /// Creates and signs a module transaction.
 fn make_module_transaction(
     exec: &FakeExecutor,
-    account: &Account,
     config: &TransactionConfig,
     module: CompiledModule,
 ) -> Result<SignedTransaction> {
@@ -226,23 +255,16 @@ fn make_module_transaction(
     module.serialize(&mut blob)?;
     let module = TransactionModule::new(blob);
 
-    let account_resource = exec.read_account_resource(&account).unwrap();
+    let params = get_transaction_parameters(exec, config);
     Ok(RawTransaction::new_module(
-        *account.address(),
-        config
-            .sequence_number
-            .unwrap_or_else(|| account_resource.sequence_number()),
+        params.sender_addr,
+        params.sequence_number,
         module,
-        config.max_gas.unwrap_or_else(|| {
-            std::cmp::min(
-                MAXIMUM_NUMBER_OF_GAS_UNITS.get(),
-                account_resource.balance(),
-            )
-        }),
-        1,
-        Duration::from_secs(u64::max_value()),
+        params.max_gas_amount,
+        params.gas_unit_price,
+        params.expiration_time,
     )
-    .sign(&account.privkey, account.pubkey.clone())?
+    .sign(params.privkey, params.pubkey.clone())?
     .into_inner())
 }
 
@@ -266,7 +288,7 @@ fn run_transaction(
             TransactionStatus::Discard(_) => Err(ErrorKind::DiscardedTransaction(output).into()),
         }
     } else {
-        panic!("transaction outputs size mismatch");
+        unreachable!("transaction outputs size mismatch")
     }
 }
 
@@ -302,35 +324,29 @@ fn serialize_and_deserialize_module(module: &CompiledModule) -> Result<()> {
     Ok(())
 }
 
-/// Tries to unwrap the given result. Upon failure, log the error and aborts.
-macro_rules! unwrap_or_abort {
-    ($res: expr, $log: expr) => {{
-        match $res {
-            Ok(r) => r,
-            Err(e) => {
-                $log.append(EvaluationOutput::Error(Box::new(e)));
-                return Ok(Status::Failure);
-            }
-        }
-    }};
-}
-
 fn eval_transaction(
-    config: &GlobalConfig,
     exec: &mut FakeExecutor,
     deps: &mut Vec<VerifiedModule>,
     idx: usize,
     transaction: &Transaction,
     log: &mut EvaluationLog,
 ) -> Result<Status> {
-    // get the account of the sender
-    let account = config
-        .get_account_for_name(&transaction.config.sender)
-        .unwrap();
-    let addr = account.address();
+    /// Unwrap the given results. Upon failure, logs the error and aborts.
+    macro_rules! unwrap_or_abort {
+        ($res: expr) => {{
+            match $res {
+                Ok(r) => r,
+                Err(e) => {
+                    log.append(EvaluationOutput::Error(Box::new(e)));
+                    return Ok(Status::Failure);
+                }
+            }
+        }};
+    }
 
-    // start processing a new transaction
-    // insert a barrier in the output
+    let sender_addr = *transaction.config.sender.address();
+
+    // Start processing a new transaction.
     log.append(EvaluationOutput::Transaction(idx));
 
     // stage 1: parse the script/module
@@ -338,7 +354,7 @@ fn eval_transaction(
         return Ok(Status::Success);
     }
     log.append(EvaluationOutput::Stage(Stage::Parser));
-    let parsed_script_or_module = unwrap_or_abort!(parse_script_or_module(&transaction.input), log);
+    let parsed_script_or_module = unwrap_or_abort!(parse_script_or_module(&transaction.input));
     log.append(EvaluationOutput::Output(Box::new(OutputType::Ast(
         parsed_script_or_module.clone(),
     ))));
@@ -352,7 +368,7 @@ fn eval_transaction(
             log.append(EvaluationOutput::Stage(Stage::Compiler));
 
             let compiled_script =
-                unwrap_or_abort!(compile_script(*addr, parsed_script, &*deps), log).0;
+                unwrap_or_abort!(compile_script(sender_addr, parsed_script, &*deps)).0;
             log.append(EvaluationOutput::Output(Box::new(
                 OutputType::CompiledScript(compiled_script.clone()),
             )));
@@ -363,12 +379,12 @@ fn eval_transaction(
             }
             log.append(EvaluationOutput::Stage(Stage::Verifier));
             let compiled_script =
-                unwrap_or_abort!(do_verify_script(compiled_script, &*deps), log).into_inner();
+                unwrap_or_abort!(do_verify_script(compiled_script, &*deps)).into_inner();
 
             // stage 4: serializer round trip
             if !transaction.config.is_stage_disabled(Stage::Serializer) {
                 log.append(EvaluationOutput::Stage(Stage::Serializer));
-                unwrap_or_abort!(serialize_and_deserialize_script(&compiled_script), log);
+                unwrap_or_abort!(serialize_and_deserialize_script(&compiled_script));
             }
 
             // stage 5: execute the script
@@ -377,8 +393,8 @@ fn eval_transaction(
             }
             log.append(EvaluationOutput::Stage(Stage::Runtime));
             let script_transaction =
-                make_script_transaction(&exec, account, &transaction.config, compiled_script)?;
-            let txn_output = unwrap_or_abort!(run_transaction(exec, script_transaction), log);
+                make_script_transaction(&exec, &transaction.config, compiled_script)?;
+            let txn_output = unwrap_or_abort!(run_transaction(exec, script_transaction));
             log.append(EvaluationOutput::Output(Box::new(
                 OutputType::TransactionOutput(txn_output),
             )));
@@ -391,7 +407,7 @@ fn eval_transaction(
             log.append(EvaluationOutput::Stage(Stage::Compiler));
 
             let compiled_module =
-                unwrap_or_abort!(compile_module(*addr, parsed_module, &*deps), log).0;
+                unwrap_or_abort!(compile_module(sender_addr, parsed_module, &*deps)).0;
             log.append(EvaluationOutput::Output(Box::new(
                 OutputType::CompiledModule(compiled_module.clone()),
             )));
@@ -408,12 +424,12 @@ fn eval_transaction(
             }
             log.append(EvaluationOutput::Stage(Stage::Verifier));
             let compiled_module =
-                unwrap_or_abort!(do_verify_module(compiled_module, &*deps), log).into_inner();
+                unwrap_or_abort!(do_verify_module(compiled_module, &*deps)).into_inner();
 
             // stage 4: serializer round trip
             if !transaction.config.is_stage_disabled(Stage::Serializer) {
                 log.append(EvaluationOutput::Stage(Stage::Serializer));
-                unwrap_or_abort!(serialize_and_deserialize_module(&compiled_module), log);
+                unwrap_or_abort!(serialize_and_deserialize_module(&compiled_module));
             }
 
             // stage 5: publish the module
@@ -422,8 +438,8 @@ fn eval_transaction(
             }
             log.append(EvaluationOutput::Stage(Stage::Runtime));
             let module_transaction =
-                make_module_transaction(&exec, account, &transaction.config, compiled_module)?;
-            let txn_output = unwrap_or_abort!(run_transaction(exec, module_transaction), log);
+                make_module_transaction(&exec, &transaction.config, compiled_module)?;
+            let txn_output = unwrap_or_abort!(run_transaction(exec, module_transaction));
             log.append(EvaluationOutput::Output(Box::new(
                 OutputType::TransactionOutput(txn_output),
             )));
@@ -436,18 +452,17 @@ fn eval_transaction(
 pub fn eval(config: &GlobalConfig, transactions: &[Transaction]) -> Result<EvaluationLog> {
     let mut log = EvaluationLog { outputs: vec![] };
 
-    // set up a fake executor with the genesis block and create the accounts
+    // Set up a fake executor with the genesis block and create the accounts.
     let mut exec = FakeExecutor::from_genesis_with_options(VMPublishingOption::Open);
     for data in config.accounts.values() {
         exec.add_account_data(&data);
     }
 
-    // set up standard library
-    // needed to compile transaction programs
+    // Get the standard library modules (compiled & verified).
     let mut deps = stdlib_modules().to_vec();
 
     for (idx, transaction) in transactions.iter().enumerate() {
-        let status = eval_transaction(config, &mut exec, &mut deps, idx, transaction, &mut log)?;
+        let status = eval_transaction(&mut exec, &mut deps, idx, transaction, &mut log)?;
         log.append(EvaluationOutput::Status(status));
     }
 

--- a/language/functional_tests/src/tests/transaction_config_tests.rs
+++ b/language/functional_tests/src/tests/transaction_config_tests.rs
@@ -104,7 +104,7 @@ fn parse_new_transaction() {
     assert!(!is_new_transaction("//! transaction"));
 }
 
-fn parse_and_build_config(global_config: &GlobalConfig, s: &str) -> Result<Config> {
+fn parse_and_build_config<'a>(global_config: &'a GlobalConfig, s: &str) -> Result<Config<'a>> {
     Config::build(&global_config, &parse_each_line_as::<Entry>(s)?)
 }
 

--- a/language/functional_tests/src/tests/utils_tests.rs
+++ b/language/functional_tests/src/tests/utils_tests.rs
@@ -1,4 +1,15 @@
-use crate::utils::parse_input;
+use crate::{
+    config::global::Config as GlobalConfig,
+    errors::*,
+    utils::{build_transactions, split_input},
+};
+
+fn parse_input(input: &str) -> Result<()> {
+    let (config, _, transactions) = split_input(&input)?;
+    let config = GlobalConfig::build(&config)?;
+    build_transactions(&config, &transactions)?;
+    Ok(())
+}
 
 #[test]
 fn parse_input_no_transactions() {
@@ -34,7 +45,7 @@ fn parse_input_config_before_first_empty_transaction() {
 fn parse_input_empty_transaction() {
     parse_input(r"
         main() {}
-        
+
         //! new-transaction
 
         //! new-transaction

--- a/language/functional_tests/tests/testsuite.rs
+++ b/language/functional_tests/tests/testsuite.rs
@@ -1,16 +1,22 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use functional_tests::{checker::check, evaluator::eval, utils::parse_input};
-use std::{fs::File, io::Read, path::Path};
+use functional_tests::{
+    checker::check,
+    config::global::Config as GlobalConfig,
+    evaluator::eval,
+    utils::{build_transactions, split_input},
+};
+use std::{fs::read_to_string, path::Path};
 
 // Runs all tests under the test/testsuite directory.
 fn functional_tests(path: &Path) -> datatest_stable::Result<()> {
-    let mut file = File::open(path)?;
-    let mut input = String::new();
-    file.read_to_string(&mut input)?;
+    let input = read_to_string(path)?;
 
-    let (config, directives, transactions) = parse_input(&input)?;
+    let (config, directives, transactions) = split_input(&input)?;
+    let config = GlobalConfig::build(&config)?;
+    let transactions = build_transactions(&config, &transactions)?;
+
     let log = eval(&config, &transactions)?;
     if let Err(e) = check(&log, &directives) {
         // TODO: allow the user to select debug/display mode


### PR DESCRIPTION
## Summary
This cleans up the code in functional tests a bit. Major changes:
- Better code reuse.
- Fewer arguments to functions & macros.
- Improved config parsing.
    - No longer counts prefix lengths manually.

## Test Plan
cargo test