### PR TITLE
[consensus] Modifying hash-based proposer election distribution

### DIFF
--- a/consensus/src/chained_bft/liveness/multi_proposer_test.rs
+++ b/consensus/src/chained_bft/liveness/multi_proposer_test.rs
@@ -21,9 +21,10 @@ fn test_multi_proposer() {
     let mut pe: Box<dyn ProposerElection<u32>> = Box::new(MultiProposer::new(proposers.clone(), 2));
     let round = 1;
     let first_hash = multi_proposer_election::hash(round);
-    let primary_idx = (first_hash % 8) as usize;
+    let primary_idx = multi_proposer_election::hash_to_bound(first_hash, 8) as usize;
     let second_hash = multi_proposer_election::hash(first_hash);
-    let secondary_idx = (second_hash % 7) as usize; // assuming no collisions in this case
+    // assuming no collisions in this case
+    let secondary_idx = multi_proposer_election::hash_to_bound(second_hash, 7) as usize;
 
     let primary_proposer = proposers[primary_idx];
     let secondary_proposer = proposers[secondary_idx];
@@ -100,7 +101,7 @@ fn test_multi_proposer_hash() {
     // Verify that the hash distributes primary proposers in a "reasonable" fashion
     let mut counts = vec![0; 10];
     for round in 0..10000 {
-        let idx = (multi_proposer_election::hash(round) % counts.len() as u64) as usize;
+        let idx = multi_proposer_election::hash_to_bound(round, counts.len() as u64) as usize;
         counts[idx] += 1;
     }
     for c in counts {


### PR DESCRIPTION
The proposer election algorithm in `multi_proposer_election.rs` is meant to uniformly select a set of proposers from the round number by doing `Hash(round) % num_proposers`, where `Hash` outputs a 64-bit integer. However, this is only a uniform distribution if `2^64 % num_proposers == 0`.

This change introduces a `hash_to_bound` function which is similar in implementation to libsodium's [`randombytes_uniform`](https://github.com/jedisct1/libsodium/blob/927dfe8e2eaa86160d3ba12a7e3258fbc322909c/src/libsodium/randombytes/randombytes.c#L118).

It takes a candidate hash output and checks if it lies in the "biased" range -- if so, it re-samples by computing the hash output again, until it receives a hash output which is not in the biased range. Each sample is expected to be outside of the bias range with probability at least 1/2.

## Test Plan

`cargo test`