### PR TITLE
[cluster-test] Add packet loss experiment and effect

### DIFF
--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -1,8 +1,12 @@
+mod packet_loss;
 mod reboot;
+mod remove_network_effects;
 mod stop_container;
 
 use failure;
+pub use packet_loss::PacketLoss;
 pub use reboot::Reboot;
+pub use remove_network_effects::RemoveNetworkEffects;
 use std::fmt::Display;
 pub use stop_container::StopContainer;
 

--- a/testsuite/cluster-test/src/effects/packet_loss.rs
+++ b/testsuite/cluster-test/src/effects/packet_loss.rs
@@ -1,6 +1,7 @@
 /// PacketLoss introduces a given percentage of PacketLoss for a given instance
 use crate::{effects::Action, instance::Instance};
 use failure;
+use slog_scope::info;
 use std::fmt;
 
 pub struct PacketLoss {
@@ -16,9 +17,9 @@ impl PacketLoss {
 
 impl Action for PacketLoss {
     fn apply(&self) -> failure::Result<()> {
-        println!("PacketLoss {:.*}% for {}", 2, self.percent, self.instance);
+        info!("PacketLoss {:.*}% for {}", 2, self.percent, self.instance);
         self.instance.run_cmd(vec![format!(
-            "sudo tc qdisc add dev eth0 root netem loss {:.*}%",
+            "sudo tc qdisc delete dev eth0 root; sudo tc qdisc add dev eth0 root netem loss {:.*}%",
             2, self.percent
         )])
     }

--- a/testsuite/cluster-test/src/effects/packet_loss.rs
+++ b/testsuite/cluster-test/src/effects/packet_loss.rs
@@ -1,0 +1,39 @@
+/// PacketLoss introduces a given percentage of PacketLoss for a given instance
+use crate::{effects::Action, instance::Instance};
+use failure;
+use std::fmt;
+
+pub struct PacketLoss {
+    instance: Instance,
+    percent: f32,
+}
+
+impl PacketLoss {
+    pub fn new(instance: Instance, percent: f32) -> Self {
+        Self { instance, percent }
+    }
+}
+
+impl Action for PacketLoss {
+    fn apply(&self) -> failure::Result<()> {
+        println!("PacketLoss {:.*}% for {}", 2, self.percent, self.instance);
+        self.instance.run_cmd(vec![format!(
+            "sudo tc qdisc add dev eth0 root netem loss {:.*}%",
+            2, self.percent
+        )])
+    }
+
+    fn is_complete(&self) -> bool {
+        true
+    }
+}
+
+impl fmt::Display for PacketLoss {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "PacketLoss {:.*}% for {}",
+            2, self.percent, self.instance
+        )
+    }
+}

--- a/testsuite/cluster-test/src/effects/remove_network_effects.rs
+++ b/testsuite/cluster-test/src/effects/remove_network_effects.rs
@@ -1,0 +1,32 @@
+/// RemoveNetworkEffect deletes all network effects introduced on an instance
+use crate::{effects::Action, instance::Instance};
+use failure;
+use std::fmt;
+
+pub struct RemoveNetworkEffects {
+    instance: Instance,
+}
+
+impl RemoveNetworkEffects {
+    pub fn new(instance: Instance) -> Self {
+        Self { instance }
+    }
+}
+
+impl Action for RemoveNetworkEffects {
+    fn apply(&self) -> failure::Result<()> {
+        println!("RemoveNetworkEffects for {}", self.instance);
+        self.instance
+            .run_cmd(vec!["sudo tc qdisc delete dev eth0 root".to_string()])
+    }
+
+    fn is_complete(&self) -> bool {
+        true
+    }
+}
+
+impl fmt::Display for RemoveNetworkEffects {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RemoveNetworkEffects for {}", self.instance)
+    }
+}

--- a/testsuite/cluster-test/src/effects/remove_network_effects.rs
+++ b/testsuite/cluster-test/src/effects/remove_network_effects.rs
@@ -1,6 +1,7 @@
 /// RemoveNetworkEffect deletes all network effects introduced on an instance
 use crate::{effects::Action, instance::Instance};
 use failure;
+use slog_scope::info;
 use std::fmt;
 
 pub struct RemoveNetworkEffects {
@@ -15,7 +16,7 @@ impl RemoveNetworkEffects {
 
 impl Action for RemoveNetworkEffects {
     fn apply(&self) -> failure::Result<()> {
-        println!("RemoveNetworkEffects for {}", self.instance);
+        info!("RemoveNetworkEffects for {}", self.instance);
         self.instance
             .run_cmd(vec!["sudo tc qdisc delete dev eth0 root".to_string()])
     }

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -1,5 +1,7 @@
+mod packet_loss_random_validators;
 mod reboot_random_validator;
 
+pub use packet_loss_random_validators::PacketLossRandomValidators;
 pub use reboot_random_validator::RebootRandomValidators;
 use std::{collections::HashSet, fmt::Display};
 

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -1,0 +1,78 @@
+/// This module provides an experiment which introduces packet loss for
+/// a given number of instances in the cluster. It undoes the packet loss
+/// in the cluster after the given duration
+use crate::{
+    cluster::Cluster,
+    effects::{Action, PacketLoss, RemoveNetworkEffects},
+    experiments::Experiment,
+    instance::Instance,
+};
+use failure;
+use rand::Rng;
+use std::{collections::HashSet, fmt, thread, time::Duration};
+
+pub struct PacketLossRandomValidators {
+    instances: Vec<Instance>,
+    percent: f32,
+    duration: Duration,
+}
+
+impl PacketLossRandomValidators {
+    pub fn new(count: usize, percent: f32, duration: Duration, cluster: &Cluster) -> Self {
+        if count > cluster.instances().len() {
+            panic!(
+                "count {} should be <= number of instances {}",
+                count,
+                cluster.instances().len()
+            );
+        }
+        let mut instances = Vec::with_capacity(count);
+        let mut all_instances = cluster.instances().clone();
+        let mut rnd = rand::thread_rng();
+        for _i in 0..count {
+            let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));
+            instances.push(instance);
+        }
+
+        Self {
+            instances,
+            percent,
+            duration,
+        }
+    }
+}
+
+impl Experiment for PacketLossRandomValidators {
+    fn affected_validators(&self) -> HashSet<String> {
+        let mut r = HashSet::new();
+        for instance in self.instances.iter() {
+            r.insert(instance.short_hash().clone());
+        }
+        r
+    }
+
+    fn run(&self) -> failure::Result<()> {
+        let mut instances = vec![];
+        for instance in self.instances.iter() {
+            let packet_loss = PacketLoss::new(instance.clone(), self.percent);
+            packet_loss.apply()?;
+            instances.push(packet_loss)
+        }
+        thread::sleep(self.duration);
+        for instance in self.instances.iter() {
+            let remove_network_effects = RemoveNetworkEffects::new(instance.clone());
+            remove_network_effects.apply()?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for PacketLossRandomValidators {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Packet Loss {:.*}% [", 2, self.percent)?;
+        for instance in self.instances.iter() {
+            write!(f, "{}, ", instance)?;
+        }
+        write!(f, "]")
+    }
+}

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -97,7 +97,11 @@ struct Args {
         help = "Percent of instances in which packet loss should be introduced"
     )]
     packet_loss_percent_instances: f32,
-    #[structopt(long, default_value = "10", help = "Percent of packet loss for each instance")]
+    #[structopt(
+        long,
+        default_value = "10",
+        help = "Percent of packet loss for each instance"
+    )]
     packet_loss_percent: f32,
     #[structopt(
         long,

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -1,3 +1,4 @@
+use cluster_test::experiments::PacketLossRandomValidators;
 use cluster_test::prometheus::Prometheus;
 use cluster_test::tx_emitter::{EmitJobRequest, EmitThreadParams};
 use cluster_test::util::unix_timestamp_now;
@@ -72,6 +73,8 @@ struct Args {
     emit_tx: bool,
     #[structopt(long, group = "action")]
     stop_experiment: bool,
+    #[structopt(long, group = "action")]
+    packet_loss_experiment: bool,
 
     // emit_tx options
     #[structopt(long, default_value = "10")]
@@ -86,6 +89,22 @@ struct Args {
     //stop_experiment options
     #[structopt(long, default_value = "10")]
     max_stopped: usize,
+
+    //packet_loss_experiment options
+    #[structopt(
+        long,
+        default_value = "10",
+        help = "Percent of instances in which packet loss should be introduced"
+    )]
+    packet_loss_percent_instances: f32,
+    #[structopt(long, default_value = "10", help = "Percent of packet loss for each instance")]
+    packet_loss_percent: f32,
+    #[structopt(
+        long,
+        default_value = "60",
+        help = "Duration in secs for which packet loss happens"
+    )]
+    packet_loss_duration_secs: u64,
 }
 
 pub fn main() {
@@ -144,6 +163,19 @@ pub fn main() {
         runner.stop();
     } else if args.start {
         runner.start();
+    } else if args.packet_loss_experiment {
+        let total_instances = runner.cluster.instances().len();
+        let packet_loss_num_instances: usize = std::cmp::min(
+            ((args.packet_loss_percent_instances / 100.0) * total_instances as f32).ceil() as usize,
+            total_instances,
+        );
+        let experiment = PacketLossRandomValidators::new(
+            packet_loss_num_instances,
+            args.packet_loss_percent,
+            Duration::from_secs(args.packet_loss_duration_secs),
+            &runner.cluster,
+        );
+        runner.run_single_experiment(Box::new(experiment)).unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

Adds `PacketLoss`, `RemoveNetworkEffect` effects and an experiment for injecting a given amount of packet loss across a given number of instances


## Test Plan

Ran this experiment on my test cluster.

```
[ec2-user:validator@ip-10-0-0-212 ~]$ ~/libra/target/cluster_test_docker_builder/cluster-test --workplace=kush --packet-loss-experiment --packet-loss-percent-instances=50 --packet-loss-percent=20
Oct 28 22:33:38.029 INFO Discovered 4 peers
Oct 28 22:33:39.248 INFO Log tail thread started in 1219 ms
PacketLoss 20.00% for 57ff8374(10.0.3.130)
Oct 28 22:33:39.315 INFO Starting experiment Packet Loss 20.00% [57ff8374(10.0.3.130), 1e5d5a74(10.0.6.55), ]
PacketLoss 20.00% for 1e5d5a74(10.0.6.55)
RemoveNetworkEffects for 57ff8374(10.0.3.130)
RemoveNetworkEffects for 1e5d5a74(10.0.6.55)
Oct 28 22:35:04.343 INFO Experiment finished, waiting until all affected validators recover
Oct 28 22:35:09.348 INFO Experiment completed
```

![image](https://user-images.githubusercontent.com/796949/67723394-28b87300-f999-11e9-82c5-2cf69f95f9a3.png)


Related to #1198