### PR TITLE
[enhancement] Add enque/deque counters to PerValidatorQueue

### DIFF
--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -5,7 +5,7 @@ use crate::counters;
 use bytes::Bytes;
 use channel::{
     self, libra_channel,
-    message_queues::{PerValidatorQueue, QueueStyle},
+    message_queues::{self, PerValidatorQueue, QueueStyle},
 };
 use consensus_types::{
     block::Block,
@@ -289,22 +289,38 @@ impl<T: Payload> NetworkTask<T> {
         let (proposal_tx, proposal_rx) = libra_channel::new(PerValidatorQueue::new(
             QueueStyle::LIFO,
             1,
-            Some(&counters::PROPOSAL_DROPPED_MSGS),
+            Some(message_queues::Counters {
+                dropped_msgs_counter: &counters::PROPOSAL_DROPPED_MSGS,
+                enqueued_msgs_counter: &counters::PROPOSAL_ENQUEUED_MSGS,
+                dequeued_msgs_counter: &counters::PROPOSAL_DEQUEUED_MSGS,
+            }),
         ));
         let (vote_tx, vote_rx) = libra_channel::new(PerValidatorQueue::new(
             QueueStyle::LIFO,
             1,
-            Some(&counters::VOTES_DROPPED_MSGS),
+            Some(message_queues::Counters {
+                dropped_msgs_counter: &counters::VOTES_DROPPED_MSGS,
+                enqueued_msgs_counter: &counters::VOTES_ENQUEUED_MSGS,
+                dequeued_msgs_counter: &counters::VOTES_DEQUEUED_MSGS,
+            }),
         ));
         let (block_request_tx, block_request_rx) = libra_channel::new(PerValidatorQueue::new(
             QueueStyle::LIFO,
             1,
-            Some(&counters::BLOCK_RETRIEVAL_DROPPED_MSGS),
+            Some(message_queues::Counters {
+                dropped_msgs_counter: &counters::BLOCK_RETRIEVAL_DROPPED_MSGS,
+                enqueued_msgs_counter: &counters::BLOCK_RETRIEVAL_ENQUEUED_MSGS,
+                dequeued_msgs_counter: &counters::BLOCK_RETRIEVAL_DEQUEUED_MSGS,
+            }),
         ));
         let (sync_info_tx, sync_info_rx) = libra_channel::new(PerValidatorQueue::new(
             QueueStyle::LIFO,
             1,
-            Some(&counters::SYNC_INFO_DROPPED_MSGS),
+            Some(message_queues::Counters {
+                dropped_msgs_counter: &counters::SYNC_INFO_DROPPED_MSGS,
+                enqueued_msgs_counter: &counters::SYNC_INFO_ENQUEUED_MSGS,
+                dequeued_msgs_counter: &counters::SYNC_INFO_DEQUEUED_MSGS,
+            }),
         ));
         let network_events = network_events.map_err(Into::<failure::Error>::into);
         let all_events = Box::new(select(network_events, self_receiver));

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -46,14 +46,25 @@ pub static ref EVENT_PROCESSING_LOOP_IDLE_DURATION_S: DurationHistogram = OP_COU
 /// Histogram of busy time (ms) of spent in event processing loop
 pub static ref EVENT_PROCESSING_LOOP_BUSY_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("event_processing_loop_busy_duration_s");
 
-/// Count of number of messages dropped by proposals channel
+/// Counters(queued,dequeued,dropped) related to proposals channel
 pub static ref PROPOSAL_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("proposal_dropped_msgs_count");
-/// Count of number of messages dropped by votes channel
+pub static ref PROPOSAL_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("proposal_enqueued_msgs_count");
+pub static ref PROPOSAL_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("proposal_dequeued_msgs_count");
+
+/// Counters(queued,dequeued,dropped) related to votes channel
 pub static ref VOTES_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("votes_dropped_msgs_count");
-/// Count of number of messages dropped by block retrieval channel
+pub static ref VOTES_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("votes_enqueued_msgs_count");
+pub static ref VOTES_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("votes_dequeued_msgs_count");
+
+/// Counters(queued,dequeued,dropped) related to block retrieval channel
 pub static ref BLOCK_RETRIEVAL_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("block_retrieval_dropped_msgs_count");
-/// Count of number of messages dropped by sync info channel
+pub static ref BLOCK_RETRIEVAL_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("block_retrieval_enqueued_msgs_count");
+pub static ref BLOCK_RETRIEVAL_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("block_retrieval_dequeued_msgs_count");
+
+/// Counters(queued,dequeued,dropped) related to sync info channel
 pub static ref SYNC_INFO_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_dropped_msgs_count");
+pub static ref SYNC_INFO_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_enqueued_msgs_count");
+pub static ref SYNC_INFO_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_dequeued_msgs_count");
 
 
 //////////////////////


### PR DESCRIPTION
## Summary

We only had the drop counter, but it would be good to have counters for queued, dequeued messages in libra_channel. This PR adds those counters.

## Test Plan

Compiles successfully

Related to #1509