### PR TITLE
Prepend libra to crypto packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - run:
           name: Run Cryptography Unit Tests with the formally verified backend
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo test -j 16 -p crypto -p secret-service --features='std fiat_u64_backend' --no-default-features
+            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo test -j 16 -p libra-crypto -p secret-service --features='std fiat_u64_backend' --no-default-features
       - run:
           name: Run All End to End Tests
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@
 name = "accumulator"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -39,7 +39,6 @@ dependencies = [
  "admission-control-proto 0.1.0",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
  "failure_ext 0.1.0",
@@ -49,6 +48,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
@@ -181,13 +181,13 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "client 0.1.0",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "generate-keypair 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-swarm 0.1.0",
@@ -556,7 +556,6 @@ dependencies = [
  "admission-control-proto 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crash-handler 0.1.0",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -564,6 +563,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
@@ -593,13 +593,13 @@ name = "cluster-test"
 version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
- "crypto 0.1.0",
  "debug-interface 0.1.0",
  "failure_ext 0.1.0",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "generate-keypair 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,11 +671,11 @@ dependencies = [
 name = "config-builder"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "generate-keypair 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
@@ -694,7 +694,6 @@ dependencies = [
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "consensus-types 0.1.0",
- "crypto 0.1.0",
  "debug-interface 0.1.0",
  "executor 0.1.0",
  "failure_ext 0.1.0",
@@ -702,6 +701,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
@@ -737,10 +737,10 @@ dependencies = [
 name = "consensus-types"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "executor 0.1.0",
  "failure_ext 0.1.0",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
@@ -786,10 +786,10 @@ name = "cost-synthesis"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
- "crypto 0.1.0",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "language_e2e_tests 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -923,46 +923,6 @@ dependencies = [
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "crypto"
-version = "0.1.0"
-dependencies = [
- "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto-derive 0.1.0",
- "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
- "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)",
- "failure_ext 0.1.0",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libra-canonical-serialization 0.1.0",
- "libra-nibble 0.1.0",
- "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)",
-]
-
-[[package]]
-name = "crypto-derive"
-version = "0.1.0"
-dependencies = [
- "failure_ext 0.1.0",
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "crypto-mac"
@@ -1258,7 +1218,6 @@ version = "0.1.0"
 dependencies = [
  "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc_helpers 0.1.0",
@@ -1266,6 +1225,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-prost-ext 0.1.0",
@@ -1380,7 +1340,6 @@ name = "functional_tests"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
- "crypto 0.1.0",
  "datatest-stable 0.1.0",
  "failure_ext 0.1.0",
  "filecheck 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1389,6 +1348,7 @@ dependencies = [
  "language_e2e_tests 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -1516,9 +1476,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "generate-keypair"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-tools 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1833,8 +1793,8 @@ version = "0.1.0"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-nibble 0.1.0",
  "libra-types 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1942,11 +1902,11 @@ version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
  "compiler 0.1.0",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1999,10 +1959,10 @@ dependencies = [
 name = "libra-config"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2011,6 +1971,46 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-crypto"
+version = "0.1.0"
+dependencies = [
+ "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)",
+ "failure_ext 0.1.0",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-crypto-derive 0.1.0",
+ "libra-nibble 0.1.0",
+ "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)",
+]
+
+[[package]]
+name = "libra-crypto-derive"
+version = "0.1.0"
+dependencies = [
+ "failure_ext 0.1.0",
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2068,7 +2068,6 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2077,6 +2076,7 @@ dependencies = [
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
@@ -2136,7 +2136,6 @@ dependencies = [
  "config-builder 0.1.0",
  "consensus 0.1.0",
  "crash-handler 0.1.0",
- "crypto 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
  "executor 0.1.0",
@@ -2145,6 +2144,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
@@ -2175,13 +2175,13 @@ version = "0.1.0"
 dependencies = [
  "client 0.1.0",
  "config-builder 0.1.0",
- "crypto 0.1.0",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug-interface 0.1.0",
  "failure_ext 0.1.0",
  "generate-keypair 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-tools 0.1.0",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2203,12 +2203,12 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-prost-ext 0.1.0",
  "num_enum 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2229,10 +2229,10 @@ name = "libra_wallet"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2250,12 +2250,12 @@ dependencies = [
  "accumulator 0.1.0",
  "arc-swap 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jellyfish-merkle 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-prost-ext 0.1.0",
@@ -2542,11 +2542,11 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-prost-ext 0.1.0",
@@ -2602,8 +2602,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "noise"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "memsocket 0.1.0",
  "netcore 0.1.0",
@@ -3811,8 +3811,8 @@ name = "safety-rules"
 version = "0.1.0"
 dependencies = [
  "consensus-types 0.1.0",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3853,8 +3853,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "scratchpad"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3873,8 +3873,6 @@ name = "secret-service"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
- "crypto-derive 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
  "failure_ext 0.1.0",
@@ -3883,6 +3881,8 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-crypto-derive 0.1.0",
  "libra-logger 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4177,13 +4177,13 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "config-builder 0.1.0",
- "crypto 0.1.0",
  "executor 0.1.0",
  "failure_ext 0.1.0",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
@@ -4235,11 +4235,11 @@ dependencies = [
 name = "storage-client"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
@@ -4252,11 +4252,11 @@ name = "storage-proto"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4268,7 +4268,6 @@ dependencies = [
 name = "storage-service"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
  "failure_ext 0.1.0",
@@ -4278,6 +4277,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-tools 0.1.0",
@@ -4490,10 +4490,10 @@ version = "0.1.0"
 dependencies = [
  "benchmark 0.1.0",
  "client 0.1.0",
- "crypto 0.1.0",
  "generate-keypair 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-swarm 0.1.0",
  "libra-tools 0.1.0",
@@ -4996,10 +4996,10 @@ dependencies = [
 name = "transaction-builder"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "ir_to_bytecode 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "stdlib 0.1.0",
  "vm 0.1.0",
@@ -5143,11 +5143,11 @@ name = "vm"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5172,11 +5172,11 @@ dependencies = [
 name = "vm-genesis"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5198,12 +5198,12 @@ version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
  "compiler 0.1.0",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
@@ -5223,10 +5223,10 @@ name = "vm_runtime_types"
 version = "0.1.0"
 dependencies = [
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crypto 0.1.0",
  "failure_ext 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5239,13 +5239,13 @@ name = "vm_validator"
 version = "0.1.0"
 dependencies = [
  "config-builder 0.1.0",
- "crypto 0.1.0",
  "executor 0.1.0",
  "failure_ext 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc_helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -22,7 +22,7 @@ tokio = "0.1.22"
 
 admission-control-proto = { path = "../admission-control-proto" }
 libra-config = { path = "../../config" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 debug-interface = { path = "../../common/debug-interface" }
 failure = { package = "failure_ext", path = "../../common/failure_ext" }
 executable-helpers = { path = "../../common/executable-helpers" }

--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -9,8 +9,8 @@ use crate::{
     mocks::local_mock_mempool::LocalMockMempool,
 };
 use admission_control_proto::{AdmissionControlStatus, SubmitTransactionResponse};
-use crypto::{ed25519::*, test_utils::TEST_SEED};
 use futures::channel::mpsc;
+use libra_crypto::{ed25519::*, test_utils::TEST_SEED};
 use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -29,15 +29,15 @@ libra_wallet = { path = "../client/libra_wallet" }
 libra-swarm = { path = "../libra-swarm" }
 libra-logger = { path = "../common/logger" }
 libra-metrics = { path = "../common/metrics" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 rusty-fork = "0.2.1"
 libra-tools = { path = "../common/tools" }
 libra-types = { path = "../types" }
 transaction-builder = { path = "../language/transaction-builder" }
 
 [dev-dependencies]
-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 
 [features]
 default = []
-testing = ["crypto/testing", "libra-swarm/testing"]
+testing = ["libra-crypto/testing", "libra-swarm/testing"]

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -6,9 +6,9 @@ use admission_control_proto::proto::{
     admission_control::SubmitTransactionResponse as ProtoSubmitTransactionResponse,
 };
 use client::{AccountData, AccountStatus};
-use crypto::{ed25519::*, test_utils::KeyPair};
 use generate_keypair::load_key_from_file;
 use lazy_static::lazy_static;
+use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_logger::prelude::*;
 use libra_metrics::OpMetrics;
 use libra_types::{account_address::AccountAddress, account_config::association_address};

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,7 +27,7 @@ structopt = "0.3.2"
 admission-control-proto = { version = "0.1.0", path = "../admission_control/admission-control-proto" }
 libra-config = { path = "../config" }
 crash-handler = { path = "../common/crash-handler" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
 libra_wallet = { path = "./libra_wallet" }
@@ -38,9 +38,9 @@ libra-tools = { path = "../common/tools/" }
 transaction-builder = { path = "../language/transaction-builder" }
 
 [dev-dependencies]
-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 libra-types = { path = "../types", features = ["testing"]}
 
 [features]
 default = []
-testing = ["libra-types/testing", "crypto/testing"]
+testing = ["libra-types/testing", "libra-crypto/testing"]

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.96"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
 ed25519-dalek = "1.0.0-pre.1"
-libra_crypto = { path = "../../crypto/crypto", package = "crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 libra-types = { path = "../../types" }
 

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -3,9 +3,9 @@
 
 use crate::{commands::*, grpc_client::GRPCClient, AccountData, AccountStatus};
 use admission_control_proto::proto::admission_control::SubmitTransactionRequest;
-use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
 use libra_config::{config::PersistableConfig, trusted_peers::ConsensusPeersConfig};
+use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_logger::prelude::*;
 use libra_tools::tempdir::TempPath;
 use libra_types::{

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -9,10 +9,10 @@ use admission_control_proto::{
     },
     AdmissionControlStatus, SubmitTransactionResponse,
 };
-use crypto::ed25519::*;
 use failure::prelude::*;
 use futures::Future;
 use grpcio::{CallOption, ChannelBuilder, EnvBuilder};
+use libra_crypto::ed25519::*;
 use libra_logger::prelude::*;
 use libra_types::{
     access_path::AccessPath,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Client (binary) is the CLI tool to interact with Libra validator.
 //! It supposes all public APIs.
-pub use crypto::{ed25519::*, test_utils::KeyPair, traits::ValidKeyStringExt};
+pub use libra_crypto::{ed25519::*, test_utils::KeyPair, traits::ValidKeyStringExt};
 pub use libra_types::{
     account_address::AccountAddress,
     transaction::{RawTransaction, TransactionArgument, TransactionPayload},

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -19,15 +19,15 @@ serde = { version = "1.0.99", default-features = false }
 toml = { version = "0.5.3", default-features = false }
 prost = "0.5.0"
 
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-tools = { path = "../common/tools" }
 libra-types = { path = "../types" }
 
 [dev-dependencies]
 libra-types = { path = "../types", features = ["testing"] }
-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 
 [features]
 default = []
-testing = ["crypto/testing", "libra-types/testing"]
+testing = ["libra-crypto/testing", "libra-types/testing"]

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.6.5"
 structopt = "0.3.2"
 
 libra-config = { path = ".." }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 generate-keypair = { path = "../generate-keypair" }
 libra-logger = { path = "../../common/logger" }

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -3,7 +3,6 @@
 
 //! Convenience structs and functions for generating configuration for a swarm of libra nodes
 use crate::util::gen_genesis_transaction_bytes;
-use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
 use libra_config::{
     config::{
@@ -18,6 +17,7 @@ use libra_config::{
     },
     utils::get_available_port,
 };
+use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_logger::prelude::*;
 use libra_types::PeerId;
 use parity_multiaddr::{Multiaddr, Protocol};

--- a/config/config-builder/src/util.rs
+++ b/config/config-builder/src/util.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::{ed25519::*, test_utils::KeyPair};
 use libra_config::{
     config::{NodeConfig, NodeConfigHelpers},
     trusted_peers::{ConfigHelpers, ConsensusPeersConfig, NetworkPeersConfig},
 };
+use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_prost_ext::MessageExt;
 use libra_types::transaction::SignatureCheckedTransaction;
 use rand::{Rng, SeedableRng};

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -14,5 +14,5 @@ structopt = "0.3.2"
 
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
-crypto = { path = "../../crypto/crypto/"}
+libra-crypto = { path = "../../crypto/crypto/"}
 libra-tools = { path = "../../common/tools" }

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::{ed25519::*, test_utils::KeyPair};
 use failure::prelude::*;
+use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_tools::tempdir::TempPath;
 use std::{
     fs::{self, File},

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     utils::{deserialize_whitelist, get_available_port, get_local_ip, serialize_whitelist},
 };
-use crypto::ValidKey;
 use failure::prelude::*;
+use libra_crypto::ValidKey;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, SCRIPT_HASH_LENGTH},

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -1,5 +1,5 @@
 use crate::trusted_peers::{deserialize_key, serialize_key};
-use crypto::{
+use libra_crypto::{
     ed25519::*,
     test_utils::TEST_SEED,
     x25519::{self, X25519StaticPrivateKey, X25519StaticPublicKey},

--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::{
+use libra_crypto::{
     ed25519::{compat, *},
     traits::{ValidKey, ValidKeyStringExt},
     x25519::{self, X25519StaticPrivateKey, X25519StaticPublicKey},

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -33,7 +33,7 @@ prometheus = { version = "0.7.0", default-features = false }
 channel = { path = "../common/channel" }
 libra-config = { path = "../config" }
 consensus-types = { path = "consensus-types", default-features = false }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 debug-interface = { path = "../common/debug-interface" }
 executor = { path = "../executor" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
@@ -57,7 +57,7 @@ proptest = "0.9.4"
 rusty-fork = "0.2.2"
 
 consensus-types = { path = "consensus-types", features = ["fuzzing", "testing"]}
-crypto = { path = "../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", features = ["testing"]}
 libra-types = { path = "../types", features = ["testing"]}
 vm-genesis = { path = "../language/vm/vm-genesis" }
 vm_validator = { path = "../vm_validator" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -14,7 +14,7 @@ rmp-serde = { version = "0.13.7", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 executor = { path = "../../executor" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 network = { path = "../../network" }
@@ -23,7 +23,7 @@ libra-types = { path = "../../types" }
 [dev-dependencies]
 proptest = "0.9.4"
 
-crypto = { path = "../../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../../crypto/crypto", features = ["testing"]}
 libra-types = { path = "../../types", features = ["testing"]}
 
 [features]

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -7,12 +7,12 @@ use crate::{
     quorum_cert::QuorumCert,
     vote_data::VoteData,
 };
-use crypto::{
+use executor::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
+use failure::{ensure, format_err};
+use libra_crypto::{
     hash::{BlockHasher, CryptoHash, CryptoHasher},
     HashValue,
 };
-use executor::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
-use failure::{ensure, format_err};
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, Signature, ValidatorSigner, ValidatorVerifier},
     ledger_info::LedgerInfo,

--- a/consensus/consensus-types/src/block_info.rs
+++ b/consensus/consensus-types/src/block_info.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::block::Block;
-use crypto::hash::HashValue;
 use failure::prelude::{Error, Result};
+use libra_crypto::hash::HashValue;
 use libra_types::transaction::Version;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -6,7 +6,7 @@ use crate::{
     block::{block_test_utils::*, Block},
     quorum_cert::QuorumCert,
 };
-use crypto::hash::{CryptoHash, HashValue};
+use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_types::crypto_proxies::{ValidatorSigner, ValidatorVerifier};
 use std::{collections::BTreeMap, panic, sync::Arc};
 

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -8,7 +8,7 @@ use crate::{
     quorum_cert::QuorumCert,
     vote_data::VoteData,
 };
-use crypto::hash::{CryptoHash, HashValue};
+use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_types::{
     crypto_proxies::{SecretKey, ValidatorSigner},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::{
+use libra_crypto::{
     hash::{CryptoHasher, RoundHasher},
     HashValue,
 };

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block_info::BlockInfo, vote_data::VoteData};
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{CryptoHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID},
     HashValue,
 };
-use failure::prelude::*;
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier},
     ledger_info::LedgerInfo,

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -5,8 +5,8 @@ use crate::{
     common::{self, Author},
     vote_data::VoteData,
 };
-use crypto::hash::CryptoHash;
 use failure::{ensure, format_err, ResultExt};
+use libra_crypto::hash::CryptoHash;
 use libra_types::{
     crypto_proxies::{Signature, ValidatorSigner, ValidatorVerifier},
     ledger_info::LedgerInfo,

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::block_info::BlockInfo;
-use crypto::{
+use failure::prelude::format_err;
+use libra_crypto::{
     hash::{CryptoHash, CryptoHasher, VoteDataHasher},
     HashValue,
 };
-use failure::prelude::format_err;
 use serde::{Deserialize, Serialize};
 use std::{
     convert::{TryFrom, TryInto},

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 
 [dependencies]
 consensus-types = { path = "../consensus-types" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 serde = { version = "1.0.99", default-features = false }
 
 [dev-dependencies]
 consensus-types = { path = "../consensus-types", features = ["testing"]}
-crypto = { path = "../../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../../crypto/crypto", features = ["testing"]}
 libra-types = { path = "../../types", features = ["testing"]}

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -6,8 +6,8 @@ use consensus_types::{
     common::{Payload, Round},
     quorum_cert::QuorumCert,
 };
-use crypto::HashValue;
 use failure::Fail;
+use libra_crypto::HashValue;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -6,7 +6,7 @@ use consensus_types::{
     block::Block, block_info::BlockInfo, common::Round, quorum_cert::QuorumCert,
     sync_info::SyncInfo, vote::Vote, vote_data::VoteData, vote_msg::VoteMsg,
 };
-use crypto::hash::{CryptoHash, HashValue};
+use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_types::{
     crypto_proxies::ValidatorSigner,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -15,9 +15,9 @@ use consensus_types::{
     timeout_certificate::TimeoutCertificate,
     vote::Vote,
 };
-use crypto::HashValue;
 use executor::{ProcessedVMOutput, StateComputeResult};
 use failure::ResultExt;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -17,8 +17,8 @@ use consensus_types::{
     vote::Vote,
     vote_data::VoteData,
 };
-use crypto::{HashValue, PrivateKey};
 use futures::executor::block_on;
+use libra_crypto::{HashValue, PrivateKey};
 use libra_types::crypto_proxies::{random_validator_verifier, ValidatorVerifier};
 use libra_types::{account_address::AccountAddress, crypto_proxies::ValidatorSigner};
 use proptest::prelude::*;

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -10,7 +10,7 @@ use consensus_types::{
     block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
     vote::Vote,
 };
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use mirai_annotations::{checked_verify_eq, precondition};

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -7,7 +7,7 @@ use consensus_types::{
     quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate,
 };
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use std::sync::Arc;
 
 mod block_store;

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -8,7 +8,7 @@ use consensus_types::{
     timeout_certificate::TimeoutCertificate,
     vote::Vote,
 };
-use crypto::{hash::CryptoHash, HashValue};
+use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_logger::prelude::*;
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier},

--- a/consensus/src/chained_bft/block_storage/pending_votes_test.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes_test.rs
@@ -4,7 +4,7 @@
 use crate::chained_bft::block_storage::pending_votes::PendingVotes;
 use crate::chained_bft::block_storage::VoteReceptionResult;
 use consensus_types::{block_info::BlockInfo, common::Round, vote::Vote, vote_data::VoteData};
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_types::crypto_proxies::random_validator_verifier;
 use libra_types::ledger_info::LedgerInfo;
 

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -14,8 +14,8 @@ use consensus_types::{
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
 };
-use crypto::HashValue;
 use failure;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::account_address::AccountAddress;
 use mirai_annotations::checked_precondition;

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -15,8 +15,8 @@ use consensus_types::{
     proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
     vote_msg::VoteMsg,
 };
-use crypto::hash::CryptoHash;
 use futures::{channel::mpsc, executor::block_on, prelude::*};
+use libra_crypto::hash::CryptoHash;
 use network::proto::ConsensusMsg_oneof;
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};
 use std::convert::TryFrom;

--- a/consensus/src/chained_bft/consensusdb/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/mod.rs
@@ -11,8 +11,8 @@ use crate::chained_bft::consensusdb::schema::{
     single_entry::{SingleEntryKey, SingleEntrySchema},
 };
 use consensus_types::{block::Block, common::Payload, quorum_cert::QuorumCert};
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use schema::{BLOCK_CF_NAME, QC_CF_NAME, SINGLE_ENTRY_CF_NAME};
 use schemadb::{

--- a/consensus/src/chained_bft/consensusdb/schema/block/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/schema/block/mod.rs
@@ -11,8 +11,8 @@
 
 use super::BLOCK_CF_NAME;
 use consensus_types::{block::Block, common::Payload};
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_prost_ext::MessageExt;
 use prost::Message;
 use schemadb::schema::{KeyCodec, Schema, ValueCodec};

--- a/consensus/src/chained_bft/consensusdb/schema/quorum_certificate/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/schema/quorum_certificate/mod.rs
@@ -11,8 +11,8 @@
 
 use super::QC_CF_NAME;
 use consensus_types::quorum_cert::QuorumCert;
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_prost_ext::MessageExt;
 use prost::Message;
 use schemadb::{

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -30,8 +30,8 @@ use consensus_types::{
     vote_data::VoteData,
     vote_msg::VoteMsg,
 };
-use crypto::HashValue;
 use failure::ResultExt;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier};
 use mirai_annotations::{

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -39,11 +39,11 @@ use consensus_types::{
     vote_data::VoteData,
     vote_msg::VoteMsg,
 };
-use crypto::HashValue;
 use futures::{
     channel::{mpsc, oneshot},
     executor::block_on,
 };
+use libra_crypto::HashValue;
 use libra_types::crypto_proxies::{
     random_validator_verifier, LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
 };

--- a/consensus/src/chained_bft/liveness/multi_proposer_test.rs
+++ b/consensus/src/chained_bft/liveness/multi_proposer_test.rs
@@ -6,7 +6,7 @@ use crate::chained_bft::liveness::{
     proposer_election::ProposerElection,
 };
 use consensus_types::{block::Block, quorum_cert::QuorumCert};
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 use libra_types::validator_signer::ValidatorSigner;
 
 #[test]

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -11,9 +11,9 @@ use consensus_types::{
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
 };
-use crypto::HashValue;
 use failure::{self, ResultExt};
 use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt, TryStreamExt};
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_prost_ext::MessageExt;
 use libra_types::account_address::AccountAddress;

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -8,9 +8,9 @@ use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
-use crypto::HashValue;
 use failure::{Result, ResultExt};
 use libra_config::config::NodeConfig;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::ledger_info::LedgerInfo;
 use rmp_serde::{from_slice, to_vec_named};

--- a/consensus/src/chained_bft/persistent_storage_test.rs
+++ b/consensus/src/chained_bft/persistent_storage_test.rs
@@ -10,7 +10,7 @@ use consensus_types::{
     block::{Block, ExecutedBlock},
     quorum_cert::QuorumCert,
 };
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use std::sync::Arc;
 
 /// Partially obtain parameters for `RecoveryData::find_root()`.

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -7,10 +7,10 @@ use crate::{
 };
 use consensus_types::block::Block;
 use consensus_types::quorum_cert::QuorumCert;
-use crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use executor::{ExecutedState, ExecutedTrees, ProcessedVMOutput, StateComputeResult};
 use failure::Result;
 use futures::{channel::mpsc, future, Future, FutureExt};
+use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use std::{pin::Pin, sync::Arc};

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -9,9 +9,9 @@ use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
-use crypto::HashValue;
 use failure::Result;
 use libra_config::config::{NodeConfig, NodeConfigHelpers};
+use libra_crypto::HashValue;
 use libra_types::ledger_info::LedgerInfo;
 use safety_rules::ConsensusState;
 use std::{

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -3,8 +3,8 @@
 
 use crate::chained_bft::block_storage::{BlockReader, BlockStore};
 use consensus_types::{quorum_cert::QuorumCert, sync_info::SyncInfo};
-use crypto::HashValue;
 use futures::executor::block_on;
+use libra_crypto::HashValue;
 use libra_logger::{set_simple_logger, set_simple_logger_prefix};
 use libra_types::{crypto_proxies::ValidatorSigner, ledger_info::LedgerInfo};
 use std::sync::Arc;

--- a/crypto/crypto-derive/Cargo.toml
+++ b/crypto/crypto-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "crypto-derive"
+name = "libra-crypto-derive"
 version = "0.1.0"
-description = "Libra custom derives for `crypto`"
+description = "Libra custom derives for `libra-crypto`"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -5,7 +5,7 @@
 //! - the `SilentDebug` and SilentDisplay macros are meant to be used on private key types, and
 //!   elide their input for confidentiality.
 //! - the `Deref` macro helps derive the canonical instances on new types.
-//! - the derive macros for `crypto::traits`, namely `ValidKey`, `PublicKey`, `PrivateKey`,
+//! - the derive macros for `libra_crypto::traits`, namely `ValidKey`, `PublicKey`, `PrivateKey`,
 //!   `VerifyingKey`, `SigningKey` and `Signature` are meant to be derived on simple unions of types
 //!   implementing these traits.
 //!
@@ -33,12 +33,12 @@
 //!
 //! ```ignore
 //! # #[macro_use] extern crate crypto-derive;
-//! use crypto::{
+//! use libra_crypto::{
 //!     hash::HashValue,
 //!     bls12381::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature},
 //!     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
 //! };
-//! use crypto_derive::{
+//! use libra_crypto_derive::{
 //!     SilentDebug, PrivateKey, PublicKey, Signature, SigningKey, ValidKey, VerifyingKey,
 //! };
 //!
@@ -206,7 +206,7 @@ fn impl_enum_tryfrom(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStr
 
     quote! {
         impl core::convert::TryFrom<&[u8]> for #name {
-            type Error = crypto::CryptoMaterialError;
+            type Error = libra_crypto::CryptoMaterialError;
             fn try_from(bytes: &[u8]) -> std::result::Result<#name, Self::Error> {
                 #try_chain
             }
@@ -234,7 +234,7 @@ fn impl_enum_validkey(name: &Ident, variants: &DataEnum) -> TokenStream {
 
     try_from.extend(quote! {
 
-        impl crypto::ValidKey for #name {
+        impl libra_crypto::ValidKey for #name {
             fn to_bytes(&self) -> Vec<u8> {
                 match self {
                     #to_bytes_arms
@@ -313,7 +313,7 @@ fn impl_enum_publickey(
         }
     };
     res.extend(quote! {
-        impl crypto::PublicKey for #name {
+        impl libra_crypto::PublicKey for #name {
             type PrivateKeyMaterial = #pkt;
         }
     });
@@ -341,7 +341,7 @@ fn impl_enum_privatekey(
 ) -> TokenStream {
     let pkt: syn::Type = public_key_type.parse().unwrap();
     let res = quote! {
-        impl crypto::PrivateKey for #name {
+        impl libra_crypto::PrivateKey for #name {
             type PublicKeyMaterial = #pkt;
         }
     };
@@ -374,7 +374,7 @@ fn impl_enum_verifyingkey(
     let pkt: syn::Type = private_key_type.parse().unwrap();
     let st: syn::Type = signature_type.parse().unwrap();
     let res = quote! {
-        impl crypto::VerifyingKey for #name {
+        impl libra_crypto::VerifyingKey for #name {
             type SigningKeyMaterial = #pkt;
             type SignatureMaterial = #st;
         }
@@ -417,11 +417,11 @@ fn impl_enum_signingkey(
         });
     }
     let res = quote! {
-        impl crypto::SigningKey for #name {
+        impl libra_crypto::SigningKey for #name {
             type VerifyingKeyMaterial = #pkt;
             type SignatureMaterial = #st;
 
-            fn sign_message(&self, message: &crypto::HashValue) -> Self::SignatureMaterial {
+            fn sign_message(&self, message: &libra_crypto::HashValue) -> Self::SignatureMaterial {
                 match self {
                     #match_arms
                 }
@@ -472,7 +472,7 @@ fn impl_enum_signature(
 
     res.extend(quote! {
 
-        impl crypto::Signature for #name {
+        impl libra_crypto::Signature for #name {
             type VerifyingKeyMaterial = #pub_kt;
             type SigningKeyMaterial = #priv_kt;
 

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "crypto"
+name = "libra-crypto"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
-description = "Libra crypto"
+description = "Libra libra-crypto"
 repository = "https://github.com/libra/libra"
 homepage = "https://libra.org"
 license = "Apache-2.0"
@@ -29,7 +29,7 @@ threshold_crypto = "0.3"
 tiny-keccak = "1.5.0"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false }
 
-crypto-derive = { path = "../crypto-derive" }
+libra-crypto-derive = { path = "../crypto-derive" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 libra-nibble = { path = "../../common/nibble" }

--- a/crypto/crypto/src/bls12381.rs
+++ b/crypto/crypto/src/bls12381.rs
@@ -7,8 +7,8 @@
 //! # Example
 //!
 //! ```
-//! use crypto::hash::{CryptoHasher, TestOnlyHasher};
-//! use crypto::{
+//! use libra_crypto::hash::{CryptoHasher, TestOnlyHasher};
+//! use libra_crypto::{
 //!     bls12381::*,
 //!     traits::{Signature, SigningKey, Uniform},
 //! };
@@ -32,8 +32,8 @@
 
 use crate::{traits::*, HashValue};
 use core::convert::TryFrom;
-use crypto_derive::{Deref, SilentDebug, SilentDisplay};
 use failure::prelude::*;
+use libra_crypto_derive::{Deref, SilentDebug, SilentDisplay};
 use pairing::{
     bls12_381::{Fr, FrRepr},
     PrimeField,

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -9,8 +9,8 @@
 //! # Examples
 //!
 //! ```
-//! use crypto::hash::{CryptoHasher, TestOnlyHasher};
-//! use crypto::{
+//! use libra_crypto::hash::{CryptoHasher, TestOnlyHasher};
+//! use libra_crypto::{
 //!     ed25519::*,
 //!     traits::{Signature, SigningKey, Uniform},
 //! };
@@ -31,9 +31,9 @@
 
 use crate::{traits::*, HashValue};
 use core::convert::TryFrom;
-use crypto_derive::{SilentDebug, SilentDisplay};
 use ed25519_dalek;
 use failure::prelude::*;
+use libra_crypto_derive::{SilentDebug, SilentDisplay};
 use serde::{de, ser};
 use std::fmt;
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -25,7 +25,7 @@
 //! # Examples
 //!
 //! ```
-//! use crypto::hash::{CryptoHasher, TestOnlyHasher};
+//! use libra_crypto::hash::{CryptoHasher, TestOnlyHasher};
 //!
 //! let mut hasher = TestOnlyHasher::default();
 //! hasher.write("Test message".as_bytes());
@@ -48,7 +48,7 @@
 //!
 //! Then, the `CryptoHash` trait should be implemented:
 //! ```
-//! # use crypto::hash::*;
+//! # use libra_crypto::hash::*;
 //! # #[derive(Default)]
 //! # struct MyNewStructHasher;
 //! # impl CryptoHasher for MyNewStructHasher {
@@ -630,7 +630,7 @@ lazy_static! {
 ///
 /// # Example
 /// ```
-/// use crypto::hash::TestOnlyHash;
+/// use libra_crypto::hash::TestOnlyHash;
 ///
 /// b"hello world".test_only_hash();
 /// ```

--- a/crypto/crypto/src/hkdf.rs
+++ b/crypto/crypto/src/hkdf.rs
@@ -58,7 +58,7 @@
 //! Run HKDF extract-then-expand so as to return 64 bytes, using 'salt', 'seed' and 'info' as
 //! inputs.
 //! ```
-//! use crypto::hkdf::Hkdf;
+//! use libra_crypto::hkdf::Hkdf;
 //! use sha2::Sha256;
 //!
 //! // some bytes required for this example.

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -3,7 +3,7 @@
 
 // This is necessary for the derive macros which rely on being used in a
 // context where the crypto crate is external
-use crate as crypto;
+use crate as libra_crypto;
 use crate::{
     bls12381::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature},
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
@@ -13,7 +13,7 @@ use crate::{
 
 use crate::hash::HashValue;
 
-use crypto_derive::{
+use libra_crypto_derive::{
     PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidKey, VerifyingKey,
 };
 use proptest::prelude::*;

--- a/crypto/crypto/src/vrf/ecvrf.rs
+++ b/crypto/crypto/src/vrf/ecvrf.rs
@@ -7,7 +7,7 @@
 //! # Examples
 //!
 //! ```
-//! use crypto::{traits::Uniform, vrf::ecvrf::*};
+//! use libra_crypto::{traits::Uniform, vrf::ecvrf::*};
 //! use rand::{rngs::StdRng, SeedableRng};
 //!
 //! let message = b"Test message";
@@ -22,7 +22,7 @@
 //! using a `VRFPublicKey`:
 //!
 //! ```
-//! # use crypto::{traits::Uniform, vrf::ecvrf::*};
+//! # use libra_crypto::{traits::Uniform, vrf::ecvrf::*};
 //! # use rand::{rngs::StdRng, SeedableRng};
 //! # let message = b"Test message";
 //! # let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
@@ -35,7 +35,7 @@
 //! Produce a pseudorandom output from a `Proof`:
 //!
 //! ```
-//! # use crypto::{traits::Uniform, vrf::ecvrf::*};
+//! # use libra_crypto::{traits::Uniform, vrf::ecvrf::*};
 //! # use rand::{rngs::StdRng, SeedableRng};
 //! # let message = b"Test message";
 //! # let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
@@ -47,7 +47,6 @@
 
 use crate::traits::*;
 use core::convert::TryFrom;
-use crypto_derive::Deref;
 use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT,
     edwards::{CompressedEdwardsY, EdwardsPoint},
@@ -57,6 +56,7 @@ use ed25519_dalek::{
     self, Digest, PublicKey as ed25519_PublicKey, SecretKey as ed25519_PrivateKey, Sha512,
 };
 use failure::prelude::*;
+use libra_crypto_derive::Deref;
 use serde::{Deserialize, Serialize};
 
 const SUITE: u8 = 0x03;

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -26,7 +26,7 @@
 //! # Examples
 //!
 //! ```
-//! use crypto::x25519::*;
+//! use libra_crypto::x25519::*;
 //! use rand::{rngs::StdRng, SeedableRng};
 //!
 //! // Derive an X25519 static key pair from seed using the extract-then-expand HKDF method from RFC 5869.
@@ -40,7 +40,7 @@
 //! assert_eq!(public_key1, public_key2);
 //!
 //! // Generate a random X25519 ephemeral key pair from an RNG (in this example a StdRng)
-//! use crypto::Uniform;
+//! use libra_crypto::Uniform;
 //! let seed = [1u8; 32];
 //! let mut rng: StdRng = SeedableRng::from_seed(seed);
 //! let private_key = X25519StaticPrivateKey::generate_for_testing(&mut rng);
@@ -57,7 +57,7 @@
 //! ```
 
 use crate::{hkdf::Hkdf, traits::*};
-use crypto_derive::{Deref, SilentDebug, SilentDisplay};
+use libra_crypto_derive::{Deref, SilentDebug, SilentDisplay};
 use rand::{rngs::EntropyRng, RngCore};
 use serde::{de, ser};
 use sha2::Sha256;

--- a/crypto/secret-service/Cargo.toml
+++ b/crypto/secret-service/Cargo.toml
@@ -20,8 +20,8 @@ serde = { version = "1.0.96", features = ["derive"] }
 structopt = "0.3.2"
 
 libra-config = { path = "../../config" }
-crypto = { path = "../crypto" }
-crypto-derive = { path = "../crypto-derive" }
+libra-crypto = { path = "../crypto" }
+libra-crypto-derive = { path = "../crypto-derive" }
 debug-interface = { path = "../../common/debug-interface" }
 executable-helpers = { path = "../../common/executable-helpers" }
 failure = { package = "failure_ext", path = "../../common/failure_ext" }

--- a/crypto/secret-service/src/crypto_wrappers.rs
+++ b/crypto/secret-service/src/crypto_wrappers.rs
@@ -4,12 +4,12 @@
 //! This module contains wrappers around nextgen crypto API to support crypto agility
 //! and to make the secret service agnostic to the details of the particular signing algorithms.
 
-use crypto::{
+use libra_crypto::{
     bls12381::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature},
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     hash::HashValue,
 };
-use crypto_derive::{
+use libra_crypto_derive::{
     Deref, PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidKey, VerifyingKey,
 };
 use serde::{Deserialize, Serialize};

--- a/crypto/secret-service/src/secret_service_client.rs
+++ b/crypto/secret-service/src/secret_service_client.rs
@@ -11,11 +11,11 @@ use crate::{
     crypto_wrappers::{GenericPublicKey, GenericSignature, KeyID},
     proto::{GenerateKeyRequest, KeyType, PublicKeyRequest, SecretServiceClient, SignRequest},
 };
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     hash::HashValue,
 };
-use failure::prelude::*;
 use std::{convert::TryFrom, sync::Arc};
 
 /// A consensus key manager - interface between consensus and the secret service.

--- a/crypto/secret-service/src/secret_service_server.rs
+++ b/crypto/secret-service/src/secret_service_server.rs
@@ -12,11 +12,11 @@ use crate::{
         PublicKeyResponse, SecretService, SignRequest, SignResponse,
     },
 };
-use crypto::{
-    bls12381::BLS12381PrivateKey, ed25519::Ed25519PrivateKey, hash::HashValue, traits::*,
-};
 use failure::prelude::*;
 use grpc_helpers::provide_grpc_response;
+use libra_crypto::{
+    bls12381::BLS12381PrivateKey, ed25519::Ed25519PrivateKey, hash::HashValue, traits::*,
+};
 use rand::{rngs::EntropyRng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use std::{

--- a/crypto/secret-service/src/unit_tests/secret_service_node_test.rs
+++ b/crypto/secret-service/src/unit_tests/secret_service_node_test.rs
@@ -6,11 +6,11 @@ use crate::{
     secret_service_client::ConsensusKeyManager,
     secret_service_node::SecretServiceNode,
 };
-use crypto::hash::HashValue;
-use crypto::traits::Signature;
 use debug_interface::node_debug_helpers::{check_node_up, create_debug_client};
 use grpcio::{ChannelBuilder, EnvBuilder};
 use libra_config::config::{NodeConfig, NodeConfigHelpers};
+use libra_crypto::hash::HashValue;
+use libra_crypto::traits::Signature;
 use libra_logger::prelude::*;
 use std::{sync::Arc, thread};
 

--- a/crypto/secret-service/src/unit_tests/secret_service_test.rs
+++ b/crypto/secret-service/src/unit_tests/secret_service_test.rs
@@ -5,7 +5,7 @@ use crate::{
     proto::KeyType,
     secret_service_server::{KeyID, SecretServiceServer},
 };
-use crypto::{
+use libra_crypto::{
     hash::HashValue,
     traits::{Signature, ValidKey},
 };

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -19,7 +19,7 @@ rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
 libra-config = { path = "../config" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 libra-logger = { path = "../common/logger" }
 libra-metrics = { path = "../common/metrics" }

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -5,13 +5,13 @@ use crate::{
     Chunk, Command, CommittableBlockBatch, ExecutableBlock, ExecutedState, ExecutedTrees,
     ProcessedVMOutput, StateComputeResult, TransactionData, OP_COUNTERS,
 };
-use crypto::{
-    hash::{CryptoHash, EventAccumulatorHasher},
-    HashValue,
-};
 use failure::prelude::*;
 use futures::channel::oneshot;
 use libra_config::config::VMConfig;
+use libra_crypto::{
+    hash::{CryptoHash, EventAccumulatorHasher},
+    HashValue,
+};
 use libra_logger::prelude::*;
 use libra_types::{
     account_address::AccountAddress,

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     CommittableBlock, Executor, OP_COUNTERS,
 };
-use crypto::{hash::GENESIS_BLOCK_ID, HashValue};
 use futures::executor::block_on;
 use grpcio::{EnvBuilder, ServerBuilder};
 use libra_config::config::{NodeConfig, NodeConfigHelpers};
+use libra_crypto::{hash::GENESIS_BLOCK_ID, HashValue};
 use libra_prost_ext::MessageExt;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -9,17 +9,17 @@ mod executor_test;
 mod mock_vm;
 
 use crate::block_processor::BlockProcessor;
-use crypto::{
+use failure::{format_err, Result};
+use futures::{channel::oneshot, executor::block_on};
+use lazy_static::lazy_static;
+use libra_config::config::NodeConfig;
+use libra_crypto::{
     hash::{
         EventAccumulatorHasher, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH,
         GENESIS_BLOCK_ID, PRE_GENESIS_BLOCK_ID, SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
     HashValue,
 };
-use failure::{format_err, Result};
-use futures::{channel::oneshot, executor::block_on};
-use lazy_static::lazy_static;
-use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_types::{
     account_address::AccountAddress,

--- a/executor/src/mock_vm/mod.rs
+++ b/executor/src/mock_vm/mod.rs
@@ -4,10 +4,10 @@
 #[cfg(test)]
 mod mock_vm_test;
 
-use crypto::ed25519::compat;
 use failure::Result;
 use lazy_static::lazy_static;
 use libra_config::config::VMConfig;
+use libra_crypto::ed25519::compat;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config_builder::util::get_test_config;
-use crypto::{ed25519::*, hash::GENESIS_BLOCK_ID, test_utils::TEST_SEED, HashValue};
 use executor::{CommittableBlock, Executor};
 use failure::prelude::*;
 use futures::executor::block_on;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
 use libra_config::config::NodeConfig;
+use libra_crypto::{ed25519::*, hash::GENESIS_BLOCK_ID, test_utils::TEST_SEED, HashValue};
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -15,7 +15,7 @@ lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 compiler = { path = "../compiler" }
 lazy_static = "1.3.0"
-crypto = { path = "../../crypto/crypto"}
+libra-crypto = { path = "../../crypto/crypto"}
 rand = "0.6.5"
 state-view = { path = "../../storage/state-view" }
 libra-types = { path = "../../types" }

--- a/language/e2e_tests/src/account.rs
+++ b/language/e2e_tests/src/account.rs
@@ -3,8 +3,8 @@
 
 //! Test infrastructure for modeling Libra accounts.
 
-use crypto::ed25519::*;
 use lazy_static::lazy_static;
+use libra_crypto::ed25519::*;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/language/e2e_tests/src/account_universe.rs
+++ b/language/e2e_tests/src/account_universe.rs
@@ -24,8 +24,8 @@ use crate::{
     account::{Account, AccountData},
     gas_costs,
 };
-use crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use lazy_static::lazy_static;
+use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_types::{
     transaction::{SignedTransaction, TransactionStatus},
     vm_error::{StatusCode, VMStatus},

--- a/language/e2e_tests/src/account_universe/rotate_key.rs
+++ b/language/e2e_tests/src/account_universe/rotate_key.rs
@@ -6,7 +6,7 @@ use crate::{
     common_transactions::rotate_key_txn,
     gas_costs,
 };
-use crypto::ed25519::{compat::keypair_strategy, *};
+use libra_crypto::ed25519::{compat::keypair_strategy, *};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{SignedTransaction, TransactionStatus},

--- a/language/e2e_tests/src/gas_costs.rs
+++ b/language/e2e_tests/src/gas_costs.rs
@@ -8,8 +8,8 @@ use crate::{
     common_transactions::{create_account_txn, peer_to_peer_txn, rotate_key_txn},
     executor::FakeExecutor,
 };
-use crypto::ed25519::compat;
 use lazy_static::lazy_static;
+use libra_crypto::ed25519::compat;
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 
 /// The gas each transaction is configured to reserve. If the gas available in the account,

--- a/language/e2e_tests/src/tests/genesis.rs
+++ b/language/e2e_tests/src/tests/genesis.rs
@@ -4,7 +4,7 @@
 use crate::{
     assert_prologue_parity, assert_status_eq, executor::FakeExecutor, transaction_status_eq,
 };
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 use libra_types::{
     access_path::AccessPath,
     account_config,

--- a/language/e2e_tests/src/tests/rotate_key.rs
+++ b/language/e2e_tests/src/tests/rotate_key.rs
@@ -6,7 +6,7 @@ use crate::{
     common_transactions::{create_account_txn, rotate_key_txn},
     executor::test_all_genesis,
 };
-use crypto::ed25519::compat;
+use libra_crypto::ed25519::compat;
 use libra_types::{
     account_address::AccountAddress,
     transaction::TransactionStatus,

--- a/language/e2e_tests/src/tests/verify_txn.rs
+++ b/language/e2e_tests/src/tests/verify_txn.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
-use crypto::{ed25519::*, HashValue};
 use libra_config::config::{NodeConfigHelpers, VMPublishingOption};
+use libra_crypto::{ed25519::*, HashValue};
 use libra_types::{
     test_helpers::transaction_test_helpers,
     transaction::{

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -18,7 +18,7 @@ vm = { path = "../vm" }
 bytecode-verifier = { path = "../bytecode-verifier" }
 language_e2e_tests = { path = "../e2e_tests" }
 libra-config = { path = "../../config" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 filecheck = "0.4.0"
 lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
@@ -26,7 +26,7 @@ regex = { version = "1.3.0", default-features = false, features = ["std", "perf"
 [dev-dependencies]
 libra-types = { path = "../../types", features = ["testing"] }
 datatest-stable = { path = "../../common/datatest-stable" }
-crypto = { path = "../../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../../crypto/crypto", features = ["testing"] }
 
 [[test]]
 name = "testsuite"

--- a/language/functional_tests/_old_move_ir_tests/src/tests/key_rotation.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/key_rotation.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::*;
-use crypto;
+use libra_crypto;
 use language_common::{error_codes::*, tooling::fake_executor::Account};
 use move_ir::{assert_error_type, assert_no_error};
 use libra_types::account_address::AccountAddress;

--- a/language/functional_tests/src/evaluator.rs
+++ b/language/functional_tests/src/evaluator.rs
@@ -8,7 +8,6 @@ use crate::{
 use bytecode_verifier::verifier::{
     verify_module_dependencies, verify_script_dependencies, VerifiedModule, VerifiedScript,
 };
-use crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use ir_to_bytecode::{
     compiler::{compile_module, compile_script},
     parser::parse_script_or_module,
@@ -16,6 +15,7 @@ use ir_to_bytecode::{
 use ir_to_bytecode_syntax::ast::ScriptOrModule;
 use language_e2e_tests::executor::FakeExecutor;
 use libra_config::config::VMPublishingOption;
+use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{

--- a/language/tools/cost-synthesis/Cargo.toml
+++ b/language/tools/cost-synthesis/Cargo.toml
@@ -22,7 +22,7 @@ vm_runtime = { path = "../../vm/vm_runtime" }
 vm_runtime_types = { path = "../../vm/vm_runtime/vm_runtime_types" }
 language_e2e_tests = { path = "../../e2e_tests" }
 vm-cache-map = { path = "../../vm/vm_runtime/vm-cache-map" }
-crypto = { path = "../../../crypto/crypto" }
+libra-crypto = { path = "../../../crypto/crypto" }
 structopt = "0.3.2"
 
 [dev-dependencies]

--- a/language/tools/cost-synthesis/src/global_state/account.rs
+++ b/language/tools/cost-synthesis/src/global_state/account.rs
@@ -1,6 +1,6 @@
 use crate::global_state::inhabitor::RandomInhabitor;
 use bytecode_verifier::VerifiedModule;
-use crypto::ed25519::{compat, Ed25519PrivateKey, Ed25519PublicKey};
+use libra_crypto::ed25519::{compat, Ed25519PrivateKey, Ed25519PublicKey};
 use libra_types::{
     access_path::AccessPath, account_address::AccountAddress, account_config, byte_array::ByteArray,
 };

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 libra-config = { path = "../../config" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 ir_to_bytecode = { path = "../compiler/ir_to_bytecode" }
 lazy_static = "1.3.0"
 stdlib = { path = "../stdlib" }
@@ -21,4 +21,4 @@ vm = { path = "../vm" }
 libra-types = { path = "../../types", features = ["testing"]}
 
 [features]
-testing = ["libra-types/testing", "crypto/testing"]
+testing = ["libra-types/testing", "libra-crypto/testing"]

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use crypto::HashValue;
 use ir_to_bytecode::{compiler::compile_program, parser::ast};
 use lazy_static::lazy_static;
 use libra_config::config::{VMConfig, VMPublishingOption};
+use libra_crypto::HashValue;
 use libra_types::{
     account_address::AccountAddress,
     byte_array::ByteArray,

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -18,7 +18,7 @@ proptest = "0.9"
 proptest-derive = "0.1.1"
 serde = { version = "1", features = ["derive"] }
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 proptest-helpers = { path = "../../common/proptest-helpers" }
 libra-types = { path = "../../types" }

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
-use crypto::ed25519::{compat, Ed25519PublicKey};
+use libra_crypto::ed25519::{compat, Ed25519PublicKey};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 
 pub struct TransactionMetadata {

--- a/language/vm/vm-genesis/Cargo.toml
+++ b/language/vm/vm-genesis/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 libra-config = { path = "../../../config" }
 failure = { path = "../../../common/failure_ext", package = "failure_ext" }
 transaction-builder = { path = "../../transaction-builder"}
-crypto = { path = "../../../crypto/crypto" }
+libra-crypto = { path = "../../../crypto/crypto" }
 stdlib = { path = "../../stdlib" }
 libra-prost-ext = { path = "../../../common/prost-ext" }
 state-view = { path = "../../../storage/state-view" }
@@ -27,7 +27,7 @@ rand = "0.6.5"
 
 [dev-dependencies]
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" }
-crypto = { path = "../../../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../../../crypto/crypto", features = ["testing"]}
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
 proptest-helpers = { path = "../../../common/proptest-helpers" }

--- a/language/vm/vm-genesis/src/lib.rs
+++ b/language/vm/vm-genesis/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crypto::{ed25519::*, traits::ValidKey};
 use failure::prelude::*;
 use lazy_static::lazy_static;
+use libra_crypto::{ed25519::*, traits::ValidKey};
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -21,7 +21,7 @@ prometheus = { version = "0.7.0", default-features = false }
 bytecode-verifier = { path = "../../bytecode-verifier" }
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" }
 libra-config = { path = "../../../config" }
-crypto = { path = "../../../crypto/crypto" }
+libra-crypto = { path = "../../../crypto/crypto" }
 libra-logger = { path = "../../../common/logger" }
 libra-metrics = { path = "../../../common/metrics" }
 state-view = { path = "../../../storage/state-view" }

--- a/language/vm/vm_runtime/src/code_cache/script_cache.rs
+++ b/language/vm/vm_runtime/src/code_cache/script_cache.rs
@@ -7,7 +7,7 @@ use crate::loaded_data::{
     loaded_module::LoadedModule,
 };
 use bytecode_verifier::VerifiedScript;
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::SCRIPT_HASH_LENGTH,

--- a/language/vm/vm_runtime/src/process_txn/validate.rs
+++ b/language/vm/vm_runtime/src/process_txn/validate.rs
@@ -8,8 +8,8 @@ use crate::{
     process_txn::{verify::VerifiedTransaction, ProcessTransaction},
     txn_executor::TransactionExecutor,
 };
-use crypto::HashValue;
 use libra_config::config::VMPublishingOption;
+use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::{SignatureCheckedTransaction, TransactionPayload, MAX_TRANSACTION_SIZE_IN_BYTES},

--- a/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
+++ b/language/vm/vm_runtime/src/unit_tests/runtime_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     txn_executor::TransactionExecutor,
 };
 use bytecode_verifier::{VerifiedModule, VerifiedScript};
-use crypto::ed25519::compat;
+use libra_crypto::ed25519::compat;
 use libra_types::{
     access_path::AccessPath, account_address::AccountAddress, byte_array::ByteArray,
     vm_error::StatusCode,

--- a/language/vm/vm_runtime/vm_runtime_types/Cargo.toml
+++ b/language/vm/vm_runtime/vm_runtime_types/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 libra-types = { path = "../../../../types" }
 vm = { path = "../../" }
 lcs = { path = "../../../../common/lcs", package = "libra-canonical-serialization" }
-crypto = { path = "../../../../crypto/crypto" }
+libra-crypto = { path = "../../../../crypto/crypto" }
 failure = { path = "../../../../common/failure_ext", package = "failure_ext" }
 
 [dev-dependencies]

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/hash.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/hash.rs
@@ -3,7 +3,7 @@
 
 use super::dispatch::NativeReturnStatus;
 use crate::value::Value;
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_types::byte_array::ByteArray;
 use sha2::{Digest, Sha256};
 use std::collections::VecDeque;

--- a/language/vm/vm_runtime/vm_runtime_types/src/native_functions/signature.rs
+++ b/language/vm/vm_runtime/vm_runtime_types/src/native_functions/signature.rs
@@ -4,7 +4,7 @@
 use super::dispatch::NativeReturnStatus;
 use crate::value::Value;
 use bit_vec::BitVec;
-use crypto::{
+use libra_crypto::{
     ed25519::{self, Ed25519PublicKey, Ed25519Signature},
     traits::*,
     HashValue,

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -31,7 +31,7 @@ grpc_helpers = { path = "../common/grpc_helpers" }
 libra-logger = { path = "../common/logger" }
 libra-mempool = { path = "../mempool" }
 libra-metrics = { path = "../common/metrics" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 network = { path = "../network" }
 state-synchronizer = { path = "../state-synchronizer" }
 storage-client = { path = "../storage/storage-client" }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -3,12 +3,12 @@
 
 use admission_control_service::runtime::AdmissionControlRuntime;
 use consensus::consensus_provider::{make_consensus_provider, ConsensusProvider};
-use crypto::{ed25519::*, ValidKey};
 use debug_interface::{node_debug_service::NodeDebugService, proto::create_node_debug_interface};
 use executor::Executor;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
 use libra_config::config::{NetworkConfig, NodeConfig, RoleType};
+use libra_crypto::{ed25519::*, ValidKey};
 use libra_logger::prelude::*;
 use libra_mempool::MempoolRuntime;
 use libra_metrics::metric_server;

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -21,12 +21,12 @@ debug-interface = { path = "../common/debug-interface" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 generate-keypair = { path = "../config/generate-keypair" }
 libra-logger = { path = "../common/logger" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 libra-tools = { path = "../common/tools" }
 
 [dev-dependencies]
-crypto = { path = "../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", features = ["testing"]}
 
 [features]
 default = []
-testing = ["crypto/testing", "client_lib/testing"]
+testing = ["libra-crypto/testing", "client_lib/testing"]

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -3,10 +3,10 @@
 
 use crate::utils;
 use config_builder::swarm_config::{SwarmConfig, SwarmConfigBuilder};
-use crypto::{ed25519::*, test_utils::KeyPair};
 use debug_interface::NodeDebugClient;
 use failure::prelude::*;
 use libra_config::config::{NodeConfig, RoleType};
+use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_logger::prelude::*;
 use libra_tools::tempdir::TempPath;
 use std::{

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -30,7 +30,7 @@ grpc_helpers = { path = "../common/grpc_helpers" }
 libra-logger = { path = "../common/logger" }
 libra-metrics = { path = "../common/metrics" }
 network = { path = "../network" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 storage-client = { path = "../storage/storage-client" }
 libra-types = { path = "../types" }
 vm_validator = { path = "../vm_validator" }

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
-use crypto::ed25519::*;
 use failure::prelude::*;
 use lazy_static::lazy_static;
 use libra_config::config::NodeConfigHelpers;
+use libra_crypto::ed25519::*;
 use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{
     account_address::AccountAddress,

--- a/mempool/src/unit_tests/service_test.rs
+++ b/mempool/src/unit_tests/service_test.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{core_mempool::CoreMempool, mempool_service::MempoolService, proto::mempool::*};
-use crypto::ed25519::compat::generate_keypair;
 use grpc_helpers::ServerHandle;
 use grpcio::{ChannelBuilder, EnvBuilder};
 use libra_config::config::NodeConfigHelpers;
+use libra_crypto::ed25519::compat::generate_keypair;
 use libra_mempool_shared_proto::proto::mempool_status::*;
 use libra_types::{
     account_address::AccountAddress,

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -25,7 +25,7 @@ admission-control-proto = { path = "../admission_control/admission-control-proto
 bounded-executor = { path = "../common/bounded-executor" }
 channel = { path = "../common/channel" }
 libra-config = { path = "../config" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 failure = { package = "failure_ext", path = "../common/failure_ext" }
 libra-types = { path = "../types" }
 libra-logger = { path = "../common/logger" }
@@ -40,7 +40,7 @@ proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 libra-types = { path = "../types", features = ["testing"]}
 proptest = { version = "0.9.4", default-features = false }
 proptest-helpers = { path = "../common/proptest-helpers" }

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -13,7 +13,6 @@ use criterion::{
     criterion_group, criterion_main, AxisScale, Bencher, Criterion, ParameterizedBenchmark,
     PlotConfiguration, Throughput,
 };
-use crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
 use futures::{
     channel::mpsc,
     executor::block_on,
@@ -21,6 +20,7 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
 };
 use libra_config::config::RoleType;
+use libra_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
 use libra_prost_ext::MessageExt;
 use network::{
     proto::{Block, ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock, RespondBlock},

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview" }
 snow = { version = "0.6.1", features=["ring-accelerated"]}
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 netcore = { path = "../netcore" }
 libra-logger = { path = "../../common/logger" }
 

--- a/network/noise/src/lib.rs
+++ b/network/noise/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! [noise]: http://noiseprotocol.org/
 
-use crypto::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
 use futures::io::{AsyncRead, AsyncWrite};
+use libra_crypto::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
 use netcore::{
     negotiate::{negotiate_inbound, negotiate_outbound_interactive},
     transport::ConnectionOrigin,
@@ -20,7 +20,7 @@ use std::io;
 mod socket;
 
 pub use self::socket::NoiseSocket;
-use crypto::ValidKey;
+use libra_crypto::ValidKey;
 
 const NOISE_IX_25519_AESGCM_SHA256_PROTOCOL_NAME: &[u8] = b"/noise_ix_25519_aesgcm_sha256/1.0.0";
 const NOISE_IX_PARAMETER: &str = "Noise_IX_25519_AESGCM_SHA256";

--- a/network/src/common.rs
+++ b/network/src/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ProtocolId;
-use crypto::{ed25519::*, x25519::X25519StaticPublicKey};
+use libra_crypto::{ed25519::*, x25519::X25519StaticPublicKey};
 use std::fmt;
 
 /// A Negotiated substream encapsulates a protocol and a substream for which that protocol has been

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -4,8 +4,8 @@
 use super::*;
 use crate::peer_manager::PeerManagerRequest;
 use core::str::FromStr;
-use crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
 use futures::SinkExt;
+use libra_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
 use memsocket::MemorySocket;
 use rand::{rngs::StdRng, SeedableRng};
 use std::io;

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -42,17 +42,17 @@ use crate::{
     NetworkPublicKeys, ProtocolId,
 };
 use channel;
-use crypto::{
-    ed25519::*,
-    hash::{CryptoHasher, DiscoveryMsgHasher},
-    HashValue,
-};
 use failure::{format_err, Fail};
 use futures::{
     future::{Future, FutureExt, TryFutureExt},
     io::{AsyncRead, AsyncWrite},
     sink::SinkExt,
     stream::{FusedStream, FuturesUnordered, Stream, StreamExt},
+};
+use libra_crypto::{
+    ed25519::*,
+    hash::{CryptoHasher, DiscoveryMsgHasher},
+    HashValue,
 };
 use libra_logger::prelude::*;
 use libra_types::{

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::{peer_manager::PeerManagerRequest, proto::DiscoveryMsg};
 use core::str::FromStr;
-use crypto::{test_utils::TEST_SEED, *};
+use libra_crypto::{test_utils::TEST_SEED, *};
 use memsocket::MemorySocket;
 use rand::{rngs::StdRng, SeedableRng};
 use tokio::runtime::Runtime;

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -5,7 +5,7 @@ use crate::{
     common::NetworkPublicKeys,
     protocols::identity::{exchange_identity, Identity},
 };
-use crypto::{
+use libra_crypto::{
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
     ValidKey,
 };

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -27,12 +27,12 @@ use crate::{
     ProtocolId,
 };
 use channel;
-use crypto::{
+use futures::StreamExt;
+use libra_config::config::RoleType;
+use libra_crypto::{
     ed25519::*,
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
 };
-use futures::StreamExt;
-use libra_config::config::RoleType;
 use libra_logger::prelude::*;
 use libra_types::{validator_signer::ValidatorSigner, PeerId};
 use netcore::{multiplexing::StreamMultiplexer, transport::boxed::BoxedTransport};

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -12,9 +12,9 @@ use crate::{
     },
     ProtocolId,
 };
-use crypto::{ed25519::compat, test_utils::TEST_SEED, traits::ValidKey, x25519};
 use futures::{executor::block_on, future::join, StreamExt};
 use libra_config::config::RoleType;
+use libra_crypto::{ed25519::compat, test_utils::TEST_SEED, traits::ValidKey, x25519};
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     proto::types::SignedTransaction,

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -31,7 +31,7 @@ vm_runtime = { path = "../language/vm/vm_runtime" }
 bytes = "0.4.12"
 
 config-builder = { path = "../config/config-builder" }
-crypto = { path = "../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", features = ["testing"]}
 parity-multiaddr = "0.5.0"
 libra-types = { path = "../types", features = ["testing"] }
 vm-genesis = { path = "../language/vm/vm-genesis" }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -5,10 +5,12 @@ use crate::{
     executor_proxy::ExecutorProxyTrait, LedgerInfo, PeerId, StateSyncClient, StateSynchronizer,
 };
 use config_builder::util::get_test_config;
-use crypto::{ed25519::*, test_utils::TEST_SEED, traits::Genesis, x25519, HashValue, SigningKey};
 use failure::{prelude::*, Result};
 use futures::{executor::block_on, future::FutureExt, Future};
 use libra_config::config::RoleType;
+use libra_crypto::{
+    ed25519::*, test_utils::TEST_SEED, traits::Genesis, x25519, HashValue, SigningKey,
+};
 use libra_types::{
     account_address::AccountAddress,
     crypto_proxies::LedgerInfoWithSignatures,

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 proptest = "0.9.1"
 
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 libra-types = { path = "../../types" }
 

--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -101,8 +101,8 @@
 //! |  ...  |   ...     |
 //! ```
 
-use crypto::hash::{CryptoHash, CryptoHasher, HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use failure::prelude::*;
+use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use libra_types::proof::{
     definition::LeafCount,
     position::{FrozenSubTreeIterator, FrozenSubtreeSiblingIterator, Position},

--- a/storage/accumulator/src/tests/mod.rs
+++ b/storage/accumulator/src/tests/mod.rs
@@ -5,7 +5,7 @@ mod proof_test;
 mod write_test;
 
 use super::*;
-use crypto::hash::TestOnlyHasher;
+use libra_crypto::hash::TestOnlyHasher;
 use libra_types::proof::definition::LeafCount;
 use proptest::{collection::vec, prelude::*};
 use std::collections::HashMap;

--- a/storage/accumulator/src/tests/write_test.rs
+++ b/storage/accumulator/src/tests/write_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
+use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use libra_types::proof::definition::LeafCount;
 use proptest::{collection::vec, prelude::*};
 

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -18,7 +18,7 @@ proptest = "0.9.2"
 proptest-derive = "0.1.2"
 serde = { version = "1.0.89", features = ["derive"] }
 
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 libra-nibble = { path = "../../common/nibble" }
 libra-types = { path = "../../types" }

--- a/storage/jellyfish-merkle/src/iterator/iterator_test.rs
+++ b/storage/jellyfish-merkle/src/iterator/iterator_test.rs
@@ -4,8 +4,8 @@
 use crate::{
     iterator::JellyfishMerkleIterator, mock_tree_store::MockTreeStore, JellyfishMerkleTree,
 };
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_types::{account_state_blob::AccountStateBlob, transaction::Version};
 use rand::{rngs::StdRng, SeedableRng};
 use std::collections::BTreeMap;

--- a/storage/jellyfish-merkle/src/iterator/mod.rs
+++ b/storage/jellyfish-merkle/src/iterator/mod.rs
@@ -14,8 +14,8 @@ use crate::{
     node_type::{InternalNode, Node, NodeKey},
     TreeReader,
 };
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_nibble::Nibble;
 use libra_types::{account_state_blob::AccountStateBlob, transaction::Version};
 

--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_nibble::Nibble;
 use mock_tree_store::MockTreeStore;
 use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -69,8 +69,8 @@ pub mod node_type;
 pub mod restore;
 mod tree_cache;
 
-use crypto::{hash::CryptoHash, HashValue};
 use failure::prelude::*;
+use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
     account_state_blob::AccountStateBlob, proof::SparseMerkleProof, transaction::Version,
 };

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -16,14 +16,14 @@ mod node_type_test;
 use crate::nibble_path::NibblePath;
 use bincode::{deserialize, serialize};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use crypto::{
+use failure::{Fail, Result, *};
+use libra_crypto::{
     hash::{
         CryptoHash, SparseMerkleInternalHasher, SparseMerkleLeafHasher,
         SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
     HashValue,
 };
-use failure::{Fail, Result, *};
 use libra_nibble::Nibble;
 use libra_types::{
     account_state_blob::AccountStateBlob,

--- a/storage/jellyfish-merkle/src/node_type/node_type_test.rs
+++ b/storage/jellyfish-merkle/src/node_type/node_type_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::{
+use libra_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -12,8 +12,8 @@ use crate::{
     node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey},
     NodeBatch, TreeReader, TreeWriter, ROOT_NIBBLE_HEIGHT,
 };
-use crypto::{hash::CryptoHash, HashValue};
 use failure::prelude::*;
+use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{account_state_blob::AccountStateBlob, transaction::Version};
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/storage/jellyfish-merkle/src/restore/restore_test.rs
+++ b/storage/jellyfish-merkle/src/restore/restore_test.rs
@@ -5,7 +5,7 @@ use crate::{
     mock_tree_store::MockTreeStore, restore::JellyfishMerkleRestore, JellyfishMerkleTree,
     TreeReader,
 };
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_types::{account_state_blob::AccountStateBlob, transaction::Version};
 use proptest::{collection::btree_map, prelude::*};
 use std::collections::BTreeMap;

--- a/storage/jellyfish-merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/mod.rs
@@ -73,8 +73,8 @@ use crate::{
     node_type::{Node, NodeKey},
     StaleNodeIndex, TreeReader, TreeUpdateBatch,
 };
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_types::transaction::Version;
 use std::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet},

--- a/storage/jellyfish-merkle/src/tree_cache/tree_cache_test.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/tree_cache_test.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{mock_tree_store::MockTreeStore, nibble_path::NibblePath, node_type::Node, NodeKey};
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_types::account_state_blob::AccountStateBlob;
 
 fn random_leaf_with_key(next_version: Version) -> (Node, NodeKey) {

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1.0.96"
 
 accumulator = { path = "../accumulator" }
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 jellyfish-merkle = { path = "../jellyfish-merkle" }
 libra-logger = { path = "../../common/logger" }

--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -16,11 +16,11 @@ use crate::{
     },
 };
 use accumulator::{HashReader, MerkleAccumulator};
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{CryptoHash, EventAccumulatorHasher},
     HashValue,
 };
-use failure::prelude::*;
 use libra_types::{
     account_address::AccountAddress,
     contract_event::ContractEvent,

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -3,8 +3,8 @@
 
 use super::*;
 use crate::LibraDB;
-use crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use itertools::Itertools;
+use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::AccountAddress,

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -14,12 +14,12 @@ use crate::{
 };
 use accumulator::{HashReader, MerkleAccumulator};
 use arc_swap::ArcSwap;
-use crypto::{
+use failure::prelude::*;
+use itertools::Itertools;
+use libra_crypto::{
     hash::{CryptoHash, TransactionAccumulatorHasher},
     HashValue,
 };
-use failure::prelude::*;
-use itertools::Itertools;
 use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,
     proof::{position::Position, AccumulatorConsistencyProof, TransactionAccumulatorProof},

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -40,10 +40,10 @@ use crate::{
     system_store::SystemStore,
     transaction_store::TransactionStore,
 };
-use crypto::hash::{CryptoHash, HashValue};
 use failure::prelude::*;
 use itertools::{izip, zip_eq};
 use lazy_static::lazy_static;
+use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_logger::prelude::*;
 use libra_metrics::OpMetrics;
 use libra_types::{

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -6,7 +6,7 @@ use crate::{
     mock_genesis::{db_with_mock_genesis, GENESIS_INFO},
     test_helper::arb_blocks_to_commit,
 };
-use crypto::hash::CryptoHash;
+use libra_crypto::hash::CryptoHash;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_config::get_account_resource_or_default, contract_event::ContractEvent,

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -4,13 +4,13 @@
 //! This module provides helpers to initialize [`LibraDB`] with fake generic state in tests.
 
 use crate::LibraDB;
-use crypto::{
+use failure::Result;
+use lazy_static::lazy_static;
+use libra_crypto::{
     ed25519::*,
     hash::{CryptoHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID},
     HashValue,
 };
-use failure::Result;
-use lazy_static::lazy_static;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,

--- a/storage/libradb/src/pruner/test.rs
+++ b/storage/libradb/src/pruner/test.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{change_set::ChangeSet, state_store::StateStore, LibraDB};
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/storage/libradb/src/schema/event_accumulator/mod.rs
+++ b/storage/libradb/src/schema/event_accumulator/mod.rs
@@ -12,8 +12,8 @@
 
 use crate::schema::{ensure_slice_len_eq, EVENT_ACCUMULATOR_CF_NAME};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use crypto::hash::HashValue;
 use failure::prelude::*;
+use libra_crypto::hash::HashValue;
 use libra_types::{proof::position::Position, transaction::Version};
 use schemadb::{
     define_schema,

--- a/storage/libradb/src/schema/jellyfish_merkle_node/test.rs
+++ b/storage/libradb/src/schema/jellyfish_merkle_node/test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::HashValue;
 use jellyfish_merkle::node_type::Node;
+use libra_crypto::HashValue;
 use libra_types::account_state_blob::AccountStateBlob;
 use proptest::prelude::*;
 use schemadb::schema::assert_encode_decode;

--- a/storage/libradb/src/schema/transaction_accumulator/mod.rs
+++ b/storage/libradb/src/schema/transaction_accumulator/mod.rs
@@ -12,8 +12,8 @@
 
 use crate::schema::{ensure_slice_len_eq, TRANSACTION_ACCUMULATOR_CF_NAME};
 use byteorder::{BigEndian, ReadBytesExt};
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_types::proof::position::Position;
 use schemadb::{
     define_schema,

--- a/storage/libradb/src/schema/transaction_info/test.rs
+++ b/storage/libradb/src/schema/transaction_info/test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::HashValue;
+use libra_crypto::HashValue;
 use libra_types::{transaction::TransactionInfo, vm_error::StatusCode};
 use schemadb::schema::assert_encode_decode;
 

--- a/storage/libradb/src/schema/validator/mod.rs
+++ b/storage/libradb/src/schema/validator/mod.rs
@@ -13,8 +13,8 @@
 use crate::schema::{ensure_slice_len_eq, VALIDATOR_CF_NAME};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use core::convert::TryFrom;
-use crypto::ed25519::{Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH};
 use failure::prelude::*;
+use libra_crypto::ed25519::{Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH};
 use libra_types::transaction::Version;
 use schemadb::{
     define_schema,

--- a/storage/libradb/src/schema/validator/test.rs
+++ b/storage/libradb/src/schema/validator/test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crypto::ed25519::compat;
 use itertools::Itertools;
+use libra_crypto::ed25519::compat;
 use libra_types::transaction::Version;
 use rand::{
     rngs::{OsRng, StdRng},

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -13,12 +13,12 @@ use crate::{
         jellyfish_merkle_node::JellyfishMerkleNodeSchema, stale_node_index::StaleNodeIndexSchema,
     },
 };
-use crypto::{hash::CryptoHash, HashValue};
 use failure::prelude::*;
 use jellyfish_merkle::{
     node_type::{LeafNode, Node, NodeKey},
     JellyfishMerkleTree, TreeReader,
 };
+use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
     account_address::AccountAddress, account_state_blob::AccountStateBlob,
     proof::SparseMerkleProof, transaction::Version,

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{pruner, LibraDB};
-use crypto::hash::CryptoHash;
+use libra_crypto::hash::CryptoHash;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -5,7 +5,7 @@
 
 use super::*;
 use crate::mock_genesis::{db_with_mock_genesis, GENESIS_INFO};
-use crypto::hash::CryptoHash;
+use libra_crypto::hash::CryptoHash;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures,

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 itertools = "0.8.0"
 
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -68,7 +68,7 @@ mod node;
 mod sparse_merkle_test;
 
 use self::node::{LeafNode, LeafValue, Node, SparseMerkleNode};
-use crypto::{
+use libra_crypto::{
     hash::{HashValueBitIterator, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/storage/scratchpad/src/sparse_merkle/node.rs
+++ b/storage/scratchpad/src/sparse_merkle/node.rs
@@ -17,7 +17,7 @@
 //!
 //! - An `EmptyNode` represents an empty subtree with zero leaf.
 
-use crypto::{
+use libra_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -5,7 +5,7 @@ use super::{
     node::{LeafNode, LeafValue, SparseMerkleNode},
     AccountState, ProofRead, SparseMerkleTree,
 };
-use crypto::{
+use libra_crypto::{
     hash::{CryptoHash, TestOnlyHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -14,7 +14,7 @@ futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features =
 futures_01 = { version = "0.1.28", package = "futures" }
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 rand = "0.6.5"
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 scratchpad = { path = "../scratchpad" }
 state-view = { path = "../state-view" }

--- a/storage/storage-client/src/state_view.rs
+++ b/storage/storage-client/src/state_view.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::StorageRead;
-use crypto::{hash::CryptoHash, HashValue};
 use failure::prelude::*;
+use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
     access_path::AccessPath, account_address::AccountAddress, proof::SparseMerkleProof,
     transaction::Version,

--- a/storage/storage-proto/Cargo.toml
+++ b/storage/storage-proto/Cargo.toml
@@ -17,7 +17,7 @@ proptest = "0.9.2"
 proptest-derive = "0.1.0"
 prost = "0.5.0"
 
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 libra-types = { path = "../../types" }
 

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -25,8 +25,8 @@
 
 pub mod proto;
 
-use crypto::HashValue;
 use failure::prelude::*;
+use libra_crypto::HashValue;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -16,7 +16,7 @@ structopt = "0.3.2"
 
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 debug-interface = { path = "../../common/debug-interface" }
 executable-helpers = { path = "../../common/executable-helpers" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -3,9 +3,9 @@
 
 //! This module provides mock storage clients for tests.
 
-use crypto::{ed25519::*, HashValue};
 use failure::prelude::*;
 use futures::prelude::*;
+use libra_crypto::{ed25519::*, HashValue};
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_state_blob::AccountStateBlob,

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -27,4 +27,4 @@ libra-swarm = { path = "../libra-swarm", features = ["testing"]}
 libra-logger = { path = "../common/logger" }
 libra-config = { path = "../config" }
 libra-tools = { path = "../common/tools" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -40,7 +40,7 @@ admission-control-proto = { path = "../../admission_control/admission-control-pr
 
 libra-types = { path = "../../types" }
 transaction-builder = { path = "../../language/transaction-builder" }
-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto" }
 generate-keypair = { path = "../../config/generate-keypair" }
 
 threadpool = "1.7.1"

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -12,17 +12,17 @@ use std::{
 };
 
 use admission_control_proto::{AdmissionControlStatus, SubmitTransactionResponse};
-use crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-    traits::Uniform,
-};
 use failure::{
     self,
     prelude::{bail, format_err},
 };
 use generate_keypair::load_key_from_file;
 use itertools::zip;
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::KeyPair,
+    traits::Uniform,
+};
 use libra_types::{
     account_address::AccountAddress,
     account_config::{association_address, get_account_resource_or_default},

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -4,8 +4,8 @@
 use cli::{
     client_proxy::ClientProxy, AccountAddress, CryptoHash, TransactionArgument, TransactionPayload,
 };
-use crypto::{ed25519::*, test_utils::KeyPair, SigningKey};
 use libra_config::config::{NodeConfig, RoleType};
+use libra_crypto::{ed25519::*, test_utils::KeyPair, SigningKey};
 use libra_logger::prelude::*;
 use libra_swarm::{swarm::LibraSwarm, utils};
 use libra_tools::tempdir::TempPath;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.99", default-features = false }
 tiny-keccak = { version = "1.5.0", default-features = false }
 
 lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
-crypto = { path = "../crypto/crypto" }
+libra-crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 proptest-helpers = { path = "../common/proptest-helpers" }
 num_enum = "0.4.1"
@@ -38,8 +38,8 @@ prost-build = "0.5.0"
 [dev-dependencies]
 libra-prost-ext = { path = "../common/prost-ext" }
 serde_json = "1.0.40"
-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 
 [features]
 default = []
-testing = ["crypto/testing"]
+testing = ["libra-crypto/testing"]

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -45,10 +45,10 @@ use crate::{
     language_storage::{ModuleId, ResourceKey, StructTag},
     validator_set::validator_set_path,
 };
-use crypto::hash::{CryptoHash, HashValue};
 use failure::prelude::*;
 use hex;
 use lazy_static::lazy_static;
+use libra_crypto::hash::{CryptoHash, HashValue};
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use radix_trie::TrieKey;

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -3,12 +3,12 @@
 
 use bech32::{Bech32, FromBase32, ToBase32};
 use bytes::Bytes;
-use crypto::{
+use failure::prelude::*;
+use hex;
+use libra_crypto::{
     hash::{AccountAddressHasher, CryptoHash, CryptoHasher},
     HashValue, VerifyingKey,
 };
-use failure::prelude::*;
-use hex;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -7,11 +7,11 @@ use crate::{
     account_address::AccountAddress, account_config::get_account_resource_or_default,
     ledger_info::LedgerInfo, proof::AccountStateProof, transaction::Version,
 };
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{AccountStateBlobHasher, CryptoHash, CryptoHasher},
     HashValue,
 };
-use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest::{arbitrary::Arbitrary, prelude::*};
 #[cfg(any(test, feature = "testing"))]

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -1,7 +1,7 @@
 use crate::account_address::AccountAddress;
 use crate::byte_array::ByteArray;
-use crypto::{ed25519::Ed25519Signature, HashValue};
 use failure::prelude::*;
+use libra_crypto::{ed25519::Ed25519Signature, HashValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -5,11 +5,11 @@ use crate::{
     account_config::AccountEvent, event::EventKey, ledger_info::LedgerInfo, proof::EventProof,
     transaction::Version,
 };
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{ContractEventHasher, CryptoHash, CryptoHasher},
     HashValue,
 };
-use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -3,7 +3,7 @@
 
 //! This module defines a data structure made to contain a cryptographic
 //! signature, in the sense of an implementation of
-//! crypto::traits::Signature. The container is an opaque NewType that
+//! libra_crypto::traits::Signature. The container is an opaque NewType that
 //! intentionally does not allow access to the inner impl.
 //!
 //! It also proxies the four methods used in consensus on structures that
@@ -11,7 +11,7 @@
 //!
 //! The goal of this structure is two-fold:
 //! - help make sure that any consensus data that uses cryptographic material is defined generically
-//!   in terms of crypto::traits, rather than accessing the implementation details of a particular
+//!   in terms of libra_crypto::traits, rather than accessing the implementation details of a particular
 //!   scheme (a.k.a. encapsulation),
 //! - contribute to a single-location place for instantiations of these polymorphic types
 //!   (`crate::chained_bft::consensus_types`)
@@ -28,7 +28,7 @@ use crate::{
         ValidatorInfo as RawValidatorInfo, ValidatorVerifier as RawValidatorVerifier, VerifyError,
     },
 };
-use crypto::{hash::HashValue, traits::Signature as RawSignature};
+use libra_crypto::{hash::HashValue, traits::Signature as RawSignature};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
@@ -44,7 +44,7 @@ impl<Sig: RawSignature> SignatureWrapper<Sig> {
         validator_verifier.verify_signature(author, message, &self.0)
     }
 
-    pub fn try_from(bytes: &[u8]) -> Result<Self, crypto::traits::CryptoMaterialError> {
+    pub fn try_from(bytes: &[u8]) -> Result<Self, libra_crypto::traits::CryptoMaterialError> {
         Sig::try_from(bytes).map(SignatureWrapper)
     }
 
@@ -78,7 +78,7 @@ impl<Sig: RawSignature> From<Sig> for SignatureWrapper<Sig> {
 // types that do not go through the instantiated polymorphic structures
 // below is banned.
 
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 use std::collections::BTreeMap;
 
 // used in chained_bft::consensus_types::block_test

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,7 +1,7 @@
 use crate::account_address::AccountAddress;
-use crypto::HashValue;
 use failure::prelude::*;
 use hex;
+use libra_crypto::HashValue;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use serde::{de, ser, Deserialize, Serialize};

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -19,8 +19,8 @@ use crate::{
     validator_change::ValidatorChangeEventWithProof,
     validator_verifier::ValidatorVerifier,
 };
-use crypto::{hash::CryptoHash, *};
 use failure::prelude::*;
+use libra_crypto::{hash::CryptoHash, *};
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use std::{

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -6,8 +6,8 @@ use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
 };
-use crypto::hash::{AccessPathHasher, CryptoHash, CryptoHasher, HashValue};
 use failure::Result;
+use libra_crypto::hash::{AccessPathHasher, CryptoHash, CryptoHasher, HashValue};
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -7,11 +7,11 @@ use crate::{
     validator_set::ValidatorSet,
     validator_verifier::{ValidatorVerifier, VerifyError},
 };
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{CryptoHash, CryptoHasher, LedgerInfoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue, *,
 };
-use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -336,7 +336,7 @@ impl<Sig: Signature> From<LedgerInfoWithSignatures<Sig>>
 mod tests {
     use crate::ledger_info::{LedgerInfo, LedgerInfoWithSignatures};
     use crate::validator_signer::ValidatorSigner;
-    use crypto::{ed25519::*, HashValue};
+    use libra_crypto::{ed25519::*, HashValue};
     use std::collections::BTreeMap;
 
     #[test]

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -7,7 +7,7 @@ use crate::proof::{
     position::{FrozenSubtreeSiblingIterator, Position},
     TestAccumulatorInternalNode,
 };
-use crypto::{
+use libra_crypto::{
     hash::{CryptoHash, TestOnlyHash, TestOnlyHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -15,11 +15,11 @@ mod accumulator_test;
 
 use super::MerkleTreeInternalNode;
 use crate::proof::definition::{LeafCount, MAX_ACCUMULATOR_LEAVES};
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
-use failure::prelude::*;
 use std::marker::PhantomData;
 
 /// The Accumulator implementation.

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -16,16 +16,16 @@ use crate::{
     ledger_info::LedgerInfo,
     transaction::{TransactionInfo, Version},
 };
+use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
-use crypto::hash::TestOnlyHasher;
-use crypto::{
+use libra_crypto::hash::TestOnlyHasher;
+use libra_crypto::{
     hash::{
         CryptoHash, CryptoHasher, EventAccumulatorHasher, TransactionAccumulatorHasher,
         ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
     HashValue,
 };
-use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -17,14 +17,14 @@ use crate::{
     ledger_info::LedgerInfo,
     transaction::{TransactionInfo, TransactionListWithProof, Version},
 };
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     hash::{
         CryptoHash, CryptoHasher, EventAccumulatorHasher, SparseMerkleInternalHasher,
         SparseMerkleLeafHasher, TestOnlyHasher, TransactionAccumulatorHasher,
     },
     HashValue,
 };
-use failure::prelude::*;
 use std::{collections::VecDeque, marker::PhantomData};
 
 pub use self::definition::{

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -8,7 +8,7 @@ use crate::proof::{
     definition::MAX_ACCUMULATOR_PROOF_DEPTH, AccumulatorConsistencyProof, AccumulatorProof,
     SparseMerkleProof,
 };
-use crypto::{
+use libra_crypto::{
     hash::{CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/types/src/proof/unit_tests/proof_proto_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_proto_conversion_test.rs
@@ -6,7 +6,7 @@ use crate::proof::{
     AccountStateProof, AccumulatorConsistencyProof, EventProof, SignedTransactionProof,
     SparseMerkleProof, TestAccumulatorProof,
 };
-use crypto::{
+use libra_crypto::{
     hash::{TestOnlyHash, ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     vm_error::StatusCode,
 };
-use crypto::{
+use libra_crypto::{
     ed25519::*,
     hash::{
         CryptoHash, TestOnlyHash, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH,

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -23,7 +23,7 @@ use crate::{
     vm_error::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
-use crypto::{
+use libra_crypto::{
     ed25519::{compat::keypair_strategy, *},
     hash::CryptoHash,
     traits::*,

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -6,7 +6,7 @@ use crate::{
     transaction::{Module, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction},
     write_set::WriteSet,
 };
-use crypto::{ed25519::*, hash::CryptoHash, traits::*};
+use libra_crypto::{ed25519::*, hash::CryptoHash, traits::*};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 static PLACEHOLDER_SCRIPT: &[u8] = include_bytes!("fixtures/scripts/placeholder_script.mvbin");

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -7,14 +7,14 @@ use crate::{
     transaction::{RawTransaction, SignedTransaction, TransactionPayload},
 };
 use chrono::Utc;
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     ed25519::*,
     hash::{CryptoHash, TestOnlyHash},
     test_utils::KeyPair,
     traits::SigningKey,
     HashValue,
 };
-use failure::prelude::*;
 
 /// Used to get the digest of a set of signed transactions.  This is used by a validator
 /// to sign a block and to verify the signatures of other validators on a block

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -14,7 +14,8 @@ use crate::{
     vm_error::{StatusCode, StatusType, VMStatus},
     write_set::WriteSet,
 };
-use crypto::{
+use failure::prelude::*;
+use libra_crypto::{
     ed25519::*,
     hash::{
         CryptoHash, CryptoHasher, EventAccumulatorHasher, RawTransactionHasher,
@@ -23,7 +24,6 @@ use crypto::{
     traits::*,
     HashValue,
 };
-use failure::prelude::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use serde::{de, ser, Deserialize, Serialize};

--- a/types/src/unit_tests/address_test.rs
+++ b/types/src/unit_tests/address_test.rs
@@ -3,8 +3,8 @@
 
 use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
 use bech32::Bech32;
-use crypto::{hash::CryptoHash, HashValue};
 use hex::FromHex;
+use libra_crypto::{hash::CryptoHash, HashValue};
 use proptest::prelude::*;
 use std::convert::{AsRef, TryFrom};
 

--- a/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
+++ b/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     proto,
 };
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;
 use std::convert::TryFrom;

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -6,7 +6,7 @@ use crate::{
     account_address::AccountAddress,
     transaction::{RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload},
 };
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 use proptest::prelude::*;
 use std::convert::TryFrom;
 

--- a/types/src/unit_tests/validator_change_proto_conversion_test.rs
+++ b/types/src/unit_tests/validator_change_proto_conversion_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::validator_change::ValidatorChangeEventWithProof;
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;
 

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{contract_event::EventWithProof, ledger_info::LedgerInfoWithSignatures};
-use crypto::*;
 use failure::*;
+use libra_crypto::*;
 use std::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -45,7 +45,7 @@ impl<Sig: Signature> From<ValidatorChangeEventWithProof<Sig>>
 }
 
 #[cfg(any(test, feature = "testing"))]
-use crypto::ed25519::*;
+use libra_crypto::ed25519::*;
 #[cfg(any(test, feature = "testing"))]
 use proptest::prelude::*;
 

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use crypto::{ed25519::*, traits::ValidKey, x25519::X25519StaticPublicKey};
 use failure::Result;
+use libra_crypto::{ed25519::*, traits::ValidKey, x25519::X25519StaticPublicKey};
 #[cfg(any(test, feature = "testing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
-use crypto::{test_utils::TEST_SEED, HashValue, *};
 use failure::Error;
+use libra_crypto::{test_utils::TEST_SEED, HashValue, *};
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;
 
@@ -85,7 +85,7 @@ impl<PrivateKey: SigningKey + Uniform> ValidatorSigner<PrivateKey> {
 pub mod proptests {
     use super::*;
     #[cfg(test)]
-    use crypto::ed25519::*;
+    use libra_crypto::ed25519::*;
     use proptest::{prelude::*, sample, strategy::LazyJust};
 
     #[allow(clippy::redundant_closure)]

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use crypto::*;
 use failure::prelude::*;
+use libra_crypto::*;
 use libra_logger::prelude::*;
 use std::collections::BTreeMap;
 
@@ -283,7 +283,7 @@ mod tests {
         validator_signer::ValidatorSigner,
         validator_verifier::{ValidatorInfo, ValidatorVerifier, VerifyError},
     };
-    use crypto::{ed25519::*, test_utils::TEST_SEED, HashValue};
+    use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue};
     use std::collections::BTreeMap;
 
     #[test]

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -24,7 +24,7 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 rand = "0.6.5"
 
 config-builder = { path = "../config/config-builder" }
-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 executor = { path = "../executor" }
 grpc_helpers = { path = "../common/grpc_helpers" }
 storage-service = { path = "../storage/storage-service" }

--- a/vm_validator/src/unit_tests/vm_validator_test.rs
+++ b/vm_validator/src/unit_tests/vm_validator_test.rs
@@ -3,12 +3,12 @@
 
 use crate::vm_validator::{TransactionValidation, VMValidator};
 use config_builder::util::get_test_config;
-use crypto::ed25519::*;
 use executor::Executor;
 use futures::future::Future;
 use grpc_helpers::ServerHandle;
 use grpcio::EnvBuilder;
 use libra_config::config::NodeConfig;
+use libra_crypto::ed25519::*;
 use libra_types::{
     account_address, account_config,
     test_helpers::transaction_test_helpers,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `crypto` and `crypto-derive` packages.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235
#1350
#1353
#1371
#1377
#1393
#1394