### PR TITLE
[types] restrict identifiers to a subset of ASCII

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -184,8 +184,8 @@ pub type FunctionSignaturePool = Vec<FunctionSignature>;
 /// locals used and their types.
 pub type LocalsSignaturePool = Vec<LocalsSignature>;
 
-// TODO: "<SELF>" wouldn't pass a checker for identifiers unless special cased -- what do we want to
-// do?
+// TODO: "<SELF>" only passes the validator for identifiers because it is special cased. Whenever
+// "<SELF>" is removed, so should the special case in identifier.rs.
 lazy_static! {
     static ref SELF_MODULE_NAME: Identifier = Identifier::new("<SELF>").unwrap();
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -36,6 +36,7 @@ num_enum = "0.4.1"
 prost-build = "0.5.0"
 
 [dev-dependencies]
+regex = "1.3.1"
 proptest = "0.9.4"
 proptest-derive = "0.1.2"
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0" }

--- a/types/src/identifier.rs
+++ b/types/src/identifier.rs
@@ -3,17 +3,64 @@
 
 //! An identifier is the name of an entity (module, resource, function, etc) in Move.
 //!
+//! A valid identifier consists of an ASCII string which satisfies any of the conditions:
+//!
+//! * The first character is a letter and the remaining characters are letters, digits or
+//!   underscores.
+//! * The first character is an underscore, and there is at least one further letter, digit or
+//!   underscore.
+//!
+//! The spec for allowed identifiers is similar to Rust's spec
+//! ([as of version 1.38](https://doc.rust-lang.org/1.38.0/reference/identifiers.html)).
+//!
+//! Allowed identifiers are currently restricted to ASCII due to unresolved issues with Unicode
+//! normalization. See [Rust issue #55467](https://github.com/rust-lang/rust/issues/55467) and the
+//! associated RFC for some discussion. Unicode identifiers may eventually be supported once these
+//! issues are worked out.
+//!
+//! This module only determines allowed identifiers at the bytecode level. Move source code will
+//! likely be more restrictive than even this, with a "raw identifier" escape hatch similar to
+//! Rust's `r#` identifiers.
+//!
 //! Among other things, identifiers are used to:
 //! * specify keys for lookups in storage
 //! * do cross-module lookups while executing transactions
-
-// TODO: restrict identifiers to a subset of ASCII
 
 use failure::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, fmt, ops::Deref};
+
+/// Describes what identifiers are allowed.
+///
+/// For now this is deliberately restrictive -- we would like to evolve this in the future.
+// TODO: "<SELF>" is coded as an exception. It should be removed once CompiledScript goes away.
+fn is_valid(s: &str) -> bool {
+    fn is_underscore_alpha_or_digit(c: char) -> bool {
+        match c {
+            '_' | 'a'..='z' | 'A'..='Z' | '0'..='9' => true,
+            _ => false,
+        }
+    }
+
+    if s == "<SELF>" {
+        return true;
+    }
+    let len = s.len();
+    let mut chars = s.chars();
+    match chars.next() {
+        Some('a'..='z') | Some('A'..='Z') => chars.all(is_underscore_alpha_or_digit),
+        Some('_') if len > 1 => chars.all(is_underscore_alpha_or_digit),
+        _ => false,
+    }
+}
+
+/// A regex describing what identifiers are allowed. Used for proptests.
+// TODO: "<SELF>" is coded as an exception. It should be removed once CompiledScript goes away.
+#[cfg(any(test, feature = "fuzzing"))]
+pub(crate) static ALLOWED_IDENTIFIERS: &str =
+    r"(?:[a-zA-Z][a-zA-Z0-9_]*)|(?:_[a-zA-Z0-9_]+)|(?:<SELF>)";
 
 /// An owned identifier.
 ///
@@ -25,8 +72,17 @@ pub struct Identifier(Box<str>);
 impl Identifier {
     /// Creates a new `Identifier` instance.
     pub fn new(s: impl Into<Box<str>>) -> Result<Self> {
-        // TODO: restrict identifiers to a subset of ASCII
-        Ok(Self(s.into()))
+        let s = s.into();
+        if Self::is_valid(&s) {
+            Ok(Self(s))
+        } else {
+            bail!("Invalid identifier '{}'", s);
+        }
+    }
+
+    /// Returns true if this string is a valid identifier.
+    pub fn is_valid(s: impl AsRef<str>) -> bool {
+        is_valid(s.as_ref())
     }
 
     /// Converts a vector of bytes to an `Identifier`.
@@ -91,8 +147,16 @@ pub struct IdentStr(str);
 
 impl IdentStr {
     pub fn new(s: &str) -> Result<&IdentStr> {
-        // TODO: restrict identifiers to a subset of ASCII.
-        Ok(str_to_ident_str(s))
+        if Self::is_valid(s) {
+            Ok(str_to_ident_str(s))
+        } else {
+            bail!("Invalid identifier '{}'", s);
+        }
+    }
+
+    /// Returns true if this string is a valid identifier.
+    pub fn is_valid(s: impl AsRef<str>) -> bool {
+        is_valid(s.as_ref())
     }
 
     /// Returns the length of `self` in bytes.
@@ -153,7 +217,11 @@ impl Arbitrary for Identifier {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with((): ()) -> Self::Strategy {
-        // TODO: restrict identifiers to a subset of ASCII
-        ".*".prop_map(|s| Identifier::new(s).unwrap()).boxed()
+        ALLOWED_IDENTIFIERS
+            .prop_map(|s| {
+                // Identifier::new will verify that generated identifiers are correct.
+                Identifier::new(s).unwrap()
+            })
+            .boxed()
     }
 }

--- a/types/src/unit_tests/identifier_test.rs
+++ b/types/src/unit_tests/identifier_test.rs
@@ -1,13 +1,74 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::identifier::{IdentStr, Identifier};
+use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS};
 use crate::test_helpers::assert_canonical_encode_decode;
+use lazy_static::lazy_static;
 use proptest::prelude::*;
+use regex::Regex;
 use serde_json;
 use std::borrow::Borrow;
 
+#[test]
+fn valid_identifiers() {
+    let valid_identifiers = [
+        "foo",
+        "FOO",
+        "Foo",
+        "foo0",
+        "FOO_0",
+        "_Foo1",
+        "FOO2_",
+        "foo_bar_baz",
+        "_0",
+        "__",
+        "____________________",
+        // TODO: <SELF> is an exception. It should be removed once CompiledScript goes away.
+        "<SELF>",
+    ];
+    for identifier in &valid_identifiers {
+        assert!(
+            Identifier::is_valid(identifier),
+            "Identifier '{}' should be valid",
+            identifier
+        );
+    }
+}
+
+#[test]
+fn invalid_identifiers() {
+    let invalid_identifiers = [
+        "",
+        "_",
+        "0",
+        "01",
+        "9876",
+        "0foo",
+        ":foo",
+        "fo\\o",
+        "fo/o",
+        "foo.",
+        "foo-bar",
+        "foo\u{1f389}",
+    ];
+    for identifier in &invalid_identifiers {
+        assert!(
+            !Identifier::is_valid(identifier),
+            "Identifier '{}' should be invalid",
+            identifier
+        );
+    }
+}
+
 proptest! {
+    #[test]
+    fn invalid_identifiers_proptest(identifier in invalid_identifier_strategy()) {
+        // This effectively checks that if a string doesn't match the ALLOWED_IDENTIFIERS regex, it
+        // will be rejected by the is_valid validator. Note that the converse is checked by the
+        // Arbitrary impl for Identifier.
+        prop_assert!(!Identifier::is_valid(&identifier));
+    }
+
     #[test]
     fn identifier_string_roundtrip(identifier in any::<Identifier>()) {
         let s = identifier.clone().into_string();
@@ -38,10 +99,24 @@ proptest! {
     }
 }
 
-/// Ensure that UserString instances serialize into strings directly, with no wrapper.
+fn invalid_identifier_strategy() -> impl Strategy<Value = String> {
+    lazy_static! {
+        static ref ALLOWED_IDENTIFIERS_REGEX: Regex = {
+            // Need to add anchors to ensure the entire string is matched.
+            Regex::new(&format!("^(?:{})$", ALLOWED_IDENTIFIERS)).unwrap()
+        };
+    }
+
+    ".*".prop_filter("Valid identifiers should not be generated", |s| {
+        // Most strings won't match the regex above, so local rejects are OK.
+        !ALLOWED_IDENTIFIERS_REGEX.is_match(s)
+    })
+}
+
+/// Ensure that Identifier instances serialize into strings directly, with no wrapper.
 #[test]
 fn serde_serialize_no_wrapper() {
     let foobar = Identifier::new("foobar").expect("should parse correctly");
-    let s = serde_json::to_string(&foobar).expect("UserString should serialize correctly");
+    let s = serde_json::to_string(&foobar).expect("Identifier should serialize correctly");
     assert_eq!(s, "\"foobar\"");
 }


### PR DESCRIPTION
The subset is similar to that of Rust, and has been chosen for similar reasons. See the doc comment for more details.

This PR defines a sort order for identifiers (simply ASCII order), partly resolving #204.