### PR TITLE
[consensus] block_store doesn't make proposals

### DIFF
--- a/consensus/consensus-types/src/block_info.rs
+++ b/consensus/consensus-types/src/block_info.rs
@@ -101,6 +101,10 @@ impl BlockInfo {
         self.executed_state_id
     }
 
+    pub fn has_reconfiguration(&self) -> bool {
+        self.next_validator_set.is_some()
+    }
+
     pub fn id(&self) -> HashValue {
         self.id
     }

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::{
-    block::Block, block_data::BlockData, common::Round, executed_block::ExecutedBlock,
-    quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
+    executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
 };
 use libra_crypto::HashValue;
 use std::sync::Arc;
@@ -56,21 +55,6 @@ pub trait BlockReader: Send + Sync {
     /// path_from_root(a) -> None
     fn path_from_root(&self, block_id: HashValue)
         -> Option<Vec<Arc<ExecutedBlock<Self::Payload>>>>;
-
-    /// Generates and returns a proposal to create a new block with the given parent and payload.
-    /// Note that it does not add the block to the tree, just generates it.
-    /// The main reason we want this function in the BlockStore maintains the QuorumCert.
-    /// The function panics in the following cases:
-    /// * If the parent or its quorum certificate are not present in the tree,
-    /// * If the given round (which is typically calculated by Pacemaker) is not greater than that
-    ///   of a parent.
-    fn create_proposal(
-        &self,
-        parent: &Block<Self::Payload>,
-        payload: Self::Payload,
-        round: Round,
-        timestamp_usecs: u64,
-    ) -> BlockData<Self::Payload>;
 
     /// Return the certified block with the highest round.
     fn highest_certified_block(&self) -> Arc<ExecutedBlock<Self::Payload>>;

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -115,7 +115,6 @@ impl<T: Payload> EpochManager<T> {
         let block_store = Arc::new(block_on(BlockStore::new(
             Arc::clone(&self.storage),
             initial_data,
-            author,
             Arc::clone(&self.state_computer),
             true,
             self.config.max_pruned_blocks_in_mem,
@@ -124,6 +123,7 @@ impl<T: Payload> EpochManager<T> {
         // txn manager is required both by proposal generator (to pull the proposers)
         // and by event processor (to update their status).
         let proposal_generator = ProposalGenerator::new(
+            author,
             block_store.clone(),
             Arc::clone(&self.txn_manager),
             self.time_service.clone(),

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -140,7 +140,7 @@ impl<T: Payload> EventProcessor<T> {
         };
         if self
             .proposer_election
-            .is_valid_proposer(self.block_store.author(), new_round_event.round)
+            .is_valid_proposer(self.proposal_generator.author(), new_round_event.round)
             .is_none()
         {
             return;
@@ -237,7 +237,7 @@ impl<T: Payload> EventProcessor<T> {
         remote_round: Round,
         remote_hqc_round: Round,
     ) {
-        if self.block_store.author() == peer {
+        if self.proposal_generator.author() == peer {
             return;
         }
         // pacemaker's round is sync_info.highest_round() + 1
@@ -657,7 +657,7 @@ impl<T: Payload> EventProcessor<T> {
             let next_round = vote_msg.vote().vote_data().proposed().round() + 1;
             if self
                 .proposer_election
-                .is_valid_proposer(self.block_store.author(), next_round)
+                .is_valid_proposer(self.proposal_generator.author(), next_round)
                 .is_none()
             {
                 debug!(

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -13,10 +13,7 @@ use crate::{
     },
     util::mock_time_service::SimulatedTimeService,
 };
-use consensus_types::{
-    common::Author,
-    proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
-};
+use consensus_types::proposal_msg::{ProposalMsg, ProposalUncheckedSignatures};
 use futures::{channel::mpsc, executor::block_on};
 use lazy_static::lazy_static;
 use libra_prost_ext::MessageExt;
@@ -57,7 +54,6 @@ lazy_static! {
 
 // helpers
 fn build_empty_store(
-    author: Author,
     storage: Arc<dyn PersistentStorage<TestPayload>>,
     initial_data: RecoveryData<TestPayload>,
 ) -> Arc<BlockStore<TestPayload>> {
@@ -66,7 +62,6 @@ fn build_empty_store(
     Arc::new(block_on(BlockStore::new(
         storage,
         initial_data,
-        author,
         Arc::new(EmptyStateComputer),
         true,
         10, // max pruned blocks in mem
@@ -112,13 +107,14 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     );
 
     // TODO: mock
-    let block_store = build_empty_store(signer.author(), storage.clone(), initial_data);
+    let block_store = build_empty_store(storage.clone(), initial_data);
 
     // TODO: remove
     let time_service = Arc::new(SimulatedTimeService::new());
 
     // TODO: remove
     let proposal_generator = ProposalGenerator::new(
+        signer.author(),
         block_store.clone(),
         Arc::new(MockTransactionManager::new()),
         time_service.clone(),

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -10,7 +10,8 @@ use crate::{
 use consensus_types::{
     block::Block,
     block_data::BlockData,
-    common::{Payload, Round},
+    common::{Author, Payload, Round},
+    quorum_cert::QuorumCert,
 };
 use failure::ResultExt;
 use libra_logger::prelude::*;
@@ -33,6 +34,8 @@ mod proposal_generator_test;
 /// TxnManager should be aware of the pending transactions in the branch that it is extending,
 /// such that it will filter them out to avoid transaction duplication.
 pub struct ProposalGenerator<T> {
+    // The account address of this validator
+    author: Author,
     // Block store is queried both for finding the branch to extend and for generating the
     // proposed block.
     block_store: Arc<dyn BlockReader<Payload = T> + Send + Sync>,
@@ -50,6 +53,7 @@ pub struct ProposalGenerator<T> {
 
 impl<T: Payload> ProposalGenerator<T> {
     pub fn new(
+        author: Author,
         block_store: Arc<dyn BlockReader<Payload = T> + Send + Sync>,
         txn_manager: Arc<dyn TxnManager<Payload = T>>,
         time_service: Arc<dyn TimeService>,
@@ -57,6 +61,7 @@ impl<T: Payload> ProposalGenerator<T> {
         enforce_increasing_timestamps: bool,
     ) -> Self {
         Self {
+            author,
             block_store,
             txn_manager,
             time_service,
@@ -66,20 +71,14 @@ impl<T: Payload> ProposalGenerator<T> {
         }
     }
 
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
     /// Creates a NIL block proposal extending the highest certified block from the block store.
     pub fn generate_nil_block(&self, round: Round) -> failure::Result<Block<T>> {
-        let hqc_block = self.block_store.highest_certified_block();
-        ensure!(
-            hqc_block.round() < round,
-            "Given round {} is lower than hqc round {}",
-            round,
-            hqc_block.round()
-        );
-        let hqc_block_qc = self
-            .block_store
-            .get_quorum_cert_for_block(hqc_block.id())
-            .ok_or_else(|| format_err!("Quorum Cert for HQC block not found"))?;
-        Ok(Block::new_nil(round, hqc_block_qc.as_ref().clone()))
+        let hqc = self.ensure_highest_quorum_cert(round)?;
+        Ok(Block::new_nil(round, hqc.as_ref().clone()))
     }
 
     /// The function generates a new proposal block: the returned future is fulfilled when the
@@ -88,7 +87,7 @@ impl<T: Payload> ProposalGenerator<T> {
     /// Errors returned by the TxnManager implementation are propagated to the caller.
     /// The logic for choosing the branch to extend is as follows:
     /// 1. The function gets the highest head of a one-chain from block tree.
-    /// The new proposal must extend hqc_block to ensure optimistic responsiveness.
+    /// The new proposal must extend hqc to ensure optimistic responsiveness.
     /// 2. The round is provided by the caller.
     /// 3. In case a given round is not greater than the calculated parent, return an OldRound
     /// error.
@@ -106,24 +105,16 @@ impl<T: Payload> ProposalGenerator<T> {
             }
         }
 
-        let hqc_block = self.block_store.highest_certified_block();
-        ensure!(
-            hqc_block.round() < round,
-            "Given round {} is lower than hqc round {}",
-            round,
-            hqc_block.round()
-        );
+        let hqc = self.ensure_highest_quorum_cert(round)?;
 
         // One needs to hold the blocks with the references to the payloads while get_block is
         // being executed: pending blocks vector keeps all the pending ancestors of the extended
         // branch.
-        let pending_blocks = match self.block_store.path_from_root(hqc_block.id()) {
-            Some(res) => res,
-            // In case the whole system moved forward between the check of a round and getting
-            // path from root.
-            None => bail!("HQC {} already pruned", hqc_block),
-        };
-        //let pending_blocks = self.get_pending_blocks(Arc::clone(&hqc_block));
+        let pending_blocks = self
+            .block_store
+            .path_from_root(hqc.certified_block().id())
+            .ok_or_else(|| format_err!("HQC {} already pruned", hqc.certified_block().id()))?;
+
         // Exclude all the pending transactions: these are all the ancestors of
         // parent (including) up to the root (excluding).
         let exclude_payload = pending_blocks
@@ -135,7 +126,7 @@ impl<T: Payload> ProposalGenerator<T> {
             if self.enforce_increasing_timestamps {
                 match wait_if_possible(
                     self.time_service.as_ref(),
-                    Duration::from_micros(hqc_block.timestamp_usecs()),
+                    Duration::from_micros(hqc.certified_block().timestamp_usecs()),
                     round_deadline,
                 )
                 .await
@@ -174,7 +165,7 @@ impl<T: Payload> ProposalGenerator<T> {
                                 counters::PROPOSAL_MAX_WAIT_EXCEEDED_COUNT.inc();
                                 bail!(
                                     "Waiting until parent block timestamp usecs {:?} would exceed the round duration {:?}, hence will not create a proposal for this round",
-                                    hqc_block.timestamp_usecs(),
+                                    hqc.certified_block().timestamp_usecs(),
                                     round_deadline);
                             }
                             WaitingError::WaitFailed {
@@ -186,7 +177,7 @@ impl<T: Payload> ProposalGenerator<T> {
                                 bail!(
                                     "Even after waiting for {:?}, parent block timestamp usecs {:?} >= current timestamp usecs {:?}, will not create a proposal for this round",
                                     wait_duration,
-                                    hqc_block.timestamp_usecs(),
+                                    hqc.certified_block().timestamp_usecs(),
                                     current_duration_since_epoch);
                             }
                         };
@@ -198,8 +189,8 @@ impl<T: Payload> ProposalGenerator<T> {
         };
 
         // Reconfiguration rule - we propose empty blocks after reconfiguration until it's committed
-        let txns = if self.block_store.root() != hqc_block
-            && hqc_block.compute_result().has_reconfiguration()
+        let txns = if self.block_store.root().id() != hqc.certified_block().id()
+            && hqc.certified_block().has_reconfiguration()
         {
             T::default()
         } else {
@@ -209,11 +200,23 @@ impl<T: Payload> ProposalGenerator<T> {
                 .with_context(|e| format!("Fail to retrieve txn: {}", e))?
         };
 
-        Ok(self.block_store.create_proposal(
-            hqc_block.block(),
+        Ok(BlockData::new_proposal(
             txns,
+            self.author,
             round,
             block_timestamp.as_micros() as u64,
+            hqc.as_ref().clone(),
         ))
+    }
+
+    fn ensure_highest_quorum_cert(&self, round: Round) -> failure::Result<Arc<QuorumCert>> {
+        let hqc = self.block_store.highest_quorum_cert();
+        ensure!(
+            hqc.certified_block().round() < round,
+            "Given round {} is lower than hqc round {}",
+            round,
+            hqc.certified_block().round()
+        );
+        Ok(hqc)
     }
 }

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -25,8 +25,9 @@ fn minute_from_now() -> Instant {
 #[test]
 fn test_proposal_generation_empty_tree() {
     let signer = ValidatorSigner::random(None);
-    let block_store = build_empty_tree(signer.author());
+    let block_store = build_empty_tree();
     let proposal_generator = ProposalGenerator::new(
+        signer.author(),
         block_store.clone(),
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
@@ -53,6 +54,7 @@ fn test_proposal_generation_parent() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let proposal_generator = ProposalGenerator::new(
+        inserter.signer().author(),
         block_store.clone(),
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
@@ -94,6 +96,7 @@ fn test_old_proposal_generation() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let proposal_generator = ProposalGenerator::new(
+        inserter.signer().author(),
         block_store.clone(),
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
@@ -113,6 +116,7 @@ fn test_empty_proposal_after_reconfiguration() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let proposal_generator = ProposalGenerator::new(
+        inserter.signer().author(),
         block_store.clone(),
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -4,7 +4,7 @@
 use crate::chained_bft::block_storage::{BlockReader, BlockStore};
 use consensus_types::{
     block::{block_test_utils::placeholder_certificate_for_block, Block},
-    common::{Author, Round},
+    common::Round,
     executed_block::ExecutedBlock,
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
@@ -74,12 +74,11 @@ pub fn build_chain() -> Vec<Arc<ExecutedBlock<TestPayload>>> {
     vec![genesis, a1, a2, a3, a4, a5, a6, a7]
 }
 
-pub fn build_empty_tree(author: Author) -> Arc<BlockStore<TestPayload>> {
+pub fn build_empty_tree() -> Arc<BlockStore<TestPayload>> {
     let (storage, initial_data) = EmptyStorage::start_for_testing();
     Arc::new(block_on(BlockStore::new(
         storage,
         initial_data,
-        author,
         Arc::new(EmptyStateComputer),
         true,
         10, // max pruned blocks in mem
@@ -98,7 +97,7 @@ impl TreeInserter {
     }
 
     pub fn new(signer: ValidatorSigner) -> Self {
-        let block_store = build_empty_tree(signer.author());
+        let block_store = build_empty_tree();
         Self {
             signer,
             payload_val: 0,

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -44,6 +44,7 @@ pub fn make_consensus_provider(
         state_sync_client,
     ))
 }
+
 /// Create a mempool client assuming the mempool is running on localhost
 fn create_mempool_client(config: &NodeConfig) -> Arc<MempoolClient> {
     let port = config.mempool.mempool_service_port;


### PR DESCRIPTION
It really didn't need to and only did since it had the signer
Now it doesn't. We only leverage the proposal generator.
As a result, the proposal generator knows the author now.
We also got to eliminate a test from the block_store to support this.

#1482 

not quite able to eliminate the block_store but one step in the right direction...