### PR TITLE
[proof] reverse the order of siblings in merkle proof

### DIFF
--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -389,15 +389,15 @@ where
         Ok(AccumulatorRangeProof::new(left_siblings, right_siblings))
     }
 
-    /// Helper function to get siblings on the path from root to given leaf. An additional filter
-    /// function can be applied to filter out certain siblings.
+    /// Helper function to get siblings on the path from the given leaf to the root. An additional
+    /// filter function can be applied to filter out certain siblings.
     fn get_siblings(
         &self,
         leaf_index: u64,
         filter: impl Fn(Position) -> bool,
     ) -> Result<Vec<HashValue>> {
         let root_pos = Position::root_from_leaf_count(self.num_leaves);
-        let mut siblings = Position::from_leaf_index(leaf_index)
+        let siblings = Position::from_leaf_index(leaf_index)
             .iter_ancestor_sibling()
             .take(root_pos.level() as usize)
             .filter_map(|p| {
@@ -408,7 +408,6 @@ where
                 }
             })
             .collect::<Result<Vec<_>>>()?;
-        siblings.reverse();
         Ok(siblings)
     }
 

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -517,7 +517,15 @@ where
                     siblings.append(&mut siblings_in_internal);
                     next_node_key = match child_node_key {
                         Some(node_key) => node_key,
-                        None => return Ok((None, SparseMerkleProof::new(None, siblings))),
+                        None => {
+                            return Ok((
+                                None,
+                                SparseMerkleProof::new(None, {
+                                    siblings.reverse();
+                                    siblings
+                                }),
+                            ))
+                        }
                     };
                 }
                 Node::Leaf(leaf_node) => {
@@ -529,7 +537,10 @@ where
                         },
                         SparseMerkleProof::new(
                             Some((leaf_node.account_key(), leaf_node.blob_hash())),
-                            siblings,
+                            {
+                                siblings.reverse();
+                                siblings
+                            },
                         ),
                     ));
                 }

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -224,15 +224,15 @@ impl SparseMerkleTree {
                 };
 
                 let num_remaining_bits = remaining_bits.len();
+                let proof_length = proof.siblings().len();
                 Ok(Self::construct_subtree(
                     remaining_bits
                         .rev()
-                        .skip(HashValue::LENGTH_IN_BITS - proof.siblings().len()),
+                        .skip(HashValue::LENGTH_IN_BITS - proof_length),
                     proof
                         .siblings()
                         .iter()
-                        .skip(HashValue::LENGTH_IN_BITS - num_remaining_bits)
-                        .rev()
+                        .take(num_remaining_bits + proof_length - HashValue::LENGTH_IN_BITS)
                         .map(|sibling_hash| {
                             Arc::new(if *sibling_hash != *SPARSE_MERKLE_PLACEHOLDER_HASH {
                                 SparseMerkleNode::new_subtree(*sibling_hash)

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -289,6 +289,7 @@ fn test_construct_subtree_at_bottom_found_subtree_node() {
     };
     let leaf = None;
     let siblings: Vec<_> = (3..7)
+        .rev()
         .map(|x| HashValue::new([x; HashValue::LENGTH]))
         .collect();
     let proof = SparseMerkleProof::new(leaf, siblings);
@@ -343,14 +344,12 @@ fn test_update_256_siblings_in_proof() {
         .take(255)
         .collect();
     siblings.push(leaf2_hash);
+    siblings.reverse();
     let proof_of_key1 = SparseMerkleProof::new(Some((key1, value1_hash)), siblings.clone());
 
-    let old_root_hash = siblings
-        .iter()
-        .rev()
-        .fold(leaf1_hash, |previous_hash, hash| {
-            hash_internal(previous_hash, *hash)
-        });
+    let old_root_hash = siblings.iter().fold(leaf1_hash, |previous_hash, hash| {
+        hash_internal(previous_hash, *hash)
+    });
     assert!(proof_of_key1
         .verify(old_root_hash, key1, Some(&blob1))
         .is_ok());
@@ -364,12 +363,9 @@ fn test_update_256_siblings_in_proof() {
 
     let new_blob1_hash = new_blob1.hash();
     let new_leaf1_hash = hash_leaf(key1, new_blob1_hash);
-    let new_root_hash = siblings
-        .iter()
-        .rev()
-        .fold(new_leaf1_hash, |previous_hash, hash| {
-            hash_internal(previous_hash, *hash)
-        });
+    let new_root_hash = siblings.iter().fold(new_leaf1_hash, |previous_hash, hash| {
+        hash_internal(previous_hash, *hash)
+    });
     assert_eq!(new_smt.root_hash(), new_root_hash);
 
     assert_eq!(
@@ -428,7 +424,7 @@ fn test_update() {
     let x_hash = hash_internal(leaf1_hash, leaf2_hash);
     let y_hash = hash_internal(x_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
     let old_root_hash = hash_internal(y_hash, leaf3_hash);
-    let proof = SparseMerkleProof::new(None, vec![leaf3_hash, x_hash]);
+    let proof = SparseMerkleProof::new(None, vec![x_hash, leaf3_hash]);
     assert!(proof.verify(old_root_hash, key4, None).is_ok());
 
     // Create the old tree and update the tree with new value and proof.
@@ -466,7 +462,7 @@ fn test_update() {
     // Next, we are going to modify key1. Create a proof for key1.
     let proof = SparseMerkleProof::new(
         Some((key1, value1_hash)),
-        vec![leaf3_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH, leaf2_hash],
+        vec![leaf2_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH, leaf3_hash],
     );
     assert!(proof.verify(old_root_hash, key1, Some(&value1)).is_ok());
 

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -446,11 +446,11 @@ impl From<AccumulatorConsistencyProof> for crate::proto::types::AccumulatorConsi
 /// left and `Y` and `Z` on the right.
 #[derive(Clone)]
 pub struct AccumulatorRangeProof<H> {
-    /// The siblings on the left of the path from root to the first leaf. Siblings near the root
+    /// The siblings on the left of the path from the first leaf to the root. Siblings near the root
     /// are at the beginning of the vector.
     left_siblings: Vec<HashValue>,
 
-    /// The sliblings on the right of the path from root to the last leaf. Siblings near the root
+    /// The sliblings on the right of the path from the last leaf to the root. Siblings near the root
     /// are at the beginning of the vector.
     right_siblings: Vec<HashValue>,
 

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -78,8 +78,8 @@ fn into_proto_siblings(siblings: Vec<HashValue>, placeholder: HashValue) -> Vec<
 /// constructed on top of this structure.
 #[derive(Clone)]
 pub struct AccumulatorProof<H> {
-    /// All siblings in this proof, including the default ones. Siblings near the root are at the
-    /// beginning of the vector.
+    /// All siblings in this proof, including the default ones. Siblings are ordered from the bottom
+    /// level to the root level.
     siblings: Vec<HashValue>,
 
     phantom: PhantomData<H>,
@@ -101,8 +101,8 @@ where
         // The sibling list could be empty in case the accumulator is empty or has a single
         // element. When it's not empty, the top most sibling will never be default, otherwise the
         // accumulator should have collapsed to a smaller one.
-        if let Some(first_sibling) = siblings.first() {
-            assert_ne!(*first_sibling, *ACCUMULATOR_PLACEHOLDER_HASH);
+        if let Some(last_sibling) = siblings.last() {
+            assert_ne!(*last_sibling, *ACCUMULATOR_PLACEHOLDER_HASH);
         }
 
         AccumulatorProof {
@@ -134,7 +134,6 @@ where
         let actual_root_hash = self
             .siblings
             .iter()
-            .rev()
             .fold(
                 (element_hash, element_index),
                 // `index` denotes the index of the ancestor of the element at the current level.
@@ -218,8 +217,8 @@ pub struct SparseMerkleProof {
     ///       empty.
     leaf: Option<(HashValue, HashValue)>,
 
-    /// All siblings in this proof, including the default ones. Siblings near the root are at the
-    /// beginning of the vector.
+    /// All siblings in this proof, including the default ones. Siblings are ordered from the bottom
+    /// level to the root level.
     siblings: Vec<HashValue>,
 }
 
@@ -229,8 +228,8 @@ impl SparseMerkleProof {
         // The sibling list could be empty in case the Sparse Merkle Tree is empty or has a single
         // element. When it's not empty, the bottom most sibling will never be default, otherwise a
         // leaf and a default sibling should have collapsed to a leaf.
-        if let Some(last_sibling) = siblings.last() {
-            assert_ne!(*last_sibling, *SPARSE_MERKLE_PLACEHOLDER_HASH);
+        if let Some(first_sibling) = siblings.first() {
+            assert_ne!(*first_sibling, *SPARSE_MERKLE_PLACEHOLDER_HASH);
         }
 
         SparseMerkleProof { leaf, siblings }
@@ -315,7 +314,6 @@ impl SparseMerkleProof {
         let actual_root_hash = self
             .siblings
             .iter()
-            .rev()
             .zip(
                 element_key
                     .iter_bits()
@@ -514,8 +512,8 @@ where
             "leaf_hashes is empty while first_leaf_index indicated non-empty list.",
         );
 
-        let mut left_sibling_iter = self.left_siblings.iter().rev().peekable();
-        let mut right_sibling_iter = self.right_siblings.iter().rev().peekable();
+        let mut left_sibling_iter = self.left_siblings.iter().peekable();
+        let mut right_sibling_iter = self.right_siblings.iter().peekable();
 
         let mut first_pos = Position::from_leaf_index(
             first_leaf_index.expect("first_leaf_index should not be None."),

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -54,12 +54,11 @@ where
                     Just(vec![]).boxed()
                 } else {
                     (
-                        arb_non_placeholder_accumulator_sibling(),
                         vec(arb_accumulator_sibling(), len - 1),
+                        arb_non_placeholder_accumulator_sibling(),
                     )
-                        .prop_map(|(first_sibling, other_siblings)| {
-                            let mut siblings = vec![first_sibling];
-                            siblings.extend(other_siblings.into_iter());
+                        .prop_map(|(mut siblings, last_sibling)| {
+                            siblings.push(last_sibling);
                             siblings
                         })
                         .boxed()
@@ -82,12 +81,11 @@ impl Arbitrary for SparseMerkleProof {
                     Just(vec![]).boxed()
                 } else {
                     (
-                        vec(arb_sparse_merkle_sibling(), len - 1),
                         arb_non_placeholder_sparse_merkle_sibling(),
+                        vec(arb_sparse_merkle_sibling(), len),
                     )
-                        .prop_map(|(other_siblings, last_sibling)| {
-                            let mut siblings = other_siblings;
-                            siblings.push(last_sibling);
+                        .prop_map(|(first_sibling, mut siblings)| {
+                            siblings[0] = first_sibling;
                             siblings
                         })
                         .boxed()

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -64,17 +64,17 @@ fn test_verify_three_element_accumulator() {
     let root_hash = TestAccumulatorInternalNode::new(internal0_hash, internal1_hash).hash();
 
     assert!(
-        TestAccumulatorProof::new(vec![internal1_hash, element1_hash])
+        TestAccumulatorProof::new(vec![element1_hash, internal1_hash])
             .verify(root_hash, element0_hash, 0)
             .is_ok()
     );
     assert!(
-        TestAccumulatorProof::new(vec![internal1_hash, element0_hash])
+        TestAccumulatorProof::new(vec![element0_hash, internal1_hash])
             .verify(root_hash, element1_hash, 1)
             .is_ok()
     );
     assert!(
-        TestAccumulatorProof::new(vec![internal0_hash, *ACCUMULATOR_PLACEHOLDER_HASH])
+        TestAccumulatorProof::new(vec![*ACCUMULATOR_PLACEHOLDER_HASH, internal0_hash])
             .verify(root_hash, element2_hash, 2)
             .is_ok()
     );
@@ -87,12 +87,9 @@ fn test_accumulator_proof_max_siblings_leftmost() {
     for i in 0..MAX_ACCUMULATOR_PROOF_DEPTH as u8 {
         siblings.push(HashValue::new([i; 32]));
     }
-    let root_hash = siblings
-        .iter()
-        .rev()
-        .fold(element_hash, |hash, sibling_hash| {
-            TestAccumulatorInternalNode::new(hash, *sibling_hash).hash()
-        });
+    let root_hash = siblings.iter().fold(element_hash, |hash, sibling_hash| {
+        TestAccumulatorInternalNode::new(hash, *sibling_hash).hash()
+    });
     let proof = TestAccumulatorProof::new(siblings);
 
     assert!(proof.verify(root_hash, element_hash, 0).is_ok());
@@ -105,12 +102,9 @@ fn test_accumulator_proof_max_siblings_rightmost() {
     for i in 0..MAX_ACCUMULATOR_PROOF_DEPTH as u8 {
         siblings.push(HashValue::new([i; 32]));
     }
-    let root_hash = siblings
-        .iter()
-        .rev()
-        .fold(element_hash, |hash, sibling_hash| {
-            TestAccumulatorInternalNode::new(*sibling_hash, hash).hash()
-        });
+    let root_hash = siblings.iter().fold(element_hash, |hash, sibling_hash| {
+        TestAccumulatorInternalNode::new(*sibling_hash, hash).hash()
+    });
     let leaf_index = (std::u64::MAX - 1) / 2;
     let proof = TestAccumulatorProof::new(siblings);
 
@@ -214,7 +208,7 @@ fn test_verify_three_element_sparse_merkle() {
         // Construct a proof of key1.
         let proof = SparseMerkleProof::new(
             Some((key1, blob1.hash())),
-            vec![*SPARSE_MERKLE_PLACEHOLDER_HASH, internal_b_hash],
+            vec![internal_b_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH],
         );
 
         // The exact key value exists.
@@ -288,7 +282,7 @@ fn test_verify_transaction() {
     );
 
     let ledger_info_to_transaction_info_proof =
-        TransactionAccumulatorProof::new(vec![internal_b_hash, txn_info0_hash]);
+        TransactionAccumulatorProof::new(vec![txn_info0_hash, internal_b_hash]);
     let proof = TransactionProof::new(ledger_info_to_transaction_info_proof, txn_info1);
 
     // The proof can be used to verify txn1.
@@ -395,10 +389,10 @@ fn test_verify_account_state_and_event() {
     );
 
     let ledger_info_to_transaction_info_proof =
-        TransactionAccumulatorProof::new(vec![internal_a_hash, *ACCUMULATOR_PLACEHOLDER_HASH]);
+        TransactionAccumulatorProof::new(vec![*ACCUMULATOR_PLACEHOLDER_HASH, internal_a_hash]);
     let transaction_info_to_account_proof = SparseMerkleProof::new(
         Some((key2, blob2.hash())),
-        vec![*SPARSE_MERKLE_PLACEHOLDER_HASH, leaf1_hash, leaf3_hash],
+        vec![leaf3_hash, leaf1_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH],
     );
     let account_state_proof = AccountStateProof::new(
         ledger_info_to_transaction_info_proof.clone(),

--- a/types/src/proto/proof.proto
+++ b/types/src/proto/proof.proto
@@ -8,7 +8,7 @@ package types;
 import "transaction_info.proto";
 
 message AccumulatorProof {
-  // The siblings. The ones near the root are at the beginning of the list. The
+  // The siblings. The ones near the leaf are at the beginning of the list. The
   // placeholder nodes are represented by empty byte arrays, other nodes should
   // be exactly 32-bytes long.
   repeated bytes siblings = 1;
@@ -33,7 +33,7 @@ message SparseMerkleProof {
   //     in the Rust structure.
   bytes leaf = 1;
 
-  // The siblings. The ones near the root are at the beginning of the list. The
+  // The siblings. The ones near the leaf are at the beginning of the list. The
   // placeholder nodes are represented by empty byte arrays, other nodes should
   // be exactly 32-bytes long.
   repeated bytes siblings = 2;
@@ -47,13 +47,13 @@ message AccumulatorConsistencyProof {
 
 message AccumulatorRangeProof {
   // The siblings on the left of the path from root to the first leaf. The ones
-  // near the root are at the beginning of the list. The placeholder nodes are
+  // near the leaf are at the beginning of the list. The placeholder nodes are
   // represented by empty byte arrays, other nodes should be exactly 32-bytes
   // long.
   repeated bytes left_siblings = 1;
 
   // The siblings on the right of the path from root to the last leaf. The ones
-  // near the root are at the beginning of the list. The placeholder nodes are
+  // near the leaf are at the beginning of the list. The placeholder nodes are
   // represented by empty byte arrays, other nodes should be exactly 32-bytes
   // long.
   repeated bytes right_siblings = 2;


### PR DESCRIPTION
## Motivation

Previously we order the sibling from root to leaf for fitting the bitmap layout. Now that the bitmap is gone, we can use the reversed order which fits the verify algorithm easily.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI
