### PR TITLE
[cluster_test] Add tc package to validator

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -38,4 +38,4 @@ cat > /etc/profile.d/libra_prompt.sh <<EOF
 export PS1="[\u:validator@\h \w]$ "
 EOF
 
-yum -y install ngrep tcpdump perf gdb nmap-ncat strace htop sysstat
+yum -y install ngrep tcpdump perf gdb nmap-ncat strace htop sysstat tc


### PR DESCRIPTION
## Summary

`tc` provides `netem`. We need `netem` for https://github.com/libra/libra/issues/1198

## Test Plan

Ran `yum install -y tc` on a validator