### PR TITLE
Enable the verification of a append only ledger

### DIFF
--- a/consensus/consensus-types/src/accumulator_extension_proof.rs
+++ b/consensus/consensus-types/src/accumulator_extension_proof.rs
@@ -1,0 +1,96 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use failure::ensure;
+#[cfg(test)]
+use libra_crypto::hash::{CryptoHash, TestOnlyHasher, ACCUMULATOR_PLACEHOLDER_HASH};
+use libra_crypto::hash::{CryptoHasher, HashValue};
+#[cfg(test)]
+use libra_types::proof::TestAccumulatorInternalNode;
+use libra_types::proof::{accumulator::InMemoryAccumulator, definition::LeafCount};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+
+/// A proof that first verifies that establishes correct computation of the root and then
+/// returns the new tree to acquire a new root and version. Note: this is used internally by
+/// VoteProposal hence why it exists within consensus-types andd not libra-types.
+/// @TODO This should contain AccumulatorConsistencyProof once that is code complete
+#[derive(Deserialize, Serialize)]
+pub struct AccumulatorExtensionProof<H> {
+    /// Represents the roots of all the full subtrees from left to right in the original accumulator.
+    frozen_subtree_roots: Vec<HashValue>,
+    /// The total number of leaves in original accumulator.
+    num_leaves: LeafCount,
+    /// The values representing the newly appended leaves.
+    leaves: Vec<HashValue>,
+
+    hasher: PhantomData<H>,
+}
+
+impl<H: CryptoHasher> AccumulatorExtensionProof<H> {
+    pub fn new(
+        frozen_subtree_roots: Vec<HashValue>,
+        num_leaves: LeafCount,
+        leaves: Vec<HashValue>,
+    ) -> Self {
+        Self {
+            frozen_subtree_roots,
+            num_leaves,
+            leaves,
+            hasher: PhantomData,
+        }
+    }
+
+    pub fn verify(&self, original_root: HashValue) -> failure::Result<InMemoryAccumulator<H>> {
+        let original_tree =
+            InMemoryAccumulator::<H>::new(self.frozen_subtree_roots.clone(), self.num_leaves)?;
+        ensure!(
+            original_tree.root_hash() == original_root,
+            "Root hashes do not match. Actual root hash: {:x}. Expected root hash: {:x}.",
+            original_tree.root_hash(),
+            original_root
+        );
+
+        Ok(original_tree.append(self.leaves.as_slice()))
+    }
+}
+
+// This test does the following:
+// 1) Test that empty has a well defined definition
+// 2) Test a single value
+// 3) Test multiple values
+// 4) Random nonsense returns an error
+#[test]
+fn test_accumulator_extension_proof() {
+    // Test empty
+    let empty = AccumulatorExtensionProof::<TestOnlyHasher>::new(vec![], 0, vec![]);
+
+    let derived_tree = empty.verify(*ACCUMULATOR_PLACEHOLDER_HASH).unwrap();
+    assert_eq!(*ACCUMULATOR_PLACEHOLDER_HASH, derived_tree.root_hash());
+    assert_eq!(derived_tree.version(), 0);
+
+    // Test a single value
+    HashValue::zero();
+    let one_tree =
+        AccumulatorExtensionProof::<TestOnlyHasher>::new(vec![], 0, vec![HashValue::zero()]);
+
+    let derived_tree = one_tree.verify(*ACCUMULATOR_PLACEHOLDER_HASH).unwrap();
+    assert_eq!(HashValue::zero(), derived_tree.root_hash());
+    assert_eq!(derived_tree.version(), 0);
+
+    // Test multiple values
+    let two_tree = AccumulatorExtensionProof::<TestOnlyHasher>::new(
+        vec![HashValue::zero()],
+        1,
+        vec![HashValue::zero()],
+    );
+
+    let derived_tree = two_tree.verify(HashValue::zero()).unwrap();
+    let two_hash = TestAccumulatorInternalNode::new(HashValue::zero(), HashValue::zero()).hash();
+    assert_eq!(two_hash, derived_tree.root_hash());
+    assert_eq!(derived_tree.version(), 1);
+
+    // Test nonsense breaks
+    let derived_tree_err = two_tree.verify(*ACCUMULATOR_PLACEHOLDER_HASH);
+    assert!(derived_tree_err.is_err());
+}

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -87,6 +87,14 @@ impl<T> ExecutedBlock<T> {
     pub fn timestamp_usecs(&self) -> u64 {
         self.block().timestamp_usecs()
     }
+
+    pub fn transaction_info_hashes(&self) -> Vec<HashValue> {
+        self.output
+            .transaction_data()
+            .iter()
+            .filter_map(|x| x.txn_info_hash())
+            .collect()
+    }
 }
 
 impl<T> ExecutedBlock<T>

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod accumulator_extension_proof;
 pub mod block;
 pub mod block_data;
 pub mod block_info;

--- a/consensus/consensus-types/src/vote_proposal.rs
+++ b/consensus/consensus-types/src/vote_proposal.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block::Block;
+use crate::{accumulator_extension_proof::AccumulatorExtensionProof, block::Block};
 use failure::prelude::{Error, Result};
-use libra_crypto::hash::HashValue;
-use libra_types::{transaction::Version, validator_set::ValidatorSet};
+use libra_crypto::hash::TransactionAccumulatorHasher;
+use libra_types::validator_set::ValidatorSet;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     convert::TryFrom,
@@ -13,66 +13,49 @@ use std::{
 
 /// This structure contains all the information needed by safety rules to
 /// evaluate a proposal / block for correctness / safety and to produce a Vote.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct VoteProposal<T> {
+    /// Contains the data necessary to construct the parent's execution output state
+    /// and the childs in a verifiable way
+    accumulator_extension_proof: AccumulatorExtensionProof<TransactionAccumulatorHasher>,
     /// The block / proposal to evaluate
     #[serde(bound(deserialize = "Block<T>: Deserialize<'de>"))]
     block: Block<T>,
-    /// The accumulator root hash after executing this block.
-    executed_state_id: HashValue,
-    /// The version of the latest transaction in the ledger.
-    version: Version,
     /// An optional field containing the set of validators for the start of the next epoch
     next_validator_set: Option<ValidatorSet>,
 }
 
 impl<T> VoteProposal<T> {
     pub fn new(
+        accumulator_extension_proof: AccumulatorExtensionProof<TransactionAccumulatorHasher>,
         block: Block<T>,
-        executed_state_id: HashValue,
-        version: Version,
         next_validator_set: Option<ValidatorSet>,
     ) -> Self {
         Self {
+            accumulator_extension_proof,
             block,
-            executed_state_id,
-            version,
             next_validator_set,
         }
+    }
+
+    pub fn accumulator_extension_proof(
+        &self,
+    ) -> &AccumulatorExtensionProof<TransactionAccumulatorHasher> {
+        &self.accumulator_extension_proof
     }
 
     pub fn block(&self) -> &Block<T> {
         &self.block
     }
 
-    pub fn executed_state_id(&self) -> HashValue {
-        self.executed_state_id
-    }
-
     pub fn next_validator_set(&self) -> Option<&ValidatorSet> {
         self.next_validator_set.as_ref()
-    }
-
-    pub fn version(&self) -> Version {
-        self.version
     }
 }
 
 impl<T: PartialEq> Display for VoteProposal<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "VoteProposal[block: {}, executed_state_id: {}, version: {}, next_validator_set: {}]",
-            self.block,
-            self.executed_state_id,
-            self.version,
-            self.next_validator_set
-                .as_ref()
-                .map_or("None".to_string(), |validator_set| format!(
-                    "{}",
-                    validator_set
-                )),
-        )
+        write!(f, "VoteProposal[block: {}]", self.block,)
     }
 }
 

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -3,10 +3,11 @@
 
 use crate::{ConsensusState, Error, SafetyRules};
 use consensus_types::{
-    block::Block, block_info::BlockInfo, common::Round, quorum_cert::QuorumCert, vote::Vote,
-    vote_data::VoteData, vote_proposal::VoteProposal,
+    accumulator_extension_proof::AccumulatorExtensionProof, block::Block, block_info::BlockInfo,
+    common::Round, quorum_cert::QuorumCert, timeout::Timeout, vote::Vote, vote_data::VoteData,
+    vote_proposal::VoteProposal,
 };
-use libra_crypto::hash::{CryptoHash, HashValue};
+use libra_crypto::hash::{CryptoHash, HashValue, TransactionAccumulatorHasher};
 use libra_types::{
     crypto_proxies::ValidatorSigner,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -17,12 +18,20 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-fn make_proposal_with_qc(
+type Proof = AccumulatorExtensionProof<TransactionAccumulatorHasher>;
+
+fn empty_proof() -> Proof {
+    Proof::new(vec![], 0, vec![])
+}
+
+fn make_proposal_with_qc_and_proof(
     round: Round,
+    proof: Proof,
     qc: QuorumCert,
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal<Round> {
     VoteProposal::<Round>::new(
+        proof,
         Block::<Round>::new_proposal(
             round,
             round,
@@ -33,33 +42,74 @@ fn make_proposal_with_qc(
             qc,
             validator_signer,
         ),
-        HashValue::zero(),
-        0,
         None,
     )
 }
 
+fn make_proposal_with_qc(
+    round: Round,
+    qc: QuorumCert,
+    validator_signer: &ValidatorSigner,
+) -> VoteProposal<Round> {
+    make_proposal_with_qc_and_proof(round, empty_proof(), qc, validator_signer)
+}
+
 fn make_proposal_with_parent(
     round: Round,
-    parent: &Block<Round>,
+    parent: &VoteProposal<Round>,
     committed: Option<&VoteProposal<Round>>,
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal<Round> {
+    let parent_output = parent
+        .accumulator_extension_proof()
+        .verify(
+            parent
+                .block()
+                .quorum_cert()
+                .certified_block()
+                .executed_state_id(),
+        )
+        .unwrap();
+
+    let proof = Proof::new(
+        parent_output.frozen_subtree_roots().clone(),
+        parent_output.num_leaves(),
+        vec![Timeout::new(0, round).hash()],
+    );
+
     let vote_data = VoteData::new(
-        BlockInfo::from_block(parent, HashValue::zero(), 0, None),
-        parent.quorum_cert().certified_block().clone(),
+        BlockInfo::from_block(
+            parent.block(),
+            parent_output.root_hash(),
+            parent_output.version(),
+            None,
+        ),
+        parent.block().quorum_cert().certified_block().clone(),
     );
 
     let ledger_info = match committed {
-        Some(committed) => LedgerInfo::new(
-            committed.version(),
-            committed.executed_state_id(),
-            vote_data.hash(),
-            committed.block().id(),
-            committed.block().epoch(),
-            committed.block().timestamp_usecs(),
-            None,
-        ),
+        Some(committed) => {
+            let tree = committed
+                .accumulator_extension_proof()
+                .verify(
+                    committed
+                        .block()
+                        .quorum_cert()
+                        .certified_block()
+                        .executed_state_id(),
+                )
+                .unwrap();
+
+            LedgerInfo::new(
+                tree.version(),
+                tree.root_hash(),
+                vote_data.hash(),
+                committed.block().id(),
+                committed.block().epoch(),
+                committed.block().timestamp_usecs(),
+                None,
+            )
+        }
         None => LedgerInfo::new(
             0,
             HashValue::zero(),
@@ -87,7 +137,7 @@ fn make_proposal_with_parent(
 
     let qc = QuorumCert::new(vote_data, ledger_info_with_signatures);
 
-    make_proposal_with_qc(round, qc, validator_signer)
+    make_proposal_with_qc_and_proof(round, proof, qc, validator_signer)
 }
 
 #[test]
@@ -126,11 +176,11 @@ fn test_preferred_block_rule() {
 
     let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
     let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
-    let b2 = make_proposal_with_parent(round + 3, a1.block(), None, &validator_signer);
-    let a2 = make_proposal_with_parent(round + 4, b1.block(), None, &validator_signer);
-    let b3 = make_proposal_with_parent(round + 5, b2.block(), None, &validator_signer);
-    let a3 = make_proposal_with_parent(round + 6, a2.block(), None, &validator_signer);
-    let a4 = make_proposal_with_parent(round + 7, a3.block(), None, &validator_signer);
+    let b2 = make_proposal_with_parent(round + 3, &a1, None, &validator_signer);
+    let a2 = make_proposal_with_parent(round + 4, &b1, None, &validator_signer);
+    let b3 = make_proposal_with_parent(round + 5, &b2, None, &validator_signer);
+    let a3 = make_proposal_with_parent(round + 6, &a2, None, &validator_signer);
+    let a4 = make_proposal_with_parent(round + 7, &a3, None, &validator_signer);
 
     safety_rules.update(a1.block().quorum_cert());
     assert_eq!(
@@ -198,10 +248,10 @@ fn test_voting_potential_commit_id() {
 
     let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
     let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
-    let a2 = make_proposal_with_parent(round + 3, a1.block(), None, &validator_signer);
-    let a3 = make_proposal_with_parent(round + 4, a2.block(), None, &validator_signer);
-    let a4 = make_proposal_with_parent(round + 5, a3.block(), Some(&a2), &validator_signer);
-    let a5 = make_proposal_with_parent(round + 6, a4.block(), Some(&a3), &validator_signer);
+    let a2 = make_proposal_with_parent(round + 3, &a1, None, &validator_signer);
+    let a3 = make_proposal_with_parent(round + 4, &a2, None, &validator_signer);
+    let a4 = make_proposal_with_parent(round + 5, &a3, Some(&a2), &validator_signer);
+    let a5 = make_proposal_with_parent(round + 6, &a4, Some(&a3), &validator_signer);
 
     for b in &[&a1, &b1, &a2, &a3] {
         safety_rules.update(b.block().quorum_cert());
@@ -262,12 +312,12 @@ fn test_voting() {
 
     let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
     let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
-    let b2 = make_proposal_with_parent(round + 3, a1.block(), None, &validator_signer);
-    let a2 = make_proposal_with_parent(round + 4, b1.block(), None, &validator_signer);
-    let a3 = make_proposal_with_parent(round + 5, a2.block(), None, &validator_signer);
-    let b3 = make_proposal_with_parent(round + 6, b2.block(), None, &validator_signer);
-    let a4 = make_proposal_with_parent(round + 7, a3.block(), None, &validator_signer);
-    let b4 = make_proposal_with_parent(round + 8, b2.block(), None, &validator_signer);
+    let b2 = make_proposal_with_parent(round + 3, &a1, None, &validator_signer);
+    let a2 = make_proposal_with_parent(round + 4, &b1, None, &validator_signer);
+    let a3 = make_proposal_with_parent(round + 5, &a2, None, &validator_signer);
+    let b3 = make_proposal_with_parent(round + 6, &b2, None, &validator_signer);
+    let a4 = make_proposal_with_parent(round + 7, &a3, None, &validator_signer);
+    let b4 = make_proposal_with_parent(round + 8, &b2, None, &validator_signer);
 
     safety_rules.update(a1.block().quorum_cert());
     let mut vote = safety_rules.construct_and_sign_vote(&a1).unwrap();
@@ -341,10 +391,10 @@ fn test_commit_rule_consecutive_rounds() {
 
     let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
     let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
-    let b2 = make_proposal_with_parent(round + 3, b1.block(), None, &validator_signer);
-    let a2 = make_proposal_with_parent(round + 4, a1.block(), None, &validator_signer);
-    let a3 = make_proposal_with_parent(round + 5, a2.block(), None, &validator_signer);
-    let a4 = make_proposal_with_parent(round + 6, a3.block(), None, &validator_signer);
+    let b2 = make_proposal_with_parent(round + 3, &b1, None, &validator_signer);
+    let a2 = make_proposal_with_parent(round + 4, &a1, None, &validator_signer);
+    let a3 = make_proposal_with_parent(round + 5, &a2, None, &validator_signer);
+    let a4 = make_proposal_with_parent(round + 6, &a3, None, &validator_signer);
 
     assert_eq!(
         safety_rules
@@ -382,4 +432,54 @@ fn test_commit_rule_consecutive_rounds() {
             .consensus_block_id(),
         a2.block().id(),
     );
+}
+
+#[test]
+fn test_bad_execution_output() {
+    let validator_signer = Arc::new(ValidatorSigner::from_int(0));
+    let mut safety_rules = SafetyRules::new(ConsensusState::default(), validator_signer.clone());
+
+    // build a tree of the following form:
+    //                 _____
+    //                /     \
+    // genesis---a1--a2--a3  evil_a3
+    //
+    // evil_a3 attempts to append to a1 but fails append only check
+    // a3 works as it properly extends a2
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = QuorumCert::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
+    let a2 = make_proposal_with_parent(round + 2, &a1, None, &validator_signer);
+    let a3 = make_proposal_with_parent(round + 3, &a2, None, &validator_signer);
+
+    let a1_output = a1
+        .accumulator_extension_proof()
+        .verify(
+            a1.block()
+                .quorum_cert()
+                .certified_block()
+                .executed_state_id(),
+        )
+        .unwrap();
+
+    let evil_proof = Proof::new(
+        a1_output.frozen_subtree_roots().clone(),
+        a1_output.num_leaves(),
+        vec![Timeout::new(0, *a3.block().payload().unwrap()).hash()],
+    );
+
+    let evil_a3 = make_proposal_with_qc_and_proof(
+        round,
+        evil_proof,
+        a3.block().quorum_cert().clone(),
+        &validator_signer,
+    );
+
+    let evil_a3_block = safety_rules.construct_and_sign_vote(&evil_a3);
+    assert!(evil_a3_block.is_err());
+
+    let a3_block = safety_rules.construct_and_sign_vote(&a3);
+    assert!(a3_block.is_ok());
 }

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -545,6 +545,7 @@ where
                     vm_output.events().iter().map(CryptoHash::hash).collect();
                 InMemoryAccumulator::<EventAccumulatorHasher>::from_leaves(&event_hashes)
             };
+            let mut txn_info_hash = None;
 
             match vm_output.status() {
                 TransactionStatus::Keep(status) => {
@@ -561,7 +562,10 @@ where
                         vm_output.gas_used(),
                         status.major_status,
                     );
-                    txn_info_hashes.push(txn_info.hash());
+
+                    let real_txn_info_hash = txn_info.hash();
+                    txn_info_hashes.push(real_txn_info_hash);
+                    txn_info_hash = Some(real_txn_info_hash);
                 }
                 TransactionStatus::Discard(_) => {
                     ensure!(
@@ -583,6 +587,7 @@ where
                 Arc::new(event_tree),
                 vm_output.gas_used(),
                 num_accounts_created,
+                txn_info_hash,
             ));
             current_state_tree = state_tree;
 

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -136,6 +136,9 @@ pub struct TransactionData {
 
     /// The number of newly created accounts.
     num_account_created: usize,
+
+    /// The transaction info hash if the VM status output was keep, None otherwise
+    txn_info_hash: Option<HashValue>,
 }
 
 impl TransactionData {
@@ -147,6 +150,7 @@ impl TransactionData {
         event_tree: Arc<InMemoryAccumulator<EventAccumulatorHasher>>,
         gas_used: u64,
         num_account_created: usize,
+        txn_info_hash: Option<HashValue>,
     ) -> Self {
         TransactionData {
             account_blobs,
@@ -156,6 +160,7 @@ impl TransactionData {
             event_tree,
             gas_used,
             num_account_created,
+            txn_info_hash,
         }
     }
 
@@ -189,6 +194,10 @@ impl TransactionData {
 
     fn prune_state_tree(&self) {
         self.state_tree.prune()
+    }
+
+    pub fn txn_info_hash(&self) -> Option<HashValue> {
+        self.txn_info_hash
     }
 }
 

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -233,6 +233,14 @@ where
         self.root_hash
     }
 
+    pub fn version(&self) -> u64 {
+        if self.num_leaves() == 0 {
+            0
+        } else {
+            self.num_leaves() - 1
+        }
+    }
+
     /// Computes the root hash of an accumulator given the frozen subtree roots and the number of
     /// leaves in this accumulator.
     fn compute_root_hash(frozen_subtree_roots: &[HashValue], num_leaves: LeafCount) -> HashValue {
@@ -264,6 +272,11 @@ where
         }
 
         current_hash
+    }
+
+    /// Returns the set of frozen subtree roots in this accumulator
+    pub fn frozen_subtree_roots(&self) -> &Vec<HashValue> {
+        &self.frozen_subtree_roots
     }
 
     /// Returns the total number of leaves in this accumulator.


### PR DESCRIPTION
Enable the verification of a append only ledger
- ProcessedVMOutput links block -> execution, so added the additional data for the proof to there (transaction info hashes)
- Need a means to verify that the extension is correct, add a new proof
- Need to update safety rules and event processor to take advantage of this so updates to VoteProposal and the respective code to talk this new method

Tests along the way to verify end-to-end correctness.

It is important to note that the existing event_processor_tests only verify correctness of genesis + 1 rounds. Fortunately the end-to-end correctness is checked by smoke tests. As future work, I'll investigate simplifying the code to event processor tests so we can perform more thorough testing with ideally less code.