### PR TITLE
[crypto] enforce that private keys do not implement Clone statically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)",
@@ -4209,6 +4210,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "statistical"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5874,6 +5880,7 @@ dependencies = [
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fa13613355688665b68639b1c378a62dbedea78aff0fc59a4fa656cbbdec657"
 "checksum statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49d57902bb128e5e38b5218d3681215ae3e322d99f65d5420e9849730d2ea372"
 "checksum stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 sha2 = "0.8.0"
 sha3 = "0.8.2"
+static_assertions = "1.0.0"
 threshold_crypto = "0.3"
 tiny-keccak = "1.5.0"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false }

--- a/crypto/crypto/src/bls12381.rs
+++ b/crypto/crypto/src/bls12381.rs
@@ -40,6 +40,8 @@ use pairing::{
 };
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+#[cfg(not(any(test, feature = "testing")))]
+use static_assertions::assert_not_impl_any;
 
 /// The length of the BLS12381PrivateKey.
 pub const BLS12381_PRIVATE_KEY_LENGTH: usize = 32;
@@ -55,6 +57,9 @@ type ThresholdBLSPrivateKey =
 /// A BLS12-381 private key.
 #[derive(Serialize, Deserialize, Deref, SilentDisplay, SilentDebug)]
 pub struct BLS12381PrivateKey(ThresholdBLSPrivateKey);
+
+#[cfg(not(any(test, feature = "testing")))]
+assert_not_impl_any!(BLS12381PrivateKey: std::clone::Clone,);
 
 /// A BLS12-381 public key.
 #[derive(Clone, Hash, Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -35,6 +35,8 @@ use ed25519_dalek;
 use failure::prelude::*;
 use libra_crypto_derive::{SilentDebug, SilentDisplay};
 use serde::{de, ser};
+#[cfg(not(any(test, feature = "testing")))]
+use static_assertions::assert_not_impl_any;
 use std::fmt;
 
 /// The length of the Ed25519PrivateKey
@@ -53,6 +55,9 @@ const L: [u8; 32] = [
 /// An Ed25519 private key
 #[derive(SilentDisplay, SilentDebug)]
 pub struct Ed25519PrivateKey(ed25519_dalek::SecretKey);
+
+#[cfg(not(any(test, feature = "testing")))]
+assert_not_impl_any!(Ed25519PrivateKey: std::clone::Clone,);
 
 /// An Ed25519 public key
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This uses [static-assertions](https://github.com/nvzqz/static-assertions-rs) (by @nvzqz) to make sure that Private Key types do not implement Clone. This should help restrictions of the feature-gating that are in preparation.
