### PR TITLE
Add version numbers to dependencies in Cargo.tomls

### DIFF
--- a/admission_control/admission-control-proto/Cargo.toml
+++ b/admission_control/admission-control-proto/Cargo.toml
@@ -15,13 +15,13 @@ futures = "0.1.28"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 prost = "0.5.0"
 
-failure = { package = "libra-failure-ext", path = "../../common/failure-ext" }
-libra-logger = { path = "../../common/logger" }
-libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
-libra-types = { path = "../../types" }
+failure = { package = "libra-failure-ext", path = "../../common/failure-ext", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -20,32 +20,32 @@ lazy_static = "1.3.0"
 rand = "0.6.5"
 tokio = "0.1.22"
 
-admission-control-proto = { path = "../admission-control-proto" }
-libra-config = { path = "../../config" }
-libra-crypto = { path = "../../crypto/crypto" }
-debug-interface = { path = "../../common/debug-interface" }
-failure = { package = "libra-failure-ext", path = "../../common/failure-ext" }
-executable-helpers = { path = "../../common/executable-helpers" }
-grpc-helpers = { path = "../../common/grpc-helpers" }
-libra-logger = { path = "../../common/logger" }
-libra-mempool = { path = "../../mempool" }
-libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto" }
-libra-metrics = { path = "../../common/metrics" }
-storage-client = { path = "../../storage/storage-client" }
-libra-types = { path = "../../types" }
-vm-validator = { path = "../../vm-validator" }
-libra-prost-ext = { path = "../../common/prost-ext" }
-network = { path = "../../network" }
+admission-control-proto = { path = "../admission-control-proto", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
+failure = { package = "libra-failure-ext", path = "../../common/failure-ext", version = "0.1.0" }
+executable-helpers = { path = "../../common/executable-helpers", version = "0.1.0" }
+grpc-helpers = { path = "../../common/grpc-helpers", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-mempool = { path = "../../mempool", version = "0.1.0" }
+libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto", version = "0.1.0" }
+libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
+storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+vm-validator = { path = "../../vm-validator", version = "0.1.0" }
+libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
+network = { path = "../../network", version = "0.1.0" }
 
-storage-service = { path = "../../storage/storage-service", optional = true }
-libra-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }
+storage-service = { path = "../../storage/storage-service", version = "0.1.0", optional = true }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 proptest = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-storage-service = { path = "../../storage/storage-service" }
-libra-types = { path = "../../types", features = ["testing"] }
-libra-proptest-helpers = { path = "../../common/proptest-helpers" }
+storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 proptest = "0.9.4"
 
 [features]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -20,23 +20,23 @@ structopt = "0.3.2"
 num_cpus = "1.10.1"
 walkdir = "2.2.9"
 
-admission-control-proto = { path = "../admission_control/admission-control-proto" }
-client = { path = "../client" }
-libra-config = { path = "../config" }
-failure = { package = "libra-failure-ext", path = "../common/failure-ext" }
-generate-keypair = { path = "../config/generate-keypair" }
-libra-wallet = { path = "../client/libra_wallet" }
-libra-swarm = { path = "../libra-swarm" }
-libra-logger = { path = "../common/logger" }
-libra-metrics = { path = "../common/metrics" }
-libra-crypto = { path = "../crypto/crypto" }
+admission-control-proto = { path = "../admission_control/admission-control-proto", version = "0.1.0" }
+client = { path = "../client", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+failure = { package = "libra-failure-ext", path = "../common/failure-ext", version = "0.1.0" }
+generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
+libra-wallet = { path = "../client/libra_wallet", version = "0.1.0" }
+libra-swarm = { path = "../libra-swarm", version = "0.1.0" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 rusty-fork = "0.2.1"
-libra-tools = { path = "../common/tools" }
-libra-types = { path = "../types" }
-transaction-builder = { path = "../language/transaction-builder" }
+libra-tools = { path = "../common/tools", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 
 [dev-dependencies]
-libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = []

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,22 +24,22 @@ serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 structopt = "0.3.2"
 
-admission-control-proto = { version = "0.1.0", path = "../admission_control/admission-control-proto" }
-libra-config = { path = "../config" }
-crash-handler = { path = "../common/crash-handler" }
-libra-crypto = { path = "../crypto/crypto" }
-failure = { package = "libra-failure-ext", path = "../common/failure-ext" }
-lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
-libra-wallet = { path = "./libra_wallet" }
-libra-logger =  { path = "../common/logger" }
-libra-metrics = { path = "../common/metrics" }
-libra-types = { path = "../types" }
-libra-tools = { path = "../common/tools/" }
-transaction-builder = { path = "../language/transaction-builder" }
+admission-control-proto = { path = "../admission_control/admission-control-proto", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+crash-handler = { path = "../common/crash-handler", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+failure = { package = "libra-failure-ext", path = "../common/failure-ext", version = "0.1.0" }
+lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-wallet = { path = "./libra_wallet", version = "0.1.0" }
+libra-logger =  { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+libra-tools = { path = "../common/tools/", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 
 [dev-dependencies]
-libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
-libra-types = { path = "../types", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -19,10 +19,10 @@ serde = "1.0.96"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
 ed25519-dalek = "1.0.0-pre.1"
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-types = { path = "../../types" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"]}
-libra-tools = { path = "../../common/tools"}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+libra-tools = { path = "../../common/tools", version = "0.1.0"}

--- a/common/bounded-executor/Cargo.toml
+++ b/common/bounded-executor/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-futures-semaphore = { path = "../futures-semaphore" }
+futures-semaphore = { path = "../futures-semaphore", version = "0.1.0" }
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["async-await"] }
 tokio = "0.2.0-alpha.6"

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview" }
 lazy_static = "1.3.0"
-libra-logger = { path = "../logger" }
-libra-metrics = { path = "../metrics" }
+libra-logger = { path = "../logger", version = "0.1.0" }
+libra-metrics = { path = "../metrics", version = "0.1.0" }
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/common/crash-handler/Cargo.toml
+++ b/common/crash-handler/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 backtrace = "0.3.37"
 toml = "0.5.3"
 
-libra-logger = { path = "../logger" }
+libra-logger = { path = "../logger", version = "0.1.0" }
 serde = { version = "1.0.96", features = ["derive"] }

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -17,9 +17,9 @@ prost = "0.5.0"
 serde_json = "1.0"
 lazy_static = "1.3.0"
 
-failure = { package = "libra-failure-ext", path = "../failure-ext" }
-libra-logger = { path = "../logger" }
-libra-metrics = { path = "../metrics" }
+failure = { package = "libra-failure-ext", path = "../failure-ext", version = "0.1.0" }
+libra-logger = { path = "../logger", version = "0.1.0" }
+libra-metrics = { path = "../metrics", version = "0.1.0" }
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/common/executable-helpers/Cargo.toml
+++ b/common/executable-helpers/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 slog-scope = "4.0"
 
-libra-config = { path = "../../config"}
-crash-handler = { path = "../crash-handler" }
-libra-logger =  { path = "../logger" }
-libra-metrics = { path = "../metrics" }
+libra-config = { path = "../../config", version = "0.1.0"}
+crash-handler = { path = "../crash-handler", version = "0.1.0" }
+libra-logger =  { path = "../logger", version = "0.1.0" }
+libra-metrics = { path = "../metrics", version = "0.1.0" }

--- a/common/failure-ext/Cargo.toml
+++ b/common/failure-ext/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 [dependencies]
 failure = "0.1.3"
 
-libra-failure-macros = { path = "failure-macros" }
+libra-failure-macros = { path = "failure-macros", version = "0.1.0" }

--- a/common/grpc-helpers/Cargo.toml
+++ b/common/grpc-helpers/Cargo.toml
@@ -14,6 +14,6 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["compat"] }
 futures_01 = { version = "0.1.28", package = "futures" }
 
-failure = { package = "libra-failure-ext", path = "../failure-ext" }
-libra-logger = { path = "../logger" }
-libra-metrics = { path = "../metrics" }
+failure = { package = "libra-failure-ext", path = "../failure-ext", version = "0.1.0" }
+libra-logger = { path = "../logger", version = "0.1.0" }
+libra-metrics = { path = "../metrics", version = "0.1.0" }

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -17,8 +17,8 @@ lazy_static = "1.3.0"
 serde_json = "1.0.40"
 prometheus = { version = "0.7.0", default-features = false }
 
-failure = { path = "../failure-ext", package = "libra-failure-ext" }
-libra-logger = { path = "../logger" }
+failure = { path = "../failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-logger = { path = "../logger", version = "0.1.0" }
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -19,14 +19,14 @@ serde = { version = "1.0.99", default-features = false }
 toml = { version = "0.5.3", default-features = false }
 prost = "0.5.0"
 
-libra-crypto = { path = "../crypto/crypto" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-libra-tools = { path = "../common/tools" }
-libra-types = { path = "../types" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-tools = { path = "../common/tools", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../types", features = ["testing"] }
-libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = []

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -15,14 +15,14 @@ parity-multiaddr = { version = "0.5.0", default-features = false }
 rand = "0.6.5"
 structopt = "0.3.2"
 
-libra-config = { path = ".." }
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-generate-keypair = { path = "../generate-keypair" }
-libra-logger = { path = "../../common/logger" }
-libra-prost-ext = { path = "../../common/prost-ext" }
-libra-types = { path = "../../types" }
-vm-genesis = { path = "../../language/vm/vm-genesis" }
+libra-config = { path = "..", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+generate-keypair = { path = "../generate-keypair", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+vm-genesis = { path = "../../language/vm/vm-genesis", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 structopt = "0.3.2"
 
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-crypto = { path = "../../crypto/crypto/"}
-libra-tools = { path = "../../common/tools" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-crypto = { path = "../../crypto/crypto/", version = "0.1.0"}
+libra-tools = { path = "../../common/tools", version = "0.1.0" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -30,26 +30,26 @@ termion = { version = "1.5.3", default-features = false }
 tokio = "=0.2.0-alpha.6"
 prometheus = { version = "0.7.0", default-features = false }
 
-channel = { path = "../common/channel" }
-libra-config = { path = "../config" }
-consensus-types = { path = "consensus-types", default-features = false }
-libra-crypto = { path = "../crypto/crypto" }
-debug-interface = { path = "../common/debug-interface" }
-executor = { path = "../executor" }
-lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-libra-logger = { path = "../common/logger" }
-libra-mempool = { path = "../mempool" }
-libra-metrics = { path = "../common/metrics" }
-network = { path = "../network" }
-libra-prost-ext = { path = "../common/prost-ext" }
-safety-rules = { path = "safety-rules" }
-state-synchronizer = { path = "../state-synchronizer" }
-schemadb = { path = "../storage/schemadb" }
-storage-client = { path = "../storage/storage-client" }
-libra-tools = { path = "../common/tools" }
-libra-types = { path = "../types" }
-vm-runtime = { path = "../language/vm/vm-runtime" }
+channel = { path = "../common/channel", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+consensus-types = { path = "consensus-types", version = "0.1.0", default-features = false }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
+executor = { path = "../executor", version = "0.1.0" }
+lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-mempool = { path = "../mempool", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+network = { path = "../network", version = "0.1.0" }
+libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
+safety-rules = { path = "safety-rules", version = "0.1.0" }
+state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
+schemadb = { path = "../storage/schemadb", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+libra-tools = { path = "../common/tools", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 cached = "0.9.0"
@@ -57,11 +57,11 @@ parity-multiaddr = "0.5.0"
 proptest = "0.9.4"
 rusty-fork = "0.2.2"
 
-consensus-types = { path = "consensus-types", features = ["fuzzing", "testing"]}
-libra-crypto = { path = "../crypto/crypto", features = ["testing"]}
-libra-types = { path = "../types", features = ["testing"]}
-vm-genesis = { path = "../language/vm/vm-genesis" }
-vm-validator = { path = "../vm-validator" }
+consensus-types = { path = "consensus-types", version = "0.1.0", features = ["fuzzing", "testing"]}
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"]}
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
+vm-genesis = { path = "../language/vm/vm-genesis", version = "0.1.0" }
+vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]
 default = []

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -13,18 +13,18 @@ rand = { version = "0.6.5", default-features = false }
 rmp-serde = { version = "0.13.7", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../../crypto/crypto" }
-executor = { path = "../../executor" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-network = { path = "../../network" }
-libra-types = { path = "../../types" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+executor = { path = "../../executor", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+network = { path = "../../network", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.4"
 
-libra-crypto = { path = "../../crypto/crypto", features = ["testing"]}
-libra-types = { path = "../../types", features = ["testing"]}
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-consensus-types = { path = "../consensus-types" }
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
+consensus-types = { path = "../consensus-types", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 serde = { version = "1.0.99", default-features = false }
-libra-types = { path = "../../types" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-consensus-types = { path = "../consensus-types", features = ["testing"]}
-libra-crypto = { path = "../../crypto/crypto", features = ["testing"]}
-libra-types = { path = "../../types", features = ["testing"]}
+consensus-types = { path = "../consensus-types", version = "0.1.0", features = ["testing"]}
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}

--- a/crypto/crypto-derive/Cargo.toml
+++ b/crypto/crypto-derive/Cargo.toml
@@ -16,4 +16,4 @@ quote = "1.0.0"
 proc-macro2 = "1.0.1"
 
 [dev-dependencies]
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext"}
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext"}

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -29,10 +29,10 @@ threshold_crypto = "0.3"
 tiny-keccak = "1.5.0"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false }
 
-libra-crypto-derive = { path = "../crypto-derive" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-libra-nibble = { path = "../../common/nibble" }
+libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 
 [dev-dependencies]
 bitvec = "0.10.1"

--- a/crypto/secret-service/Cargo.toml
+++ b/crypto/secret-service/Cargo.toml
@@ -19,17 +19,17 @@ rand_chacha = "0.1.1"
 serde = { version = "1.0.96", features = ["derive"] }
 structopt = "0.3.2"
 
-libra-config = { path = "../../config" }
-libra-crypto = { path = "../crypto" }
-libra-crypto-derive = { path = "../crypto-derive" }
-debug-interface = { path = "../../common/debug-interface" }
-executable-helpers = { path = "../../common/executable-helpers" }
-failure = { package = "libra-failure-ext", path = "../../common/failure-ext" }
-grpc-helpers = { path = "../../common/grpc-helpers" }
-libra-logger = { path = "../../common/logger" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../crypto", version = "0.1.0" }
+libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
+executable-helpers = { path = "../../common/executable-helpers", version = "0.1.0" }
+failure = { package = "libra-failure-ext", path = "../../common/failure-ext", version = "0.1.0" }
+grpc-helpers = { path = "../../common/grpc-helpers", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
 
 [dev-dependencies]
-libra-config = { path = "../../config", features = ["testing"]}
+libra-config = { path = "../../config", version = "0.1.0", features = ["testing"]}
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -11,24 +11,24 @@ edition = "2018"
 
 [dependencies]
 backoff = { version = "0.1.5", default-features = false }
-config-builder = { path = "../config/config-builder" }
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview" }
 itertools = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
-libra-config = { path = "../config" }
-libra-crypto = { path = "../crypto/crypto" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-libra-logger = { path = "../common/logger" }
-libra-metrics = { path = "../common/metrics" }
-libra-prost-ext = { path = "../common/prost-ext" }
-scratchpad = { path = "../storage/scratchpad" }
-libra-state-view = { path = "../storage/state-view" }
-storage-client = { path = "../storage/storage-client" }
-libra-types = { path = "../types" }
-vm-runtime = { path = "../language/vm/vm-runtime" }
+libra-config = { path = "../config", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
+scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
+libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 grpcio = { version = "=0.5.0-alpha.4", default-features = false }
@@ -36,11 +36,11 @@ proptest = "0.9.2"
 rand = "0.6.5"
 rusty-fork = "0.2.1"
 
-libra-config = { path = "../config", features = ["testing"]}
-grpc-helpers = { path = "../common/grpc-helpers" }
-libra-types = { path = "../types", features = ["testing"]}
+libra-config = { path = "../config", version = "0.1.0", features = ["testing"]}
+grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
 
-storage-proto = { path = "../storage/storage-proto" }
-storage-service = { path = "../storage/storage-service" }
-vm-genesis = { path = "../language/vm/vm-genesis" }
-transaction-builder = { path = "../language/transaction-builder" }
+storage-proto = { path = "../storage/storage-proto", version = "0.1.0" }
+storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+vm-genesis = { path = "../language/vm/vm-genesis", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 criterion = "0.3.0"
 proptest = "0.9.4"
 
-language-e2e-tests = { path = "../e2e-tests" }
-libra-proptest-helpers = { path = "../../common/proptest-helpers" }
-libra-types = { path = "../../types" }
+language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
 
 [[bench]]
 name = "transactions"

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -13,16 +13,16 @@ edition = "2018"
 mirai-annotations = "1.4.0"
 petgraph = "0.4"
 
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-vm = { path = "../vm" }
-libra-types = { path = "../../types" }
-vm-runtime-types = { path = "../vm/vm-runtime/vm-runtime-types" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+vm = { path = "../vm", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+vm-runtime-types = { path = "../vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
 
 
 [dev-dependencies]
-invalid-mutations = { path = "invalid-mutations" }
-libra-types = { path = "../../types", features = ["testing"]}
-vm = { path = "../vm", features = ["testing"]}
+invalid-mutations = { path = "invalid-mutations", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+vm = { path = "../vm", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/language/bytecode-verifier/bytecode_verifier_tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode_verifier_tests/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dev-dependencies]
 petgraph = "0.4"
 proptest = "0.9.2"
-bytecode-verifier = {path = "../", features = ["testing"]}
-failure = { path = "../../../common/failure-ext", package = "libra-failure-ext" }
-libra-types = { path = "../../../types", features = ["testing"]}
-invalid-mutations = { path = "../invalid-mutations" }
-vm = { path = "../../vm", features = ["testing"]}
+bytecode-verifier = {path = "../", version = "0.1.0", features = ["testing"]}
+failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}
+invalid-mutations = { path = "../invalid-mutations", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0", features = ["testing"]}

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 
 [dependencies]
 proptest = "0.9"
-libra-proptest-helpers = { path = "../../../common/proptest-helpers" }
-vm = { path = "../../vm" }
-libra-types = { path = "../../../types" }
+libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
 
 [dev-dependencies]
-vm = { path = "../../vm", features = ["testing"] }
+vm = { path = "../../vm", version = "0.1.0", features = ["testing"] }

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytecode-verifier = { path = "../bytecode-verifier" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-ir-to-bytecode = { path = "ir-to-bytecode" }
-bytecode_source_map = { path = "bytecode_source_map" }
-stdlib = { path = "../stdlib" }
-libra-types = { path = "../../types" }
-vm = { path = "../vm" }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+ir-to-bytecode = { path = "ir-to-bytecode", version = "0.1.0" }
+bytecode_source_map = { path = "bytecode_source_map", version = "0.1.0" }
+stdlib = { path = "../stdlib", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+vm = { path = "../vm", version = "0.1.0" }
 structopt = "0.3.2"
 serde_json = "1.0.40"
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/language/compiler/bytecode_source_map/Cargo.toml
+++ b/language/compiler/bytecode_source_map/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../../common/failure-ext", package = "libra-failure-ext" }
-ir-to-bytecode-syntax = { path = "../ir-to-bytecode/syntax" }
-bytecode-verifier = { path = "../../bytecode-verifier" }
-libra-types = { path = "../../../types" }
-vm = { path = "../../vm" }
+failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+ir-to-bytecode-syntax = { path = "../ir-to-bytecode/syntax", version = "0.1.0" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
 codespan = { version = "0.2.1" }
 codespan-reporting = "0.2.1"
 structopt = "0.3.2"
@@ -19,4 +19,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
-libra-types = { path = "../../../types", features = ["testing"] }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../../common/failure-ext", package = "libra-failure-ext" }
-ir-to-bytecode-syntax = { path = "syntax" }
-libra-types = { path = "../../../types" }
-vm = { path = "../../vm" }
-bytecode_source_map = { path = "../bytecode_source_map" }
+failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+ir-to-bytecode-syntax = { path = "syntax", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+bytecode_source_map = { path = "../bytecode_source_map", version = "0.1.0" }
 lalrpop-util = "0.17.2"
 log = "0.4.7"
 codespan = "0.2.1"
 codespan-reporting = "0.2.1"
 
 [dev-dependencies]
-libra-types = { path = "../../../types", features = ["testing"] }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -12,15 +12,15 @@ build = "build.rs"
 
 [dependencies]
 codespan = { version = "0.2.1", features = ["serialization"] }
-failure = { path = "../../../../common/failure-ext", package = "libra-failure-ext" }
+failure = { path = "../../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 hex = "0.3.2"
 lazy_static = "1.4.0"
 lalrpop-util = "0.17.2"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
-libra-types = { path = "../../../../types" }
+libra-types = { path = "../../../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../../../types", features = ["testing"] }
+libra-types = { path = "../../../../types", version = "0.1.0", features = ["testing"] }
 
 [build-dependencies]
 lalrpop = "0.17.2"

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -10,28 +10,28 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bytecode-verifier = { path = "../bytecode-verifier" }
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-compiler = { path = "../compiler" }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+compiler = { path = "../compiler", version = "0.1.0" }
 lazy_static = "1.3.0"
-libra-crypto = { path = "../../crypto/crypto"}
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0"}
 rand = "0.6.5"
-libra-state-view = { path = "../../storage/state-view" }
-libra-types = { path = "../../types" }
-transaction-builder = { path = "../transaction-builder", features = ["testing"]}
-vm = { path = "../vm" }
-vm-genesis = { path = "../vm/vm-genesis" }
-vm-runtime = { path = "../vm/vm-runtime" }
-vm-runtime-types = { path = "../vm/vm-runtime/vm-runtime-types" }
+libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["testing"]}
+vm = { path = "../vm", version = "0.1.0" }
+vm-genesis = { path = "../vm/vm-genesis", version = "0.1.0" }
+vm-runtime = { path = "../vm/vm-runtime", version = "0.1.0" }
+vm-runtime-types = { path = "../vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
-libra-proptest-helpers = { path = "../../common/proptest-helpers" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 prost = "0.5.0"
-libra-config =  { path = "../../config" }
-libra-logger = { path = "../../common/logger" }
-stdlib = { path = "../stdlib" }
+libra-config =  { path = "../../config", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+stdlib = { path = "../stdlib", version = "0.1.0" }
 walkdir = "2.2.9"
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -9,24 +9,24 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-ir-to-bytecode-syntax = { path = "../compiler/ir-to-bytecode/syntax" }
-ir-to-bytecode = { path = "../compiler/ir-to-bytecode" }
-stdlib = { path = "../stdlib" }
-libra-types = { path = "../../types" }
-vm = { path = "../vm" }
-bytecode-verifier = { path = "../bytecode-verifier" }
-language-e2e-tests = { path = "../e2e-tests" }
-libra-config = { path = "../../config" }
-libra-crypto = { path = "../../crypto/crypto" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+ir-to-bytecode-syntax = { path = "../compiler/ir-to-bytecode/syntax", version = "0.1.0" }
+ir-to-bytecode = { path = "../compiler/ir-to-bytecode", version = "0.1.0" }
+stdlib = { path = "../stdlib", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+vm = { path = "../vm", version = "0.1.0" }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 filecheck = "0.4.0"
 lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"] }
-datatest-stable = { path = "../../common/datatest-stable" }
-libra-crypto = { path = "../../crypto/crypto", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["testing"] }
 
 [[test]]
 name = "testsuite"

--- a/language/stackless-bytecode/bytecode-to-boogie/Cargo.toml
+++ b/language/stackless-bytecode/bytecode-to-boogie/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytecode-verifier = { path = "../../bytecode-verifier" }
-vm = { path = "../../vm" }
-libra-types = { path = "../../../types" }
-bytecode_source_map = { path = "../../compiler/bytecode_source_map" }
-ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
-stackless-bytecode-generator = { path = "../generator"}
-stdlib = { path = "../../stdlib" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+bytecode_source_map = { path = "../../compiler/bytecode_source_map", version = "0.1.0" }
+ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
+stackless-bytecode-generator = { path = "../generator", version = "0.1.0"}
+stdlib = { path = "../../stdlib", version = "0.1.0" }
 num = "0.2.0"
 
 [dev-dependencies]
 proptest = "0.9"
-libra-types = { path = "../../../types", features = ["testing"]}
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}

--- a/language/stackless-bytecode/generator/Cargo.toml
+++ b/language/stackless-bytecode/generator/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-vm = { path = "../../vm" }
-ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
-stdlib = { path = "../../stdlib" }
+vm = { path = "../../vm", version = "0.1.0" }
+ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
 #
 [dev-dependencies]
 # invalid-mutations = { path = "invalid-mutations" }
 proptest = "0.9"
-libra-types = { path = "../../../types", features = ["testing"]}
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}

--- a/language/stackless-bytecode/tree_heap/Cargo.toml
+++ b/language/stackless-bytecode/tree_heap/Cargo.toml
@@ -6,15 +6,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-functional_tests = { path = "../../functional_tests" }
-bytecode-verifier = { path = "../../bytecode-verifier" }
-vm = { path = "../../vm" }
-libra-types = { path = "../../../types" }
-ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
-stackless-bytecode-generator = { path = "../generator"}
-stdlib = { path = "../../stdlib" }
+functional_tests = { path = "../../functional_tests", version = "0.1.0" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
+stackless-bytecode-generator = { path = "../generator", version = "0.1.0"}
+stdlib = { path = "../../stdlib", version = "0.1.0" }
 num = "0.2.0"
 
 [dev-dependencies]
 proptest = "0.9"
-libra-types = { path = "../../../types", features = ["testing"]}
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -10,11 +10,11 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bytecode-verifier = { path = "../bytecode-verifier" }
-ir-to-bytecode = { path = "../compiler/ir-to-bytecode" }
-libra-types = { path = "../../types" }
-bytecode_source_map = { path = "../compiler/bytecode_source_map" }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+ir-to-bytecode = { path = "../compiler/ir-to-bytecode", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+bytecode_source_map = { path = "../compiler/bytecode_source_map", version = "0.1.0" }
 lazy_static = "1.3.0"
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/language/tools/cost-synthesis/Cargo.toml
+++ b/language/tools/cost-synthesis/Cargo.toml
@@ -14,19 +14,19 @@ csv = "1.1.1"
 rand = "0.6.5"
 lazy_static = "1.3.0"
 
-bytecode-verifier = { path = "../../bytecode-verifier" }
-stdlib = { path = "../../stdlib" }
-libra-types = { path = "../../../types" }
-vm = { path = "../../vm" }
-vm-runtime = { path = "../../vm/vm-runtime" }
-vm-runtime-types = { path = "../../vm/vm-runtime/vm-runtime-types" }
-language-e2e-tests = { path = "../../e2e-tests" }
-vm-cache-map = { path = "../../vm/vm-runtime/vm-cache-map" }
-libra-crypto = { path = "../../../crypto/crypto" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+vm-runtime = { path = "../../vm/vm-runtime", version = "0.1.0" }
+vm-runtime-types = { path = "../../vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
+language-e2e-tests = { path = "../../e2e-tests", version = "0.1.0" }
+vm-cache-map = { path = "../../vm/vm-runtime/vm-cache-map", version = "0.1.0" }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 structopt = "0.3.2"
 
 [dev-dependencies]
-libra-types = { path = "../../../types", features = ["testing"] }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = ["vm-runtime/instruction_synthesis"]

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -15,15 +15,15 @@ log = "0.4"
 env_logger = "0.6"
 mirai-annotations = "1.4.0"
 structopt = "0.3.2"
-bytecode-verifier = { path = "../../bytecode-verifier" }
-cost-synthesis = { path = "../cost-synthesis" }
-vm = { path = "../../vm" }
-vm-runtime = { path = "../../vm/vm-runtime" }
-vm-runtime-types = { path = "../../vm/vm-runtime/vm-runtime-types" }
-vm-cache-map = { path = "../../vm/vm-runtime/vm-cache-map" }
-language-e2e-tests = { path = "../../e2e-tests" }
-stdlib = { path = "../../stdlib" }
-libra-types = { path = "../../../types", features = ["testing"] }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+cost-synthesis = { path = "../cost-synthesis", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+vm-runtime = { path = "../../vm/vm-runtime", version = "0.1.0" }
+vm-runtime-types = { path = "../../vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
+vm-cache-map = { path = "../../vm/vm-runtime/vm-cache-map", version = "0.1.0" }
+language-e2e-tests = { path = "../../e2e-tests", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
 
 [features]
 mirai-contracts = []

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -9,16 +9,16 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-libra-config = { path = "../../config" }
-libra-crypto = { path = "../../crypto/crypto" }
-ir-to-bytecode = { path = "../compiler/ir-to-bytecode" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+ir-to-bytecode = { path = "../compiler/ir-to-bytecode", version = "0.1.0" }
 lazy_static = "1.3.0"
-stdlib = { path = "../stdlib" }
-libra-types = { path = "../../types" }
-vm = { path = "../vm" }
+stdlib = { path = "../stdlib", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+vm = { path = "../vm", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 testing = ["libra-types/testing", "libra-crypto/testing"]

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -17,15 +17,15 @@ mirai-annotations = "1.4.0"
 proptest = "0.9"
 proptest-derive = "0.1.1"
 serde = { version = "1", features = ["derive"] }
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-proptest-helpers = { path = "../../common/proptest-helpers" }
-libra-types = { path = "../../types" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 serde_json = "1"
-libra-types = { path = "../../types", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/language/vm/serializer_tests/Cargo.toml
+++ b/language/vm/serializer_tests/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dev-dependencies]
 proptest = "0.9"
 proptest-derive = "0.1.1"
-vm = { path = "../", features = ["testing"]}
+vm = { path = "../", version = "0.1.0", features = ["testing"]}
 
 [features]
 testing = ["vm/testing"]

--- a/language/vm/vm-genesis/Cargo.toml
+++ b/language/vm/vm-genesis/Cargo.toml
@@ -10,25 +10,25 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-libra-config = { path = "../../../config" }
-failure = { path = "../../../common/failure-ext", package = "libra-failure-ext" }
-transaction-builder = { path = "../../transaction-builder"}
-libra-crypto = { path = "../../../crypto/crypto" }
-stdlib = { path = "../../stdlib" }
-libra-prost-ext = { path = "../../../common/prost-ext" }
-libra-state-view = { path = "../../../storage/state-view" }
-libra-types = { path = "../../../types" }
-vm = { path = "../" }
-vm-cache-map = { path = "../vm-runtime/vm-cache-map" }
-vm-runtime = { path = "../vm-runtime" }
-vm-runtime-types = { path = "../vm-runtime/vm-runtime-types" }
+libra-config = { path = "../../../config", version = "0.1.0" }
+failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+transaction-builder = { path = "../../transaction-builder", version = "0.1.0"}
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
+libra-prost-ext = { path = "../../../common/prost-ext", version = "0.1.0" }
+libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../", version = "0.1.0" }
+vm-cache-map = { path = "../vm-runtime/vm-cache-map", version = "0.1.0" }
+vm-runtime = { path = "../vm-runtime", version = "0.1.0" }
+vm-runtime-types = { path = "../vm-runtime/vm-runtime-types", version = "0.1.0" }
 lazy_static = "1.3.0"
 rand = "0.6.5"
 
 [dev-dependencies]
-lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../../../crypto/crypto", features = ["testing"]}
+lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0", features = ["testing"]}
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
-libra-proptest-helpers = { path = "../../../common/proptest-helpers" }
-libra-types = { path = "../../../types", features = ["testing"] }
+libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }

--- a/language/vm/vm-runtime/Cargo.toml
+++ b/language/vm/vm-runtime/Cargo.toml
@@ -18,24 +18,24 @@ rental = "0.5.4"
 mirai-annotations = "1.4.0"
 prometheus = { version = "0.7.0", default-features = false }
 
-bytecode-verifier = { path = "../../bytecode-verifier" }
-lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization" }
-libra-config = { path = "../../../config" }
-libra-crypto = { path = "../../../crypto/crypto" }
-libra-logger = { path = "../../../common/logger" }
-libra-metrics = { path = "../../../common/metrics" }
-libra-state-view = { path = "../../../storage/state-view" }
-libra-types = { path = "../../../types" }
-vm = { path = "../" }
-vm-cache-map = { path = "vm-cache-map" }
-vm-runtime-types = { path = "vm-runtime-types" }
-failure = { path = "../../../common/failure-ext", package = "libra-failure-ext" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../../../config", version = "0.1.0" }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+libra-logger = { path = "../../../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../../../common/metrics", version = "0.1.0" }
+libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../", version = "0.1.0" }
+vm-cache-map = { path = "vm-cache-map", version = "0.1.0" }
+vm-runtime-types = { path = "vm-runtime-types", version = "0.1.0" }
+failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 
 [dev-dependencies]
-compiler = { path = "../../compiler" }
+compiler = { path = "../../compiler", version = "0.1.0" }
 
-libra-types = { path = "../../../types", features = ["testing"] }
-vm = { path = "../", features = ["testing"]}
+libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
+vm = { path = "../", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/language/vm/vm-runtime/vm-runtime-types/Cargo.toml
+++ b/language/vm/vm-runtime/vm-runtime-types/Cargo.toml
@@ -15,15 +15,15 @@ lazy_static = "1.3.0"
 proptest = "0.9"
 sha2 = "0.8.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
-libra-types = { path = "../../../../types" }
-vm = { path = "../../" }
-lcs = { path = "../../../../common/lcs", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../../../../crypto/crypto" }
-failure = { path = "../../../../common/failure-ext", package = "libra-failure-ext" }
+libra-types = { path = "../../../../types", version = "0.1.0" }
+vm = { path = "../../", version = "0.1.0" }
+lcs = { path = "../../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 
 [dev-dependencies]
-libra-types = { path = "../../../../types", features = ["testing"] }
-vm = { path = "../../", features = ["testing"]}
+libra-types = { path = "../../../../types", version = "0.1.0", features = ["testing"] }
+vm = { path = "../../", version = "0.1.0", features = ["testing"]}
 
 [features]
 instruction_synthesis = []

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -18,27 +18,27 @@ signal-hook = "0.1.10"
 structopt = "0.3.2"
 tokio = "=0.2.0-alpha.6"
 
-admission-control-proto = { path = "../admission_control/admission-control-proto" }
-admission-control-service = { path = "../admission_control/admission-control-service" }
-libra-config = { path = "../config" }
-consensus = { path = "../consensus" }
-crash-handler = { path = "../common/crash-handler" }
-debug-interface = { path = "../common/debug-interface" }
-executable-helpers = { path = "../common/executable-helpers" }
-executor = { path = "../executor" }
+admission-control-proto = { path = "../admission_control/admission-control-proto", version = "0.1.0" }
+admission-control-service = { path = "../admission_control/admission-control-service", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+consensus = { path = "../consensus", version = "0.1.0" }
+crash-handler = { path = "../common/crash-handler", version = "0.1.0" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
+executable-helpers = { path = "../common/executable-helpers", version = "0.1.0" }
+executor = { path = "../executor", version = "0.1.0" }
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["async-await", "io-compat", "compat"] }
-grpc-helpers = { path = "../common/grpc-helpers" }
-libra-logger = { path = "../common/logger" }
-libra-mempool = { path = "../mempool" }
-libra-metrics = { path = "../common/metrics" }
-libra-crypto = { path = "../crypto/crypto" }
-network = { path = "../network" }
-state-synchronizer = { path = "../state-synchronizer" }
-storage-client = { path = "../storage/storage-client" }
-storage-service = { path = "../storage/storage-service" }
-libra-types = { path = "../types" }
-vm-runtime = { path = "../language/vm/vm-runtime" }
+grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-mempool = { path = "../mempool", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+network = { path = "../network", version = "0.1.0" }
+state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
-config-builder = { path = "../config/config-builder" }
-libra-types = { path = "../types", features = ["testing"]}
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -10,22 +10,22 @@ publish = false
 edition = "2018"
 
 [dependencies]
-client_lib = { package = "client", path = "../client" }
+client_lib = { package = "client", path = "../client", version = "0.1.0" }
 ctrlc = { version = "3.1.3", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 structopt = "0.3.2"
 
-libra-config = { path = "../config" }
-config-builder = { path = "../config/config-builder" }
-debug-interface = { path = "../common/debug-interface" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-generate-keypair = { path = "../config/generate-keypair" }
-libra-logger = { path = "../common/logger" }
-libra-crypto = { path = "../crypto/crypto" }
-libra-tools = { path = "../common/tools" }
+libra-config = { path = "../config", version = "0.1.0" }
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-tools = { path = "../common/tools", version = "0.1.0" }
 
 [dev-dependencies]
-libra-crypto = { path = "../crypto/crypto", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -22,24 +22,24 @@ prost = "0.5.0"
 tokio = "=0.2.0-alpha.6"
 ttl_cache = "0.4.2"
 
-libra-mempool-shared-proto = { path = "mempool-shared-proto" }
-bounded-executor = { path = "../common/bounded-executor" }
-libra-config = { path = "../config" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-grpc-helpers = { path = "../common/grpc-helpers" }
-libra-logger = { path = "../common/logger" }
-libra-metrics = { path = "../common/metrics" }
-network = { path = "../network" }
-libra-crypto = { path = "../crypto/crypto" }
-storage-client = { path = "../storage/storage-client" }
-libra-types = { path = "../types" }
-vm-validator = { path = "../vm-validator" }
+libra-mempool-shared-proto = { path = "mempool-shared-proto", version = "0.1.0" }
+bounded-executor = { path = "../common/bounded-executor", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+network = { path = "../network", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"
-channel = { path = "../common/channel" }
-storage-service = { path = "../storage/storage-service" }
-libra-types = { path = "../types", features = ["testing"] }
+channel = { path = "../common/channel", version = "0.1.0" }
+storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/mempool/mempool-shared-proto/Cargo.toml
+++ b/mempool/mempool-shared-proto/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 prost = "0.5.0"
 bytes = "0.4.12"
 
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,30 +21,30 @@ rand = "0.6.5"
 tokio = "=0.2.0-alpha.6"
 tokio-retry = "0.2.0"
 
-admission-control-proto = { path = "../admission_control/admission-control-proto" }
-bounded-executor = { path = "../common/bounded-executor" }
-channel = { path = "../common/channel" }
-libra-config = { path = "../config" }
-libra-crypto = { path = "../crypto/crypto" }
-failure = { package = "libra-failure-ext", path = "../common/failure-ext" }
-libra-types = { path = "../types" }
-libra-logger = { path = "../common/logger" }
-memsocket = { path = "memsocket" }
-libra-metrics = { path = "../common/metrics" }
-netcore = { path = "netcore" }
-noise = { path = "noise" }
-libra-prost-ext = { path = "../common/prost-ext" }
+admission-control-proto = { path = "../admission_control/admission-control-proto", version = "0.1.0" }
+bounded-executor = { path = "../common/bounded-executor", version = "0.1.0" }
+channel = { path = "../common/channel", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+failure = { package = "libra-failure-ext", path = "../common/failure-ext", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+memsocket = { path = "memsocket", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+netcore = { path = "netcore", version = "0.1.0" }
+noise = { path = "noise", version = "0.1.0" }
+libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
 
 proptest = { version = "0.9.4", default-features = false, optional = true }
-libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
-libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
-libra-types = { path = "../types", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
 proptest = { version = "0.9.4", default-features = false }
-libra-proptest-helpers = { path = "../common/proptest-helpers" }
-socket-bench-server = { path = "socket-bench-server" }
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
+socket-bench-server = { path = "socket-bench-server", version = "0.1.0" }
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -18,4 +18,4 @@ pin-project = "0.4.2"
 tokio = "=0.2.0-alpha.6"
 yamux = { version = "0.2.1", default-features = false }
 
-memsocket = { path = "../memsocket" }
+memsocket = { path = "../memsocket", version = "0.1.0" }

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 [dependencies]
 futures = { version = "=0.3.0-alpha.19", package = "futures-preview" }
 snow = { version = "0.6.1", features=["ring-accelerated"]}
-libra-crypto = { path = "../../crypto/crypto" }
-netcore = { path = "../netcore" }
-libra-logger = { path = "../../common/logger" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+netcore = { path = "../netcore", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
 
 [dev-dependencies]
-memsocket = { path = "../memsocket" }
+memsocket = { path = "../memsocket", version = "0.1.0" }

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -16,7 +16,7 @@ futures_01 = { version = "0.1.28", package = "futures" }
 parity-multiaddr = "0.5.0"
 tokio = "=0.2.0-alpha.6"
 
-libra-logger = { path = "../../common/logger" }
-memsocket = { path = "../memsocket" }
-netcore = { path = "../netcore" }
-noise = { path = "../noise" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+memsocket = { path = "../memsocket", version = "0.1.0" }
+netcore = { path = "../netcore", version = "0.1.0" }
+noise = { path = "../noise", version = "0.1.0" }

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -17,23 +17,23 @@ rand = "0.6.5"
 tokio = "=0.2.0-alpha.6"
 prometheus = { version = "0.7.0", default-features = false }
 
-libra-config = { path = "../config" }
-executor = { path = "../executor" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-libra-logger = { path = "../common/logger" }
-libra-metrics = { path = "../common/metrics" }
-network = { path = "../network" }
-storage-client = { path = "../storage/storage-client" }
-libra-types = { path = "../types" }
-vm-runtime = { path = "../language/vm/vm-runtime" }
+libra-config = { path = "../config", version = "0.1.0" }
+executor = { path = "../executor", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+network = { path = "../network", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 bytes = "0.4.12"
 
-config-builder = { path = "../config/config-builder" }
-libra-crypto = { path = "../crypto/crypto", features = ["testing"]}
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"]}
 parity-multiaddr = "0.5.0"
-libra-types = { path = "../types", features = ["testing"] }
-vm-genesis = { path = "../language/vm/vm-genesis" }
-transaction-builder = { path = "../language/transaction-builder" }
-channel = { path = "../common/channel" }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
+vm-genesis = { path = "../language/vm/vm-genesis", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
+channel = { path = "../common/channel", version = "0.1.0" }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 proptest = "0.9.1"
 
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-types = { path = "../../types" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -18,14 +18,14 @@ proptest = "0.9.2"
 proptest-derive = "0.1.2"
 serde = { version = "1.0.89", features = ["derive"] }
 
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-nibble = { path = "../../common/nibble" }
-libra-types = { path = "../../types" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"
-libra-types = { path = "../../types", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -25,22 +25,22 @@ strum = "0.15.0"
 strum_macros = "0.15.0"
 serde = "1.0.96"
 
-accumulator = { path = "../accumulator" }
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-jellyfish-merkle = { path = "../jellyfish-merkle" }
-libra-logger = { path = "../../common/logger" }
-libra-metrics = { path = "../../common/metrics" }
-libra-prost-ext = { path = "../../common/prost-ext" }
-schemadb = { path = "../schemadb" }
-storage-proto = { path = "../storage-proto" }
-libra-tools = { path = "../../common/tools" }
-libra-types = { path = "../../types" }
+accumulator = { path = "../accumulator", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+jellyfish-merkle = { path = "../jellyfish-merkle", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
+libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
+schemadb = { path = "../schemadb", version = "0.1.0" }
+storage-proto = { path = "../storage-proto", version = "0.1.0" }
+libra-tools = { path = "../../common/tools", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-proptest-helpers = { path = "../../common/proptest-helpers" }
-libra-types = { path = "../../types", features = ["testing"]}
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.3.0"
 
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-metrics = { path = "../../common/metrics" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 
 [dependencies.rocksdb]
 git = "https://github.com/pingcap/rust-rocksdb.git"
@@ -23,4 +23,4 @@ rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59"
 byteorder = "1.3.2"
 proptest = "0.9.4"
 tempfile = "3.1.0"
-libra-tools = { path = "../../common/tools" }
+libra-tools = { path = "../../common/tools", version = "0.1.0" }

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 itertools = "0.8.0"
 
-libra-crypto = { path = "../../crypto/crypto" }
-libra-types = { path = "../../types" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.4"
 
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/storage/state-view/Cargo.toml
+++ b/storage/state-view/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-types = { path = "../../types" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -14,12 +14,12 @@ futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features =
 futures_01 = { version = "0.1.28", package = "futures" }
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 rand = "0.6.5"
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-scratchpad = { path = "../scratchpad" }
-libra-state-view = { path = "../state-view" }
-storage-proto = { path = "../storage-proto" }
-libra-types = { path = "../../types" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+scratchpad = { path = "../scratchpad", version = "0.1.0" }
+libra-state-view = { path = "../state-view", version = "0.1.0" }
+storage-proto = { path = "../storage-proto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/storage/storage-proto/Cargo.toml
+++ b/storage/storage-proto/Cargo.toml
@@ -17,13 +17,13 @@ proptest = "0.9.2"
 proptest-derive = "0.1.0"
 prost = "0.5.0"
 
-libra-crypto = { path = "../../crypto/crypto" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-libra-types = { path = "../../types" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-types = { path = "../../types", version = "0.1.0" }
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
 
 [dev-dependencies]
-libra-types = { path = "../../types", features = ["testing"]}
-libra-prost-ext = { path = "../../common/prost-ext" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -14,27 +14,27 @@ futures = { version = "=0.3.0-alpha.19", package = "futures-preview", features =
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 structopt = "0.3.2"
 
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-libra-config = { path = "../../config" }
-libra-crypto = { path = "../../crypto/crypto" }
-debug-interface = { path = "../../common/debug-interface" }
-executable-helpers = { path = "../../common/executable-helpers" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-grpc-helpers = { path = "../../common/grpc-helpers" }
-libradb = { path = "../libradb" }
-libra-logger = { path = "../../common/logger" }
-libra-metrics = { path = "../../common/metrics" }
-storage-client = { path = "../storage-client" }
-storage-proto = { path = "../storage-proto" }
-libra-types = { path = "../../types" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
+executable-helpers = { path = "../../common/executable-helpers", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+grpc-helpers = { path = "../../common/grpc-helpers", version = "0.1.0" }
+libradb = { path = "../libradb", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
+storage-client = { path = "../storage-client", version = "0.1.0" }
+storage-proto = { path = "../storage-proto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 rand = "0.6.5"
 
 [dev-dependencies]
 itertools = "0.8.0"
 proptest = "0.9.2"
-libra-tools = { path = "../../common/tools" }
-libradb = { path = "../libradb", features = ["testing"] }
-libra-types = { path = "../../types", features = ["testing"] }
+libra-tools = { path = "../../common/tools", version = "0.1.0" }
+libradb = { path = "../libradb", version = "0.1.0", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = []

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -20,11 +20,11 @@ rusty-fork = "0.2.1"
 # In order to limit the potential waiting time for binaries to be built while
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
-benchmark = { path = "../benchmark" }
-cli = { path = "../client", package="client" }
-generate-keypair = { path = "../config/generate-keypair" }
-libra-swarm = { path = "../libra-swarm", features = ["testing"]}
-libra-logger = { path = "../common/logger" }
-libra-config = { path = "../config" }
-libra-tools = { path = "../common/tools" }
-libra-crypto = { path = "../crypto/crypto" }
+benchmark = { path = "../benchmark", version = "0.1.0" }
+cli = { path = "../client", version = "0.1.0", package="client" }
+generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
+libra-swarm = { path = "../libra-swarm", version = "0.1.0", features = ["testing"]}
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+libra-tools = { path = "../common/tools", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -34,13 +34,13 @@ slog-scope = "4.0"
 slog-async = "2.3"
 slog-envlogger = "2.1.0"
 
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
-debug-interface = { path = "../../common/debug-interface"}
-admission-control-proto = { path = "../../admission_control/admission-control-proto" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
+admission-control-proto = { path = "../../admission_control/admission-control-proto", version = "0.1.0" }
 
-libra-types = { path = "../../types" }
-transaction-builder = { path = "../../language/transaction-builder" }
-libra-crypto = { path = "../../crypto/crypto" }
-generate-keypair = { path = "../../config/generate-keypair" }
+libra-types = { path = "../../types", version = "0.1.0" }
+transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+generate-keypair = { path = "../../config/generate-keypair", version = "0.1.0" }
 
 threadpool = "1.7.1"

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -11,35 +11,35 @@ edition = "2018"
 # common dependencies
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
-lcs = { path = "../../common/lcs", package = "libra-canonical-serialization" }
-failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 hex = { version = "0.3.2", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 proptest = { version = "0.9.4", default-features = false }
-libra-proptest-helpers = { path = "../../common/proptest-helpers" }
-libra-prost-ext = { path = "../../common/prost-ext" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
 prost = "0.5.0"
 rusty-fork = { version = "0.2.2", default-features = false }
 sha-1 = { version = "0.8.1", default-features = false }
 structopt = "0.3.2"
 
 # List out modules with data structures being fuzzed here.
-admission-control-service = { path = "../../admission_control/admission-control-service" }
-consensus = { path = "../../consensus" }
-libra-types = { path = "../../types" }
-network = { path = "../../network" }
-vm = { path = "../../language/vm" }
-vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types" }
-consensus-types = { path = "../../consensus/consensus-types"}
+admission-control-service = { path = "../../admission_control/admission-control-service", version = "0.1.0" }
+consensus = { path = "../../consensus", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+network = { path = "../../network", version = "0.1.0" }
+vm = { path = "../../language/vm", version = "0.1.0" }
+vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
+consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0"}
 
 [dev-dependencies]
-datatest-stable = { path = "../../common/datatest-stable" }
+datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 rusty-fork = "0.2.2"
 stats_alloc = "0.1.8"
 
-libra-types = { path = "../../types", features = ["testing"] }
-vm = { path = "../../language/vm", features = ["testing"] }
-vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+vm = { path = "../../language/vm", version = "0.1.0", features = ["testing"] }
+vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = ["testing", "fuzzing"]

--- a/testsuite/libra-fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra-fuzzer/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-libra-fuzzer = { path = ".." }
+libra-fuzzer = { path = "..", version = "0.1.0" }
 lazy_static = { version = "1.3.0", default-features = false }
 
 # Prevent this from interfering with workspaces

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4.7", default-features = false }
 hex = { version = "0.3.2", default-features = false }
 itertools = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
-libra-logger = { path = "../common/logger" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
 proptest = { version = "0.9.4", default-features = false }
 proptest-derive = { version = "0.1.2", default-features = false }
 prost = "0.5.0"
@@ -26,19 +26,19 @@ rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }
 tiny-keccak = { version = "1.5.0", default-features = false }
 
-lcs = { path = "../common/lcs", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../crypto/crypto" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
-libra-proptest-helpers = { path = "../common/proptest-helpers" }
+lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 num_enum = "0.4.1"
 
 [build-dependencies]
 prost-build = "0.5.0"
 
 [dev-dependencies]
-libra-prost-ext = { path = "../common/prost-ext" }
+libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
 serde_json = "1.0.40"
-libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = []

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -10,24 +10,24 @@ publish = false
 edition = "2018"
 
 [dependencies]
-libra-config = { path = "../config" }
-failure = { path = "../common/failure-ext", package = "libra-failure-ext" }
+libra-config = { path = "../config", version = "0.1.0" }
+failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 futures = "0.1.28"
-scratchpad = { path = "../storage/scratchpad" }
-libra-state-view = { path = "../storage/state-view" }
-storage-client = { path = "../storage/storage-client" }
-libra-types = { path = "../types" }
-vm-runtime = { path = "../language/vm/vm-runtime" }
+scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
+libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 rand = "0.6.5"
 
-config-builder = { path = "../config/config-builder" }
-libra-crypto = { path = "../crypto/crypto", features = ["testing"] }
-executor = { path = "../executor" }
-grpc-helpers = { path = "../common/grpc-helpers" }
-storage-service = { path = "../storage/storage-service" }
-libra-types = { path = "../types", features = ["testing"] }
-vm-runtime = { path = "../language/vm/vm-runtime" }
-transaction-builder = { path = "../language/transaction-builder" }
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
+executor = { path = "../executor", version = "0.1.0" }
+grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
+storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
+vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To publish on [crates.io](https://crates.io) all package dependencies specified with paths need to also specify a version that will match the crates.io version of the dependency. This PR adds those version numbers. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Only cosmetic changes, existing CI should suffice
