### PR TITLE
[language] Change test generation to no longer directly create a TransactionExecutor

### DIFF
--- a/language/e2e_tests/src/lib.rs
+++ b/language/e2e_tests/src/lib.rs
@@ -62,7 +62,7 @@ pub fn execute(
     execute_function(script, modules, args, &data_view)
 }
 
-fn verify(
+pub fn verify(
     sender_address: &AccountAddress,
     compiled_script: CompiledScript,
     modules: Vec<CompiledModule>,

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -16,28 +16,22 @@ extern crate mirai_annotations;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
-use crate::config::{Args, EXECUTE_UNVERIFIED_MODULE, GAS_METERING, RUN_ON_VM};
+use crate::config::{Args, EXECUTE_UNVERIFIED_MODULE, RUN_ON_VM};
 use bytecode_generator::BytecodeGenerator;
 use bytecode_verifier::VerifiedModule;
 use cost_synthesis::module_generator::ModuleBuilder;
-use language_e2e_tests::data_store::FakeDataStore;
-use libra_types::{account_address::AccountAddress, byte_array::ByteArray};
+use language_e2e_tests::{execute, verify};
+use libra_types::{
+    account_address::AccountAddress, byte_array::ByteArray, transaction::TransactionArgument,
+};
 use std::{fs, io::Write, panic};
 use vm::{
+    access::ScriptAccess,
     file_format::{
-        Bytecode, CompiledModuleMut, FunctionDefinitionIndex, FunctionSignature, SignatureToken,
+        Bytecode, CompiledModule, CompiledModuleMut, FunctionSignature, SignatureToken,
         StructDefinitionIndex,
     },
-    transaction_metadata::TransactionMetadata,
-    CompiledModule,
 };
-use vm_cache_map::Arena;
-use vm_runtime::{
-    code_cache::module_cache::{ModuleCache, VMModuleCache},
-    loaded_data::function::{FunctionRef, FunctionReference},
-    txn_executor::TransactionExecutor,
-};
-use vm_runtime_types::value::Value;
 
 /// This function calls the Bytecode verifier to test it
 fn run_verifier(module: CompiledModule) -> Result<VerifiedModule, String> {
@@ -51,45 +45,37 @@ fn run_verifier(module: CompiledModule) -> Result<VerifiedModule, String> {
 /// This function runs a verified module in the VM runtime
 /// This code is based on `cost-synthesis/src/vm_runner.rs`
 fn run_vm(module: VerifiedModule) -> Result<(), String> {
-    use vm::access::ModuleAccess;
-    let mut modules = ::stdlib::stdlib_modules().to_vec();
+    let modules = ::stdlib::stdlib_modules().to_vec();
     // The standard library modules are bounded
     assume!(modules.len() < usize::max_value());
-    modules.push(module);
-    let root_module = modules
-        .last()
-        .expect("[VM Setup] Unable to get root module");
-    let allocator = Arena::new();
-    let module_id = root_module.self_id();
-    let module_cache = VMModuleCache::new(&allocator);
-    let entry_idx = FunctionDefinitionIndex::new(0);
-    let data_cache = FakeDataStore::default();
-    module_cache.cache_module(root_module.clone());
-    let loaded_module = module_cache
-        .get_loaded_module(&module_id)
-        .expect("[Module Lookup] Invariant violation while looking up module")
-        .expect("[Module Lookup] Runtime error while looking up module");
-    for m in modules.clone() {
-        module_cache.cache_module(m);
-    }
-    let mut vm =
-        TransactionExecutor::new(&module_cache, &data_cache, TransactionMetadata::default());
-    let entry_func = FunctionRef::new(&loaded_module, entry_idx);
-    let mut function_args: Vec<Value> = Vec::new();
-    for arg_type in entry_func.signature().arg_types.clone() {
-        function_args.push(match arg_type {
-            SignatureToken::Address => Value::address(AccountAddress::new([0; 32])),
-            SignatureToken::U64 => Value::u64(0),
-            SignatureToken::Bool => Value::bool(true),
-            SignatureToken::String => Value::string("".into()),
-            SignatureToken::ByteArray => Value::byte_array(ByteArray::new(vec![])),
-            _ => unimplemented!("Unsupported argument type: {:#?}", arg_type),
-        });
-    }
-    if !GAS_METERING {
-        vm.turn_off_gas_metering();
-    }
-    match vm.execute_function(&module_id, &entry_func.name(), function_args) {
+
+    let script = module.into_inner().into_script();
+    let (script, modules) = verify(
+        &AccountAddress::default(),
+        script,
+        modules
+            .into_iter()
+            .map(|module| module.into_inner())
+            .collect(),
+    );
+    let main = script.main();
+    let main_handle = script.function_handle_at(main.function);
+    let function_signature = script.function_signature_at(main_handle.signature);
+
+    let main_args: Vec<TransactionArgument> = function_signature
+        .arg_types
+        .iter()
+        .map(|sig_tok| match sig_tok {
+            SignatureToken::Address => TransactionArgument::Address(AccountAddress::new([0; 32])),
+            SignatureToken::U64 => TransactionArgument::U64(0),
+            SignatureToken::Bool => TransactionArgument::Bool(true),
+            SignatureToken::String => TransactionArgument::String("".into()),
+            SignatureToken::ByteArray => TransactionArgument::ByteArray(ByteArray::new(vec![])),
+            _ => unimplemented!("Unsupported argument type: {:#?}", sig_tok),
+        })
+        .collect();
+
+    match execute(script, main_args, modules) {
         Ok(_) => Ok(()),
         Err(e) => Err(format!("Runtime error: {:?}", e)),
     }

--- a/language/vm/vm_runtime/src/txn_executor.rs
+++ b/language/vm/vm_runtime/src/txn_executor.rs
@@ -557,6 +557,7 @@ where
         for arg in args.into_iter() {
             let push_result = self.execution_stack.push(match arg {
                 TransactionArgument::U64(i) => Value::u64(i),
+                TransactionArgument::Bool(b) => Value::bool(b),
                 TransactionArgument::Address(a) => Value::address(a),
                 TransactionArgument::ByteArray(b) => Value::byte_array(b),
                 TransactionArgument::String(s) => Value::string(VMString::new(s)),

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -13,12 +13,14 @@ pub enum TransactionArgument {
     Address(AccountAddress),
     String(String),
     ByteArray(ByteArray),
+    Bool(bool),
 }
 
 impl fmt::Debug for TransactionArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TransactionArgument::U64(value) => write!(f, "{{U64: {}}}", value),
+            TransactionArgument::Bool(boolean) => write!(f, "{{BOOL: {}}}", boolean),
             TransactionArgument::Address(address) => write!(f, "{{ADDRESS: {:?}}}", address),
             TransactionArgument::String(string) => write!(f, "{{STRING: {}}}", string),
             TransactionArgument::ByteArray(byte_array) => {
@@ -86,6 +88,11 @@ pub fn parse_as_u64(s: &str) -> Result<TransactionArgument> {
     Ok(TransactionArgument::U64(s.parse::<u64>()?))
 }
 
+/// Parses the given string as a bool.
+pub fn parse_as_bool(s: &str) -> Result<TransactionArgument> {
+    Ok(TransactionArgument::Bool(s.parse::<bool>()?))
+}
+
 macro_rules! return_if_ok {
     ($e: expr) => {{
         if let Ok(res) = $e {
@@ -98,6 +105,7 @@ macro_rules! return_if_ok {
 pub fn parse_as_transaction_argument(s: &str) -> Result<TransactionArgument> {
     return_if_ok!(parse_as_address(s));
     return_if_ok!(parse_as_u64(s));
+    return_if_ok!(parse_as_bool(s));
     return_if_ok!(parse_as_byte_array(s));
     Err(ErrorKind::ParseError(format!("cannot parse \"{}\" as transaction argument", s)).into())
 }
@@ -114,6 +122,12 @@ mod test_transaction_argument {
         for s in &["xx", "", "-3"] {
             parse_as_u64(s).unwrap_err();
         }
+    }
+
+    #[test]
+    fn parse_bool() {
+        parse_as_bool("true").unwrap();
+        parse_as_bool("false").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Previously this setup the VM for running a generated module in much the same way as we do in cost synthesis. However, in this case we don't need to directly interact with the interpreter, so we can call in via normal means. Also, directly setting up the VM will cause problems shortly when we update to an on-chain gas schedule so removing this out in preparation for that diff, and also because it's the right thing to do :) 
