### PR TITLE
Migrating everything from SignedTransaction to Transaction

### DIFF
--- a/admission_control/admission-control-proto/src/proto/admission_control.proto
+++ b/admission_control/admission-control-proto/src/proto/admission_control.proto
@@ -23,8 +23,8 @@ message AdmissionControlMsg {
 // -----------------------------------------------------------------------------
 // The request for transaction submission.
 message SubmitTransactionRequest {
-  // Transaction signed by wallet.
-  types.SignedTransaction signed_txn = 1;
+  // Transaction submitted by user.
+  types.SignedTransaction transaction = 1;
 }
 
 // AC response status containing code and optionally an error message.

--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -28,7 +28,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
     let signed_txn = gen.generate(proptest::arbitrary::any::<SignedTransaction>());
     // wrap it in a SubmitTransactionRequest
     let mut req = SubmitTransactionRequest::default();
-    req.signed_txn = Some(signed_txn.into());
+    req.transaction = Some(signed_txn.into());
 
     let mut bytes = bytes::BytesMut::with_capacity(req.encoded_len());
     req.encode(&mut bytes).unwrap();

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -110,14 +110,14 @@ where
             return Ok(response);
         }
 
-        let signed_txn_proto = req.signed_txn.clone().unwrap_or_else(Default::default);
+        let txn_proto = req.transaction.clone().unwrap_or_else(Default::default);
 
-        let signed_txn = match SignedTransaction::try_from(signed_txn_proto.clone()) {
+        let signed_txn = match SignedTransaction::try_from(txn_proto.clone()) {
             Ok(t) => t,
             Err(e) => {
                 security_log(SecurityEvent::InvalidTransactionAC)
                     .error(&e)
-                    .data(&signed_txn_proto)
+                    .data(&txn_proto)
                     .log();
                 let mut response = SubmitTransactionResponse::default();
                 response.status = Some(Status::AcStatus(
@@ -153,7 +153,7 @@ where
         let sender = signed_txn.sender();
         let account_state = block_on(get_account_state(self.storage_read_client.clone(), sender));
         let mut add_transaction_request = AddTransactionWithValidationRequest::default();
-        add_transaction_request.signed_txn = req.signed_txn.clone();
+        add_transaction_request.signed_txn = req.transaction.clone();
         add_transaction_request.max_gas_cost = gas_cost;
 
         if let Ok((sequence_number, balance)) = account_state {

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -153,7 +153,7 @@ where
         let sender = signed_txn.sender();
         let account_state = block_on(get_account_state(self.storage_read_client.clone(), sender));
         let mut add_transaction_request = AddTransactionWithValidationRequest::default();
-        add_transaction_request.signed_txn = req.transaction.clone();
+        add_transaction_request.transaction = req.transaction.clone();
         add_transaction_request.max_gas_cost = gas_cost;
 
         if let Ok((sequence_number, balance)) = account_state {
@@ -196,7 +196,7 @@ where
                     } else {
                         debug!(
                             "txn failed in mempool, status: {:?}, txn: {:?}",
-                            status, add_transaction_request.signed_txn
+                            status, add_transaction_request.transaction
                         );
                         OP_COUNTERS.inc_by("submit_txn.mempool.failure", 1);
                         response.status = Some(Status::MempoolStatus(status));

--- a/admission_control/admission-control-service/src/mocks/local_mock_mempool.rs
+++ b/admission_control/admission-control-service/src/mocks/local_mock_mempool.rs
@@ -43,9 +43,9 @@ impl MempoolClientTrait for LocalMockMempool {
         let sys_error_add = [102_u8; ADDRESS_LENGTH];
         let accepted_add = [103_u8; ADDRESS_LENGTH];
         let mempool_full = [104_u8; ADDRESS_LENGTH];
-        let signed_txn =
+        let transaction =
             SignedTransaction::try_from(req.clone().transaction.unwrap().clone()).unwrap();
-        let sender = signed_txn.sender();
+        let sender = transaction.sender();
         if sender.as_ref() == insufficient_balance_add {
             status.set_code(MempoolAddTransactionStatusCode::InsufficientBalance);
         } else if sender.as_ref() == invalid_seq_add {

--- a/admission_control/admission-control-service/src/mocks/local_mock_mempool.rs
+++ b/admission_control/admission-control-service/src/mocks/local_mock_mempool.rs
@@ -44,7 +44,7 @@ impl MempoolClientTrait for LocalMockMempool {
         let accepted_add = [103_u8; ADDRESS_LENGTH];
         let mempool_full = [104_u8; ADDRESS_LENGTH];
         let signed_txn =
-            SignedTransaction::try_from(req.clone().signed_txn.unwrap().clone()).unwrap();
+            SignedTransaction::try_from(req.clone().transaction.unwrap().clone()).unwrap();
         let sender = signed_txn.sender();
         if sender.as_ref() == insufficient_balance_add {
             status.set_code(MempoolAddTransactionStatusCode::InsufficientBalance);

--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -53,7 +53,7 @@ fn test_submit_txn_inner_vm() {
     let mut req: SubmitTransactionRequest = SubmitTransactionRequest::default();
     let sender = AccountAddress::new([0; ADDRESS_LENGTH]);
     let keypair = compat::generate_keypair(&mut rng);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(
@@ -61,12 +61,12 @@ fn test_submit_txn_inner_vm() {
         VMStatus::new(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST),
     );
     let sender = AccountAddress::new([1; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::INVALID_SIGNATURE));
     let sender = AccountAddress::new([2; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(
@@ -74,34 +74,34 @@ fn test_submit_txn_inner_vm() {
         VMStatus::new(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE),
     );
     let sender = AccountAddress::new([3; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::SEQUENCE_NUMBER_TOO_NEW));
     let sender = AccountAddress::new([4; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::SEQUENCE_NUMBER_TOO_OLD));
     let sender = AccountAddress::new([5; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::TRANSACTION_EXPIRED));
     let sender = AccountAddress::new([6; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::INVALID_AUTH_KEY));
     let sender = AccountAddress::new([8; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), keypair.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::EXECUTED));
 
     let sender = AccountAddress::new([8; ADDRESS_LENGTH]);
     let test_key = compat::generate_keypair(&mut rng);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(sender, 0, keypair.0.clone(), test_key.1.clone(), None).into());
     let response = ac_service.submit_transaction_inner(req.clone()).unwrap();
     assert_status(response, VMStatus::new(StatusCode::INVALID_SIGNATURE));
@@ -113,7 +113,7 @@ fn test_submit_txn_inner_mempool() {
     let mut req: SubmitTransactionRequest = SubmitTransactionRequest::default();
     let keypair = compat::generate_keypair(None);
     let insufficient_balance_add = AccountAddress::new([100; ADDRESS_LENGTH]);
-    req.signed_txn = Some(
+    req.transaction = Some(
         get_test_signed_txn(
             insufficient_balance_add,
             0,
@@ -132,7 +132,7 @@ fn test_submit_txn_inner_mempool() {
         MempoolAddTransactionStatusCode::InsufficientBalance
     );
     let invalid_seq_add = AccountAddress::new([101; ADDRESS_LENGTH]);
-    req.signed_txn = Some(
+    req.transaction = Some(
         get_test_signed_txn(
             invalid_seq_add,
             0,
@@ -151,7 +151,7 @@ fn test_submit_txn_inner_mempool() {
         MempoolAddTransactionStatusCode::InvalidSeqNumber
     );
     let sys_error_add = AccountAddress::new([102; ADDRESS_LENGTH]);
-    req.signed_txn = Some(
+    req.transaction = Some(
         get_test_signed_txn(sys_error_add, 0, keypair.0.clone(), keypair.1.clone(), None).into(),
     );
     let response = SubmitTransactionResponse::try_from(
@@ -163,7 +163,7 @@ fn test_submit_txn_inner_mempool() {
         MempoolAddTransactionStatusCode::InvalidUpdate
     );
     let accepted_add = AccountAddress::new([103; ADDRESS_LENGTH]);
-    req.signed_txn = Some(
+    req.transaction = Some(
         get_test_signed_txn(accepted_add, 0, keypair.0.clone(), keypair.1.clone(), None).into(),
     );
     let response = SubmitTransactionResponse::try_from(
@@ -175,7 +175,7 @@ fn test_submit_txn_inner_mempool() {
         AdmissionControlStatus::Accepted,
     );
     let accepted_add = AccountAddress::new([104; ADDRESS_LENGTH]);
-    req.signed_txn =
+    req.transaction =
         Some(get_test_signed_txn(accepted_add, 0, keypair.0.clone(), keypair.1, None).into());
     let response = SubmitTransactionResponse::try_from(
         ac_service.submit_transaction_inner(req.clone()).unwrap(),

--- a/benchmark/src/load_generator.rs
+++ b/benchmark/src/load_generator.rs
@@ -107,7 +107,7 @@ fn gen_submit_transaction_request<T: TransactionSigner>(
         Err(e)
     })?;
     let mut req = SubmitTransactionRequest::default();
-    req.signed_txn = Some(signed_txn.into());
+    req.transaction = Some(signed_txn.into());
     sender_account.sequence_number += 1;
     OP_COUNTER.inc("create_txn_request.success");
     Ok(Request::WriteRequest(req))

--- a/benchmark/src/load_generator.rs
+++ b/benchmark/src/load_generator.rs
@@ -14,7 +14,7 @@ use libra_types::{
     get_with_proof::{RequestItem, UpdateToLatestLedgerRequest},
     proto::types::UpdateToLatestLedgerRequest as ProtoUpdateToLatestLedgerRequest,
     transaction::{
-        helpers::{create_signed_txn, TransactionSigner},
+        helpers::{create_user_txn, TransactionSigner},
         Script, TransactionPayload,
     },
 };
@@ -93,7 +93,7 @@ fn gen_submit_transaction_request<T: TransactionSigner>(
 ) -> Result<Request> {
     // If generation fails here, sequence number will not be increased,
     // so it is fine to continue later generation.
-    let signed_txn = create_signed_txn(
+    let signed_txn = create_user_txn(
         signer,
         TransactionPayload::Script(program),
         sender_account.address,

--- a/benchmark/src/load_generator.rs
+++ b/benchmark/src/load_generator.rs
@@ -93,7 +93,7 @@ fn gen_submit_transaction_request<T: TransactionSigner>(
 ) -> Result<Request> {
     // If generation fails here, sequence number will not be increased,
     // so it is fine to continue later generation.
-    let signed_txn = create_user_txn(
+    let transaction = create_user_txn(
         signer,
         TransactionPayload::Script(program),
         sender_account.address,
@@ -107,7 +107,7 @@ fn gen_submit_transaction_request<T: TransactionSigner>(
         Err(e)
     })?;
     let mut req = SubmitTransactionRequest::default();
-    req.transaction = Some(signed_txn.into());
+    req.transaction = Some(transaction.into());
     sender_account.sequence_number += 1;
     OP_COUNTER.inc("create_txn_request.success");
     Ok(Request::WriteRequest(req))

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -18,7 +18,7 @@ use libra_types::{
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::{ContractEvent, EventWithProof},
     transaction::{
-        helpers::{create_signed_txn, create_unsigned_txn, TransactionSigner},
+        helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
         parse_as_transaction_argument, RawTransaction, Script, SignedTransaction, Transaction,
         TransactionArgument, TransactionPayload, Version,
     },
@@ -1014,7 +1014,7 @@ impl ClientProxy {
             Some(key_pair) => Box::new(key_pair),
             None => Box::new(&self.wallet),
         };
-        let signed_txn = create_signed_txn(
+        let transaction = create_user_txn(
             *signer,
             program,
             sender_account.address,
@@ -1025,7 +1025,7 @@ impl ClientProxy {
         )
         .unwrap();
         let mut req = SubmitTransactionRequest::default();
-        req.transaction = Some(signed_txn.into());
+        req.transaction = Some(transaction.into());
         Ok(req)
     }
 

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -535,13 +535,13 @@ impl ClientProxy {
         public_key: Ed25519PublicKey,
         signature: Ed25519Signature,
     ) -> Result<()> {
-        let signed_txn = SignedTransaction::new(raw_txn, public_key.clone(), signature);
+        let transaction = SignedTransaction::new(raw_txn, public_key.clone(), signature);
 
         let mut req = SubmitTransactionRequest::default();
-        let sender_address = signed_txn.sender();
-        let sender_sequence = signed_txn.sequence_number();
+        let sender_address = transaction.sender();
+        let sender_sequence = transaction.sequence_number();
 
-        req.transaction = Some(signed_txn.into());
+        req.transaction = Some(transaction.into());
         self.client.submit_transaction(None, &req)?;
         // blocking by default (until transaction completion)
         self.wait_for_transaction(sender_address, sender_sequence + 1);

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -541,7 +541,7 @@ impl ClientProxy {
         let sender_address = signed_txn.sender();
         let sender_sequence = signed_txn.sequence_number();
 
-        req.signed_txn = Some(signed_txn.into());
+        req.transaction = Some(signed_txn.into());
         self.client.submit_transaction(None, &req)?;
         // blocking by default (until transaction completion)
         self.wait_for_transaction(sender_address, sender_sequence + 1);
@@ -1025,7 +1025,7 @@ impl ClientProxy {
         )
         .unwrap();
         let mut req = SubmitTransactionRequest::default();
-        req.signed_txn = Some(signed_txn.into());
+        req.transaction = Some(signed_txn.into());
         Ok(req)
     }
 

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -605,7 +605,7 @@ impl ClientProxy {
     pub fn get_committed_txn_by_acc_seq(
         &mut self,
         space_delim_strings: &[&str],
-    ) -> Result<Option<(SignedTransaction, Option<Vec<ContractEvent>>)>> {
+    ) -> Result<Option<(Transaction, Option<Vec<ContractEvent>>)>> {
         ensure!(
             space_delim_strings.len() == 4,
             "Invalid number of arguments to get transaction by account and sequence number"

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -24,7 +24,7 @@ use libra_types::{
     get_with_proof::{
         RequestItem, ResponseItem, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,
     },
-    transaction::{SignedTransaction, Transaction, Version},
+    transaction::{Transaction, Version},
     vm_error::StatusCode,
 };
 use std::convert::TryFrom;
@@ -214,7 +214,7 @@ impl GRPCClient {
         account: AccountAddress,
         sequence_number: u64,
         fetch_events: bool,
-    ) -> Result<Option<(SignedTransaction, Option<Vec<ContractEvent>>)>> {
+    ) -> Result<Option<(Transaction, Option<Vec<ContractEvent>>)>> {
         let req_item = RequestItem::GetAccountTransactionBySequenceNumber {
             account,
             sequence_number,
@@ -227,7 +227,7 @@ impl GRPCClient {
             .remove(0)
             .into_get_account_txn_by_seq_num_response()?;
 
-        Ok(signed_txn_with_proof.map(|t| (t.signed_transaction, t.events)))
+        Ok(signed_txn_with_proof.map(|t| (t.transaction, t.events)))
     }
 
     /// Get transactions in range (start_version..start_version + limit - 1) from validator.

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -222,12 +222,12 @@ impl GRPCClient {
         };
 
         let mut response = self.get_with_proof_sync(vec![req_item])?;
-        let (signed_txn_with_proof, _) = response
+        let (txn_with_proof, _) = response
             .response_items
             .remove(0)
             .into_get_account_txn_by_seq_num_response()?;
 
-        Ok(signed_txn_with_proof.map(|t| (t.transaction, t.events)))
+        Ok(txn_with_proof.map(|t| (t.transaction, t.events)))
     }
 
     /// Get transactions in range (start_version..start_version + limit - 1) from validator.

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -84,10 +84,10 @@ impl TxnManager for MempoolProxy {
     ) -> Pin<Box<dyn Future<Output = Result<Self::Payload>> + Send>> {
         let mut exclude_txns = vec![];
         for payload in exclude_payloads {
-            for signed_txn in payload {
+            for transaction in payload {
                 let mut txn_meta = TransactionExclusion::default();
-                txn_meta.sender = signed_txn.sender().into();
-                txn_meta.sequence_number = signed_txn.sequence_number();
+                txn_meta.sender = transaction.sender().into();
+                txn_meta.sequence_number = transaction.sequence_number();
                 exclude_txns.push(txn_meta);
             }
         }

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -552,10 +552,20 @@ define_hasher! {
 
 define_hasher! {
     /// The hasher used to compute the hash of a SignedTransaction object.
+    /// TODO: this can be removed once we hash Transaction instead of SignedTransaction everywhere.
     (
         SignedTransactionHasher,
         SIGNED_TRANSACTION_HASHER,
         b"SignedTransaction"
+    )
+}
+
+define_hasher! {
+    /// The hasher used to complete the hash of a Transaction object.
+    (
+        TransactionHasher,
+        TRANSACTION_HASHER,
+        b"TRANSACTION"
     )
 }
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -551,16 +551,6 @@ define_hasher! {
 }
 
 define_hasher! {
-    /// The hasher used to compute the hash of a SignedTransaction object.
-    /// TODO: this can be removed once we hash Transaction instead of SignedTransaction everywhere.
-    (
-        SignedTransactionHasher,
-        SIGNED_TRANSACTION_HASHER,
-        b"SignedTransaction"
-    )
-}
-
-define_hasher! {
     /// The hasher used to complete the hash of a Transaction object.
     (
         TransactionHasher,

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -555,7 +555,7 @@ where
                     // Compute hash for the TransactionInfo object. We need the hash of the
                     // transaction itself, the state root hash as well as the event root hash.
                     let txn_info = TransactionInfo::new(
-                        txn.as_signed_user_txn()?.hash(),
+                        txn.hash(),
                         state_tree.root_hash(),
                         event_tree.root_hash(),
                         vm_output.gas_used(),

--- a/executor/src/mock_vm/mock_vm_test.rs
+++ b/executor/src/mock_vm/mock_vm_test.rs
@@ -8,7 +8,6 @@ use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
-    transaction::Transaction,
     write_set::WriteOp,
 };
 use vm_runtime::VMExecutor;
@@ -38,10 +37,7 @@ fn test_mock_vm_different_senders() {
     let amount = 100;
     let mut txns = vec![];
     for i in 0..10 {
-        txns.push(Transaction::UserTransaction(encode_mint_transaction(
-            gen_address(i),
-            amount,
-        )));
+        txns.push(encode_mint_transaction(gen_address(i), amount));
     }
 
     let outputs = MockVM::execute_block(
@@ -75,9 +71,7 @@ fn test_mock_vm_same_sender() {
     let sender = gen_address(1);
     let mut txns = vec![];
     for _i in 0..10 {
-        txns.push(Transaction::UserTransaction(encode_mint_transaction(
-            sender, amount,
-        )));
+        txns.push(encode_mint_transaction(sender, amount));
     }
 
     let outputs = MockVM::execute_block(
@@ -116,7 +110,7 @@ fn test_mock_vm_payment() {
     ));
 
     let output = MockVM::execute_block(
-        txns.into_iter().map(Transaction::UserTransaction).collect(),
+        txns,
         &VMConfig::empty_whitelist_FOR_TESTING(),
         &MockStateView,
     )

--- a/executor/src/mock_vm/mod.rs
+++ b/executor/src/mock_vm/mod.rs
@@ -263,7 +263,7 @@ pub fn encode_transfer_program(recipient: AccountAddress, amount: u64) -> Script
     Script::new(vec![], vec![argument1, argument2])
 }
 
-pub fn encode_mint_transaction(sender: AccountAddress, amount: u64) -> SignedTransaction {
+pub fn encode_mint_transaction(sender: AccountAddress, amount: u64) -> Transaction {
     encode_transaction(sender, encode_mint_program(amount))
 }
 
@@ -271,19 +271,21 @@ pub fn encode_transfer_transaction(
     sender: AccountAddress,
     recipient: AccountAddress,
     amount: u64,
-) -> SignedTransaction {
+) -> Transaction {
     encode_transaction(sender, encode_transfer_program(recipient, amount))
 }
 
-fn encode_transaction(sender: AccountAddress, program: Script) -> SignedTransaction {
+fn encode_transaction(sender: AccountAddress, program: Script) -> Transaction {
     let raw_transaction =
         RawTransaction::new_script(sender, 0, program, 0, 0, std::time::Duration::from_secs(0));
 
     let (privkey, pubkey) = compat::generate_keypair(None);
-    raw_transaction
-        .sign(&privkey, pubkey)
-        .expect("Failed to sign raw transaction.")
-        .into_inner()
+    Transaction::UserTransaction(
+        raw_transaction
+            .sign(&privkey, pubkey)
+            .expect("Failed to sign raw transaction.")
+            .into_inner(),
+    )
 }
 
 fn decode_transaction(txn: &SignedTransaction) -> MockVMTransaction {

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -714,15 +714,15 @@ fn verify_committed_txn_status(
     txn_with_proof: Option<&TransactionWithProof>,
     expected_txn: &Transaction,
 ) -> Result<()> {
-    let signed_txn = &txn_with_proof
+    let txn = &txn_with_proof
         .ok_or_else(|| format_err!("Transaction is not committed."))?
-        .signed_transaction;
+        .transaction;
 
     ensure!(
-        *expected_txn == Transaction::UserTransaction(signed_txn.clone()),
+        expected_txn == txn,
         "The two transactions do not match. Expected txn: {:?}, returned txn: {:?}",
         expected_txn,
-        signed_txn,
+        txn,
     );
 
     Ok(())

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -18,7 +18,7 @@ use libra_types::{
     get_with_proof::{verify_update_to_latest_ledger_response, RequestItem},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     test_helpers::transaction_test_helpers::get_test_signed_txn,
-    transaction::{Script, SignedTransactionWithProof, Transaction, TransactionListWithProof},
+    transaction::{Script, Transaction, TransactionListWithProof, TransactionWithProof},
 };
 use rand::SeedableRng;
 use std::{collections::BTreeMap, sync::Arc};
@@ -711,10 +711,10 @@ fn verify_transactions(
 }
 
 fn verify_committed_txn_status(
-    signed_txn_with_proof: Option<&SignedTransactionWithProof>,
+    txn_with_proof: Option<&TransactionWithProof>,
     expected_txn: &Transaction,
 ) -> Result<()> {
-    let signed_txn = &signed_txn_with_proof
+    let signed_txn = &txn_with_proof
         .ok_or_else(|| format_err!("Transaction is not committed."))?
         .signed_transaction;
 
@@ -729,12 +729,12 @@ fn verify_committed_txn_status(
 }
 
 fn verify_uncommitted_txn_status(
-    signed_txn_with_proof: Option<&SignedTransactionWithProof>,
+    txn_with_proof: Option<&TransactionWithProof>,
     proof_of_current_sequence_number: Option<&AccountStateWithProof>,
     expected_seq_num: u64,
 ) -> Result<()> {
     ensure!(
-        signed_txn_with_proof.is_none(),
+        txn_with_proof.is_none(),
         "Transaction is unexpectedly committed."
     );
 

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -133,7 +133,7 @@ impl Account {
     ///
     /// This is the most generic way to create a transaction for testing.
     /// Max gas amount and gas unit price are ignored for WriteSet transactions.
-    pub fn create_signed_txn(
+    pub fn create_user_txn(
         &self,
         payload: TransactionPayload,
         sequence_number: u64,

--- a/language/e2e-tests/src/tests/genesis.rs
+++ b/language/e2e-tests/src/tests/genesis.rs
@@ -22,7 +22,7 @@ fn invalid_genesis_write_set() {
     let write_set = WriteSetMut::new(vec![write_op]).freeze().unwrap();
     let address = account_config::association_address();
     let (private_key, public_key) = compat::generate_keypair(None);
-    let signed_txn = transaction_test_helpers::get_write_set_txn(
+    let txn = transaction_test_helpers::get_write_set_txn(
         address,
         0,
         private_key,
@@ -31,8 +31,8 @@ fn invalid_genesis_write_set() {
     )
     .into_inner();
     assert_prologue_parity!(
-        executor.verify_transaction(signed_txn.clone()),
-        executor.execute_transaction(signed_txn).status(),
+        executor.verify_transaction(txn.clone()),
+        executor.execute_transaction(txn).status(),
         VMStatus::new(StatusCode::INVALID_WRITE_SET)
     );
 }

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -401,7 +401,7 @@ pub fn test_no_publishing() {
     let random_module = compile_module_with_address(sender.address(), &module);
     let txn = sender
         .account()
-        .create_signed_txn(random_module, 10, 100_000, 1);
+        .create_user_txn(random_module, 10, 100_000, 1);
     assert_prologue_parity!(
         executor.verify_transaction(txn.clone()),
         executor.execute_transaction(txn).status(),
@@ -444,7 +444,7 @@ pub fn test_open_publishing_invalid_address() {
     let random_module = compile_module_with_address(receiver.address(), &module);
     let txn = sender
         .account()
-        .create_signed_txn(random_module, 10, 100_000, 1);
+        .create_user_txn(random_module, 10, 100_000, 1);
 
     // verify and fail because the addresses don't match
     let vm_status = executor.verify_transaction(txn.clone()).unwrap();
@@ -494,7 +494,7 @@ pub fn test_open_publishing() {
     let random_module = compile_module_with_address(sender.address(), &program);
     let txn = sender
         .account()
-        .create_signed_txn(random_module, 10, 100_000, 1);
+        .create_user_txn(random_module, 10, 100_000, 1);
     assert_eq!(executor.verify_transaction(txn.clone()), None);
     assert_eq!(
         executor.execute_transaction(txn).status(),
@@ -552,7 +552,7 @@ fn test_dependency_fails_verification() {
         ..Compiler::default()
     };
     let script = compiler.into_script_blob(code).expect("Failed to compile");
-    let txn = sender.account().create_signed_txn(
+    let txn = sender.account().create_user_txn(
         TransactionPayload::Script(Script::new(script, vec![])),
         10,
         100_000,

--- a/language/functional_tests/_old_move_ir_tests/src/tests/key_rotation.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/key_rotation.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::*;
-use libra_crypto;
 use language_common::{error_codes::*, tooling::fake_executor::Account};
-use move_ir::{assert_error_type, assert_no_error};
+use libra_crypto;
 use libra_types::account_address::AccountAddress;
+use move_ir::{assert_error_type, assert_no_error};
 
 #[test]
 fn cant_send_transaction_with_old_key_after_rotation() {
@@ -66,7 +66,7 @@ main() {{
     };
 
     let sequence_number = test_env.get_txn_sequence_number(0);
-    let txn = test_env.create_signed_txn(
+    let txn = test_env.create_user_txn(
         to_standalone_script(b"main() { return; }"),
         old_account.addr,
         new_account,

--- a/language/functional_tests/_old_move_ir_tests/src/tests/transaction_scripts.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/transaction_scripts.rs
@@ -79,7 +79,7 @@ fn create_account_script() {
 
     // make sure the account has been created by sending a transaction from it
     let sequence_number = 0;
-    let txn = test_env.create_signed_txn(
+    let txn = test_env.create_user_txn(
         to_script(b"main() { return; }", vec![]),
         fresh_address.clone(),
         fresh_account,
@@ -113,7 +113,7 @@ fn rotate_authentication_key_script() {
 
     // make sure rotation worked by sending with the new key
     let sequence_number = 1;
-    let txn = test_env.create_signed_txn(
+    let txn = test_env.create_user_txn(
         to_standalone_script(b"main() { return; }"),
         old_account.addr,
         new_account,

--- a/language/functional_tests/_old_move_ir_tests/src/tests/verify_transaction.rs
+++ b/language/functional_tests/_old_move_ir_tests/src/tests/verify_transaction.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::*;
+use libra_types::transaction::{RawTransaction, Script, SignedTransaction, TransactionPayload};
 use move_ir::assert_no_error;
 use proptest::prelude::*;
 use std::time::Duration;
-use libra_types::transaction::{RawTransaction, SignedTransaction, TransactionPayload, Script};
 
 #[test]
 fn verify_txn_accepts_good_sequence_number() {
@@ -95,7 +95,7 @@ fn verify_txn_accepts_good_signature() {
     let test_env = TestEnvironment::default();
 
     let sender_account = test_env.accounts.get_account(0);
-    let signed_txn = test_env.create_signed_txn(
+    let signed_txn = test_env.create_user_txn(
         to_script(b"main() { return; }", vec![]),
         sender_account.addr,
         sender_account,

--- a/mempool/src/mempool_service.rs
+++ b/mempool/src/mempool_service.rs
@@ -37,7 +37,7 @@ impl Mempool for MempoolService {
         trace!("[GRPC] Mempool::add_transaction_with_validation");
         let _timer = SVC_COUNTERS.req(&ctx);
         let mut success = true;
-        let proto_transaction = req.signed_txn.unwrap_or_else(Default::default);
+        let proto_transaction = req.transaction.unwrap_or_else(Default::default);
         match SignedTransaction::try_from(proto_transaction) {
             Err(e) => {
                 success = false;

--- a/mempool/src/proto/mempool.proto
+++ b/mempool/src/proto/mempool.proto
@@ -38,7 +38,7 @@ service Mempool {
 
 message AddTransactionWithValidationRequest {
   // Transaction from a wallet
-  types.SignedTransaction signed_txn = 1;
+  types.SignedTransaction transaction = 1;
   // Max amount of gas required to execute the transaction
   // Without running the program, it is very difficult to determine this number,
   // so we use the max gas specified by the signed transaction.

--- a/mempool/src/unit_tests/service_test.rs
+++ b/mempool/src/unit_tests/service_test.rs
@@ -53,7 +53,7 @@ fn create_add_transaction_request(expiration_time: u64) -> AddTransactionWithVal
         None,
     )
     .into();
-    req.signed_txn = Some(transaction);
+    req.transaction = Some(transaction);
     req.max_gas_cost = 10;
     req.account_balance = 1000;
     req
@@ -88,7 +88,7 @@ fn test_get_block() {
     let response = client.get_block(&GetBlockRequest::default()).unwrap();
     let block = response.block.unwrap();
     assert_eq!(block.transactions.len(), 1);
-    assert_eq!(block.transactions[0], req.signed_txn.unwrap(),);
+    assert_eq!(block.transactions[0], req.transaction.unwrap(),);
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn test_consensus_callbacks() {
 
     // remove: transaction is committed
     let mut transaction = CommittedTransaction::default();
-    let signed_txn = SignedTransaction::try_from(add_req.signed_txn.unwrap().clone()).unwrap();
+    let signed_txn = SignedTransaction::try_from(add_req.transaction.unwrap().clone()).unwrap();
     let sender = signed_txn.sender().as_ref().to_vec();
     transaction.sender = sender;
     transaction.sequence_number = 0;

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -55,8 +55,8 @@ use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof},
     get_with_proof::{RequestItem, ResponseItem},
     proof::{
-        AccountStateProof, AccumulatorConsistencyProof, EventProof, SignedTransactionProof,
-        SparseMerkleProof, TransactionListProof,
+        AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
+        TransactionListProof, TransactionProof,
     },
     transaction::{
         SignedTransactionWithProof, TransactionInfo, TransactionListWithProof, TransactionToCommit,
@@ -699,7 +699,7 @@ impl LibraDB {
             let (txn_info, txn_info_accumulator_proof) = self
                 .ledger_store
                 .get_transaction_info_with_proof(version, ledger_version)?;
-            SignedTransactionProof::new(txn_info_accumulator_proof, txn_info)
+            TransactionProof::new(txn_info_accumulator_proof, txn_info)
         };
         let signed_transaction = self
             .transaction_store

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -428,7 +428,7 @@ impl LibraDB {
         let txn_infos = izip!(txns_to_commit, state_root_hashes, event_root_hashes)
             .map(|(t, s, e)| {
                 Ok(TransactionInfo::new(
-                    t.as_signed_user_txn()?.hash(),
+                    t.transaction().hash(),
                     s,
                     e,
                     t.gas_used(),

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -701,10 +701,7 @@ impl LibraDB {
                 .get_transaction_info_with_proof(version, ledger_version)?;
             TransactionProof::new(txn_info_accumulator_proof, txn_info)
         };
-        let signed_transaction = self
-            .transaction_store
-            .get_transaction(version)?
-            .try_into()?;
+        let transaction = self.transaction_store.get_transaction(version)?;
 
         // If events were requested, also fetch those.
         let events = if fetch_events {
@@ -715,7 +712,7 @@ impl LibraDB {
 
         Ok(TransactionWithProof {
             version,
-            signed_transaction,
+            transaction,
             events,
             proof,
         })

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -307,11 +307,11 @@ fn verify_committed_transactions(
         // Verify transaction hash.
         assert_eq!(
             txn_info.transaction_hash(),
-            txn_to_commit.as_signed_user_txn()?.hash()
+            txn_to_commit.transaction().hash()
         );
 
         // Fetch and verify transaction itself.
-        let txn = txn_to_commit.as_signed_user_txn()?;
+        let txn = txn_to_commit.transaction().as_signed_user_txn()?;
         let txn_with_proof = db.get_transaction_with_proof(cur_ver, ledger_version, true)?;
         txn_with_proof.verify_user_txn(
             ledger_info,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -306,7 +306,7 @@ fn verify_committed_transactions(
 
         // Verify transaction hash.
         assert_eq!(
-            txn_info.signed_transaction_hash(),
+            txn_info.transaction_hash(),
             txn_to_commit.as_signed_user_txn()?.hash()
         );
 

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -313,12 +313,22 @@ fn verify_committed_transactions(
         // Fetch and verify transaction itself.
         let txn = txn_to_commit.as_signed_user_txn()?;
         let txn_with_proof = db.get_transaction_with_proof(cur_ver, ledger_version, true)?;
-        txn_with_proof.verify(ledger_info, cur_ver, txn.sender(), txn.sequence_number())?;
+        txn_with_proof.verify_user_txn(
+            ledger_info,
+            cur_ver,
+            txn.sender(),
+            txn.sequence_number(),
+        )?;
 
         let txn_with_proof = db
             .get_txn_by_account(txn.sender(), txn.sequence_number(), ledger_version, true)?
             .expect("Should exist.");
-        txn_with_proof.verify(ledger_info, cur_ver, txn.sender(), txn.sequence_number())?;
+        txn_with_proof.verify_user_txn(
+            ledger_info,
+            cur_ver,
+            txn.sender(),
+            txn.sequence_number(),
+        )?;
 
         let txn_list_with_proof =
             db.get_transactions(cur_ver, 1, ledger_version, true /* fetch_events */)?;

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -44,11 +44,13 @@ fn gen_mock_genesis() -> (
         /* gas_unit_price = */ 0,
         /* expiration_time = */ std::time::Duration::new(0, 0),
     );
-    let signed_txn = raw_txn
-        .sign(&privkey, pubkey)
-        .expect("Signing failed.")
-        .into_inner();
-    let signed_txn_hash = signed_txn.hash();
+    let genesis_txn = Transaction::UserTransaction(
+        raw_txn
+            .sign(&privkey, pubkey)
+            .expect("Signing failed.")
+            .into_inner(),
+    );
+    let txn_hash = genesis_txn.hash();
 
     let some_blob = AccountStateBlob::from(vec![1u8]);
     let account_states = vec![(some_addr, some_blob.clone())]
@@ -56,7 +58,7 @@ fn gen_mock_genesis() -> (
         .collect::<HashMap<_, _>>();
 
     let txn_to_commit = TransactionToCommit::new(
-        Transaction::UserTransaction(signed_txn),
+        genesis_txn,
         account_states.clone(),
         vec![], /* events */
         0,      /* gas_used */
@@ -66,7 +68,7 @@ fn gen_mock_genesis() -> (
     // The genesis state tree has a single leaf node, so the root hash is the hash of that node.
     let state_root_hash = SparseMerkleLeafNode::new(some_addr.hash(), some_blob.hash()).hash();
     let txn_info = TransactionInfo::new(
-        signed_txn_hash,
+        txn_hash,
         state_root_hash,
         *ACCUMULATOR_PLACEHOLDER_HASH,
         0,

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -33,7 +33,7 @@ fn to_blocks_to_commit(
                 cur_ver += 1;
                 let mut cs = ChangeSet::new();
 
-                let txn_hash = txn_to_commit.as_signed_user_txn()?.hash();
+                let txn_hash = txn_to_commit.transaction().hash();
                 let state_root_hash = db.state_store.put_account_state_sets(
                     vec![txn_to_commit.account_states().clone()],
                     cur_ver,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -303,7 +303,7 @@ fn gen_submit_transaction_request(
     script: Script,
     sender_account: &mut AccountData,
 ) -> SubmitTransactionRequest {
-    let signed_txn = create_user_txn(
+    let transaction = create_user_txn(
         &sender_account.key_pair,
         TransactionPayload::Script(script),
         sender_account.address,
@@ -314,7 +314,7 @@ fn gen_submit_transaction_request(
     )
     .expect("Failed to create signed transaction");
     let mut req = SubmitTransactionRequest::default();
-    req.transaction = Some(signed_txn.into());
+    req.transaction = Some(transaction.into());
     sender_account.sequence_number += 1;
     req
 }

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -31,7 +31,7 @@ use libra_types::{
         request_item::RequestedItems, GetAccountStateRequest, RequestItem,
         UpdateToLatestLedgerRequest,
     },
-    transaction::{helpers::create_signed_txn, Script, TransactionPayload},
+    transaction::{helpers::create_user_txn, Script, TransactionPayload},
 };
 use rand::{
     prelude::ThreadRng,
@@ -303,7 +303,7 @@ fn gen_submit_transaction_request(
     script: Script,
     sender_account: &mut AccountData,
 ) -> SubmitTransactionRequest {
-    let signed_txn = create_signed_txn(
+    let signed_txn = create_user_txn(
         &sender_account.key_pair,
         TransactionPayload::Script(script),
         sender_account.address,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -314,7 +314,7 @@ fn gen_submit_transaction_request(
     )
     .expect("Failed to create signed transaction");
     let mut req = SubmitTransactionRequest::default();
-    req.signed_txn = Some(signed_txn.into());
+    req.transaction = Some(signed_txn.into());
     sender_account.sequence_number += 1;
     req
 }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -519,7 +519,7 @@ fn test_external_transaction_signer() {
     assert!(submit_txn_result.is_ok());
 
     // query the transaction and check it contains the same values as requested
-    let submitted_signed_txn = client_proxy
+    let txn = client_proxy
         .get_committed_txn_by_acc_seq(&[
             "txn_acc_seq",
             &format!("{}", sender_address),
@@ -529,6 +529,9 @@ fn test_external_transaction_signer() {
         .unwrap()
         .unwrap()
         .0;
+    let submitted_signed_txn = txn
+        .as_signed_user_txn()
+        .expect("Query should get user transaction.");
 
     assert_eq!(submitted_signed_txn.sender(), sender_address);
     assert_eq!(submitted_signed_txn.sequence_number(), sequence_number);

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -15,7 +15,7 @@ use crate::{
         GetAccountTransactionBySequenceNumberResponse, GetEventsByEventAccessPathRequest,
         GetEventsByEventAccessPathResponse, GetTransactionsRequest, GetTransactionsResponse,
     },
-    transaction::{SignedTransactionWithProof, TransactionListWithProof, Version},
+    transaction::{TransactionListWithProof, TransactionWithProof, Version},
     validator_change::ValidatorChangeEventWithProof,
     validator_verifier::ValidatorVerifier,
 };
@@ -240,7 +240,7 @@ fn verify_response_item(
                 fetch_events,
             },
             ResponseItem::GetAccountTransactionBySequenceNumber {
-                signed_transaction_with_proof,
+                transaction_with_proof,
                 proof_of_current_sequence_number,
             },
         ) => verify_get_txn_by_seq_num_resp(
@@ -248,7 +248,7 @@ fn verify_response_item(
             *account,
             *sequence_number,
             *fetch_events,
-            signed_transaction_with_proof.as_ref(),
+            transaction_with_proof.as_ref(),
             proof_of_current_sequence_number.as_ref(),
         ),
         // GetEventsByEventAccessPath
@@ -303,20 +303,20 @@ fn verify_get_txn_by_seq_num_resp(
     req_account: AccountAddress,
     req_sequence_number: u64,
     req_fetch_events: bool,
-    signed_transaction_with_proof: Option<&SignedTransactionWithProof>,
+    transaction_with_proof: Option<&TransactionWithProof>,
     proof_of_current_sequence_number: Option<&AccountStateWithProof>,
 ) -> Result<()> {
-    match (signed_transaction_with_proof, proof_of_current_sequence_number) {
-        (Some(signed_transaction_with_proof), None) => {
+    match (transaction_with_proof, proof_of_current_sequence_number) {
+        (Some(transaction_with_proof), None) => {
             ensure!(
-                req_fetch_events == signed_transaction_with_proof.events.is_some(),
+                req_fetch_events == transaction_with_proof.events.is_some(),
                 "Bad GetAccountTxnBySeqNum response. Events requested: {}, events returned: {}.",
                 req_fetch_events,
-                signed_transaction_with_proof.events.is_some(),
+                transaction_with_proof.events.is_some(),
             );
-            signed_transaction_with_proof.verify(
+            transaction_with_proof.verify_user_txn(
                 ledger_info,
-                signed_transaction_with_proof.version,
+                transaction_with_proof.version,
                 req_account,
                 req_sequence_number,
             )
@@ -335,7 +335,7 @@ fn verify_get_txn_by_seq_num_resp(
         },
         _ => bail!(
             "Bad GetAccountTxnBySeqNum response. txn_proof.is_none():{}, cur_seq_num_proof.is_none():{}",
-            signed_transaction_with_proof.is_none(),
+            transaction_with_proof.is_none(),
             proof_of_current_sequence_number.is_none(),
         )
     }
@@ -573,7 +573,7 @@ impl From<RequestItem> for crate::proto::types::RequestItem {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum ResponseItem {
     GetAccountTransactionBySequenceNumber {
-        signed_transaction_with_proof: Option<SignedTransactionWithProof>,
+        transaction_with_proof: Option<TransactionWithProof>,
         proof_of_current_sequence_number: Option<AccountStateWithProof>,
     },
     // this can't be the first variant, tracked here https://github.com/AltSysrq/proptest/issues/141
@@ -602,18 +602,12 @@ impl ResponseItem {
 
     pub fn into_get_account_txn_by_seq_num_response(
         self,
-    ) -> Result<(
-        Option<SignedTransactionWithProof>,
-        Option<AccountStateWithProof>,
-    )> {
+    ) -> Result<(Option<TransactionWithProof>, Option<AccountStateWithProof>)> {
         match self {
             ResponseItem::GetAccountTransactionBySequenceNumber {
-                signed_transaction_with_proof,
+                transaction_with_proof,
                 proof_of_current_sequence_number,
-            } => Ok((
-                signed_transaction_with_proof,
-                proof_of_current_sequence_number,
-            )),
+            } => Ok((transaction_with_proof, proof_of_current_sequence_number)),
             _ => bail!("Not ResponseItem::GetAccountTransactionBySequenceNumber."),
         }
     }
@@ -661,8 +655,8 @@ impl TryFrom<crate::proto::types::ResponseItem> for ResponseItem {
                 }
             }
             GetAccountTransactionBySequenceNumberResponse(response) => {
-                let signed_transaction_with_proof = response
-                    .signed_transaction_with_proof
+                let transaction_with_proof = response
+                    .transaction_with_proof
                     .map(TryInto::try_into)
                     .transpose()?;
                 let proof_of_current_sequence_number = response
@@ -671,7 +665,7 @@ impl TryFrom<crate::proto::types::ResponseItem> for ResponseItem {
                     .transpose()?;
 
                 ResponseItem::GetAccountTransactionBySequenceNumber {
-                    signed_transaction_with_proof,
+                    transaction_with_proof,
                     proof_of_current_sequence_number,
                 }
             }
@@ -718,11 +712,11 @@ impl From<ResponseItem> for crate::proto::types::ResponseItem {
                 account_state_with_proof: Some(account_state_with_proof.into()),
             }),
             ResponseItem::GetAccountTransactionBySequenceNumber {
-                signed_transaction_with_proof,
+                transaction_with_proof,
                 proof_of_current_sequence_number,
             } => ResponseItems::GetAccountTransactionBySequenceNumberResponse(
                 GetAccountTransactionBySequenceNumberResponse {
-                    signed_transaction_with_proof: signed_transaction_with_proof.map(Into::into),
+                    transaction_with_proof: transaction_with_proof.map(Into::into),
                     proof_of_current_sequence_number: proof_of_current_sequence_number
                         .map(Into::into),
                 },

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -675,11 +675,11 @@ impl TransactionProof {
         transaction_version: Version,
     ) -> Result<()> {
         ensure!(
-            transaction_hash == self.transaction_info.signed_transaction_hash(),
+            transaction_hash == self.transaction_info.transaction_hash(),
             "The hash of transaction does not match the transaction info in proof. \
              Transaction hash: {:x}. Transaction hash provided by proof: {:x}.",
             transaction_hash,
-            self.transaction_info.signed_transaction_hash()
+            self.transaction_info.transaction_hash()
         );
 
         if let Some(event_root_hash) = event_root_hash {
@@ -1005,11 +1005,11 @@ impl TransactionListProof {
         itertools::zip_eq(transaction_hashes, &self.transaction_infos)
             .map(|(txn_hash, txn_info)| {
                 ensure!(
-                    *txn_hash == txn_info.signed_transaction_hash(),
+                    *txn_hash == txn_info.transaction_hash(),
                     "The hash of transaction does not match the transaction info in proof. \
                      Transaction hash: {:x}. Transaction hash in txn_info: {:x}.",
                     txn_hash,
-                    txn_info.signed_transaction_hash(),
+                    txn_info.transaction_hash(),
                 );
                 Ok(())
             })

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -27,8 +27,8 @@ use std::marker::PhantomData;
 
 pub use self::definition::{
     AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, AccumulatorRangeProof,
-    EventAccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleProof,
-    TransactionAccumulatorProof, TransactionAccumulatorRangeProof, TransactionListProof,
+    EventAccumulatorProof, EventProof, SparseMerkleProof, TransactionAccumulatorProof,
+    TransactionAccumulatorRangeProof, TransactionListProof, TransactionProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proof/unit_tests/proof_proto_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_proto_conversion_test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::proof::{
-    AccountStateProof, AccumulatorConsistencyProof, EventProof, SignedTransactionProof,
-    SparseMerkleProof, TestAccumulatorProof, TestAccumulatorRangeProof, TransactionListProof,
+    AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
+    TestAccumulatorProof, TestAccumulatorRangeProof, TransactionListProof, TransactionProof,
 };
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;
@@ -34,8 +34,8 @@ proptest! {
     }
 
     #[test]
-    fn test_signed_transaction_proof_protobuf_conversion_roundtrip(proof in any::<SignedTransactionProof>()) {
-        assert_protobuf_encode_decode::<crate::proto::types::SignedTransactionProof, SignedTransactionProof>(&proof);
+    fn test_transaction_proof_protobuf_conversion_roundtrip(proof in any::<TransactionProof>()) {
+        assert_protobuf_encode_decode::<crate::proto::types::TransactionProof, TransactionProof>(&proof);
     }
 
     #[test]

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -11,7 +11,7 @@ use crate::{
         SparseMerkleProof, TestAccumulatorInternalNode, TestAccumulatorProof,
         TransactionAccumulatorInternalNode, TransactionAccumulatorProof, TransactionProof,
     },
-    transaction::{RawTransaction, Script, TransactionInfo},
+    transaction::{RawTransaction, Script, Transaction, TransactionInfo},
     vm_error::StatusCode,
 };
 use libra_crypto::{
@@ -346,16 +346,19 @@ fn test_verify_account_state_and_event() {
     let txn_info1_hash = b"worldworld".test_only_hash();
 
     let (privkey, pubkey) = compat::generate_keypair(None);
-    let txn2_hash = RawTransaction::new_script(
-        AccountAddress::from_public_key(&pubkey),
-        /* sequence_number = */ 0,
-        Script::new(vec![], vec![]),
-        /* max_gas_amount = */ 0,
-        /* gas_unit_price = */ 0,
-        /* expiration_time = */ std::time::Duration::new(0, 0),
+    let txn2_hash = Transaction::UserTransaction(
+        RawTransaction::new_script(
+            AccountAddress::from_public_key(&pubkey),
+            /* sequence_number = */ 0,
+            Script::new(vec![], vec![]),
+            /* max_gas_amount = */ 0,
+            /* gas_unit_price = */ 0,
+            /* expiration_time = */ std::time::Duration::new(0, 0),
+        )
+        .sign(&privkey, pubkey)
+        .expect("Signing failed.")
+        .into_inner(),
     )
-    .sign(&privkey, pubkey)
-    .expect("Signing failed.")
     .hash();
 
     let event0_hash = b"event0".test_only_hash();

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -314,7 +314,7 @@ fn test_verify_account_state_and_event() {
     //                 transaction_info2
     //                /    /           \
     //              /     /              \
-    //    signed_txn  state_root          event_root
+    //           txn  state_root          event_root
     //                  /    \               / \
     //                 c      default  event0   event1
     //                / \

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -7,9 +7,9 @@ use crate::{
     ledger_info::LedgerInfo,
     proof::{
         definition::MAX_ACCUMULATOR_PROOF_DEPTH, AccountStateProof, EventAccumulatorInternalNode,
-        EventAccumulatorProof, EventProof, SignedTransactionProof, SparseMerkleInternalNode,
-        SparseMerkleLeafNode, SparseMerkleProof, TestAccumulatorInternalNode, TestAccumulatorProof,
-        TransactionAccumulatorInternalNode, TransactionAccumulatorProof,
+        EventAccumulatorProof, EventProof, SparseMerkleInternalNode, SparseMerkleLeafNode,
+        SparseMerkleProof, TestAccumulatorInternalNode, TestAccumulatorProof,
+        TransactionAccumulatorInternalNode, TransactionAccumulatorProof, TransactionProof,
     },
     transaction::{RawTransaction, Script, TransactionInfo},
     vm_error::StatusCode,
@@ -247,7 +247,7 @@ fn test_verify_three_element_sparse_merkle() {
 }
 
 #[test]
-fn test_verify_signed_transaction() {
+fn test_verify_transaction() {
     //            root
     //           /     \
     //         /         \
@@ -289,7 +289,7 @@ fn test_verify_signed_transaction() {
 
     let ledger_info_to_transaction_info_proof =
         TransactionAccumulatorProof::new(vec![internal_b_hash, txn_info0_hash]);
-    let proof = SignedTransactionProof::new(ledger_info_to_transaction_info_proof, txn_info1);
+    let proof = TransactionProof::new(ledger_info_to_transaction_info_proof, txn_info1);
 
     // The proof can be used to verify txn1.
     assert!(proof.verify(&ledger_info, txn1_hash, None, 1).is_ok());

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -768,7 +768,7 @@ impl TransactionToCommitGen {
     /// Materialize considering current states in the universe.
     pub fn materialize(self, universe: &mut AccountInfoUniverse) -> TransactionToCommit {
         let (sender_index, txn_gen) = self.transaction_gen;
-        let signed_txn = txn_gen.materialize(sender_index, universe).into_inner();
+        let transaction = txn_gen.materialize(sender_index, universe).into_inner();
 
         let events = self
             .event_gens
@@ -789,7 +789,7 @@ impl TransactionToCommitGen {
             .collect();
 
         TransactionToCommit::new(
-            Transaction::UserTransaction(signed_txn),
+            Transaction::UserTransaction(transaction),
             account_states,
             events,
             self.gas_used,

--- a/types/src/proto/get_with_proof.proto
+++ b/types/src/proto/get_with_proof.proto
@@ -247,7 +247,7 @@ message GetAccountTransactionBySequenceNumberRequest {
 message GetAccountTransactionBySequenceNumberResponse {
   // When the transaction requested is committed, return the committed
   // transaction with proof.
-  SignedTransactionWithProof signed_transaction_with_proof = 2;
+  TransactionWithProof transaction_with_proof = 2;
   // When the transaction requested is not committed, we give a proof that
   // shows the current sequence number is smaller than what would have been if
   // the transaction was committed.

--- a/types/src/proto/proof.proto
+++ b/types/src/proto/proof.proto
@@ -59,8 +59,8 @@ message AccumulatorRangeProof {
   repeated bytes right_siblings = 2;
 }
 
-// The complete proof used to authenticate a signed transaction.
-message SignedTransactionProof {
+// The complete proof used to authenticate a transaction.
+message TransactionProof {
   AccumulatorProof ledger_info_to_transaction_info_proof = 1;
   TransactionInfo transaction_info = 2;
 }

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -40,8 +40,8 @@ message SignedTransactionWithProof {
     // The transaction itself.
     SignedTransaction signed_transaction = 2;
 
-    // The proof authenticating the signed transaction.
-    SignedTransactionProof proof = 3;
+    // The proof authenticating the transaction.
+    TransactionProof proof = 3;
 
     // The events yielded by executing the transaction, if requested.
     EventsList events = 4;

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -33,7 +33,7 @@ message Transaction {
     bytes transaction = 1;
 }
 
-message SignedTransactionWithProof {
+message TransactionWithProof {
     // The version of the returned signed transaction.
     uint64 version = 1;
 

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -38,7 +38,7 @@ message TransactionWithProof {
     uint64 version = 1;
 
     // The transaction itself.
-    SignedTransaction signed_transaction = 2;
+    Transaction transaction = 2;
 
     // The proof authenticating the transaction.
     TransactionProof proof = 3;

--- a/types/src/proto/transaction.proto
+++ b/types/src/proto/transaction.proto
@@ -23,8 +23,8 @@ message TransactionArgument {
 
 // A generic structure that represents signed RawTransaction
 message SignedTransaction {
-    // LCS byte code representation of a SignedTransaction
-    bytes signed_txn = 5;
+    // LCS bytes representation of a SignedTransaction.
+    bytes txn_bytes = 5;
 }
 
 // A generic structure that represents a transaction, covering all possible

--- a/types/src/proto/transaction_info.proto
+++ b/types/src/proto/transaction_info.proto
@@ -10,8 +10,8 @@ package types;
 // transaction. This are later returned to the client so that a client can
 // validate the tree
 message TransactionInfo {
-  // Hash of the signed transaction that is stored
-  bytes signed_transaction_hash = 1;
+  // Hash of the transaction that is stored.
+  bytes transaction_hash = 1;
 
   // The root hash of Sparse Merkle Tree describing the world state at the end
   // of this transaction

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -21,7 +21,7 @@ use libra_crypto::{
 pub fn get_signed_transactions_digest(signed_txns: &[ProtoSignedTransaction]) -> HashValue {
     let mut signatures = vec![];
     for transaction in signed_txns {
-        let signed_txn: SignedTransaction = lcs::from_bytes(&transaction.signed_txn)
+        let signed_txn: SignedTransaction = lcs::from_bytes(&transaction.txn_bytes)
             .expect("Unable to deserialize SignedTransaction");
         signatures.extend_from_slice(&signed_txn.signature().to_bytes());
     }

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -51,7 +51,7 @@ pub trait TransactionSigner {
 }
 
 /// Craft a transaction request.
-pub fn create_signed_txn<T: TransactionSigner + ?Sized>(
+pub fn create_user_txn<T: TransactionSigner + ?Sized>(
     signer: &T,
     payload: TransactionPayload,
     sender_address: AccountAddress,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -661,14 +661,14 @@ impl TryFrom<crate::proto::types::TransactionInfo> for TransactionInfo {
     type Error = Error;
 
     fn try_from(proto_txn_info: crate::proto::types::TransactionInfo) -> Result<Self> {
-        let signed_txn_hash = HashValue::from_slice(&proto_txn_info.signed_transaction_hash)?;
+        let transaction_hash = HashValue::from_slice(&proto_txn_info.transaction_hash)?;
         let state_root_hash = HashValue::from_slice(&proto_txn_info.state_root_hash)?;
         let event_root_hash = HashValue::from_slice(&proto_txn_info.event_root_hash)?;
         let gas_used = proto_txn_info.gas_used;
         let major_status =
             StatusCode::try_from(proto_txn_info.major_status).unwrap_or(StatusCode::UNKNOWN_STATUS);
         Ok(TransactionInfo::new(
-            signed_txn_hash,
+            transaction_hash,
             state_root_hash,
             event_root_hash,
             gas_used,
@@ -680,7 +680,7 @@ impl TryFrom<crate::proto::types::TransactionInfo> for TransactionInfo {
 impl From<TransactionInfo> for crate::proto::types::TransactionInfo {
     fn from(txn_info: TransactionInfo) -> Self {
         Self {
-            signed_transaction_hash: txn_info.signed_transaction_hash.to_vec(),
+            transaction_hash: txn_info.transaction_hash.to_vec(),
             state_root_hash: txn_info.state_root_hash.to_vec(),
             event_root_hash: txn_info.event_root_hash.to_vec(),
             gas_used: txn_info.gas_used,
@@ -695,7 +695,7 @@ impl From<TransactionInfo> for crate::proto::types::TransactionInfo {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TransactionInfo {
     /// The hash of this transaction.
-    signed_transaction_hash: HashValue,
+    transaction_hash: HashValue,
 
     /// The root hash of Sparse Merkle Tree describing the world state at the end of this
     /// transaction.
@@ -714,17 +714,17 @@ pub struct TransactionInfo {
 }
 
 impl TransactionInfo {
-    /// Constructs a new `TransactionInfo` object using signed transaction hash, state root hash
-    /// and event root hash.
+    /// Constructs a new `TransactionInfo` object using transaction hash, state root hash and event
+    /// root hash.
     pub fn new(
-        signed_transaction_hash: HashValue,
+        transaction_hash: HashValue,
         state_root_hash: HashValue,
         event_root_hash: HashValue,
         gas_used: u64,
         major_status: StatusCode,
     ) -> TransactionInfo {
         TransactionInfo {
-            signed_transaction_hash,
+            transaction_hash,
             state_root_hash,
             event_root_hash,
             gas_used,
@@ -733,8 +733,8 @@ impl TransactionInfo {
     }
 
     /// Returns the hash of this transaction.
-    pub fn signed_transaction_hash(&self) -> HashValue {
-        self.signed_transaction_hash
+    pub fn transaction_hash(&self) -> HashValue {
+        self.transaction_hash
     }
 
     /// Returns root hash of Sparse Merkle Tree describing the world state at the end of this

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -420,14 +420,14 @@ impl TryFrom<crate::proto::types::SignedTransaction> for SignedTransaction {
     type Error = Error;
 
     fn try_from(txn: crate::proto::types::SignedTransaction) -> Result<Self> {
-        lcs::from_bytes(&txn.signed_txn).map_err(Into::into)
+        lcs::from_bytes(&txn.txn_bytes).map_err(Into::into)
     }
 }
 
 impl From<SignedTransaction> for crate::proto::types::SignedTransaction {
     fn from(txn: SignedTransaction) -> Self {
-        let signed_txn = lcs::to_bytes(&txn).expect("Unable to serialize SignedTransaction");
-        Self { signed_txn }
+        let txn_bytes = lcs::to_bytes(&txn).expect("Unable to serialize SignedTransaction");
+        Self { txn_bytes }
     }
 }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     block_metadata::BlockMetadata,
     contract_event::ContractEvent,
     ledger_info::LedgerInfo,
-    proof::{accumulator::InMemoryAccumulator, SignedTransactionProof, TransactionListProof},
+    proof::{accumulator::InMemoryAccumulator, TransactionListProof, TransactionProof},
     vm_error::{StatusCode, StatusType, VMStatus},
     write_set::WriteSet,
 };
@@ -453,7 +453,7 @@ pub struct SignedTransactionWithProof {
     pub version: Version,
     pub signed_transaction: SignedTransaction,
     pub events: Option<Vec<ContractEvent>>,
-    pub proof: SignedTransactionProof,
+    pub proof: TransactionProof,
 }
 
 impl SignedTransactionWithProof {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -16,7 +16,7 @@ use libra_crypto::{
     ed25519::*,
     hash::{
         CryptoHash, CryptoHasher, EventAccumulatorHasher, RawTransactionHasher,
-        SignedTransactionHasher, TransactionInfoHasher,
+        SignedTransactionHasher, TransactionHasher, TransactionInfoHasher,
     },
     traits::*,
     HashValue,
@@ -1094,6 +1094,16 @@ impl Transaction {
             // TODO: display proper information for client
             Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
         }
+    }
+}
+
+impl CryptoHash for Transaction {
+    type Hasher = TransactionHasher;
+
+    fn hash(&self) -> HashValue {
+        let mut state = Self::Hasher::default();
+        state.write(&lcs::to_bytes(self).expect("Failed to serialize Transaction."));
+        state.finish()
     }
 }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -451,7 +451,7 @@ impl From<SignatureCheckedTransaction> for crate::proto::types::SignedTransactio
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TransactionWithProof {
     pub version: Version,
-    pub signed_transaction: SignedTransaction,
+    pub transaction: Transaction,
     pub events: Option<Vec<ContractEvent>>,
     pub proof: TransactionProof,
 }
@@ -473,8 +473,7 @@ impl TransactionWithProof {
         sender: AccountAddress,
         sequence_number: u64,
     ) -> Result<()> {
-        // TODO: this will become `self.transaction.as_signed_user_txn()?`.
-        let signed_transaction = &self.signed_transaction;
+        let signed_transaction = self.transaction.as_signed_user_txn()?;
 
         ensure!(
             self.version == version,
@@ -513,9 +512,9 @@ impl TryFrom<crate::proto::types::TransactionWithProof> for TransactionWithProof
 
     fn try_from(mut proto: crate::proto::types::TransactionWithProof) -> Result<Self> {
         let version = proto.version;
-        let signed_transaction = proto
-            .signed_transaction
-            .ok_or_else(|| format_err!("Missing signed_transaction"))?
+        let transaction = proto
+            .transaction
+            .ok_or_else(|| format_err!("Missing transaction"))?
             .try_into()?;
         let proof = proto
             .proof
@@ -534,7 +533,7 @@ impl TryFrom<crate::proto::types::TransactionWithProof> for TransactionWithProof
 
         Ok(Self {
             version,
-            signed_transaction,
+            transaction,
             proof,
             events,
         })
@@ -545,7 +544,7 @@ impl From<TransactionWithProof> for crate::proto::types::TransactionWithProof {
     fn from(mut txn: TransactionWithProof) -> Self {
         Self {
             version: txn.version,
-            signed_transaction: Some(txn.signed_transaction.into()),
+            transaction: Some(txn.transaction.into()),
             proof: Some(txn.proof.into()),
             events: txn
                 .events

--- a/types/src/unit_tests/transaction_proto_conversion_test.rs
+++ b/types/src/unit_tests/transaction_proto_conversion_test.rs
@@ -17,8 +17,8 @@ proptest! {
     }
 
     #[test]
-    fn test_signed_txn_with_proof(signed_txn_with_proof in any::<SignedTransactionWithProof>()) {
-        assert_protobuf_encode_decode::<crate::proto::types::SignedTransactionWithProof, SignedTransactionWithProof>(&signed_txn_with_proof);
+    fn test_txn_with_proof(txn_with_proof in any::<TransactionWithProof>()) {
+        assert_protobuf_encode_decode::<crate::proto::types::TransactionWithProof, TransactionWithProof>(&txn_with_proof);
     }
 
     #[test]

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -93,7 +93,7 @@ fn test_validate_transaction() {
 
     let address = account_config::association_address();
     let program = encode_transfer_script(&address, 100);
-    let signed_txn = transaction_test_helpers::get_test_signed_txn(
+    let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         keypair.private_key,
@@ -101,7 +101,7 @@ fn test_validate_transaction() {
         Some(program),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret, None);
@@ -118,7 +118,7 @@ fn test_validate_invalid_signature() {
 
     let address = account_config::association_address();
     let program = encode_transfer_script(&address, 100);
-    let signed_txn = transaction_test_helpers::get_test_unchecked_txn(
+    let transaction = transaction_test_helpers::get_test_unchecked_txn(
         address,
         1,
         other_private_key,
@@ -126,7 +126,7 @@ fn test_validate_invalid_signature() {
         Some(program),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret.unwrap().major_status, StatusCode::INVALID_SIGNATURE);
@@ -262,7 +262,7 @@ fn test_validate_unknown_script() {
     let vm_validator = TestValidator::new(&config);
 
     let address = account_config::association_address();
-    let signed_txn = transaction_test_helpers::get_test_signed_txn(
+    let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         keypair.private_key,
@@ -270,7 +270,7 @@ fn test_validate_unknown_script() {
         None,
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret.unwrap().major_status, StatusCode::UNKNOWN_SCRIPT);
@@ -285,7 +285,7 @@ fn test_validate_module_publishing() {
     let vm_validator = TestValidator::new(&config);
 
     let address = account_config::association_address();
-    let signed_txn = transaction_test_helpers::get_test_signed_module_publishing_transaction(
+    let transaction = transaction_test_helpers::get_test_signed_module_publishing_transaction(
         address,
         1,
         keypair.private_key,
@@ -293,7 +293,7 @@ fn test_validate_module_publishing() {
         Module::new(vec![]),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret.unwrap().major_status, StatusCode::UNKNOWN_MODULE);
@@ -310,7 +310,7 @@ fn test_validate_invalid_auth_key() {
 
     let address = account_config::association_address();
     let program = encode_transfer_script(&address, 100);
-    let signed_txn = transaction_test_helpers::get_test_signed_txn(
+    let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         other_private_key,
@@ -318,7 +318,7 @@ fn test_validate_invalid_auth_key() {
         Some(program),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret.unwrap().major_status, StatusCode::INVALID_AUTH_KEY);
@@ -331,7 +331,7 @@ fn test_validate_balance_below_gas_fee() {
 
     let address = account_config::association_address();
     let program = encode_transfer_script(&address, 100);
-    let signed_txn = transaction_test_helpers::get_test_signed_transaction(
+    let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1,
         keypair.private_key.clone(),
@@ -344,7 +344,7 @@ fn test_validate_balance_below_gas_fee() {
         Some(1_000_000),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(
@@ -361,7 +361,7 @@ fn test_validate_account_doesnt_exist() {
     let address = account_config::association_address();
     let random_account_addr = account_address::AccountAddress::random();
     let program = encode_transfer_script(&address, 100);
-    let signed_txn = transaction_test_helpers::get_test_signed_transaction(
+    let transaction = transaction_test_helpers::get_test_signed_transaction(
         random_account_addr,
         1,
         keypair.private_key,
@@ -372,7 +372,7 @@ fn test_validate_account_doesnt_exist() {
         None,
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(
@@ -388,7 +388,7 @@ fn test_validate_sequence_number_too_new() {
 
     let address = account_config::association_address();
     let program = encode_transfer_script(&address, 100);
-    let signed_txn = transaction_test_helpers::get_test_signed_txn(
+    let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         keypair.private_key,
@@ -396,7 +396,7 @@ fn test_validate_sequence_number_too_new() {
         Some(program),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret, None);
@@ -410,7 +410,7 @@ fn test_validate_invalid_arguments() {
     let address = account_config::association_address();
     let (program_script, _) = encode_transfer_script(&address, 100).into_inner();
     let program = Script::new(program_script, vec![TransactionArgument::U64(42)]);
-    let signed_txn = transaction_test_helpers::get_test_signed_txn(
+    let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         keypair.private_key,
@@ -418,7 +418,7 @@ fn test_validate_invalid_arguments() {
         Some(program),
     );
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret.unwrap().major_status, StatusCode::TYPE_MISMATCH);
@@ -430,7 +430,7 @@ fn test_validate_non_genesis_write_set() {
     let vm_validator = TestValidator::new(&config);
 
     let address = account_config::association_address();
-    let signed_txn = transaction_test_helpers::get_write_set_txn(
+    let transaction = transaction_test_helpers::get_write_set_txn(
         address,
         1,
         keypair.private_key,
@@ -439,7 +439,7 @@ fn test_validate_non_genesis_write_set() {
     )
     .into_inner();
     let ret = vm_validator
-        .validate_transaction(signed_txn)
+        .validate_transaction(transaction)
         .wait()
         .unwrap();
     assert_eq!(ret.unwrap().major_status, StatusCode::REJECTED_WRITE_SET);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Part of the effort for https://github.com/libra/libra/issues/1173. We start to use `Transaction` instead of `SignedTransaction` for computing root hash.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

CI.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
