### PR TITLE
[enhancement] Add a drop counter to PerValidatorQueue

### DIFF
--- a/common/channel/src/libra_channel_test.rs
+++ b/common/channel/src/libra_channel_test.rs
@@ -91,7 +91,8 @@ fn test_multiple_validators_helper(
     num_messages_per_validator: usize,
     expected_last_message: usize,
 ) {
-    let (mut sender, mut receiver) = libra_channel::new(PerValidatorQueue::new(queue_style, 1));
+    let (mut sender, mut receiver) =
+        libra_channel::new(PerValidatorQueue::new(queue_style, 1, None));
     let num_validators = 128;
     for message in 0..num_messages_per_validator {
         for validator in 0..num_validators {

--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -17,7 +17,7 @@ struct VoteMsg {
 
 #[test]
 fn test_fifo() {
-    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3);
+    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3, None);
     let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
 
     // Test order
@@ -76,7 +76,7 @@ fn test_fifo() {
 
 #[test]
 fn test_lifo() {
-    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3);
+    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3, None);
     let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
 
     // Test order
@@ -135,7 +135,7 @@ fn test_lifo() {
 
 #[test]
 fn test_fifo_round_robin() {
-    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3);
+    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3, None);
     let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
     let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
     let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
@@ -206,7 +206,7 @@ fn test_fifo_round_robin() {
 
 #[test]
 fn test_lifo_round_robin() {
-    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3);
+    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3, None);
     let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
     let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
     let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);


### PR DESCRIPTION
## Summary

PerValidatorQueue can now optionally take a Counter as a parameter which will be incremented every time a message is dropped from any of the validator queues tracked by PerValidatorQueue

## Test Plan

Verified that these counters show up in prometheus

![image](https://user-images.githubusercontent.com/796949/67541089-906e7580-f69c-11e9-9968-ddabf1136f7e.png)
