### PR TITLE
[testing] Add more tests for libra_channel

### DIFF
--- a/common/channel/src/libra_channel_test.rs
+++ b/common/channel/src/libra_channel_test.rs
@@ -1,6 +1,10 @@
-use crate::libra_channel;
-use crate::libra_channel::MessageQueue;
+use crate::{
+    libra_channel::{self, MessageQueue},
+    message_queues::{PerValidatorQueue, QueueStyle},
+};
 use futures::{executor::block_on, FutureExt, StreamExt};
+use libra_types::account_address::AccountAddress;
+use libra_types::account_address::ADDRESS_LENGTH;
 use std::collections::VecDeque;
 use std::thread;
 use std::time::Duration;
@@ -80,4 +84,40 @@ fn test_waker() {
     thread::sleep(Duration::from_millis(100));
     sender.put(0, 2);
     join_handle.join().unwrap();
+}
+
+fn test_multiple_validators_helper(
+    queue_style: QueueStyle,
+    num_messages_per_validator: usize,
+    expected_last_message: usize,
+) {
+    let (mut sender, mut receiver) = libra_channel::new(PerValidatorQueue::new(queue_style, 1));
+    let num_validators = 128;
+    for message in 0..num_messages_per_validator {
+        for validator in 0..num_validators {
+            sender.put(
+                AccountAddress::new([validator as u8; ADDRESS_LENGTH]),
+                (validator, message),
+            );
+        }
+    }
+    block_on(async {
+        for i in 0..num_validators {
+            assert_eq!(
+                receiver.select_next_some().await,
+                (i, expected_last_message)
+            );
+        }
+    });
+    assert_eq!(receiver.select_next_some().now_or_never(), None);
+}
+
+#[test]
+fn test_multiple_validators_fifo() {
+    test_multiple_validators_helper(QueueStyle::FIFO, 1024, 0);
+}
+
+#[test]
+fn test_multiple_validators_lifo() {
+    test_multiple_validators_helper(QueueStyle::LIFO, 1024, 1023);
 }


### PR DESCRIPTION
## Summary

Add a couple of tests to verify that dropping and round robin works in libra_channel.

We use 128 validators and each of them send 1024 messages. Based on the queue style, we make appropriate assertions on the receiver end after the messages have been sent by the sender.

Related to #1323

## Test Plan

This is a test