### PR TITLE
[crypto] un-mask GENESIS_BLOCK_ID

### DIFF
--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -608,7 +608,6 @@ lazy_static! {
         create_literal_hash("PRE_GENESIS_BLOCK_ID");
 
     /// Genesis block id is used as a parent of the very first block executed by the executor.
-    #[cfg(any(test, feature = "testing"))]
     pub static ref GENESIS_BLOCK_ID: HashValue =
         // This maintains the invariant that block.id() == block.hash(), for
         // the genesis block and allows us to (de/)serialize it consistently


### PR DESCRIPTION
This removes the masking flag on GENESIS_BLOCK_ID. It was introduced
in #1477, but put on a `lazy_static` macro, which expands into several
interrelated declarations. As the masking flag only applied to the
lexically first of them, masking it, its dependent would fail to find
that first declaration.

The result would be a
```
error[E0573]: expected type, found static `GENESIS_BLOCK_ID`
```

on macro expansion, when compiling `libra-crypto` specifically.