### PR TITLE
Prepend libra to nibble package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
- "nibble 0.1.0",
+ "libra-nibble 0.1.0",
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1852,8 +1852,8 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
+ "libra-nibble 0.1.0",
  "libra-types 0.1.0",
- "nibble 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2100,6 +2100,14 @@ dependencies = [
  "failure_ext 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-nibble"
+version = "0.1.0"
+dependencies = [
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2553,14 +2561,6 @@ dependencies = [
 name = "new_debug_unreachable"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "nibble"
-version = "0.1.0"
-dependencies = [
- "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "nibble_vec"

--- a/common/nibble/Cargo.toml
+++ b/common/nibble/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "nibble"
+name = "libra-nibble"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
-description = "Libra nibble"
+description = "Libra libra-nibble"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -32,7 +32,7 @@ x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "
 crypto_derive = { path = "../crypto_derive" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-nibble = { path = "../../common/nibble" }
+libra-nibble = { path = "../../common/nibble" }
 
 [dev-dependencies]
 bitvec = "0.10.1"

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -71,7 +71,7 @@
 use bytes::Bytes;
 use failure::prelude::*;
 use lazy_static::lazy_static;
-use nibble::Nibble;
+use libra_nibble::Nibble;
 use proptest_derive::Arbitrary;
 use rand::{rngs::EntropyRng, Rng};
 use serde::{de, ser};

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.89", features = ["derive"] }
 
 crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
-nibble = { path = "../../common/nibble" }
+libra-nibble = { path = "../../common/nibble" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]

--- a/storage/jellyfish-merkle/src/iterator/mod.rs
+++ b/storage/jellyfish-merkle/src/iterator/mod.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 use crypto::HashValue;
 use failure::prelude::*;
+use libra_nibble::Nibble;
 use libra_types::{account_state_blob::AccountStateBlob, transaction::Version};
-use nibble::Nibble;
 
 /// `NodeVisitInfo` keeps track of the status of an internal node during the iteration process. It
 /// indicates which ones of its children have been visited.

--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -3,8 +3,8 @@
 
 use super::*;
 use crypto::HashValue;
+use libra_nibble::Nibble;
 use mock_tree_store::MockTreeStore;
-use nibble::Nibble;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
 

--- a/storage/jellyfish-merkle/src/nibble_path/mod.rs
+++ b/storage/jellyfish-merkle/src/nibble_path/mod.rs
@@ -8,7 +8,7 @@
 mod nibble_path_test;
 
 use crate::ROOT_NIBBLE_HEIGHT;
-use nibble::Nibble;
+use libra_nibble::Nibble;
 use proptest::{collection::vec, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::{fmt, iter::FromIterator};

--- a/storage/jellyfish-merkle/src/nibble_path/nibble_path_test.rs
+++ b/storage/jellyfish-merkle/src/nibble_path/nibble_path_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{arb_internal_nibble_path, skip_common_prefix, NibblePath};
-use nibble::Nibble;
+use libra_nibble::Nibble;
 use proptest::prelude::*;
 
 #[test]

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -24,12 +24,12 @@ use crypto::{
     HashValue,
 };
 use failure::{Fail, Result, *};
+use libra_nibble::Nibble;
 use libra_types::{
     account_state_blob::AccountStateBlob,
     proof::{SparseMerkleInternalNode, SparseMerkleLeafNode},
     transaction::Version,
 };
-use nibble::Nibble;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::cast::FromPrimitive;
 use proptest::{collection::hash_map, prelude::*};


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `nibble` package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235
#1350
#1353 