### PR TITLE
[consensus] simplify VoteReceptionResult enum

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -328,7 +328,7 @@ fn test_insert_vote() {
         // filter out duplicates
         assert_eq!(
             block_store.insert_vote_and_qc(&vote, &validator_verifier),
-            VoteReceptionResult::DuplicateVote,
+            VoteReceptionResult::VoteAdded(0),
         );
         // qc is still not there
         assert!(block_store.get_quorum_cert_for_block(block.id()).is_none());

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -286,8 +286,9 @@ where
         validator_verifier: &ValidatorVerifier,
     ) -> VoteReceptionResult {
         let block_id = vote.vote_data().proposed().id();
-        if let Some(old_qc) = self.id_to_quorum_cert.get(&block_id) {
-            return VoteReceptionResult::OldQuorumCertificate(Arc::clone(old_qc));
+        // This block has already been certified.
+        if self.id_to_quorum_cert.get(&block_id).is_some() {
+            return VoteReceptionResult::VoteAdded(0);
         }
         let res = self.pending_votes.insert_vote(vote, validator_verifier);
         if let VoteReceptionResult::NewQuorumCertificate(_) = res {

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -16,22 +16,19 @@ mod pending_votes;
 
 pub use block_store::{sync_manager::BlockRetriever, BlockStore};
 
-/// Result of the vote processing. The failure case (Verification error) is returned
-/// as the Error part of the result.
+/// Result of processing the vote.
+/// The failure case (Verification error) is returned as the Error part of the result.
 #[derive(Debug, PartialEq)]
 pub enum VoteReceptionResult {
-    /// The vote has been added but QC has not been formed yet. Return the amount of voting power
-    /// the given (proposal, execution) pair.
+    /// The vote has been added but a new certificate is not formed.
+    /// Zero vote is added in the following cases:
+    ///  1. The very same vote message has been processed in the past.
+    ///  2. The very same author has already voted for another proposal in this round (equivocation).
+    ///  3. This block has been already certified.
     VoteAdded(u64),
-    /// The very same vote message has been processed in past.
-    DuplicateVote,
-    /// The very same author has already voted for another proposal in this round (equivocation).
-    EquivocateVote,
-    /// This block has been already certified.
-    OldQuorumCertificate(Arc<QuorumCert>),
-    /// This block has just been certified after adding the vote.
+    /// The vote completes a new QuorumCert.
     NewQuorumCertificate(Arc<QuorumCert>),
-    /// The vote completes a new TimeoutCertificate
+    /// The vote completes a new TimeoutCertificate.
     NewTimeoutCertificate(Arc<TimeoutCertificate>),
 }
 

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -155,7 +155,7 @@ impl PendingVotes {
         if li_digest == last_voted_info.li_digest {
             if is_timeout == last_voted_info.is_timeout {
                 // Author has already voted for the very same LedgerInfo
-                return Err(VoteReceptionResult::DuplicateVote);
+                return Err(VoteReceptionResult::VoteAdded(0));
             } else {
                 // Author has already voted for this LedgerInfo, but this time the Vote's
                 // round signature is different.
@@ -184,7 +184,7 @@ impl PendingVotes {
                 author.short_str(),
                 round
             );
-            return Err(VoteReceptionResult::EquivocateVote);
+            return Err(VoteReceptionResult::VoteAdded(0));
         }
         if let Some(pending_tc) = self.round_to_tc.get_mut(&last_voted_info.round) {
             // Removing signature from last tc

--- a/consensus/src/chained_bft/block_storage/pending_votes_test.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes_test.rs
@@ -49,7 +49,7 @@ fn test_qc_aggregation() {
     // same author voting for the same thing: result is DuplicateVote
     assert_eq!(
         pending_votes.insert_vote(&vote_data_1_author_0, &validator),
-        VoteReceptionResult::DuplicateVote
+        VoteReceptionResult::VoteAdded(0)
     );
     // same author voting for a different result in the same round:
     // override the prev value and return equivocation
@@ -63,7 +63,7 @@ fn test_qc_aggregation() {
     );
     assert_eq!(
         pending_votes.insert_vote(&vote_data_2_author_0, &validator),
-        VoteReceptionResult::EquivocateVote
+        VoteReceptionResult::VoteAdded(0)
     );
     // A different author voting for a different result in the same round but without a round
     // signature: VoteAdded


### PR DESCRIPTION
Changes:
- Remove `DuplicateVote`, `EquivocateVote`, and `OldQuorumCertificate`.
- Consolidate all non-new certificate results to `VoteReceptionResult::VoteAdded`.

Background:
- The purpose of this change is to pull out `PendingVotes` from `BlockTree`.
- In the future, adding votes will be handled by the `EventProcessor`, and obtaining the new certificate will be handled separately in `PendingVotes`.

Test:
- `cargo test -p consensus`

Closes #1398 