### PR TITLE
Prepend libra to config package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,6 @@ dependencies = [
  "admission-control-proto 0.1.0",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.1.0",
  "crypto 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
@@ -49,6 +48,7 @@ dependencies = [
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
@@ -181,13 +181,13 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "client 0.1.0",
- "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "generate-keypair 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-swarm 0.1.0",
@@ -555,7 +555,6 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.1.0",
  "crash-handler 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
@@ -564,6 +563,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
@@ -668,32 +668,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.1.0"
-dependencies = [
- "crypto 0.1.0",
- "failure_ext 0.1.0",
- "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-tools 0.1.0",
- "libra-types 0.1.0",
- "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "config-builder"
 version = "0.1.0"
 dependencies = [
- "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "generate-keypair 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -711,7 +693,6 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
- "config 0.1.0",
  "consensus-types 0.1.0",
  "crypto 0.1.0",
  "debug-interface 0.1.0",
@@ -720,6 +701,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
@@ -1263,8 +1245,8 @@ dependencies = [
 name = "executable-helpers"
 version = "0.1.0"
 dependencies = [
- "config 0.1.0",
  "crash-handler 0.1.0",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1275,7 +1257,6 @@ name = "executor"
 version = "0.1.0"
 dependencies = [
  "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.1.0",
  "config-builder 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
@@ -1284,6 +1265,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
@@ -1398,7 +1380,6 @@ name = "functional_tests"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
- "config 0.1.0",
  "crypto 0.1.0",
  "datatest-stable 0.1.0",
  "failure_ext 0.1.0",
@@ -1407,6 +1388,7 @@ dependencies = [
  "ir_to_bytecode_syntax 0.1.0",
  "language_e2e_tests 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-types 0.1.0",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -1960,11 +1942,11 @@ version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
  "compiler 0.1.0",
- "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2011,6 +1993,24 @@ dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-config"
+version = "0.1.0"
+dependencies = [
+ "crypto 0.1.0",
+ "failure_ext 0.1.0",
+ "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-tools 0.1.0",
+ "libra-types 0.1.0",
+ "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2068,7 +2068,6 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2077,6 +2076,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
@@ -2133,7 +2133,6 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "admission-control-service 0.1.0",
- "config 0.1.0",
  "config-builder 0.1.0",
  "consensus 0.1.0",
  "crash-handler 0.1.0",
@@ -2145,6 +2144,7 @@ dependencies = [
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
@@ -2166,7 +2166,6 @@ name = "libra-swarm"
 version = "0.1.0"
 dependencies = [
  "client 0.1.0",
- "config 0.1.0",
  "config-builder 0.1.0",
  "crypto 0.1.0",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2174,6 +2173,7 @@ dependencies = [
  "failure_ext 0.1.0",
  "generate-keypair 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-tools 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2533,12 +2533,12 @@ dependencies = [
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
- "config 0.1.0",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
@@ -3873,7 +3873,6 @@ name = "secret-service"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.1.0",
  "crypto 0.1.0",
  "crypto-derive 0.1.0",
  "debug-interface 0.1.0",
@@ -3883,6 +3882,7 @@ dependencies = [
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4176,7 +4176,6 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
- "config 0.1.0",
  "config-builder 0.1.0",
  "crypto 0.1.0",
  "executor 0.1.0",
@@ -4184,6 +4183,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
@@ -4268,7 +4268,6 @@ dependencies = [
 name = "storage-service"
 version = "0.1.0"
 dependencies = [
- "config 0.1.0",
  "crypto 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
@@ -4278,6 +4277,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
@@ -4490,10 +4490,10 @@ version = "0.1.0"
 dependencies = [
  "benchmark 0.1.0",
  "client 0.1.0",
- "config 0.1.0",
  "crypto 0.1.0",
  "generate-keypair 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-swarm 0.1.0",
  "libra-tools 0.1.0",
@@ -4996,10 +4996,10 @@ dependencies = [
 name = "transaction-builder"
 version = "0.1.0"
 dependencies = [
- "config 0.1.0",
  "crypto 0.1.0",
  "ir_to_bytecode 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-types 0.1.0",
  "stdlib 0.1.0",
  "vm 0.1.0",
@@ -5172,11 +5172,11 @@ dependencies = [
 name = "vm-genesis"
 version = "0.1.0"
 dependencies = [
- "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5198,12 +5198,12 @@ version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
  "compiler 0.1.0",
- "config 0.1.0",
  "crypto 0.1.0",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
@@ -5238,7 +5238,6 @@ dependencies = [
 name = "vm_validator"
 version = "0.1.0"
 dependencies = [
- "config 0.1.0",
  "config-builder 0.1.0",
  "crypto 0.1.0",
  "executor 0.1.0",
@@ -5246,6 +5245,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.6.5"
 tokio = "0.1.22"
 
 admission-control-proto = { path = "../admission-control-proto" }
-config = { path = "../../config" }
+libra-config = { path = "../../config" }
 crypto = { path = "../../crypto/crypto" }
 debug-interface = { path = "../../common/debug-interface" }
 failure = { package = "failure_ext", path = "../../common/failure_ext" }

--- a/admission_control/admission-control-service/src/runtime.rs
+++ b/admission_control/admission-control-service/src/runtime.rs
@@ -6,13 +6,13 @@ use admission_control_proto::proto::admission_control::{
     create_admission_control, AdmissionControlClient, SubmitTransactionRequest,
     SubmitTransactionResponse,
 };
-use config::config::NodeConfig;
 use futures::{
     channel::{mpsc, oneshot},
     future::{FutureExt, TryFutureExt},
 };
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder, ServerBuilder};
+use libra_config::config::NodeConfig;
 use libra_mempool::proto::mempool::MempoolClient;
 use network::validator_network::{AdmissionControlNetworkEvents, AdmissionControlNetworkSender};
 use std::{cmp::min, sync::Arc};

--- a/admission_control/admission-control-service/src/upstream_proxy.rs
+++ b/admission_control/admission-control-service/src/upstream_proxy.rs
@@ -7,12 +7,12 @@ use admission_control_proto::proto::admission_control::{
     AdmissionControlMsg, SubmitTransactionRequest, SubmitTransactionResponse,
 };
 use bytes::Bytes;
-use config::config::{AdmissionControlConfig, NodeConfig, RoleType};
 use failure::format_err;
 use futures::{
     channel::{mpsc, oneshot},
     stream::{select_all, StreamExt},
 };
+use libra_config::config::{AdmissionControlConfig, NodeConfig, RoleType};
 use libra_logger::prelude::*;
 use network::validator_network::{
     AdmissionControlNetworkEvents, AdmissionControlNetworkSender, Event, RpcError,

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -22,7 +22,7 @@ walkdir = "2.2.9"
 
 admission-control-proto = { path = "../admission_control/admission-control-proto" }
 client = { path = "../client" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 generate-keypair = { path = "../config/generate-keypair" }
 libra_wallet = { path = "../client/libra_wallet" }

--- a/benchmark/src/bin/ruben.rs
+++ b/benchmark/src/bin/ruben.rs
@@ -66,7 +66,7 @@ mod tests {
         OP_COUNTER,
     };
     use client::AccountData;
-    use config::config::RoleType;
+    use libra_config::config::RoleType;
     use libra_swarm::swarm::LibraSwarm;
     use libra_tools::tempdir::TempPath;
     use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};

--- a/benchmark/src/cli_opt.rs
+++ b/benchmark/src/cli_opt.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::{NodeConfig, PersistableConfig};
 use failure::prelude::*;
+use libra_config::config::{NodeConfig, PersistableConfig};
 use libra_logger::prelude::*;
 use std::{ffi::OsStr, fs, net::IpAddr, path::PathBuf, str::FromStr};
 use structopt::{clap::arg_enum, StructOpt};

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0.40"
 structopt = "0.3.2"
 
 admission-control-proto = { version = "0.1.0", path = "../admission_control/admission-control-proto" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 crash-handler = { path = "../common/crash-handler" }
 crypto = { path = "../crypto/crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -3,9 +3,9 @@
 
 use crate::{commands::*, grpc_client::GRPCClient, AccountData, AccountStatus};
 use admission_control_proto::proto::admission_control::SubmitTransactionRequest;
-use config::{config::PersistableConfig, trusted_peers::ConsensusPeersConfig};
 use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
+use libra_config::{config::PersistableConfig, trusted_peers::ConsensusPeersConfig};
 use libra_logger::prelude::*;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
@@ -1093,7 +1093,7 @@ impl fmt::Display for AccountEntry {
 #[cfg(test)]
 mod tests {
     use crate::client_proxy::{parse_bool, AddressAndIndex, ClientProxy};
-    use config::{config::PersistableConfig, trusted_peers::ConfigHelpers};
+    use libra_config::{config::PersistableConfig, trusted_peers::ConfigHelpers};
     use libra_tools::tempdir::TempPath;
     use libra_wallet::io_utils;
     use proptest::prelude::*;

--- a/common/executable-helpers/Cargo.toml
+++ b/common/executable-helpers/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 slog-scope = "4.0"
 
-config = { path = "../../config"}
+libra-config = { path = "../../config"}
 crash-handler = { path = "../crash-handler" }
 libra-logger =  { path = "../logger" }
 libra-metrics = { path = "../metrics" }

--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::{NodeConfig, NodeConfigHelpers};
+use libra_config::config::{NodeConfig, NodeConfigHelpers};
 use libra_logger::prelude::*;
 use slog_scope::GlobalLoggerGuard;
 use std::path::Path;

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "config"
+name = "libra-config"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
-description = "Libra config"
+description = "Libra libra-config"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "config-builder"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
-description = "Libra config builder"
+description = "Libra libra-config builder"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ parity-multiaddr = { version = "0.5.0", default-features = false }
 rand = "0.6.5"
 structopt = "0.3.2"
 
-config = { path = ".." }
+libra-config = { path = ".." }
 crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 generate-keypair = { path = "../generate-keypair" }

--- a/config/config-builder/src/bin/libra-config.rs
+++ b/config/config-builder/src/bin/libra-config.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::RoleType;
 use config_builder::swarm_config::SwarmConfigBuilder;
+use libra_config::config::RoleType;
 use std::convert::TryInto;
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -3,7 +3,9 @@
 
 //! Convenience structs and functions for generating configuration for a swarm of libra nodes
 use crate::util::gen_genesis_transaction_bytes;
-use config::{
+use crypto::{ed25519::*, test_utils::KeyPair};
+use failure::prelude::*;
+use libra_config::{
     config::{
         BaseConfig, ConsensusConfig, NetworkConfig, NodeConfig, NodeConfigHelpers,
         PersistableConfig, RoleType, VMPublishingOption,
@@ -16,8 +18,6 @@ use config::{
     },
     utils::get_available_port,
 };
-use crypto::{ed25519::*, test_utils::KeyPair};
-use failure::prelude::*;
 use libra_logger::prelude::*;
 use libra_types::PeerId;
 use parity_multiaddr::{Multiaddr, Protocol};

--- a/config/config-builder/src/util.rs
+++ b/config/config-builder/src/util.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::{
+use crypto::{ed25519::*, test_utils::KeyPair};
+use libra_config::{
     config::{NodeConfig, NodeConfigHelpers},
     trusted_peers::{ConfigHelpers, ConsensusPeersConfig, NetworkPeersConfig},
 };
-use crypto::{ed25519::*, test_utils::KeyPair};
 use libra_types::transaction::SignatureCheckedTransaction;
 use prost_ext::MessageExt;
 use rand::{Rng, SeedableRng};

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -31,7 +31,7 @@ tokio = "=0.2.0-alpha.6"
 prometheus = { version = "0.7.0", default-features = false }
 
 channel = { path = "../common/channel" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 consensus-types = { path = "consensus-types", default-features = false }
 crypto = { path = "../crypto/crypto" }
 debug-interface = { path = "../common/debug-interface" }

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -13,10 +13,10 @@ use crate::{
     state_replication::StateMachineReplication,
     txn_manager::MempoolProxy,
 };
-use config::config::NodeConfig;
 use consensus_types::common::Author;
 use executor::Executor;
 use failure::prelude::*;
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_mempool::proto::mempool::MempoolClient;
 use libra_types::{

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -22,10 +22,10 @@ use crate::{
     util::time_service::{ClockTimeService, TimeService},
 };
 use channel;
-use config::config::{ConsensusConfig, ConsensusProposerType};
 use consensus_types::common::{Payload, Round};
 use failure::prelude::*;
 use futures::{executor::block_on, select, stream::StreamExt};
+use libra_config::config::{ConsensusConfig, ConsensusProposerType};
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::{ValidatorSigner, ValidatorVerifier};
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -28,7 +28,7 @@ use crate::chained_bft::{
     persistent_storage::RecoveryData,
     test_utils::{consensus_runtime, with_smr_id},
 };
-use config::config::ConsensusProposerType::{
+use libra_config::config::ConsensusProposerType::{
     self, FixedProposer, MultipleOrderedProposers, RotatingProposer,
 };
 use libra_types::crypto_proxies::{

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -4,13 +4,13 @@
 use crate::{
     chained_bft::consensusdb::ConsensusDB, consensus_provider::create_storage_read_client,
 };
-use config::config::NodeConfig;
 use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
 use crypto::HashValue;
 use failure::{Result, ResultExt};
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_types::ledger_info::LedgerInfo;
 use rmp_serde::{from_slice, to_vec_named};

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -5,13 +5,13 @@ use crate::chained_bft::persistent_storage::{
     PersistentLivenessStorage, PersistentStorage, RecoveryData,
 };
 
-use config::config::{NodeConfig, NodeConfigHelpers};
 use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
 use crypto::HashValue;
 use failure::Result;
+use libra_config::config::{NodeConfig, NodeConfigHelpers};
 use libra_types::ledger_info::LedgerInfo;
 use safety_rules::ConsensusState;
 use std::{

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::NodeConfig;
 use failure::prelude::*;
+use libra_config::config::NodeConfig;
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};
 
 use crate::chained_bft::chained_bft_consensus_provider::ChainedBftProvider;

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -416,7 +416,7 @@ pub mod compat {
     ///
     /// Warning: if you pass in None, this will not return distinct
     /// results every time! Should you want to write non-deterministic
-    /// tests, look at config::config_builder::util::get_test_config
+    /// tests, look at libra_config::config_builder::util::get_test_config
     pub fn generate_keypair<'a, T>(opt_rng: T) -> (Ed25519PrivateKey, Ed25519PublicKey)
     where
         T: Into<Option<&'a mut StdRng>> + Sized,

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -383,7 +383,7 @@ pub mod compat {
     ///
     /// Warning: if you pass in None, this will not return distinct
     /// results every time! Should you want to write non-deterministic
-    /// tests, look at config::config_builder::util::get_test_config
+    /// tests, look at libra_config::config_builder::util::get_test_config
     pub fn generate_keypair<'a, T>(opt_rng: T) -> (X25519StaticPrivateKey, X25519StaticPublicKey)
     where
         T: Into<Option<&'a mut StdRng>> + Sized,

--- a/crypto/secret-service/Cargo.toml
+++ b/crypto/secret-service/Cargo.toml
@@ -19,7 +19,7 @@ rand_chacha = "0.1.1"
 serde = { version = "1.0.96", features = ["derive"] }
 structopt = "0.3.2"
 
-config = { path = "../../config" }
+libra-config = { path = "../../config" }
 crypto = { path = "../crypto" }
 crypto-derive = { path = "../crypto-derive" }
 debug-interface = { path = "../../common/debug-interface" }
@@ -29,7 +29,7 @@ grpc_helpers = { path = "../../common/grpc_helpers" }
 libra-logger = { path = "../../common/logger" }
 
 [dev-dependencies]
-config = { path = "../../config", features = ["testing"]}
+libra-config = { path = "../../config", features = ["testing"]}
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/crypto/secret-service/src/secret_service_node.rs
+++ b/crypto/secret-service/src/secret_service_node.rs
@@ -8,10 +8,10 @@
 //! responses that it gives back. For an example on how to run the secret service see main.rs.
 
 use crate::{proto::create_secret_service, secret_service_server::SecretServiceServer};
-use config::config::NodeConfig;
 use debug_interface::{node_debug_service::NodeDebugService, proto::create_node_debug_interface};
 use failure::prelude::*;
 use grpc_helpers::spawn_service_thread;
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use std::thread;
 

--- a/crypto/secret-service/src/unit_tests/secret_service_node_test.rs
+++ b/crypto/secret-service/src/unit_tests/secret_service_node_test.rs
@@ -6,11 +6,11 @@ use crate::{
     secret_service_client::ConsensusKeyManager,
     secret_service_node::SecretServiceNode,
 };
-use config::config::{NodeConfig, NodeConfigHelpers};
 use crypto::hash::HashValue;
 use crypto::traits::Signature;
 use debug_interface::node_debug_helpers::{check_node_up, create_debug_client};
 use grpcio::{ChannelBuilder, EnvBuilder};
+use libra_config::config::{NodeConfig, NodeConfigHelpers};
 use libra_logger::prelude::*;
 use std::{sync::Arc, thread};
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = { version = "1.3.0", default-features = false }
 rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
-config = { path = "../config" }
+libra-config = { path = "../config" }
 crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-logger = { path = "../common/logger" }
@@ -36,7 +36,7 @@ proptest = "0.9.2"
 rand = "0.6.5"
 rusty-fork = "0.2.1"
 
-config = { path = "../config", features = ["testing"]}
+libra-config = { path = "../config", features = ["testing"]}
 grpc_helpers = { path = "../common/grpc_helpers" }
 libra-types = { path = "../types", features = ["testing"]}
 

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -5,13 +5,13 @@ use crate::{
     Chunk, Command, CommittableBlockBatch, ExecutableBlock, ExecutedState, ExecutedTrees,
     ProcessedVMOutput, StateComputeResult, TransactionData, OP_COUNTERS,
 };
-use config::config::VMConfig;
 use crypto::{
     hash::{CryptoHash, EventAccumulatorHasher},
     HashValue,
 };
 use failure::prelude::*;
 use futures::channel::oneshot;
+use libra_config::config::VMConfig;
 use libra_logger::prelude::*;
 use libra_types::{
     account_address::AccountAddress,

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     CommittableBlock, Executor, OP_COUNTERS,
 };
-use config::config::{NodeConfig, NodeConfigHelpers};
 use crypto::{hash::GENESIS_BLOCK_ID, HashValue};
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, ServerBuilder};
+use libra_config::config::{NodeConfig, NodeConfigHelpers};
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     crypto_proxies::LedgerInfoWithSignatures,

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -9,7 +9,6 @@ mod executor_test;
 mod mock_vm;
 
 use crate::block_processor::BlockProcessor;
-use config::config::NodeConfig;
 use crypto::{
     hash::{
         EventAccumulatorHasher, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH,
@@ -20,6 +19,7 @@ use crypto::{
 use failure::{format_err, Result};
 use futures::{channel::oneshot, executor::block_on};
 use lazy_static::lazy_static;
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_types::{
     account_address::AccountAddress,

--- a/executor/src/mock_vm/mock_vm_test.rs
+++ b/executor/src/mock_vm/mock_vm_test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{balance_ap, encode_mint_transaction, encode_transfer_transaction, seqnum_ap, MockVM};
-use config::config::VMConfig;
 use failure::Result;
+use libra_config::config::VMConfig;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/executor/src/mock_vm/mod.rs
+++ b/executor/src/mock_vm/mod.rs
@@ -4,10 +4,10 @@
 #[cfg(test)]
 mod mock_vm_test;
 
-use config::config::VMConfig;
 use crypto::ed25519::compat;
 use failure::Result;
 use lazy_static::lazy_static;
+use libra_config::config::VMConfig;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::NodeConfig;
 use config_builder::util::get_test_config;
 use crypto::{ed25519::*, hash::GENESIS_BLOCK_ID, test_utils::TEST_SEED, HashValue};
 use executor::{CommittableBlock, Executor};
@@ -9,6 +8,7 @@ use failure::prelude::*;
 use futures::executor::block_on;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
+use libra_config::config::NodeConfig;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -28,7 +28,7 @@ proptest = "0.9.3"
 proptest-derive = "0.1.1"
 proptest-helpers = { path = "../../common/proptest-helpers" }
 prost = "0.5.0"
-config =  { path = "../../config" }
+libra-config =  { path = "../../config" }
 libra-logger = { path = "../../common/logger" }
 stdlib = { path = "../stdlib" }
 walkdir = "2.2.9"

--- a/language/e2e_tests/src/executor.rs
+++ b/language/e2e_tests/src/executor.rs
@@ -7,7 +7,7 @@ use crate::{
     account::{Account, AccountData},
     data_store::{FakeDataStore, GENESIS_WRITE_SET, TESTNET_GENESIS},
 };
-use config::config::{NodeConfig, NodeConfigHelpers, VMPublishingOption};
+use libra_config::config::{NodeConfig, NodeConfigHelpers, VMPublishingOption};
 use libra_types::{
     access_path::AccessPath,
     account_config::AccountResource,

--- a/language/e2e_tests/src/tests/module_publishing.rs
+++ b/language/e2e_tests/src/tests/module_publishing.rs
@@ -5,7 +5,7 @@ use crate::{
     account::AccountData, assert_prologue_parity, assert_status_eq,
     compile::compile_module_with_address, executor::FakeExecutor, transaction_status_eq,
 };
-use config::config::VMPublishingOption;
+use libra_config::config::VMPublishingOption;
 use libra_types::{
     transaction::TransactionStatus,
     vm_error::{StatusCode, StatusType, VMStatus},

--- a/language/e2e_tests/src/tests/peer_to_peer.rs
+++ b/language/e2e_tests/src/tests/peer_to_peer.rs
@@ -7,7 +7,7 @@ use crate::{
     executor::{test_all_genesis, FakeExecutor},
     gas_costs, transaction_status_eq,
 };
-use config::config::VMPublishingOption;
+use libra_config::config::VMPublishingOption;
 use libra_types::{
     account_config::AccountEvent,
     transaction::{SignedTransaction, TransactionOutput, TransactionPayload, TransactionStatus},

--- a/language/e2e_tests/src/tests/verify_txn.rs
+++ b/language/e2e_tests/src/tests/verify_txn.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
-use config::config::{NodeConfigHelpers, VMPublishingOption};
 use crypto::{ed25519::*, HashValue};
+use libra_config::config::{NodeConfigHelpers, VMPublishingOption};
 use libra_types::{
     test_helpers::transaction_test_helpers,
     transaction::{

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -17,7 +17,7 @@ libra-types = { path = "../../types" }
 vm = { path = "../vm" }
 bytecode-verifier = { path = "../bytecode-verifier" }
 language_e2e_tests = { path = "../e2e_tests" }
-config = { path = "../../config" }
+libra-config = { path = "../../config" }
 crypto = { path = "../../crypto/crypto" }
 filecheck = "0.4.0"
 lazy_static = "1.3.0"

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -8,7 +8,6 @@ use crate::{
 use bytecode_verifier::verifier::{
     verify_module_dependencies, verify_script_dependencies, VerifiedModule, VerifiedScript,
 };
-use config::config::VMPublishingOption;
 use crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use ir_to_bytecode::{
     compiler::{compile_module, compile_script},
@@ -16,6 +15,7 @@ use ir_to_bytecode::{
 };
 use ir_to_bytecode_syntax::ast::ScriptOrModule;
 use language_e2e_tests::executor::FakeExecutor;
+use libra_config::config::VMPublishingOption;
 use libra_types::{
     account_address::AccountAddress,
     transaction::{

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-config = { path = "../../config" }
+libra-config = { path = "../../config" }
 crypto = { path = "../../crypto/crypto" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 lazy_static = "1.3.0"

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use config::config::{VMConfig, VMPublishingOption};
 use crypto::HashValue;
 use ir_to_bytecode::{compiler::compile_program, parser::ast};
 use lazy_static::lazy_static;
+use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_types::{
     account_address::AccountAddress,
     byte_array::ByteArray,

--- a/language/vm/vm-genesis/Cargo.toml
+++ b/language/vm/vm-genesis/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-config = { path = "../../../config" }
+libra-config = { path = "../../../config" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 transaction-builder = { path = "../../transaction-builder"}
 crypto = { path = "../../../crypto/crypto" }

--- a/language/vm/vm-genesis/src/main.rs
+++ b/language/vm/vm-genesis/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::{config::PersistableConfig, trusted_peers::ConfigHelpers};
+use libra_config::{config::PersistableConfig, trusted_peers::ConfigHelpers};
 use prost_ext::MessageExt;
 use std::{fs::File, io::prelude::*};
 use transaction_builder::default_config;

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -20,7 +20,7 @@ prometheus = { version = "0.7.0", default-features = false }
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" }
-config = { path = "../../../config" }
+libra-config = { path = "../../../config" }
 crypto = { path = "../../../crypto/crypto" }
 libra-logger = { path = "../../../common/logger" }
 libra-metrics = { path = "../../../common/metrics" }

--- a/language/vm/vm_runtime/src/block_processor.rs
+++ b/language/vm/vm_runtime/src/block_processor.rs
@@ -11,7 +11,7 @@ use crate::{
     data_cache::BlockDataCache,
     process_txn::{execute::ExecutedTransaction, validate::ValidationMode, ProcessTransaction},
 };
-use config::config::VMPublishingOption;
+use libra_config::config::VMPublishingOption;
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::{

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -136,8 +136,8 @@ pub use move_vm::MoveVM;
 pub use process_txn::verify::static_verify_program;
 pub use txn_executor::execute_function;
 
-use config::config::VMConfig;
 use failure::prelude::*;
+use libra_config::config::VMConfig;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,

--- a/language/vm/vm_runtime/src/move_vm.rs
+++ b/language/vm/vm_runtime/src/move_vm.rs
@@ -26,7 +26,7 @@ rental! {
     }
 }
 
-use config::config::VMConfig;
+use libra_config::config::VMConfig;
 pub use move_vm_definition::MoveVMImpl;
 
 /// A wrapper to make VMRuntime standalone and thread safe.

--- a/language/vm/vm_runtime/src/process_txn/mod.rs
+++ b/language/vm/vm_runtime/src/process_txn/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     code_cache::module_cache::ModuleCache, data_cache::RemoteCache,
     loaded_data::loaded_module::LoadedModule,
 };
-use config::config::VMPublishingOption;
+use libra_config::config::VMPublishingOption;
 use libra_types::transaction::SignatureCheckedTransaction;
 use std::marker::PhantomData;
 use vm::errors::VMResult;

--- a/language/vm/vm_runtime/src/process_txn/validate.rs
+++ b/language/vm/vm_runtime/src/process_txn/validate.rs
@@ -8,8 +8,8 @@ use crate::{
     process_txn::{verify::VerifiedTransaction, ProcessTransaction},
     txn_executor::TransactionExecutor,
 };
-use config::config::VMPublishingOption;
 use crypto::HashValue;
+use libra_config::config::VMPublishingOption;
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::{SignatureCheckedTransaction, TransactionPayload, MAX_TRANSACTION_SIZE_IN_BYTES},

--- a/language/vm/vm_runtime/src/runtime.rs
+++ b/language/vm/vm_runtime/src/runtime.rs
@@ -13,8 +13,8 @@ use crate::{
     loaded_data::loaded_module::LoadedModule,
     process_txn::{validate::ValidationMode, ProcessTransaction},
 };
-use config::config::{VMConfig, VMPublishingOption};
 use failure::prelude::*;
+use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -20,7 +20,7 @@ tokio = "=0.2.0-alpha.6"
 
 admission-control-proto = { path = "../admission_control/admission-control-proto" }
 admission-control-service = { path = "../admission_control/admission-control-service" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 consensus = { path = "../consensus" }
 crash-handler = { path = "../common/crash-handler" }
 debug-interface = { path = "../common/debug-interface" }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use admission_control_service::runtime::AdmissionControlRuntime;
-use config::config::{NetworkConfig, NodeConfig, RoleType};
 use consensus::consensus_provider::{make_consensus_provider, ConsensusProvider};
 use crypto::{ed25519::*, ValidKey};
 use debug_interface::{node_debug_service::NodeDebugService, proto::create_node_debug_interface};
 use executor::Executor;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
+use libra_config::config::{NetworkConfig, NodeConfig, RoleType};
 use libra_logger::prelude::*;
 use libra_mempool::MempoolRuntime;
 use libra_metrics::metric_server;

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -15,7 +15,7 @@ ctrlc = { version = "3.1.3", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 structopt = "0.3.2"
 
-config = { path = "../config" }
+libra-config = { path = "../config" }
 config-builder = { path = "../config/config-builder" }
 debug-interface = { path = "../common/debug-interface" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::{NodeConfig, RoleType};
+use libra_config::config::{NodeConfig, RoleType};
 use libra_swarm::{client, swarm::LibraSwarm};
 use libra_tools::tempdir::TempPath;
 use std::path::Path;

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::utils;
-use config::config::{NodeConfig, RoleType};
 use config_builder::swarm_config::{SwarmConfig, SwarmConfigBuilder};
 use crypto::{ed25519::*, test_utils::KeyPair};
 use debug_interface::NodeDebugClient;
 use failure::prelude::*;
+use libra_config::config::{NodeConfig, RoleType};
 use libra_logger::prelude::*;
 use libra_tools::tempdir::TempPath;
 use std::{

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -24,7 +24,7 @@ ttl_cache = "0.4.2"
 
 libra-mempool-shared-proto = { path = "mempool-shared-proto" }
 bounded-executor = { path = "../common/bounded-executor" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 libra-logger = { path = "../common/logger" }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -14,7 +14,7 @@ use crate::{
     OP_COUNTERS,
 };
 use chrono::Utc;
-use config::config::NodeConfig;
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_mempool_shared_proto::{
     proto::mempool_status::MempoolAddTransactionStatusCode, MempoolAddTransactionStatus,

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     OP_COUNTERS,
 };
-use config::config::MempoolConfig;
 use failure::prelude::*;
+use libra_config::config::MempoolConfig;
 use libra_logger::prelude::*;
 use libra_mempool_shared_proto::{
     proto::mempool_status::MempoolAddTransactionStatusCode, MempoolAddTransactionStatus,

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
-use config::config::NodeConfigHelpers;
 use crypto::ed25519::*;
 use failure::prelude::*;
 use lazy_static::lazy_static;
+use libra_config::config::NodeConfigHelpers;
 use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{
     account_address::AccountAddress,

--- a/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
@@ -8,7 +8,7 @@ use crate::core_mempool::{
     },
     CoreMempool, TimelineState,
 };
-use config::config::NodeConfigHelpers;
+use libra_config::config::NodeConfigHelpers;
 use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::transaction::SignedTransaction;
 use std::{collections::HashSet, time::Duration};

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -6,12 +6,12 @@ use crate::{
     shared_mempool::{start_shared_mempool, SharedMempoolNotification, SyncEvent},
 };
 use channel;
-use config::config::{NodeConfig, NodeConfigHelpers};
 use futures::{
     sync::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
     Stream,
 };
 use futures_preview::{compat::Stream01CompatExt, executor::block_on, SinkExt, StreamExt};
+use libra_config::config::{NodeConfig, NodeConfigHelpers};
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
     interface::{NetworkNotification, NetworkRequest},

--- a/mempool/src/runtime.rs
+++ b/mempool/src/runtime.rs
@@ -5,9 +5,9 @@ use crate::{
     core_mempool::CoreMempool, mempool_service::MempoolService, proto::mempool,
     shared_mempool::start_shared_mempool,
 };
-use config::config::NodeConfig;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
+use libra_config::config::NodeConfig;
 use network::validator_network::{MempoolNetworkEvents, MempoolNetworkSender};
 use std::{
     cmp::max,

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -6,9 +6,9 @@ use crate::{
     OP_COUNTERS,
 };
 use bounded_executor::BoundedExecutor;
-use config::config::{MempoolConfig, NodeConfig};
 use futures::sync::mpsc::UnboundedSender;
 use futures_preview::{compat::Future01CompatExt, future::join_all, Stream, StreamExt};
+use libra_config::config::{MempoolConfig, NodeConfig};
 use libra_logger::prelude::*;
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{

--- a/mempool/src/unit_tests/service_test.rs
+++ b/mempool/src/unit_tests/service_test.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{core_mempool::CoreMempool, mempool_service::MempoolService, proto::mempool::*};
-use config::config::NodeConfigHelpers;
 use crypto::ed25519::compat::generate_keypair;
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder};
+use libra_config::config::NodeConfigHelpers;
 use libra_mempool_shared_proto::proto::mempool_status::*;
 use libra_types::{
     account_address::AccountAddress,

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -24,7 +24,7 @@ tokio-retry = "0.2.0"
 admission-control-proto = { path = "../admission_control/admission-control-proto" }
 bounded-executor = { path = "../common/bounded-executor" }
 channel = { path = "../common/channel" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 crypto = { path = "../crypto/crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 libra-types = { path = "../types" }

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -8,7 +8,6 @@
 // Allow writing 1 * KiB or 1 * MiB
 #![allow(clippy::identity_op)]
 
-use config::config::RoleType;
 use core::str::FromStr;
 use criterion::{
     criterion_group, criterion_main, AxisScale, Bencher, Criterion, ParameterizedBenchmark,
@@ -21,6 +20,7 @@ use futures::{
     sink::SinkExt,
     stream::{FuturesUnordered, StreamExt},
 };
+use libra_config::config::RoleType;
 use network::{
     proto::{Block, ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock, RespondBlock},
     protocols::rpc::error::RpcError,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -10,7 +10,6 @@ use crate::{
     ProtocolId,
 };
 use channel;
-use config::config::RoleType;
 use futures::{
     channel::oneshot,
     executor::block_on,
@@ -18,6 +17,7 @@ use futures::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     stream::StreamExt,
 };
+use libra_config::config::RoleType;
 use libra_types::PeerId;
 use memsocket::MemorySocket;
 use netcore::{

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -10,8 +10,8 @@ use crate::{
     utils::MessageExt,
     ProtocolId,
 };
-use config::config::RoleType;
 use futures::{sink::SinkExt, stream::StreamExt};
+use libra_config::config::RoleType;
 use libra_types::PeerId;
 use netcore::{
     compat::IoCompat,
@@ -150,8 +150,8 @@ mod tests {
         protocols::identity::{exchange_identity, Identity},
         ProtocolId,
     };
-    use config::config::RoleType;
     use futures::{executor::block_on, future::join};
+    use libra_config::config::RoleType;
     use libra_types::PeerId;
     use memsocket::MemorySocket;
     use netcore::{

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -27,12 +27,12 @@ use crate::{
     ProtocolId,
 };
 use channel;
-use config::config::RoleType;
 use crypto::{
     ed25519::*,
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
 };
 use futures::StreamExt;
+use libra_config::config::RoleType;
 use libra_logger::prelude::*;
 use libra_types::{validator_signer::ValidatorSigner, PeerId};
 use netcore::{multiplexing::StreamMultiplexer, transport::boxed::BoxedTransport};

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -12,9 +12,9 @@ use crate::{
     },
     ProtocolId,
 };
-use config::config::RoleType;
 use crypto::{ed25519::compat, test_utils::TEST_SEED, traits::ValidKey, x25519};
 use futures::{executor::block_on, future::join, StreamExt};
+use libra_config::config::RoleType;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     proto::types::SignedTransaction,

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.6.5"
 tokio = "=0.2.0-alpha.6"
 prometheus = { version = "0.7.0", default-features = false }
 
-config = { path = "../config" }
+libra-config = { path = "../config" }
 executor = { path = "../executor" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-logger = { path = "../common/logger" }

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -7,13 +7,13 @@ use crate::{
     peer_manager::{PeerManager, PeerScoreUpdateType},
     LedgerInfo, PeerId,
 };
-use config::config::StateSyncConfig;
 use failure::prelude::*;
 use futures::{
     channel::{mpsc, oneshot},
     stream::{futures_unordered::FuturesUnordered, select_all},
     StreamExt,
 };
+use libra_config::config::StateSyncConfig;
 use libra_logger::prelude::*;
 use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures, transaction::TransactionListWithProof,

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -1,9 +1,9 @@
 use crate::LedgerInfo;
-use config::config::NodeConfig;
 use executor::Executor;
 use failure::prelude::*;
 use futures::{channel::oneshot, Future, FutureExt};
 use grpcio::EnvBuilder;
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier},

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -5,7 +5,6 @@ use crate::{
     coordinator::{CoordinatorMessage, SyncCoordinator},
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
 };
-use config::config::{NodeConfig, StateSyncConfig};
 use executor::Executor;
 use failure::prelude::*;
 use futures::{
@@ -13,6 +12,7 @@ use futures::{
     future::Future,
     SinkExt,
 };
+use libra_config::config::{NodeConfig, StateSyncConfig};
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use network::validator_network::{StateSynchronizerEvents, StateSynchronizerSender};
 use std::sync::Arc;

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -4,11 +4,11 @@
 use crate::{
     executor_proxy::ExecutorProxyTrait, LedgerInfo, PeerId, StateSyncClient, StateSynchronizer,
 };
-use config::config::RoleType;
 use config_builder::util::get_test_config;
 use crypto::{ed25519::*, test_utils::TEST_SEED, traits::Genesis, x25519, HashValue, SigningKey};
 use failure::{prelude::*, Result};
 use futures::{executor::block_on, future::FutureExt, Future};
+use libra_config::config::RoleType;
 use libra_types::{
     account_address::AccountAddress,
     crypto_proxies::LedgerInfoWithSignatures,

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -15,7 +15,7 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["pr
 structopt = "0.3.2"
 
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-config = { path = "../../config" }
+libra-config = { path = "../../config" }
 crypto = { path = "../../crypto/crypto" }
 debug-interface = { path = "../../common/debug-interface" }
 executable-helpers = { path = "../../common/executable-helpers" }

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -9,9 +9,9 @@
 
 pub mod mocks;
 
-use config::config::NodeConfig;
 use failure::prelude::*;
 use grpc_helpers::{provide_grpc_response, spawn_service_thread_with_drop_closure, ServerHandle};
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_metrics::counters::SVC_COUNTERS;
 use libra_types::proto::types::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse};

--- a/storage/storage-service/src/main.rs
+++ b/storage/storage-service/src/main.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::NodeConfig;
 use debug_interface::{node_debug_service::NodeDebugService, proto::create_node_debug_interface};
 use executable_helpers::helpers::setup_executable;
 use failure::prelude::*;
 use grpc_helpers::spawn_service_thread;
+use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use std::{path::PathBuf, thread};
 use structopt::StructOpt;

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use config::config::NodeConfigHelpers;
 use grpcio::EnvBuilder;
 use itertools::zip_eq;
+use libra_config::config::NodeConfigHelpers;
 use libra_types::get_with_proof::{RequestItem, ResponseItem};
 use libradb::mock_genesis::db_with_mock_genesis;
 #[cfg(any(test, feature = "testing"))]

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -25,6 +25,6 @@ cli = { path = "../client", package="client" }
 generate-keypair = { path = "../config/generate-keypair" }
 libra-swarm = { path = "../libra-swarm", features = ["testing"]}
 libra-logger = { path = "../common/logger" }
-config = { path = "../config" }
+libra-config = { path = "../config" }
 libra-tools = { path = "../common/tools" }
 crypto = { path = "../crypto/crypto" }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -4,8 +4,8 @@
 use cli::{
     client_proxy::ClientProxy, AccountAddress, CryptoHash, TransactionArgument, TransactionPayload,
 };
-use config::config::{NodeConfig, RoleType};
 use crypto::{ed25519::*, test_utils::KeyPair, SigningKey};
+use libra_config::config::{NodeConfig, RoleType};
 use libra_logger::prelude::*;
 use libra_swarm::{swarm::LibraSwarm, utils};
 use libra_tools::tempdir::TempPath;

--- a/testsuite/tests/libratest/throughput_test.rs
+++ b/testsuite/tests/libratest/throughput_test.rs
@@ -7,7 +7,7 @@ use benchmark::{
     load_generator::PairwiseTransferTxnGenerator,
     Benchmarker,
 };
-use config::config::RoleType;
+use libra_config::config::RoleType;
 use libra_swarm::swarm::LibraSwarm;
 use num::traits::Float;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-config = { path = "../config" }
+libra-config = { path = "../config" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 futures = "0.1.28"
 scratchpad = { path = "../storage/scratchpad" }

--- a/vm_validator/src/unit_tests/vm_validator_test.rs
+++ b/vm_validator/src/unit_tests/vm_validator_test.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::vm_validator::{TransactionValidation, VMValidator};
-use config::config::NodeConfig;
 use config_builder::util::get_test_config;
 use crypto::ed25519::*;
 use executor::Executor;
 use futures::future::Future;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
+use libra_config::config::NodeConfig;
 use libra_types::{
     account_address, account_config,
     test_helpers::transaction_test_helpers,

--- a/vm_validator/src/vm_validator.rs
+++ b/vm_validator/src/vm_validator.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use config::config::NodeConfig;
 use failure::prelude::*;
 use futures::future::{err, ok, Future};
+use libra_config::config::NodeConfig;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_config::get_account_resource_or_default,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `config` package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235
#1350
#1353
#1371
#1377