### PR TITLE
[state sync] add new sync_to API to state sync client

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -138,7 +138,7 @@ impl StateComputer for ExecutionProxy {
     fn sync_to(&self, commit: QuorumCert) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
         counters::STATE_SYNC_COUNT.inc();
         self.synchronizer
-            .sync_to(commit.ledger_info().clone())
+            .sync_to_deprecated(commit.ledger_info().clone())
             .boxed()
     }
 

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::PeerId;
 use crate::{
     coordinator::{CoordinatorMessage, SyncCoordinator},
     executor_proxy::{ExecutorProxy, ExecutorProxyTrait},
@@ -12,7 +13,7 @@ use futures::{
     future::Future,
     SinkExt,
 };
-use libra_config::config::{NodeConfig, StateSyncConfig};
+use libra_config::config::{NodeConfig, RoleType, StateSyncConfig};
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use network::validator_network::{StateSynchronizerEvents, StateSynchronizerSender};
 use std::sync::Arc;
@@ -32,11 +33,17 @@ impl StateSynchronizer {
         config: &NodeConfig,
     ) -> Self {
         let executor_proxy = ExecutorProxy::new(executor, config);
-        Self::bootstrap_with_executor_proxy(network, &config.state_sync, executor_proxy)
+        Self::bootstrap_with_executor_proxy(
+            network,
+            config.get_role(),
+            &config.state_sync,
+            executor_proxy,
+        )
     }
 
     pub fn bootstrap_with_executor_proxy<E: ExecutorProxyTrait + 'static>(
         network: Vec<(StateSynchronizerSender, StateSynchronizerEvents)>,
+        role: RoleType,
         state_sync_config: &StateSyncConfig,
         executor_proxy: E,
     ) -> Self {
@@ -50,6 +57,7 @@ impl StateSynchronizer {
 
         let coordinator = SyncCoordinator::new(
             coordinator_receiver,
+            role,
             state_sync_config.clone(),
             executor_proxy,
         );
@@ -74,12 +82,31 @@ pub struct StateSyncClient {
 
 impl StateSyncClient {
     /// Sync validator's state up to given `version`
-    pub fn sync_to(&self, target: LedgerInfoWithSignatures) -> impl Future<Output = Result<bool>> {
+    pub fn sync_to_deprecated(
+        &self,
+        target: LedgerInfoWithSignatures,
+    ) -> impl Future<Output = Result<bool>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
         async move {
             sender
-                .send(CoordinatorMessage::Requested(target, cb_sender))
+                .send(CoordinatorMessage::RequestedDeprecated(target, cb_sender))
+                .await?;
+            let sync_status = cb_receiver.await?;
+            Ok(sync_status)
+        }
+    }
+
+    /// Sync validator's state up to remote peers
+    pub fn sync_to(
+        &self,
+        peers: Vec<PeerId>,
+    ) -> impl Future<Output = Result<(LedgerInfoWithSignatures, PeerId)>> {
+        let mut sender = self.coordinator_sender.clone();
+        let (cb_sender, cb_receiver) = oneshot::channel();
+        async move {
+            sender
+                .send(CoordinatorMessage::Requested(peers, cb_sender))
                 .await?;
             let sync_status = cb_receiver.await?;
             Ok(sync_status)


### PR DESCRIPTION
new `sync_to` API will accept Vec<PeerId> as parameter
it will perform synchronization until it reaches state of one of remote peers
return result will be new LedgerInfoWithSignatures and remote peerId
old api is marked as deprecated and will be removed after Consensus finishes transition to new flow