### PR TITLE
[Proof] Introduce AccumulatorRangeProof

### DIFF
--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -374,7 +374,9 @@ where
             num_leaves > 0,
             "num_leaves is zero while first_leaf_index is not None.",
         );
-        let last_leaf_index = first_leaf_index + num_leaves - 1;
+        let last_leaf_index = first_leaf_index
+            .checked_add(num_leaves - 1)
+            .ok_or_else(|| format_err!("Requesting too many leaves."))?;
         ensure!(
             last_leaf_index < self.num_leaves as u64,
             "Invalid last_leaf_index: {}, num_leaves: {}",

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -28,8 +28,9 @@ use libra_crypto::{
 use std::{collections::VecDeque, marker::PhantomData};
 
 pub use self::definition::{
-    AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, EventAccumulatorProof,
-    EventProof, SignedTransactionProof, SparseMerkleProof, TransactionAccumulatorProof,
+    AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, AccumulatorRangeProof,
+    EventAccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleProof,
+    TransactionAccumulatorProof,
 };
 
 #[cfg(any(test, feature = "testing"))]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I wanted to make things more consistent. `AccumulatorProof` is a generic struct that proves one leaf exists in a Merkle accumulator and `SignedTransactionWithProof` is an object that contains an instance of this proof. Similarly, `AccumulatorRangeProof` is a generic struct that proves a list of leaves exist in a Merkle accumulator, and `TransactionListWithProof` will contain an instance of this proof.

This also means that the proof does not depend on the data -- it doesn't matter if data is a list of transaction or a list of events. This way the tests for the proof verification will be easier to write.

This change also removes some of the unnecessary hashes in the proof to make it a bit smaller.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.
