### PR TITLE
[CI][easy] fix code coverage report script

### DIFF
--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -81,7 +81,7 @@ echo "Cleaning project..."
 echo "Running tests..."
 while read -r line; do
         dirline=$(realpath $(dirname "$line"));
-        (cd "$dirline"; cargo test)
+        (cd "$dirline"; cargo +nightly test --all-features)
 done < <(find "$TEST_DIR" -name 'Cargo.toml')
 
 # Make the coverage directory if it doesn't exist


### PR DESCRIPTION
## Motivation
We worked around Cargo's feature unification so that we can separate
testing and fuzzing code (1d1cb400 [build]).  But the original
`cargo test` is not able to run the tests on a crate. We need to pass
`--all-feature` option as well.

This fixes the following error when running the coverage report script
```
error[E0433]: failed to resolve: could not find `test_helpers` in `libra_types`
```

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally and observed the coverage test runs through crates.