### PR TITLE
[consensus][restart] commit up to highest ledger info after rebuild

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -242,7 +242,6 @@ impl<T: Payload> ChainedBftSMR<T> {
             proposer_election,
             proposal_generator,
             safety_rules,
-            state_computer,
             txn_manager,
             network.clone(),
             Arc::clone(&self.storage),

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -137,9 +137,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     // TODO: have two different nodes, one for proposing, one for accepting a proposal
     let proposer_election = Box::new(RotatingProposer::new(vec![signer.author()], 1));
 
-    // TODO: do we want to fuzz the real StateComputer as well?
-    let empty_state_computer = Arc::new(EmptyStateComputer);
-
     // We do not want to care about the time
     let enforce_increasing_timestamps = false;
 
@@ -151,7 +148,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         proposer_election,
         proposal_generator,
         safety_rules,
-        empty_state_computer,
         Arc::new(MockTransactionManager::new()),
         network,
         storage.clone(),

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -179,7 +179,6 @@ impl NodeSetup {
             proposer_election,
             proposal_generator,
             safety_rules,
-            state_computer,
             Arc::new(MockTransactionManager::new()),
             network,
             storage.clone(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

During restart, if we have LI(S) as ancestor of LI(C), we'll start from LI(S).

This PR enforces us to commit to LI(C) so that  we provide guarantee LI(C) == LI(S) after start consensus, this also simplifies the reasoning of restart + reconfiguration.

We can probably further improve it by having commit triggered by `insert_quorum_cert`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
