### PR TITLE
Timeout Signing in TCB

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -1,10 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{
-    hash::{CryptoHasher, RoundHasher},
-    HashValue,
-};
 use libra_types::account_address::AccountAddress;
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
@@ -34,11 +30,4 @@ impl<T> Payload for T where
         + Eq
         + 'static
 {
-}
-
-pub fn timeout_hash(round: Round, epoch: u64) -> HashValue {
-    let digest = lcs::to_bytes(&(round, epoch)).expect("Should serialize");
-    let mut state = RoundHasher::default();
-    state.write(digest.as_ref());
-    state.finish()
 }

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -7,6 +7,7 @@ pub mod common;
 pub mod proposal_msg;
 pub mod quorum_cert;
 pub mod sync_info;
+pub mod timeout;
 pub mod timeout_certificate;
 pub mod vote;
 pub mod vote_data;

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -3,7 +3,9 @@
 
 use crate::{block::Block, common::Round};
 use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue, TimeoutHasher};
+use libra_types::crypto_proxies::{Signature, ValidatorSigner};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 /// This structure contains all the information necessary to construct a signature
 /// on the equivalent of a timeout message
@@ -34,6 +36,13 @@ impl Timeout {
     pub fn round(&self) -> Round {
         self.round
     }
+
+    pub fn sign(&self, signer: &ValidatorSigner) -> Signature {
+        signer
+            .sign_message(self.hash())
+            .expect("Failed to sign Timeout")
+            .into()
+    }
 }
 
 impl CryptoHash for Timeout {
@@ -44,5 +53,11 @@ impl CryptoHash for Timeout {
         let mut state = Self::Hasher::default();
         state.write(bytes.as_ref());
         state.finish()
+    }
+}
+
+impl Display for Timeout {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "Timeout: [epoch: {}, round: {}]", self.epoch, self.round,)
     }
 }

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{block::Block, common::Round};
+use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue, TimeoutHasher};
+use serde::{Deserialize, Serialize};
+
+/// This structure contains all the information necessary to construct a signature
+/// on the equivalent of a timeout message
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Timeout {
+    /// Epoch number corresponds to the set of validators that are active for this round.
+    epoch: u64,
+    /// The consensus protocol executes proposals (blocks) in rounds, which monotically increase per epoch.
+    round: Round,
+}
+
+impl Timeout {
+    pub fn new(epoch: u64, round: Round) -> Self {
+        Self { epoch, round }
+    }
+
+    pub fn from_block<T>(block: &Block<T>) -> Self {
+        Self {
+            epoch: block.epoch(),
+            round: block.round(),
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn round(&self) -> Round {
+        self.round
+    }
+}
+
+impl CryptoHash for Timeout {
+    type Hasher = TimeoutHasher;
+
+    fn hash(&self) -> HashValue {
+        let bytes = lcs::to_bytes(self).expect("Timeout serialization failed");
+        let mut state = Self::Hasher::default();
+        state.write(bytes.as_ref());
+        state.finish()
+    }
+}

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -66,17 +66,12 @@ impl Vote {
 
     /// Generates a round signature, which can then be used for aggregating a timeout certificate.
     /// Typically called for generating vote messages that are sent upon timeouts.
-    pub fn add_timeout_signature(&mut self, validator_signer: &ValidatorSigner) {
+    pub fn add_timeout_signature(&mut self, signature: Signature) {
         if self.timeout_signature.is_some() {
             return; // round signature is already set
         }
 
-        self.timeout_signature.replace(
-            validator_signer
-                .sign_message(self.timeout().hash())
-                .expect("Failed to sign round")
-                .into(),
-        );
+        self.timeout_signature.replace(signature);
     }
 
     pub fn vote_data(&self) -> &VoteData {

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -6,13 +6,17 @@ use consensus_types::{
     block_info::BlockInfo,
     common::{Payload, Round},
     quorum_cert::QuorumCert,
+    timeout::Timeout,
     vote::Vote,
     vote_data::VoteData,
     vote_proposal::VoteProposal,
 };
 use failure::Fail;
-use libra_crypto::HashValue;
-use libra_types::{crypto_proxies::ValidatorSigner, ledger_info::LedgerInfo};
+use libra_crypto::hash::HashValue;
+use libra_types::{
+    crypto_proxies::{Signature, ValidatorSigner},
+    ledger_info::LedgerInfo,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
@@ -235,5 +239,11 @@ impl SafetyRules {
             self.construct_ledger_info(proposed_block),
             &self.validator_signer,
         ))
+    }
+
+    /// As the holder of the private key, SafetyRules also signs what is effectively a
+    /// timeout message. This returns the signature for that timeout message.
+    pub fn sign_timeout(&self, timeout: &Timeout) -> Result<Signature, Error> {
+        Ok(timeout.sign(&self.validator_signer))
     }
 }

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -22,7 +22,7 @@ mod safety_rules_test;
 
 #[derive(Debug, Fail, Eq, PartialEq)]
 /// Different reasons for proposal rejection
-pub enum ProposalReject {
+pub enum Error {
     /// This proposal's round is less than round of preferred block.
     /// Returns the id of the preferred block.
     #[fail(
@@ -200,11 +200,11 @@ impl SafetyRules {
     pub fn construct_and_sign_vote<T: Payload>(
         &mut self,
         vote_proposal: &VoteProposal<T>,
-    ) -> Result<Vote, ProposalReject> {
+    ) -> Result<Vote, Error> {
         let proposed_block = vote_proposal.block();
 
         if proposed_block.round() <= self.state.last_vote_round() {
-            return Err(ProposalReject::OldProposal {
+            return Err(Error::OldProposal {
                 proposal_round: proposed_block.round(),
                 last_vote_round: self.state.last_vote_round(),
             });
@@ -214,7 +214,7 @@ impl SafetyRules {
             >= self.state.preferred_block_round();
 
         if !respects_preferred_block {
-            return Err(ProposalReject::ProposalRoundLowerThenPreferredBlock {
+            return Err(Error::ProposalRoundLowerThenPreferredBlock {
                 preferred_block_round: self.state.preferred_block_round(),
             });
         }

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ConsensusState, ProposalReject, SafetyRules};
+use crate::{ConsensusState, Error, SafetyRules};
 use consensus_types::{
     block::Block, block_info::BlockInfo, common::Round, quorum_cert::QuorumCert, vote::Vote,
     vote_data::VoteData, vote_proposal::VoteProposal,
@@ -272,7 +272,7 @@ fn test_voting() {
     safety_rules.update(b2.block().quorum_cert());
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b2),
-        Err(ProposalReject::OldProposal {
+        Err(Error::OldProposal {
             last_vote_round: 4,
             proposal_round: 3,
         })
@@ -293,7 +293,7 @@ fn test_voting() {
     safety_rules.update(a4.block().quorum_cert());
     assert_eq!(
         safety_rules.construct_and_sign_vote(&a4),
-        Err(ProposalReject::OldProposal {
+        Err(Error::OldProposal {
             last_vote_round: 7,
             proposal_round: 7,
         })
@@ -301,7 +301,7 @@ fn test_voting() {
     safety_rules.update(b4.block().quorum_cert());
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b4),
-        Err(ProposalReject::ProposalRoundLowerThenPreferredBlock {
+        Err(Error::ProposalRoundLowerThenPreferredBlock {
             preferred_block_round: 4,
         })
     );

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -117,10 +117,11 @@ impl PendingVotes {
         validator_verifier: &ValidatorVerifier,
     ) -> Option<VoteReceptionResult> {
         let timeout_signature = vote.timeout_signature().cloned()?;
-        let round = vote.vote_data().proposed().round();
-        let tc = self.round_to_tc.entry(round).or_insert_with(|| {
-            TimeoutCertificate::new(vote.vote_data().proposed().epoch(), round, HashMap::new())
-        });
+        let timeout = vote.timeout();
+        let tc = self
+            .round_to_tc
+            .entry(timeout.round())
+            .or_insert_with(|| TimeoutCertificate::new(timeout, HashMap::new()));
         tc.add_signature(vote.author(), timeout_signature);
         match validator_verifier.check_voting_power(tc.signatures().keys()) {
             Ok(_) => Some(VoteReceptionResult::NewTimeoutCertificate(Arc::new(

--- a/consensus/src/chained_bft/block_storage/pending_votes_test.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes_test.rs
@@ -180,7 +180,10 @@ fn test_tc_aggregation() {
         li1.clone(),
         &signers[0],
     );
-    vote_round_1_author_0.add_timeout_signature(&signers[0]);
+
+    let timeout = vote_round_1_author_0.timeout();
+    let signature = timeout.sign(&signers[0]);
+    vote_round_1_author_0.add_timeout_signature(signature);
 
     // first time a new vote is added the result is VoteAdded
     assert_eq!(
@@ -204,7 +207,9 @@ fn test_tc_aggregation() {
     );
 
     // if that vote is now enhanced with a round signature, it can form a TC
-    vote2_round_1_author_1.add_timeout_signature(&signers[1]);
+    let timeout = vote2_round_1_author_1.timeout();
+    let signature = timeout.sign(&signers[1]);
+    vote2_round_1_author_1.add_timeout_signature(signature);
     match pending_votes.insert_vote(&vote2_round_1_author_1, &validator) {
         VoteReceptionResult::NewTimeoutCertificate(tc) => {
             assert!(validator.check_voting_power(tc.signatures().keys()).is_ok());
@@ -231,7 +236,9 @@ fn test_tc_aggregation_keep_last_only() {
         li1.clone(),
         &signers[0],
     );
-    vote_round_1_author_0.add_timeout_signature(&signers[0]);
+    let timeout = vote_round_1_author_0.timeout();
+    let signature = timeout.sign(&signers[0]);
+    vote_round_1_author_0.add_timeout_signature(signature);
 
     // first time a new vote is added the result is VoteAdded
     assert_eq!(
@@ -248,7 +255,9 @@ fn test_tc_aggregation_keep_last_only() {
         li2.clone(),
         &signers[0],
     );
-    vote_round_2_author_0.add_timeout_signature(&signers[0]);
+    let timeout = vote_round_2_author_0.timeout();
+    let signature = timeout.sign(&signers[0]);
+    vote_round_2_author_0.add_timeout_signature(signature);
     assert_eq!(
         pending_votes.insert_vote(&vote_round_2_author_0, &validator),
         VoteReceptionResult::VoteAdded(1)
@@ -263,7 +272,9 @@ fn test_tc_aggregation_keep_last_only() {
         li3.clone(),
         &signers[1],
     );
-    vote3_round_1_author_1.add_timeout_signature(&signers[1]);
+    let timeout = vote3_round_1_author_1.timeout();
+    let signature = timeout.sign(&signers[1]);
+    vote3_round_1_author_1.add_timeout_signature(signature);
     assert_eq!(
         pending_votes.insert_vote(&vote3_round_1_author_1, &validator),
         VoteReceptionResult::VoteAdded(1)
@@ -278,7 +289,9 @@ fn test_tc_aggregation_keep_last_only() {
         li4.clone(),
         &signers[1],
     );
-    vote4_round_2_author_1.add_timeout_signature(&signers[1]);
+    let timeout = vote4_round_2_author_1.timeout();
+    let signature = timeout.sign(&signers[1]);
+    vote4_round_2_author_1.add_timeout_signature(signature);
     match pending_votes.insert_vote(&vote4_round_2_author_1, &validator) {
         VoteReceptionResult::NewTimeoutCertificate(tc) => {
             assert!(validator.check_voting_power(tc.signatures().keys()).is_ok());

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -34,6 +34,7 @@ use consensus_types::{
     proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
+    timeout::Timeout,
     timeout_certificate::TimeoutCertificate,
     vote::Vote,
     vote_data::VoteData,
@@ -664,7 +665,7 @@ fn process_timeout_certificate_test() {
         genesis_qc.clone(),
         node.block_store.signer(),
     );
-    let tc = TimeoutCertificate::new(1, 1, HashMap::new());
+    let tc = TimeoutCertificate::new(Timeout::new(1, 1), HashMap::new());
 
     block_on(async move {
         let skip_round_proposal = ProposalMsg::<TestPayload>::new(

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -557,8 +557,8 @@ fn process_vote_timeout_msg_test() {
         placeholder_ledger_info(),
         &non_proposer.signer,
     );
-
-    vote_on_timeout.add_timeout_signature(&non_proposer.signer);
+    let signature = vote_on_timeout.timeout().sign(&non_proposer.signer);
+    vote_on_timeout.add_timeout_signature(signature);
 
     let vote_msg_on_timeout = VoteMsg::new(
         vote_on_timeout,

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -563,18 +563,8 @@ define_hasher! {
 }
 
 define_hasher! {
-    /// The hasher used to compute the hash of a PacemakerTimeout object.
-    (PacemakerTimeoutHasher, PACEMAKER_TIMEOUT_HASHER, b"PacemakerTimeout")
-}
-
-define_hasher! {
-    /// The hasher used to compute the hash of a TimeoutMsgHasher object.
-    (TimeoutMsgHasher, TIMEOUT_MSG_HASHER, b"TimeoutMsg")
-}
-
-define_hasher! {
-    /// The hasher used to compute the hash of a Round
-    (RoundHasher, ROUND_HASHER, b"Round")
+    /// The hasher used to compute the hash of a TimeoutProposal
+    (TimeoutHasher, ROUND_HASHER, b"Timeout")
 }
 
 define_hasher! {


### PR DESCRIPTION
Three commits:
- Make a TimeoutProposal as the interface for communicating the signing request to the TCB and to consolidate the logic that goes into signing for the purposes of hashing / signature
- Rename safety_rules::ProposalReject to Error since we will reuse this on all the signing APIs
- Move signing of TimeoutProposal to TCB