### PR TITLE
[cluster_test] Auto restart cluster-test when it exits

### DIFF
--- a/docker/cluster_test/run.sh
+++ b/docker/cluster_test/run.sh
@@ -2,9 +2,13 @@
 export ALLOW_DEPLOY=yes
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 
-mv run.out run.out.bak || echo 'run.out does not exist'
-if ! ./cluster-test --workplace cluster-test --run > run.out ; then
-  REQUEST=\{\"text\":\"cluster_test\ terminated\"\}
+
+while true; do
+  mv run.out run.out.bak || echo 'run.out does not exist'
+  REQUEST="{\"text\":\"cluster_test starting.\"}"
   curl -X POST -H 'Content-type: application/json' --data "$REQUEST" "$SLACK_URL"
-  exit 1
-fi
+  ./cluster-test --workplace cluster-test --run > run.out
+  REQUEST="{\"text\":\"cluster_test terminated with status: $?.\"}"
+  curl -X POST -H 'Content-type: application/json' --data "$REQUEST" "$SLACK_URL"
+  sleep 30
+done


### PR DESCRIPTION
## Summary

The current cluster-test run script exits whenever cluster-test exits. This requires someone to ssh and restart the cluster-test.

This change updates the run script to restart the cluster-test whenever it exits.

## Test Plan

Ran script on cluster-test machine