### PR TITLE
let `TransactionListWithProof` carry `enum Transaction`

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -19,7 +19,7 @@ use libra_types::{
     contract_event::{ContractEvent, EventWithProof},
     transaction::{
         helpers::{create_signed_txn, create_unsigned_txn, TransactionSigner},
-        parse_as_transaction_argument, RawTransaction, Script, SignedTransaction,
+        parse_as_transaction_argument, RawTransaction, Script, SignedTransaction, Transaction,
         TransactionArgument, TransactionPayload, Version,
     },
 };
@@ -637,7 +637,7 @@ impl ClientProxy {
     pub fn get_committed_txn_by_range(
         &mut self,
         space_delim_strings: &[&str],
-    ) -> Result<Vec<(SignedTransaction, Option<Vec<ContractEvent>>)>> {
+    ) -> Result<Vec<(Transaction, Option<Vec<ContractEvent>>)>> {
         ensure!(
             space_delim_strings.len() == 4,
             "Invalid number of arguments to get transaction by range"

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -24,7 +24,7 @@ use libra_types::{
     get_with_proof::{
         RequestItem, ResponseItem, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,
     },
-    transaction::{SignedTransaction, Version},
+    transaction::{SignedTransaction, Transaction, Version},
     vm_error::StatusCode,
 };
 use std::convert::TryFrom;
@@ -236,7 +236,7 @@ impl GRPCClient {
         start_version: u64,
         limit: u64,
         fetch_events: bool,
-    ) -> Result<Vec<(SignedTransaction, Option<Vec<ContractEvent>>)>> {
+    ) -> Result<Vec<(Transaction, Option<Vec<ContractEvent>>)>> {
         // Make the request.
         let req_item = RequestItem::GetTransactions {
             start_version,

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -257,14 +257,7 @@ where
         );
         let vm_outputs = {
             let _timer = OP_COUNTERS.timer("vm_execute_chunk_time_s");
-            V::execute_block(
-                transactions
-                    .iter()
-                    .map(|txn| Transaction::UserTransaction(txn.clone()))
-                    .collect(),
-                &self.vm_config,
-                &state_view,
-            )?
+            V::execute_block(transactions.to_vec(), &self.vm_config, &state_view)?
         };
 
         // Since other validators have committed these transactions, their status should all be
@@ -277,11 +270,6 @@ where
 
         let (account_to_btree, account_to_proof) = state_view.into();
 
-        // TODO: Remove once `TransactionListWithProof` carries `enum Transaction`
-        let transactions = transactions
-            .into_iter()
-            .map(Transaction::UserTransaction)
-            .collect::<Vec<_>>();
         let (output, _next_validator_set) = Self::process_vm_outputs(
             account_to_btree,
             account_to_proof,

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -641,7 +641,8 @@ fn verify_transactions(
     let txns = txn_list_with_proof
         .transaction_and_infos
         .iter()
-        .map(|(txn, _)| Transaction::UserTransaction(txn.clone()))
+        .map(|(txn, _)| txn)
+        .cloned()
         .collect::<Vec<_>>();
     ensure!(
         expected_txns == &txns[..],

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -17,7 +17,7 @@ use libra_types::{
     ledger_info::LedgerInfo as TypesLedgerInfo,
     proof::AccumulatorProof,
     test_helpers::transaction_test_helpers::get_test_signed_txn,
-    transaction::{TransactionInfo, TransactionListWithProof},
+    transaction::{Transaction, TransactionInfo, TransactionListWithProof},
     vm_error::StatusCode,
 };
 use network::{
@@ -83,13 +83,13 @@ impl MockExecutorProxy {
         let sender = AccountAddress::from_public_key(&GENESIS_KEYPAIR.1);
         let receiver = AccountAddress::new([0xff; 32]);
         let program = encode_transfer_script(&receiver, 1);
-        let transaction = get_test_signed_txn(
+        let transaction = Transaction::UserTransaction(get_test_signed_txn(
             sender,
             version + 1,
             GENESIS_KEYPAIR.0.clone(),
             GENESIS_KEYPAIR.1.clone(),
             Some(program),
-        );
+        ));
 
         let txn_info = TransactionInfo::new(
             HashValue::zero(),

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -707,7 +707,10 @@ impl LibraDB {
                 .get_transaction_info_with_proof(version, ledger_version)?;
             SignedTransactionProof::new(txn_info_accumulator_proof, txn_info)
         };
-        let signed_transaction = self.transaction_store.get_transaction(version)?;
+        let signed_transaction = self
+            .transaction_store
+            .get_transaction(version)?
+            .try_into()?;
 
         // If events were requested, also fetch those.
         let events = if fetch_events {

--- a/storage/libradb/src/transaction_store/mod.rs
+++ b/storage/libradb/src/transaction_store/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 use failure::prelude::*;
 use libra_types::{
     account_address::AccountAddress,
-    transaction::{SignedTransaction, Transaction, Version},
+    transaction::{Transaction, Version},
 };
 use schemadb::DB;
 use std::sync::Arc;
@@ -45,17 +45,10 @@ impl TransactionStore {
     }
 
     /// Get signed transaction given `version`
-    pub fn get_transaction(&self, version: Version) -> Result<SignedTransaction> {
-        let txn = self
-            .db
+    pub fn get_transaction(&self, version: Version) -> Result<Transaction> {
+        self.db
             .get::<TransactionSchema>(&version)?
-            .ok_or_else(|| LibraDbError::NotFound(format!("Txn {}", version)))?;
-
-        match txn {
-            Transaction::UserTransaction(user_txn) => Ok(user_txn),
-            // TODO: support other variants after API change
-            _ => unreachable!("Currently only supports user transactions."),
-        }
+            .ok_or_else(|| LibraDbError::NotFound(format!("Txn {}", version)).into())
     }
 
     /// Save signed transaction at `version`

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -22,7 +22,7 @@ use libra_types::{
         UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,
     },
     test_helpers::transaction_test_helpers::get_test_signed_txn,
-    transaction::Version,
+    transaction::{Transaction, Version},
     vm_error::StatusCode,
 };
 use rand::{
@@ -256,7 +256,7 @@ fn get_mock_txn_data(
     start_seq: u64,
     end_seq: u64,
 ) -> (
-    Vec<libra_types::proto::types::SignedTransaction>,
+    Vec<libra_types::proto::types::Transaction>,
     Vec<TransactionInfo>,
 ) {
     let mut seed_rng = OsRng::new().expect("can't access OsRng");
@@ -266,7 +266,13 @@ fn get_mock_txn_data(
     let mut txns = vec![];
     let mut infos = vec![];
     for i in start_seq..=end_seq {
-        let txn = get_test_signed_txn(address, i, priv_key.clone(), pub_key.clone(), None);
+        let txn = Transaction::UserTransaction(get_test_signed_txn(
+            address,
+            i,
+            priv_key.clone(),
+            pub_key.clone(),
+            None,
+        ));
         txns.push(txn.into());
 
         let info = get_transaction_info().into();

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -121,7 +121,7 @@ pub(crate) fn verify_transaction_list(
         .map(|(txn, txn_info)| {
             // Verify all transaction_infos and signed_transactions are consistent.
             ensure!(
-                txn.hash() == txn_info.signed_transaction_hash(),
+                txn.as_signed_user_txn()?.hash() == txn_info.signed_transaction_hash(),
                 "Some hash of signed transaction does not match the corresponding transaction info in proof"
             );
             Ok(txn_info.hash())

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::transaction::Transaction;
 use crate::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -467,7 +468,7 @@ fn test_verify_account_state_and_event() {
 // Return a variable length of transaction_and_info list with a random range within [0,
 // list_length).
 fn arb_signed_txn_list_and_range(
-) -> impl Strategy<Value = (Vec<(SignedTransaction, TransactionInfo)>, usize, usize)> {
+) -> impl Strategy<Value = (Vec<(Transaction, TransactionInfo)>, usize, usize)> {
     vec(
         (any::<SignedTransaction>(), any::<TransactionInfo>()),
         0..100,
@@ -486,7 +487,7 @@ fn arb_signed_txn_list_and_range(
             .map(|(txn, txn_info)| {
                 let txn_hash = txn.hash();
                 (
-                    txn,
+                    Transaction::UserTransaction(txn),
                     TransactionInfo::new(
                         txn_hash,
                         txn_info.state_root_hash(),

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -820,7 +820,7 @@ fn arb_transaction_list_with_proof() -> impl Strategy<Value = TransactionListWit
         let transaction_and_infos: Vec<_> = transaction_and_infos_and_events
             .clone()
             .into_iter()
-            .map(|(transaction, info, _event)| (transaction, info))
+            .map(|(transaction, info, _event)| (Transaction::UserTransaction(transaction), info))
             .collect();
         let events: Vec<_> = transaction_and_infos_and_events
             .into_iter()

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -89,7 +89,7 @@ message TransactionToCommit {
 // verification will fail.
 message TransactionListWithProof {
     // The list of transactions.
-    repeated SignedTransaction transactions = 1;
+    repeated Transaction transactions = 1;
 
     // The list of corresponding TransactionInfo objects.
     repeated TransactionInfo infos = 2;

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -887,7 +887,7 @@ impl From<TransactionToCommit> for crate::proto::types::TransactionToCommit {
 /// 3. The list has 2+ transactions/transaction_infos. The both proofs must exist.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransactionListWithProof {
-    pub transaction_and_infos: Vec<(SignedTransaction, TransactionInfo)>,
+    pub transaction_and_infos: Vec<(Transaction, TransactionInfo)>,
     pub events: Option<Vec<Vec<ContractEvent>>>,
     pub first_transaction_version: Option<Version>,
     pub proof_of_first_transaction: Option<TransactionAccumulatorProof>,
@@ -897,7 +897,7 @@ pub struct TransactionListWithProof {
 impl TransactionListWithProof {
     /// Constructor.
     pub fn new(
-        transaction_and_infos: Vec<(SignedTransaction, TransactionInfo)>,
+        transaction_and_infos: Vec<(Transaction, TransactionInfo)>,
         events: Option<Vec<Vec<ContractEvent>>>,
         first_transaction_version: Option<Version>,
         proof_of_first_transaction: Option<TransactionAccumulatorProof>,
@@ -1010,7 +1010,7 @@ impl TryFrom<crate::proto::types::TransactionListWithProof> for TransactionListW
             itertools::zip_eq(proto.transactions.into_iter(), proto.infos.into_iter())
                 .map(|(txn, info)| {
                     Ok((
-                        SignedTransaction::try_from(txn)?,
+                        Transaction::try_from(txn)?,
                         TransactionInfo::try_from(info)?,
                     ))
                 })
@@ -1100,6 +1100,18 @@ impl Transaction {
         match self {
             Transaction::UserTransaction(txn) => Ok(txn),
             _ => Err(format_err!("Not a user transaction.")),
+        }
+    }
+
+    pub fn format_for_client(&self, get_transaction_name: impl Fn(&[u8]) -> String) -> String {
+        match self {
+            Transaction::UserTransaction(user_txn) => {
+                user_txn.format_for_client(get_transaction_name)
+            }
+            // TODO: display proper information for client
+            Transaction::WriteSet(_write_set) => String::from("genesis"),
+            // TODO: display proper information for client
+            Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
         }
     }
 }


### PR DESCRIPTION
... instead of `SignedTransaction`

## Motivation
Another step towards using `enum Transaction` everywhere instead of `SignedTransaction`. 

part of the effort around #1173

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing coverage.

## Related PRs
based on #1287 