### PR TITLE
[monitoring] Expose non-numeric metrics

### DIFF
--- a/common/metrics/build.rs
+++ b/common/metrics/build.rs
@@ -9,6 +9,6 @@ fn main() {
         .args(&["rev-parse", "--short", "HEAD"])
         .output()
         .unwrap();
-    let git_rev = &String::from_utf8(output.stdout).unwrap();
+    let git_rev = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_REVISION={}", git_rev);
 }

--- a/common/metrics/build.rs
+++ b/common/metrics/build.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+/// Save revision info to environment variable
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .unwrap();
+    let git_rev = &String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_REVISION={}", git_rev);
+}

--- a/common/metrics/src/json_metrics.rs
+++ b/common/metrics/src/json_metrics.rs
@@ -1,0 +1,17 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+// Use to expose non-numeric metrics
+pub fn get_json_metrics() -> HashMap<String, String> {
+    let mut json_metrics: HashMap<String, String> = HashMap::new();
+    json_metrics = add_revision_hash(json_metrics);
+    serde_json::to_string(&json_metrics).unwrap();
+    json_metrics
+}
+
+fn add_revision_hash(mut json_metrics: HashMap<String, String>) -> HashMap<String, String> {
+    json_metrics.insert("revision".to_string(), env!("GIT_REVISION").to_string());
+    json_metrics
+}

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -8,6 +8,7 @@ extern crate prometheus;
 
 pub mod counters;
 mod json_encoder;
+mod json_metrics;
 pub mod metric_server;
 mod public_metrics;
 

--- a/common/metrics/src/public_metrics.rs
+++ b/common/metrics/src/public_metrics.rs
@@ -3,6 +3,8 @@
 
 use lazy_static::lazy_static;
 
+// A list of metrics which will be made public to all the partners
 lazy_static! {
-    pub static ref PUBLIC_METRICS: Vec<String> = vec!["libra_network_peers".to_string()];
+    pub static ref PUBLIC_METRICS: Vec<String> =
+        vec!["libra_network_peers".to_string(), "revision".to_string()];
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Issue #1530 
Currently all our metrics are numeric counters, because Prometheus does not support non-numeric metrics. In the meantime, we want to have some non-numeric metrics exposed, e.g. current revision hash, list of validator IP address etc.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- `cargo run -p libra-swarm -- -s -l -n 4`
- grab the port number from `node.config.toml` file
- check the metrics:
```
[sherryxiao@devvm1881.prn3 ~] curl --silent "http://localhost:36575/json_metrics"
{"revision":"9999aa9e"}
```
