### PR TITLE
[build] Remove testing feature and ensure correct builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --bin xtask --"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,19 +71,27 @@ jobs:
       - run:
           name: Build Release
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [023] ]] || RUST_BACKTRACE=1 cargo build -j 16 --all --release
+            [[ $CIRCLE_NODE_INDEX =~ [023] ]] || RUST_BACKTRACE=1 cargo build -j 16 --release
       - run:
           name: Build Dev
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [01] ]] || RUST_BACKTRACE=1 cargo build -j 16 --all
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p benchmark
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p libra-swarm
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p cluster-test
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p libra-fuzzer
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p language_benchmarks
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p bytecode-to-boogie
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p cost-synthesis
+            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p test-generation
       - run:
           name: Run All Unit Tests
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo test -j 16 --all --exclude testsuite
+            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo xtask test-unit
       - run:
           name: Run Cryptography Unit Tests with the formally verified backend
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 cargo test -j 16 -p libra-crypto -p secret-service --features='std fiat_u64_backend' --no-default-features
+            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || ( RUST_BACKTRACE=1 cd crypto/crypto && cargo test --features='std fiat_u64_backend fuzzing' --no-default-features )
       - run:
           name: Run All End to End Tests
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,5 @@ Temporary Items
 # Generated VM config in vm-genesis
 language/vm/vm-genesis/genesis/vm_config.toml
 
-# local cargo config
-.cargo/config
-
 # Terraform
 .terraform/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,6 @@ dependencies = [
  "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode-syntax 0.1.0",
- "lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-failure-ext 0.1.0",
  "libra-types 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1812,11 +1811,6 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "language-e2e-tests"
@@ -4391,6 +4385,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-id"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5386,6 +5398,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yamux"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5557,7 +5577,6 @@ dependencies = [
 "checksum js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc9a97d7cec30128fd8b28a7c1f9df1c001ceb9b441e2b755e24130a6b43c79"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c277d18683b36349ab5cd030158b54856fca6bb2d5dc5263b06288f486958b7c"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
@@ -5759,6 +5778,8 @@ dependencies = [
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4d29c937875c7fdf8af9b1edac17ebbe167e342a01072ce53b168c544c8a7608"
+"checksum thiserror-impl 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "836d68a4d4b9be617c45ac0b2d3aefbca3c3945947c81365bbb341fffbdccd1b"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,22 @@ members = [
     "client",
     "client/libra_wallet",
     "common/bounded-executor",
+    "common/channel",
     "common/crash-handler",
     "common/datatest-stable",
     "common/debug-interface",
     "common/executable-helpers",
     "common/failure-ext",
+    "common/failure-ext/failure-macros",
     "common/futures-semaphore",
+    "common/grpc-helpers",
     "common/lcs",
     "common/logger",
     "common/metrics",
+    "common/nibble",
     "common/proptest-helpers",
     "common/prost-ext",
+    "common/tools",
     "config",
     "config/config-builder",
     "config/generate-keypair",
@@ -44,6 +49,7 @@ members = [
     "language/stackless-bytecode/bytecode-to-boogie",
     "language/stackless-bytecode/generator",
     "language/stackless-bytecode/tree_heap",
+    "language/stdlib",
     "language/vm",
     "language/vm/serializer_tests",
     "language/vm/vm-runtime",
@@ -74,6 +80,19 @@ members = [
     "testsuite/libra-fuzzer",
     "types",
     "vm-validator",
+    "xtask",
+]
+
+# NOTE: These members should never include crates that require fuzzing
+# features or test features. These are the crates we want built with no extra
+# test-only code included.
+default-members = [
+    "client",
+    "crypto/secret-service",
+    "language/compiler",
+    "language/vm/vm-genesis",
+    "libra-node",
+    "storage/storage-service",
 ]
 
 [profile.release]

--- a/admission_control/admission-control-proto/Cargo.toml
+++ b/admission_control/admission-control-proto/Cargo.toml
@@ -20,9 +20,10 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
-
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
 prost-build = "0.5.0"
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -37,17 +37,13 @@ vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
 network = { path = "../../network", version = "0.1.0" }
 
-storage-service = { path = "../../storage/storage-service", version = "0.1.0", optional = true }
-libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 proptest = { version = "0.9.4", optional = true }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }
+storage-service = { path = "../../storage/storage-service" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
-libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
-proptest = "0.9.4"
 
 [features]
 default = []
-fuzzing = ["storage-service", "libra-proptest-helpers", "proptest"]
+fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing", "storage-service/fuzzing"]

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -43,7 +43,7 @@ use vm_validator::vm_validator::{get_account_state, TransactionValidation};
 #[path = "unit_tests/admission_control_service_test.rs"]
 mod admission_control_service_test;
 
-#[cfg(any(feature = "fuzzing", test))]
+#[cfg(feature = "fuzzing")]
 #[path = "admission_control_fuzzing.rs"]
 /// fuzzing module for admission control
 pub mod fuzzing;

--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -13,7 +13,7 @@
 
 /// AC gRPC service.
 pub mod admission_control_service;
-#[cfg(any(test, feature = "fuzzing"))]
+#[cfg(feature = "fuzzing")]
 /// Useful Mocks
 pub mod mocks;
 /// AC runtime to launch gRPC and network service

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -29,15 +29,8 @@ libra-wallet = { path = "../client/libra_wallet", version = "0.1.0" }
 libra-swarm = { path = "../libra-swarm", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
 rusty-fork = "0.2.1"
 libra-tools = { path = "../common/tools", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
-
-[dev-dependencies]
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
-
-[features]
-default = []
-testing = ["libra-crypto/testing", "libra-swarm/testing"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1.28"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 hex = "0.3.2"
 itertools = "0.8.0"
-proptest = "0.9.2"
+proptest = { version = "0.9.2", optional = true }
 rustyline = "5.0.3"
 rust_decimal = "1.0.2"
 num-traits = "0.2"
@@ -38,9 +38,8 @@ libra-tools = { path = "../common/tools/", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 
 [dev-dependencies]
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
+proptest = "0.9.2"
 
 [features]
 default = []
-testing = ["libra-types/testing", "libra-crypto/testing"]
+fuzzing = ["proptest", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -24,5 +24,8 @@ failure = { path = "../../common/failure-ext", version = "0.1.0", package = "lib
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
-libra-tools = { path = "../../common/tools", version = "0.1.0"}
+libra-tools = { path = "../../common/tools", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -214,7 +214,7 @@ impl ClientProxy {
     }
 
     /// Clone all accounts held in the client.
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn copy_all_accounts(&self) -> Vec<AccountData> {
         self.accounts.clone()
     }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) mod transfer_commands;
 /// Struct used to store data for each created account.  We track the sequence number
 /// so we can create new transactions easily
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 pub struct AccountData {
     /// Address of the account.
     pub address: AccountAddress,

--- a/common/executable-helpers/Cargo.toml
+++ b/common/executable-helpers/Cargo.toml
@@ -12,7 +12,11 @@ edition = "2018"
 [dependencies]
 slog-scope = "4.0"
 
-libra-config = { path = "../../config", version = "0.1.0"}
+libra-config = { path = "../../config", version = "0.1.0" }
 crash-handler = { path = "../crash-handler", version = "0.1.0" }
 libra-logger =  { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-config/fuzzing"]

--- a/common/nibble/Cargo.toml
+++ b/common/nibble/Cargo.toml
@@ -10,5 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-proptest = "0.9.4"
+proptest = { version = "0.9.4", optional = true }
 serde = { version = "1.0.101", features = ["derive"] }
+
+[features]
+default = []
+fuzzing = ["proptest"]

--- a/common/nibble/src/lib.rs
+++ b/common/nibble/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! `Nibble` represents a four-bit unsigned integer.
 
+#[cfg(feature = "fuzzing")]
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -29,6 +30,7 @@ impl fmt::LowerHex for Nibble {
     }
 }
 
+#[cfg(feature = "fuzzing")]
 impl Arbitrary for Nibble {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -24,10 +24,6 @@ failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-
 libra-tools = { path = "../common/tools", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
-
 [features]
 default = []
-testing = ["libra-crypto/testing", "libra-types/testing"]
+fuzzing = ["libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -24,5 +24,6 @@ libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 vm-genesis = { path = "../../language/vm/vm-genesis", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+[features]
+default = []
+fuzzing = ["libra-config/fuzzing"]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -46,7 +46,7 @@ static CONFIG_TEMPLATE: &[u8] = include_bytes!("../data/configs/node.config.toml
 /// The config file is broken up into sections for each module
 /// so that only that module can be passed around
 #[derive(Debug, Deserialize, Serialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 pub struct NodeConfig {
     //TODO Add configuration for multiple chain's in a future diff
     #[serde(default)]
@@ -152,7 +152,7 @@ impl BaseConfig {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Clone for BaseConfig {
     fn clone(&self) -> Self {
         Self {
@@ -303,7 +303,7 @@ impl Default for StorageConfig {
     }
 }
 
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct NetworkConfig {
@@ -398,7 +398,7 @@ impl NetworkConfig {
     }
 }
 
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ConsensusConfig {
@@ -800,7 +800,7 @@ impl VMConfig {
     /// Creates a new `VMConfig` where the whitelist is empty. This should only be used for testing.
     #[allow(non_snake_case)]
     #[doc(hidden)]
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn empty_whitelist_FOR_TESTING() -> Self {
         VMConfig {
             publishing_options: VMPublishingOption::Locked(HashSet::new()),

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -10,7 +10,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 enum PrivateKeyContainer<T> {
     Present(T),
     Removed,
@@ -70,7 +70,7 @@ where
 // NetworkKeyPairs is used to store a node's Network specific keypairs.
 // It is filled via a config file at the moment.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 pub struct NetworkKeyPairs {
     network_signing_private_key: PrivateKeyContainer<Ed25519PrivateKey>,
     #[serde(serialize_with = "serialize_key")]
@@ -141,7 +141,7 @@ impl NetworkKeyPairs {
 // ConsensusKeyPair is used to store a validator's consensus keypair.
 // It is filled via a config file at the moment.
 #[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 pub struct ConsensusKeyPair {
     consensus_private_key: PrivateKeyContainer<Ed25519PrivateKey>,
     #[serde(serialize_with = "serialize_opt_key")]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -29,6 +29,7 @@ siphasher = { version = "0.3.0", default-features = false }
 termion = { version = "1.5.3", default-features = false }
 tokio = "=0.2.0-alpha.6"
 prometheus = { version = "0.7.0", default-features = false }
+proptest = { version = "0.9.4", optional = true }
 
 channel = { path = "../common/channel", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
@@ -57,12 +58,9 @@ parity-multiaddr = "0.5.0"
 proptest = "0.9.4"
 rusty-fork = "0.2.2"
 
-consensus-types = { path = "consensus-types", version = "0.1.0", features = ["fuzzing", "testing"]}
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"]}
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
 vm-genesis = { path = "../language/vm/vm-genesis", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = []
+fuzzing = ["proptest", "consensus-types/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -23,10 +23,6 @@ libra-types = { path = "../../types", version = "0.1.0" }
 [dev-dependencies]
 proptest = "0.9.4"
 
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["testing"]}
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
-
 [features]
 default = []
-fuzzing = []
-testing = ["proptest"]
+fuzzing = ["proptest", "libra-types/fuzzing", "libra-crypto/fuzzing"]

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 #[path = "block_test_utils.rs"]
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod block_test_utils;
 
 #[cfg(test)]
@@ -119,7 +119,7 @@ impl<T> Block<T>
 where
     T: Default + PartialEq + Serialize,
 {
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn make_genesis_block() -> Self {
         Self::make_genesis_block_from_ledger_info(&LedgerInfo::genesis())
     }

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -66,7 +66,7 @@ impl QuorumCert {
         }
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn certificate_for_genesis() -> QuorumCert {
         Self::certificate_for_genesis_from_ledger_info(&LedgerInfo::genesis(), *GENESIS_BLOCK_ID)
     }

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -13,7 +13,6 @@ failure = { path = "../../common/failure-ext", version = "0.1.0", package = "lib
 serde = { version = "1.0.99", default-features = false }
 libra-types = { path = "../../types", version = "0.1.0" }
 
-[dev-dependencies]
-consensus-types = { path = "../consensus-types", version = "0.1.0", features = ["testing"]}
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["testing"]}
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+[features]
+default = []
+fuzzing = ["consensus-types/fuzzing"]

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -199,20 +199,21 @@ impl<T: Payload> ChainedBftSMR<T> {
             .expect("Consensus start: No valid runtime found!")
             .executor();
         let time_service = Arc::new(ClockTimeService::new(executor.clone()));
+        let author = signer.author();
         let network = ConsensusNetworkImpl::new(
-            signer.author(),
+            author,
             network_sender.clone(),
             network_events,
             Arc::clone(&epoch_mgr),
         );
 
         let last_vote = initial_data.last_vote();
-        let safety_rules = SafetyRules::new(initial_data.state(), signer.clone());
+        let safety_rules = SafetyRules::new(initial_data.state(), signer);
 
         let block_store = Arc::new(block_on(BlockStore::new(
             Arc::clone(&self.storage),
             initial_data,
-            signer.author(),
+            author,
             Arc::clone(&state_computer),
             true,
             self.config.max_pruned_blocks_in_mem,

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -19,8 +19,8 @@ hex = "0.3"
 hmac = "0.7.1"
 lazy_static = "1.3.0"
 pairing = "0.14.2"
-proptest = "0.9.1"
-proptest-derive = "0.1.0"
+proptest = { version = "0.9.1", optional = true }
+proptest-derive = { version = "0.1.0", optional = true }
 rand = "0.6.5"
 serde = { version = "1.0.96", features = ["derive"] }
 sha2 = "0.8.0"
@@ -37,11 +37,14 @@ libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 [dev-dependencies]
 bitvec = "0.10.1"
 byteorder = "1.3.2"
+proptest = "0.9.1"
+proptest-derive = "0.1.0"
 ripemd160 = "0.8.0"
 
 [features]
 default = ["std", "u64_backend"]
-testing = ["std", "u64_backend"]
+cloneable-private-keys = []
+fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 std = ["curve25519-dalek/std", "ed25519-dalek/std", "x25519-dalek/std"]
 u64_backend = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
 fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -396,12 +396,12 @@ fn check_s_lt_l(s: &[u8]) -> bool {
 /// disappear after
 pub mod compat {
     use crate::ed25519::*;
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     use proptest::strategy::LazyJust;
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     use proptest::{prelude::*, strategy::Strategy};
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "cloneable-private-keys"))]
     impl Clone for Ed25519PrivateKey {
         fn clone(&self) -> Self {
             let serialized: &[u8] = &(self.to_bytes());
@@ -430,7 +430,7 @@ pub mod compat {
     }
 
     /// Used to produce keypairs from a seed for testing purposes
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     pub fn keypair_strategy() -> impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)> {
         // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
         // keypair to be generated, which appears to not be very useful.
@@ -454,7 +454,7 @@ pub mod compat {
         (private_key, public_key)
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     impl Arbitrary for Ed25519PublicKey {
         type Parameters = ();
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -72,6 +72,7 @@ use bytes::Bytes;
 use failure::prelude::*;
 use lazy_static::lazy_static;
 use libra_nibble::Nibble;
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use rand::{rngs::EntropyRng, Rng};
 use serde::{de, ser};
@@ -87,7 +88,8 @@ mod hash_test;
 const SHORT_STRING_LENGTH: usize = 4;
 
 /// Output value of our hash function. Intentionally opaque for safety and modularity.
-#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord, Arbitrary)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct HashValue {
     hash: [u8; HashValue::LENGTH],
 }
@@ -608,7 +610,6 @@ lazy_static! {
         create_literal_hash("PRE_GENESIS_BLOCK_ID");
 
     /// Genesis block id is used as a parent of the very first block executed by the executor.
-    #[cfg(any(test, feature = "testing"))]
     pub static ref GENESIS_BLOCK_ID: HashValue =
         // This maintains the invariant that block.id() == block.hash(), for
         // the genesis block and allows us to (de/)serialize it consistently

--- a/crypto/crypto/src/test_utils.rs
+++ b/crypto/crypto/src/test_utils.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 pub const TEST_SEED: [u8; 32] = [0u8; 32];
 
 /// A keypair consisting of a private and public key
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(feature = "cloneable-private-keys", derive(Clone))]
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyPair<S, P>
 where

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -371,9 +371,9 @@ impl<'de> de::Deserialize<'de> for X25519StaticPublicKey {
 /// disappear after.
 pub mod compat {
     use crate::traits::*;
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     use proptest::strategy::LazyJust;
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     use proptest::{prelude::*, strategy::Strategy};
 
     use crate::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
@@ -397,7 +397,7 @@ pub mod compat {
     }
 
     /// Used to produce keypairs from a seed for testing purposes
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn keypair_strategy(
     ) -> impl Strategy<Value = (X25519StaticPrivateKey, X25519StaticPublicKey)> {
         // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
@@ -411,7 +411,7 @@ pub mod compat {
             .no_shrink()
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     impl Arbitrary for X25519StaticPublicKey {
         type Parameters = ();
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {

--- a/crypto/secret-service/Cargo.toml
+++ b/crypto/secret-service/Cargo.toml
@@ -28,8 +28,9 @@ failure = { package = "libra-failure-ext", path = "../../common/failure-ext", ve
 grpc-helpers = { path = "../../common/grpc-helpers", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 
-[dev-dependencies]
-libra-config = { path = "../../config", version = "0.1.0", features = ["testing"]}
-
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
+
+[features]
+default = []
+fuzzing = ["libra-config/fuzzing"]

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -36,11 +36,12 @@ proptest = "0.9.2"
 rand = "0.6.5"
 rusty-fork = "0.2.1"
 
-libra-config = { path = "../config", version = "0.1.0", features = ["testing"]}
 grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
-
 storage-proto = { path = "../storage/storage-proto", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 vm-genesis = { path = "../language/vm/vm-genesis", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-config/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -15,10 +15,7 @@ proptest = "0.9.4"
 
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
-
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 
 [[bench]]
 name = "transactions"

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -18,12 +18,9 @@ vm = { path = "../vm", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 vm-runtime-types = { path = "../vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
 
-
 [dev-dependencies]
 invalid-mutations = { path = "invalid-mutations", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
-vm = { path = "../vm", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []
-testing = ["vm/testing", "libra-types/testing"]
+fuzzing = ["libra-types/fuzzing"]

--- a/language/bytecode-verifier/bytecode_verifier_tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode_verifier_tests/Cargo.toml
@@ -12,8 +12,9 @@ edition = "2018"
 [dev-dependencies]
 petgraph = "0.4"
 proptest = "0.9.2"
-bytecode-verifier = {path = "../", version = "0.1.0", features = ["testing"]}
-failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}
+
+bytecode-verifier = { path = "../", version = "0.1.0" }
+failure = { path = "../../../common/failure-ext", package = "libra-failure-ext" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing"] }
 invalid-mutations = { path = "../invalid-mutations", version = "0.1.0" }
-vm = { path = "../../vm", version = "0.1.0", features = ["testing"]}
+vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }

--- a/language/bytecode-verifier/bytecode_verifier_tests/src/lib.rs
+++ b/language/bytecode-verifier/bytecode_verifier_tests/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 pub mod unit_tests;

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -10,10 +10,11 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-proptest = "0.9"
-libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+proptest = "0.9"
+libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 
-[dev-dependencies]
-vm = { path = "../../vm", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -20,5 +20,6 @@ vm = { path = "../vm", version = "0.1.0" }
 structopt = "0.3.2"
 serde_json = "1.0.40"
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -18,5 +18,6 @@ structopt = "0.3.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-[dev-dependencies]
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -15,10 +15,10 @@ ir-to-bytecode-syntax = { path = "syntax", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-source-map = { path = "../bytecode-source-map", version = "0.1.0" }
-lalrpop-util = "0.17.2"
 log = "0.4.7"
 codespan = "0.2.1"
 codespan-reporting = "0.2.1"
 
-[dev-dependencies]
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -17,5 +17,6 @@ lazy_static = "1.4.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 libra-types = { path = "../../../../types", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../../../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -15,11 +15,11 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 compiler = { path = "../compiler", version = "0.1.0" }
 lazy_static = "1.3.0"
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0"}
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 rand = "0.6.5"
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
-transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["testing"]}
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["fuzzing"]}
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../vm/vm-genesis", version = "0.1.0" }
 vm-runtime = { path = "../vm/vm-runtime", version = "0.1.0" }
@@ -32,6 +32,3 @@ libra-config =  { path = "../../config", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }
 walkdir = "2.2.9"
-
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -24,9 +24,7 @@ lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 
 [dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["testing"] }
 
 [[test]]
 name = "testsuite"

--- a/language/stackless-bytecode/bytecode-to-boogie/Cargo.toml
+++ b/language/stackless-bytecode/bytecode-to-boogie/Cargo.toml
@@ -21,4 +21,7 @@ num = "0.2.0"
 
 [dev-dependencies]
 proptest = "0.9"
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/stackless-bytecode/generator/Cargo.toml
+++ b/language/stackless-bytecode/generator/Cargo.toml
@@ -17,4 +17,8 @@ stdlib = { path = "../../stdlib", version = "0.1.0" }
 [dev-dependencies]
 # invalid-mutations = { path = "invalid-mutations" }
 proptest = "0.9"
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}
+libra-types = { path = "../../../types", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/stackless-bytecode/tree_heap/Cargo.toml
+++ b/language/stackless-bytecode/tree_heap/Cargo.toml
@@ -17,4 +17,7 @@ num = "0.2.0"
 
 [dev-dependencies]
 proptest = "0.9"
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"]}
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -16,5 +16,6 @@ libra-types = { path = "../../types", version = "0.1.0" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map", version = "0.1.0" }
 lazy_static = "1.3.0"
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/tools/cost-synthesis/Cargo.toml
+++ b/language/tools/cost-synthesis/Cargo.toml
@@ -22,11 +22,8 @@ vm-runtime = { path = "../../vm/vm-runtime", version = "0.1.0" }
 vm-runtime-types = { path = "../../vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
 language-e2e-tests = { path = "../../e2e-tests", version = "0.1.0" }
 vm-cache-map = { path = "../../vm/vm-runtime/vm-cache-map", version = "0.1.0" }
-libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
 structopt = "0.3.2"
-
-[dev-dependencies]
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
 
 [features]
 default = ["vm-runtime/instruction_synthesis"]

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 env_logger = "0.6"
 mirai-annotations = "1.4.0"
 structopt = "0.3.2"
+
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 cost-synthesis = { path = "../cost-synthesis", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
@@ -23,7 +24,7 @@ vm-runtime-types = { path = "../../vm/vm-runtime/vm-runtime-types", version = "0
 vm-cache-map = { path = "../../vm/vm-runtime/vm-cache-map", version = "0.1.0" }
 language-e2e-tests = { path = "../../e2e-tests", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
+libra-types = { path = "../../../types", version = "0.1.0" }
 
 [features]
 mirai-contracts = []

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -17,8 +17,6 @@ stdlib = { path = "../stdlib", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
-
 [features]
-testing = ["libra-types/testing", "libra-crypto/testing"]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -18,7 +18,7 @@ use stdlib::{
         ROTATE_CONSENSUS_PUBKEY_TXN_BODY,
     },
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use vm::file_format::Bytecode;
 
 lazy_static! {
@@ -59,7 +59,7 @@ pub fn encode_transfer_script(recipient: &AccountAddress, amount: u64) -> Script
 
 /// Encode a program transferring `amount` coins from `sender` to `recipient` but padd the output
 /// bytecode with unreachable instructions.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub fn encode_transfer_script_with_padding(
     recipient: &AccountAddress,
     amount: u64,

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -14,20 +14,23 @@ byteorder = "1.3.2"
 hex = "0.3.2"
 lazy_static = "1.3.0"
 mirai-annotations = "1.4.0"
-proptest = "0.9"
-proptest-derive = "0.1.1"
+proptest = { version = "0.9", optional = true }
+proptest-derive = { version = "0.1.1", optional = true }
 serde = { version = "1", features = ["derive"] }
+
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
-failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
-libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
+failure = { path = "../../common/failure-ext", package = "libra-failure-ext" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
+proptest = "0.9"
+proptest-derive = "0.1.1"
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 serde_json = "1"
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []
 mirai-contracts = []
-testing = ["libra-types/testing"]
+fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "libra-types/fuzzing"]

--- a/language/vm/serializer_tests/Cargo.toml
+++ b/language/vm/serializer_tests/Cargo.toml
@@ -12,7 +12,4 @@ edition = "2018"
 [dev-dependencies]
 proptest = "0.9"
 proptest-derive = "0.1.1"
-vm = { path = "../", version = "0.1.0", features = ["testing"]}
-
-[features]
-testing = ["vm/testing"]
+vm = { path = "../", version = "0.1.0", features = ["fuzzing"] }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -38,9 +38,9 @@ use libra_types::{
     language_storage::ModuleId,
     vm_error::{StatusCode, VMStatus},
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 
 /// Generic index into one of the tables in the binary format.
@@ -53,8 +53,8 @@ macro_rules! define_index {
         doc: $comment: literal,
     } => {
         #[derive(Clone, Copy, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-        #[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-        #[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+        #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+        #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
         #[doc=$comment]
         pub struct $name(pub TableIndex);
 
@@ -219,8 +219,8 @@ pub const NO_TYPE_ACTUALS: LocalsSignatureIndex = LocalsSignatureIndex(0);
 /// Type definitions (fields) are private to the module. Outside the module a
 /// Type is an opaque handle.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct ModuleHandle {
     /// Index into the `AddressPool`. Identifies the account that holds the module.
     pub address: AddressPoolIndex,
@@ -242,8 +242,8 @@ pub struct ModuleHandle {
 /// At link time kind checking is performed and an error is reported if there is a
 /// mismatch with the definition.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct StructHandle {
     /// The module that defines the type.
     pub module: ModuleHandleIndex,
@@ -268,8 +268,8 @@ pub struct StructHandle {
 /// ensure the function reference is valid and it is also used by the verifier to type check
 /// function calls.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct FunctionHandle {
     /// The module that defines the function.
     pub module: ModuleHandleIndex,
@@ -284,8 +284,8 @@ pub struct FunctionHandle {
 
 /// `StructFieldInformation` indicates whether a struct is native or has user-specified fields
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub enum StructFieldInformation {
     Native,
     Declared {
@@ -300,8 +300,8 @@ pub enum StructFieldInformation {
 /// A `StructDefinition` is a type definition. It either indicates it is native or
 // defines all the user-specified fields declared on the type.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct StructDefinition {
     /// The `StructHandle` for this `StructDefinition`. This has the name and the resource flag
     /// for the type.
@@ -324,8 +324,8 @@ impl StructDefinition {
 /// A `FieldDefinition` is the definition of a field: the type the field is defined on,
 /// its name and the field type.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct FieldDefinition {
     /// The type (resource or unrestricted) the field is defined on.
     pub struct_: StructHandleIndex,
@@ -338,8 +338,8 @@ pub struct FieldDefinition {
 /// A `FunctionDefinition` is the implementation of a function. It defines
 /// the *prototype* of the function and the function body.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(params = "usize"))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
 pub struct FunctionDefinition {
     /// The prototype of the function (module, name, signature).
     pub function: FunctionHandleIndex,
@@ -357,7 +357,7 @@ pub struct FunctionDefinition {
     pub acquires_global_resources: Vec<StructDefinitionIndex>,
     /// Code for this function.
     #[cfg_attr(
-        any(test, feature = "testing"),
+        any(test, feature = "fuzzing"),
         proptest(strategy = "any_with::<CodeUnit>(params)")
     )]
     pub code: CodeUnit,
@@ -382,8 +382,8 @@ impl FunctionDefinition {
 /// A type definition. `SignatureToken` allows the definition of the set of known types and their
 /// composition.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct TypeSignature(pub SignatureToken);
 
 /// A `FunctionSignature` describes the types of a function.
@@ -392,18 +392,18 @@ pub struct TypeSignature(pub SignatureToken);
 /// types and carries kind constraints for those type parameters (empty list for non-generic
 /// functions).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(params = "usize"))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
 pub struct FunctionSignature {
     /// The list of return types.
     #[cfg_attr(
-        any(test, feature = "testing"),
+        any(test, feature = "fuzzing"),
         proptest(strategy = "vec(any::<SignatureToken>(), 0..=params)")
     )]
     pub return_types: Vec<SignatureToken>,
     /// The list of arguments to the function.
     #[cfg_attr(
-        any(test, feature = "testing"),
+        any(test, feature = "fuzzing"),
         proptest(strategy = "vec(any::<SignatureToken>(), 0..=params)")
     )]
     pub arg_types: Vec<SignatureToken>,
@@ -416,11 +416,11 @@ pub struct FunctionSignature {
 /// Locals include the arguments to the function from position `0` to argument `count - 1`.
 /// The remaining elements are the type of each local.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(params = "usize"))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
 pub struct LocalsSignature(
     #[cfg_attr(
-        any(test, feature = "testing"),
+        any(test, feature = "fuzzing"),
         proptest(strategy = "vec(any::<SignatureToken>(), 0..=params)")
     )]
     pub Vec<SignatureToken>,
@@ -448,7 +448,7 @@ pub type TypeParameterIndex = u16;
 ///
 /// Currently there are three kinds in Move: `All`, `Resource` and `Unrestricted`.
 #[derive(Debug, Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum Kind {
     /// Represents the super set of all types. The type might actually be a `Resource` or
     /// `Unrestricted` A type might be in this set if it is not known to be a `Resource` or
@@ -518,7 +518,7 @@ pub enum SignatureToken {
 }
 
 /// `Arbitrary` for `SignatureToken` cannot be derived automatically as it's a recursive type.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for SignatureToken {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
@@ -764,8 +764,8 @@ impl SignatureToken {
 
 /// A `CodeUnit` is the body of a function. It has the function header and the instruction stream.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(params = "usize"))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(params = "usize"))]
 pub struct CodeUnit {
     /// Max stack size for the function - currently unused.
     pub max_stack_size: u16,
@@ -773,7 +773,7 @@ pub struct CodeUnit {
     pub locals: LocalsSignatureIndex,
     /// Code stream, function body.
     #[cfg_attr(
-        any(test, feature = "testing"),
+        any(test, feature = "fuzzing"),
         proptest(strategy = "vec(any::<Bytecode>(), 0..=params)")
     )]
     pub code: Vec<Bytecode>,
@@ -793,8 +793,8 @@ impl CodeUnit {
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
 #[derive(Clone, Hash, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub enum Bytecode {
     /// Pop and discard the value at the top of the stack.
     /// The value on the stack must be an unrestricted type.
@@ -1483,7 +1483,7 @@ pub struct CompiledModuleMut {
 
 // Need a custom implementation of Arbitrary because as of proptest-derive 0.1.1, the derivation
 // doesn't work for structs with more than 10 fields.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for CompiledScriptMut {
     type Strategy = BoxedStrategy<Self>;
     /// The size of the compiled script.
@@ -1535,7 +1535,7 @@ impl Arbitrary for CompiledScriptMut {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for CompiledModuleMut {
     type Strategy = BoxedStrategy<Self>;
     /// The size of the compiled module.

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -19,7 +19,7 @@ pub mod file_format_common;
 pub mod gas_schedule;
 pub mod internals;
 pub mod printers;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod resolver;
 pub mod serializer;

--- a/language/vm/src/vm_string.rs
+++ b/language/vm/src/vm_string.rs
@@ -8,7 +8,7 @@
 //! mixing with other sorts of strings. For example, it is not possible to use one as an
 //! identifier for name resolution.
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, fmt, ops::Deref, result, string::FromUtf8Error};
@@ -17,8 +17,8 @@ use std::{borrow::Borrow, fmt, ops::Deref, result, string::FromUtf8Error};
 ///
 /// For more details, see the module level documentation.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct VMString(Box<str>);
 // A VMString cannot be mutated so use Box<str> instead of String -- it is 1 word smaller.
 

--- a/language/vm/vm-genesis/Cargo.toml
+++ b/language/vm/vm-genesis/Cargo.toml
@@ -27,8 +27,10 @@ rand = "0.6.5"
 
 [dev-dependencies]
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
-libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0", features = ["testing"]}
 proptest = "0.9.3"
 proptest-derive = "0.1.1"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/vm/vm-genesis/src/lib.rs
+++ b/language/vm/vm-genesis/src/lib.rs
@@ -66,7 +66,7 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(test, derive(Clone))]
 pub struct Account {
     pub addr: AccountAddress,
     pub privkey: Ed25519PrivateKey,

--- a/language/vm/vm-runtime/Cargo.toml
+++ b/language/vm/vm-runtime/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 hex = "0.3.2"
 lazy_static = "1.3.0"
-proptest = "0.9"
 rayon = "1.1"
 rental = "0.5.4"
 mirai-annotations = "1.4.0"
@@ -32,13 +31,12 @@ vm-runtime-types = { path = "vm-runtime-types", version = "0.1.0" }
 failure = { path = "../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 
 [dev-dependencies]
-compiler = { path = "../../compiler", version = "0.1.0" }
+proptest = "0.9"
 
-libra-types = { path = "../../../types", version = "0.1.0", features = ["testing"] }
-vm = { path = "../", version = "0.1.0", features = ["testing"]}
+compiler = { path = "../../compiler", version = "0.1.0" }
 
 [features]
 default = []
 instruction_synthesis = []
-testing = ["libra-types/testing"]
 mirai-contracts = []
+fuzzing = ["vm/fuzzing"]

--- a/language/vm/vm-runtime/vm-runtime-types/Cargo.toml
+++ b/language/vm/vm-runtime/vm-runtime-types/Cargo.toml
@@ -12,9 +12,10 @@ edition = "2018"
 [dependencies]
 bit-vec = "0.6.1"
 lazy_static = "1.3.0"
-proptest = "0.9"
+proptest = { version = "0.9", optional = true }
 sha2 = "0.8.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
+
 libra-types = { path = "../../../../types", version = "0.1.0" }
 vm = { path = "../../", version = "0.1.0" }
 lcs = { path = "../../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -22,9 +23,9 @@ libra-crypto = { path = "../../../../crypto/crypto", version = "0.1.0" }
 failure = { path = "../../../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 
 [dev-dependencies]
-libra-types = { path = "../../../../types", version = "0.1.0", features = ["testing"] }
-vm = { path = "../../", version = "0.1.0", features = ["testing"]}
+proptest = "0.9"
 
 [features]
+default = []
 instruction_synthesis = []
-testing = ["libra-types/testing"]
+fuzzing = ["proptest", "libra-types/fuzzing", "vm/fuzzing"]

--- a/language/vm/vm-runtime/vm-runtime-types/src/lib.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/lib.rs
@@ -6,7 +6,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 mod proptest_types;
 
 pub mod loaded_data;

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -41,4 +41,7 @@ vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -15,18 +15,11 @@ ctrlc = { version = "3.1.3", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 structopt = "0.3.2"
 
-libra-config = { path = "../config", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0", features = ["fuzzing"] }
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
 libra-tools = { path = "../common/tools", version = "0.1.0" }
-
-[dev-dependencies]
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"]}
-
-[features]
-default = []
-testing = ["libra-crypto/testing", "client_lib/testing"]

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -38,8 +38,11 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 [dev-dependencies]
 rand = "0.6.5"
 channel = { path = "../common/channel", version = "0.1.0" }
-storage-service = { path = "../storage/storage-service", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
+storage-service = { path = "../storage/storage-service", version = "0.1.0", features = ["fuzzing"] }
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -41,14 +41,14 @@ libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0
 
 [dev-dependencies]
 criterion = "0.3.0"
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"]}
-proptest = { version = "0.9.4", default-features = false }
-libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 socket-bench-server = { path = "socket-bench-server", version = "0.1.0" }
 
 [build-dependencies]
 prost-build = "0.5.0"
+
+[features]
+default = []
+fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing"]
 
 [[bench]]
 name = "socket_muxer_bench"
@@ -57,7 +57,3 @@ harness = false
 [[bench]]
 name = "network_bench"
 harness = false
-
-[features]
-default = []
-fuzzing = ["proptest", "libra-proptest-helpers"]

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -31,9 +31,12 @@ vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 bytes = "0.4.12"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"]}
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 parity-multiaddr = "0.5.0"
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
 vm-genesis = { path = "../language/vm/vm-genesis", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 channel = { path = "../common/channel", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -10,12 +10,14 @@ publish = false
 edition = "2018"
 
 [dependencies]
-proptest = "0.9.1"
-
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+proptest = "0.9.1"
+
+[features]
+default = []
+fuzzing = ["libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -14,8 +14,8 @@ bincode = "1.1.1"
 byteorder = "1.3.2"
 num-derive = "0.2"
 num-traits = "0.2"
-proptest = "0.9.2"
-proptest-derive = "0.1.2"
+proptest = { version = "0.9.2", optional = true }
+proptest-derive = { version = "0.1.2", optional = true }
 serde = { version = "1.0.89", features = ["derive"] }
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
@@ -25,8 +25,9 @@ libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+proptest = "0.9.2"
+proptest-derive = "0.1.2"
 
 [features]
 default = []
-testing = ["libra-types/testing"]
+fuzzing = ["proptest", "proptest-derive", "libra-crypto/fuzzing", "libra-types/fuzzing", "libra-nibble/fuzzing"]

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -83,6 +83,7 @@ use libra_types::{
 };
 use nibble_path::{skip_common_prefix, NibbleIterator, NibblePath};
 use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey};
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::collections::{BTreeMap, BTreeSet};
 use tree_cache::TreeCache;
@@ -120,7 +121,8 @@ pub type NodeBatch = BTreeMap<NodeKey, Node>;
 pub type StaleNodeIndexBatch = BTreeSet<StaleNodeIndex>;
 
 /// Indicates a node becomes stale since `stale_since_version`.
-#[derive(Arbitrary, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StaleNodeIndex {
     /// The version since when the node is overwritten and becomes stale.
     pub stale_since_version: Version,

--- a/storage/jellyfish-merkle/src/nibble_path/mod.rs
+++ b/storage/jellyfish-merkle/src/nibble_path/mod.rs
@@ -9,6 +9,7 @@ mod nibble_path_test;
 
 use crate::ROOT_NIBBLE_HEIGHT;
 use libra_nibble::Nibble;
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::{fmt, iter::FromIterator};
@@ -45,6 +46,7 @@ impl FromIterator<Nibble> for NibblePath {
     }
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for NibblePath {
     type Parameters = ();
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
@@ -53,6 +55,7 @@ impl Arbitrary for NibblePath {
     type Strategy = BoxedStrategy<Self>;
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
     fn arb_nibble_path()(
         mut bytes in vec(any::<u8>(), 0..=ROOT_NIBBLE_HEIGHT/2),
@@ -68,6 +71,7 @@ prop_compose! {
     }
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
     fn arb_internal_nibble_path()(
         nibble_path in arb_nibble_path().prop_filter(

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -32,7 +32,9 @@ use libra_types::{
 };
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::cast::FromPrimitive;
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::hash_map, prelude::*};
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -42,7 +44,8 @@ use std::{
 };
 
 /// The unique key of each node.
-#[derive(Arbitrary, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct NodeKey {
     // The version at which the node is created.
     version: Version,
@@ -128,7 +131,8 @@ impl NodeKey {
 }
 
 /// Each child of [`InternalNode`] encapsulates a nibble forking at this node.
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct Child {
     // The hash value of this child node.
     pub hash: HashValue,
@@ -282,6 +286,7 @@ impl From<LeafNode> for Node {
     }
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for InternalNode {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -16,8 +16,8 @@ itertools = "0.8.0"
 lazy_static = "1.2.0"
 num-derive = "0.2"
 num-traits = "0.2"
-proptest = "0.9.2"
-proptest-derive = "0.1.2"
+proptest = { version = "0.9.2", optional = true }
+proptest-derive = { version = "0.1.2", optional = true }
 prost = "0.5.0"
 rand = "0.6.5"
 rusty-fork = "0.2.1"
@@ -37,11 +37,13 @@ schemadb = { path = "../schemadb", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-tools = { path = "../../common/tools", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 
 [dev-dependencies]
+proptest = "0.9.2"
+proptest-derive = "0.1.2"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 
 [features]
 default = []
-testing = ["libra-types/testing"]
+fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "libra-crypto/fuzzing", "jellyfish-merkle/fuzzing", "libra-types/fuzzing"]

--- a/storage/libradb/src/event_store/mod.rs
+++ b/storage/libradb/src/event_store/mod.rs
@@ -114,7 +114,7 @@ impl EventStore {
                 // from the most recent end, for limited tries.
                 // TODO: Optimize: Physical store use reverse order.
                 let mut n_try_recent = 10;
-                #[cfg(any(test, feature = "testing"))]
+                #[cfg(test)]
                 let mut n_try_recent = 1;
                 while seq > 0 && n_try_recent > 0 {
                     seq -= 1;

--- a/storage/libradb/src/ledger_counters/mod.rs
+++ b/storage/libradb/src/ledger_counters/mod.rs
@@ -1,9 +1,9 @@
 use crate::OP_COUNTER;
 use num_derive::ToPrimitive;
 use num_traits::ToPrimitive;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 use proptest::{collection::hash_map, prelude::*};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -12,7 +12,7 @@ use strum_macros::{AsRefStr, EnumIter};
 
 /// Types of ledger counters.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ToPrimitive, EnumIter, AsRefStr)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(test, derive(Arbitrary))]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum LedgerCounter {
     EventsCreated = 101,
@@ -128,7 +128,7 @@ impl LedgerCounters {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 prop_compose! {
     pub(crate) fn ledger_counters_strategy()(
         counters_map in hash_map(any::<LedgerCounter>(), any::<usize>(), 0..3)
@@ -142,7 +142,7 @@ prop_compose! {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 impl Arbitrary for LedgerCounters {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -10,7 +10,7 @@
 // Used in other crates for testing.
 pub mod mock_genesis;
 // Used in this and other crates for testing.
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod test_helper;
 
 pub mod errors;

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -18,4 +18,6 @@ libra-types = { path = "../../types", version = "0.1.0" }
 [dev-dependencies]
 proptest = "0.9.4"
 
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/storage/state-view/Cargo.toml
+++ b/storage/state-view/Cargo.toml
@@ -13,5 +13,6 @@ edition = "2018"
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 libra-types = { path = "../../types", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -21,5 +21,6 @@ libra-state-view = { path = "../state-view", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 
-[dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/storage/storage-proto/Cargo.toml
+++ b/storage/storage-proto/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2018"
 bytes = "0.4.12"
 futures = "0.1.28"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
-proptest = "0.9.2"
-proptest-derive = "0.1.0"
+proptest = { version = "0.9.2", optional = true }
+proptest-derive = { version = "0.1.0", optional = true }
 prost = "0.5.0"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
@@ -25,5 +25,10 @@ libra-types = { path = "../../types", version = "0.1.0" }
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
 
 [dev-dependencies]
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"]}
 libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
+proptest = "0.9.2"
+proptest-derive = "0.1.0"
+
+[features]
+default = []
+fuzzing = ["proptest", "proptest-derive", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -35,7 +35,7 @@ use libra_types::{
     proof::SparseMerkleProof,
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
 
@@ -147,7 +147,7 @@ impl Into<(Option<AccountStateBlob>, SparseMerkleProof)>
 
 /// Helper to construct and parse [`proto::storage::SaveTransactionsRequest`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct SaveTransactionsRequest {
     pub txns_to_commit: Vec<TransactionToCommit>,
     pub first_version: Version,
@@ -208,7 +208,7 @@ impl From<SaveTransactionsRequest> for crate::proto::storage::SaveTransactionsRe
 
 /// Helper to construct and parse [`proto::storage::GetTransactionsRequest`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetTransactionsRequest {
     pub start_version: Version,
     pub batch_size: u64,
@@ -259,7 +259,7 @@ impl From<GetTransactionsRequest> for crate::proto::storage::GetTransactionsRequ
 
 /// Helper to construct and parse [`proto::storage::GetTransactionsResponse`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetTransactionsResponse {
     pub txn_list_with_proof: TransactionListWithProof,
 }
@@ -296,7 +296,7 @@ impl From<GetTransactionsResponse> for crate::proto::storage::GetTransactionsRes
 
 /// Helper to construct and parse [`proto::storage::StartupInfo`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StartupInfo {
     pub ledger_info: LedgerInfo,
     pub latest_version: Version,
@@ -349,7 +349,7 @@ impl From<StartupInfo> for crate::proto::storage::StartupInfo {
 
 /// Helper to construct and parse [`proto::storage::GetStartupInfoResponse`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetStartupInfoResponse {
     pub info: Option<StartupInfo>,
 }
@@ -374,7 +374,7 @@ impl From<GetStartupInfoResponse> for crate::proto::storage::GetStartupInfoRespo
 
 /// Helper to construct and parse [`proto::storage::GetLatestLedgerInfosPerEpochRequest`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetLatestLedgerInfosPerEpochRequest {
     pub start_epoch: u64,
 }
@@ -410,7 +410,7 @@ impl From<GetLatestLedgerInfosPerEpochRequest>
 
 /// Helper to construct and parse [`proto::storage::GetLatestLedgerInfosPerEpochResponse`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetLatestLedgerInfosPerEpochResponse {
     pub latest_ledger_infos: Vec<LedgerInfoWithSignatures>,
 }

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -28,14 +28,13 @@ storage-client = { path = "../storage-client", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 rand = "0.6.5"
+proptest = { version = "0.9.2", optional = true }
 
 [dev-dependencies]
 itertools = "0.8.0"
-proptest = "0.9.2"
 libra-tools = { path = "../../common/tools", version = "0.1.0" }
-libradb = { path = "../libradb", version = "0.1.0", features = ["testing"] }
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
+proptest = "0.9.2"
 
 [features]
 default = []
-testing = ["libradb/testing", "libra-types/testing"]
+fuzzing = ["proptest", "libradb/fuzzing"]

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -7,6 +7,7 @@
 //! [`storage-client`](../storage-client/index.html) instead of via
 //! [`StorageClient`](../storage-proto/proto/storage_grpc/struct.StorageClient.html) directly.
 
+#[cfg(feature = "fuzzing")]
 pub mod mocks;
 
 use failure::prelude::*;

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -7,7 +7,7 @@ use itertools::zip_eq;
 use libra_config::config::NodeConfigHelpers;
 use libra_types::get_with_proof::{RequestItem, ResponseItem};
 use libradb::mock_genesis::db_with_mock_genesis;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 use libradb::test_helper::arb_blocks_to_commit;
 use proptest::prelude::*;
 use std::collections::HashMap;

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -21,10 +21,10 @@ rusty-fork = "0.2.1"
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
 benchmark = { path = "../benchmark", version = "0.1.0" }
-cli = { path = "../client", version = "0.1.0", package="client" }
+cli = { path = "../client", version = "0.1.0", package="client", features = ["fuzzing"] }
 generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
-libra-swarm = { path = "../libra-swarm", version = "0.1.0", features = ["testing"]}
+libra-swarm = { path = "../libra-swarm", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-tools = { path = "../common/tools", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -38,7 +38,7 @@ failure = { path = "../../common/failure-ext", version = "0.1.0", package = "lib
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
 admission-control-proto = { path = "../../admission_control/admission-control-proto", version = "0.1.0" }
 
-libra-types = { path = "../../types", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 generate-keypair = { path = "../../config/generate-keypair", version = "0.1.0" }

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -24,27 +24,18 @@ sha-1 = { version = "0.8.1", default-features = false }
 structopt = "0.3.2"
 
 # List out modules with data structures being fuzzed here.
-admission-control-service = { path = "../../admission_control/admission-control-service", version = "0.1.0" }
-consensus = { path = "../../consensus", version = "0.1.0" }
-consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features = ["testing"] }
-libra-types = { path = "../../types", version = "0.1.0" }
-network = { path = "../../network", version = "0.1.0" }
-vm = { path = "../../language/vm", version = "0.1.0" }
-vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types", version = "0.1.0" }
+admission-control-service = { path = "../../admission_control/admission-control-service", version = "0.1.0", features = ["fuzzing"] }
+consensus = { path = "../../consensus", version = "0.1.0", features = ["fuzzing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+network = { path = "../../network", version = "0.1.0", features = ["fuzzing"] }
+vm = { path = "../../language/vm", version = "0.1.0", features = ["fuzzing"] }
+vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types", version = "0.1.0", features = ["fuzzing"] }
+consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features = ["fuzzing"] }
 
 [dev-dependencies]
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 rusty-fork = "0.2.2"
 stats_alloc = "0.1.8"
-
-libra-types = { path = "../../types", version = "0.1.0", features = ["testing"] }
-vm = { path = "../../language/vm", version = "0.1.0", features = ["testing"] }
-vm-runtime-types = { path = "../../language/vm/vm-runtime/vm-runtime-types", version = "0.1.0", features = ["testing"] }
-
-[features]
-default = ["testing", "fuzzing"]
-fuzzing = ["admission-control-service/fuzzing", "consensus/fuzzing", "network/fuzzing", "consensus-types/fuzzing"]
-testing = ["libra-types/testing", "vm/testing", "vm-runtime-types/testing"]
 
 [[test]]
 name = "artifacts"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,8 +18,8 @@ hex = { version = "0.3.2", default-features = false }
 itertools = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
-proptest = { version = "0.9.4", default-features = false }
-proptest-derive = { version = "0.1.2", default-features = false }
+proptest = { version = "0.9.4", default-features = false, optional = true }
+proptest-derive = { version = "0.1.2", default-features = false, optional = true }
 prost = "0.5.0"
 radix_trie = { version = "0.1.4", default-features = false }
 rand = "0.6.5"
@@ -29,17 +29,20 @@ tiny-keccak = { version = "1.5.0", default-features = false }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
-libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 num_enum = "0.4.1"
 
 [build-dependencies]
 prost-build = "0.5.0"
 
 [dev-dependencies]
+proptest = "0.9.4"
+proptest-derive = "0.1.2"
+libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }
 libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
 serde_json = "1.0.40"
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
+
 
 [features]
 default = []
-testing = ["libra-crypto/testing"]
+fuzzing = ["proptest", "proptest-derive", "libra-proptest-helpers", "libra-crypto/fuzzing"]

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -49,7 +49,7 @@ use failure::prelude::*;
 use hex;
 use lazy_static::lazy_static;
 use libra_crypto::hash::{CryptoHash, HashValue};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use radix_trie::TrieKey;
 use serde::{Deserialize, Serialize};
@@ -201,7 +201,7 @@ lazy_static! {
 }
 
 #[derive(Clone, Eq, PartialEq, Default, Hash, Serialize, Deserialize, Ord, PartialOrd)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccessPath {
     pub address: AccountAddress,
     pub path: Vec<u8>,

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -9,7 +9,7 @@ use libra_crypto::{
     hash::{AccountAddressHasher, CryptoHash, CryptoHasher},
     HashValue, VerifyingKey,
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de, ser};
@@ -24,7 +24,7 @@ const LIBRA_NETWORK_ID_SHORT: &str = "lb";
 /// A struct that represents an account address.
 /// Currently Public Key is used.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Default, Clone, Copy)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountAddress([u8; ADDRESS_LENGTH]);
 
 impl AccountAddress {

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use failure::prelude::*;
 use lazy_static::lazy_static;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto};
@@ -74,7 +74,7 @@ pub fn account_struct_tag() -> StructTag {
 /// A Rust representation of an Account resource.
 /// This is not how the Account is represented in the VM but it's a convenient representation.
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountResource {
     authentication_key: ByteArray,
     balance: u64,

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use crate::account_config::{account_resource_path, AccountResource};
 use crate::{
     account_address::AccountAddress, account_config::get_account_resource_or_default,
@@ -12,9 +12,9 @@ use libra_crypto::{
     hash::{AccountStateBlobHasher, CryptoHash, CryptoHasher},
     HashValue,
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::{arbitrary::Arbitrary, prelude::*};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -88,7 +88,7 @@ impl From<AccountStateBlob> for crate::proto::types::AccountStateBlob {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl From<AccountResource> for AccountStateBlob {
     fn from(account_resource: AccountResource) -> Self {
         let mut account_state: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
@@ -118,14 +118,14 @@ impl CryptoHash for AccountStateBlob {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
     pub fn account_state_blob_strategy()(account_resource in any::<AccountResource>()) -> AccountStateBlob {
         AccountStateBlob::from(account_resource)
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for AccountStateBlob {
     type Parameters = ();
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
@@ -136,7 +136,7 @@ impl Arbitrary for AccountStateBlob {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountStateWithProof {
     /// The transaction version at which this account state is seen.
     pub version: Version,

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -10,7 +10,7 @@ use libra_crypto::{
     hash::{ContractEventHasher, CryptoHash, CryptoHasher},
     HashValue,
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -106,7 +106,7 @@ impl From<ContractEvent> for crate::proto::types::Event {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct EventWithProof {
     pub transaction_version: u64, // Should be `Version`
     pub event_index: u64,

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -82,7 +82,7 @@ use libra_crypto::ed25519::*;
 use std::collections::BTreeMap;
 
 // used in chained_bft::consensus_types::block_test
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub type SecretKey = Ed25519PrivateKey;
 
 pub type Signature = SignatureWrapper<Ed25519Signature>;

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -2,7 +2,7 @@ use crate::account_address::AccountAddress;
 use failure::prelude::*;
 use hex;
 use libra_crypto::HashValue;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(feature = "fuzzing")]
 use proptest_derive::Arbitrary;
 use serde::{de, ser, Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
@@ -12,7 +12,7 @@ pub const EVENT_KEY_LENGTH: usize = 32;
 
 /// A struct that represents a globally unique id for an Event stream that a user can listen to.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default, Clone, Copy)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 pub struct EventKey([u8; EVENT_KEY_LENGTH]);
 
 impl EventKey {
@@ -31,7 +31,7 @@ impl EventKey {
         self.0.to_vec()
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     /// Create a random event key for testing
     pub fn random() -> Self {
         EventKey::try_from(HashValue::random().to_vec().as_slice()).unwrap()
@@ -121,12 +121,12 @@ impl EventHandle {
         self.count
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     pub fn count_mut(&mut self) -> &mut u64 {
         &mut self.count
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     /// Create a random event handle for testing
     pub fn random_handle(count: u64) -> Self {
         Self {
@@ -135,7 +135,7 @@ impl EventHandle {
         }
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(feature = "fuzzing")]
     /// Derive a unique handle by using an AccountAddress and a counter.
     pub fn new_from_address(addr: &AccountAddress, salt: u64) -> Self {
         Self {

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use failure::prelude::*;
 use libra_crypto::{hash::CryptoHash, *};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::{
     cmp,
@@ -31,7 +31,7 @@ use std::{
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct UpdateToLatestLedgerRequest {
     pub client_known_version: u64,
     pub requested_items: Vec<RequestItem>,
@@ -434,7 +434,7 @@ fn verify_get_txns_resp(
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum RequestItem {
     GetAccountTransactionBySequenceNumber {
         account: AccountAddress,
@@ -570,7 +570,7 @@ impl From<RequestItem> for crate::proto::types::RequestItem {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum ResponseItem {
     GetAccountTransactionBySequenceNumber {
         signed_transaction_with_proof: Option<SignedTransactionWithProof>,

--- a/types/src/identifier.rs
+++ b/types/src/identifier.rs
@@ -10,7 +10,7 @@
 // TODO: restrict identifiers to a subset of ASCII
 
 use failure::prelude::*;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, fmt, ops::Deref};
@@ -147,7 +147,7 @@ fn str_to_ident_str(s: &str) -> &IdentStr {
     unsafe { &*(s as *const str as *const IdentStr) }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for Identifier {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use failure::Result;
 use libra_crypto::hash::{AccessPathHasher, CryptoHash, CryptoHasher, HashValue};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -48,8 +48,8 @@ impl ResourceKey {
 /// Represents the initial key into global storage where we first index by the address, and then
 /// the struct tag
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct ModuleId {
     address: AccountAddress,
     name: Identifier,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -8,13 +8,13 @@ use crate::{
     validator_verifier::{ValidatorVerifier, VerifyError},
 };
 use failure::prelude::*;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use libra_crypto::{
     hash::{CryptoHash, CryptoHasher, LedgerInfoHasher},
     HashValue, *,
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -41,7 +41,7 @@ use std::{
 /// votes. It sets `consensus_data_hash` to represent B so that if those 2f+1 votes are gathered a
 /// QC is formed on B.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct LedgerInfo {
     /// The version of the latest transaction in the ledger.
     version: Version,
@@ -155,7 +155,7 @@ impl LedgerInfo {
     }
 
     /// To bootstrap the system until we execute and commit the genesis txn before start.
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(any(test, feature = "fuzzing"))]
     pub fn genesis() -> Self {
         Self::new(
             0,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -15,10 +15,10 @@ pub mod identifier;
 pub mod language_storage;
 pub mod ledger_info;
 pub mod proof;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod proto;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod test_helpers;
 pub mod transaction;
 pub mod validator_change;

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -18,7 +18,7 @@ use crate::{
     transaction::{TransactionInfo, Version},
 };
 use failure::prelude::*;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::hash::TestOnlyHasher;
 use libra_crypto::{
     hash::{
@@ -27,7 +27,7 @@ use libra_crypto::{
     },
     HashValue,
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
@@ -199,7 +199,7 @@ impl<H> From<AccumulatorProof<H>> for crate::proto::types::AccumulatorProof {
 
 pub type TransactionAccumulatorProof = AccumulatorProof<TransactionAccumulatorHasher>;
 pub type EventAccumulatorProof = AccumulatorProof<EventAccumulatorHasher>;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub type TestAccumulatorProof = AccumulatorProof<TestOnlyHasher>;
 
 /// A proof that can be used to authenticate an element in a Sparse Merkle Tree given trusted root
@@ -621,7 +621,7 @@ where
 /// the correctness of the `TransactionInfo` object, and the `TransactionInfo` object that is
 /// supposed to match the `SignedTransaction`.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct SignedTransactionProof {
     /// The accumulator proof from ledger info root to leaf that authenticates the hash of the
     /// `TransactionInfo` object.
@@ -726,7 +726,7 @@ impl From<SignedTransactionProof> for crate::proto::types::SignedTransactionProo
 /// `AccumulatorProof` from `LedgerInfo` to `TransactionInfo`, the `TransactionInfo` object and the
 /// `SparseMerkleProof` from state root to the account.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountStateProof {
     /// The accumulator proof from ledger info root to leaf that authenticates the hash of the
     /// `TransactionInfo` object.
@@ -836,7 +836,7 @@ impl From<AccountStateProof> for crate::proto::types::AccountStateProof {
 /// `AccumulatorProof` from `LedgerInfo` to `TransactionInfo`, the `TransactionInfo` object and the
 /// `AccumulatorProof` from event accumulator root to the event.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct EventProof {
     /// The accumulator proof from ledger info root to leaf that authenticates the hash of the
     /// `TransactionInfo` object.

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -4,7 +4,7 @@
 pub mod accumulator;
 pub mod definition;
 pub mod position;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_proof;
 
 #[cfg(test)]
@@ -33,7 +33,7 @@ pub use self::definition::{
     TransactionAccumulatorProof,
 };
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub use self::definition::TestAccumulatorProof;
 
 pub(crate) fn verify_transaction_list(

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -24,7 +24,7 @@ use libra_crypto::{
     traits::*,
     HashValue,
 };
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{de, ser, Deserialize, Serialize};
 use std::{
@@ -451,7 +451,7 @@ impl From<SignatureCheckedTransaction> for crate::proto::types::SignedTransactio
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct SignedTransactionWithProof {
     pub version: Version,
     pub signed_transaction: SignedTransaction,
@@ -691,7 +691,7 @@ impl From<TransactionInfo> for crate::proto::types::TransactionInfo {
 /// `TransactionInfo` is the object we store in the transaction accumulator. It consists of the
 /// transaction as well as the execution result of this transaction.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TransactionInfo {
     /// The hash of this transaction.
     signed_transaction_hash: HashValue,
@@ -1078,7 +1078,7 @@ impl From<TransactionListWithProof> for crate::proto::types::TransactionListWith
 /// We suppress the clippy warning here as we would expect most of the transaction to be user
 /// transaction.
 #[allow(clippy::large_enum_variant)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Transaction {
     /// Transaction submitted by the user. e.g: P2P payment transaction, publishing module

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -44,12 +44,12 @@ impl<Sig: Signature> From<ValidatorChangeEventWithProof<Sig>>
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::ed25519::*;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
     fn arb_validator_change_event_with_proof()(
         ledger_info_with_sigs in any::<LedgerInfoWithSignatures<Ed25519Signature>>(),
@@ -61,7 +61,7 @@ prop_compose! {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 impl Arbitrary for ValidatorChangeEventWithProof<Ed25519Signature> {
     type Parameters = ();
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -4,7 +4,7 @@
 use crate::account_address::AccountAddress;
 use failure::Result;
 use libra_crypto::{ed25519::*, traits::ValidKey, x25519::X25519StaticPublicKey};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
@@ -15,7 +15,7 @@ use std::{convert::TryFrom, fmt};
 /// keys for creating secure channels of communication between validators.  The validators and
 /// their public keys and voting power may or may not change between epochs.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct ValidatorPublicKeys {
     // Hash value of the current public key of the account address
     account_address: AccountAddress,

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use failure::prelude::*;
 use lazy_static::lazy_static;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -46,7 +46,7 @@ pub(crate) fn validator_set_path() -> Vec<u8> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct ValidatorSet(Vec<ValidatorPublicKeys>);
 
 impl fmt::Display for ValidatorSet {

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 /// validating. This struct can be used for all signing operations including block and network
 /// signing, respectively.
 #[derive(Debug)]
-#[cfg_attr(any(test, feature = "testing"), derive(Clone))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 pub struct ValidatorSigner<PrivateKey: SigningKey> {
     author: AccountAddress,
     public_key: PrivateKey::VerifyingKeyMaterial,
@@ -81,7 +81,7 @@ impl<PrivateKey: SigningKey + Uniform> ValidatorSigner<PrivateKey> {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod proptests {
     use super::*;
     #[cfg(test)]

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -5,9 +5,9 @@
 
 use failure::prelude::*;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{de, ser};
 use std::{convert::TryFrom, fmt};
@@ -45,8 +45,8 @@ pub static EXECUTION_STATUS_MAX_CODE: u64 = 4999;
 /// A `VMStatus` is represented as a required major status that is semantic coupled with with
 /// an optional sub status and message.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-#[cfg_attr(any(test, feature = "testing"), derive(Arbitrary))]
-#[cfg_attr(any(test, feature = "testing"), proptest(no_params))]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct VMStatus {
     /// The major status, e.g. ABORTED, OUT_OF_GAS, etc.
     pub major_status: StatusCode,

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -24,10 +24,13 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 rand = "0.6.5"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["testing"] }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
 executor = { path = "../executor", version = "0.1.0" }
 grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0", features = ["testing"] }
 vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra extended cargo tasks"
+edition = "2018"
+publish = false
+license = "Apache-2.0"
+
+[dependencies]
+structopt = "0.3.2"
+thiserror = "1.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+use structopt::StructOpt;
+
+mod test_unit;
+
+#[derive(Debug, StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Debug, StructOpt)]
+enum Command {
+    #[structopt(name = "test-unit")]
+    /// Run unit tests
+    TestUnit {
+        #[structopt(long, short)]
+        /// Restrict unit tests to a specific pacakge
+        package: Option<String>,
+    },
+}
+
+// When invoked as a cargo subcommand, cargo passes too many arguments so we need to filter out
+// arg[1] if it matches the end of arg[0], e.i. "cargo-X X foo" should become "cargo-X foo".
+fn args() -> impl Iterator<Item = String> {
+    let mut args: Vec<String> = ::std::env::args().collect();
+
+    if args.len() >= 2 && args[0].ends_with(&format!("cargo-{}", args[1])) {
+        args.remove(1);
+    }
+
+    args.into_iter()
+}
+
+fn main() -> Result<(), Box<impl Error>> {
+    let args = Args::from_iter(args());
+
+    match args.cmd {
+        Command::TestUnit { package } => test_unit::run(package),
+    }
+}

--- a/xtask/src/test_unit.rs
+++ b/xtask/src/test_unit.rs
@@ -1,0 +1,76 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum TestUnitError {
+    #[error("tests failed for some crate (not crypto or testsuite)")]
+    NonCrypto,
+    #[error("tests failed for libra-crypto")]
+    Crypto,
+    #[error("crate failed")]
+    Specific(String),
+}
+
+fn project_root() -> PathBuf {
+    Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf()
+}
+
+pub fn run(package: Option<String>) -> Result<(), Box<TestUnitError>> {
+    if let Some(package) = package {
+        if run_cargo_test_on_package(&package, package != "libra-crypto") {
+            Ok(())
+        } else {
+            Err(Box::new(TestUnitError::Specific(package.to_string())))
+        }
+    } else {
+        if !run_cargo_test_on_most_things() {
+            return Err(Box::new(TestUnitError::NonCrypto));
+        }
+        if !run_cargo_test_on_package("libra-crypto", false) {
+            return Err(Box::new(TestUnitError::Crypto));
+        }
+        Ok(())
+    }
+}
+
+fn run_cargo_test_on_package(package: &str, with_all_features: bool) -> bool {
+    let mut args = if with_all_features {
+        vec!["test", "--all-features"]
+    } else {
+        vec!["test"]
+    };
+    args.push("-p");
+    args.push(package);
+    let output = Command::new("cargo")
+        .current_dir(project_root())
+        .args(args)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    output.status.success()
+}
+
+fn run_cargo_test_on_most_things() -> bool {
+    let output = Command::new("cargo")
+        .current_dir(project_root())
+        .args(&[
+            "test",
+            "--all",
+            "--all-features",
+            "--exclude",
+            "libra-crypto",
+            "--exclude",
+            "testsuite",
+        ])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()
+        .unwrap();
+    output.status.success()
+}


### PR DESCRIPTION
Libra used the 'testing' feature as well as overloaded dev-dependencies to
enable testing features of dependencies at test time. Unfortunately due to
Cargo's feature unification, this resulted in every build including test and
fuzzing code, including code that allowed private keys to be cloned.

This retains the testing and fuzzing support while removing the feature
unification problems. This is accomplished by never overloading features in
dev-dependencies, and instead passing wanted features on the command line at
testing time. It also avoids other cases of feature unification by using
default-members to control what gets built by default. Building all targets
simultaneously will always result in feature unification turning on things as
some of our targets are test only and cargo unifies features globally per
invocation of cargo build.

Because this increase the complexity of running unit tests, some of which need
extra flags now, a new extension to Cargo is added called xtask. Use `cargo
xtask test-unit` or `cargo xtask test-unit -p CRATE` to unit test all crates
or an individual one. The test-unit command knows what flags each crate needs
for testing.
