### PR TITLE
[language] native functions NativeReturnStatus change

### DIFF
--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -22,8 +22,8 @@ use vm::{
     IndexKind,
 };
 use vm_runtime_types::{
-    native_functions::dispatch::dispatch_native_function,
-    native_structs::dispatch::dispatch_native_struct,
+    native_functions::dispatch::resolve_native_function,
+    native_structs::dispatch::resolve_native_struct,
 };
 
 /// A program that has been verified for internal consistency.
@@ -375,7 +375,7 @@ fn verify_native_functions(module_view: &ModuleView<VerifiedModule>) -> Vec<VMSt
         .filter(|fdv| fdv.1.is_native())
     {
         let function_name = native_function_definition_view.name();
-        match dispatch_native_function(&module_id, function_name) {
+        match resolve_native_function(&module_id, function_name) {
             None => errors.push(verification_error(
                 IndexKind::FunctionHandle,
                 idx,
@@ -409,7 +409,7 @@ fn verify_native_structs(module_view: &ModuleView<VerifiedModule>) -> Vec<VMStat
     {
         let struct_name = native_struct_definition_view.name();
 
-        match dispatch_native_struct(&module_id, struct_name) {
+        match resolve_native_struct(&module_id, struct_name) {
             None => errors.push(verification_error(
                 IndexKind::StructHandle,
                 idx,

--- a/language/vm/vm-runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm-runtime/src/code_cache/module_cache.rs
@@ -28,7 +28,7 @@ use vm::{
 use vm_cache_map::{Arena, CacheRefMap};
 use vm_runtime_types::{
     loaded_data::{struct_def::StructDef, types::Type},
-    native_structs::dispatch::dispatch_native_struct,
+    native_structs::dispatch::resolve_native_struct,
     type_context::TypeContext,
 };
 
@@ -328,7 +328,7 @@ impl<'alloc> VMModuleCache<'alloc> {
                     let struct_def_module_id =
                         StructHandleView::new(module, struct_handle).module_id();
                     StructDef::Native(
-                        dispatch_native_struct(&struct_def_module_id, struct_name)
+                        resolve_native_struct(&struct_def_module_id, struct_name)
                             .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?
                             .struct_type
                             .clone(),

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/hash.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/hash.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::dispatch::NativeReturnStatus;
-use crate::value::Value;
+use crate::{native_functions::dispatch::NativeResult, value::Value};
 use libra_crypto::HashValue;
 use libra_types::{
     byte_array::ByteArray,
@@ -10,48 +9,39 @@ use libra_types::{
 };
 use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
+use vm::errors::VMResult;
 
 const SHA2_COST: u64 = 30;
 const SHA3_COST: u64 = 30;
 
-pub fn native_sha2_256(mut arguments: VecDeque<Value>) -> NativeReturnStatus {
+pub fn native_sha2_256(mut arguments: VecDeque<Value>) -> VMResult<NativeResult> {
     if arguments.len() != 1 {
         let msg = format!(
             "wrong number of arguments for sha2_256 expected 1 found {}",
             arguments.len()
         );
-        return NativeReturnStatus::InvariantError(
-            VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-        );
+        return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
     }
     let hash_arg = pop_arg!(arguments, ByteArray);
     let cost = SHA2_COST * hash_arg.len() as u64;
 
     let hash_vec = Sha256::digest(hash_arg.as_bytes()).to_vec();
     let return_values = vec![Value::byte_array(ByteArray::new(hash_vec))];
-    NativeReturnStatus::Success {
-        cost,
-        return_values,
-    }
+    Ok(NativeResult::ok(cost, return_values))
 }
 
-pub fn native_sha3_256(mut arguments: VecDeque<Value>) -> NativeReturnStatus {
+pub fn native_sha3_256(mut arguments: VecDeque<Value>) -> VMResult<NativeResult> {
     if arguments.len() != 1 {
         let msg = format!(
             "wrong number of arguments for sha3_256 expected 1 found {}",
             arguments.len()
         );
-        return NativeReturnStatus::InvariantError(
-            VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-        );
+        return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
     }
     let hash_arg = pop_arg!(arguments, ByteArray);
     let cost = SHA3_COST * hash_arg.len() as u64;
 
     let hash_vec = HashValue::from_sha3_256(hash_arg.as_bytes()).to_vec();
     let return_values = vec![Value::byte_array(ByteArray::new(hash_vec))];
-    NativeReturnStatus::Success {
-        cost,
-        return_values,
-    }
+    Ok(NativeResult::ok(cost, return_values))
 }

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/primitive_helpers.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/primitive_helpers.rs
@@ -1,21 +1,19 @@
-use super::dispatch::NativeReturnStatus;
-use crate::value::Value;
+use crate::{native_functions::dispatch::NativeResult, value::Value};
 use libra_types::{
     account_address::AccountAddress,
     byte_array::ByteArray,
     vm_error::{StatusCode, VMStatus},
 };
 use std::collections::VecDeque;
+use vm::errors::VMResult;
 
-pub fn native_bytearray_concat(mut arguments: VecDeque<Value>) -> NativeReturnStatus {
+pub fn native_bytearray_concat(mut arguments: VecDeque<Value>) -> VMResult<NativeResult> {
     if arguments.len() != 2 {
         let msg = format!(
             "wrong number of arguments for bytearray_concat expected 2 found {}",
             arguments.len()
         );
-        return NativeReturnStatus::InvariantError(
-            VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-        );
+        return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
     }
     let arg2 = pop_arg!(arguments, ByteArray);
     let arg1 = pop_arg!(arguments, ByteArray);
@@ -25,21 +23,16 @@ pub fn native_bytearray_concat(mut arguments: VecDeque<Value>) -> NativeReturnSt
     // TODO: Figure out the gas cost for concatenation.
     let cost = return_val.len() as u64;
     let return_values = vec![Value::byte_array(ByteArray::new(return_val))];
-    NativeReturnStatus::Success {
-        cost,
-        return_values,
-    }
+    Ok(NativeResult::ok(cost, return_values))
 }
 
-pub fn native_address_to_bytes(mut arguments: VecDeque<Value>) -> NativeReturnStatus {
+pub fn native_address_to_bytes(mut arguments: VecDeque<Value>) -> VMResult<NativeResult> {
     if arguments.len() != 1 {
         let msg = format!(
             "wrong number of arguments for address_to_bytes expected 1 found {}",
             arguments.len()
         );
-        return NativeReturnStatus::InvariantError(
-            VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-        );
+        return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
     }
     let arg = pop_arg!(arguments, AccountAddress);
     let return_val = arg.to_vec();
@@ -47,21 +40,16 @@ pub fn native_address_to_bytes(mut arguments: VecDeque<Value>) -> NativeReturnSt
     // TODO: Figure out the gas cost for conversion.
     let cost = return_val.len() as u64;
     let return_values = vec![Value::byte_array(ByteArray::new(return_val))];
-    NativeReturnStatus::Success {
-        cost,
-        return_values,
-    }
+    Ok(NativeResult::ok(cost, return_values))
 }
 
-pub fn native_u64_to_bytes(mut arguments: VecDeque<Value>) -> NativeReturnStatus {
+pub fn native_u64_to_bytes(mut arguments: VecDeque<Value>) -> VMResult<NativeResult> {
     if arguments.len() != 1 {
         let msg = format!(
             "wrong number of arguments for u64_to_bytes expected 1 found {}",
             arguments.len()
         );
-        return NativeReturnStatus::InvariantError(
-            VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-        );
+        return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
     }
     let arg = pop_arg!(arguments, u64);
     let return_val: Vec<u8> = arg.to_le_bytes().to_vec();
@@ -69,8 +57,5 @@ pub fn native_u64_to_bytes(mut arguments: VecDeque<Value>) -> NativeReturnStatus
     // TODO: Figure out the gas cost for conversion.
     let cost = return_val.len() as u64;
     let return_values = vec![Value::byte_array(ByteArray::new(return_val))];
-    NativeReturnStatus::Success {
-        cost,
-        return_values,
-    }
+    Ok(NativeResult::ok(cost, return_values))
 }

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/dispatch.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/dispatch.rs
@@ -28,7 +28,7 @@ pub struct NativeStruct {
 
 /// Looks up the expected native struct definition from the module id (address and module) and
 /// function name where it was expected to be declared
-pub fn dispatch_native_struct(
+pub fn resolve_native_struct(
     module: &ModuleId,
     struct_name: &IdentStr,
 ) -> Option<&'static NativeStruct> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
@@ -1,10 +1,10 @@
 use crate::{
-    native_functions::dispatch::NativeReturnStatus,
+    native_functions::dispatch::NativeResult,
     native_structs::NativeStructValue,
     pop_arg,
     value::{MutVal, ReferenceValue, Value},
 };
-use libra_types::vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, VMStatus};
+use libra_types::vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, StatusType, VMStatus};
 use serde::Serialize;
 use std::{collections::VecDeque, ops::Add};
 use vm::errors::VMResult;
@@ -41,86 +41,71 @@ fn get_vector(v: &NativeStructValue) -> VMResult<&NativeVector> {
 macro_rules! get_vector_ref {
     ($args: expr) => {
         match $args.pop_front() {
-            Some(v) => match v.value_as::<ReferenceValue>() {
-                Ok(reference) => reference,
-                Err(err) => return NativeReturnStatus::InvariantError(err),
-            },
+            Some(v) => v.value_as::<ReferenceValue>()?,
             None => {
-                return NativeReturnStatus::InvariantError(
-                    VMStatus::new(StatusCode::UNREACHABLE)
-                        .with_message("native vector reference must exist".to_string()),
-                )
+                return Err(VMStatus::new(StatusCode::UNREACHABLE)
+                    .with_message("native vector reference must exist".to_string()));
             }
         };
     };
 }
 
 impl NativeVector {
-    pub fn native_empty(_args: VecDeque<Value>) -> NativeReturnStatus {
-        NativeReturnStatus::Success {
-            return_values: vec![Value::native_struct(NativeStructValue::Vector(
+    pub fn native_empty(_args: VecDeque<Value>) -> VMResult<NativeResult> {
+        Ok(NativeResult::ok(
+            EMPTY_COST,
+            vec![Value::native_struct(NativeStructValue::Vector(
                 NativeVector(vec![]),
             ))],
-            cost: EMPTY_COST,
-        }
+        ))
     }
 
-    pub fn native_length(mut args: VecDeque<Value>) -> NativeReturnStatus {
-        let reference = get_vector_ref!(args);
-        match reference.read_native_struct(|struct_ref| {
-            get_vector(struct_ref).and_then(|native_vec| Ok(native_vec.0.len()))
-        }) {
-            Ok(len) => NativeReturnStatus::Success {
-                cost: LENGTH_COST,
-                return_values: vec![Value::u64(len as u64)],
-            },
-            Err(err) => NativeReturnStatus::InvariantError(err),
-        }
+    pub fn native_length(mut args: VecDeque<Value>) -> VMResult<NativeResult> {
+        let reference: ReferenceValue = get_vector_ref!(args);
+        reference.read_native_struct(|struct_ref| {
+            get_vector(struct_ref).and_then(|native_vec| {
+                Ok(NativeResult::ok(
+                    LENGTH_COST,
+                    vec![Value::u64(native_vec.0.len() as u64)],
+                ))
+            })
+        })
     }
 
-    pub fn native_push_back(mut args: VecDeque<Value>) -> NativeReturnStatus {
+    pub fn native_push_back(mut args: VecDeque<Value>) -> VMResult<NativeResult> {
         if args.len() != 2 {
             let msg = format!(
                 "wrong number of arguments for push_back expected 2 found {}",
                 args.len()
             );
-            return NativeReturnStatus::InvariantError(
-                VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-            );
+            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
         }
-        let reference = get_vector_ref!(args);
+        let reference: ReferenceValue = get_vector_ref!(args);
         let elem = match args.pop_front() {
             Some(v) => MutVal::new(v),
             None => {
-                return NativeReturnStatus::InvariantError(
-                    VMStatus::new(StatusCode::UNREACHABLE).with_message(
-                        "wrong number of arguments for push_back, expected value".to_string(),
-                    ),
-                );
+                return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(
+                    "wrong number of arguments for push_back, expected value".to_string(),
+                ));
             }
         };
-        match reference.mutate_native_struct(|struct_ref| {
-            get_mut_vector(struct_ref).and_then(|native_vec| Ok(native_vec.0.push(elem)))
-        }) {
-            Ok(_) => NativeReturnStatus::Success {
-                cost: PUSH_BACK_COST,
-                return_values: vec![],
-            },
-            Err(err) => NativeReturnStatus::InvariantError(err),
-        }
+        reference.mutate_native_struct(|struct_ref| {
+            get_mut_vector(struct_ref).and_then(|native_vec| {
+                native_vec.0.push(elem);
+                Ok(NativeResult::ok(PUSH_BACK_COST, vec![]))
+            })
+        })
     }
 
-    pub fn native_borrow(mut args: VecDeque<Value>) -> NativeReturnStatus {
+    pub fn native_borrow(mut args: VecDeque<Value>) -> VMResult<NativeResult> {
         if args.len() != 2 {
             let msg = format!(
                 "wrong number of arguments for borrow expected 2 found {}",
                 args.len()
             );
-            return NativeReturnStatus::InvariantError(
-                VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-            );
+            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
         }
-        let reference = get_vector_ref!(args);
+        let reference: ReferenceValue = get_vector_ref!(args);
         let idx = pop_arg!(args, u64);
         match reference.get_native_struct_reference(|struct_ref| {
             get_vector(struct_ref).and_then(|native_vec| match native_vec.0.get(idx as usize) {
@@ -129,122 +114,90 @@ impl NativeVector {
                     .with_sub_status(INDEX_OUT_OF_BOUNDS)),
             })
         }) {
-            Ok(v) => NativeReturnStatus::Success {
-                cost: BORROW_COST,
-                return_values: vec![v],
-            },
-            Err(err) => match err.major_status {
-                StatusCode::NATIVE_FUNCTION_ERROR => NativeReturnStatus::Aborted {
-                    cost: BORROW_COST,
-                    error_code: err,
-                },
-                _ => NativeReturnStatus::InvariantError(err),
-            },
+            Ok(val) => Ok(NativeResult::ok(BORROW_COST, vec![val])),
+            Err(err) => {
+                if err.is(StatusType::InvariantViolation) {
+                    Ok(NativeResult::err(BORROW_COST, err))
+                } else {
+                    Err(err)
+                }
+            }
         }
     }
 
-    pub fn native_pop(mut args: VecDeque<Value>) -> NativeReturnStatus {
+    pub fn native_pop(mut args: VecDeque<Value>) -> VMResult<NativeResult> {
         if args.len() != 1 {
             let msg = format!(
                 "wrong number of arguments for pop expected 1 found {}",
                 args.len()
             );
-            return NativeReturnStatus::InvariantError(
-                VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-            );
+            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
         }
 
-        let reference = get_vector_ref!(args);
-        match reference.mutate_native_struct(|struct_ref| {
+        let reference: ReferenceValue = get_vector_ref!(args);
+        reference.mutate_native_struct(|struct_ref| {
             get_mut_vector(struct_ref).and_then(|native_vec| match native_vec.0.pop() {
-                Some(val) => val.into_value(),
-                None => {
-                    Err(VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                        .with_sub_status(POP_EMPTY_VEC))
-                }
+                Some(val) => Ok(NativeResult::ok(POP_COST, vec![val.into_value()?])),
+                None => Ok(NativeResult::err(
+                    POP_COST,
+                    VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR).with_sub_status(POP_EMPTY_VEC),
+                )),
             })
-        }) {
-            Ok(v) => NativeReturnStatus::Success {
-                cost: POP_COST,
-                return_values: vec![v],
-            },
-            Err(err) => match err.major_status {
-                StatusCode::NATIVE_FUNCTION_ERROR => NativeReturnStatus::Aborted {
-                    cost: POP_COST,
-                    error_code: err,
-                },
-                _ => NativeReturnStatus::InvariantError(err),
-            },
-        }
+        })
     }
 
-    pub fn native_destroy_empty(mut args: VecDeque<Value>) -> NativeReturnStatus {
+    pub fn native_destroy_empty(mut args: VecDeque<Value>) -> VMResult<NativeResult> {
         if let Some(v) = args.pop_front() {
             if let Ok(NativeStructValue::Vector(NativeVector(v))) =
                 v.value_as::<NativeStructValue>()
             {
                 return if v.is_empty() {
-                    NativeReturnStatus::Success {
-                        cost: DESTROY_EMPTY_VEC_COST,
-                        return_values: vec![],
-                    }
+                    Ok(NativeResult::ok(DESTROY_EMPTY_VEC_COST, vec![]))
                 } else {
-                    NativeReturnStatus::Aborted {
-                        cost: DESTROY_EMPTY_VEC_COST,
-                        error_code: VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
+                    Ok(NativeResult::err(
+                        DESTROY_EMPTY_VEC_COST,
+                        VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
                             .with_sub_status(DESTROY_NON_EMPTY_VEC),
-                    }
+                    ))
                 };
             }
         }
-        NativeReturnStatus::InvariantError(
-            VMStatus::new(StatusCode::UNREACHABLE)
-                .with_message("wrong number of arguments for empty".to_string()),
-        )
+        Err(VMStatus::new(StatusCode::UNREACHABLE)
+            .with_message("bad arguments to destroy_empty".to_string()))
     }
 
-    pub fn native_swap(mut args: VecDeque<Value>) -> NativeReturnStatus {
+    pub fn native_swap(mut args: VecDeque<Value>) -> VMResult<NativeResult> {
         if args.len() != 3 {
             let msg = format!(
                 "wrong number of arguments for swap expected 3 found {}",
                 args.len()
             );
-            return NativeReturnStatus::InvariantError(
-                VMStatus::new(StatusCode::UNREACHABLE).with_message(msg),
-            );
+            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
         }
 
-        let reference = get_vector_ref!(args);
+        let reference: ReferenceValue = get_vector_ref!(args);
         let index1 = pop_arg!(args, u64);
         let index2 = pop_arg!(args, u64);
 
         // We need to check the indices before performing the swap in order to make sure the
         // indices are within bounds.
-        match reference.read_native_struct(|struct_ref| {
+        let len = reference.read_native_struct(|struct_ref| {
             get_vector(struct_ref).and_then(|native_vec| Ok(native_vec.0.len() as u64))
-        }) {
-            Ok(len) => {
-                if index1 >= len || index2 >= len {
-                    return NativeReturnStatus::Aborted {
-                        cost: SWAP_COST,
-                        error_code: VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                            .with_sub_status(INDEX_OUT_OF_BOUNDS),
-                    };
-                }
-            }
-            Err(err) => return NativeReturnStatus::InvariantError(err),
+        })?;
+        if index1 >= len || index2 >= len {
+            return Ok(NativeResult::err(
+                SWAP_COST,
+                VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
+                    .with_sub_status(INDEX_OUT_OF_BOUNDS),
+            ));
         }
 
-        match reference.mutate_native_struct(|struct_ref| {
-            get_mut_vector(struct_ref)
-                .and_then(|native_vec| Ok(native_vec.0.swap(index1 as usize, index2 as usize)))
-        }) {
-            Ok(_) => NativeReturnStatus::Success {
-                cost: SWAP_COST,
-                return_values: vec![],
-            },
-            Err(err) => NativeReturnStatus::InvariantError(err),
-        }
+        reference.mutate_native_struct(|struct_ref| {
+            get_mut_vector(struct_ref).and_then(|native_vec| {
+                native_vec.0.swap(index1 as usize, index2 as usize);
+                Ok(NativeResult::ok(SWAP_COST, vec![]))
+            })
+        })
     }
 
     pub(crate) fn get(&self, idx: u64) -> Option<MutVal> {


### PR DESCRIPTION
The comment in `language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs`
for `NativeResult` should describe this change well. Looking at native functions implementations
should also provide a clear view of the change.
Effectively instead of returning a `NativeReturnStatus` from native functions we return a
`VMResult<NativeResult>` which plugs into the way we report errors a bit more naturally.
A `NativeResult` carries a cost always and it's the way errors should be returned if they
are intended to charge the user. Typically for invariant violation a `VMResult` should be returned.
There is more code deleted than added so it seems a change in the right directions.
Benchmarks seem to show a minor win (less than 5%) - which may not be a win at all - but
at least it does not look like this regresses anything. I am running more tests on
a devserver to get a better sense.

I am curious if people think this is not a good direction to go.
There are reasons the model previously always returned a `NativeReturnStatus`
however I don't think this lose clarity and, in fact, it should make things
more natural as I mentioned.
But others may have a different perspective...
