### PR TITLE
[crypto] assert private keys not cloneable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)",
@@ -2092,7 +2093,6 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "admission-control-service 0.1.0",
- "config-builder 0.1.0",
  "consensus 0.1.0",
  "crash-handler 0.1.0",
  "debug-interface 0.1.0",
@@ -4130,6 +4130,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "statistical"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5760,6 +5765,7 @@ dependencies = [
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fa13613355688665b68639b1c378a62dbedea78aff0fc59a4fa656cbbdec657"
 "checksum statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49d57902bb128e5e38b5218d3681215ae3e322d99f65d5420e9849730d2ea372"
 "checksum stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a260c96bf26273969f360c2fc2e2c7732acc2ce49d939c7243c7230c2ad179d0"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 sha2 = "0.8.0"
 sha3 = "0.8.2"
+static_assertions = { version = "1.0.0", optional = true }
 threshold_crypto = "0.3"
 tiny-keccak = "1.5.0"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false }
@@ -43,6 +44,7 @@ ripemd160 = "0.8.0"
 
 [features]
 default = ["std", "u64_backend"]
+assert-private-keys-not-cloneable = ["static_assertions"]
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 std = ["curve25519-dalek/std", "ed25519-dalek/std", "x25519-dalek/std"]

--- a/crypto/crypto/src/bls12381.rs
+++ b/crypto/crypto/src/bls12381.rs
@@ -56,6 +56,9 @@ type ThresholdBLSPrivateKey =
 #[derive(Serialize, Deserialize, Deref, SilentDisplay, SilentDebug)]
 pub struct BLS12381PrivateKey(ThresholdBLSPrivateKey);
 
+#[cfg(feature = "assert-private-keys-not-cloneable")]
+static_assertions::assert_not_impl_any!(BLS12381PrivateKey: Clone);
+
 /// A BLS12-381 public key.
 #[derive(Clone, Hash, Serialize, Deserialize, Deref, Debug, PartialEq, Eq)]
 pub struct BLS12381PublicKey(threshold_crypto::PublicKey);

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -54,6 +54,9 @@ const L: [u8; 32] = [
 #[derive(SilentDisplay, SilentDebug)]
 pub struct Ed25519PrivateKey(ed25519_dalek::SecretKey);
 
+#[cfg(feature = "assert-private-keys-not-cloneable")]
+static_assertions::assert_not_impl_any!(Ed25519PrivateKey: Clone);
+
 /// An Ed25519 public key
 #[derive(Clone, Debug)]
 pub struct Ed25519PublicKey(ed25519_dalek::PublicKey);

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -39,9 +39,6 @@ storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
-[dev-dependencies]
-config-builder = { path = "../config/config-builder", version = "0.1.0" }
-
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing"]
+assert-private-keys-not-cloneable = ["libra-crypto/assert-private-keys-not-cloneable"]

--- a/x.toml
+++ b/x.toml
@@ -1,5 +1,6 @@
 [package-exceptions]
 libra-crypto = { path = "crypto/crypto", all-features = false }
+libra-node = { path = "libra-node" }
 testsuite = { path = "testsuite", system = true }
 
 [clippy]


### PR DESCRIPTION
This adds the `assert-private-keys-not-cloneable` feature to the crypto crate which, well, asserts that private key material isn't cloneable via a static assertion. The crypto crate should be included with this feature turned on in production binaries, e.g. `libra-node`, `client`, etc.

This does not currently compile due to some nasty feature unification stuff that @metajack is currently fixing (or rather working around the issue). Once Jack's changes have landed we should be able to land this.

Ref: #1403
