### PR TITLE
Prepend libra to proptest-helpers package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,12 @@ dependencies = [
  "libra-mempool 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "network 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
@@ -1730,9 +1730,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "invalid-mutations"
 version = "0.1.0"
 dependencies = [
+ "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "vm 0.1.0",
 ]
 
@@ -1891,9 +1891,9 @@ version = "0.1.0"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language_e2e_tests 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
 ]
 
 [[package]]
@@ -1908,10 +1908,10 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-view 0.1.0",
@@ -2026,11 +2026,11 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "network 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2162,6 +2162,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-proptest-helpers"
+version = "0.1.0"
+dependencies = [
+ "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-prost-ext"
 version = "0.1.0"
 dependencies = [
@@ -2210,11 +2219,11 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "num_enum 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2258,6 +2267,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
@@ -2265,7 +2275,6 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2549,6 +2558,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "memsocket 0.1.0",
@@ -2557,7 +2567,6 @@ dependencies = [
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3081,15 +3090,6 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proptest-helpers"
-version = "0.1.0"
-dependencies = [
- "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5163,11 +5163,11 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5192,11 +5192,11 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest-helpers 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-view 0.1.0",
  "stdlib 0.1.0",

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -38,16 +38,16 @@ libra-prost-ext = { path = "../../common/prost-ext" }
 network = { path = "../../network" }
 
 storage-service = { path = "../../storage/storage-service", optional = true }
-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }
 proptest = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
 storage-service = { path = "../../storage/storage-service" }
 libra-types = { path = "../../types", features = ["testing"] }
-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers" }
 proptest = "0.9.4"
 
 [features]
 default = []
-fuzzing = ["storage-service", "proptest-helpers", "proptest"]
+fuzzing = ["storage-service", "libra-proptest-helpers", "proptest"]

--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -7,9 +7,9 @@ use crate::{
     mocks::local_mock_mempool::LocalMockMempool,
 };
 use futures::channel::mpsc;
+use libra_proptest_helpers::ValueGenerator;
 use libra_types::transaction::SignedTransaction;
 use proptest;
-use proptest_helpers::ValueGenerator;
 use prost::Message;
 use std::sync::Arc;
 use storage_service::mocks::mock_storage_client::MockStorageReadClient;

--- a/common/proptest-helpers/Cargo.toml
+++ b/common/proptest-helpers/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "proptest-helpers"
+name = "libra-proptest-helpers"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 description = "Libra proptest helpers"

--- a/common/proptest-helpers/src/growing_subset.rs
+++ b/common/proptest-helpers/src/growing_subset.rs
@@ -15,7 +15,7 @@ use std::iter::FromIterator;
 /// # Examples
 ///
 /// ```
-/// use proptest_helpers::GrowingSubset;
+/// use libra_proptest_helpers::GrowingSubset;
 /// let items = vec![(1, "a"), (3, "c"), (2, "b"), (2, "d")];
 /// let mut subset: GrowingSubset<_, _> = items.into_iter().collect();
 ///

--- a/common/proptest-helpers/src/lib.rs
+++ b/common/proptest-helpers/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 ///
 /// ```
 /// use proptest::prelude::*;
-/// use proptest_helpers::with_stack_size;
+/// use libra_proptest_helpers::with_stack_size;
 ///
 /// with_stack_size(4 * 1024 * 1024, || proptest!(|(x in 0usize..128)| {
 ///     // assertions go here

--- a/common/proptest-helpers/src/repeat_vec.rs
+++ b/common/proptest-helpers/src/repeat_vec.rs
@@ -18,7 +18,7 @@ use std::iter;
 /// # Examples
 ///
 /// ```
-/// use proptest_helpers::RepeatVec;
+/// use libra_proptest_helpers::RepeatVec;
 ///
 /// let mut repeat_vec = RepeatVec::new();
 /// repeat_vec.extend("a", 10); // logically, insert "a" 10 times
@@ -33,7 +33,7 @@ use std::iter;
 /// The data structure doesn't care about whether the inserted items are equal or not.
 ///
 /// ```
-/// use proptest_helpers::RepeatVec;
+/// use libra_proptest_helpers::RepeatVec;
 ///
 /// let mut repeat_vec = RepeatVec::new();
 /// repeat_vec.extend("a", 10); // logically, insert "a" 10 times
@@ -78,7 +78,7 @@ impl<T> RepeatVec<T> {
     /// # Examples
     ///
     /// ```
-    /// use proptest_helpers::RepeatVec;
+    /// use libra_proptest_helpers::RepeatVec;
     ///
     /// let mut repeat_vec = RepeatVec::new();
     ///

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ criterion = "0.3.0"
 proptest = "0.9.4"
 
 language_e2e_tests = { path = "../e2e_tests" }
-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]

--- a/language/benchmarks/src/transactions.rs
+++ b/language/benchmarks/src/transactions.rs
@@ -7,9 +7,9 @@ use language_e2e_tests::{
     executor::FakeExecutor,
     gas_costs::TXN_RESERVED,
 };
+use libra_proptest_helpers::ValueGenerator;
 use libra_types::transaction::SignedTransaction;
 use proptest::{collection::vec, strategy::Strategy};
-use proptest_helpers::ValueGenerator;
 
 /// Benchmarking support for transactions.
 #[derive(Clone, Debug)]

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 proptest = "0.9"
-proptest-helpers = { path = "../../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../../common/proptest-helpers" }
 vm = { path = "../../vm" }
 libra-types = { path = "../../../types" }
 

--- a/language/bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use libra_proptest_helpers::pick_slice_idxs;
 use libra_types::vm_error::{StatusCode, VMStatus};
 use proptest::{
     prelude::*,
     sample::{self, Index as PropIndex},
 };
-use proptest_helpers::pick_slice_idxs;
 use std::collections::BTreeMap;
 use vm::{
     errors::{append_err_info, bounds_error},

--- a/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use libra_proptest_helpers::pick_slice_idxs;
 use libra_types::vm_error::{StatusCode, VMStatus};
 use proptest::{prelude::*, sample::Index as PropIndex};
-use proptest_helpers::pick_slice_idxs;
 use std::collections::BTreeMap;
 use vm::{
     errors::{append_err_info, bytecode_offset_err},

--- a/language/bytecode-verifier/invalid-mutations/src/signature.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/signature.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use libra_proptest_helpers::{pick_slice_idxs, RepeatVec};
 use libra_types::vm_error::{StatusCode, VMStatus};
 use proptest::{
     prelude::*,
     sample::{select, Index as PropIndex},
 };
-use proptest_helpers::{pick_slice_idxs, RepeatVec};
 use std::{collections::BTreeMap, iter};
 use vm::{
     errors::append_err_info,

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -26,7 +26,7 @@ vm_runtime = { path = "../vm/vm_runtime" }
 vm_runtime_types = { path = "../vm/vm_runtime/vm_runtime_types" }
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers" }
 prost = "0.5.0"
 libra-config =  { path = "../../config" }
 libra-logger = { path = "../../common/logger" }

--- a/language/e2e_tests/src/account_universe/create_account.rs
+++ b/language/e2e_tests/src/account_universe/create_account.rs
@@ -9,13 +9,13 @@ use crate::{
     common_transactions::create_account_txn,
     gas_costs,
 };
+use libra_proptest_helpers::Index;
 use libra_types::{
     transaction::{SignedTransaction, TransactionStatus},
     vm_error::{StatusCode, VMStatus},
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
-use proptest_helpers::Index;
 
 /// Represents a create-account transaction performed in the account universe.
 ///

--- a/language/e2e_tests/src/account_universe/peer_to_peer.rs
+++ b/language/e2e_tests/src/account_universe/peer_to_peer.rs
@@ -9,13 +9,13 @@ use crate::{
     common_transactions::peer_to_peer_txn,
     gas_costs,
 };
+use libra_proptest_helpers::Index;
 use libra_types::{
     transaction::{SignedTransaction, TransactionStatus},
     vm_error::{StatusCode, VMStatus},
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
-use proptest_helpers::Index;
 
 /// Represents a peer-to-peer transaction performed in the account universe.
 ///

--- a/language/e2e_tests/src/account_universe/rotate_key.rs
+++ b/language/e2e_tests/src/account_universe/rotate_key.rs
@@ -7,6 +7,7 @@ use crate::{
     gas_costs,
 };
 use libra_crypto::ed25519::{compat::keypair_strategy, *};
+use libra_proptest_helpers::Index;
 use libra_types::{
     account_address::AccountAddress,
     transaction::{SignedTransaction, TransactionStatus},
@@ -14,7 +15,6 @@ use libra_types::{
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
-use proptest_helpers::Index;
 
 /// Represents a rotate-key transaction performed in the account universe.
 #[derive(Arbitrary, Clone, Debug)]

--- a/language/e2e_tests/src/account_universe/universe.rs
+++ b/language/e2e_tests/src/account_universe/universe.rs
@@ -8,12 +8,12 @@ use crate::{
     account_universe::{default_num_accounts, default_num_transactions, AccountCurrent},
     executor::FakeExecutor,
 };
+use libra_proptest_helpers::{pick_slice_idxs, Index};
 use proptest::{
     collection::{vec, SizeRange},
     prelude::*,
 };
 use proptest_derive::Arbitrary;
-use proptest_helpers::{pick_slice_idxs, Index};
 
 /// A set of accounts which can be used to construct an initial state.
 ///

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1", features = ["derive"] }
 lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]

--- a/language/vm/src/proptest_types.rs
+++ b/language/vm/src/proptest_types.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     vm_string::VMString,
 };
+use libra_proptest_helpers::GrowingSubset;
 use libra_types::{account_address::AccountAddress, byte_array::ByteArray, identifier::Identifier};
 use proptest::{
     collection::{vec, SizeRange},
@@ -20,7 +21,6 @@ use proptest::{
     prelude::*,
     sample::Index as PropIndex,
 };
-use proptest_helpers::GrowingSubset;
 
 mod functions;
 mod signature;

--- a/language/vm/vm-genesis/Cargo.toml
+++ b/language/vm/vm-genesis/Cargo.toml
@@ -30,5 +30,5 @@ lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" 
 libra-crypto = { path = "../../../crypto/crypto", features = ["testing"]}
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
-proptest-helpers = { path = "../../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../../common/proptest-helpers" }
 libra-types = { path = "../../../types", features = ["testing"] }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -36,14 +36,14 @@ noise = { path = "noise" }
 libra-prost-ext = { path = "../common/prost-ext" }
 
 proptest = { version = "0.9.4", default-features = false, optional = true }
-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
+libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
 libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
 libra-types = { path = "../types", features = ["testing"]}
 proptest = { version = "0.9.4", default-features = false }
-proptest-helpers = { path = "../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../common/proptest-helpers" }
 socket-bench-server = { path = "socket-bench-server" }
 
 [build-dependencies]
@@ -59,4 +59,4 @@ harness = false
 
 [features]
 default = []
-fuzzing = ["proptest", "proptest-helpers"]
+fuzzing = ["proptest", "libra-proptest-helpers"]

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -14,10 +14,10 @@ use futures::{
     io::{AsyncReadExt, AsyncWriteExt},
     stream::StreamExt,
 };
+use libra_proptest_helpers::ValueGenerator;
 use libra_types::{account_address::ADDRESS_LENGTH, PeerId};
 use memsocket::MemorySocket;
 use proptest::{arbitrary::any, collection::vec, prop_oneof, strategy::Strategy};
-use proptest_helpers::ValueGenerator;
 use std::{io, time::Duration};
 use tokio::{
     codec::{Encoder, LengthDelimitedCodec},

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -39,7 +39,7 @@ libra-tools = { path = "../../common/tools" }
 libra-types = { path = "../../types" }
 
 [dev-dependencies]
-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers" }
 libra-types = { path = "../../types", features = ["testing"]}
 
 [features]

--- a/storage/libradb/src/event_store/test.rs
+++ b/storage/libradb/src/event_store/test.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::LibraDB;
 use itertools::Itertools;
 use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
+use libra_proptest_helpers::Index;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::AccountAddress,
@@ -17,7 +18,6 @@ use proptest::{
     prelude::*,
     strategy::Union,
 };
-use proptest_helpers::Index;
 use rand::Rng;
 use std::collections::HashMap;
 

--- a/storage/libradb/src/transaction_store/test.rs
+++ b/storage/libradb/src/transaction_store/test.rs
@@ -3,10 +3,10 @@
 
 use super::*;
 use crate::LibraDB;
+use libra_proptest_helpers::Index;
 use libra_tools::tempdir::TempPath;
 use libra_types::proptest_types::{AccountInfoUniverse, SignatureCheckedTransactionGen};
 use proptest::{collection::vec, prelude::*};
-use proptest_helpers::Index;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -16,7 +16,7 @@ failure = { path = "../../common/failure_ext", package = "failure_ext" }
 hex = { version = "0.3.2", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 proptest = { version = "0.9.4", default-features = false }
-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers" }
 libra-prost-ext = { path = "../../common/prost-ext" }
 prost = "0.5.0"
 rusty-fork = { version = "0.2.2", default-features = false }

--- a/testsuite/libra-fuzzer/src/commands.rs
+++ b/testsuite/libra-fuzzer/src/commands.rs
@@ -3,7 +3,7 @@
 
 use crate::FuzzTarget;
 use failure::prelude::*;
-use proptest_helpers::ValueGenerator;
+use libra_proptest_helpers::ValueGenerator;
 use sha1::{Digest, Sha1};
 use std::{
     env,

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -34,7 +34,7 @@ macro_rules! proto_fuzz_target {
             fn generate(
                 &self,
                 _idx: usize,
-                gen: &mut ::proptest_helpers::ValueGenerator,
+                gen: &mut ::libra_proptest_helpers::ValueGenerator,
             ) -> Option<Vec<u8>> {
                 use libra_prost_ext::MessageExt;
 

--- a/testsuite/libra-fuzzer/src/fuzz_targets/admission_control.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/admission_control.rs
@@ -1,6 +1,6 @@
 use crate::FuzzTargetImpl;
 use admission_control_service::admission_control_service::fuzzing::{fuzzer, generate_corpus};
-use proptest_helpers::ValueGenerator;
+use libra_proptest_helpers::ValueGenerator;
 
 #[derive(Clone, Debug, Default)]
 pub struct AdmissionControlSubmitTransactionRequest;

--- a/testsuite/libra-fuzzer/src/fuzz_targets/compiled_module.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/compiled_module.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FuzzTargetImpl;
+use libra_proptest_helpers::ValueGenerator;
 use proptest::prelude::*;
-use proptest_helpers::ValueGenerator;
 use vm::file_format::{CompiledModule, CompiledModuleMut};
 
 #[derive(Clone, Debug, Default)]

--- a/testsuite/libra-fuzzer/src/fuzz_targets/consensus_proposal.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/consensus_proposal.rs
@@ -1,6 +1,6 @@
 use crate::FuzzTargetImpl;
 use consensus::event_processor_fuzzing::{fuzz_proposal, generate_corpus_proposal};
-use proptest_helpers::ValueGenerator;
+use libra_proptest_helpers::ValueGenerator;
 
 #[derive(Clone, Debug, Default)]
 pub struct ConsensusProposal;

--- a/testsuite/libra-fuzzer/src/fuzz_targets/inbound_rpc_protocol.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/inbound_rpc_protocol.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FuzzTargetImpl;
+use libra_proptest_helpers::ValueGenerator;
 use network::protocols::rpc;
-use proptest_helpers::ValueGenerator;
 
 #[derive(Clone, Debug, Default)]
 pub struct RpcInboundRequest;

--- a/testsuite/libra-fuzzer/src/fuzz_targets/inner_signed_transaction.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/inner_signed_transaction.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::FuzzTargetImpl;
+use libra_proptest_helpers::ValueGenerator;
 use libra_types::transaction::SignedTransaction;
 use proptest::prelude::*;
-use proptest_helpers::ValueGenerator;
 
 #[derive(Clone, Debug, Default)]
 pub struct SignedTransactionTarget;

--- a/testsuite/libra-fuzzer/src/fuzz_targets/vm_value.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/vm_value.rs
@@ -4,7 +4,7 @@
 use crate::FuzzTargetImpl;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use failure::prelude::*;
-use proptest_helpers::ValueGenerator;
+use libra_proptest_helpers::ValueGenerator;
 use std::io::Cursor;
 use vm_runtime_types::{
     loaded_data::{struct_def::StructDef, types::Type},

--- a/testsuite/libra-fuzzer/src/lib.rs
+++ b/testsuite/libra-fuzzer/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use proptest_helpers::ValueGenerator;
+use libra_proptest_helpers::ValueGenerator;
 use std::{fmt, ops::Deref, str::FromStr};
 
 pub mod commands;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -29,7 +29,7 @@ tiny-keccak = { version = "1.5.0", default-features = false }
 lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
-proptest-helpers = { path = "../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../common/proptest-helpers" }
 num_enum = "0.4.1"
 
 [build-dependencies]

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -29,13 +29,13 @@ use libra_crypto::{
     traits::*,
     HashValue,
 };
+use libra_proptest_helpers::Index;
 use proptest::{
     collection::{vec, SizeRange},
     option,
     prelude::*,
 };
 use proptest_derive::Arbitrary;
-use proptest_helpers::Index;
 use std::time::Duration;
 
 prop_compose! {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `proptest-helpers` package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235
#1350
#1353
#1371
#1377
#1393
#1394
#1396