### PR TITLE
[config] use OsRng for generate-keypair binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-failure-ext 0.1.0",
  "libra-tools 0.1.0",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+rand = "0.6.5"
 structopt = "0.3.2"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -4,6 +4,7 @@
 use failure::prelude::*;
 use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_tools::tempdir::TempPath;
+use rand::{rngs::OsRng, Rng, SeedableRng};
 use std::{
     fs::{self, File},
     io::Write,
@@ -17,7 +18,10 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
         panic!("Specified output file path is a directory");
     }
 
-    let (private_key, _) = compat::generate_keypair(None);
+    let mut seed_rng = OsRng::new().expect("can't access OsRng");
+    let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
+
+    let (private_key, _) = compat::generate_keypair(&mut rng);
     let keypair = KeyPair::from(private_key);
 
     // Write to disk


### PR DESCRIPTION
before same TEST_SEED was used
so `generate-keypair` used to generate same keypair on every run
