### PR TITLE
Prepend libra to metrics package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,8 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "network 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -189,11 +189,11 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-swarm 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libra_wallet 0.1.0",
- "metrics 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -492,7 +492,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
- "metrics 0.1.0",
+ "libra-metrics 0.1.0",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -565,10 +565,10 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libra_wallet 0.1.0",
- "metrics 0.1.0",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -722,9 +722,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1084,7 +1084,7 @@ dependencies = [
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
- "metrics 0.1.0",
+ "libra-metrics 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1266,7 +1266,7 @@ dependencies = [
  "config 0.1.0",
  "crash-handler 0.1.0",
  "libra-logger 0.1.0",
- "metrics 0.1.0",
+ "libra-metrics 0.1.0",
  "slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1285,8 +1285,8 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-ext 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1592,7 +1592,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
- "metrics 0.1.0",
+ "libra-metrics 0.1.0",
 ]
 
 [[package]]
@@ -2078,9 +2078,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "metrics 0.1.0",
  "network 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2100,6 +2100,22 @@ dependencies = [
  "failure_ext 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-metrics"
+version = "0.1.0"
+dependencies = [
+ "assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_ext 0.1.0",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-logger 0.1.0",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2130,8 +2146,8 @@ dependencies = [
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "network 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2232,9 +2248,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2392,22 +2408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.1.0"
-dependencies = [
- "assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_ext 0.1.0",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-logger 0.1.0",
- "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,9 +2539,9 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "memsocket 0.1.0",
- "metrics 0.1.0",
  "netcore 0.1.0",
  "noise 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3831,8 +3831,8 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
- "metrics 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4184,8 +4184,8 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "network 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4278,10 +4278,10 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "libradb 0.1.0",
- "metrics 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
@@ -5203,8 +5203,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-types 0.1.0",
- "metrics 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -30,7 +30,7 @@ grpc_helpers = { path = "../../common/grpc_helpers" }
 libra-logger = { path = "../../common/logger" }
 libra-mempool = { path = "../../mempool" }
 libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
-metrics = { path = "../../common/metrics" }
+libra-metrics = { path = "../../common/metrics" }
 storage-client = { path = "../../storage/storage-client" }
 libra-types = { path = "../../types" }
 vm_validator = { path = "../../vm_validator" }

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -29,11 +29,11 @@ use libra_mempool_shared_proto::proto::mempool_status::{
     MempoolAddTransactionStatus,
     MempoolAddTransactionStatusCode::{self, MempoolIsFull},
 };
+use libra_metrics::counters::SVC_COUNTERS;
 use libra_types::{
     proto::types::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse},
     transaction::SignedTransaction,
 };
-use metrics::counters::SVC_COUNTERS;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use storage_client::StorageRead;

--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -21,7 +21,7 @@ pub mod runtime;
 /// Handler for sending transaction write requests upstream if needed
 mod upstream_proxy;
 use lazy_static::lazy_static;
-use metrics::OpMetrics;
+use libra_metrics::OpMetrics;
 
 use libra_types::account_address::AccountAddress;
 type PeerId = AccountAddress;

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -28,7 +28,7 @@ generate-keypair = { path = "../config/generate-keypair" }
 libra_wallet = { path = "../client/libra_wallet" }
 libra-swarm = { path = "../libra-swarm" }
 libra-logger = { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 crypto = { path = "../crypto/crypto" }
 rusty-fork = "0.2.1"
 libra-tools = { path = "../common/tools" }

--- a/benchmark/src/bin_utils.rs
+++ b/benchmark/src/bin_utils.rs
@@ -10,7 +10,7 @@ use admission_control_proto::proto::admission_control::AdmissionControlClient;
 use client::AccountData;
 use grpcio::{ChannelBuilder, EnvBuilder};
 use libra_logger::{self, prelude::*};
-use metrics::metric_server::start_server;
+use libra_metrics::metric_server::start_server;
 use std::{sync::Arc, time};
 
 const COMMIT_RATIO_THRESHOLD: f64 = 0.7;

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -10,8 +10,8 @@ use crypto::{ed25519::*, test_utils::KeyPair};
 use generate_keypair::load_key_from_file;
 use lazy_static::lazy_static;
 use libra_logger::prelude::*;
+use libra_metrics::OpMetrics;
 use libra_types::{account_address::AccountAddress, account_config::association_address};
-use metrics::OpMetrics;
 use rand::Rng;
 use std::{collections::HashMap, convert::TryInto, sync::Arc, thread, time};
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,7 +32,7 @@ failure = { package = "failure_ext", path = "../common/failure_ext" }
 lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
 libra_wallet = { path = "./libra_wallet" }
 libra-logger =  { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 libra-types = { path = "../types" }
 libra-tools = { path = "../common/tools/" }
 transaction-builder = { path = "../language/transaction-builder" }

--- a/client/src/commands.rs
+++ b/client/src/commands.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 
 use failure::prelude::*;
+use libra_metrics::counters::*;
 use libra_types::account_address::ADDRESS_LENGTH;
-use metrics::counters::*;
 use std::{collections::HashMap, sync::Arc};
 
 /// Print the error and bump up error counter.

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview" }
 lazy_static = "1.3.0"
 libra-logger = { path = "../logger" }
-metrics = { path = "../metrics" }
+libra-metrics = { path = "../metrics" }
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/common/channel/src/lib.rs
+++ b/common/channel/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Provides an mpsc (multi-producer single-consumer) channel wrapped in an
-//! [`IntGauge`](metrics::IntGauge)
+//! [`IntGauge`](libra_metrics::IntGauge)
 
 use futures::{
     channel::mpsc,
@@ -11,7 +11,7 @@ use futures::{
     task::{Context, Poll},
 };
 use libra_logger::prelude::*;
-use metrics::IntGauge;
+use libra_metrics::IntGauge;
 use std::{
     pin::Pin,
     time::{Duration, Instant},

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.3.0"
 
 failure = { package = "failure_ext", path = "../failure_ext" }
 libra-logger = { path = "../logger" }
-metrics = { path = "../metrics" }
+libra-metrics = { path = "../metrics" }
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use futures::Future;
 use libra_logger::prelude::*;
-use metrics::counters::COUNTER_ADMISSION_CONTROL_CANNOT_SEND_REPLY;
+use libra_metrics::counters::COUNTER_ADMISSION_CONTROL_CANNOT_SEND_REPLY;
 
 #[derive(Clone, Default)]
 pub struct NodeDebugService {}
@@ -32,7 +32,7 @@ impl NodeDebugInterface for NodeDebugService {
     ) {
         info!("[GRPC] get_node_details");
         let mut response = GetNodeDetailsResponse::default();
-        response.stats = metrics::get_all_metrics();
+        response.stats = libra_metrics::get_all_metrics();
         ctx.spawn(sink.success(response).map_err(default_reply_error_logger))
     }
 

--- a/common/executable-helpers/Cargo.toml
+++ b/common/executable-helpers/Cargo.toml
@@ -15,4 +15,4 @@ slog-scope = "4.0"
 config = { path = "../../config"}
 crash-handler = { path = "../crash-handler" }
 libra-logger =  { path = "../logger" }
-metrics = { path = "../metrics" }
+libra-metrics = { path = "../metrics" }

--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -26,7 +26,7 @@ pub fn load_config_from_path(config: Option<&Path>) -> NodeConfig {
 pub fn setup_metrics(peer_id: &str, node_config: &NodeConfig) {
     let metrics_dir = node_config.get_metrics_dir();
     if !metrics_dir.as_os_str().is_empty() {
-        metrics::dump_all_metrics_to_file_periodically(
+        libra_metrics::dump_all_metrics_to_file_periodically(
             &metrics_dir,
             &format!("{}.metrics", peer_id),
             node_config.metrics.collection_interval_ms,

--- a/common/grpc_helpers/Cargo.toml
+++ b/common/grpc_helpers/Cargo.toml
@@ -16,4 +16,4 @@ futures_01 = { version = "0.1.28", package = "futures" }
 
 failure = { package = "failure_ext", path = "../failure_ext" }
 libra-logger = { path = "../logger" }
-metrics = { path = "../metrics" }
+libra-metrics = { path = "../metrics" }

--- a/common/grpc_helpers/src/lib.rs
+++ b/common/grpc_helpers/src/lib.rs
@@ -6,7 +6,7 @@ use futures::{compat::Future01CompatExt, future::Future, prelude::*};
 use futures_01::future::Future as Future01;
 use grpcio::{ChannelBuilder, EnvBuilder, ServerBuilder};
 use libra_logger::prelude::*;
-use metrics::counters::SVC_COUNTERS;
+use libra_metrics::counters::SVC_COUNTERS;
 use std::{
     str::from_utf8,
     sync::{

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "metrics"
+name = "libra-metrics"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
-description = "Libra metrics"
+description = "Libra libra-metrics"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"

--- a/common/metrics/src/metric_server.rs
+++ b/common/metrics/src/metric_server.rs
@@ -29,7 +29,7 @@ fn serve_metrics(req: Request<Body>) -> impl Future<Item = Response<Body>, Error
             *resp.body_mut() = Body::from(buffer);
         }
         (&Method::GET, "/counters") => {
-            // Json encoded metrics;
+            // Json encoded libra_metrics;
             let encoder = JsonEncoder;
             let buffer = encode_metrics(encoder);
             *resp.body_mut() = Body::from(buffer);

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -39,7 +39,7 @@ executor = { path = "../executor" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-logger = { path = "../common/logger" }
 libra-mempool = { path = "../mempool" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 network = { path = "../network" }
 prost-ext = { path = "../common/prost-ext" }
 safety-rules = { path = "safety-rules" }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use metrics::{DurationHistogram, OpMetrics};
+use libra_metrics::{DurationHistogram, OpMetrics};
 use prometheus::{Histogram, IntCounter, IntGauge};
 
 lazy_static::lazy_static! {

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -22,7 +22,7 @@ config = { path = "../config" }
 crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-logger = { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 prost-ext = { path = "../common/prost-ext" }
 scratchpad = { path = "../storage/scratchpad" }
 state-view = { path = "../storage/state-view" }

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -43,7 +43,8 @@ use storage_client::{StorageRead, StorageWrite};
 use vm_runtime::VMExecutor;
 
 lazy_static! {
-    static ref OP_COUNTERS: metrics::OpMetrics = metrics::OpMetrics::new_and_registered("executor");
+    static ref OP_COUNTERS: libra_metrics::OpMetrics =
+        libra_metrics::OpMetrics::new_and_registered("executor");
 }
 
 /// A structure that specifies the result of the execution.

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -23,7 +23,7 @@ lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" 
 config = { path = "../../../config" }
 crypto = { path = "../../../crypto/crypto" }
 libra-logger = { path = "../../../common/logger" }
-metrics = { path = "../../../common/metrics" }
+libra-metrics = { path = "../../../common/metrics" }
 state-view = { path = "../../../storage/state-view" }
 libra-types = { path = "../../../types" }
 vm = { path = "../" }

--- a/language/vm/vm_runtime/src/counters.rs
+++ b/language/vm/vm_runtime/src/counters.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
+use libra_metrics::OpMetrics;
 use libra_types::{
     transaction::TransactionStatus,
     vm_error::{StatusCode, StatusType, VMStatus},
 };
-use metrics::OpMetrics;
 use prometheus::{IntCounter, IntGauge};
 use std::{convert::TryFrom, time::Instant};
 

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -30,7 +30,7 @@ futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features =
 grpc_helpers = { path = "../common/grpc_helpers" }
 libra-logger = { path = "../common/logger" }
 libra-mempool = { path = "../mempool" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 crypto = { path = "../crypto/crypto" }
 network = { path = "../network" }
 state-synchronizer = { path = "../state-synchronizer" }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -11,8 +11,8 @@ use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
 use libra_logger::prelude::*;
 use libra_mempool::MempoolRuntime;
+use libra_metrics::metric_server;
 use libra_types::account_address::AccountAddress as PeerId;
-use metrics::metric_server;
 use network::{
     validator_network::{
         network_builder::{NetworkBuilder, TransportType},

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -28,7 +28,7 @@ config = { path = "../config" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 libra-logger = { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 network = { path = "../network" }
 crypto = { path = "../crypto/crypto" }
 storage-client = { path = "../storage/storage-client" }

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -61,7 +61,7 @@ mod shared_mempool;
 
 // module op counters
 use lazy_static::lazy_static;
-use metrics::OpMetrics;
+use libra_metrics::OpMetrics;
 lazy_static! {
     static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("mempool");
 }

--- a/mempool/src/mempool_service.rs
+++ b/mempool/src/mempool_service.rs
@@ -9,11 +9,11 @@ use crate::{
 use futures::Future;
 use grpc_helpers::{create_grpc_invalid_arg_status, default_reply_error_logger};
 use libra_logger::prelude::*;
+use libra_metrics::counters::SVC_COUNTERS;
 use libra_types::{
     account_address::AccountAddress, proto::types::SignedTransactionsBlock,
     transaction::SignedTransaction,
 };
-use metrics::counters::SVC_COUNTERS;
 use std::{
     cmp,
     collections::HashSet,

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -30,7 +30,7 @@ failure = { package = "failure_ext", path = "../common/failure_ext" }
 libra-types = { path = "../types" }
 libra-logger = { path = "../common/logger" }
 memsocket = { path = "memsocket" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 netcore = { path = "netcore" }
 noise = { path = "noise" }
 prost-ext = { path = "../common/prost-ext" }

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use metrics::{Histogram, IntCounter, IntGauge, OpMetrics};
+use libra_metrics::{Histogram, IntCounter, IntGauge, OpMetrics};
 
 lazy_static::lazy_static! {
     pub static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("network");

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -21,7 +21,7 @@ config = { path = "../config" }
 executor = { path = "../executor" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-logger = { path = "../common/logger" }
-metrics = { path = "../common/metrics" }
+libra-metrics = { path = "../common/metrics" }
 network = { path = "../network" }
 storage-client = { path = "../storage/storage-client" }
 libra-types = { path = "../types" }

--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use metrics::{DurationHistogram, OpMetrics};
+use libra_metrics::{DurationHistogram, OpMetrics};
 use prometheus::{IntCounter, IntGauge};
 
 lazy_static::lazy_static! {

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -31,7 +31,7 @@ crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 jellyfish-merkle = { path = "../jellyfish-merkle" }
 libra-logger = { path = "../../common/logger" }
-metrics = { path = "../../common/metrics" }
+libra-metrics = { path = "../../common/metrics" }
 prost-ext = { path = "../../common/prost-ext" }
 schemadb = { path = "../schemadb" }
 storage-proto = { path = "../storage-proto" }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -45,6 +45,7 @@ use failure::prelude::*;
 use itertools::{izip, zip_eq};
 use lazy_static::lazy_static;
 use libra_logger::prelude::*;
+use libra_metrics::OpMetrics;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -62,7 +63,6 @@ use libra_types::{
         Version,
     },
 };
-use metrics::OpMetrics;
 use schemadb::{ColumnFamilyOptions, ColumnFamilyOptionsMap, DB, DEFAULT_CF_NAME};
 use std::{convert::TryInto, iter::Iterator, path::Path, sync::Arc, time::Instant};
 use storage_proto::StartupInfo;

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 lazy_static = "1.3.0"
 
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
-metrics = { path = "../../common/metrics" }
+libra-metrics = { path = "../../common/metrics" }
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -17,7 +17,7 @@ pub mod schema;
 use crate::schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec};
 use failure::prelude::*;
 use lazy_static::lazy_static;
-use metrics::OpMetrics;
+use libra_metrics::OpMetrics;
 use rocksdb::{
     rocksdb_options::ColumnFamilyDescriptor, CFHandle, DBOptions, Writable, WriteOptions,
 };

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -23,7 +23,7 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../../common/grpc_helpers" }
 libradb = { path = "../libradb" }
 libra-logger = { path = "../../common/logger" }
-metrics = { path = "../../common/metrics" }
+libra-metrics = { path = "../../common/metrics" }
 storage-client = { path = "../storage-client" }
 storage-proto = { path = "../storage-proto" }
 libra-types = { path = "../../types" }

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -13,9 +13,9 @@ use config::config::NodeConfig;
 use failure::prelude::*;
 use grpc_helpers::{provide_grpc_response, spawn_service_thread_with_drop_closure, ServerHandle};
 use libra_logger::prelude::*;
+use libra_metrics::counters::SVC_COUNTERS;
 use libra_types::proto::types::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse};
 use libradb::LibraDB;
-use metrics::counters::SVC_COUNTERS;
 use std::{
     convert::TryFrom,
     ops::Deref,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `metrics` package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235
#1350
#1353
#1371