### PR TITLE
[libra_swarm] modify interface for role type awareness

### DIFF
--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -75,11 +75,11 @@ fn main() {
         None
     };
     validator_swarm
-        .launch_attempt(!args.enable_logging)
+        .launch_attempt(RoleType::Validator, !args.enable_logging)
         .expect("Failed to launch validator swarm");
     if let Some(ref mut swarm) = full_node_swarm {
         swarm
-            .launch_attempt(!args.enable_logging)
+            .launch_attempt(RoleType::FullNode, !args.enable_logging)
             .expect("Failed to launch full node swarm");
     }
 

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -80,7 +80,7 @@ impl TestEnvironment {
         };
         let num_attempts = 5;
         for _ in 0..num_attempts {
-            match swarm.launch_attempt(false) {
+            match swarm.launch_attempt(role, false) {
                 Ok(_) => {
                     return;
                 }
@@ -302,7 +302,10 @@ fn test_basic_restartability() {
     let peer_to_restart = 0;
     // restart node
     env.validator_swarm.kill_node(peer_to_restart);
-    assert!(env.validator_swarm.add_node(peer_to_restart, false).is_ok());
+    assert!(env
+        .validator_swarm
+        .add_node(peer_to_restart, RoleType::Validator, false)
+        .is_ok());
     assert_eq!(
         Decimal::from_f64(90.0),
         Decimal::from_str(&client_proxy.get_balance(&["b", "0"]).unwrap()).ok()
@@ -360,7 +363,10 @@ fn test_startup_sync_state() {
     // behind consensus db and forcing a state sync
     // during a node startup
     fs::remove_dir_all(state_db_path).unwrap();
-    assert!(env.validator_swarm.add_node(peer_to_stop, false).is_ok());
+    assert!(env
+        .validator_swarm
+        .add_node(peer_to_stop, RoleType::Validator, false)
+        .is_ok());
     let max_tries = 60;
     for retry in 0..max_tries {
         if retry == max_tries - 1 {
@@ -437,7 +443,10 @@ fn test_basic_state_synchronization() {
     }
 
     // Reconnect and synchronize the state
-    assert!(env.validator_swarm.add_node(node_to_restart, false).is_ok());
+    assert!(env
+        .validator_swarm
+        .add_node(node_to_restart, RoleType::Validator, false)
+        .is_ok());
 
     // Wait for all the nodes to catch up
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Use new counter `libra_network_peers` to get connected peer numbers.
- Update the interface to be aware of different role type so that we check on the right counter.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `cargo run --bin libra-swarm -- -n 4 -s` to make sure we can still start local cluster.
- `cargo run --bin libra-swarm -- -n 4 -f 2 -s` to make sure we can still start local cluster with full nodes successfully.
