### PR TITLE
Prepend libra to state-view package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,13 +1229,13 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-prost-ext 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-view 0.1.0",
  "storage-client 0.1.0",
  "storage-proto 0.1.0",
  "storage-service 0.1.0",
@@ -1909,12 +1909,12 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-view 0.1.0",
  "stdlib 0.1.0",
  "transaction-builder 0.1.0",
  "vm 0.1.0",
@@ -2176,6 +2176,14 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-state-view"
+version = "0.1.0"
+dependencies = [
+ "failure_ext 0.1.0",
+ "libra-types 0.1.0",
 ]
 
 [[package]]
@@ -4199,14 +4207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "state-view"
-version = "0.1.0"
-dependencies = [
- "failure_ext 0.1.0",
- "libra-types 0.1.0",
-]
-
-[[package]]
 name = "statistical"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,10 +4240,10 @@ dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
- "state-view 0.1.0",
  "storage-proto 0.1.0",
 ]
 
@@ -5194,11 +5194,11 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-view 0.1.0",
  "stdlib 0.1.0",
  "transaction-builder 0.1.0",
  "vm 0.1.0",
@@ -5221,13 +5221,13 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "state-view 0.1.0",
  "vm 0.1.0",
  "vm-cache-map 0.1.0",
  "vm_runtime_types 0.1.0",
@@ -5261,10 +5261,10 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
- "state-view 0.1.0",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "transaction-builder 0.1.0",

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -25,7 +25,7 @@ libra-logger = { path = "../common/logger" }
 libra-metrics = { path = "../common/metrics" }
 libra-prost-ext = { path = "../common/prost-ext" }
 scratchpad = { path = "../storage/scratchpad" }
-state-view = { path = "../storage/state-view" }
+libra-state-view = { path = "../storage/state-view" }
 storage-client = { path = "../storage/storage-client" }
 libra-types = { path = "../types" }
 vm_runtime = { path = "../language/vm/vm_runtime" }

--- a/executor/src/mock_vm/mock_vm_test.rs
+++ b/executor/src/mock_vm/mock_vm_test.rs
@@ -4,13 +4,13 @@
 use super::{balance_ap, encode_mint_transaction, encode_transfer_transaction, seqnum_ap, MockVM};
 use failure::Result;
 use libra_config::config::VMConfig;
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
     transaction::Transaction,
     write_set::WriteOp,
 };
-use state_view::StateView;
 use vm_runtime::VMExecutor;
 
 fn gen_address(index: u8) -> AccountAddress {

--- a/executor/src/mock_vm/mod.rs
+++ b/executor/src/mock_vm/mod.rs
@@ -8,6 +8,7 @@ use failure::Result;
 use lazy_static::lazy_static;
 use libra_config::config::VMConfig;
 use libra_crypto::ed25519::compat;
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
@@ -20,7 +21,6 @@ use libra_types::{
     vm_error::{StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
-use state_view::StateView;
 use std::collections::HashMap;
 use vm_runtime::VMExecutor;
 

--- a/language/e2e_tests/Cargo.toml
+++ b/language/e2e_tests/Cargo.toml
@@ -17,7 +17,7 @@ compiler = { path = "../compiler" }
 lazy_static = "1.3.0"
 libra-crypto = { path = "../../crypto/crypto"}
 rand = "0.6.5"
-state-view = { path = "../../storage/state-view" }
+libra-state-view = { path = "../../storage/state-view" }
 libra-types = { path = "../../types" }
 transaction-builder = { path = "../transaction-builder", features = ["testing"]}
 vm = { path = "../vm" }

--- a/language/e2e_tests/src/data_store.rs
+++ b/language/e2e_tests/src/data_store.rs
@@ -6,6 +6,7 @@
 use crate::account::AccountData;
 use failure::prelude::*;
 use lazy_static::lazy_static;
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     language_storage::ModuleId,
@@ -13,7 +14,6 @@ use libra_types::{
     write_set::{WriteOp, WriteSet},
 };
 use prost::Message;
-use state_view::StateView;
 use std::convert::TryFrom;
 use std::{collections::HashMap, fs::File, io::prelude::*, path::PathBuf};
 use vm::{errors::*, CompiledModule};

--- a/language/e2e_tests/src/executor.rs
+++ b/language/e2e_tests/src/executor.rs
@@ -8,6 +8,7 @@ use crate::{
     data_store::{FakeDataStore, GENESIS_WRITE_SET, TESTNET_GENESIS},
 };
 use libra_config::config::{NodeConfig, NodeConfigHelpers, VMPublishingOption};
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     account_config::AccountResource,
@@ -16,7 +17,6 @@ use libra_types::{
     vm_error::VMStatus,
     write_set::WriteSet,
 };
-use state_view::StateView;
 use vm::CompiledModule;
 use vm_runtime::{MoveVM, VMExecutor, VMVerifier};
 

--- a/language/vm/vm-genesis/Cargo.toml
+++ b/language/vm/vm-genesis/Cargo.toml
@@ -16,7 +16,7 @@ transaction-builder = { path = "../../transaction-builder"}
 libra-crypto = { path = "../../../crypto/crypto" }
 stdlib = { path = "../../stdlib" }
 libra-prost-ext = { path = "../../../common/prost-ext" }
-state-view = { path = "../../../storage/state-view" }
+libra-state-view = { path = "../../../storage/state-view" }
 libra-types = { path = "../../../types" }
 vm = { path = "../" }
 vm-cache-map = { path = "../vm_runtime/vm-cache-map" }

--- a/language/vm/vm-genesis/src/lib.rs
+++ b/language/vm/vm-genesis/src/lib.rs
@@ -4,6 +4,7 @@
 use failure::prelude::*;
 use lazy_static::lazy_static;
 use libra_crypto::{ed25519::*, traits::ValidKey};
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -14,7 +15,6 @@ use libra_types::{
     validator_set::ValidatorSet,
 };
 use rand::{rngs::StdRng, SeedableRng};
-use state_view::StateView;
 use std::time::Duration;
 use stdlib::stdlib_modules;
 use vm::{access::ModuleAccess, transaction_metadata::TransactionMetadata};

--- a/language/vm/vm_runtime/Cargo.toml
+++ b/language/vm/vm_runtime/Cargo.toml
@@ -24,7 +24,7 @@ libra-config = { path = "../../../config" }
 libra-crypto = { path = "../../../crypto/crypto" }
 libra-logger = { path = "../../../common/logger" }
 libra-metrics = { path = "../../../common/metrics" }
-state-view = { path = "../../../storage/state-view" }
+libra-state-view = { path = "../../../storage/state-view" }
 libra-types = { path = "../../../types" }
 vm = { path = "../" }
 vm-cache-map = { path = "vm-cache-map" }

--- a/language/vm/vm_runtime/src/block_processor.rs
+++ b/language/vm/vm_runtime/src/block_processor.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use libra_config::config::VMPublishingOption;
 use libra_logger::prelude::*;
+use libra_state_view::StateView;
 use libra_types::{
     transaction::{
         SignatureCheckedTransaction, SignedTransaction, TransactionOutput, TransactionStatus,
@@ -21,7 +22,6 @@ use libra_types::{
     write_set::WriteSet,
 };
 use rayon::prelude::*;
-use state_view::StateView;
 use vm_cache_map::Arena;
 
 pub fn execute_block<'alloc>(

--- a/language/vm/vm_runtime/src/code_cache/module_adapter.rs
+++ b/language/vm/vm_runtime/src/code_cache/module_adapter.rs
@@ -3,8 +3,8 @@
 //! Fetches code data from the blockchain.
 
 use libra_logger::prelude::*;
+use libra_state_view::StateView;
 use libra_types::language_storage::ModuleId;
-use state_view::StateView;
 use std::collections::HashMap;
 use vm::file_format::CompiledModule;
 

--- a/language/vm/vm_runtime/src/data_cache.rs
+++ b/language/vm/vm_runtime/src/data_cache.rs
@@ -3,13 +3,13 @@
 //! Scratchpad for on chain values during the execution.
 
 use libra_logger::prelude::*;
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     language_storage::ModuleId,
     vm_error::{sub_status, StatusCode, VMStatus},
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
-use state_view::StateView;
 use std::{collections::btree_map::BTreeMap, mem::replace};
 use vm::{
     errors::*,

--- a/language/vm/vm_runtime/src/lib.rs
+++ b/language/vm/vm_runtime/src/lib.rs
@@ -138,11 +138,11 @@ pub use txn_executor::execute_function;
 
 use failure::prelude::*;
 use libra_config::config::VMConfig;
+use libra_state_view::StateView;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
 };
-use state_view::StateView;
 use vm::IndexKind;
 
 /// This trait describes the VM's verification interfaces.

--- a/language/vm/vm_runtime/src/move_vm.rs
+++ b/language/vm/vm_runtime/src/move_vm.rs
@@ -6,11 +6,11 @@ use crate::{
     VMVerifier,
 };
 use failure::prelude::*;
+use libra_state_view::StateView;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::VMStatus,
 };
-use state_view::StateView;
 use std::sync::Arc;
 use vm_cache_map::Arena;
 

--- a/language/vm/vm_runtime/src/runtime.rs
+++ b/language/vm/vm_runtime/src/runtime.rs
@@ -16,11 +16,11 @@ use crate::{
 use failure::prelude::*;
 use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_logger::prelude::*;
+use libra_state_view::StateView;
 use libra_types::{
     transaction::{SignedTransaction, Transaction, TransactionOutput},
     vm_error::{StatusCode, VMStatus},
 };
-use state_view::StateView;
 use std::convert::TryFrom;
 use vm_cache_map::Arena;
 

--- a/storage/state-view/Cargo.toml
+++ b/storage/state-view/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "state-view"
+name = "libra-state-view"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 description = "Libra state view"

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.6.5"
 libra-crypto = { path = "../../crypto/crypto" }
 failure = { path = "../../common/failure_ext", package = "failure_ext" }
 scratchpad = { path = "../scratchpad" }
-state-view = { path = "../state-view" }
+libra-state-view = { path = "../state-view" }
 storage-proto = { path = "../storage-proto" }
 libra-types = { path = "../../types" }
 

--- a/storage/storage-client/src/state_view.rs
+++ b/storage/storage-client/src/state_view.rs
@@ -4,12 +4,12 @@
 use crate::StorageRead;
 use failure::prelude::*;
 use libra_crypto::{hash::CryptoHash, HashValue};
+use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath, account_address::AccountAddress, proof::SparseMerkleProof,
     transaction::Version,
 };
 use scratchpad::{AccountState, SparseMerkleTree};
-use state_view::StateView;
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap},

--- a/vm_validator/Cargo.toml
+++ b/vm_validator/Cargo.toml
@@ -14,7 +14,7 @@ libra-config = { path = "../config" }
 failure = { path = "../common/failure_ext", package = "failure_ext" }
 futures = "0.1.28"
 scratchpad = { path = "../storage/scratchpad" }
-state-view = { path = "../storage/state-view" }
+libra-state-view = { path = "../storage/state-view" }
 storage-client = { path = "../storage/storage-client" }
 libra-types = { path = "../types" }
 vm_runtime = { path = "../language/vm/vm_runtime" }

--- a/vm_validator/src/mocks/mock_vm_validator.rs
+++ b/vm_validator/src/mocks/mock_vm_validator.rs
@@ -3,12 +3,12 @@
 
 use crate::vm_validator::TransactionValidation;
 use futures::future::{ok, Future};
+use libra_state_view::StateView;
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
     transaction::SignedTransaction,
     vm_error::{StatusCode, VMStatus},
 };
-use state_view::StateView;
 use std::convert::TryFrom;
 use vm_runtime::VMVerifier;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish to crates.io, all packages need to have unique names. Prepending libra to the names of all packages provides unique names for all packages. This PR prepends libra to the `state-view` package.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing tests should suffice.

## Related PRs

#1226
#1235
#1350
#1353
#1371
#1377
#1393
#1394
#1396
#1402