### PR TITLE
[enhancement] Refactor libra_channel interface to add an explicit Key

### DIFF
--- a/common/channel/src/libra_channel.rs
+++ b/common/channel/src/libra_channel.rs
@@ -54,7 +54,7 @@ impl<T: MessageQueue> Sender<T> {
     /// This adds the message into the internal queue data structure. This is a non-blocking
     /// synchronous call.
     /// TODO: We can have this return a boolean if the queue of a validator is capacity
-    pub fn put(&mut self, key: <T as MessageQueue>::Key, message: <T as MessageQueue>::Message) {
+    pub fn put(&mut self, key: T::Key, message: T::Message) {
         let mut shared_state = self.shared_state.lock().unwrap();
         shared_state.internal_queue.push(key, message);
         if let Some(w) = shared_state.waker.take() {

--- a/common/channel/src/libra_channel_test.rs
+++ b/common/channel/src/libra_channel_test.rs
@@ -10,9 +10,10 @@ struct TestMessageQueue {
 }
 
 impl MessageQueue for TestMessageQueue {
+    type Key = u8;
     type Message = u8;
 
-    fn push(&mut self, message: Self::Message) {
+    fn push(&mut self, _key: Self::Key, message: Self::Message) {
         self.queue.push_back(message);
     }
 
@@ -27,10 +28,10 @@ fn test_send_recv_order() {
         queue: VecDeque::new(),
     };
     let (mut sender, mut receiver) = libra_channel::new(mq);
-    sender.put(0);
-    sender.put(1);
-    sender.put(2);
-    sender.put(3);
+    sender.put(0, 0);
+    sender.put(0, 1);
+    sender.put(0, 2);
+    sender.put(0, 3);
     let task = async move {
         // Ensure that messages are received in order
         assert_eq!(receiver.select_next_some().await, 0);
@@ -73,10 +74,10 @@ fn test_waker() {
         });
     });
     thread::sleep(Duration::from_millis(100));
-    sender.put(0);
+    sender.put(0, 0);
     thread::sleep(Duration::from_millis(100));
-    sender.put(1);
+    sender.put(0, 1);
     thread::sleep(Duration::from_millis(100));
-    sender.put(2);
+    sender.put(0, 2);
     join_handle.join().unwrap();
 }

--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -1,5 +1,5 @@
 use crate::libra_channel::MessageQueue;
-use crate::message_queues::{PerValidatorQueue, QueueStyle, ValidatorMessage};
+use crate::message_queues::{PerValidatorQueue, QueueStyle};
 use libra_types::account_address::AccountAddress;
 use libra_types::account_address::ADDRESS_LENGTH;
 
@@ -7,26 +7,12 @@ use libra_types::account_address::ADDRESS_LENGTH;
 #[derive(Debug, PartialEq)]
 struct ProposalMsg {
     msg: String,
-    validator: AccountAddress,
-}
-
-impl ValidatorMessage for ProposalMsg {
-    fn get_validator(&self) -> AccountAddress {
-        self.validator
-    }
 }
 
 /// This represents a vote message from a validator
 #[derive(Debug, PartialEq)]
 struct VoteMsg {
     msg: String,
-    validator: AccountAddress,
-}
-
-impl ValidatorMessage for VoteMsg {
-    fn get_validator(&self) -> AccountAddress {
-        self.validator
-    }
 }
 
 #[test]
@@ -35,39 +21,53 @@ fn test_fifo() {
     let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
 
     // Test order
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg2".to_string(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg3".to_string(),
+        ProposalMsg {
+            msg: "msg2".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
+        ProposalMsg {
+            msg: "msg3".to_string(),
+        },
+    );
     assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
 
     // Test max queue size
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg2".to_string(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg3".to_string(),
+        ProposalMsg {
+            msg: "msg2".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg4".to_string(),
+        ProposalMsg {
+            msg: "msg3".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
+        ProposalMsg {
+            msg: "msg4".to_string(),
+        },
+    );
     assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
@@ -80,39 +80,53 @@ fn test_lifo() {
     let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
 
     // Test order
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg2".to_string(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg3".to_string(),
+        ProposalMsg {
+            msg: "msg2".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
+        ProposalMsg {
+            msg: "msg3".to_string(),
+        },
+    );
     assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
 
     // Test max queue size
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg2".to_string(),
+        ProposalMsg {
+            msg: "msg1".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg3".to_string(),
+        ProposalMsg {
+            msg: "msg2".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
-    q.push(ProposalMsg {
-        msg: "msg4".to_string(),
+        ProposalMsg {
+            msg: "msg3".to_string(),
+        },
+    );
+    q.push(
         validator,
-    });
+        ProposalMsg {
+            msg: "msg4".to_string(),
+        },
+    );
     assert_eq!(q.pop().unwrap().msg, "msg4".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
     assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
@@ -126,60 +140,65 @@ fn test_fifo_round_robin() {
     let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
     let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
 
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
-        validator: validator1,
-    });
-    q.push(ProposalMsg {
-        msg: "msg2".to_string(),
-        validator: validator1,
-    });
-    q.push(ProposalMsg {
-        msg: "msg3".to_string(),
-        validator: validator1,
-    });
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
-        validator: validator2,
-    });
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
-        validator: validator3,
-    });
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg1".to_string(),
+        },
+    );
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg2".to_string(),
+        },
+    );
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg3".to_string(),
+        },
+    );
+    q.push(
+        validator2,
+        ProposalMsg {
+            msg: "validator2_msg1".to_string(),
+        },
+    );
+    q.push(
+        validator3,
+        ProposalMsg {
+            msg: "validator3_msg1".to_string(),
+        },
+    );
 
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg1".to_string(),
-            validator: validator1
+            msg: "validator1_msg1".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg1".to_string(),
-            validator: validator2
+            msg: "validator2_msg1".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg1".to_string(),
-            validator: validator3
+            msg: "validator3_msg1".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg2".to_string(),
-            validator: validator1
+            msg: "validator1_msg2".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg3".to_string(),
-            validator: validator1
+            msg: "validator1_msg3".to_string(),
         }
     );
     assert_eq!(q.pop(), None);
@@ -192,60 +211,65 @@ fn test_lifo_round_robin() {
     let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
     let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
 
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
-        validator: validator1,
-    });
-    q.push(ProposalMsg {
-        msg: "msg2".to_string(),
-        validator: validator1,
-    });
-    q.push(ProposalMsg {
-        msg: "msg3".to_string(),
-        validator: validator1,
-    });
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
-        validator: validator2,
-    });
-    q.push(ProposalMsg {
-        msg: "msg1".to_string(),
-        validator: validator3,
-    });
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg1".to_string(),
+        },
+    );
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg2".to_string(),
+        },
+    );
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg3".to_string(),
+        },
+    );
+    q.push(
+        validator2,
+        ProposalMsg {
+            msg: "validator2_msg1".to_string(),
+        },
+    );
+    q.push(
+        validator3,
+        ProposalMsg {
+            msg: "validator3_msg1".to_string(),
+        },
+    );
 
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg3".to_string(),
-            validator: validator1
+            msg: "validator1_msg3".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg1".to_string(),
-            validator: validator2
+            msg: "validator2_msg1".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg1".to_string(),
-            validator: validator3
+            msg: "validator3_msg1".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg2".to_string(),
-            validator: validator1
+            msg: "validator1_msg2".to_string(),
         }
     );
     assert_eq!(
         q.pop().unwrap(),
         ProposalMsg {
-            msg: "msg1".to_string(),
-            validator: validator1
+            msg: "validator1_msg1".to_string(),
         }
     );
     assert_eq!(q.pop(), None);


### PR DESCRIPTION
## Summary

The current libra_channel interface is agnostic of the concept of a `Key`. We have pushed the abstraction of `Key` to `ValidatorMessage` trait which forces each message to implement a trait which returns `AccountAddress`

This PR updates the libra_channel interface to accept an arbitrary `Key` in its `put()` method which will make it easy on the Sender side to add messages. The Sender side will no longer be forced to implement `ValidatorMessage` trait.

With this design, we do leak the concept of a `Key` explicitly to the sender, but we were not hiding it very well with the `ValidatorMessage` trait either.

In a way, this is better than the previous design because, they Key is no longer forced to be an `AccountAddress`, but anything which implements `Eq + Hash`

Related to issue #1323

## Test Plan

Updated unit tests