### PR TITLE
[consensus] Move block signing to SafetyRules

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -192,6 +192,13 @@ where
             quorum_cert,
         );
 
+        Self::new_proposal_from_block_data(block_data, validator_signer)
+    }
+
+    pub fn new_proposal_from_block_data(
+        block_data: BlockData<T>,
+        validator_signer: &ValidatorSigner,
+    ) -> Self {
         let id = block_data.hash();
         let signature = validator_signer
             .sign_message(id)

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -3,6 +3,7 @@
 
 use consensus_types::{
     block::Block,
+    block_data::BlockData,
     block_info::BlockInfo,
     common::{Payload, Round},
     quorum_cert::QuorumCert,
@@ -133,6 +134,10 @@ impl SafetyRules {
         }
     }
 
+    pub fn signer(&self) -> &ValidatorSigner {
+        &self.validator_signer
+    }
+
     /// Learn about a new quorum certificate. Several things can happen as a result of that:
     /// 1) update the preferred block to a higher value.
     /// 2) commit some blocks.
@@ -237,6 +242,13 @@ impl SafetyRules {
             ),
             self.validator_signer.author(),
             self.construct_ledger_info(proposed_block),
+            &self.validator_signer,
+        ))
+    }
+
+    pub fn sign_proposal<T: Payload>(&self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
+        Ok(Block::new_proposal_from_block_data(
+            block_data,
             &self.validator_signer,
         ))
     }

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::{
-    block::Block, common::Round, executed_block::ExecutedBlock, quorum_cert::QuorumCert,
-    timeout_certificate::TimeoutCertificate,
+    block::Block, block_data::BlockData, common::Round, executed_block::ExecutedBlock,
+    quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
 };
 use libra_crypto::HashValue;
 use std::sync::Arc;
@@ -57,21 +57,20 @@ pub trait BlockReader: Send + Sync {
     fn path_from_root(&self, block_id: HashValue)
         -> Option<Vec<Arc<ExecutedBlock<Self::Payload>>>>;
 
-    /// Generates and returns a block with the given parent and payload.
+    /// Generates and returns a proposal to create a new block with the given parent and payload.
     /// Note that it does not add the block to the tree, just generates it.
-    /// The main reason we want this function in the BlockStore is the fact that the signer required
-    /// for signing the newly created block is held by the block store.
+    /// The main reason we want this function in the BlockStore maintains the QuorumCert.
     /// The function panics in the following cases:
     /// * If the parent or its quorum certificate are not present in the tree,
     /// * If the given round (which is typically calculated by Pacemaker) is not greater than that
     ///   of a parent.
-    fn create_block(
+    fn create_proposal(
         &self,
         parent: &Block<Self::Payload>,
         payload: Self::Payload,
         round: Round,
         timestamp_usecs: u64,
-    ) -> Block<Self::Payload>;
+    ) -> BlockData<Self::Payload>;
 
     /// Return the certified block with the highest round.
     fn highest_certified_block(&self) -> Arc<ExecutedBlock<Self::Payload>>;

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -212,7 +212,7 @@ impl<T: Payload> ChainedBftSMR<T> {
         let block_store = Arc::new(block_on(BlockStore::new(
             Arc::clone(&self.storage),
             initial_data,
-            signer,
+            signer.author(),
             Arc::clone(&state_computer),
             true,
             self.config.max_pruned_blocks_in_mem,

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -14,7 +14,10 @@ use crate::{
     },
     util::mock_time_service::SimulatedTimeService,
 };
-use consensus_types::proposal_msg::{ProposalMsg, ProposalUncheckedSignatures};
+use consensus_types::{
+    common::Author,
+    proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
+};
 use futures::{channel::mpsc, executor::block_on};
 use lazy_static::lazy_static;
 use libra_prost_ext::MessageExt;
@@ -58,7 +61,7 @@ lazy_static! {
 
 // helpers
 fn build_empty_store(
-    signer: ValidatorSigner,
+    author: Author,
     storage: Arc<dyn PersistentStorage<TestPayload>>,
     initial_data: RecoveryData<TestPayload>,
 ) -> Arc<BlockStore<TestPayload>> {
@@ -67,7 +70,7 @@ fn build_empty_store(
     Arc::new(block_on(BlockStore::new(
         storage,
         initial_data,
-        signer,
+        author,
         Arc::new(EmptyStateComputer),
         true,
         10, // max pruned blocks in mem
@@ -114,7 +117,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     );
 
     // TODO: mock
-    let block_store = build_empty_store(signer.clone(), storage.clone(), initial_data);
+    let block_store = build_empty_store(signer.author(), storage.clone(), initial_data);
 
     // TODO: remove
     let time_service = Arc::new(SimulatedTimeService::new());

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use consensus_types::{
     block::Block,
+    block_data::BlockData,
     common::{Payload, Round},
 };
 use failure::ResultExt;
@@ -95,7 +96,7 @@ impl<T: Payload> ProposalGenerator<T> {
         &self,
         round: Round,
         round_deadline: Instant,
-    ) -> failure::Result<Block<T>> {
+    ) -> failure::Result<BlockData<T>> {
         {
             let mut last_round_generated = self.last_round_generated.lock().unwrap();
             if *last_round_generated < round {
@@ -208,7 +209,7 @@ impl<T: Payload> ProposalGenerator<T> {
                 .with_context(|e| format!("Fail to retrieve txn: {}", e))?
         };
 
-        Ok(self.block_store.create_block(
+        Ok(self.block_store.create_proposal(
             hqc_block.block(),
             txns,
             round,


### PR DESCRIPTION
Wow... this isolates the private key to the TCB!!!
Notes:
- BlockStore no longer produces Blocks but rather BlockData since it
doesn't have the private key and it seems strange to give it direct
access to SafetyRules
- ProposalGenerator doesn't produce Blocks but rather BlockData for the
same reason above
- For testing, TreeInserter now owns the block store and the signing key

This was an eye opening trip through the consensus code base...
it feels like something we could simplify...

Please ignore the first commit