### PR TITLE
[consensus] derive state_compute_result from vm output

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -16,18 +16,15 @@ use std::{
 pub struct ExecutedBlock<T> {
     /// Block data that cannot be regenerated.
     block: Block<T>,
-    /// The processed output needed by executor.
-    output: Arc<ProcessedVMOutput>,
-    /// The state compute result is calculated for all the pending blocks prior to insertion to
-    /// the tree (the initial root node might not have it, because it's been already
-    /// committed). The execution results are not persisted: they're recalculated again for the
+    /// The execution output is calculated for all the pending blocks prior to insertion to
+    /// the tree. The execution results are not persisted: they're recalculated again for the
     /// pending blocks upon restart.
-    compute_result: Arc<StateComputeResult>,
+    output: Arc<ProcessedVMOutput>,
 }
 
 impl<T: PartialEq> PartialEq for ExecutedBlock<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.block == other.block && self.compute_result == other.compute_result
+        self.block == other.block && self.compute_result() == other.compute_result()
     }
 }
 
@@ -40,15 +37,10 @@ impl<T: PartialEq> Display for ExecutedBlock<T> {
 }
 
 impl<T> ExecutedBlock<T> {
-    pub fn new(
-        block: Block<T>,
-        output: ProcessedVMOutput,
-        compute_result: StateComputeResult,
-    ) -> Self {
+    pub fn new(block: Block<T>, output: ProcessedVMOutput) -> Self {
         Self {
             block,
             output: Arc::new(output),
-            compute_result: Arc::new(compute_result),
         }
     }
 
@@ -56,8 +48,8 @@ impl<T> ExecutedBlock<T> {
         &self.block
     }
 
-    pub fn compute_result(&self) -> &Arc<StateComputeResult> {
-        &self.compute_result
+    pub fn compute_result(&self) -> StateComputeResult {
+        self.output().state_compute_result()
     }
 
     pub fn epoch(&self) -> u64 {

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -17,7 +17,7 @@ use consensus_types::{
     timeout_certificate::TimeoutCertificate,
     vote::Vote,
 };
-use executor::{ProcessedVMOutput, StateComputeResult};
+use executor::ProcessedVMOutput;
 use failure::ResultExt;
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
@@ -108,11 +108,15 @@ impl<T: Payload> BlockStore<T> {
         max_pruned_blocks_in_mem: usize,
     ) -> BlockTree<T> {
         let (root_block, root_qc, root_li) = (root.0, root.1, root.2);
-        // root_compute_res will not used anywhere so use default value to simplify code.
-        let root_compute_res = StateComputeResult::default();
         // TODO: check root matches the committed_trees.
-        let root_output = ProcessedVMOutput::new(vec![], state_computer.committed_trees());
-        let executed_root_block = ExecutedBlock::new(root_block, root_output, root_compute_res);
+        let root_output = ProcessedVMOutput::new(vec![], state_computer.committed_trees(), None);
+        assert_eq!(
+            root_qc.certified_block().executed_state_id(),
+            root_output.accu_root(),
+            "We have inconsistent executed state with Quorum Cert for root block {}",
+            root_block.id()
+        );
+        let executed_root_block = ExecutedBlock::new(root_block, root_output);
         let mut tree = BlockTree::new(
             executed_root_block,
             root_qc,
@@ -131,7 +135,7 @@ impl<T: Payload> BlockStore<T> {
                 .expect("Parent block must exist")
                 .executed_trees()
                 .clone();
-            let (output, state_compute_result) = state_computer
+            let output = state_computer
                 .compute(&block, parent_trees)
                 .await
                 .expect("fail to rebuild scratchpad");
@@ -139,12 +143,12 @@ impl<T: Payload> BlockStore<T> {
             if let Some(qc) = quorum_certs.get(&block.id()) {
                 assert_eq!(
                     qc.certified_block().executed_state_id(),
-                    state_compute_result.executed_state.state_id,
+                    output.accu_root(),
                     "We have inconsistent executed state with Quorum Cert for block {}",
                     block.id()
                 );
             }
-            tree.insert_block(ExecutedBlock::new(block, output, state_compute_result))
+            tree.insert_block(ExecutedBlock::new(block, output))
                 .expect("Block insertion failed while build the tree");
         }
         quorum_certs.into_iter().for_each(|(_, qc)| {
@@ -217,29 +221,27 @@ impl<T: Payload> BlockStore<T> {
         // Reconfiguration rule - if a block is a child of pending reconfiguration, it needs to be empty
         // So we roll over the executed state until it's committed and we start new epoch.
         let parent_state = parent_block.compute_result();
-        let (output, state_compute_result) =
-            if self.root() != parent_block && parent_state.has_reconfiguration() {
-                ensure!(
-                    block.payload().filter(|p| **p != T::default()).is_none(),
-                    "Reconfiguration suffix should not carry payload"
-                );
-                (
-                    parent_block.output().as_ref().clone(),
-                    StateComputeResult {
-                        executed_state: parent_state.executed_state.clone(),
-                        compute_status: vec![],
-                    },
-                )
-            } else {
-                let parent_trees = parent_block.executed_trees().clone();
-                // Although NIL blocks don't have payload, we still send a T::default() to compute
-                // because we may inject a block prologue transaction.
-                self.state_computer
-                    .compute(&block, parent_trees)
-                    .await
-                    .with_context(|e| format!("Execution failure for block {}: {:?}", block, e))?
-            };
-        Ok(ExecutedBlock::new(block, output, state_compute_result))
+
+        let output = if self.root() != parent_block && parent_state.has_reconfiguration() {
+            ensure!(
+                block.payload().filter(|p| **p != T::default()).is_none(),
+                "Reconfiguration suffix should not carry payload"
+            );
+            ProcessedVMOutput::new(
+                vec![],
+                parent_block.output().executed_trees().clone(),
+                parent_block.output().validators().clone(),
+            )
+        } else {
+            let parent_trees = parent_block.executed_trees().clone();
+            // Although NIL blocks don't have payload, we still send a T::default() to compute
+            // because we may inject a block prologue transaction.
+            self.state_computer
+                .compute(&block, parent_trees)
+                .await
+                .with_context(|e| format!("Execution failure for block {}: {:?}", block, e))?
+        };
+        Ok(ExecutedBlock::new(block, output))
     }
 
     /// Validates quorum certificates and inserts it into block tree assuming dependencies exist.
@@ -251,15 +253,12 @@ impl<T: Payload> BlockStore<T> {
         // corruption, for example.
         match self.get_block(qc.certified_block().id()) {
             Some(executed_block) => {
-                // TODO: Once we fill in the root compute result, we should remove this
-                if self.root() != executed_block {
-                    assert_eq!(
+                assert_eq!(
                         executed_block.compute_result().executed_state.state_id,
                         qc.certified_block().executed_state_id(),
                         "QC for block {} has a different execution result than the local computation. Restart and try again.",
                         qc.certified_block().id(),
                     );
-                }
             }
             None => bail!("Insert {} without having the block in store first", qc),
         }
@@ -470,17 +469,12 @@ impl<T: Payload> BlockStore<T> {
     ) -> failure::Result<Arc<ExecutedBlock<T>>> {
         self.insert_single_quorum_cert(block.quorum_cert().clone())?;
         let executed_block = self.execute_block(block).await?;
-        let output = executed_block.output().as_ref().clone();
-        let mut compute_result = executed_block.compute_result().as_ref().clone();
-        compute_result.executed_state.validators = Some(ValidatorSet::new(vec![]));
+        let mut output = executed_block.output().as_ref().clone();
+        output.set_validators(ValidatorSet::new(vec![]));
         Ok(self
             .inner
             .write()
             .unwrap()
-            .insert_block(ExecutedBlock::new(
-                executed_block.block().clone(),
-                output,
-                compute_result,
-            ))?)
+            .insert_block(ExecutedBlock::new(executed_block.block().clone(), output))?)
     }
 }

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -810,11 +810,7 @@ impl<T: Payload> EventProcessor<T> {
                 let compute_result = committed.compute_result();
                 if let Err(e) = self
                     .txn_manager
-                    .commit_txns(
-                        payload,
-                        compute_result.as_ref(),
-                        committed.timestamp_usecs(),
-                    )
+                    .commit_txns(payload, &compute_result, committed.timestamp_usecs())
                     .await
                 {
                     error!("Failed to notify mempool: {:?}", e);

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -7,10 +7,9 @@ use crate::{
 };
 use consensus_types::block::Block;
 use consensus_types::quorum_cert::QuorumCert;
-use executor::{ExecutedState, ExecutedTrees, ProcessedVMOutput, StateComputeResult};
+use executor::{ExecutedTrees, ProcessedVMOutput};
 use failure::Result;
 use futures::{channel::mpsc, future, Future, FutureExt};
-use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use std::{pin::Pin, sync::Arc};
@@ -39,17 +38,11 @@ impl StateComputer for MockStateComputer {
         &self,
         _block: &Block<Self::Payload>,
         _parent_executed_trees: ExecutedTrees,
-    ) -> Pin<Box<dyn Future<Output = Result<(ProcessedVMOutput, StateComputeResult)>> + Send>> {
-        future::ok((
-            ProcessedVMOutput::new(vec![], ExecutedTrees::new_empty()),
-            StateComputeResult {
-                executed_state: ExecutedState {
-                    state_id: *ACCUMULATOR_PLACEHOLDER_HASH,
-                    version: 0,
-                    validators: None,
-                },
-                compute_status: vec![],
-            },
+    ) -> Pin<Box<dyn Future<Output = Result<ProcessedVMOutput>> + Send>> {
+        future::ok(ProcessedVMOutput::new(
+            vec![],
+            ExecutedTrees::new_empty(),
+            None,
         ))
         .boxed()
     }
@@ -96,17 +89,11 @@ impl StateComputer for EmptyStateComputer {
         &self,
         _block: &Block<Self::Payload>,
         _parent_executed_trees: ExecutedTrees,
-    ) -> Pin<Box<dyn Future<Output = Result<(ProcessedVMOutput, StateComputeResult)>> + Send>> {
-        future::ok((
-            ProcessedVMOutput::new(vec![], ExecutedTrees::new_empty()),
-            StateComputeResult {
-                executed_state: ExecutedState {
-                    state_id: *ACCUMULATOR_PLACEHOLDER_HASH,
-                    version: 0,
-                    validators: None,
-                },
-                compute_status: vec![],
-            },
+    ) -> Pin<Box<dyn Future<Output = Result<ProcessedVMOutput>> + Send>> {
+        future::ok(ProcessedVMOutput::new(
+            vec![],
+            ExecutedTrees::new_empty(),
+            None,
         ))
         .boxed()
     }

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -48,7 +48,7 @@ pub trait StateComputer: Send + Sync {
         block: &Block<Self::Payload>,
         // The executed trees of parent block.
         executed_trees: ExecutedTrees,
-    ) -> Pin<Box<dyn Future<Output = Result<(ProcessedVMOutput, StateComputeResult)>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<ProcessedVMOutput>> + Send>>;
 
     /// Send a successful commit. A future is fulfilled when the state is finalized.
     fn commit(

--- a/storage/storage-client/src/state_view.rs
+++ b/storage/storage-client/src/state_view.rs
@@ -79,13 +79,14 @@ impl<'a> VerifiedStateView<'a> {
     /// on top of it represented by `speculative_state`.
     pub fn new(
         reader: Arc<dyn StorageRead>,
-        latest_persistent_version_and_state_root: (Option<Version>, HashValue),
+        latest_persistent_version: Option<Version>,
+        latest_persistent_state_root: HashValue,
         speculative_state: &'a SparseMerkleTree,
     ) -> Self {
         Self {
             reader,
-            latest_persistent_version: latest_persistent_version_and_state_root.0,
-            latest_persistent_state_root: latest_persistent_version_and_state_root.1,
+            latest_persistent_version,
+            latest_persistent_state_root,
             speculative_state,
             account_to_btree_cache: RefCell::new(HashMap::new()),
             account_to_proof_cache: RefCell::new(HashMap::new()),

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -88,10 +88,8 @@ impl TransactionValidation for VMValidator {
                         let smt = SparseMerkleTree::new(state_root);
                         let state_view = VerifiedStateView::new(
                             Arc::clone(&self.storage_read_client),
-                            (
-                                Some(ledger_info_with_sigs.ledger_info().version()),
-                                state_root,
-                            ),
+                            Some(ledger_info_with_sigs.ledger_info().version()),
+                            state_root,
                             &smt,
                         );
                         Box::new(ok(self.vm.validate_transaction(txn, &state_view)))


### PR DESCRIPTION
## Motivation

`state_compute_result` is derivable from `vm_output` so there is no need to return both of them from executor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI


