### PR TITLE
[state sync] alter sync_to API

### DIFF
--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -272,8 +272,9 @@ impl SynchronizerEnv {
     }
 
     fn sync_to_new_flow(&self, peer_id: usize, version: u64) -> bool {
-        let (li, peer) = block_on(self.clients[peer_id].sync_to(vec![self.peers[1]])).unwrap();
-        self.peers[1] == peer && li.ledger_info().version() == version
+        let target = MockExecutorProxy::mock_ledger_info(self.peers[1], version);
+        let li = block_on(self.clients[peer_id].sync_to(target)).unwrap();
+        li.ledger_info().version() == version
     }
 
     fn commit(&self, peer_id: usize, version: u64) {


### PR DESCRIPTION
new version of `sync_to` routine performs state synchronization until it reaches target state
(e.g. its `local version >= target.version`)
