### PR TITLE
[consensus][fix] do not consider root as reconfig block

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -514,4 +514,7 @@ fn test_empty_reconfiguration_suffix() {
     assert!(a5.compute_result().has_reconfiguration());
     // Block continues another branch can carry payload
     inserter.insert_block(&a2, 4, None);
+    block_tree.prune_tree(a3.id());
+    // If reconfiguration is committed, the child block can carry payload
+    let _a6 = inserter.insert_block(&a3, 4, None);
 }

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -201,7 +201,9 @@ impl<T: Payload> ProposalGenerator<T> {
         };
 
         // Reconfiguration rule - we propose empty blocks after reconfiguration until it's committed
-        let txns = if hqc_block.compute_result().has_reconfiguration() {
+        let txns = if self.block_store.root() != hqc_block
+            && hqc_block.compute_result().has_reconfiguration()
+        {
             T::default()
         } else {
             self.txn_manager


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We should only consider pending blocks as reconfiguration but not root, this is surfaced in https://github.com/libra/libra/pull/1397 when we derive the real genesis state compute result and fill validators field for genesis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Added test coverage.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
