### PR TITLE
[language] add new translator using tree_heap model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,6 +5006,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_heap"
+version = "0.1.0"
+dependencies = [
+ "bytecode-verifier 0.1.0",
+ "functional_tests 0.1.0",
+ "ir_to_bytecode 0.1.0",
+ "libra-types 0.1.0",
+ "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stackless_bytecode_generator 0.1.0",
+ "stdlib 0.1.0",
+ "vm 0.1.0",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "language/compiler/bytecode_source_map",
     "language/stackless_bytecode/bytecode-to-boogie",
     "language/stackless_bytecode/generator",
+    "language/stackless_bytecode/tree_heap",
     "language/vm",
     "language/vm/serializer_tests",
     "language/vm/vm_runtime",

--- a/language/stackless_bytecode/tree_heap/Cargo.toml
+++ b/language/stackless_bytecode/tree_heap/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tree_heap"
+version = "0.1.0"
+authors = ["Libra <oncall+libra@xmail.facebook.com>"]
+publish = false
+edition = "2018"
+
+[dependencies]
+functional_tests = { path = "../../functional_tests" }
+bytecode-verifier = { path = "../../bytecode-verifier" }
+vm = { path = "../../vm" }
+libra-types = { path = "../../../types" }
+ir_to_bytecode = { path = "../../compiler/ir_to_bytecode" }
+stackless_bytecode_generator = { path = "../generator"}
+stdlib = { path = "../../stdlib" }
+num = "0.2.0"
+
+[dev-dependencies]
+proptest = "0.9"
+libra-types = { path = "../../../types", features = ["testing"]}

--- a/language/stackless_bytecode/tree_heap/output.bpl
+++ b/language/stackless_bytecode/tree_heap/output.bpl
@@ -1,0 +1,735 @@
+type TypeName;
+type FieldName;
+type LocalName;
+type Address = int;
+type ByteArray;
+type String;
+
+type {:datatype} Edge;
+function {:constructor} Field(f: FieldName): Edge;
+function {:constructor} Index(i: int): Edge;
+function {:constructor} String(s: String): Edge;
+
+type {:datatype} Path;
+function {:constructor} Path(p: [int]Edge, size: int): Path;
+
+const DefaultPath: [int]Edge;
+
+type {:datatype} Value;
+function {:constructor} Boolean(b: bool): Value;
+function {:constructor} Integer(i: int): Value;
+function {:constructor} Address(a: Address): Value;
+function {:constructor} ByteArray(b: ByteArray): Value;
+function {:constructor} Str(a: String): Value;
+function {:constructor} Map(m: [Edge]Value): Value;
+
+const DefaultMap: [Edge]Value;
+
+type {:datatype} Reference;
+function {:constructor} Reference(rt: RefType, p: Path): Reference;
+
+type {:datatype} RefType;
+function {:constructor} Global(a: Address, t: TypeName): RefType;
+function {:constructor} Local(l: int): RefType;
+
+type {:datatype} TypeStore;
+function {:constructor} TypeStore(domain: [TypeName]bool, contents: [TypeName]Value): TypeStore;
+
+type {:datatype} GlobalStore;
+function {:constructor} GlobalStore(domain: [Address]bool, contents: [Address]TypeStore): GlobalStore;
+
+var gs : GlobalStore;
+var ls : [int]Value;
+var ls_size : int;
+
+procedure {:inline 1} Exists(address: Value, t: TypeName) returns (dst: Value)
+requires is#Address(address);
+{
+    dst := Boolean(domain#GlobalStore(gs)[a#Address(address)] && domain#TypeStore(contents#GlobalStore(gs)[a#Address(address)])[t]);
+}
+
+procedure {:inline 1} MoveToSender(t: TypeName, v: Value)
+{
+    var a: Address;
+    var ts: TypeStore;
+    a := sender#Transaction_cons(txn);
+    assert domain#GlobalStore(gs)[a];
+    ts := contents#GlobalStore(gs)[a];
+    assert !domain#TypeStore(ts)[t];
+    ts := TypeStore(domain#TypeStore(ts)[t := true], contents#TypeStore(ts)[t := v]);
+    gs := GlobalStore(domain#GlobalStore(gs), contents#GlobalStore(gs)[a := ts]);
+}
+
+procedure {:inline 1} MoveFrom(address: Value, t: TypeName) returns (dst: Value)
+requires is#Address(address);
+{
+    var a: Address;
+    var ts: TypeStore;
+    a := a#Address(address);
+    assert domain#GlobalStore(gs)[a];
+    ts := contents#GlobalStore(gs)[a];
+    assert domain#TypeStore(ts)[t];
+    dst := contents#TypeStore(ts)[t];
+    ts := TypeStore(domain#TypeStore(ts)[t := false], contents#TypeStore(ts));
+    gs := GlobalStore(domain#GlobalStore(gs), contents#GlobalStore(gs)[a := ts]);
+}
+
+procedure {:inline 1} BorrowGlobal(address: Value, t: TypeName) returns (dst: Reference)
+requires is#Address(address);
+{
+    var a: Address;
+    var v: Value;
+    var ts: TypeStore;
+    a := a#Address(address);
+    assert domain#GlobalStore(gs)[a];
+    ts := contents#GlobalStore(gs)[a];
+    assert domain#TypeStore(ts)[t];
+    dst := Reference(Global(a, t), Path(DefaultPath, 0));
+}
+
+procedure {:inline 1} BorrowLoc(l: int) returns (dst: Reference)
+{
+    dst := Reference(Local(l), Path(DefaultPath, 0));
+}
+
+procedure {:inline 1} BorrowField(src: Reference, f: FieldName) returns (dst: Reference)
+{
+    var p: Path;
+    var size: int;
+    p := p#Reference(src);
+    size := size#Path(p);
+	p := Path(p#Path(p)[size := Field(f)], size+1);
+    dst := Reference(rt#Reference(src), p);
+
+}
+
+procedure {:inline 1} WriteRef(to: Reference, new_v: Value)
+{
+    var a: Address;
+    var ts: TypeStore;
+    var t: TypeName;
+    var v: Value;
+    if (is#Global(rt#Reference(to))) {
+        a := a#Global(rt#Reference(to));
+        assert domain#GlobalStore(gs)[a];
+        ts := contents#GlobalStore(gs)[a];
+        t := t#Global(rt#Reference(to));
+        assert domain#TypeStore(ts)[t];
+        v := contents#TypeStore(ts)[t];
+        call v := UpdateValueMax(p#Reference(to), 0, v, new_v);
+        ts := TypeStore(domain#TypeStore(ts), contents#TypeStore(ts)[t := v]);
+        gs := GlobalStore(domain#GlobalStore(gs), contents#GlobalStore(gs)[a := ts]);
+    } else {
+        v := ls[l#Local(rt#Reference(to))];
+        call v := UpdateValueMax(p#Reference(to), 0, v, new_v);
+        ls := ls[l#Local(rt#Reference(to)) := v];
+    }
+}
+
+procedure {:inline 1} ReadRef(from: Reference) returns (v: Value)
+{
+    var a: Address;
+    var ts: TypeStore;
+    var t: TypeName;
+    if (is#Global(rt#Reference(from))) {
+        a := a#Global(rt#Reference(from));
+        assert domain#GlobalStore(gs)[a];
+        ts := contents#GlobalStore(gs)[a];
+        t := t#Global(rt#Reference(from));
+        assert domain#TypeStore(ts)[t];
+        call v := ReadValueMax(p#Reference(from), 0, contents#TypeStore(ts)[t]);
+    } else {
+        call v := ReadValueMax(p#Reference(from), 0, ls[l#Local(rt#Reference(from))]);
+    }
+}
+
+
+procedure {:inline 1} CopyOrMoveRef(local: Reference) returns (dst: Reference)
+{
+    dst := local;
+}
+
+procedure {:inline 1} CopyOrMoveValue(local: Value) returns (dst: Value)
+{
+    dst := local;
+}
+
+procedure {:inline 1} FreezeRef(src: Reference) returns (dest: Reference)
+{
+    dest := src;
+}
+
+// Eq, Pack, and Unpack are auto-generated for each type T
+const MAX_U64: int;
+axiom MAX_U64 == 9223372036854775807;
+var abort_flag: bool;
+
+procedure {:inline 1} Add(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src1) + i#Integer(src2) > MAX_U64) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) + i#Integer(src2));
+}
+
+procedure {:inline 1} Sub(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src1) < i#Integer(src2)) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) - i#Integer(src2));
+}
+
+procedure {:inline 1} Mul(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src1) * i#Integer(src2) > MAX_U64) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) * i#Integer(src2));
+}
+
+procedure {:inline 1} Div(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src2) == 0) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) div i#Integer(src2));
+}
+
+procedure {:inline 1} Mod(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src2) == 0) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) mod i#Integer(src2));
+}
+
+procedure {:inline 1} Lt(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) < i#Integer(src2));
+}
+
+procedure {:inline 1} Gt(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) > i#Integer(src2));
+}
+
+procedure {:inline 1} Le(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) <= i#Integer(src2));
+}
+
+procedure {:inline 1} Ge(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) >= i#Integer(src2));
+}
+
+procedure {:inline 1} And(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) && b#Boolean(src2));
+}
+
+procedure {:inline 1} Or(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) || b#Boolean(src2));
+}
+
+procedure {:inline 1} Not(src: Value) returns (dst: Value)
+{
+    assert is#Boolean(src);
+    dst := Boolean(!b#Boolean(src));
+}
+
+procedure {:inline 1} Eq_int(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) == i#Integer(src2));
+}
+
+procedure {:inline 1} Neq_int(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) != i#Integer(src2));
+}
+
+procedure {:inline 1} Eq_bool(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) == b#Boolean(src2));
+}
+
+procedure {:inline 1} Neq_bool(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) != b#Boolean(src2));
+}
+
+procedure {:inline 1} Eq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) == a#Address(src2));
+}
+
+procedure {:inline 1} Neq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) != a#Address(src2));
+}
+
+procedure {:inline 1} Eq_bytearray(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#ByteArray(src1) && is#ByteArray(src2);
+    dst := Boolean(b#ByteArray(src1) == b#ByteArray(src2));
+}
+
+procedure {:inline 1} Neq_bytearray(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#ByteArray(src1) && is#ByteArray(src2);
+    dst := Boolean(b#ByteArray(src1) != b#ByteArray(src2));
+}
+
+procedure {:inline 1} LdConst(val: int) returns (ret: Value)
+{
+    ret := Integer(val);
+}
+
+procedure {:inline 1} LdAddr(val: Address) returns (ret: Value)
+{
+    ret := Address(val);
+}
+
+procedure {:inline 1} LdByteArray(val: ByteArray) returns (ret: Value)
+{
+    ret := ByteArray(val);
+}
+
+procedure {:inline 1} LdStr(val: String) returns (ret: Value)
+{
+    ret := Str(val);
+}
+
+procedure {:inline 1} LdTrue() returns (ret: Value)
+{
+    ret := Boolean(true);
+}
+
+procedure {:inline 1} LdFalse() returns (ret: Value)
+{
+    ret := Boolean(false);
+}
+
+// Transaction builtin instructions
+type {:datatype} Transaction;
+var txn: Transaction;
+function {:constructor} Transaction_cons(
+  gas_unit_price: int, max_gas_units: int, public_key: ByteArray,
+  sender: Address, sequence_number: int, gas_remaining: int) : Transaction;
+
+procedure {:inline 1} GetGasRemaining() returns (ret_gas_remaining: Value)
+{
+  ret_gas_remaining := Integer(gas_remaining#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSequenceNumber() returns (ret_sequence_number: Value)
+{
+  ret_sequence_number := Integer(sequence_number#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnPublicKey() returns (ret_public_key: Value)
+{
+  ret_public_key := ByteArray(public_key#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSenderAddress() returns (ret_sender: Value)
+{
+  ret_sender := Address(sender#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnMaxGasUnits() returns (ret_max_gas_units: Value)
+{
+  ret_max_gas_units := Integer(max_gas_units#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnGasUnitPrice() returns (ret_gas_unit_price: Value)
+{
+  ret_gas_unit_price := Integer(gas_unit_price#Transaction_cons(txn));
+}
+
+
+// everything below is auto generated
+
+const unique Test3_T: TypeName;
+const unique Test3_T_f: FieldName;
+const unique Test3_T_g: FieldName;
+
+procedure {:inline 1} Pack_Test3_T(v0: Value, v1: Value) returns (v: Value)
+{
+    assert is#Integer(v0);
+    assert is#Integer(v1);
+    v := Map(DefaultMap[Field(Test3_T_f) := v0][Field(Test3_T_g) := v1]);
+}
+
+procedure {:inline 1} Unpack_Test3_T(v: Value) returns (v0: Value, v1: Value)
+{
+    assert is#Map(v);
+    v0 := m#Map(v)[Field(Test3_T_f)];
+    v1 := m#Map(v)[Field(Test3_T_g)];
+}
+
+procedure {:inline 1} Eq_Test3_T(v1: Value, v2: Value) returns (res: Value)
+{
+    var b0: Value;
+    var b1: Value;
+    assert is#Map(v1) && is#Map(v2);
+    call b0 := Eq_int(m#Map(v1)[Field(Test3_T_f)], m#Map(v2)[Field(Test3_T_f)]);
+    call b1 := Eq_int(m#Map(v1)[Field(Test3_T_g)], m#Map(v2)[Field(Test3_T_g)]);
+    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
+}
+
+procedure {:inline 1} Neq_Test3_T(v1: Value, v2: Value) returns (res: Value)
+{
+    var res_val: Value;
+    var res_bool: bool;
+    assert is#Map(v1) && is#Map(v2);
+    call res_val := Eq_Test3_T(v1, v2);
+    res := Boolean(!b#Boolean(res_val));
+}
+
+procedure {:inline 1} ReadValue0(p: Path, i: int, v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := v;
+    } else {
+        assert false;
+    }
+}
+
+procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := v;
+    } else {
+        e := p#Path(p)[i];
+        v' := m#Map(v)[e];
+        call v' := ReadValue0(p, i+1, v');
+    }
+}
+
+procedure {:inline 1} UpdateValue0(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := new_v;
+    } else {
+        assert false;
+    }
+}
+
+procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := new_v;
+    } else {
+        e := p#Path(p)[i];
+        v' := m#Map(v)[e];
+        call v' := UpdateValue0(p, i+1, v', new_v);
+        v' := Map(m#Map(v)[e := v']);
+    }
+}
+
+procedure Test3_test3 (arg0: Value) returns ()
+{
+    // declare local variables
+    var t0: Value; // bool
+    var t1: Value; // Test3_T
+    var t2: Reference; // Test3_T_ref
+    var t3: Reference; // int_ref
+    var t4: Reference; // int_ref
+    var t5: Reference; // int_ref
+    var t6: Reference; // int_ref
+    var t7: Value; // int
+    var t8: Value; // int
+    var t9: Value; // int
+    var t10: Value; // int
+    var t11: Value; // Test3_T
+    var t12: Reference; // Test3_T_ref
+    var t13: Value; // bool
+    var t14: Reference; // Test3_T_ref
+    var t15: Reference; // int_ref
+    var t16: Reference; // Test3_T_ref
+    var t17: Reference; // int_ref
+    var t18: Value; // int
+    var t19: Reference; // int_ref
+    var t20: Value; // bool
+    var t21: Value; // bool
+    var t22: Reference; // Test3_T_ref
+    var t23: Reference; // int_ref
+    var t24: Reference; // Test3_T_ref
+    var t25: Reference; // int_ref
+    var t26: Value; // int
+    var t27: Reference; // int_ref
+    var t28: Reference; // Test3_T_ref
+    var t29: Reference; // int_ref
+    var t30: Reference; // Test3_T_ref
+    var t31: Reference; // int_ref
+    var t32: Reference; // int_ref
+    var t33: Value; // int
+    var t34: Reference; // int_ref
+    var t35: Value; // int
+    var t36: Value; // bool
+    var t37: Value; // int
+    var t38: Value; // int
+    var t39: Value; // bool
+    var t40: Value; // bool
+    var t41: Value; // int
+    var t42: Value; // int
+    var t43: Value; // int
+    var t44: Value; // bool
+    var t45: Value; // bool
+    var t46: Value; // int
+    var t47: Value; // int
+    var t48: Value; // int
+    var t49: Value; // bool
+    var t50: Value; // bool
+    var t51: Value; // int
+    var t52: Value; // int
+    var t53: Value; // int
+    var t54: Value; // bool
+    var t55: Value; // bool
+    var t56: Value; // int
+
+    var tmp: Value;
+    var old_size: int;
+    assume !abort_flag;
+
+    // assume arguments are of correct types
+    assume is#Boolean(arg0);
+
+    old_size := ls_size;
+    ls_size := ls_size + 57;
+    ls[old_size+0] := arg0;
+
+    // bytecode translation starts here
+    call tmp := LdConst(0);
+    ls[old_size+9] := tmp;
+
+    call tmp := LdConst(0);
+    ls[old_size+10] := tmp;
+
+    assume is#Integer(ls[old_size+9]);
+
+    assume is#Integer(ls[old_size+10]);
+
+    call tmp := Pack_Test3_T(ls[old_size+9], ls[old_size+10]);
+    ls[old_size+11] := tmp;
+
+    call tmp := CopyOrMoveValue(ls[old_size+11]);
+    ls[old_size+1] := tmp;
+
+    call t12 := BorrowLoc(old_size+1);
+
+    call t2 := CopyOrMoveRef(t12);
+
+    call tmp := CopyOrMoveValue(ls[old_size+0]);
+    ls[old_size+13] := tmp;
+
+    tmp := ls[old_size + 13];
+    if (!b#Boolean(tmp)) { goto Label_12; }
+
+    call t14 := CopyOrMoveRef(t2);
+
+    call t15 := BorrowField(t14, Test3_T_f);
+
+    call t3 := CopyOrMoveRef(t15);
+
+    goto Label_15;
+
+Label_12:
+    call t16 := CopyOrMoveRef(t2);
+
+    call t17 := BorrowField(t16, Test3_T_g);
+
+    call t3 := CopyOrMoveRef(t17);
+
+Label_15:
+    call tmp := LdConst(10);
+    ls[old_size+18] := tmp;
+
+    call t19 := CopyOrMoveRef(t3);
+
+    call WriteRef(t19, ls[old_size+18]);
+
+    call tmp := CopyOrMoveValue(ls[old_size+0]);
+    ls[old_size+20] := tmp;
+
+    call tmp := Not(ls[old_size+20]);
+    ls[old_size+21] := tmp;
+
+    tmp := ls[old_size + 21];
+    if (!b#Boolean(tmp)) { goto Label_25; }
+
+    call t22 := CopyOrMoveRef(t2);
+
+    call t23 := BorrowField(t22, Test3_T_f);
+
+    call t4 := CopyOrMoveRef(t23);
+
+    goto Label_28;
+
+Label_25:
+    call t24 := CopyOrMoveRef(t2);
+
+    call t25 := BorrowField(t24, Test3_T_g);
+
+    call t4 := CopyOrMoveRef(t25);
+
+Label_28:
+    call tmp := LdConst(20);
+    ls[old_size+26] := tmp;
+
+    call t27 := CopyOrMoveRef(t4);
+
+    call WriteRef(t27, ls[old_size+26]);
+
+    call t28 := CopyOrMoveRef(t2);
+
+    call t29 := BorrowField(t28, Test3_T_f);
+
+    call t5 := CopyOrMoveRef(t29);
+
+    call t30 := CopyOrMoveRef(t2);
+
+    call t31 := BorrowField(t30, Test3_T_g);
+
+    call t6 := CopyOrMoveRef(t31);
+
+    call t32 := CopyOrMoveRef(t5);
+
+    call tmp := ReadRef(t32);
+    assume is#Integer(tmp);
+
+    ls[old_size+33] := tmp;
+
+    call tmp := CopyOrMoveValue(ls[old_size+33]);
+    ls[old_size+7] := tmp;
+
+    call t34 := CopyOrMoveRef(t6);
+
+    call tmp := ReadRef(t34);
+    assume is#Integer(tmp);
+
+    ls[old_size+35] := tmp;
+
+    call tmp := CopyOrMoveValue(ls[old_size+35]);
+    ls[old_size+8] := tmp;
+
+    call tmp := CopyOrMoveValue(ls[old_size+0]);
+    ls[old_size+36] := tmp;
+
+    tmp := ls[old_size + 36];
+    if (!b#Boolean(tmp)) { goto Label_60; }
+
+    call tmp := CopyOrMoveValue(ls[old_size+7]);
+    ls[old_size+37] := tmp;
+
+    call tmp := LdConst(10);
+    ls[old_size+38] := tmp;
+
+    call tmp := Eq_int(ls[old_size+37], ls[old_size+38]);
+    ls[old_size+39] := tmp;
+
+    call tmp := Not(ls[old_size+39]);
+    ls[old_size+40] := tmp;
+
+    tmp := ls[old_size + 40];
+    if (!b#Boolean(tmp)) { goto Label_52; }
+
+    call tmp := LdConst(42);
+    ls[old_size+41] := tmp;
+
+    assert false;
+
+Label_52:
+    call tmp := CopyOrMoveValue(ls[old_size+8]);
+    ls[old_size+42] := tmp;
+
+    call tmp := LdConst(20);
+    ls[old_size+43] := tmp;
+
+    call tmp := Eq_int(ls[old_size+42], ls[old_size+43]);
+    ls[old_size+44] := tmp;
+
+    call tmp := Not(ls[old_size+44]);
+    ls[old_size+45] := tmp;
+
+    tmp := ls[old_size + 45];
+    if (!b#Boolean(tmp)) { goto Label_59; }
+
+    call tmp := LdConst(42);
+    ls[old_size+46] := tmp;
+
+    assert false;
+
+Label_59:
+    goto Label_74;
+
+Label_60:
+    call tmp := CopyOrMoveValue(ls[old_size+7]);
+    ls[old_size+47] := tmp;
+
+    call tmp := LdConst(20);
+    ls[old_size+48] := tmp;
+
+    call tmp := Eq_int(ls[old_size+47], ls[old_size+48]);
+    ls[old_size+49] := tmp;
+
+    call tmp := Not(ls[old_size+49]);
+    ls[old_size+50] := tmp;
+
+    tmp := ls[old_size + 50];
+    if (!b#Boolean(tmp)) { goto Label_67; }
+
+    call tmp := LdConst(42);
+    ls[old_size+51] := tmp;
+
+    assert false;
+
+Label_67:
+    call tmp := CopyOrMoveValue(ls[old_size+8]);
+    ls[old_size+52] := tmp;
+
+    call tmp := LdConst(10);
+    ls[old_size+53] := tmp;
+
+    call tmp := Eq_int(ls[old_size+52], ls[old_size+53]);
+    ls[old_size+54] := tmp;
+
+    call tmp := Not(ls[old_size+54]);
+    ls[old_size+55] := tmp;
+
+    tmp := ls[old_size + 55];
+    if (!b#Boolean(tmp)) { goto Label_74; }
+
+    call tmp := LdConst(42);
+    ls[old_size+56] := tmp;
+
+    assert false;
+
+Label_74:
+    return;
+
+}

--- a/language/stackless_bytecode/tree_heap/src/bytecode_function_generator.rs
+++ b/language/stackless_bytecode/tree_heap/src/bytecode_function_generator.rs
@@ -1,0 +1,146 @@
+//! This module generates the Boogie version of bytecode instructions in the format of Boogie
+//! procedures.
+use crate::translator::*;
+use bytecode_verifier::VerifiedModule;
+use vm::access::ModuleAccess;
+impl BoogieTranslator {
+    pub fn emit_stratified_functions(&self) -> String {
+        let mut res = String::new();
+        let mut update_value_str = String::new();
+        for i in 0..=self.max_struct_depth {
+            if i == self.max_struct_depth {
+                res.push_str(
+                    "procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value)\n{\n"
+                );
+                update_value_str.push_str(
+                    "procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)\n{\n"
+                );
+            } else {
+                res.push_str(&format!(
+                    "procedure {{:inline 1}} ReadValue{}(p: Path, i: int, v: Value) returns (v': Value)\n{{\n",
+                    i,
+                ));
+                update_value_str.push_str(&format!(
+                    "procedure {{:inline 1}} UpdateValue{}(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)\n{{\n",
+                    i,
+                ));
+            }
+
+            res.push_str("    var e: Edge;\n");
+            res.push_str("    if (i == size#Path(p)) {\n");
+            res.push_str("        v' := v;\n");
+            res.push_str("    } else {\n");
+
+            update_value_str.push_str("    var e: Edge;\n");
+            update_value_str.push_str("    if (i == size#Path(p)) {\n");
+            update_value_str.push_str("        v' := new_v;\n");
+            update_value_str.push_str("    } else {\n");
+
+            if i == 0 {
+                res.push_str("        assert false;\n");
+                update_value_str.push_str("        assert false;\n");
+            } else {
+                res.push_str("        e := p#Path(p)[i];\n");
+                res.push_str("        v' := m#Map(v)[e];\n");
+                res.push_str(&format!(
+                    "        call v' := ReadValue{}(p, i+1, v');\n",
+                    i - 1
+                ));
+                update_value_str.push_str("        e := p#Path(p)[i];\n");
+                update_value_str.push_str("        v' := m#Map(v)[e];\n");
+                update_value_str.push_str(&format!(
+                    "        call v' := UpdateValue{}(p, i+1, v', new_v);\n",
+                    i - 1,
+                ));
+                update_value_str.push_str("        v' := Map(m#Map(v)[e := v']);\n");
+            }
+            res.push_str("    }\n}\n\n");
+            update_value_str.push_str("    }\n}\n\n");
+        }
+        res.push_str(&update_value_str);
+        res
+    }
+
+    pub fn emit_struct_specific_functions(
+        &self,
+        module: &VerifiedModule,
+        def_idx: usize,
+    ) -> String {
+        let mut res = String::from("\n");
+        let field_info = get_field_info_from_def_index(module, def_idx);
+        let struct_handle_index = module.struct_defs()[def_idx].struct_handle;
+        let struct_name = struct_name_from_handle_index(module, struct_handle_index);
+        let mut args_str = String::new();
+        let mut typechecking_str = String::new();
+        let mut fields_str = String::new();
+        // pack
+        for (i, (field_name, (_, value_cons))) in field_info.iter().enumerate() {
+            if i > 0 {
+                args_str.push_str(", ");
+            }
+            args_str.push_str(&format!("v{}: Value", i));
+            typechecking_str.push_str(&format!("    assert is#{}(v{});\n", value_cons, i));
+            fields_str.push_str(&format!(
+                "[Field({}_{}) := v{}]",
+                struct_name, field_name, i
+            ));
+        }
+        res.push_str(&format!(
+            "procedure {{:inline 1}} Pack_{}({}) returns (v: Value)\n{{\n",
+            struct_name, args_str
+        ));
+        res.push_str(&typechecking_str);
+        res.push_str(&format!("    v := Map(DefaultMap{});\n}}\n\n", fields_str));
+
+        // unpack
+        res.push_str(&format!(
+            "procedure {{:inline 1}} Unpack_{}(v: Value) returns ({})\n{{\n",
+            struct_name, args_str
+        ));
+        res.push_str("    assert is#Map(v);\n");
+        for (i, (field_name, _)) in field_info.iter().enumerate() {
+            res.push_str(&format!(
+                "    v{} := m#Map(v)[Field({}_{})];\n",
+                i, struct_name, field_name
+            ));
+        }
+        res.push_str("}\n\n");
+
+        // Eq
+        let mut bool_res_str = String::new();
+        let mut bool_assign_str = String::new();
+        res.push_str(&format!(
+            "procedure {{:inline 1}} Eq_{}(v1: Value, v2: Value) returns (res: Value)\n{{\n",
+            struct_name,
+        ));
+        for (i, (field_name, (field_type, _))) in field_info.iter().enumerate() {
+            res.push_str(&format!("    var b{}: Value;\n", i));
+            bool_res_str.push_str(&format!(" && b#Boolean(b{})", i));
+            bool_assign_str.push_str(&format!(
+                "    call b{} := Eq_{}(m#Map(v1)[Field({}_{})], m#Map(v2)[Field({}_{})]);\n",
+                i, field_type, struct_name, field_name, struct_name, field_name,
+            ));
+        }
+        res.push_str("    assert is#Map(v1) && is#Map(v2);\n");
+        res.push_str(&bool_assign_str);
+        res.push_str(&format!(
+            "    res := Boolean(true{});\n}}\n\n",
+            bool_res_str
+        ));
+
+        // Neq
+        res.push_str(&format!(
+            "procedure {{:inline 1}} Neq_{}(v1: Value, v2: Value) returns (res: Value)\n{{\n",
+            struct_name,
+        ));
+        res.push_str("    var res_val: Value;\n");
+        res.push_str("    var res_bool: bool;\n");
+        res.push_str("    assert is#Map(v1) && is#Map(v2);\n");
+        res.push_str(&format!(
+            "    call res_val := Eq_{}(v1, v2);\n",
+            struct_name,
+        ));
+        res.push_str("    res := Boolean(!b#Boolean(res_val));\n}\n\n");
+        res
+    }
+}

--- a/language/stackless_bytecode/tree_heap/src/bytecode_instrs.bpl
+++ b/language/stackless_bytecode/tree_heap/src/bytecode_instrs.bpl
@@ -1,0 +1,367 @@
+type TypeName;
+type FieldName;
+type LocalName;
+type Address = int;
+type ByteArray;
+type String;
+
+type {:datatype} Edge;
+function {:constructor} Field(f: FieldName): Edge;
+function {:constructor} Index(i: int): Edge;
+function {:constructor} String(s: String): Edge;
+
+type {:datatype} Path;
+function {:constructor} Path(p: [int]Edge, size: int): Path;
+
+const DefaultPath: [int]Edge;
+
+type {:datatype} Value;
+function {:constructor} Boolean(b: bool): Value;
+function {:constructor} Integer(i: int): Value;
+function {:constructor} Address(a: Address): Value;
+function {:constructor} ByteArray(b: ByteArray): Value;
+function {:constructor} Str(a: String): Value;
+function {:constructor} Map(m: [Edge]Value): Value;
+
+const DefaultMap: [Edge]Value;
+
+type {:datatype} Reference;
+function {:constructor} Reference(rt: RefType, p: Path): Reference;
+
+type {:datatype} RefType;
+function {:constructor} Global(a: Address, t: TypeName): RefType;
+function {:constructor} Local(l: int): RefType;
+
+type {:datatype} TypeStore;
+function {:constructor} TypeStore(domain: [TypeName]bool, contents: [TypeName]Value): TypeStore;
+
+type {:datatype} GlobalStore;
+function {:constructor} GlobalStore(domain: [Address]bool, contents: [Address]TypeStore): GlobalStore;
+
+var gs : GlobalStore;
+var ls : [int]Value;
+var ls_size : int;
+
+procedure {:inline 1} Exists(address: Value, t: TypeName) returns (dst: Value)
+requires is#Address(address);
+{
+    dst := Boolean(domain#GlobalStore(gs)[a#Address(address)] && domain#TypeStore(contents#GlobalStore(gs)[a#Address(address)])[t]);
+}
+
+procedure {:inline 1} MoveToSender(t: TypeName, v: Value)
+{
+    var a: Address;
+    var ts: TypeStore;
+    a := sender#Transaction_cons(txn);
+    assert domain#GlobalStore(gs)[a];
+    ts := contents#GlobalStore(gs)[a];
+    assert !domain#TypeStore(ts)[t];
+    ts := TypeStore(domain#TypeStore(ts)[t := true], contents#TypeStore(ts)[t := v]);
+    gs := GlobalStore(domain#GlobalStore(gs), contents#GlobalStore(gs)[a := ts]);
+}
+
+procedure {:inline 1} MoveFrom(address: Value, t: TypeName) returns (dst: Value)
+requires is#Address(address);
+{
+    var a: Address;
+    var ts: TypeStore;
+    a := a#Address(address);
+    assert domain#GlobalStore(gs)[a];
+    ts := contents#GlobalStore(gs)[a];
+    assert domain#TypeStore(ts)[t];
+    dst := contents#TypeStore(ts)[t];
+    ts := TypeStore(domain#TypeStore(ts)[t := false], contents#TypeStore(ts));
+    gs := GlobalStore(domain#GlobalStore(gs), contents#GlobalStore(gs)[a := ts]);
+}
+
+procedure {:inline 1} BorrowGlobal(address: Value, t: TypeName) returns (dst: Reference)
+requires is#Address(address);
+{
+    var a: Address;
+    var v: Value;
+    var ts: TypeStore;
+    a := a#Address(address);
+    assert domain#GlobalStore(gs)[a];
+    ts := contents#GlobalStore(gs)[a];
+    assert domain#TypeStore(ts)[t];
+    dst := Reference(Global(a, t), Path(DefaultPath, 0));
+}
+
+procedure {:inline 1} BorrowLoc(l: int) returns (dst: Reference)
+{
+    dst := Reference(Local(l), Path(DefaultPath, 0));
+}
+
+procedure {:inline 1} BorrowField(src: Reference, f: FieldName) returns (dst: Reference)
+{
+    var p: Path;
+    var size: int;
+    p := p#Reference(src);
+    size := size#Path(p);
+	p := Path(p#Path(p)[size := Field(f)], size+1);
+    dst := Reference(rt#Reference(src), p);
+
+}
+
+procedure {:inline 1} WriteRef(to: Reference, new_v: Value)
+{
+    var a: Address;
+    var ts: TypeStore;
+    var t: TypeName;
+    var v: Value;
+    if (is#Global(rt#Reference(to))) {
+        a := a#Global(rt#Reference(to));
+        assert domain#GlobalStore(gs)[a];
+        ts := contents#GlobalStore(gs)[a];
+        t := t#Global(rt#Reference(to));
+        assert domain#TypeStore(ts)[t];
+        v := contents#TypeStore(ts)[t];
+        call v := UpdateValueMax(p#Reference(to), 0, v, new_v);
+        ts := TypeStore(domain#TypeStore(ts), contents#TypeStore(ts)[t := v]);
+        gs := GlobalStore(domain#GlobalStore(gs), contents#GlobalStore(gs)[a := ts]);
+    } else {
+        v := ls[l#Local(rt#Reference(to))];
+        call v := UpdateValueMax(p#Reference(to), 0, v, new_v);
+        ls := ls[l#Local(rt#Reference(to)) := v];
+    }
+}
+
+procedure {:inline 1} ReadRef(from: Reference) returns (v: Value)
+{
+    var a: Address;
+    var ts: TypeStore;
+    var t: TypeName;
+    if (is#Global(rt#Reference(from))) {
+        a := a#Global(rt#Reference(from));
+        assert domain#GlobalStore(gs)[a];
+        ts := contents#GlobalStore(gs)[a];
+        t := t#Global(rt#Reference(from));
+        assert domain#TypeStore(ts)[t];
+        call v := ReadValueMax(p#Reference(from), 0, contents#TypeStore(ts)[t]);
+    } else {
+        call v := ReadValueMax(p#Reference(from), 0, ls[l#Local(rt#Reference(from))]);
+    }
+}
+
+
+procedure {:inline 1} CopyOrMoveRef(local: Reference) returns (dst: Reference)
+{
+    dst := local;
+}
+
+procedure {:inline 1} CopyOrMoveValue(local: Value) returns (dst: Value)
+{
+    dst := local;
+}
+
+procedure {:inline 1} FreezeRef(src: Reference) returns (dest: Reference)
+{
+    dest := src;
+}
+
+// Eq, Pack, and Unpack are auto-generated for each type T
+const MAX_U64: int;
+axiom MAX_U64 == 9223372036854775807;
+var abort_flag: bool;
+
+procedure {:inline 1} Add(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src1) + i#Integer(src2) > MAX_U64) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) + i#Integer(src2));
+}
+
+procedure {:inline 1} Sub(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src1) < i#Integer(src2)) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) - i#Integer(src2));
+}
+
+procedure {:inline 1} Mul(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src1) * i#Integer(src2) > MAX_U64) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) * i#Integer(src2));
+}
+
+procedure {:inline 1} Div(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src2) == 0) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) div i#Integer(src2));
+}
+
+procedure {:inline 1} Mod(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    if (i#Integer(src2) == 0) {
+        abort_flag := true;
+    }
+    dst := Integer(i#Integer(src1) mod i#Integer(src2));
+}
+
+procedure {:inline 1} Lt(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) < i#Integer(src2));
+}
+
+procedure {:inline 1} Gt(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) > i#Integer(src2));
+}
+
+procedure {:inline 1} Le(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) <= i#Integer(src2));
+}
+
+procedure {:inline 1} Ge(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) >= i#Integer(src2));
+}
+
+procedure {:inline 1} And(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) && b#Boolean(src2));
+}
+
+procedure {:inline 1} Or(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) || b#Boolean(src2));
+}
+
+procedure {:inline 1} Not(src: Value) returns (dst: Value)
+{
+    assert is#Boolean(src);
+    dst := Boolean(!b#Boolean(src));
+}
+
+procedure {:inline 1} Eq_int(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) == i#Integer(src2));
+}
+
+procedure {:inline 1} Neq_int(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Integer(src1) && is#Integer(src2);
+    dst := Boolean(i#Integer(src1) != i#Integer(src2));
+}
+
+procedure {:inline 1} Eq_bool(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) == b#Boolean(src2));
+}
+
+procedure {:inline 1} Neq_bool(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Boolean(src1) && is#Boolean(src2);
+    dst := Boolean(b#Boolean(src1) != b#Boolean(src2));
+}
+
+procedure {:inline 1} Eq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) == a#Address(src2));
+}
+
+procedure {:inline 1} Neq_address(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#Address(src1) && is#Address(src2);
+    dst := Boolean(a#Address(src1) != a#Address(src2));
+}
+
+procedure {:inline 1} Eq_bytearray(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#ByteArray(src1) && is#ByteArray(src2);
+    dst := Boolean(b#ByteArray(src1) == b#ByteArray(src2));
+}
+
+procedure {:inline 1} Neq_bytearray(src1: Value, src2: Value) returns (dst: Value)
+{
+    assert is#ByteArray(src1) && is#ByteArray(src2);
+    dst := Boolean(b#ByteArray(src1) != b#ByteArray(src2));
+}
+
+procedure {:inline 1} LdConst(val: int) returns (ret: Value)
+{
+    ret := Integer(val);
+}
+
+procedure {:inline 1} LdAddr(val: Address) returns (ret: Value)
+{
+    ret := Address(val);
+}
+
+procedure {:inline 1} LdByteArray(val: ByteArray) returns (ret: Value)
+{
+    ret := ByteArray(val);
+}
+
+procedure {:inline 1} LdStr(val: String) returns (ret: Value)
+{
+    ret := Str(val);
+}
+
+procedure {:inline 1} LdTrue() returns (ret: Value)
+{
+    ret := Boolean(true);
+}
+
+procedure {:inline 1} LdFalse() returns (ret: Value)
+{
+    ret := Boolean(false);
+}
+
+// Transaction builtin instructions
+type {:datatype} Transaction;
+var txn: Transaction;
+function {:constructor} Transaction_cons(
+  gas_unit_price: int, max_gas_units: int, public_key: ByteArray,
+  sender: Address, sequence_number: int, gas_remaining: int) : Transaction;
+
+procedure {:inline 1} GetGasRemaining() returns (ret_gas_remaining: Value)
+{
+  ret_gas_remaining := Integer(gas_remaining#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSequenceNumber() returns (ret_sequence_number: Value)
+{
+  ret_sequence_number := Integer(sequence_number#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnPublicKey() returns (ret_public_key: Value)
+{
+  ret_public_key := ByteArray(public_key#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnSenderAddress() returns (ret_sender: Value)
+{
+  ret_sender := Address(sender#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnMaxGasUnits() returns (ret_max_gas_units: Value)
+{
+  ret_max_gas_units := Integer(max_gas_units#Transaction_cons(txn));
+}
+
+procedure {:inline 1} GetTxnGasUnitPrice() returns (ret_gas_unit_price: Value)
+{
+  ret_gas_unit_price := Integer(gas_unit_price#Transaction_cons(txn));
+}

--- a/language/stackless_bytecode/tree_heap/src/lib.rs
+++ b/language/stackless_bytecode/tree_heap/src/lib.rs
@@ -1,0 +1,4 @@
+//! Translates bytecode to Boogie.
+
+pub mod bytecode_function_generator;
+pub mod translator;

--- a/language/stackless_bytecode/tree_heap/src/main.rs
+++ b/language/stackless_bytecode/tree_heap/src/main.rs
@@ -1,0 +1,51 @@
+use bytecode_verifier::VerifiedModule;
+use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
+use libra_types::account_address::AccountAddress;
+use std::{
+    env,
+    fs::{self, File},
+    io::prelude::*,
+};
+use tree_heap::translator::BoogieTranslator;
+
+fn compile_files(file_names: Vec<String>) -> Vec<VerifiedModule> {
+    let mut verified_modules = vec![];
+    let files_len = file_names.len();
+    let dep_files = &file_names[0..files_len];
+    let address = AccountAddress::default();
+    for file_name in dep_files {
+        let code = fs::read_to_string(file_name).unwrap();
+        let module = parse_module(&code).unwrap();
+        let (compiled_module, _) =
+            compile_module(address, module, &verified_modules).expect("module failed to compile");
+        let verified_module_res = VerifiedModule::new(compiled_module);
+
+        match verified_module_res {
+            Err(e) => {
+                panic!("{:?}", e);
+            }
+            Ok(verified_module) => {
+                verified_modules.push(verified_module);
+            }
+        }
+    }
+    verified_modules
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let file_names = &args[1..];
+    // read files and compile into compiled modules
+    let modules = compile_files(file_names.to_vec());
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+    let mut f = File::create("output.bpl").expect("Unable to create file");
+
+    // write resulting code into output.bpl
+    write!(f, "{}", res).expect("unable to write file");
+}

--- a/language/stackless_bytecode/tree_heap/src/translator.rs
+++ b/language/stackless_bytecode/tree_heap/src/translator.rs
@@ -1,0 +1,831 @@
+//! This module translates the bytecode of a module to Boogie code.
+
+use bytecode_verifier::VerifiedModule;
+use libra_types::identifier::Identifier;
+use num::{BigInt, Num};
+use stackless_bytecode_generator::{
+    stackless_bytecode::StacklessBytecode::{self, *},
+    stackless_bytecode_generator::{StacklessFunction, StacklessModuleGenerator},
+};
+use std::collections::{BTreeMap, BTreeSet};
+use vm::{
+    access::ModuleAccess,
+    file_format::{
+        FieldDefinitionIndex, FunctionHandleIndex, ModuleHandleIndex, SignatureToken,
+        StructDefinitionIndex, StructHandleIndex,
+    },
+    internals::ModuleIndex,
+    views::{
+        FieldDefinitionView, FunctionHandleView, SignatureTokenView, StructDefinitionView,
+        StructHandleView, ViewInternals,
+    },
+};
+
+pub struct BoogieTranslator {
+    pub modules: Vec<VerifiedModule>,
+    pub struct_defs: BTreeMap<String, usize>,
+    pub max_struct_depth: usize,
+    pub module_name_to_idx: BTreeMap<Identifier, usize>,
+}
+
+pub struct ModuleTranslator<'a> {
+    pub module: &'a VerifiedModule,
+    pub stackless_bytecode: Vec<StacklessFunction>,
+    pub all_type_strs: BTreeSet<String>,
+}
+
+impl BoogieTranslator {
+    pub fn new(modules: &[VerifiedModule]) -> Self {
+        let mut struct_defs: BTreeMap<String, usize> = BTreeMap::new();
+        let mut module_name_to_idx: BTreeMap<Identifier, usize> = BTreeMap::new();
+        for (module_idx, module) in modules.iter().enumerate() {
+            let module_name =
+                module.identifier_at(module.module_handle_at(ModuleHandleIndex::new(0)).name);
+            module_name_to_idx.insert(module_name.into(), module_idx);
+            for (idx, struct_def) in module.struct_defs().iter().enumerate() {
+                let struct_name = format!(
+                    "{}_{}",
+                    module_name,
+                    module
+                        .identifier_at(module.struct_handle_at(struct_def.struct_handle).name)
+                        .to_string()
+                );
+                struct_defs.insert(struct_name, idx);
+            }
+        }
+        Self {
+            modules: modules.to_vec(),
+            struct_defs,
+            max_struct_depth: 0,
+            module_name_to_idx,
+        }
+    }
+
+    pub fn translate(&mut self) -> String {
+        let mut res = String::from("\n\n// everything below is auto generated\n\n");
+        // generate names and struct specific functions for all structs
+        res.push_str(&self.emit_struct_code());
+
+        // generate IsPrefix and UpdateValue to the max depth
+        res.push_str(&self.emit_stratified_functions());
+
+        for module in self.modules.iter() {
+            let mut mt = ModuleTranslator::new(&module);
+            res.push_str(&mt.translate());
+        }
+        res
+    }
+
+    pub fn emit_struct_code(&mut self) -> String {
+        let mut res = String::new();
+        for module in self.modules.iter() {
+            for (def_idx, struct_def) in module.struct_defs().iter().enumerate() {
+                let struct_name = struct_name_from_handle_index(module, struct_def.struct_handle);
+                res.push_str(&format!("const unique {}: TypeName;\n", struct_name));
+                let struct_definition_view = StructDefinitionView::new(module, struct_def);
+                if struct_definition_view.is_native() {
+                    continue;
+                }
+                let field_info = get_field_info_from_def_index(module, def_idx);
+                for (field_name, _) in field_info {
+                    res.push_str(&format!(
+                        "const unique {}_{}: FieldName;\n",
+                        struct_name, field_name
+                    ));
+                }
+                res.push_str(&self.emit_struct_specific_functions(module, def_idx));
+                let struct_handle_index = struct_def.struct_handle;
+                // calculate the max depth of a struct
+                self.max_struct_depth = std::cmp::max(
+                    self.max_struct_depth,
+                    self.get_struct_depth(
+                        module,
+                        &SignatureToken::Struct(struct_handle_index, vec![]),
+                    ),
+                );
+            }
+        }
+        res
+    }
+
+    fn get_struct_depth(&self, module: &VerifiedModule, sig: &SignatureToken) -> usize {
+        if let SignatureToken::Struct(idx, _) = sig {
+            let mut max_field_depth = 0;
+            let struct_handle = module.struct_handle_at(*idx);
+            let struct_handle_view = StructHandleView::new(module, struct_handle);
+            let module_name = module.identifier_at(struct_handle_view.module_handle().name);
+            let def_module_idx = self
+                .module_name_to_idx
+                .get(module_name)
+                .unwrap_or_else(|| panic!("no module named {}", module_name));
+            let def_module = &self.modules[*def_module_idx];
+            let struct_name = struct_name_from_handle_index(module, *idx);
+            let def_idx = *self
+                .struct_defs
+                .get(&struct_name)
+                .expect("can't find struct def");
+            let struct_definition = &def_module.struct_defs()[def_idx];
+            let struct_definition_view = StructDefinitionView::new(def_module, struct_definition);
+            if struct_definition_view.is_native() {
+                return 0;
+            }
+            for field_definition_view in struct_definition_view.fields().unwrap() {
+                let field_depth = self.get_struct_depth(
+                    def_module,
+                    field_definition_view.type_signature().token().as_inner(),
+                );
+                max_field_depth = std::cmp::max(max_field_depth, field_depth);
+            }
+            max_field_depth + 1
+        } else {
+            0
+        }
+    }
+}
+
+impl<'a> ModuleTranslator<'a> {
+    pub fn new(module: &'a VerifiedModule) -> Self {
+        let stackless_bytecode = StacklessModuleGenerator::new(module.as_inner()).generate_module();
+        let mut all_type_strs = BTreeSet::new();
+        for struct_def in module.struct_defs().iter() {
+            let struct_name = struct_name_from_handle_index(module, struct_def.struct_handle);
+            all_type_strs.insert(struct_name);
+        }
+        Self {
+            module,
+            stackless_bytecode,
+            all_type_strs,
+        }
+    }
+
+    pub fn translate(&mut self) -> String {
+        let mut res = String::new();
+        // translation of stackless bytecode
+        for (idx, function_def) in self.module.function_defs().iter().enumerate() {
+            if function_def.is_native() {
+                res.push_str(&self.generate_function_sig(idx, false, &None));
+                res.push_str(";\n");
+                continue;
+            }
+            res.push_str(&self.translate_function(idx));
+        }
+        res
+    }
+
+    pub fn translate_function(&self, idx: usize) -> String {
+        let mut res = String::new();
+        // generate function signature
+        res.push_str(&self.generate_function_sig(idx, false, &None)); // no inline
+                                                                      // generate function body
+        res.push_str(&self.generate_function_body(idx, false, &None));
+        res
+    }
+
+    pub fn translate_bytecode(
+        &self,
+        bytecode: &StacklessBytecode,
+        func_idx: usize,
+        arg_names: &Option<Vec<String>>,
+    ) -> String {
+        let mut res = String::new();
+        let stmts = match bytecode {
+            Branch(target) => vec![format!("goto Label_{};", target)],
+            BrTrue(target, idx) => vec![
+                format!("tmp := ls[old_size + {}];", idx),
+                format!("if (b#Boolean(tmp)) {{ goto Label_{}; }}", target),
+            ],
+            BrFalse(target, idx) => vec![
+                format!("tmp := ls[old_size + {}];", idx),
+                format!("if (!b#Boolean(tmp)) {{ goto Label_{}; }}", target),
+            ],
+            MoveLoc(dest, src) => {
+                if self.is_local_ref(*dest, func_idx) {
+                    vec![format!(
+                        "call t{} := CopyOrMoveRef({});",
+                        dest,
+                        self.get_local_name(*src as usize, arg_names)
+                    )]
+                } else {
+                    vec![
+                        format!("call tmp := CopyOrMoveValue(ls[old_size+{}]);", src),
+                        format!("ls[old_size+{}] := tmp;", dest),
+                    ]
+                }
+            }
+            CopyLoc(dest, src) => {
+                if self.is_local_ref(*dest, func_idx) {
+                    vec![format!(
+                        "call t{} := CopyOrMoveRef({});",
+                        dest,
+                        self.get_local_name(*src as usize, arg_names)
+                    )]
+                } else {
+                    vec![
+                        format!("call tmp := CopyOrMoveValue(ls[old_size+{}]);", src),
+                        format!("ls[old_size+{}] := tmp;", dest),
+                    ]
+                }
+            }
+            StLoc(dest, src) => {
+                if self.is_local_ref(*dest as usize, func_idx) {
+                    vec![format!(
+                        "call {} := CopyOrMoveRef(t{});",
+                        self.get_local_name(*dest as usize, arg_names),
+                        src
+                    )]
+                } else {
+                    vec![
+                        format!("call tmp := CopyOrMoveValue(ls[old_size+{}]);", src),
+                        format!("ls[old_size+{}] := tmp;", dest),
+                    ]
+                }
+            }
+            BorrowLoc(dest, src) => vec![format!("call t{} := BorrowLoc(old_size+{});", dest, src)],
+            ReadRef(dest, src) => vec![
+                format!("call tmp := ReadRef(t{});", src),
+                self.format_type_checking("tmp".to_string(), &self.get_local_type(*dest, func_idx)),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            WriteRef(dest, src) => vec![format!("call WriteRef(t{}, ls[old_size+{}]);", dest, src)],
+            FreezeRef(dest, src) => vec![format!("call t{} := FreezeRef(t{});", dest, src)],
+            Call(dests, callee_index, _, args) => {
+                let callee_name = self.function_name_from_handle_index(*callee_index);
+                let mut dest_str = String::new();
+                let mut args_str = String::new();
+                let mut dest_type_assumptions = vec![];
+                let mut tmp_assignments = vec![];
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        args_str.push_str(", ");
+                    }
+                    if self.is_local_ref(*arg, func_idx) {
+                        args_str.push_str(&format!("t{}", arg));
+                    } else {
+                        args_str.push_str(&format!("ls[old_size+{}]", arg));
+                    }
+                }
+                for (i, dest) in dests.iter().enumerate() {
+                    if i > 0 {
+                        dest_str.push_str(", ");
+                    }
+                    dest_str.push_str(&format!("t{}", dest));
+                    dest_type_assumptions.push(self.format_type_checking(
+                        format!("t{}", dest),
+                        &self.get_local_type(*dest, func_idx),
+                    ));
+                    if !self.is_local_ref(*dest, func_idx) {
+                        tmp_assignments.push(format!("ls[old_size+{}] := t{};", dest, dest));
+                    }
+                }
+                let mut res_vec = vec![];
+                if dest_str == "" {
+                    res_vec.push(format!("call {}({});", callee_name, args_str))
+                } else {
+                    res_vec.push(format!(
+                        "call {} := {}({});",
+                        dest_str, callee_name, args_str
+                    ));
+                }
+                res_vec.extend(dest_type_assumptions);
+                res_vec.extend(tmp_assignments);
+                res_vec
+            }
+            Pack(dest, struct_def_index, _, fields) => {
+                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+                let mut fields_str = String::new();
+                let mut res_vec = vec![];
+                for (idx, field_temp) in fields.iter().enumerate() {
+                    if idx > 0 {
+                        fields_str.push_str(", ");
+                    }
+                    fields_str.push_str(&format!("ls[old_size+{}]", field_temp));
+                    res_vec.push(self.format_type_checking(
+                        format!("ls[old_size+{}]", field_temp),
+                        &self.get_local_type(*field_temp, func_idx),
+                    ));
+                }
+                res_vec.push(format!("call tmp := Pack_{}({});", struct_str, fields_str));
+                res_vec.push(format!("ls[old_size+{}] := tmp;", dest));
+                res_vec
+            }
+            Unpack(dests, struct_def_index, _, src) => {
+                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+                let mut dests_str = String::new();
+                let mut dest_type_assumptions = vec![];
+                let mut tmp_assignments = vec![];
+                for (idx, dest) in dests.iter().enumerate() {
+                    if idx > 0 {
+                        dests_str.push_str(", ");
+                    }
+                    dests_str.push_str(&format!("t{}", dest));
+                    dest_type_assumptions.push(self.format_type_checking(
+                        format!("t{}", dest),
+                        &self.get_local_type(*dest, func_idx),
+                    ));
+                    if !self.is_local_ref(*dest, func_idx) {
+                        tmp_assignments.push(format!("ls[old_size+{}] := t{};", dest, dest));
+                    }
+                }
+                let mut res_vec = vec![format!(
+                    "call {} := Unpack_{}(ls[old_size+{}]);",
+                    dests_str, struct_str, src
+                )];
+                res_vec.extend(dest_type_assumptions);
+                res_vec.extend(tmp_assignments);
+                res_vec
+            }
+            BorrowField(dest, src, field_def_index) => {
+                let field_name = self.field_name_from_index(*field_def_index);
+                vec![format!(
+                    "call t{} := BorrowField(t{}, {});",
+                    dest, src, field_name
+                )]
+            }
+            Exists(dest, addr, struct_def_index, _) => {
+                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+                vec![
+                    format!("call tmp := Exists(ls[old_size+{}], {});", addr, struct_str),
+                    format!("ls[old_size+{}] := tmp;", dest),
+                ]
+            }
+            BorrowGlobal(dest, addr, struct_def_index, _) => {
+                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+                vec![format!(
+                    "call t{} := BorrowGlobal(ls[old_size+{}], {});",
+                    dest, addr, struct_str,
+                )]
+            }
+            MoveToSender(src, struct_def_index, _) => {
+                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+                vec![format!(
+                    "call MoveToSender({}, ls[old_size+{}]);",
+                    struct_str, src,
+                )]
+            }
+            MoveFrom(dest, src, struct_def_index, _) => {
+                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+                vec![
+                    format!(
+                        "call tmp := MoveFrom(ls[old_size+{}], {});",
+                        src, struct_str,
+                    ),
+                    format!("ls[old_size+{}] := tmp;", dest),
+                    self.format_type_checking(
+                        format!("t{}", dest),
+                        &self.get_local_type(*dest, func_idx),
+                    ),
+                ]
+            }
+            Ret(rets) => {
+                let mut ret_assignments = vec![];
+                for (i, r) in rets.iter().enumerate() {
+                    if self.is_local_ref(*r, func_idx) {
+                        ret_assignments.push(format!("ret{} := t{};", i, r));
+                    } else {
+                        ret_assignments.push(format!("ret{} := ls[old_size+{}];", i, r));
+                    }
+                }
+                ret_assignments.push("return;".to_string());
+                ret_assignments
+            }
+            LdTrue(idx) => vec![
+                "call tmp := LdTrue();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            LdFalse(idx) => vec![
+                "call tmp := LdFalse();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            LdConst(idx, num) => vec![
+                format!("call tmp := LdConst({});", num),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            LdAddr(idx, addr_idx) => {
+                let addr = self.module.address_pool()[(*addr_idx).into_index()];
+                let addr_int = BigInt::from_str_radix(&addr.to_string(), 16).unwrap();
+                vec![
+                    format!("call tmp := LdAddr({});", addr_int),
+                    format!("ls[old_size+{}] := tmp;", idx),
+                ]
+            }
+            Not(dest, operand) => vec![
+                format!("call tmp := Not(ls[old_size+{}]);", operand),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Add(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Add(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Sub(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Sub(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Mul(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Mul(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Div(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Div(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Mod(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Mod(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Lt(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Lt(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Gt(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Gt(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Le(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Le(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Ge(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Ge(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Or(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := Or(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            And(dest, op1, op2) => vec![
+                format!(
+                    "call tmp := And(ls[old_size+{}], ls[old_size+{}]);",
+                    op1, op2
+                ),
+                format!("ls[old_size+{}] := tmp;", dest),
+            ],
+            Eq(dest, op1, op2) => {
+                let operand_type = self.get_local_type(*op1, func_idx);
+                vec![
+                    format!(
+                        "call tmp := Eq_{}(ls[old_size+{}], ls[old_size+{}]);",
+                        format_type(self.module, &operand_type),
+                        op1,
+                        op2
+                    ),
+                    format!("ls[old_size+{}] := tmp;", dest),
+                ]
+            }
+            Neq(dest, op1, op2) => {
+                let operand_type = self.get_local_type(*op1, func_idx);
+                vec![
+                    format!(
+                        "call tmp := Neq_{}(ls[old_size+{}], ls[old_size+{}]);",
+                        format_type(self.module, &operand_type),
+                        op1,
+                        op2
+                    ),
+                    format!("ls[old_size+{}] := tmp;", dest),
+                ]
+            }
+            BitOr(_, _, _) | BitAnd(_, _, _) | Xor(_, _, _) => {
+                vec!["// bit operation not supported".into()]
+            }
+            Abort(_) => vec!["assert false;".into()],
+            GetGasRemaining(idx) => vec![
+                "call tmp := GetGasRemaining();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            GetTxnSequenceNumber(idx) => vec![
+                "call tmp := GetTxnSequenceNumber();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            GetTxnPublicKey(idx) => vec![
+                "call tmp := GetTxnPublicKey();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            GetTxnSenderAddress(idx) => vec![
+                "call tmp := GetTxnSenderAddress();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            GetTxnMaxGasUnits(idx) => vec![
+                "call tmp := GetTxnMaxGasUnits();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            GetTxnGasUnitPrice(idx) => vec![
+                "call tmp := GetTxnGasUnitPrice();".to_string(),
+                format!("ls[old_size+{}] := tmp;", idx),
+            ],
+            CreateAccount(idx) => vec![format!("call CreateAccount(t{});", idx)],
+            _ => vec!["// unimplemented instruction".into()],
+        };
+        for code in stmts {
+            res.push_str(&format!("    {}\n", code));
+        }
+        res.push('\n');
+        res
+    }
+
+    pub fn generate_function_sig(
+        &self,
+        idx: usize,
+        inline: bool,
+        arg_names: &Option<Vec<String>>,
+    ) -> String {
+        let function_def = &self.module.function_defs()[idx];
+        let fun_name = self.function_name_from_definition_index(idx);
+        let function_handle = self.module.function_handle_at(function_def.function);
+        let function_signature = self.module.function_signature_at(function_handle.signature);
+        let mut args = String::new();
+        let mut rets = String::new();
+        for (i, arg_type) in function_signature.arg_types.iter().enumerate() {
+            if i > 0 {
+                args.push_str(", ");
+            }
+            args.push_str(&format!(
+                "{}: {}",
+                self.get_arg_name(i, arg_names),
+                self.format_value_or_ref(&arg_type)
+            ));
+        }
+        for (i, return_type) in function_signature.return_types.iter().enumerate() {
+            if i > 0 {
+                rets.push_str(", ");
+            }
+            rets.push_str(&format!(
+                "ret{}: {}",
+                i,
+                self.format_value_or_ref(&return_type)
+            ));
+        }
+        if inline {
+            format!(
+                "procedure {{:inline 1}} {}_inline ({}) returns ({})",
+                fun_name, args, rets
+            )
+        } else {
+            format!("procedure {} ({}) returns ({})", fun_name, args, rets)
+        }
+    }
+
+    pub fn generate_function_body(
+        &self,
+        idx: usize,
+        inline: bool,
+        arg_names: &Option<Vec<String>>,
+    ) -> String {
+        let mut res = String::new();
+        let function_def = &self.module.function_defs()[idx];
+        let code = &self.stackless_bytecode[idx];
+
+        res.push_str("\n{\n");
+        res.push_str("    // declare local variables\n");
+
+        let function_handle = self.module.function_handle_at(function_def.function);
+        let function_signature = self.module.function_signature_at(function_handle.signature);
+        let num_args = function_signature.arg_types.len();
+        let mut ref_vars = BTreeSet::new(); // set of locals that are references
+        let mut val_vars = BTreeSet::new(); // set of locals that are not
+        let mut arg_assignment_str = String::new();
+        let mut arg_value_assumption_str = String::new();
+        for (i, local_type) in code.local_types.iter().enumerate() {
+            if i < num_args {
+                if !self.is_local_ref(i, idx) {
+                    arg_assignment_str.push_str(&format!(
+                        "    ls[old_size+{}] := {};\n",
+                        i,
+                        self.get_arg_name(i, arg_names)
+                    ));
+                } else {
+                    arg_assignment_str.push_str(&format!(
+                        "    {} := {};\n",
+                        self.get_local_name(i, arg_names),
+                        self.get_arg_name(i, arg_names)
+                    ));
+                }
+
+                arg_value_assumption_str.push_str(&format!(
+                    "    {}",
+                    self.format_type_checking(self.get_arg_name(i, arg_names), local_type)
+                ));
+            }
+            if SignatureTokenView::new(self.module, local_type).is_reference() {
+                ref_vars.insert(i);
+            } else {
+                val_vars.insert(i);
+            }
+
+            res.push_str(&format!(
+                "    var {}: {}; // {}\n",
+                self.get_local_name(i, arg_names),
+                self.format_value_or_ref(&local_type),
+                format_type(self.module, &local_type)
+            ));
+        }
+        res.push_str("\n    var tmp: Value;\n");
+        res.push_str("    var old_size: int;\n");
+        if !inline {
+            res.push_str("    assume !abort_flag;\n");
+        }
+        res.push_str("\n    // assume arguments are of correct types\n");
+        res.push_str(&arg_value_assumption_str);
+        res.push_str("\n    old_size := ls_size;\n");
+        res.push_str(&format!(
+            "    ls_size := ls_size + {};\n",
+            code.local_types.len()
+        ));
+        res.push_str(&arg_assignment_str);
+        res.push_str("\n    // bytecode translation starts here\n");
+
+        // identify all the branching targets so we can insert labels in front of them
+        let mut branching_targets: BTreeSet<usize> = BTreeSet::new();
+        for bytecode in code.code.iter() {
+            match bytecode {
+                Branch(target) | BrTrue(target, _) | BrFalse(target, _) => {
+                    branching_targets.insert(*target as usize);
+                }
+                _ => {}
+            }
+        }
+
+        for (offset, bytecode) in code.code.iter().enumerate() {
+            // uncomment to print out bytecode for debugging purpose
+            // println!("{:?}", bytecode);
+
+            // insert labels for branching targets
+            if branching_targets.contains(&offset) {
+                res.push_str(&format!("Label_{}:\n", offset));
+            }
+            res.push_str(&self.translate_bytecode(bytecode, idx, arg_names));
+        }
+        res.push_str("}\n");
+        res
+    }
+
+    pub fn get_local_name(&self, idx: usize, arg_names: &Option<Vec<String>>) -> String {
+        if let Some(names) = arg_names {
+            if idx < names.len() {
+                return format!("new_{}", names[idx]);
+            }
+        }
+        format!("t{}", idx)
+    }
+
+    pub fn get_arg_name(&self, idx: usize, arg_names: &Option<Vec<String>>) -> String {
+        if let Some(names) = arg_names {
+            format!("old_{}", names[idx])
+        } else {
+            format!("arg{}", idx)
+        }
+    }
+
+    /*
+        utility functions below
+    */
+    pub fn struct_name_from_definition_index(&self, idx: StructDefinitionIndex) -> String {
+        let struct_handle = self.module.struct_def_at(idx).struct_handle;
+        struct_name_from_handle_index(self.module, struct_handle)
+    }
+
+    pub fn field_name_from_index(&self, idx: FieldDefinitionIndex) -> String {
+        let field_definition = self.module.field_def_at(idx);
+        let struct_handle_index = field_definition.struct_;
+        let struct_name = struct_name_from_handle_index(self.module, struct_handle_index);
+        let field_name = FieldDefinitionView::new(self.module, field_definition).name();
+        format!("{}_{}", struct_name, field_name)
+    }
+
+    fn function_name_from_definition_index(&self, idx: usize) -> String {
+        let function_handle_index = self.module.function_defs()[idx].function;
+        self.function_name_from_handle_index(function_handle_index)
+    }
+
+    fn function_name_from_handle_index(&self, idx: FunctionHandleIndex) -> String {
+        let function_handle = self.module.function_handle_at(idx);
+        let module_handle_index = function_handle.module;
+        let mut module_name = self
+            .module
+            .identifier_at(self.module.module_handle_at(module_handle_index).name)
+            .as_str();
+        if module_name == "<SELF>" {
+            module_name = "self";
+        } // boogie doesn't allow '<' or '>'
+        let function_handle_view = FunctionHandleView::new(self.module, function_handle);
+        let function_name = function_handle_view.name();
+        format!("{}_{}", module_name, function_name)
+    }
+
+    pub fn get_local_type(&self, local_idx: usize, func_idx: usize) -> SignatureToken {
+        self.stackless_bytecode[func_idx].local_types[local_idx].clone()
+    }
+
+    pub fn is_local_ref(&self, local_idx: usize, func_idx: usize) -> bool {
+        let sig = &self.stackless_bytecode[func_idx].local_types[local_idx];
+        match sig {
+            SignatureToken::MutableReference(_) | SignatureToken::Reference(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_local_mutable_ref(&self, local_idx: usize, func_idx: usize) -> bool {
+        let sig = &self.stackless_bytecode[func_idx].local_types[local_idx];
+        match sig {
+            SignatureToken::MutableReference(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn format_value_or_ref(&self, sig: &SignatureToken) -> String {
+        match sig {
+            SignatureToken::Reference(_) | SignatureToken::MutableReference(_) => "Reference",
+            _ => "Value",
+        }
+        .into()
+    }
+
+    pub fn format_type_checking(&self, name: String, sig: &SignatureToken) -> String {
+        match sig {
+            SignatureToken::Reference(_) | SignatureToken::MutableReference(_) => "".to_string(),
+            _ => format!("assume is#{}({});\n", format_value_cons(sig), name,),
+        }
+    }
+}
+
+pub fn struct_name_from_handle_index(module: &VerifiedModule, idx: StructHandleIndex) -> String {
+    let struct_handle = module.struct_handle_at(idx);
+    let struct_handle_view = StructHandleView::new(module, struct_handle);
+    let module_name = module.identifier_at(struct_handle_view.module_handle().name);
+    let struct_name = struct_handle_view.name();
+    format!("{}_{}", module_name, struct_name)
+}
+
+pub fn format_type(module: &VerifiedModule, sig: &SignatureToken) -> String {
+    match sig {
+        SignatureToken::Bool => "bool".into(),
+        SignatureToken::U64 => "int".into(),
+        SignatureToken::String => "string".into(),
+        SignatureToken::ByteArray => "bytearray".into(),
+        SignatureToken::Address => "address".into(),
+        SignatureToken::Struct(idx, _) => struct_name_from_handle_index(module, *idx),
+        SignatureToken::Reference(t) | SignatureToken::MutableReference(t) => {
+            format!("{}_ref", format_type(module, &*t))
+        }
+        SignatureToken::TypeParameter(_) => "unsupported".into(),
+    }
+}
+
+pub fn format_value_cons(sig: &SignatureToken) -> String {
+    match sig {
+        SignatureToken::Bool => "Boolean",
+        SignatureToken::U64 => "Integer",
+        SignatureToken::String => "Str",
+        SignatureToken::ByteArray => "ByteArray",
+        SignatureToken::Address => "Address",
+        SignatureToken::Struct(_, _) => "Map",
+        _ => "unsupported",
+    }
+    .into()
+}
+
+pub fn get_field_info_from_def_index(
+    module: &VerifiedModule,
+    def_idx: usize,
+) -> BTreeMap<String, (String, String)> {
+    let mut name_to_type = BTreeMap::new();
+    let struct_definition = &module.struct_defs()[def_idx];
+    let struct_definition_view = StructDefinitionView::new(module, struct_definition);
+    for field_definition_view in struct_definition_view.fields().unwrap() {
+        let field_name = field_definition_view.name().to_string();
+        let sig = field_definition_view.type_signature().token().as_inner();
+        name_to_type.insert(
+            field_name,
+            (format_type(module, sig), format_value_cons(sig)),
+        );
+    }
+    name_to_type
+}

--- a/language/stackless_bytecode/tree_heap/test_mvir/test-arithmetic.mvir
+++ b/language/stackless_bytecode/tree_heap/test_mvir/test-arithmetic.mvir
@@ -1,0 +1,56 @@
+module TestArithmetic {
+	public add_two_number(x: u64, y: u64): u64*u64 {
+		let res: u64;
+		let z: u64;
+		res = move(x) + move(y);
+		z = 3;
+		return move(z),move(res);
+	}
+
+	public multiple_ops(x: u64, y: u64, z: u64): u64 {
+		let res: u64;
+		res = (move(x) + move(y)) * move(z);
+		return move(res);
+	}
+
+	public bool_ops(a: u64, b: u64) {
+      let c: bool;
+      let d: bool;
+      c = (copy(a) > copy(b)) && (copy(a) >= copy(b));
+      d = (copy(a) < copy(b)) || (copy(a) <= copy(b));
+      assert((move(c) != move(d)), 42);
+      return;
+  }
+
+
+	public arithmetic_ops(a: u64, b: u64): u64 * u64 {
+      let c: u64;
+      c = (6 + 4 - 1) * 2 / 3 % 4;
+			assert(copy(c) == 2, 42);
+      return move(c), move(a);
+  }
+
+	public overflow() {
+		  let x: u64;
+			let y: u64;
+			x = 9223372036854775807;
+			y = move(x) + 1;
+			return;
+	}
+
+	public underflow() {
+		  let x: u64;
+			let y: u64;
+			x = 0;
+			y = move(x) - 1;
+			return;
+	}
+
+	public div_by_zero() {
+		  let x: u64;
+			let y: u64;
+			x = 0;
+			y = 1/move(x);
+			return;
+	}
+}

--- a/language/stackless_bytecode/tree_heap/test_mvir/test-control-flow.mvir
+++ b/language/stackless_bytecode/tree_heap/test_mvir/test-control-flow.mvir
@@ -1,0 +1,13 @@
+module TestControlFlow {
+
+	// bytecode: [MoveLoc(0), BrFalse(6), LdConst(1), LdConst(2), Add, Ret, LdConst(0), Ret]
+	public branch_once(cond: bool) : u64 {
+
+		if (move(cond)) {
+			return 1+2;
+		} else {
+			return 0;
+		}
+	}
+
+}

--- a/language/stackless_bytecode/tree_heap/test_mvir/test-func-call.mvir
+++ b/language/stackless_bytecode/tree_heap/test_mvir/test-func-call.mvir
@@ -1,0 +1,24 @@
+module TestFuncCall {
+
+
+	public f(x: u64) : u64 {
+		return move(x)+1;
+	}
+
+	public g(x: u64) : u64 {
+		return move(x)+2;
+	}
+
+	public h(b: bool) : u64 {
+		let x: u64;
+		let y: u64;
+		x = 3;
+		if (copy(b)) {
+			y = Self.f(move(x));
+		} else {
+		    y = Self.g(move(x));
+		}
+		assert((copy(b) && (copy(y) == 4)) || (!copy(b) && (copy(y) == 5)), 42);
+		return move(y);
+	}
+}

--- a/language/stackless_bytecode/tree_heap/test_mvir/test-reference.mvir
+++ b/language/stackless_bytecode/tree_heap/test_mvir/test-reference.mvir
@@ -1,0 +1,23 @@
+module TestReference {
+    resource T {
+        value: u64,
+    }
+
+    public mut_b(b: &mut u64){
+        *move(b) = 10;
+        return;
+    }
+
+    public mut_ref() {
+        let b: u64;
+        let b_ref: &mut u64;
+
+        b = 20;
+        b_ref = &mut b;
+        // mutable reference passed into a function call
+        Self.mut_b(copy(b_ref));
+        b = *move(b_ref);
+        assert(move(b) == 10, 42);
+        return;
+    }
+}

--- a/language/stackless_bytecode/tree_heap/test_mvir/test-struct.mvir
+++ b/language/stackless_bytecode/tree_heap/test_mvir/test-struct.mvir
@@ -1,0 +1,71 @@
+module TestStruct {
+
+    resource B {
+        addr: address,
+        val: u64,
+    }
+
+    resource A {
+        val: u64,
+        b: Self.B,
+    }
+
+    resource C {
+        val: u64,
+        b: Self.A,
+    }
+
+    resource T {
+        x: u64,
+    }
+
+    public identity(a: Self.A, c: Self.C): Self.A*Self.C {
+        return move(a), move(c);
+    }
+
+    public module_builtins(a: address):  bool acquires T  {
+        let t: Self.T;
+        let t_ref1: &mut Self.T;
+        let t_ref2: &mut Self.T;
+        let b: bool;
+        b = exists<T>(copy(a));
+        assert(copy(b), 42);
+        t_ref1 = borrow_global_mut<T>(copy(a));
+        _ = move(t_ref1);
+        t_ref2 = borrow_global_mut<T>(copy(a));
+        _ = move(t_ref2);
+        t = move_from<T>(copy(a));
+        move_to_sender<T>(move(t));
+        return move(b);
+    }
+
+    public nested_struct(a: address) : Self.B
+    {
+        let var_a: Self.A;
+        let var_b: Self.B;
+        let var_b_ref: &Self.B;
+        let b_val_ref: &u64;
+        let b_val: u64;
+
+        if (false) {
+            var_b = B { addr: copy(a), val: 1 };
+        } else {
+            var_b = B { addr: copy(a), val: 42 };
+        }
+        var_b_ref = &var_b;
+        b_val_ref = &move(var_b_ref).val;
+        b_val = *move(b_val_ref);
+        assert(move(b_val) == 42, 42);
+        return move(var_b);
+    }
+
+    public try_unpack(a: address): u64 {
+        let v: u64;
+        let b: Self.B;
+        let aa: address;
+        b = B { addr: copy(a), val: 42 };
+        B { aa, v } = move(b);
+        assert(move(a) == move(aa), 0);
+        return move(v);
+    }
+}

--- a/language/stackless_bytecode/tree_heap/test_mvir/test3.mvir
+++ b/language/stackless_bytecode/tree_heap/test_mvir/test3.mvir
@@ -1,0 +1,51 @@
+module Test3 {
+
+	struct T {
+		f: u64,
+		g: u64,
+	}
+
+	public test3(flag: bool) {
+		let x: Self.T;
+		let x_ref: &mut Self.T;
+		let f_or_g_ref: &mut u64;
+		let f_or_g_ref2: &mut u64;
+		let f_ref: &u64;
+		let g_ref: &u64;
+		let f: u64;
+		let g: u64;
+
+		x = T { f: 0, g:0 };
+		x_ref = &mut x;
+
+		if (copy(flag)) {
+			f_or_g_ref = &mut copy(x_ref).f;
+		} else {
+			f_or_g_ref = &mut copy(x_ref).g;
+		}
+
+		*move(f_or_g_ref) = 10;
+
+		if (!copy(flag)) {
+			f_or_g_ref2 = &mut copy(x_ref).f;
+		} else {
+			f_or_g_ref2 = &mut copy(x_ref).g;
+		}
+
+		*move(f_or_g_ref2) = 20;
+
+		f_ref = &copy(x_ref).f;
+		g_ref = &move(x_ref).g;
+		f = *move(f_ref);
+		g = *move(g_ref);
+
+		if (copy(flag)) {
+			assert(move(f) == 10, 42);
+			assert(move(g) == 20, 42);
+		} else {
+			assert(move(f) == 20, 42);
+			assert(move(g) == 10, 42);
+		}
+		return;
+	}
+}

--- a/language/stackless_bytecode/tree_heap/tests/translator_tests.rs
+++ b/language/stackless_bytecode/tree_heap/tests/translator_tests.rs
@@ -1,0 +1,132 @@
+use bytecode_verifier::VerifiedModule;
+use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
+use libra_types::account_address::AccountAddress;
+use std::fs;
+use stdlib::stdlib_modules;
+use tree_heap::translator::BoogieTranslator;
+
+// mod translator;
+fn compile_files(file_names: Vec<String>) -> Vec<VerifiedModule> {
+    let mut verified_modules = stdlib_modules().to_vec();
+    let files_len = file_names.len();
+    let dep_files = &file_names[0..files_len];
+
+    // assuming the last file is a program that might contain a script
+    let address = AccountAddress::default();
+    for file_name in dep_files {
+        let code = fs::read_to_string(file_name).unwrap();
+        let module = parse_module(&code).unwrap();
+        let (compiled_module, _) =
+            compile_module(address, module, &verified_modules).expect("module failed to compile");
+        let verified_module_res = VerifiedModule::new(compiled_module);
+
+        match verified_module_res {
+            Err(e) => {
+                panic!("{:?}", e);
+            }
+            Ok(verified_module) => {
+                verified_modules.push(verified_module);
+            }
+        }
+    }
+    verified_modules
+}
+
+#[test]
+fn test3() {
+    let mut file_names = vec![];
+    let name = "test_mvir/test3.mvir".to_string();
+    file_names.push(name);
+    let modules = compile_files(file_names.to_vec());
+
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+    // This is probably too sensitive to minor changes in libra; commenting for now.
+    //    let expected_code = fs::read_to_string("test_mvir/test3.bpl.expect").unwrap();
+    //    assert_eq!(res, expected_code);
+}
+
+#[test]
+fn test_arithmetic() {
+    let mut file_names = vec![];
+    let name = "test_mvir/test-arithmetic.mvir".to_string();
+    file_names.push(name);
+    let modules = compile_files(file_names.to_vec());
+
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+}
+
+#[test]
+fn test_control_flow() {
+    let mut file_names = vec![];
+    let name = "test_mvir/test-control-flow.mvir".to_string();
+    file_names.push(name);
+    let modules = compile_files(file_names.to_vec());
+
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+}
+
+#[test]
+fn test_func_call() {
+    let mut file_names = vec![];
+    let name = "test_mvir/test-func-call.mvir".to_string();
+    file_names.push(name);
+    let modules = compile_files(file_names.to_vec());
+
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+}
+
+#[test]
+fn test_reference() {
+    let mut file_names = vec![];
+    let name = "test_mvir/test-reference.mvir".to_string();
+    file_names.push(name);
+    let modules = compile_files(file_names.to_vec());
+
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+}
+
+#[test]
+fn test_struct() {
+    let mut file_names = vec![];
+    let name = "test_mvir/test-struct.mvir".to_string();
+    file_names.push(name);
+    let modules = compile_files(file_names.to_vec());
+
+    let mut ts = BoogieTranslator::new(&modules);
+    let mut res = String::new();
+
+    // handwritten boogie code
+    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
+    res.push_str(&written_code);
+    res.push_str(&ts.translate());
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I moved the translator tree_heap model(memory model 3) from my private repo to here.
This initial version is guaranteed to contain bugs but it does pass all the tests in test_mvir. However in some cases, preconditions or inline decorators need to be added to make Boogie happy. 
For example, we need to add the following preconditions to `module_builtins` in `test-struct.mvir`:

```
requires domain#GlobalStore(gs)[a#Address(arg0)];
requires domain#TypeStore(contents#GlobalStore(gs)[a#Address(arg0)])[TestStruct_T];
requires domain#GlobalStore(gs)[sender#Transaction_cons(txn)];
requires !domain#TypeStore(contents#GlobalStore(gs)[sender#Transaction_cons(txn)])[TestStruct_T];
```
There are more changes to be made. For example, `CreateAccount` is not implemented because it is supposed to call the `LibraAccount` module(as of last time I heard).
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
