### PR TITLE
[monitoring][1/x] Create new network counter with dimensions

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -3,16 +3,45 @@
 
 use lazy_static;
 use libra_metrics::{Histogram, IntCounter, IntGauge, OpMetrics};
-use prometheus::IntGaugeVec;
+use prometheus::{IntCounterVec, IntGaugeVec};
 
 lazy_static::lazy_static! {
-    pub static ref NETWORK_PEERS: IntGaugeVec = register_int_gauge_vec!(
+    pub static ref LIBRA_NETWORK_PEERS: IntGaugeVec = register_int_gauge_vec!(
         // metric name
         "libra_network_peers",
         // metric description
         "Libra network peers counter",
         // metric labels (dimensions)
-        &["state", "role"]
+        &["role", "state"]
+    ).unwrap();
+
+    pub static ref LIBRA_NETWORK_RPC_MESSAGES: IntCounterVec = register_int_counter_vec!(
+        "libra_network_rpc_messages",
+        "Libra network rpc messages counters",
+        &["type", "state"]
+    ).unwrap();
+
+    pub static ref LIBRA_NETWORK_RPC_BYTES: IntCounterVec = register_int_counter_vec!(
+        "libra_network_rpc_bytes",
+        "Libra network rpc bytes counters",
+        &["type", "state"]
+    ).unwrap();
+
+    pub static ref LIBRA_NETWORK_RPC_LATENCY: Histogram = register_histogram!(
+        "libra_network_rpc_latency_seconds",
+        "Libra network rpc latency histogram"
+    ).unwrap();
+
+    pub static ref LIBRA_NETWORK_DIRECT_SEND_MESSAGES: IntCounterVec = register_int_counter_vec!(
+        "libra_network_direct_send_messages",
+        "Libra network direct send protocol counters, measured by messages",
+        &["state"]
+    ).unwrap();
+
+    pub static ref LIBRA_NETWORK_DIRECT_SEND_BYTES: IntCounterVec = register_int_counter_vec!(
+        "libra_network_direct_send_bytes",
+        "Libra network direct send protocol counters, measured by bytes",
+        &["state"]
     ).unwrap();
 }
 

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -299,7 +299,13 @@ where
             }
             NetworkRequest::SendMessage(peer_id, msg) => {
                 counters::DIRECT_SEND_MESSAGES_SENT.inc();
+                counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
+                    .with_label_values(&["sent"])
+                    .inc();
                 counters::DIRECT_SEND_BYTES_SENT.inc_by(msg.mdata.len() as i64);
+                counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
+                    .with_label_values(&["sent"])
+                    .inc_by(msg.mdata.len() as i64);
                 ds_reqs_tx
                     .send(DirectSendRequest::SendMessage(peer_id, msg))
                     .await
@@ -371,7 +377,13 @@ where
         match notif {
             DirectSendNotification::RecvMessage(peer_id, msg) => {
                 counters::DIRECT_SEND_MESSAGES_RECEIVED.inc();
+                counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
+                    .with_label_values(&["received"])
+                    .inc();
                 counters::DIRECT_SEND_BYTES_RECEIVED.inc_by(msg.mdata.len() as i64);
+                counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
+                    .with_label_values(&["received"])
+                    .inc_by(msg.mdata.len() as i64);
                 let ch = upstream_handlers
                     .get_mut(&msg.protocol)
                     .expect("DirectSend protocol not registered");

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -282,8 +282,8 @@ where
                     }
                 }
                 // update libra_network_peer counter
-                counters::NETWORK_PEERS
-                    .with_label_values(&["connected", &role.to_string()])
+                counters::LIBRA_NETWORK_PEERS
+                    .with_label_values(&[&role.to_string(), "connected"])
                     .dec();
                 // Send LostPeer notifications to subscribers
                 for ch in &mut self.peer_event_handlers {
@@ -452,12 +452,13 @@ where
         );
         self.active_peers.insert(peer_id, peer_handle);
         self.executor.spawn(peer.start());
-        // update libra_network_peer counter
-        counters::NETWORK_PEERS
-            .with_label_values(&["connected", &role.to_string()])
-            .inc();
         // Send NewPeer notifications to subscribers
         if send_new_peer_notification {
+            // update libra_network_peer counter
+            counters::LIBRA_NETWORK_PEERS
+                .with_label_values(&[&role.to_string(), "connected"])
+                .inc();
+
             for ch in &mut self.peer_event_handlers {
                 ch.send(PeerManagerNotification::NewPeer(peer_id, address.clone()))
                     .await

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -254,6 +254,16 @@ where
                     )
                     .get(),
             );
+            counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
+                .with_label_values(&["dropped"])
+                .inc_by(
+                    counters::OP_COUNTERS
+                        .peer_gauge(
+                            &counters::PENDING_DIRECT_SEND_OUTBOUND_MESSAGES,
+                            &peer_id.short_str(),
+                        )
+                        .get(),
+                );
         };
         executor.spawn(f_substream);
 
@@ -303,6 +313,9 @@ where
                     .await
                 {
                     counters::DIRECT_SEND_MESSAGES_DROPPED.inc();
+                    counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
+                        .with_label_values(&["dropped"])
+                        .inc();
                     warn!("DirectSend to peer {} failed: {}", peer_id.short_str(), e);
                 }
             }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Rewrite the Libra network counters following Prometheus best practice (https://prometheus.io/docs/practices/naming/), doing this with batches so it's easier to review.

## Test Plan

- `curl --silent "http://localhost:53388/metrics"` to get metrics
- compare the metrics to make sure values looks the same.
```
sherryxiao-mbp:0 sherryxiao$ curl --silent "http://localhost:49578/metrics" | grep direct_send
# HELP libra_network_direct_send_bytes Libra network direct send protocal counters, measured by bytes
# TYPE libra_network_direct_send_bytes counter
libra_network_direct_send_bytes{state="received"} 7336729
libra_network_direct_send_bytes{state="sent"} 7338414
# HELP libra_network_direct_send_messages Libra network direct send protocal counters, measured by messages
# TYPE libra_network_direct_send_messages counter
libra_network_direct_send_messages{state="dropped"} 13
libra_network_direct_send_messages{state="received"} 3772
libra_network_direct_send_messages{state="sent"} 3779
network{op="direct_send_bytes_received"} 7336729
network{op="direct_send_bytes_sent"} 7338414
network{op="direct_send_messages_dropped"} 13
network{op="direct_send_messages_received"} 3772
network{op="direct_send_messages_sent"} 3779
```
```
sherryxiao-mbp:0 sherryxiao$ curl --silent "http://localhost:49578/metrics" | grep rpc
# HELP libra_network_rpc_bytes Libra network rpc bytes counters
# TYPE libra_network_rpc_bytes counter
libra_network_rpc_bytes{state="sent",type="response"} 3220
# HELP libra_network_rpc_messages Libra network rpc messages counters
# TYPE libra_network_rpc_messages counter
libra_network_rpc_messages{state="received",type="request"} 4
libra_network_rpc_messages{state="sent",type="response"} 4
network{op="rpc_requests_received"} 4
network{op="rpc_response_bytes_sent"} 3220
network{op="rpc_responses_sent"} 4
```
