### PR TITLE
[consensus][reconfig] generate genesis/qc from storage instead of hard code

### DIFF
--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -68,7 +68,7 @@ impl QuorumCert {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn certificate_for_genesis() -> QuorumCert {
-        Self::certificate_for_genesis_from_ledger_info(&LedgerInfo::genesis())
+        Self::certificate_for_genesis_from_ledger_info(&LedgerInfo::genesis(), *GENESIS_BLOCK_ID)
     }
 
     /// QuorumCert for the genesis block deterministically generated from end-epoch LedgerInfo:
@@ -76,11 +76,14 @@ impl QuorumCert {
     /// - the accumulator root hash of the LedgerInfo is set to the last executed state of previous
     ///   epoch.
     /// - the map of signatures is empty because genesis block is implicitly agreed.
-    pub fn certificate_for_genesis_from_ledger_info(ledger_info: &LedgerInfo) -> QuorumCert {
+    pub fn certificate_for_genesis_from_ledger_info(
+        ledger_info: &LedgerInfo,
+        genesis_id: HashValue,
+    ) -> QuorumCert {
         let ancestor = BlockInfo::new(
             ledger_info.epoch(),
             0,
-            *GENESIS_BLOCK_ID,
+            genesis_id,
             ledger_info.transaction_accumulator_hash(),
             ledger_info.version(),
             ledger_info.timestamp_usecs(),
@@ -92,7 +95,7 @@ impl QuorumCert {
             ledger_info.version(),
             ledger_info.transaction_accumulator_hash(),
             vote_data.hash(),
-            *GENESIS_BLOCK_ID,
+            genesis_id,
             ledger_info.epoch() + 1,
             ledger_info.timestamp_usecs(),
             ledger_info.next_validator_set().cloned(),

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -618,6 +618,7 @@ lazy_static! {
         create_literal_hash("PRE_GENESIS_BLOCK_ID");
 
     /// Genesis block id is used as a parent of the very first block executed by the executor.
+    #[cfg(any(test, feature = "testing"))]
     pub static ref GENESIS_BLOCK_ID: HashValue =
         // This maintains the invariant that block.id() == block.hash(), for
         // the genesis block and allows us to (de/)serialize it consistently

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -8,8 +8,10 @@ use crate::{
     validator_verifier::{ValidatorVerifier, VerifyError},
 };
 use failure::prelude::*;
+#[cfg(any(test, feature = "testing"))]
+use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use libra_crypto::{
-    hash::{CryptoHash, CryptoHasher, LedgerInfoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
+    hash::{CryptoHash, CryptoHasher, LedgerInfoHasher},
     HashValue, *,
 };
 #[cfg(any(test, feature = "testing"))]
@@ -153,6 +155,7 @@ impl LedgerInfo {
     }
 
     /// To bootstrap the system until we execute and commit the genesis txn before start.
+    #[cfg(any(test, feature = "testing"))]
     pub fn genesis() -> Self {
         Self::new(
             0,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We hard code the genesis block and its quorum cert, and it starts to fail for https://github.com/libra/libra/pull/1397/files when we read the real executed_state id and compare with the fake one in qc.

This PR moves one step forward by generating the genesis block/qc from the last ledger info in storage, although we still can't read the validator set from it.

Also we finally make the GENESIS_BLOCK_ID test-only. As a followup, we probably want to clean up block id from executor since it introduced some confusion.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
