### PR TITLE
[cluster_test] parallelize minting

### DIFF
--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -21,7 +21,7 @@ const COMMIT_RATIO_THRESHOLD: f64 = 0.7;
 /// clients, even though all of them originate from the same benchmarker
 /// process. We add a unique user-agent to bypass some of gRPC default
 /// optimization that group connections from the same source onto
-/// a single completion queue (making requests sequntial).
+/// a single completion queue (making requests sequential).
 ///
 /// index: unique identifier for the channel, to uniquify clients
 fn create_ac_client(index: usize, conn_addr: &str) -> AdmissionControlClient {
@@ -32,7 +32,7 @@ fn create_ac_client(index: usize, conn_addr: &str) -> AdmissionControlClient {
     AdmissionControlClient::new(ch)
 }
 
-/// Creat a vector of AdmissionControlClient and connect them to validators.
+/// Create a vector of AdmissionControlClient and connect them to validators.
 pub fn create_ac_clients(
     num_clients: usize,
     validator_addresses: &[String],


### PR DESCRIPTION
- Introduce "core accounts" which serve as the initial accounts for the faucet account to mint on.
- No longer sequentially mint `X` coins on `Y` accounts (=> O(`Y`)).
- Mint `X * Y / Y'` coins on `Y'` accounts (=> O(`Y'`)), and transfer `X` coins to rest of the accounts in parallel (=> O(`Y/Y'`)). It is assumed`X` << `X * Y / Y'`, or `Y` >> `Y'`.

Tested with the transaction generator using the command given from running `cargo run -p libra-swarm -- -s -n 4`. Minting completed successfully. The outputs match those of pre-change. Below are more details:
```
~/libra$ cargo run -p libra-swarm -- -s -n 4
    Finished dev [unoptimized + debuginfo] target(s) in 0.81s
     Running `target/debug/libra-swarm -s -n 4`
Faucet account created in (loaded from) file "/var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b4a2cafda7f3bea75fda5befd9eb16fe/temp_faucet_keys"
Base directory containing logs and configs: Temporary(TempPath { path_buf: "/var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b15df34927a189edb256502a4ac9fd3b", persist: false })
To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:
	cargo run --bin client -- -a localhost -p 52868 -s "/var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b15df34927a189edb256502a4ac9fd3b/0/consensus_peers.config.toml" -m "/var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b4a2cafda7f3bea75fda5befd9eb16fe/temp_faucet_keys"
To run transaction generator run:
	cargo run --bin cluster-test -- --mint-file "/var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b4a2cafda7f3bea75fda5befd9eb16fe/temp_faucet_keys" --swarm --peers "localhost:52868,localhost:52886,localhost:52904,localhost:52922"  --emit-tx
Loading client...
Connected to validator at: localhost:52868

~/libra$ cargo run --bin cluster-test -- --mint-file "/var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b4a2cafda7f3bea75fda5befd9eb16fe/temp_faucet_keys" --swarm --peers "localhost:52868,localhost:52886,localhost:52904,localhost:52922"  --emit-tx
    Finished dev [unoptimized + debuginfo] target(s) in 1.07s
     Running `target/debug/cluster-test --mint-file /var/folders/dj/6d209rz91k55zqjk47ndtmcm0000gn/T/b4a2cafda7f3bea75fda5befd9eb16fe/temp_faucet_keys --swarm --peers 'localhost:52868,localhost:52886,localhost:52904,localhost:52922' --emit-tx`
Oct 18 17:00:06.283 INFO Minting accounts
Oct 18 17:00:12.091 INFO Mint is done
```

Closes #1197 