### PR TITLE
[functional tests] verify comments when parse_script_or_module

### DIFF
--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -84,7 +84,7 @@ fn strip_comments_and_verify(string: &str) -> Result<String> {
 /// Given the raw input of a file, creates a `ScriptOrModule` enum
 /// Fails with `Err(_)` if the text cannot be parsed`
 pub fn parse_script_or_module(s: &str) -> Result<ast::ScriptOrModule> {
-    let stripped_string = &strip_comments(s);
+    let stripped_string = &strip_comments_and_verify(s)?;
     let parser = syntax::ScriptOrModuleParser::new();
     parser
         .parse(stripped_string)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

Fix https://github.com/libra/libra/issues/1074
Functional tests use the same restricted character set as the compiler.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
Yes
## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

This change did not add new code, just use exists test case.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
