### PR TITLE
[language][execution] Bubble up VM startup errors and allow entire-block failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,6 +5199,7 @@ dependencies = [
  "compiler 0.1.0",
  "config 0.1.0",
  "crypto 0.1.0",
+ "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -263,7 +263,7 @@ where
                     .collect(),
                 &self.vm_config,
                 &state_view,
-            )
+            )?
         };
 
         // Since other validators have committed these transactions, their status should all be
@@ -520,7 +520,7 @@ where
                 executable_block.transactions.clone(),
                 &self.vm_config,
                 &state_view,
-            )
+            )?
         };
 
         let status: Vec<_> = vm_outputs

--- a/executor/src/mock_vm/mock_vm_test.rs
+++ b/executor/src/mock_vm/mock_vm_test.rs
@@ -48,7 +48,8 @@ fn test_mock_vm_different_senders() {
         txns.clone(),
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
-    );
+    )
+    .expect("MockVM should not fail to start");
 
     for (output, txn) in itertools::zip_eq(outputs.iter(), txns.iter()) {
         let sender = txn.as_signed_user_txn().unwrap().sender();
@@ -83,7 +84,8 @@ fn test_mock_vm_same_sender() {
         txns,
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
-    );
+    )
+    .expect("MockVM should not fail to start");
 
     for (i, output) in outputs.iter().enumerate() {
         assert_eq!(
@@ -117,7 +119,8 @@ fn test_mock_vm_payment() {
         txns.into_iter().map(Transaction::UserTransaction).collect(),
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
-    );
+    )
+    .expect("MockVM should not fail to start");
 
     let mut output_iter = output.iter();
     output_iter.next();

--- a/executor/src/mock_vm/mod.rs
+++ b/executor/src/mock_vm/mod.rs
@@ -6,6 +6,7 @@ mod mock_vm_test;
 
 use config::config::VMConfig;
 use crypto::ed25519::compat;
+use failure::Result;
 use lazy_static::lazy_static;
 use libra_types::{
     access_path::AccessPath,
@@ -52,7 +53,7 @@ impl VMExecutor for MockVM {
         transactions: Vec<Transaction>,
         _config: &VMConfig,
         state_view: &dyn StateView,
-    ) -> Vec<TransactionOutput> {
+    ) -> Result<Vec<TransactionOutput>> {
         if state_view.is_genesis() {
             assert_eq!(
                 transactions.len(),
@@ -61,7 +62,7 @@ impl VMExecutor for MockVM {
             );
             let output =
                 TransactionOutput::new(gen_genesis_writeset(), vec![], 0, KEEP_STATUS.clone());
-            return vec![output];
+            return Ok(vec![output]);
         }
 
         // output_cache is used to store the output of transactions so they are visible to later
@@ -133,7 +134,7 @@ impl VMExecutor for MockVM {
             }
         }
 
-        outputs
+        Ok(outputs)
     }
 }
 

--- a/language/e2e_tests/src/executor.rs
+++ b/language/e2e_tests/src/executor.rs
@@ -140,6 +140,7 @@ impl FakeExecutor {
             &self.config.vm_config,
             &self.data_store,
         )
+        .expect("The VM should not fail to start")
     }
 
     pub fn execute_transaction(&self, txn: SignedTransaction) -> TransactionOutput {

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -29,6 +29,7 @@ libra-types = { path = "../../../types" }
 vm = { path = "../" }
 vm-cache-map = { path = "vm-cache-map" }
 vm_runtime_types = { path = "vm_runtime_types" }
+failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 
 [dev-dependencies]
 compiler = { path = "../../compiler" }

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -137,6 +137,7 @@ pub use process_txn::verify::static_verify_program;
 pub use txn_executor::execute_function;
 
 use config::config::VMConfig;
+use failure::prelude::*;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
@@ -168,5 +169,5 @@ pub trait VMExecutor {
         transactions: Vec<Transaction>,
         config: &VMConfig,
         state_view: &dyn StateView,
-    ) -> Vec<TransactionOutput>;
+    ) -> Result<Vec<TransactionOutput>>;
 }

--- a/language/vm/vm_runtime/src/move_vm.rs
+++ b/language/vm/vm_runtime/src/move_vm.rs
@@ -5,6 +5,7 @@ use crate::{
     counters::*, loaded_data::loaded_module::LoadedModule, runtime::VMRuntime, VMExecutor,
     VMVerifier,
 };
+use failure::prelude::*;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
@@ -65,7 +66,7 @@ impl VMExecutor for MoveVM {
         transactions: Vec<Transaction>,
         config: &VMConfig,
         state_view: &dyn StateView,
-    ) -> Vec<TransactionOutput> {
+    ) -> Result<Vec<TransactionOutput>> {
         let vm = MoveVMImpl::new(Box::new(Arena::new()), |arena| {
             // XXX This means that scripts and modules are NOT tested against the whitelist! This
             // needs to be fixed.

--- a/language/vm/vm_runtime/src/runtime.rs
+++ b/language/vm/vm_runtime/src/runtime.rs
@@ -14,6 +14,7 @@ use crate::{
     process_txn::{validate::ValidationMode, ProcessTransaction},
 };
 use config::config::{VMConfig, VMPublishingOption};
+use failure::prelude::*;
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
@@ -112,7 +113,7 @@ impl<'alloc> VMRuntime<'alloc> {
         &self,
         txn_block: Vec<Transaction>,
         data_view: &dyn StateView,
-    ) -> Vec<TransactionOutput> {
+    ) -> Result<Vec<TransactionOutput>> {
         let txns = txn_block
             .into_iter()
             .map(|txn| {
@@ -120,12 +121,12 @@ impl<'alloc> VMRuntime<'alloc> {
                     .expect("All transactions should be user transaction")
             })
             .collect();
-        execute_block(
+        Ok(execute_block(
             txns,
             &self.code_cache,
             &self.script_cache,
             data_view,
             &self.publishing_option,
-        )
+        ))
     }
 }


### PR DESCRIPTION
Certain conditions may cause the VM to be unable to start. This commit
allows the VM to signify this back up to the executor, and from there
for it to bubble that error back out to consensus. 

Right now we don't have anything that will trigger the error case, but there is a PR upcoming that will, so this is putting in the plumbing for this.

