### PR TITLE
[cluster-test] Do not setup faucet and lb attachment for cluster test

### DIFF
--- a/terraform/faucet.tf
+++ b/terraform/faucet.tf
@@ -73,6 +73,7 @@ resource "aws_ecs_service" "faucet" {
   task_definition                    = aws_ecs_task_definition.faucet.arn
   desired_count                      = 1
   deployment_minimum_healthy_percent = 0
+  count                              = var.cluster_test ? 0 : 1
 
   tags = {
     Role      = "faucet"

--- a/terraform/load-balancing.tf
+++ b/terraform/load-balancing.tf
@@ -27,7 +27,7 @@ resource "aws_lb_target_group" "validator-ac" {
 }
 
 resource "aws_lb_target_group_attachment" "validator-ac" {
-  count            = length(var.peer_ids)
+  count            = var.cluster_test ? 0 : length(var.peer_ids)
   target_group_arn = aws_lb_target_group.validator-ac.arn
   target_id        = element(aws_instance.validator.*.id, count.index)
 }


### PR DESCRIPTION
Setting up those resources take time during tf apply and they are not needed
