### PR TITLE
[docker] Fix docker build caching issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,5 @@
 .git/
 **/.terraform/
 terraform/
-docker/validator/
-docker/client/
 target/
 !target/libra-node-builder/libra-node


### PR DESCRIPTION
Ignoring these directories is breaking caching during builds. I suspect
the reason is that the specified dockerfile is added to the context, but
this results in different contexts for each of the different builds.
Including all the dockerfiles keeps the context consistent.