### PR TITLE
Rewrite Vote containers

### DIFF
--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -8,5 +8,6 @@ pub mod proposal_msg;
 pub mod quorum_cert;
 pub mod sync_info;
 pub mod timeout_certificate;
+pub mod vote;
 pub mod vote_data;
 pub mod vote_msg;

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -1,0 +1,183 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    common::{self, Author},
+    vote_data::VoteData,
+};
+use crypto::hash::CryptoHash;
+use failure::{ensure, format_err, ResultExt};
+use libra_types::{
+    crypto_proxies::{Signature, ValidatorSigner, ValidatorVerifier},
+    ledger_info::LedgerInfo,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::{TryFrom, TryInto},
+    fmt::{Display, Formatter},
+};
+
+/// Vote is the struct that is ultimately sent by the voter in response for
+/// receiving a proposal.
+/// Vote carries the `LedgerInfo` of a block that is going to be committed in case this vote
+/// is gathers QuorumCertificate (see the detailed explanation in the comments of `LedgerInfo`).
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct Vote {
+    /// The data of the vote
+    vote_data: VoteData,
+    /// The identity of the voter.
+    author: Author,
+    /// LedgerInfo of a block that is going to be committed in case this vote gathers QC.
+    ledger_info: LedgerInfo,
+    /// Signature of the LedgerInfo
+    signature: Signature,
+    /// The round signatures can be aggregated into a timeout certificate if present.
+    round_signature: Option<Signature>,
+}
+
+impl Display for Vote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Vote: [vote data: {}, author: {}, is_timeout: {}, {}]",
+            self.vote_data,
+            self.author.short_str(),
+            self.is_timeout(),
+            self.ledger_info
+        )
+    }
+}
+
+impl Vote {
+    /// Generates a new Vote corresponding to the "fast-vote" path without the round signatures
+    /// that can be aggregated into a timeout certificate
+    pub fn new(
+        vote_data: VoteData,
+        author: Author,
+        mut ledger_info_placeholder: LedgerInfo,
+        validator_signer: &ValidatorSigner,
+    ) -> Self {
+        ledger_info_placeholder.set_consensus_data_hash(vote_data.hash());
+        let li_sig = validator_signer
+            .sign_message(ledger_info_placeholder.hash())
+            .expect("Failed to sign LedgerInfo");
+        Self {
+            vote_data,
+            author,
+            ledger_info: ledger_info_placeholder,
+            signature: li_sig.into(),
+            round_signature: None,
+        }
+    }
+
+    /// Generates a round signature, which can then be used for aggregating a timeout certificate.
+    /// Typically called for generating vote messages that are sent upon timeouts.
+    pub fn add_round_signature(&mut self, validator_signer: &ValidatorSigner) {
+        if self.round_signature.is_some() {
+            return; // round signature is already set
+        }
+        self.round_signature.replace(
+            validator_signer
+                .sign_message(common::round_hash(self.vote_data().proposed().round()))
+                .expect("Failed to sign round")
+                .into(),
+        );
+    }
+
+    pub fn vote_data(&self) -> &VoteData {
+        &self.vote_data
+    }
+
+    /// Return the author of the vote
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    /// Return the LedgerInfo associated with this vote
+    pub fn ledger_info(&self) -> &LedgerInfo {
+        &self.ledger_info
+    }
+
+    /// Return the signature of the vote
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Returns the signature for the vote_data().proposed().round() that can be aggregated for
+    /// TimeoutCertificate.
+    pub fn round_signature(&self) -> Option<&Signature> {
+        self.round_signature.as_ref()
+    }
+
+    /// The vote message is considered a timeout vote message if it carries a signature on the
+    /// round, which can then be used for aggregating it to the TimeoutCertificate.
+    pub fn is_timeout(&self) -> bool {
+        self.round_signature.is_some()
+    }
+
+    /// Verifies that the consensus data hash of LedgerInfo corresponds to the vote info,
+    /// and then verifies the signature.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
+        ensure!(
+            self.ledger_info.consensus_data_hash() == self.vote_data.hash(),
+            "Vote's hash mismatch with LedgerInfo"
+        );
+        self.signature()
+            .verify(validator, self.author(), self.ledger_info.hash())
+            .with_context(|e| format!("Fail to verify Vote: {:?}", e))?;
+        if let Some(round_signature) = &self.round_signature {
+            round_signature
+                .verify(
+                    validator,
+                    self.author(),
+                    common::round_hash(self.vote_data().proposed().round()),
+                )
+                .with_context(|e| format!("Fail to verify Vote: {:?}", e))?;
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<network::proto::Vote> for Vote {
+    type Error = failure::Error;
+
+    fn try_from(proto: network::proto::Vote) -> failure::Result<Self> {
+        let vote_data = proto
+            .vote_data
+            .ok_or_else(|| format_err!("Missing vote_data"))?
+            .try_into()?;
+        let author = Author::try_from(proto.author)?;
+        let ledger_info = proto
+            .ledger_info
+            .ok_or_else(|| format_err!("Missing ledger_info"))?
+            .try_into()?;
+        let signature = Signature::try_from(&proto.signature)?;
+        let round_signature = if proto.round_signature.is_empty() {
+            None
+        } else {
+            Some(Signature::try_from(&proto.round_signature)?)
+        };
+        Ok(Self {
+            vote_data,
+            author,
+            ledger_info,
+            signature,
+            round_signature,
+        })
+    }
+}
+
+impl From<Vote> for network::proto::Vote {
+    fn from(vote: Vote) -> Self {
+        Self {
+            vote_data: Some(vote.vote_data.into()),
+            author: vote.author.into(),
+            ledger_info: Some(vote.ledger_info.into()),
+            signature: vote.signature.to_bytes(),
+            round_signature: vote
+                .round_signature
+                .map(|sig| sig.to_bytes())
+                .unwrap_or_else(Vec::new),
+        }
+    }
+}

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -1,17 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    common::{self, Author},
-    sync_info::SyncInfo,
-    vote_data::VoteData,
-};
-use crypto::hash::CryptoHash;
-use failure::{bail, ensure, format_err, ResultExt};
-use libra_types::{
-    crypto_proxies::{Signature, ValidatorSigner, ValidatorVerifier},
-    ledger_info::LedgerInfo,
-};
+use crate::{sync_info::SyncInfo, vote::Vote};
+use failure::{bail, format_err};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::{TryFrom, TryInto},
@@ -24,127 +15,31 @@ use std::{
 /// is gathers QuorumCertificate (see the detailed explanation in the comments of `LedgerInfo`).
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct VoteMsg {
-    /// The data of the vote
-    vote_data: VoteData,
-    /// The identity of the voter.
-    author: Author,
-    /// LedgerInfo of a block that is going to be committed in case this vote gathers QC.
-    ledger_info: LedgerInfo,
-    /// Signature of the LedgerInfo
-    signature: Signature,
-    /// The round signatures can be aggregated into a timeout certificate if present.
-    round_signature: Option<Signature>,
+    /// The container for the vote (VoteData, LedgerInfo, Signature)
+    vote: Vote,
     /// Sync info carries information about highest QC, TC and LedgerInfo
     sync_info: SyncInfo,
 }
 
 impl Display for VoteMsg {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "Vote: [vote data: {}, author: {}, is_timeout: {}, {}]",
-            self.vote_data,
-            self.author.short_str(),
-            self.is_timeout(),
-            self.ledger_info
-        )
+        write!(f, "VoteMsg: [{}]", self.vote,)
     }
 }
 
 impl VoteMsg {
-    /// Generates a new VoteMsg corresponding to the "fast-vote" path without the round signatures
-    /// that can be aggregated into a timeout certificate
-    pub fn new(
-        vote_data: VoteData,
-        author: Author,
-        mut ledger_info_placeholder: LedgerInfo,
-        validator_signer: &ValidatorSigner,
-        sync_info: SyncInfo,
-    ) -> Self {
-        ledger_info_placeholder.set_consensus_data_hash(vote_data.hash());
-        let li_sig = validator_signer
-            .sign_message(ledger_info_placeholder.hash())
-            .expect("Failed to sign LedgerInfo");
-        Self {
-            vote_data,
-            author,
-            ledger_info: ledger_info_placeholder,
-            signature: li_sig.into(),
-            round_signature: None,
-            sync_info,
-        }
+    pub fn new(vote: Vote, sync_info: SyncInfo) -> Self {
+        Self { vote, sync_info }
     }
 
-    /// Generates a round signature, which can then be used for aggregating a timeout certificate.
-    /// Typically called for generating vote messages that are sent upon timeouts.
-    pub fn add_round_signature(&mut self, validator_signer: &ValidatorSigner) {
-        if self.round_signature.is_some() {
-            return; // round signature is already set
-        }
-        self.round_signature.replace(
-            validator_signer
-                .sign_message(common::round_hash(self.vote_data().proposed().round()))
-                .expect("Failed to sign round")
-                .into(),
-        );
-    }
-
-    pub fn vote_data(&self) -> &VoteData {
-        &self.vote_data
-    }
-
-    /// Return the author of the vote
-    pub fn author(&self) -> Author {
-        self.author
-    }
-
-    /// Return the LedgerInfo associated with this vote
-    pub fn ledger_info(&self) -> &LedgerInfo {
-        &self.ledger_info
-    }
-
-    /// Return the signature of the vote
-    pub fn signature(&self) -> &Signature {
-        &self.signature
+    /// Container for actual voting material
+    pub fn vote(&self) -> &Vote {
+        &self.vote
     }
 
     /// SyncInfo of the given vote message
     pub fn sync_info(&self) -> &SyncInfo {
         &self.sync_info
-    }
-
-    /// Returns the signature for the vote_data().proposed().round() that can be aggregated for
-    /// TimeoutCertificate.
-    pub fn round_signature(&self) -> Option<&Signature> {
-        self.round_signature.as_ref()
-    }
-
-    /// The vote message is considered a timeout vote message if it carries a signature on the
-    /// round, which can then be used for aggregating it to the TimeoutCertificate.
-    pub fn is_timeout(&self) -> bool {
-        self.round_signature.is_some()
-    }
-
-    /// Verifies that the consensus data hash of LedgerInfo corresponds to the vote info,
-    /// and then verifies the signature.
-    pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
-        ensure!(
-            self.ledger_info.consensus_data_hash() == self.vote_data.hash(),
-            "Vote's hash mismatch with LedgerInfo"
-        );
-        self.signature()
-            .verify(validator, self.author(), self.ledger_info.hash())
-            .with_context(|e| format!("Fail to verify VoteMsg: {:?}", e))?;
-        if let Some(round_signature) = &self.round_signature {
-            round_signature
-                .verify(
-                    validator,
-                    self.author(),
-                    common::round_hash(self.vote_data().proposed().round()),
-                )
-                .with_context(|e| format!("Fail to verify VoteMsg: {:?}", e))?;
-        }
-        Ok(())
     }
 }
 
@@ -152,33 +47,15 @@ impl TryFrom<network::proto::VoteMsg> for VoteMsg {
     type Error = failure::Error;
 
     fn try_from(proto: network::proto::VoteMsg) -> failure::Result<Self> {
-        let vote_data = proto
-            .vote_data
-            .ok_or_else(|| format_err!("Missing vote_data"))?
+        let vote = proto
+            .vote
+            .ok_or_else(|| format_err!("Missing vote"))?
             .try_into()?;
-        let author = Author::try_from(proto.author)?;
-        let ledger_info = proto
-            .ledger_info
-            .ok_or_else(|| format_err!("Missing ledger_info"))?
-            .try_into()?;
-        let signature = Signature::try_from(&proto.signature)?;
-        let round_signature = if proto.round_signature.is_empty() {
-            None
-        } else {
-            Some(Signature::try_from(&proto.round_signature)?)
-        };
         let sync_info = proto
             .sync_info
             .ok_or_else(|| format_err!("Missing sync_info"))?
             .try_into()?;
-        Ok(Self {
-            vote_data,
-            author,
-            ledger_info,
-            signature,
-            round_signature,
-            sync_info,
-        })
+        Ok(Self { vote, sync_info })
     }
 }
 
@@ -196,14 +73,7 @@ impl TryFrom<network::proto::ConsensusMsg> for VoteMsg {
 impl From<VoteMsg> for network::proto::VoteMsg {
     fn from(vote_msg: VoteMsg) -> Self {
         Self {
-            vote_data: Some(vote_msg.vote_data.into()),
-            author: vote_msg.author.into(),
-            ledger_info: Some(vote_msg.ledger_info.into()),
-            signature: vote_msg.signature.to_bytes(),
-            round_signature: vote_msg
-                .round_signature
-                .map(|sig| sig.to_bytes())
-                .unwrap_or_else(Vec::new),
+            vote: Some(vote_msg.vote.into()),
             sync_info: Some(vote_msg.sync_info.into()),
         }
     }

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -148,10 +148,10 @@ impl VoteMsg {
     }
 }
 
-impl TryFrom<network::proto::Vote> for VoteMsg {
+impl TryFrom<network::proto::VoteMsg> for VoteMsg {
     type Error = failure::Error;
 
-    fn try_from(proto: network::proto::Vote) -> failure::Result<Self> {
+    fn try_from(proto: network::proto::VoteMsg) -> failure::Result<Self> {
         let vote_data = proto
             .vote_data
             .ok_or_else(|| format_err!("Missing vote_data"))?
@@ -187,24 +187,24 @@ impl TryFrom<network::proto::ConsensusMsg> for VoteMsg {
 
     fn try_from(proto: network::proto::ConsensusMsg) -> failure::Result<Self> {
         match proto.message {
-            Some(network::proto::ConsensusMsg_oneof::Vote(vote)) => vote.try_into(),
+            Some(network::proto::ConsensusMsg_oneof::VoteMsg(vote_msg)) => vote_msg.try_into(),
             _ => bail!("Missing vote"),
         }
     }
 }
 
-impl From<VoteMsg> for network::proto::Vote {
-    fn from(vote: VoteMsg) -> Self {
+impl From<VoteMsg> for network::proto::VoteMsg {
+    fn from(vote_msg: VoteMsg) -> Self {
         Self {
-            vote_data: Some(vote.vote_data.into()),
-            author: vote.author.into(),
-            ledger_info: Some(vote.ledger_info.into()),
-            signature: vote.signature.to_bytes(),
-            round_signature: vote
+            vote_data: Some(vote_msg.vote_data.into()),
+            author: vote_msg.author.into(),
+            ledger_info: Some(vote_msg.ledger_info.into()),
+            signature: vote_msg.signature.to_bytes(),
+            round_signature: vote_msg
                 .round_signature
                 .map(|sig| sig.to_bytes())
                 .unwrap_or_else(Vec::new),
-            sync_info: Some(vote.sync_info.into()),
+            sync_info: Some(vote_msg.sync_info.into()),
         }
     }
 }

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -4,7 +4,7 @@
 use crate::{ConsensusState, ProposalReject, SafetyRules};
 use consensus_types::{
     block::Block, block_info::BlockInfo, common::Round, quorum_cert::QuorumCert,
-    sync_info::SyncInfo, vote_data::VoteData, vote_msg::VoteMsg,
+    sync_info::SyncInfo, vote::Vote, vote_data::VoteData, vote_msg::VoteMsg,
 };
 use crypto::hash::{CryptoHash, HashValue};
 use libra_types::{
@@ -74,20 +74,23 @@ fn make_block_with_parent(
     };
 
     let vote_msg = VoteMsg::new(
-        vote_data.clone(),
-        validator_signer.author(),
-        ledger_info,
-        validator_signer,
+        Vote::new(
+            vote_data.clone(),
+            validator_signer.author(),
+            ledger_info,
+            validator_signer,
+        ),
         sync_info,
     );
 
     let mut ledger_info_with_signatures =
-        LedgerInfoWithSignatures::new(vote_msg.ledger_info().clone(), BTreeMap::new());
+        LedgerInfoWithSignatures::new(vote_msg.vote().ledger_info().clone(), BTreeMap::new());
 
     vote_msg
+        .vote()
         .signature()
         .clone()
-        .add_to_li(vote_msg.author(), &mut ledger_info_with_signatures);
+        .add_to_li(vote_msg.vote().author(), &mut ledger_info_with_signatures);
 
     let qc = QuorumCert::new(vote_data, ledger_info_with_signatures);
 

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -13,7 +13,7 @@ use consensus_types::{
     common::{Payload, Round},
     quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate,
-    vote_msg::VoteMsg,
+    vote::Vote,
 };
 use crypto::HashValue;
 use executor::{ProcessedVMOutput, StateComputeResult};
@@ -341,13 +341,13 @@ impl<T: Payload> BlockStore<T> {
     /// A and the votes for execution result B are aggregated separately).
     pub fn insert_vote(
         &self,
-        vote_msg: VoteMsg,
+        vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         self.inner
             .write()
             .unwrap()
-            .insert_vote(&vote_msg, validator_verifier)
+            .insert_vote(vote, validator_verifier)
     }
 
     /// Prune the tree up to next_root_id (keep next_root_id's block).  Any branches not part of
@@ -544,10 +544,10 @@ impl<T: Payload> BlockStore<T> {
     /// Can't be used in production, because production insertion potentially requires state sync
     pub fn insert_vote_and_qc(
         &self,
-        vote_msg: VoteMsg,
+        vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
-        let r = self.insert_vote(vote_msg, validator_verifier);
+        let r = self.insert_vote(vote, validator_verifier);
         if let VoteReceptionResult::NewQuorumCertificate(ref qc) = r {
             self.insert_single_quorum_cert(qc.as_ref().clone()).unwrap();
         }

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use consensus_types::{
     block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
-    vote_msg::VoteMsg,
+    vote::Vote,
 };
 use crypto::HashValue;
 use executor::StateComputeResult;
@@ -294,14 +294,14 @@ where
 
     pub(super) fn insert_vote(
         &mut self,
-        vote_msg: &VoteMsg,
+        vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
-        let block_id = vote_msg.vote_data().proposed().id();
+        let block_id = vote.vote_data().proposed().id();
         if let Some(old_qc) = self.id_to_quorum_cert.get(&block_id) {
             return VoteReceptionResult::OldQuorumCertificate(Arc::clone(old_qc));
         }
-        let res = self.pending_votes.insert_vote(vote_msg, validator_verifier);
+        let res = self.pending_votes.insert_vote(vote, validator_verifier);
         if let VoteReceptionResult::NewQuorumCertificate(_) = res {
             // Note that the block might not be present locally, in which case we cannot calculate
             // time between block creation and qc

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -6,7 +6,7 @@ use consensus_types::{
     common::{Author, Round},
     quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate,
-    vote_msg::VoteMsg,
+    vote::Vote,
 };
 use crypto::{hash::CryptoHash, HashValue};
 use libra_logger::prelude::*;
@@ -61,17 +61,17 @@ impl PendingVotes {
     /// TimeoutCertificate if either can can be formed
     pub fn insert_vote(
         &mut self,
-        vote_msg: &VoteMsg,
+        vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
-        if let Err(e) = self.replace_prev_vote(vote_msg) {
+        if let Err(e) = self.replace_prev_vote(vote) {
             return e;
         }
-        let vote_aggr_res = self.aggregate_qc(vote_msg, validator_verifier);
+        let vote_aggr_res = self.aggregate_qc(vote, validator_verifier);
         if let VoteReceptionResult::NewQuorumCertificate(_) = vote_aggr_res {
             return vote_aggr_res;
         }
-        match self.aggregate_tc(vote_msg, &validator_verifier) {
+        match self.aggregate_tc(vote, &validator_verifier) {
             Some(VoteReceptionResult::NewTimeoutCertificate(tc)) => {
                 VoteReceptionResult::NewTimeoutCertificate(tc)
             }
@@ -82,31 +82,30 @@ impl PendingVotes {
     /// Check whether the newly inserted vote completes a QC
     fn aggregate_qc(
         &mut self,
-        vote_msg: &VoteMsg,
+        vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         // Note that the digest covers the ledger info information, which is also indirectly
         // covering vote data hash (in its `consensus_data_hash` field).
-        let li_digest = vote_msg.ledger_info().hash();
+        let li_digest = vote.ledger_info().hash();
         let li_with_sig = self.li_digest_to_votes.entry(li_digest).or_insert_with(|| {
-            LedgerInfoWithSignatures::new(vote_msg.ledger_info().clone(), BTreeMap::new())
+            LedgerInfoWithSignatures::new(vote.ledger_info().clone(), BTreeMap::new())
         });
         // TODO: we'd prefer to use LedgerInfoWithSignatures::add_signature instead, but the
         // CryptoProxy types should be properly updated first.
-        vote_msg
-            .signature()
+        vote.signature()
             .clone()
-            .add_to_li(vote_msg.author(), li_with_sig);
+            .add_to_li(vote.author(), li_with_sig);
 
         match validator_verifier.check_voting_power(li_with_sig.signatures().keys()) {
             Ok(_) => VoteReceptionResult::NewQuorumCertificate(Arc::new(QuorumCert::new(
-                vote_msg.vote_data().clone(),
+                vote.vote_data().clone(),
                 li_with_sig.clone(),
             ))),
             Err(VerifyError::TooLittleVotingPower { voting_power, .. }) => {
                 VoteReceptionResult::VoteAdded(voting_power)
             }
-            _ => panic!("Unexpected verification error, vote_msg = {}", vote_msg),
+            _ => panic!("Unexpected verification error, vote = {}", vote),
         }
     }
 
@@ -114,33 +113,33 @@ impl PendingVotes {
     /// new TimeoutCertificate, otherwise, return None.
     fn aggregate_tc(
         &mut self,
-        vote_msg: &VoteMsg,
+        vote: &Vote,
         validator_verifier: &ValidatorVerifier,
     ) -> Option<VoteReceptionResult> {
-        let round_signature = vote_msg.round_signature().cloned()?;
-        let round = vote_msg.vote_data().proposed().round();
+        let round_signature = vote.round_signature().cloned()?;
+        let round = vote.vote_data().proposed().round();
         let tc = self
             .round_to_tc
             .entry(round)
             .or_insert_with(|| TimeoutCertificate::new(round, HashMap::new()));
-        tc.add_signature(vote_msg.author(), round_signature);
+        tc.add_signature(vote.author(), round_signature);
         match validator_verifier.check_voting_power(tc.signatures().keys()) {
             Ok(_) => Some(VoteReceptionResult::NewTimeoutCertificate(Arc::new(
                 tc.clone(),
             ))),
             Err(VerifyError::TooLittleVotingPower { .. }) => None,
-            _ => panic!("Unexpected verification error, vote_msg = {}", vote_msg),
+            _ => panic!("Unexpected verification error, vote = {}", vote),
         }
     }
 
     /// If this is the first vote from Author, add it to map. If Author has
     /// already voted on same block then return DuplicateVote error. If Author has already voted
     /// on some other result, prune the last vote and insert new one in map.
-    fn replace_prev_vote(&mut self, vote_msg: &VoteMsg) -> Result<(), VoteReceptionResult> {
-        let author = vote_msg.author();
-        let round = vote_msg.vote_data().proposed().round();
-        let li_digest = vote_msg.ledger_info().hash();
-        let is_timeout = vote_msg.is_timeout();
+    fn replace_prev_vote(&mut self, vote: &Vote) -> Result<(), VoteReceptionResult> {
+        let author = vote.author();
+        let round = vote.vote_data().proposed().round();
+        let li_digest = vote.ledger_info().hash();
+        let is_timeout = vote.is_timeout();
         let vote_info = LastVoteInfo {
             li_digest,
             round,
@@ -159,7 +158,7 @@ impl PendingVotes {
                 // Author has already voted for the very same LedgerInfo
                 return Err(VoteReceptionResult::DuplicateVote);
             } else {
-                // Author has already voted for this LedgerInfo, but this time the VoteMsg's
+                // Author has already voted for this LedgerInfo, but this time the Vote's
                 // round signature is different.
                 // Do not replace the prev vote, try to may be gather a TC.
                 return Ok(());

--- a/consensus/src/chained_bft/block_storage/pending_votes_test.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes_test.rs
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chained_bft::block_storage::pending_votes::PendingVotes;
-use crate::chained_bft::{block_storage::VoteReceptionResult, test_utils};
-
-use consensus_types::{
-    block_info::BlockInfo, common::Round, vote_data::VoteData, vote_msg::VoteMsg,
-};
+use crate::chained_bft::block_storage::VoteReceptionResult;
+use consensus_types::{block_info::BlockInfo, common::Round, vote::Vote, vote_data::VoteData};
 use crypto::HashValue;
 use libra_types::crypto_proxies::random_validator_verifier;
 use libra_types::ledger_info::LedgerInfo;
@@ -37,12 +34,11 @@ fn test_qc_aggregation() {
 
     let li1 = random_ledger_info();
     let vote_data_1 = random_vote_data(1);
-    let vote_data_1_author_0 = VoteMsg::new(
+    let vote_data_1_author_0 = Vote::new(
         vote_data_1.clone(),
         signers[0].author(),
         li1.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
 
     // first time a new vote is added the result is VoteAdded
@@ -59,12 +55,11 @@ fn test_qc_aggregation() {
     // override the prev value and return equivocation
     let li2 = random_ledger_info();
     let vote_data_2 = random_vote_data(1);
-    let vote_data_2_author_0 = VoteMsg::new(
+    let vote_data_2_author_0 = Vote::new(
         vote_data_2.clone(),
         signers[0].author(),
         li2.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_data_2_author_0, &validator),
@@ -72,24 +67,22 @@ fn test_qc_aggregation() {
     );
     // A different author voting for a different result in the same round but without a round
     // signature: VoteAdded
-    let vote_data_2_author_1 = VoteMsg::new(
+    let vote_data_2_author_1 = Vote::new(
         vote_data_2.clone(),
         signers[1].author(),
         li2.clone(),
         &signers[1],
-        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_data_2_author_1, &validator),
         VoteReceptionResult::VoteAdded(1)
     );
     // Two votes for the ledger info form a QC
-    let vote_data_2_author_2 = VoteMsg::new(
+    let vote_data_2_author_2 = Vote::new(
         vote_data_2.clone(),
         signers[2].author(),
         li2.clone(),
         &signers[2],
-        test_utils::placeholder_sync_info(),
     );
     match pending_votes.insert_vote(&vote_data_2_author_2, &validator) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
@@ -113,12 +106,11 @@ fn test_qc_aggregation_keep_last_only() {
 
     let li1 = random_ledger_info();
     let vote_round_1 = random_vote_data(1);
-    let vote_round_1_author_0 = VoteMsg::new(
+    let vote_round_1_author_0 = Vote::new(
         vote_round_1.clone(),
         signers[0].author(),
         li1.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
 
     // first time a new vote is added the result is VoteAdded
@@ -130,12 +122,11 @@ fn test_qc_aggregation_keep_last_only() {
     // same author voting for the next round: the previous vote is replaced
     let li2 = random_ledger_info();
     let vote_round_2 = random_vote_data(2);
-    let vote_round_2_author_0 = VoteMsg::new(
+    let vote_round_2_author_0 = Vote::new(
         vote_round_2.clone(),
         signers[0].author(),
         li2.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_round_2_author_0, &validator),
@@ -143,12 +134,11 @@ fn test_qc_aggregation_keep_last_only() {
     );
 
     // another author voting for round 1 cannot form a QC because the old vote is gone
-    let vote_round_1_author_1 = VoteMsg::new(
+    let vote_round_1_author_1 = Vote::new(
         vote_round_1.clone(),
         signers[1].author(),
         li1.clone(),
         &signers[1],
-        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_round_1_author_1, &validator),
@@ -156,12 +146,11 @@ fn test_qc_aggregation_keep_last_only() {
     );
 
     // another author voting for the vote data in round 2 can finally form a QC
-    let vote_round_2_author_1 = VoteMsg::new(
+    let vote_round_2_author_1 = Vote::new(
         vote_round_2.clone(),
         signers[1].author(),
         li2.clone(),
         &signers[1],
-        test_utils::placeholder_sync_info(),
     );
     match pending_votes.insert_vote(&vote_round_2_author_1, &validator) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
@@ -185,12 +174,11 @@ fn test_tc_aggregation() {
 
     let li1 = random_ledger_info();
     let vote_round_1 = random_vote_data(1);
-    let mut vote_round_1_author_0 = VoteMsg::new(
+    let mut vote_round_1_author_0 = Vote::new(
         vote_round_1.clone(),
         signers[0].author(),
         li1.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
     vote_round_1_author_0.add_round_signature(&signers[0]);
 
@@ -204,12 +192,11 @@ fn test_tc_aggregation() {
     // round signature
     let li2 = random_ledger_info();
     let vote2_round_1 = random_vote_data(1);
-    let mut vote2_round_1_author_1 = VoteMsg::new(
+    let mut vote2_round_1_author_1 = Vote::new(
         vote2_round_1.clone(),
         signers[1].author(),
         li2.clone(),
         &signers[1],
-        test_utils::placeholder_sync_info(),
     );
     assert_eq!(
         pending_votes.insert_vote(&vote2_round_1_author_1, &validator),
@@ -238,12 +225,11 @@ fn test_tc_aggregation_keep_last_only() {
 
     let li1 = random_ledger_info();
     let vote_round_1 = random_vote_data(1);
-    let mut vote_round_1_author_0 = VoteMsg::new(
+    let mut vote_round_1_author_0 = Vote::new(
         vote_round_1.clone(),
         signers[0].author(),
         li1.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
     vote_round_1_author_0.add_round_signature(&signers[0]);
 
@@ -256,12 +242,11 @@ fn test_tc_aggregation_keep_last_only() {
     // A vote for round 2 overrides the previous vote
     let li2 = random_ledger_info();
     let vote_round_2 = random_vote_data(2);
-    let mut vote_round_2_author_0 = VoteMsg::new(
+    let mut vote_round_2_author_0 = Vote::new(
         vote_round_2.clone(),
         signers[0].author(),
         li2.clone(),
         &signers[0],
-        test_utils::placeholder_sync_info(),
     );
     vote_round_2_author_0.add_round_signature(&signers[0]);
     assert_eq!(
@@ -272,12 +257,11 @@ fn test_tc_aggregation_keep_last_only() {
     // a new vote for round 1 cannot form a TC
     let li3 = random_ledger_info();
     let vote3_round_1 = random_vote_data(1);
-    let mut vote3_round_1_author_1 = VoteMsg::new(
+    let mut vote3_round_1_author_1 = Vote::new(
         vote3_round_1.clone(),
         signers[1].author(),
         li3.clone(),
         &signers[1],
-        test_utils::placeholder_sync_info(),
     );
     vote3_round_1_author_1.add_round_signature(&signers[1]);
     assert_eq!(
@@ -288,12 +272,11 @@ fn test_tc_aggregation_keep_last_only() {
     // a new vote for round 2 should form a TC
     let li4 = random_ledger_info();
     let vote4_round_2 = random_vote_data(2);
-    let mut vote4_round_2_author_1 = VoteMsg::new(
+    let mut vote4_round_2_author_1 = Vote::new(
         vote4_round_2.clone(),
         signers[1].author(),
         li4.clone(),
         &signers[1],
-        test_utils::placeholder_sync_info(),
     );
     vote4_round_2_author_1.add_round_signature(&signers[1]);
     match pending_votes.insert_vote(&vote4_round_2_author_1, &validator) {

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -224,7 +224,7 @@ fn start_with_proposal_test() {
             .into_iter()
             .map(|(_, msg)| VoteMsg::try_from(msg).unwrap())
             .collect();
-        let proposed_block_id = votes[0].vote_data().proposed().id();
+        let proposed_block_id = votes[0].vote().vote_data().proposed().id();
 
         // Verify that the proposed block id is indeed present in the block store.
         assert!(nodes[0]
@@ -332,7 +332,7 @@ fn basic_commit_and_restart() {
                 .wait_for_messages(1, NetworkPlayground::votes_only)
                 .await;
             let vote_msg = VoteMsg::try_from(votes[0].1.clone()).unwrap();
-            block_ids.push(vote_msg.vote_data().proposed().id());
+            block_ids.push(vote_msg.vote().vote_data().proposed().id());
         }
 
         assert!(
@@ -412,7 +412,7 @@ fn basic_block_retrieval() {
                 .wait_for_messages(1, NetworkPlayground::votes_only)
                 .await;
             let vote_msg = VoteMsg::try_from(votes[0].1.clone()).unwrap();
-            let proposal_id = vote_msg.vote_data().proposed().id();
+            let proposal_id = vote_msg.vote().vote_data().proposed().id();
             first_proposals.push(proposal_id);
         }
         // The next proposal is delivered to all: as a result nodes[2] should retrieve the missing
@@ -471,7 +471,7 @@ fn block_retrieval_with_timeout() {
                 .wait_for_messages(1, NetworkPlayground::votes_only)
                 .await;
             let vote_msg = VoteMsg::try_from(votes[0].1.clone()).unwrap();
-            let proposal_id = vote_msg.vote_data().proposed().id();
+            let proposal_id = vote_msg.vote().vote_data().proposed().id();
             first_proposals.push(proposal_id);
         }
         // The next proposal is delivered to all: as a result nodes[2] should retrieve the missing
@@ -529,7 +529,7 @@ fn basic_state_sync() {
                 .wait_for_messages(1, NetworkPlayground::votes_only)
                 .await;
             let vote_msg = VoteMsg::try_from(votes[0].1.clone()).unwrap();
-            let proposal_id = vote_msg.vote_data().proposed().id();
+            let proposal_id = vote_msg.vote().vote_data().proposed().id();
             proposals.push(proposal_id);
         }
 
@@ -609,7 +609,7 @@ fn state_sync_on_timeout() {
                 .wait_for_messages(1, NetworkPlayground::votes_only)
                 .await;
             let vote_msg = VoteMsg::try_from(votes[0].1.clone()).unwrap();
-            let proposal_id = vote_msg.vote_data().proposed().id();
+            let proposal_id = vote_msg.vote().vote_data().proposed().id();
             proposals.push(proposal_id);
         }
 
@@ -831,9 +831,9 @@ fn secondary_proposers() {
             .await;
         let mut secondary_proposal_ids = vec![];
         for msg in timeout_votes {
-            let vote = VoteMsg::try_from(msg.1).unwrap();
-            assert!(vote.is_timeout());
-            secondary_proposal_ids.push(vote.vote_data().proposed().id());
+            let vote_msg = VoteMsg::try_from(msg.1).unwrap();
+            assert!(vote_msg.vote().is_timeout());
+            secondary_proposal_ids.push(vote_msg.vote().vote_data().proposed().id());
         }
         assert_eq!(secondary_proposal_ids.len(), 4);
         let secondary_proposal_id = secondary_proposal_ids[0];

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -370,7 +370,7 @@ fn basic_commit_and_restart() {
                 let msg = playground
                     .wait_for_messages(1, NetworkPlayground::exclude_timeout_msg)
                     .await;
-                if let Some(ConsensusMsg_oneof::Vote(_)) = msg[0].1.message {
+                if let Some(ConsensusMsg_oneof::VoteMsg(_)) = msg[0].1.message {
                     round += 1;
                     break;
                 }

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -351,7 +351,9 @@ fn process_successful_proposal_test() {
                 }
 
                 match m.1.message {
-                    Some(ConsensusMsg_oneof::Vote(vote)) => Some(VoteMsg::try_from(vote).unwrap()),
+                    Some(ConsensusMsg_oneof::VoteMsg(vote_msg)) => {
+                        Some(VoteMsg::try_from(vote_msg).unwrap())
+                    }
                     _ => None,
                 }
             })
@@ -413,7 +415,9 @@ fn process_old_proposal_test() {
                 }
 
                 match m.1.message {
-                    Some(ConsensusMsg_oneof::Vote(vote)) => Some(VoteMsg::try_from(vote).unwrap()),
+                    Some(ConsensusMsg_oneof::VoteMsg(vote_msg)) => {
+                        Some(VoteMsg::try_from(vote_msg).unwrap())
+                    }
                     _ => None,
                 }
             })

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -378,6 +378,7 @@ where
         let vote_msg = VoteMsg::try_from(vote_msg)?;
         debug!("Received {}", vote_msg);
         vote_msg
+            .vote()
             .verify(self.epoch_mgr.validators().as_ref())
             .map_err(|e| {
                 security_log(SecurityEvent::InvalidConsensusVote)

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -9,7 +9,8 @@ use crate::chained_bft::{
 use channel;
 use consensus_types::{
     block::Block, block_info::BlockInfo, common::Author, proposal_msg::ProposalMsg,
-    quorum_cert::QuorumCert, sync_info::SyncInfo, vote_data::VoteData, vote_msg::VoteMsg,
+    quorum_cert::QuorumCert, sync_info::SyncInfo, vote::Vote, vote_data::VoteData,
+    vote_msg::VoteMsg,
 };
 use futures::{channel::mpsc, executor::block_on, SinkExt, StreamExt};
 use network::{
@@ -259,7 +260,7 @@ impl NetworkPlayground {
     pub fn timeout_votes_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
         // Timeout votes carry non-empty round signatures.
         if let Some(ConsensusMsg_oneof::VoteMsg(vote_msg)) = &msg_copy.1.message {
-            !vote_msg.round_signature.is_empty()
+            !vote_msg.vote.as_ref().unwrap().round_signature.is_empty()
         } else {
             false
         }
@@ -347,10 +348,12 @@ fn test_network_api() {
         nodes.push(node);
     }
     let vote_msg = VoteMsg::new(
-        VoteData::new(BlockInfo::random(1), BlockInfo::random(0)),
-        peers[0],
-        placeholder_ledger_info(),
-        &signers[0],
+        Vote::new(
+            VoteData::new(BlockInfo::random(1), BlockInfo::random(0)),
+            peers[0],
+            placeholder_ledger_info(),
+            &signers[0],
+        ),
         test_utils::placeholder_sync_info(),
     );
     let previous_block = Block::make_genesis_block();

--- a/consensus/src/chained_bft/proto_test.rs
+++ b/consensus/src/chained_bft/proto_test.rs
@@ -51,13 +51,13 @@ fn test_proto_convert_proposal() {
 #[test]
 fn test_proto_convert_vote() {
     let signer = ValidatorSigner::random(None);
-    let vote = VoteMsg::new(
+    let vote_msg = VoteMsg::new(
         VoteData::new(BlockInfo::random(1), BlockInfo::random(0)),
         signer.author(),
         placeholder_ledger_info(),
         &signer,
         test_utils::placeholder_sync_info(),
     );
-    let vote_proto = network::proto::Vote::from(vote.clone());
-    assert_eq!(vote, vote_proto.try_into().unwrap());
+    let vote_msg_proto = network::proto::VoteMsg::from(vote_msg.clone());
+    assert_eq!(vote_msg, vote_msg_proto.try_into().unwrap());
 }

--- a/consensus/src/chained_bft/proto_test.rs
+++ b/consensus/src/chained_bft/proto_test.rs
@@ -8,6 +8,7 @@ use consensus_types::{
     proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
+    vote::Vote,
     vote_data::VoteData,
     vote_msg::VoteMsg,
 };
@@ -52,10 +53,12 @@ fn test_proto_convert_proposal() {
 fn test_proto_convert_vote() {
     let signer = ValidatorSigner::random(None);
     let vote_msg = VoteMsg::new(
-        VoteData::new(BlockInfo::random(1), BlockInfo::random(0)),
-        signer.author(),
-        placeholder_ledger_info(),
-        &signer,
+        Vote::new(
+            VoteData::new(BlockInfo::random(1), BlockInfo::random(0)),
+            signer.author(),
+            placeholder_ledger_info(),
+            &signer,
+        ),
         test_utils::placeholder_sync_info(),
     );
     let vote_msg_proto = network::proto::VoteMsg::from(vote_msg.clone());

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -8,7 +8,7 @@ use crate::chained_bft::persistent_storage::{
 use config::config::{NodeConfig, NodeConfigHelpers};
 use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
-    timeout_certificate::TimeoutCertificate, vote_msg::VoteMsg,
+    timeout_certificate::TimeoutCertificate, vote::Vote,
 };
 use crypto::HashValue;
 use failure::Result;
@@ -24,7 +24,7 @@ pub struct MockSharedStorage<T> {
     pub block: Mutex<HashMap<HashValue, Block<T>>>,
     pub qc: Mutex<HashMap<HashValue, QuorumCert>>,
     pub state: Mutex<ConsensusState>,
-    pub last_vote: Mutex<Option<VoteMsg>>,
+    pub last_vote: Mutex<Option<Vote>>,
 
     // Liveness state
     pub highest_timeout_certificate: Mutex<Option<TimeoutCertificate>>,
@@ -153,13 +153,13 @@ impl<T: Payload> PersistentStorage<T> for MockStorage<T> {
         Ok(())
     }
 
-    fn save_consensus_state(&self, state: ConsensusState, last_vote: VoteMsg) -> Result<()> {
+    fn save_consensus_state(&self, state: ConsensusState, last_vote: &Vote) -> Result<()> {
         *self.shared_storage.state.lock().unwrap() = state;
         self.shared_storage
             .last_vote
             .lock()
             .unwrap()
-            .replace(last_vote);
+            .replace(last_vote.clone());
         Ok(())
     }
 
@@ -215,7 +215,7 @@ impl<T: Payload> PersistentStorage<T> for EmptyStorage {
         Ok(())
     }
 
-    fn save_consensus_state(&self, _: ConsensusState, _: VoteMsg) -> Result<()> {
+    fn save_consensus_state(&self, _: ConsensusState, _: &Vote) -> Result<()> {
         Ok(())
     }
 

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -11,7 +11,7 @@ import "transaction.proto";
 message ConsensusMsg {
   oneof message {
     Proposal proposal = 1;
-    Vote vote = 2;
+    VoteMsg vote_msg = 2;
     RequestBlock request_block = 3;
     RespondBlock respond_block = 4;
     SyncInfo sync_info = 6;
@@ -107,7 +107,7 @@ message VoteData {
   BlockInfo parent = 2;
 }
 
-message Vote {
+message VoteMsg {
   // The actual vote information.
   VoteData vote_data = 1;
   // Author of the vote.

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -107,7 +107,7 @@ message VoteData {
   BlockInfo parent = 2;
 }
 
-message VoteMsg {
+message Vote {
   // The actual vote information.
   VoteData vote_data = 1;
   // Author of the vote.
@@ -119,8 +119,13 @@ message VoteMsg {
   bytes signature = 4;
   // The round signatures can be aggregated into the timeout certificate.
   bytes round_signature = 5;
+}
+
+message VoteMsg {
+  // The container of the vote material
+  Vote vote = 1;
   // Sync info for exchanging information about highest QC, TC and LedgerInfo
-  SyncInfo sync_info = 6;
+  SyncInfo sync_info = 2;
 }
 
 message RequestBlock {

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
     consensus::{
         consensus_msg::Message as ConsensusMsg_oneof, Block, BlockInfo, BlockRetrievalStatus,
         ConsensusMsg, Proposal, QuorumCert, RequestBlock, RespondBlock, SyncInfo,
-        TimeoutCertificate, Vote, VoteData,
+        TimeoutCertificate, VoteData, VoteMsg,
     },
     mempool::MempoolSyncMsg,
     network::{

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
     consensus::{
         consensus_msg::Message as ConsensusMsg_oneof, Block, BlockInfo, BlockRetrievalStatus,
         ConsensusMsg, Proposal, QuorumCert, RequestBlock, RespondBlock, SyncInfo,
-        TimeoutCertificate, VoteData, VoteMsg,
+        TimeoutCertificate, Vote, VoteData, VoteMsg,
     },
     mempool::MempoolSyncMsg,
     network::{

--- a/network/src/validator_network/consensus.rs
+++ b/network/src/validator_network/consensus.rs
@@ -183,15 +183,17 @@ impl ConsensusNetworkSender {
 mod tests {
     use super::*;
     use crate::{
-        proto::{VoteData, VoteMsg},
+        proto::{Vote, VoteData, VoteMsg},
         protocols::rpc::InboundRpcRequest,
     };
     use futures::{channel::oneshot, executor::block_on, future::try_join};
 
     fn new_test_vote() -> ConsensusMsg {
         let vote_data = VoteData::default();
+        let mut vote = Vote::default();
         let mut vote_msg = VoteMsg::default();
-        vote_msg.vote_data = Some(vote_data);
+        vote.vote_data = Some(vote_data);
+        vote_msg.vote = Some(vote);
 
         ConsensusMsg {
             message: Some(ConsensusMsg_oneof::VoteMsg(vote_msg)),

--- a/network/src/validator_network/consensus.rs
+++ b/network/src/validator_network/consensus.rs
@@ -183,18 +183,18 @@ impl ConsensusNetworkSender {
 mod tests {
     use super::*;
     use crate::{
-        proto::{Vote, VoteData},
+        proto::{VoteData, VoteMsg},
         protocols::rpc::InboundRpcRequest,
     };
     use futures::{channel::oneshot, executor::block_on, future::try_join};
 
     fn new_test_vote() -> ConsensusMsg {
         let vote_data = VoteData::default();
-        let mut vote = Vote::default();
-        vote.vote_data = Some(vote_data);
+        let mut vote_msg = VoteMsg::default();
+        vote_msg.vote_data = Some(vote_data);
 
         ConsensusMsg {
-            message: Some(ConsensusMsg_oneof::Vote(vote)),
+            message: Some(ConsensusMsg_oneof::VoteMsg(vote_msg)),
         }
     }
 


### PR DESCRIPTION
As a precursor to introducing a TCB API (hopefully the last set of commits required). I believe commit 1 should be easy but commit 2 may require changes. If that's the case let me know and I can break this up into two PRs.

commit 1:
rename proto::vote to proto::vote_msg
    - naming should (always) be consistent
    - the VoteMsg is a container used to send out responses to proposals, it
    might contain both votes and metadata (e.g. SyncInfo) as a result the
    Vote should be a struct within VoteMsg
commit 2: 
add a new struct Vote to VoteMsg
    VoteMsg is a general purpose container for submitting a vote
    It may contain metadata that has nothing to do with a vote (SyncInfo)
    This diff separates that container from the actual vote material by
    creating a new struct (Vote) that explicitly handles vote material.
    In turn, this allows VoteMsg to container additional fields that
    may not be relevant to voting but to consensus at large.