### PR TITLE
[Consensus] Fix erroneous error messages upon commit

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -234,7 +234,8 @@ impl<T: Payload> BlockStore<T> {
         // B_i and figure out we only have B_j.
         // Here we commit up to the highest_ledger_info to maintain highest_ledger_info == state_computer.committed_trees.
         if let Some(block_to_commit) = self.highest_ledger_info().committed_block_id() {
-            if block_to_commit != self.root().id() {
+            let highest_li_commit_round = self.get_block(block_to_commit).map_or(0, |b| b.round());
+            if highest_li_commit_round > self.root().round() {
                 let finality_proof = self.highest_ledger_info().ledger_info().clone();
                 if let Err(e) = self.commit(finality_proof).await {
                     warn!("{:?}", e);


### PR DESCRIPTION
We started polluting logs with spurious error messages about commits for too low rounds,
while in fact the block_store::commit() function was called without actually checking that the
commit carried by the highest LI is higher than the current root.
This PR is adding the check prior to calling BlockStore::commit().
