### PR TITLE
[language] fix test.sh

### DIFF
--- a/language/test.sh
+++ b/language/test.sh
@@ -5,7 +5,7 @@
 
 # This script runs `cargo test` for each crate in the subdir
 
-base_cmd="cargo test"
+base_cmd="cargo test --all-features"
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 while read line; do
     echo $line;


### PR DESCRIPTION
1d1cb400 ([build] Remove testing feature and ensure correct builds,
2019-10-22) introduced some changes to how we run tests across our
project. One unfortunate consequence is that a plain `cargo test` isn't
sufficient to run tests on a crate with a "fuzzing" feature. Instead the
fuzzing feature needs to be explicitly turned on. This fixes the
language test.sh script to ensure that `--all-features` is passed when
invoking `cargo test` across the language crates.