### PR TITLE
[TF] fix validator sets gen for nightly

### DIFF
--- a/terraform/validator-sets/build.sh
+++ b/terraform/validator-sets/build.sh
@@ -1,23 +1,24 @@
 #!/bin/sh
 set -e
 
-OUTDIR="${1?[Specify relative output directory]}"
+OUT_DIR="${1?[Specify relative output directory]}"
 shift
 
-mkdir -p "$OUTDIR"
+LIBRA_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../.. && pwd)"
+TF_WORK_DIR="$LIBRA_DIR/terraform/validator-sets"
+OUTPUT_DIR="$TF_WORK_DIR/$OUT_DIR"
+mkdir -p "$OUTPUT_DIR"
 
-cd ../..
 
-if [ ! -e "terraform/validator-sets/$OUTDIR/mint.key" ]; then
-	cargo run --bin generate-keypair -- -o "terraform/validator-sets/$OUTDIR/mint.key"
+if [ ! -e "$OUTPUT_DIR/mint.key" ]; then
+	cargo run -p generate-keypair --bin generate-keypair -- -o "$OUTPUT_DIR/mint.key"
 fi
 
-cargo run --bin libra-config -- -b config/data/configs/node.config.toml -m "terraform/validator-sets/$OUTDIR/mint.key" -o "terraform/validator-sets/$OUTDIR/val" -d -r validator "$@"
-cargo run --bin libra-config -- -b config/data/configs/node.config.toml -m "terraform/validator-sets/$OUTDIR/mint.key" -o "terraform/validator-sets/$OUTDIR/fn" -u "terraform/validator-sets/$OUTDIR/val/0" -r full_node -n 10
+cd $LIBRA_DIR && cargo run -p config-builder --bin libra-config -- -b $LIBRA_DIR/config/data/configs/node.config.toml -m "$OUTPUT_DIR/mint.key" -o "$OUTPUT_DIR/val" -d -r validator "$@"
+cd $LIBRA_DIR && cargo run -p config-builder --bin libra-config -- -b $LIBRA_DIR/config/data/configs/node.config.toml -m "$OUTPUT_DIR/mint.key" -o "$OUTPUT_DIR/fn" -u "$OUTPUT_DIR/val/0" -r full_node -n 10
 
-cd -
 
-cd $OUTDIR/val
+cd "$OUTPUT_DIR/val"
 mv */*.keys.toml .
 mv 1/*.network_peers.config.toml network_peers.config.toml
 mv 1/consensus_peers.config.toml ../consensus_peers.config.toml
@@ -25,7 +26,7 @@ mv 1/genesis.blob ../
 rm */*.toml */*.blob
 find . -mindepth 1 -type d -print0 | xargs -0 rmdir
 
-cd ../fn
+cd "$OUTPUT_DIR/fn"
 mv */*.keys.toml .
 mv 0/*.network_peers.config.toml network_peers.config.toml
 rm */*.toml */*.blob


### PR DESCRIPTION
## Motivation
We recently made changes in build to work around Cargo's feature unification so that we can separate testing and fuzzing code (1d1cb400).  But it gets out of sync with the build script that generates the validator config in nightly, where the target package was not found by Cargo.  We need to update the config gen script to specify both the package (-p) and bin (--bin) in Cargo.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally and inspected the generated the validator configs.
```
[youngyl@devvm842:libra fix_validator_sets_gen]$ terraform/validator-sets/build.sh nightly -n 100
    Finished dev [unoptimized + debuginfo] target(s) in 0.33s
     Running `target/debug/libra-config -b /home/youngyl/work/libra/config/data/configs/node.config.toml -m /home/youngyl/work/libra/terraform/validator-sets/nightly/mint.key -o /home/youngyl/work/libra/terraform/validator-sets/nightly/val -d -r validator -n 100`
    Finished dev [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/libra-config -b /home/youngyl/work/libra/config/data/configs/node.config.toml -m /home/youngyl/work/libra/terraform/validator-sets/nightly/mint.key -o /home/youngyl/work/libra/terraform/validator-sets/nightly/fn -u /home/youngyl/work/libra/terraform/validator-sets/nightly/val/0 -r full_node -n 10`
[youngyl@devvm842:libra fix_validator_sets_gen]$
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
