### PR TITLE
[monitoring] Recreate network counters with dimensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,6 +2577,7 @@ dependencies = [
  "noise 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -24,6 +24,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     collections::HashSet,
     convert::TryFrom,
+    fmt,
     fs::File,
     io::{Read, Write},
     path::{Path, PathBuf},
@@ -120,6 +121,15 @@ where
             "validator" => RoleType::Validator,
             "full_node" => RoleType::FullNode,
             _ => unimplemented!("Invalid node role: {}", t.as_ref()),
+        }
+    }
+}
+
+impl fmt::Display for RoleType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RoleType::Validator => write!(f, "validator"),
+            RoleType::FullNode => write!(f, "full_node"),
         }
     }
 }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1.3.0"
 parity-multiaddr = "0.5.0"
 pin-project = "0.4.2"
 prost = "0.5.0"
+prometheus = { version = "0.7.0", default-features = false }
 rand = "0.6.5"
 tokio = "=0.2.0-alpha.6"
 tokio-retry = "0.2.0"

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -3,6 +3,18 @@
 
 use lazy_static;
 use libra_metrics::{Histogram, IntCounter, IntGauge, OpMetrics};
+use prometheus::IntGaugeVec;
+
+lazy_static::lazy_static! {
+    pub static ref NETWORK_PEERS: IntGaugeVec = register_int_gauge_vec!(
+        // metric name
+        "libra_network_peers",
+        // metric description
+        "Libra network peers counter",
+        // metric labels (dimensions)
+        &["state", "role"]
+    ).unwrap();
+}
 
 lazy_static::lazy_static! {
     pub static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("network");

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -7,6 +7,9 @@
 // </Black magic>
 
 // Public exports
+#[macro_use]
+extern crate prometheus;
+
 pub use common::NetworkPublicKeys;
 pub use interface::NetworkProvider;
 

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -20,6 +20,7 @@ use futures::{
     sink::SinkExt,
     stream::{Fuse, FuturesUnordered, StreamExt},
 };
+use libra_config::config::RoleType;
 use libra_logger::prelude::*;
 use libra_types::PeerId;
 use netcore::{
@@ -132,7 +133,7 @@ where
 {
     NewConnection(Identity, Multiaddr, ConnectionOrigin, TMuxer),
     NewSubstream(PeerId, NegotiatedSubstream<TMuxer::Substream>),
-    PeerDisconnected(PeerId, ConnectionOrigin, DisconnectReason),
+    PeerDisconnected(PeerId, RoleType, ConnectionOrigin, DisconnectReason),
 }
 
 /// Responsible for handling and maintaining connections to other Peers
@@ -260,7 +261,7 @@ where
                 let event = PeerManagerNotification::NewInboundSubstream(peer_id, substream);
                 ch.send(event).await.unwrap();
             }
-            InternalEvent::PeerDisconnected(peer_id, origin, _reason) => {
+            InternalEvent::PeerDisconnected(peer_id, role, origin, _reason) => {
                 let peer = self
                     .active_peers
                     .remove(&peer_id)
@@ -280,6 +281,10 @@ where
                         error!("oneshot channel receiver dropped");
                     }
                 }
+                // update libra_network_peer counter
+                counters::NETWORK_PEERS
+                    .with_label_values(&["connected", &role.to_string()])
+                    .dec();
                 // Send LostPeer notifications to subscribers
                 for ch in &mut self.peer_event_handlers {
                     ch.send(PeerManagerNotification::LostPeer(
@@ -387,6 +392,7 @@ where
         connection: TMuxer,
     ) {
         let peer_id = identity.peer_id();
+        let role = identity.role();
         assert_ne!(self.own_peer_id, peer_id);
 
         let mut send_new_peer_notification = true;
@@ -446,7 +452,11 @@ where
         );
         self.active_peers.insert(peer_id, peer_handle);
         self.executor.spawn(peer.start());
-
+        // update libra_network_peer counter
+        counters::NETWORK_PEERS
+            .with_label_values(&["connected", &role.to_string()])
+            .inc();
+        // Send NewPeer notifications to subscribers
         if send_new_peer_notification {
             for ch in &mut self.peer_event_handlers {
                 ch.send(PeerManagerNotification::NewPeer(peer_id, address.clone()))
@@ -1040,6 +1050,7 @@ where
         self.internal_event_tx
             .send(InternalEvent::PeerDisconnected(
                 self.identity.peer_id(),
+                self.identity.role(),
                 self.origin,
                 reason,
             ))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

First attempt to use a different way for creating counters. I'm using prometheus functions directly instead of using the OpMetrics so it's easier to add dimensions.
Also moved the counter update before notification calls. Currently we only bump the counter when we send out the notification, but we should update the counter no matter if we send the notification to subscriber or not.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `cargo run -p libra-swarm -- -s -l -n 4`
- `curl --silent "http://localhost:50326/metrics" | grep libra`
```
sherryxiao-mbp:0 sherryxiao$ curl --silent "http://localhost:64007/metrics" | grep libra
# HELP libra_network_peers Libra network peers counter
# TYPE libra_network_peers gauge
libra_network_peers{role="Validator",state="connected"} 3
```
- manually killed one validator
```
sherryxiao-mbp:0 sherryxiao$ curl --silent "http://localhost:64007/metrics" | grep libra
# HELP libra_network_peers Libra network peers counter
# TYPE libra_network_peers gauge
libra_network_peers{role="Validator",state="connected"} 2
```
- start the network with 2 full nodes:
```
sherryxiao-mbp:0 sherryxiao$ curl --silent "http://localhost:61419/metrics"
# HELP libra_network_peers Libra network peers counter
# TYPE libra_network_peers gauge
libra_network_peers{role="full_node",state="connected"} 2
libra_network_peers{role="validator",state="connected"} 4
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
