### PR TITLE
[enhancement] Create PerValidatorQueue which implements MessageQueue

### DIFF
--- a/common/channel/src/lib.rs
+++ b/common/channel/src/lib.rs
@@ -24,6 +24,10 @@ pub mod libra_channel;
 #[cfg(test)]
 mod libra_channel_test;
 
+pub mod message_queues;
+#[cfg(test)]
+mod message_queues_test;
+
 const MAX_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Wrapper around a value with an entry timestamp

--- a/common/channel/src/message_queues.rs
+++ b/common/channel/src/message_queues.rs
@@ -1,7 +1,7 @@
 use crate::libra_channel::MessageQueue;
 use libra_logger::{self, prelude::*};
 use libra_types::account_address::AccountAddress;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 
 /// ValidatorMessage trait needs to be implemented by every message which gets pushed into the Libra
 /// channel so that we can ensure fairness among validators
@@ -16,6 +16,7 @@ pub trait ValidatorMessage {
 /// QueueStyle also determines the policy for dropping messages.
 /// With LIFO, oldest messages are dropped.
 /// With FIFO, newest messages are dropped.
+#[derive(Clone, Copy)]
 pub enum QueueStyle {
     LIFO,
     FIFO,
@@ -30,13 +31,14 @@ pub enum QueueStyle {
 /// fashion among validators.
 /// If there are no messages, in any of the queues, `None` is returned.
 pub struct PerValidatorQueue<T> {
+    /// QueueStyle for the messages stored per validator
     queue_style: QueueStyle,
     /// per_validator_queue maintains a map from a Validator to a queue
     /// of all the messages from that Validator. A Validator is
     /// represented by AccountAddress
     per_validator_queue: HashMap<AccountAddress, VecDeque<T>>,
-    /// This is a list of Validators which have pending messages
-    /// This list will be used for performing round robin among
+    /// This is a (round-robin)queue of Validators which have pending messages
+    /// This queue will be used for performing round robin among
     /// Validators for choosing the next message
     round_robin_queue: VecDeque<AccountAddress>,
     /// Maximum number of messages to store per validator
@@ -55,37 +57,66 @@ impl<T> PerValidatorQueue<T> {
             queue_style,
             max_queue_size: max_queue_size_per_validator,
             per_validator_queue: HashMap::new(),
-            round_robin_queue: Vec::new(),
+            round_robin_queue: VecDeque::new(),
         }
     }
+
+    /// Given a validator, pops the message from its queue and returns the message
+    /// It also returns a boolean indicating whether the validators queue is empty
+    /// after popping the message
+    fn pop_from_validator_queue(&mut self, validator: AccountAddress) -> (Option<T>, bool) {
+        if let Some(q) = self.per_validator_queue.get_mut(&validator) {
+            if q.is_empty() {
+                return (None, true);
+            }
+            // Extract message from the validator's queue
+            let retval = match self.queue_style {
+                QueueStyle::FIFO => q.pop_front(),
+                QueueStyle::LIFO => q.pop_back(),
+            };
+            (retval, q.is_empty())
+        } else {
+            (None, true)
+        }
+    }
+
 }
+
+
 
 impl<T: ValidatorMessage> MessageQueue for PerValidatorQueue<T> {
     type Message = T;
 
+    /// push a message to the appropriate queue in per_validator_queue
+    /// add the validator to round_robin_queue if it didnt already exist
     fn push(&mut self, message: Self::Message) {
         let validator = message.get_validator();
+        let max_queue_size = self.max_queue_size;
         let validator_message_queue = self.per_validator_queue
             .entry(validator)
-            .or_insert_with(|| VecDeque::with_capacity(self.max_queue_size));
+            .or_insert_with(|| VecDeque::with_capacity(max_queue_size));
+        // Add the validator to our round-robin queue is its not already there
         if validator_message_queue.is_empty() {
             self.round_robin_queue.push_back(validator);
         }
-        if validator_message_queue.len() == self.max_queue_size {
+        // Push the message to the actual validator message queue
+        if validator_message_queue.len() == max_queue_size {
             match self.queue_style {
                 // Drop the newest message for FIFO
                 QueueStyle::FIFO => (),
                 // Drop the oldest message for LIFO
                 QueueStyle::LIFO => {
-                    q.pop_front();
-                    q.push_back(message);
+                    validator_message_queue.pop_front();
+                    validator_message_queue.push_back(message);
                 }
             };
         } else {
-            q.push_back(message);
+            validator_message_queue.push_back(message);
         }
     }
 
+    /// pop a message from the appropriate queue in per_validator_queue
+    /// remove the validator from the round_robin_queue if it has no more messages
     fn pop(&mut self) -> Option<Self::Message> {
         let validator;
         if let Some(v) = self.round_robin_queue.pop_front() {
@@ -93,26 +124,10 @@ impl<T: ValidatorMessage> MessageQueue for PerValidatorQueue<T> {
         } else {
             return None;
         }
-        let retval;
-        if let Some(q) = self.per_validator_queue.get_mut(&validator) {
-            if q.is_empty() {
-                crit!("validator: {:?} is present in round_robin_queue, its queue has zero messages", validator);
-                return None;
-            }
-            // Extract message from the validator's queue
-            retval = match self.queue_style {
-                QueueStyle::FIFO => q.pop_front(),
-                QueueStyle::LIFO => q.pop_back(),
-            };
-            // If the validator has no more messages, remove it from the round robin list:
-            // self.round_robin_queue
-            if !q.is_empty() {
-                self.round_robin_queue.push_back(validator);
-            }
-        } else {
-            crit!("validator: {:?} is present in round_robin_queue, its missing from self.per_validator_queue", validator);
-            return None;
+        let (message, is_q_empty) = self.pop_from_validator_queue(validator);
+        if !is_q_empty {
+            self.round_robin_queue.push_back(validator);
         }
-        retval
+        message
     }
 }

--- a/common/channel/src/message_queues.rs
+++ b/common/channel/src/message_queues.rs
@@ -1,0 +1,118 @@
+use crate::libra_channel::MessageQueue;
+use libra_logger::{self, prelude::*};
+use libra_types::account_address::AccountAddress;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// ValidatorMessage trait needs to be implemented by every message which gets pushed into the Libra
+/// channel so that we can ensure fairness among validators
+pub trait ValidatorMessage {
+    /// Extract the Validator from which this message arrived. This
+    /// will be used for ensuring fairness among validators.
+    fn get_validator(&self) -> AccountAddress;
+}
+
+/// QueueStyle is an enum which can be used as a configuration option for
+/// PerValidatorQueue. Since the queue per validator is going to be bounded,
+/// QueueStyle also determines the policy for dropping messages.
+/// With LIFO, oldest messages are dropped.
+/// With FIFO, newest messages are dropped.
+pub enum QueueStyle {
+    LIFO,
+    FIFO,
+}
+
+/// PerValidatorQueue maintains a queue of messages per validator. It
+/// is a bounded queue per validator and the style (FIFO, LIFO) is
+/// configurable. When a new message is added using `push`, it is added to
+/// the validator's queue.
+/// When `pop` is called, the next message is picked from one
+/// of the validator's queue and returned. This happens in a round-robin
+/// fashion among validators.
+/// If there are no messages, in any of the queues, `None` is returned.
+pub struct PerValidatorQueue<T> {
+    queue_style: QueueStyle,
+    /// per_validator_queue maintains a map from a Validator to a queue
+    /// of all the messages from that Validator. A Validator is
+    /// represented by AccountAddress
+    per_validator_queue: HashMap<AccountAddress, VecDeque<T>>,
+    /// This is a list of Validators which have pending messages
+    /// This list will be used for performing round robin among
+    /// Validators for choosing the next message
+    round_robin_queue: VecDeque<AccountAddress>,
+    /// Maximum number of messages to store per validator
+    max_queue_size: usize,
+}
+
+impl<T> PerValidatorQueue<T> {
+    /// Create a new PerValidatorQueue with the provided QueueStyle and
+    /// max_queue_size_per_validator
+    pub fn new(queue_style: QueueStyle, max_queue_size_per_validator: usize) -> Self {
+        assert!(
+            max_queue_size_per_validator > 0,
+            "max_queue_size_per_validator should be > 0"
+        );
+        Self {
+            queue_style,
+            max_queue_size: max_queue_size_per_validator,
+            per_validator_queue: HashMap::new(),
+            round_robin_queue: Vec::new(),
+        }
+    }
+}
+
+impl<T: ValidatorMessage> MessageQueue for PerValidatorQueue<T> {
+    type Message = T;
+
+    fn push(&mut self, message: Self::Message) {
+        let validator = message.get_validator();
+        let validator_message_queue = self.per_validator_queue
+            .entry(validator)
+            .or_insert_with(|| VecDeque::with_capacity(self.max_queue_size));
+        if validator_message_queue.is_empty() {
+            self.round_robin_queue.push_back(validator);
+        }
+        if validator_message_queue.len() == self.max_queue_size {
+            match self.queue_style {
+                // Drop the newest message for FIFO
+                QueueStyle::FIFO => (),
+                // Drop the oldest message for LIFO
+                QueueStyle::LIFO => {
+                    q.pop_front();
+                    q.push_back(message);
+                }
+            };
+        } else {
+            q.push_back(message);
+        }
+    }
+
+    fn pop(&mut self) -> Option<Self::Message> {
+        let validator;
+        if let Some(v) = self.round_robin_queue.pop_front() {
+            validator = v;
+        } else {
+            return None;
+        }
+        let retval;
+        if let Some(q) = self.per_validator_queue.get_mut(&validator) {
+            if q.is_empty() {
+                crit!("validator: {:?} is present in round_robin_queue, its queue has zero messages", validator);
+                return None;
+            }
+            // Extract message from the validator's queue
+            retval = match self.queue_style {
+                QueueStyle::FIFO => q.pop_front(),
+                QueueStyle::LIFO => q.pop_back(),
+            };
+            // If the validator has no more messages, remove it from the round robin list:
+            // self.round_robin_queue
+            if !q.is_empty() {
+                self.round_robin_queue.push_back(validator);
+            }
+        } else {
+            crit!("validator: {:?} is present in round_robin_queue, its missing from self.per_validator_queue", validator);
+            return None;
+        }
+        retval
+    }
+}

--- a/common/channel/src/message_queues.rs
+++ b/common/channel/src/message_queues.rs
@@ -75,10 +75,7 @@ impl<T> PerValidatorQueue<T> {
             (None, true)
         }
     }
-
 }
-
-
 
 impl<T: ValidatorMessage> MessageQueue for PerValidatorQueue<T> {
     type Message = T;
@@ -88,7 +85,8 @@ impl<T: ValidatorMessage> MessageQueue for PerValidatorQueue<T> {
     fn push(&mut self, message: Self::Message) {
         let validator = message.get_validator();
         let max_queue_size = self.max_queue_size;
-        let validator_message_queue = self.per_validator_queue
+        let validator_message_queue = self
+            .per_validator_queue
             .entry(validator)
             .or_insert_with(|| VecDeque::with_capacity(max_queue_size));
         // Add the validator to our round-robin queue if it's not already there
@@ -116,7 +114,9 @@ impl<T: ValidatorMessage> MessageQueue for PerValidatorQueue<T> {
     fn pop(&mut self) -> Option<Self::Message> {
         let validator = match self.round_robin_queue.pop_front() {
             Some(v) => v,
-            _ => { return None; }
+            _ => {
+                return None;
+            }
         };
         let (message, is_q_empty) = self.pop_from_validator_queue(validator);
         if !is_q_empty {

--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -1,0 +1,252 @@
+use crate::libra_channel::MessageQueue;
+use crate::message_queues::{PerValidatorQueue, QueueStyle, ValidatorMessage};
+use libra_types::account_address::AccountAddress;
+use libra_types::account_address::ADDRESS_LENGTH;
+
+/// This represents a proposal message from a validator
+#[derive(Debug, PartialEq)]
+struct ProposalMsg {
+    msg: String,
+    validator: AccountAddress,
+}
+
+impl ValidatorMessage for ProposalMsg {
+    fn get_validator(&self) -> AccountAddress {
+        self.validator
+    }
+}
+
+/// This represents a vote message from a validator
+#[derive(Debug, PartialEq)]
+struct VoteMsg {
+    msg: String,
+    validator: AccountAddress,
+}
+
+impl ValidatorMessage for VoteMsg {
+    fn get_validator(&self) -> AccountAddress {
+        self.validator
+    }
+}
+
+#[test]
+fn test_fifo() {
+    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3);
+    let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+
+    // Test order
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg2".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg3".to_string(),
+        validator,
+    });
+    assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
+
+    // Test max queue size
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg2".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg3".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg4".to_string(),
+        validator,
+    });
+    assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn test_lifo() {
+    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3);
+    let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+
+    // Test order
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg2".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg3".to_string(),
+        validator,
+    });
+    assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
+
+    // Test max queue size
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg2".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg3".to_string(),
+        validator,
+    });
+    q.push(ProposalMsg {
+        msg: "msg4".to_string(),
+        validator,
+    });
+    assert_eq!(q.pop().unwrap().msg, "msg4".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn test_fifo_round_robin() {
+    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3);
+    let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+    let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
+
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator: validator1,
+    });
+    q.push(ProposalMsg {
+        msg: "msg2".to_string(),
+        validator: validator1,
+    });
+    q.push(ProposalMsg {
+        msg: "msg3".to_string(),
+        validator: validator1,
+    });
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator: validator2,
+    });
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator: validator3,
+    });
+
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+            validator: validator1
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+            validator: validator2
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+            validator: validator3
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg2".to_string(),
+            validator: validator1
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg3".to_string(),
+            validator: validator1
+        }
+    );
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn test_lifo_round_robin() {
+    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3);
+    let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+    let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
+
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator: validator1,
+    });
+    q.push(ProposalMsg {
+        msg: "msg2".to_string(),
+        validator: validator1,
+    });
+    q.push(ProposalMsg {
+        msg: "msg3".to_string(),
+        validator: validator1,
+    });
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator: validator2,
+    });
+    q.push(ProposalMsg {
+        msg: "msg1".to_string(),
+        validator: validator3,
+    });
+
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg3".to_string(),
+            validator: validator1
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+            validator: validator2
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+            validator: validator3
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg2".to_string(),
+            validator: validator1
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+            validator: validator1
+        }
+    );
+    assert_eq!(q.pop(), None);
+}


### PR DESCRIPTION
## Summary

PerValidatorQueue is an implementation of the `MessageQueue` trait. It internally uses a HashMap  `Validators => Queue<Message>` to store messages per validator. The Queue is configurable to be FIFO or LIFO and the max Queue size per Validator is also configurable.

When popping messages, `PerValidatorQueue` performs round robin among validators which have pending messages and sends them out one by one.

In addition to the HashMap, the `PerValidatorQueue` data structure also stores a `Vec<Validator>` and a `HashSet<Validator>`. These two collections represent the set validators which have messages pending and are used for performing round-robin.

Related to #1323

## Test Plan

Added unit tests