### PR TITLE
[monitoring] Expose public metrics to a different port

### DIFF
--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -62,7 +62,7 @@ pub fn try_start_metrics_server(args: &BenchOpt) {
     if let Some(metrics_server_address) = &args.metrics_server_address {
         let address = metrics_server_address.clone();
         std::thread::spawn(move || {
-            start_server(address);
+            start_server(address, 9101, false);
         });
     }
 }

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -9,6 +9,7 @@ extern crate prometheus;
 pub mod counters;
 mod json_encoder;
 pub mod metric_server;
+mod public_metrics;
 
 mod service_metrics;
 pub use service_metrics::ServiceMetrics;

--- a/common/metrics/src/metric_server.rs
+++ b/common/metrics/src/metric_server.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::json_encoder::JsonEncoder;
+use crate::public_metrics::PUBLIC_METRICS;
 use futures::future;
 use hyper::{
     rt::{self, Future},
@@ -9,14 +10,33 @@ use hyper::{
     Body, Method, Request, Response, Server, StatusCode,
 };
 use libra_logger::prelude::*;
-use prometheus::{Encoder, TextEncoder};
+use prometheus::{proto::MetricFamily, Encoder, TextEncoder};
 use std::net::{SocketAddr, ToSocketAddrs};
 
-fn encode_metrics(encoder: impl Encoder) -> Vec<u8> {
-    let metric_families = prometheus::gather();
+fn encode_metrics(encoder: impl Encoder, whitelist: Vec<String>) -> Vec<u8> {
+    let mut metric_families = prometheus::gather();
+    if !whitelist.is_empty() {
+        metric_families = whitelist_metrics(metric_families, whitelist);
+    }
     let mut buffer = vec![];
     encoder.encode(&metric_families, &mut buffer).unwrap();
     buffer
+}
+
+// filtering metrics from the prometheus collections
+// only return the whitelisted metrics
+fn whitelist_metrics(
+    metric_families: Vec<MetricFamily>,
+    whitelist: Vec<String>,
+) -> Vec<MetricFamily> {
+    let mut whitelist_metrics = Vec::new();
+    for mf in metric_families {
+        let name = mf.get_name();
+        if whitelist.contains(&name.to_string()) {
+            whitelist_metrics.push(mf.clone());
+        }
+    }
+    whitelist_metrics
 }
 
 fn serve_metrics(req: Request<Body>) -> impl Future<Item = Response<Body>, Error = hyper::Error> {
@@ -25,13 +45,13 @@ fn serve_metrics(req: Request<Body>) -> impl Future<Item = Response<Body>, Error
         (&Method::GET, "/metrics") => {
             //Prometheus server expects metrics to be on host:port/metrics
             let encoder = TextEncoder::new();
-            let buffer = encode_metrics(encoder);
+            let buffer = encode_metrics(encoder, Vec::new());
             *resp.body_mut() = Body::from(buffer);
         }
         (&Method::GET, "/counters") => {
             // Json encoded libra_metrics;
             let encoder = JsonEncoder;
-            let buffer = encode_metrics(encoder);
+            let buffer = encode_metrics(encoder, Vec::new());
             *resp.body_mut() = Body::from(buffer);
         }
         _ => {
@@ -42,25 +62,61 @@ fn serve_metrics(req: Request<Body>) -> impl Future<Item = Response<Body>, Error
     future::ok(resp)
 }
 
-pub fn start_server<T: ToSocketAddrs>(to_addr: T) {
-    let addr: SocketAddr = to_addr
+fn serve_public_metrics(
+    req: Request<Body>,
+) -> impl Future<Item = Response<Body>, Error = hyper::Error> {
+    let mut resp = Response::new(Body::empty());
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/metrics") => {
+            let encoder = TextEncoder::new();
+            // encode public metrics defined in common/metrics/src/public_metrics.rs
+            let buffer = encode_metrics(encoder, PUBLIC_METRICS.to_vec());
+            *resp.body_mut() = Body::from(buffer);
+        }
+        _ => {
+            *resp.status_mut() = StatusCode::NOT_FOUND;
+        }
+    };
+
+    future::ok(resp)
+}
+
+pub fn start_server(host: String, port: u16, public_metric: bool) {
+    let addr: SocketAddr = (host.as_str(), port)
         .to_socket_addrs()
-        .unwrap_or_else(|_| panic!("Failed to parse address"))
+        .unwrap_or_else(|_| panic!("Failed to parse {}:{} as address", host, port))
         .next()
         .unwrap();
 
-    rt::run(rt::lazy(move || {
-        match Server::try_bind(&addr) {
-            Ok(srv) => {
-                let srv = srv
-                    .serve(|| service_fn(serve_metrics))
-                    .map_err(|e| eprintln!("server error: {}", e));
-                info!("Metric server listening on http://{}", addr);
-                rt::spawn(srv);
-            }
-            Err(e) => error!("Metric server bind error: {}", e),
-        };
+    if public_metric {
+        rt::run(rt::lazy(move || {
+            match Server::try_bind(&addr) {
+                Ok(srv) => {
+                    let srv = srv
+                        .serve(|| service_fn(serve_public_metrics))
+                        .map_err(|e| eprintln!("server error: {}", e));
+                    info!("Metric server listening on http://{}", addr);
+                    rt::spawn(srv);
+                }
+                Err(e) => error!("Metric server bind error: {}", e),
+            };
 
-        Ok(())
-    }));
+            Ok(())
+        }));
+    } else {
+        rt::run(rt::lazy(move || {
+            match Server::try_bind(&addr) {
+                Ok(srv) => {
+                    let srv = srv
+                        .serve(|| service_fn(serve_metrics))
+                        .map_err(|e| eprintln!("server error: {}", e));
+                    info!("Metric server listening on http://{}", addr);
+                    rt::spawn(srv);
+                }
+                Err(e) => error!("Metric server bind error: {}", e),
+            };
+
+            Ok(())
+        }));
+    }
 }

--- a/common/metrics/src/public_metrics.rs
+++ b/common/metrics/src/public_metrics.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref PUBLIC_METRICS: Vec<String> = vec!["libra_network_peers".to_string()];
+}

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -256,6 +256,7 @@ pub struct DebugInterfaceConfig {
     pub storage_node_debug_port: u16,
     // This has similar use to the core-node-debug-server itself
     pub metrics_server_port: u16,
+    pub public_metrics_server_port: u16,
     pub address: String,
 }
 
@@ -266,6 +267,7 @@ impl Default for DebugInterfaceConfig {
             storage_node_debug_port: 6194,
             secret_service_node_debug_port: 6195,
             metrics_server_port: 9101,
+            public_metrics_server_port: 9102,
             address: "localhost".to_string(),
         }
     }
@@ -721,6 +723,7 @@ impl NodeConfigHelpers {
         config.admission_control.admission_control_service_port = get_available_port();
         config.debug_interface.admission_control_node_debug_port = get_available_port();
         config.debug_interface.metrics_server_port = get_available_port();
+        config.debug_interface.public_metrics_server_port = get_available_port();
         config.debug_interface.secret_service_node_debug_port = get_available_port();
         config.debug_interface.storage_node_debug_port = get_available_port();
         config.execution.port = get_available_port();

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -245,7 +245,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
     let metrics_port = node_config.debug_interface.metrics_server_port;
     let metric_host = node_config.debug_interface.address.clone();
-    thread::spawn(move || metric_server::start_server((metric_host.as_str(), metrics_port)));
+    thread::spawn(move || metric_server::start_server(metric_host, metrics_port, false));
+    let public_metrics_port = node_config.debug_interface.public_metrics_server_port;
+    let public_metric_host = node_config.debug_interface.address.clone();
+    thread::spawn(move || {
+        metric_server::start_server(public_metric_host, public_metrics_port, true)
+    });
 
     let state_synchronizer = StateSynchronizer::bootstrap(
         state_sync_network_handles,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Expose public_metrics to a different port. Using a separate port so that it will be easier for partners to config on their side.
Temporarily put network_gauge as the public_metrics we expose right now, will gather a list of metrics we want to publish and replace it later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `cargo run -p libra-swarm -- -s -l -n 4`
- get the port number from node.config.toml file
- `curl --silent "http://localhost:63470/metrics"`
- `curl --silent "http://localhost:63472/metrics"` // public port
- make sure metrics are collected correctly.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
