### PR TITLE
[consensus] improve restartability testing

### DIFF
--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::block::block_test_utils::placeholder_certificate_for_block;
 use crate::{
     block::{block_test_utils::*, Block},
     quorum_cert::QuorumCert,
@@ -50,6 +51,7 @@ fn test_nil_block() {
         nil_block.round(),
         nil_block.quorum_cert().certified_block().id(),
         nil_block.quorum_cert().certified_block().round(),
+        None,
     );
     println!(
         "{:?} {:?}",
@@ -119,6 +121,7 @@ fn test_block_qc() {
         a1.round(),
         a1.quorum_cert().certified_block().id(),
         a1.quorum_cert().certified_block().round(),
+        None,
     );
 
     let result = panic::catch_unwind(|| {

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -201,6 +201,7 @@ pub fn placeholder_certificate_for_block(
     certified_block_round: u64,
     certified_parent_block_id: HashValue,
     certified_parent_block_round: u64,
+    consensus_block_id: Option<HashValue>,
 ) -> QuorumCert {
     // Assuming executed state to be Genesis state.
     let genesis_ledger_info = LedgerInfo::genesis();
@@ -227,6 +228,10 @@ pub fn placeholder_certificate_for_block(
     // the consensus data hash that carries the actual vote.
     let mut ledger_info_placeholder = placeholder_ledger_info();
     ledger_info_placeholder.set_consensus_data_hash(vote_data.hash());
+
+    if let Some(bid) = consensus_block_id {
+        ledger_info_placeholder.set_consensus_block_id(bid)
+    }
 
     let mut signatures = BTreeMap::new();
     for signer in signers {

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -525,12 +525,12 @@ impl<T: Payload> BlockReader for BlockStore<T> {
 #[cfg(any(test, feature = "fuzzing"))]
 impl<T: Payload> BlockStore<T> {
     /// Returns the number of blocks in the tree
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.inner.read().unwrap().len()
     }
 
     /// Returns the number of child links in the tree
-    fn child_links(&self) -> usize {
+    pub(crate) fn child_links(&self) -> usize {
         self.inner.read().unwrap().child_links()
     }
 

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -515,6 +515,7 @@ fn process_vote_timeout_msg_test() {
         1,
         block_0.quorum_cert().certified_block().id(),
         block_0.quorum_cert().certified_block().round(),
+        None,
     );
     non_proposer
         .block_store
@@ -833,7 +834,7 @@ fn basic_restart_test() {
     proposals.push(a1);
     for i in 2..=num_proposals {
         let parent = proposals.last().unwrap();
-        let proposal = inserter.insert_block(&parent, i);
+        let proposal = inserter.insert_block(&parent, i, None);
         proposals.push(proposal);
     }
     for proposal in &proposals {

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -68,7 +68,7 @@ fn test_proposal_generation_parent() {
     );
 
     // Once a1 is certified, it should be the one to choose from
-    inserter.insert_qc_for_block(a1.as_ref());
+    inserter.insert_qc_for_block(a1.as_ref(), None);
     let a1_child_res =
         block_on(proposal_generator.generate_proposal(11, minute_from_now())).unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
@@ -76,7 +76,7 @@ fn test_proposal_generation_parent() {
     assert_eq!(a1_child_res.quorum_cert().certified_block().id(), a1.id());
 
     // Once b1 is certified, it should be the one to choose from
-    inserter.insert_qc_for_block(b1.as_ref());
+    inserter.insert_qc_for_block(b1.as_ref(), None);
     let b1_child_res =
         block_on(proposal_generator.generate_proposal(12, minute_from_now())).unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
@@ -97,7 +97,7 @@ fn test_old_proposal_generation() {
     );
     let genesis = block_store.root();
     let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
-    inserter.insert_qc_for_block(a1.as_ref());
+    inserter.insert_qc_for_block(a1.as_ref(), None);
 
     let proposal_err = block_on(proposal_generator.generate_proposal(1, minute_from_now())).err();
     assert!(proposal_err.is_some());
@@ -121,20 +121,20 @@ fn test_empty_proposal_after_reconfiguration() {
         block_on(proposal_generator.generate_proposal(42, minute_from_now())).unwrap();
     assert!(!normal_proposal.payload().unwrap().is_empty());
     let a2 = inserter.insert_reconfiguration_block(&a1, 2);
-    inserter.insert_qc_for_block(a2.as_ref());
+    inserter.insert_qc_for_block(a2.as_ref(), None);
     // The direct child is empty
     let empty_proposal_1 =
         block_on(proposal_generator.generate_proposal(43, minute_from_now())).unwrap();
     assert!(empty_proposal_1.payload().unwrap().is_empty());
     // insert one more block after reconfiguration
     let a3 = inserter.create_block_with_qc(
-        inserter.create_qc_for_block(a2.as_ref()),
+        inserter.create_qc_for_block(a2.as_ref(), None),
         a2.as_ref(),
         4,
         vec![],
     );
     let a3 = block_on(block_store.execute_and_insert_block(a3)).unwrap();
-    inserter.insert_qc_for_block(a3.as_ref());
+    inserter.insert_qc_for_block(a3.as_ref(), None);
     // Indirect child is empty too
     let empty_proposal_2 =
         block_on(proposal_generator.generate_proposal(44, minute_from_now())).unwrap();

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -20,6 +20,10 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(test)]
+#[path = "persistent_storage_test.rs"]
+mod persistent_storage_test;
+
 /// Persistent storage for liveness data
 pub trait PersistentLivenessStorage: Send + Sync {
     /// Persist the highest timeout certificate for improved liveness - proof for other replicas

--- a/consensus/src/chained_bft/persistent_storage_test.rs
+++ b/consensus/src/chained_bft/persistent_storage_test.rs
@@ -1,0 +1,250 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::chained_bft::test_utils::{placeholder_ledger_info, TestPayload};
+use crate::chained_bft::{
+    persistent_storage::RecoveryData,
+    test_utils::{build_chain, build_simple_tree},
+};
+use consensus_types::{
+    block::{Block, ExecutedBlock},
+    quorum_cert::QuorumCert,
+};
+use crypto::HashValue;
+use std::sync::Arc;
+
+/// Partially obtain parameters for `RecoveryData::find_root()`.
+/// The parameter of `storage_ledger` will be manually defined, and will control the output of `find_root()`.
+fn get_find_root_params(
+    executed_blocks: Vec<Arc<ExecutedBlock<TestPayload>>>,
+) -> (Vec<Block<TestPayload>>, Vec<QuorumCert>) {
+    executed_blocks
+        .iter()
+        .map(|eb| (eb.block().clone(), eb.block().quorum_cert().clone()))
+        .unzip()
+}
+
+/// Verify that the found root matches the expected root.
+fn is_correct_root(
+    blocks: &[Block<TestPayload>],
+    committed_b_idx: usize,
+    found_root: (Block<TestPayload>, QuorumCert, QuorumCert),
+) -> bool {
+    let root = &blocks[committed_b_idx];
+    let qc = blocks[committed_b_idx + 1].quorum_cert();
+    let li = blocks[committed_b_idx + 3].quorum_cert();
+    *root == found_root.0 && *qc == found_root.1 && *li == found_root.2
+}
+
+/// Verify that the found root is the genesis.
+fn is_genesis_root(found_root: (Block<TestPayload>, QuorumCert, QuorumCert)) -> bool {
+    let genesis = Block::make_genesis_block();
+    genesis == found_root.0
+        && QuorumCert::certificate_for_genesis() == found_root.1
+        && QuorumCert::certificate_for_genesis() == found_root.2
+}
+
+/// Testing strategy for `RecoveryData::find_root()`
+///
+/// Partition the inputs as follows:
+///  - blocks:          non-branched chain: Genesis--> A1--> A2--> A3--> A4---> ...
+///
+///                     simple tree:              ╭--> A1--> A2--> A3
+///                                         Genesis--> B1--> B2
+///                                                     ╰--> C1
+///  - quorum_certs:    non-branched chain, simple tree (matches the `blocks` input above)
+///  - storage_ledger:  disconnect,
+///                     ancestor of the root,
+///                     root (i.e. LI(S).block.round == LI(C).block.round),
+///                     special case (i.e. genesis)
+///
+/// Partition the outputs as follows:
+///  - validity:        root found, root not found
+///  - LI(S) and LI(C) relationship:    LI(S) exist && LI(S) is an ancestor of LI(C)
+///                                     LI(S) exist && LI(S) is NOT an ancestor of LI(C)
+///                                     LI(S) does not exist
+
+/// covers
+///  - blocks: non-branched chain
+///  - quorum_certs: non-branched chain
+///  - storage_ledger: disconnect
+///  - validity: root found
+///  - LI(S) and LI(C) relationship: LI(S) does not exist
+///
+/// ==> LI(C) is the root block
+#[test]
+fn test_chain_restartability_root_from_consensusdb() {
+    let executed_blocks = build_chain();
+    let (blocks, quorum_certs) = get_find_root_params(executed_blocks);
+
+    // Define ledger info for storage.
+    let li_storage = &blocks[0];
+    let mut storage_ledger = placeholder_ledger_info();
+    storage_ledger.set_consensus_block_id(li_storage.id());
+
+    // The root of the chain of blocks must have a parent, a grandparent, a child, and a grandchild.
+    for b_idx_start in 2..blocks.len() - 3 {
+        for b_idx_end in b_idx_start + 3..blocks.len() {
+            // Arbitrarily trim the blocks, while keeping the following invariant.
+            // Trimming the blocks disconnects LI(S) from LI(C).
+            // Obtain parameters for `RecoveryData::find_root()`.
+            let mut blocks_advanced = blocks[b_idx_start..=b_idx_end].to_vec();
+            let mut qc_advanced = quorum_certs[b_idx_start..=b_idx_end].to_vec();
+
+            // Subset of blocks is fed into `find_root()` so that LI(S) is disconnected from LI(C).
+            let found_root =
+                RecoveryData::find_root(&mut blocks_advanced, &mut qc_advanced, &storage_ledger)
+                    .unwrap();
+
+            // Verify that LI(C) is the root.
+            assert!(is_correct_root(&blocks, b_idx_end - 3, found_root));
+        }
+    }
+}
+
+/// covers
+///  - blocks: non-branched chain
+///  - quorum_certs: non-branched chain
+///  - storage_ledger: ancestor of the root
+///  - validity: root found
+///  - LI(S) and LI(C) relationship: LI(S) exist && LI(S) is an ancestor of LI(C)
+///
+/// ==> LI(S) is the root block
+#[test]
+fn test_chain_restartability_root_from_storage() {
+    let executed_blocks = build_chain();
+    let (blocks, quorum_certs) = get_find_root_params(executed_blocks);
+
+    for committed_b_idx in 2..blocks.len() - 4 {
+        // Define ledger info for storage.
+        let li_storage = &blocks[committed_b_idx];
+        let mut storage_ledger = placeholder_ledger_info();
+        storage_ledger.set_consensus_block_id(li_storage.id());
+
+        for b_idx_end in committed_b_idx + 4..blocks.len() {
+            let mut blocks_advanced = blocks[committed_b_idx..=b_idx_end].to_vec();
+            let mut qc_advanced = quorum_certs[committed_b_idx..=b_idx_end].to_vec();
+
+            // Subset of blocks is fed into `find_root()` so that LI(S) is disconnected from LI(C).
+            let found_root =
+                RecoveryData::find_root(&mut blocks_advanced, &mut qc_advanced, &storage_ledger)
+                    .unwrap();
+
+            // Verify that LI(S) is the root.
+            assert!(is_correct_root(&blocks, committed_b_idx, found_root));
+        }
+    }
+}
+
+/// covers
+///  - blocks: non-branched chain
+///  - quorum_certs: non-branched chain
+///  - storage_ledger: root
+///  - validity: root found
+///  - LI(S) and LI(C) relationship: LI(S) exist && LI(S) is an ancestor of LI(C)
+///                                  (note: a block is considered to be an ancestor of itself)
+///
+/// ==> LI(S) is the root block
+#[test]
+fn test_chain_restartability_same_root() {
+    let executed_blocks = build_chain();
+    let (blocks, quorum_certs) = get_find_root_params(executed_blocks);
+
+    for committed_b_idx in 2..blocks.len() - 4 {
+        // Define ledger info for storage.
+        let li_storage = &blocks[committed_b_idx];
+        let mut storage_ledger = placeholder_ledger_info();
+        storage_ledger.set_consensus_block_id(li_storage.id());
+        let b_idx_end = committed_b_idx + 3;
+
+        let mut blocks_advanced = blocks[committed_b_idx..=b_idx_end].to_vec();
+        let mut qc_advanced = quorum_certs[committed_b_idx..=b_idx_end].to_vec();
+
+        // Subset of blocks is fed into `find_root()` so that LI(S) is disconnected from LI(C).
+        let found_root =
+            RecoveryData::find_root(&mut blocks_advanced, &mut qc_advanced, &storage_ledger)
+                .unwrap();
+
+        // Verify that LI(S) is the root.
+        assert!(is_correct_root(&blocks, committed_b_idx, found_root));
+    }
+}
+
+/// covers
+///  - blocks: simple tree
+///  - quorum_certs: simple tree
+///  - storage_ledger: special case (i.e. genesis)
+///  - validity: root found
+///  - LI(S) and LI(C) relationship: LI(S) does not exist
+///
+/// ==> LI(C) is the root block
+#[test]
+fn test_tree_restartability_root_from_consensusdb() {
+    let (executed_blocks, _) = build_simple_tree();
+    let (mut blocks, mut quorum_certs) = get_find_root_params(executed_blocks.clone());
+
+    // Use a random hash value as the consensus block id.
+    // (i.e. LI(S) does not exist.)
+    let mut storage_ledger = placeholder_ledger_info();
+    storage_ledger.set_consensus_block_id(HashValue::random());
+
+    // Verify that LI(C) is the root.
+    // If B0 <- [C0 <- B1] <- [C1 <- B2] <- [C2 <- B3], then `find_root` returns (B0, C0, C0).
+    let found_root =
+        RecoveryData::find_root(&mut blocks, &mut quorum_certs, &storage_ledger).unwrap();
+    assert!(is_genesis_root(found_root));
+}
+
+/// covers
+///  - blocks: simple tree
+///  - quorum_certs: simple tree
+///  - storage_ledger: root + special case (i.e. genesis)
+///  - validity: root found
+///  - LI(S) and LI(C) relationship: LI(S) exist && LI(S) is an ancestor of LI(C)
+///                                  (note: a block is considered to be an ancestor of itself)
+///
+/// ==> LI(S) is the root block
+#[test]
+fn test_tree_restartability_same_root() {
+    let (executed_blocks, _) = build_simple_tree();
+    let (mut blocks, mut quorum_certs) = get_find_root_params(executed_blocks.clone());
+
+    // Construct the storage ledger such that LI(S) is the ancestor of LI(C).
+    // In this case LI(S) and LI(C) are equal.
+    let mut storage_ledger = placeholder_ledger_info();
+    storage_ledger.set_consensus_block_id(executed_blocks[0].block().id());
+
+    // Verify that LI(S) is the root.
+    // If B0 <- [C0 <- B1] <- [C1 <- B2] <- [C2 <- B3], then `find_root` returns (B0, C0, C0).
+    let found_root =
+        RecoveryData::find_root(&mut blocks, &mut quorum_certs, &storage_ledger).unwrap();
+    assert!(is_genesis_root(found_root));
+}
+
+/// covers
+///  - blocks: non-branched chain
+///  - quorum_certs: non-branched chain
+///  - storage_ledger: disconnect
+///  - validity: root not found
+///  - LI(S) and LI(C) relationship: N/A
+///
+/// ==> Error
+#[test]
+fn test_not_restartable_too_short() {
+    let executed_blocks = build_chain();
+    let (blocks, quorum_certs) = get_find_root_params(executed_blocks);
+
+    // Set a random storage ledger parameter for `RecoveryData::find_root()`.
+    // `find_root()` will panic regardless of the storage ledger.
+    let mut storage_ledger = placeholder_ledger_info();
+    storage_ledger.set_consensus_block_id(HashValue::random());
+
+    let mut blocks_shortened = blocks[5..].to_vec();
+    let mut qc_shortened = quorum_certs[5..].to_vec();
+
+    // Subset of blocks is inputted to `find_root()` so that LI(S) is disconnected from LI(C).
+    // `find_root()` returns an Error.
+    assert!(
+        RecoveryData::find_root(&mut blocks_shortened, &mut qc_shortened, &storage_ledger).is_err()
+    );
+}

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -1,13 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chained_bft::block_storage::BlockStore;
-use consensus_types::{
-    block::{block_test_utils::placeholder_certificate_for_block, Block, ExecutedBlock},
-    common::Round,
-    quorum_cert::QuorumCert,
-    sync_info::SyncInfo,
-};
+use crate::chained_bft::block_storage::{BlockReader, BlockStore};
+use consensus_types::{quorum_cert::QuorumCert, sync_info::SyncInfo};
 use crypto::HashValue;
 use futures::executor::block_on;
 use libra_types::{crypto_proxies::ValidatorSigner, ledger_info::LedgerInfo};
@@ -20,20 +15,70 @@ mod mock_state_computer;
 mod mock_storage;
 mod mock_txn_manager;
 
+use consensus_types::block::block_test_utils::placeholder_certificate_for_block;
+use consensus_types::block::{Block, ExecutedBlock};
+use consensus_types::common::Round;
 pub use mock_state_computer::{EmptyStateComputer, MockStateComputer};
 pub use mock_storage::{EmptyStorage, MockStorage};
 pub use mock_txn_manager::MockTransactionManager;
 
 pub type TestPayload = Vec<usize>;
 
-pub fn build_empty_tree() -> Arc<BlockStore<Vec<usize>>> {
+pub fn build_simple_tree() -> (
+    Vec<Arc<ExecutedBlock<TestPayload>>>,
+    Arc<BlockStore<TestPayload>>,
+) {
+    let block_store = build_empty_tree();
+    let genesis = block_store.root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert_eq!(block_store.block_exists(genesis_block.id()), true);
+
+    //       ╭--> A1--> A2--> A3
+    // Genesis--> B1--> B2
+    //             ╰--> C1
+    let mut inserter = TreeInserter::new(block_store.clone());
+    let a1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis_block, 1);
+    let a2 = inserter.insert_block(&a1, 2, None);
+    let a3 = inserter.insert_block(&a2, 3, Some(genesis.id()));
+    let b1 =
+        inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis_block, 4);
+    let b2 = inserter.insert_block(&b1, 5, None);
+    let c1 = inserter.insert_block(&b1, 6, None);
+
+    assert_eq!(block_store.len(), 7);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+
+    (vec![genesis_block, a1, a2, a3, b1, b2, c1], block_store)
+}
+
+pub fn build_chain() -> Vec<Arc<ExecutedBlock<TestPayload>>> {
+    let block_store = build_empty_tree();
+    let mut inserter = TreeInserter::new(block_store.clone());
+    let genesis = block_store.root();
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
+    let a2 = inserter.insert_block(&a1, 2, None);
+    let a3 = inserter.insert_block(&a2, 3, Some(genesis.id()));
+    let a4 = inserter.insert_block(&a3, 4, Some(a1.id()));
+    let a5 = inserter.insert_block(&a4, 5, Some(a2.id()));
+    let a6 = inserter.insert_block(&a5, 6, Some(a3.id()));
+    let a7 = inserter.insert_block(&a6, 7, Some(a4.id()));
+    vec![genesis, a1, a2, a3, a4, a5, a6, a7]
+}
+
+pub fn build_empty_tree() -> Arc<BlockStore<TestPayload>> {
     let signer = ValidatorSigner::random(None);
     build_empty_tree_with_custom_signing(signer)
 }
 
 pub fn build_empty_tree_with_custom_signing(
     my_signer: ValidatorSigner,
-) -> Arc<BlockStore<Vec<usize>>> {
+) -> Arc<BlockStore<TestPayload>> {
     let (storage, initial_data) = EmptyStorage::start_for_testing();
     Arc::new(block_on(BlockStore::new(
         storage,
@@ -47,11 +92,11 @@ pub fn build_empty_tree_with_custom_signing(
 
 pub struct TreeInserter {
     payload_val: usize,
-    block_store: Arc<BlockStore<Vec<usize>>>,
+    block_store: Arc<BlockStore<TestPayload>>,
 }
 
 impl TreeInserter {
-    pub fn new(block_store: Arc<BlockStore<Vec<usize>>>) -> Self {
+    pub fn new(block_store: Arc<BlockStore<TestPayload>>) -> Self {
         Self {
             payload_val: 0,
             block_store,
@@ -63,21 +108,21 @@ impl TreeInserter {
     /// `insert_block_with_qc`.
     pub fn insert_block(
         &mut self,
-        parent: &ExecutedBlock<Vec<usize>>,
+        parent: &ExecutedBlock<TestPayload>,
         round: Round,
-    ) -> Arc<ExecutedBlock<Vec<usize>>> {
+        consensus_block_id: Option<HashValue>,
+    ) -> Arc<ExecutedBlock<TestPayload>> {
         // Node must carry a QC to its parent
-        let parent_qc = self.create_qc_for_block(parent);
-
+        let parent_qc = self.create_qc_for_block(parent, consensus_block_id);
         self.insert_block_with_qc(parent_qc, parent, round)
     }
 
     pub fn insert_block_with_qc(
         &mut self,
         parent_qc: QuorumCert,
-        parent: &ExecutedBlock<Vec<usize>>,
+        parent: &ExecutedBlock<TestPayload>,
         round: Round,
-    ) -> Arc<ExecutedBlock<Vec<usize>>> {
+    ) -> Arc<ExecutedBlock<TestPayload>> {
         self.payload_val += 1;
         block_on(
             self.block_store
@@ -91,19 +136,28 @@ impl TreeInserter {
         .unwrap()
     }
 
-    pub fn create_qc_for_block(&self, block: &ExecutedBlock<TestPayload>) -> QuorumCert {
+    pub fn create_qc_for_block(
+        &self,
+        block: &ExecutedBlock<TestPayload>,
+        consensus_block_id: Option<HashValue>,
+    ) -> QuorumCert {
         placeholder_certificate_for_block(
             vec![self.block_store.signer()],
             block.id(),
             block.round(),
             block.quorum_cert().certified_block().id(),
             block.quorum_cert().certified_block().round(),
+            consensus_block_id,
         )
     }
 
-    pub fn insert_qc_for_block(&self, block: &ExecutedBlock<TestPayload>) {
+    pub fn insert_qc_for_block(
+        &self,
+        block: &ExecutedBlock<TestPayload>,
+        consensus_block_id: Option<HashValue>,
+    ) {
         self.block_store
-            .insert_single_quorum_cert(self.create_qc_for_block(block))
+            .insert_single_quorum_cert(self.create_qc_for_block(block, consensus_block_id))
             .unwrap()
     }
 
@@ -133,7 +187,7 @@ impl TreeInserter {
         block_on(
             self.block_store
                 .insert_reconfiguration_block(self.create_block_with_qc(
-                    self.create_qc_for_block(parent),
+                    self.create_qc_for_block(parent, None),
                     parent,
                     round,
                     vec![self.payload_val],

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -131,6 +131,10 @@ impl LedgerInfo {
         self.consensus_data_hash = consensus_data_hash;
     }
 
+    pub fn set_consensus_block_id(&mut self, consensus_block_id: HashValue) {
+        self.consensus_block_id = consensus_block_id;
+    }
+
     pub fn epoch(&self) -> u64 {
         self.epoch
     }


### PR DESCRIPTION
- Add unit tests for `RecoveryData::find_root()`.
- Update `test_utils` directory with new tree constructors.
- Update `TreeInserter::insert_block()` to define proper QC and LI for 3-chains.
- Remove duplicate function `placeholder_certificate_for_block()`, and refactor usages.

Reattempt of #1333 
Closes #1195 