### PR TITLE
[consensus] simplify proposal_msg's proto representation

### DIFF
--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{sync_info::SyncInfo, vote::Vote};
+#[cfg(any(test, feature = "fuzzing"))]
 use failure::bail;
 use serde::{Deserialize, Serialize};
+#[cfg(any(test, feature = "fuzzing"))]
+use std::convert::TryInto;
 use std::{
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     fmt::{Display, Formatter},
 };
 

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -182,9 +182,7 @@ fn direct_send_bench(b: &mut Bencher, msg_len: &usize) {
 fn compose_proposal(msg_len: usize) -> ConsensusMsg {
     let mut msg = ConsensusMsg::default();
     let mut proposal = Proposal::default();
-    let mut block = Block::default();
-    block.bytes = vec![0u8; msg_len];
-    proposal.proposed_block = Some(block);
+    proposal.bytes = vec![0u8; msg_len];
     msg.message = Some(ConsensusMsg_oneof::Proposal(proposal));
     msg
 }

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -19,10 +19,7 @@ message ConsensusMsg {
 }
 
 message Proposal {
-  // The proposed block
-  Block proposed_block = 1;
-  // Information about the highest QC, LedgerInfo, TimeoutCertificate, etc.
-  SyncInfo sync_info = 2;
+  bytes bytes = 1;
 }
 
 message SyncInfo {


### PR DESCRIPTION
- consisted of two fields likely due to nuances of serde
- found how-to that describes a really trivial means for fixing that
(https://serde.rs/attr-bound.html)
- now our consensus api has no special fields just message containers