### PR TITLE
[cluster_test] Fix fn wait_until_all_healthy

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -596,12 +596,12 @@ impl ClusterTestRunner {
             }
             let deadline = now + HEALTH_POLL_INTERVAL;
             let events = self.logs.recv_all_until_deadline(deadline);
-            if self
-                .health_check_runner
-                .run(&events, &HashSet::new(), true)
-                .is_err()
+            if let Ok(failed_instances) =
+                self.health_check_runner.run(&events, &HashSet::new(), true)
             {
-                break;
+                if failed_instances.is_empty() {
+                    break;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

#1305 introduced a bug in `fn wait_until_all_healthy` where we were breaking prematurely instead of waiting for all the validators to be healthy. This fixes the logic in `wait_until_all_healthy`

## Test Plan

Built binary, ran it on cluster-test workspace

Related to #1244

Bug introduced by #1305

