### PR TITLE
[cluster_test] Only print health-check when there are unexpected failures

### DIFF
--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -157,13 +157,14 @@ impl HealthCheckRunner {
         messages.push(format!(""));
         messages.push(format!(""));
 
-        if !only_print_on_failure || !failed.is_empty() {
-            messages.iter().for_each(|m| println!("{}", m));
-        }
         let affected_validators_set_refs = HashSet::from_iter(affected_validators_set.iter());
         let failed_set: HashSet<&String> = HashSet::from_iter(failed.iter());
-        let only_affected_validators_failed = failed_set.is_subset(&affected_validators_set_refs);
-        if !only_affected_validators_failed {
+        let unexpected_failures = !failed_set.is_subset(&affected_validators_set_refs);
+        if !only_print_on_failure || unexpected_failures {
+            messages.iter().for_each(|m| println!("{}", m));
+        }
+
+        if unexpected_failures {
             let unexpected_failures = failed_set
                 .difference(&affected_validators_set_refs)
                 .join(",");


### PR DESCRIPTION
# Summary

We were printing health-check results when there was at least one failure in the validators. This updates that logic to print only when there are unexpected failures.

## Test Plan

Built and ran this on cluster-test-runner machine.

Sample logs
```
Oct 17 18:16:14.831 INFO Starting experiment Reboot [85ef1c9c(10.0.8.128), 44f4ba84(10.0.3.149), 4c9880fc(10.0.5.16), ]
Rebooting 85ef1c9c(10.0.8.128)
Rebooting 44f4ba84(10.0.3.149)
Rebooting 4c9880fc(10.0.5.16)
Rebooting 85ef1c9c(10.0.8.128) in progress - did not reboot yet
Rebooting 85ef1c9c(10.0.8.128) complete
Rebooting 44f4ba84(10.0.3.149) complete
Rebooting 4c9880fc(10.0.5.16) complete
Oct 17 18:16:36.920 INFO Experiment finished, waiting until all affected validators recover
Oct 17 18:17:13.415 INFO Experiment completed
Rebooting 6ee34e2d(10.0.5.161)
Oct 17 18:17:30.996 INFO Starting experiment Reboot [6ee34e2d(10.0.5.161), 9a002180(10.0.9.97), 583efa89(10.0.11.100), ]
Rebooting 9a002180(10.0.9.97)
Rebooting 583efa89(10.0.11.100)
Rebooting 6ee34e2d(10.0.5.161) in progress - did not reboot yet
Rebooting 6ee34e2d(10.0.5.161) complete
Rebooting 9a002180(10.0.9.97) complete
Rebooting 583efa89(10.0.11.100) complete
Oct 17 18:17:53.607 INFO Experiment finished, waiting until all affected validators recover
Oct 17 18:18:45.992 INFO Experiment completed
```

Related to #1244

