### PR TITLE
[consensus][reconfig] setup channels to propogate epoch changes

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -121,7 +121,9 @@ impl<T: Payload> ChainedBftSMR<T> {
                         idle_duration = pre_select_instant.elapsed();
                         event_processor.process_sync_info_msg(sync_info_msg.0, sync_info_msg.1).await;
                     }
-                    // TODO: with epoch changes populated , event_processor = epoch_mgr.start_epoch(..)
+                    epoch_change = network_receivers.epoch_change.select_next_some() => {
+                        idle_duration = pre_select_instant.elapsed();
+                    }
                     complete => {
                         break;
                     }

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -20,7 +20,8 @@ use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_prost_ext::MessageExt;
 use libra_types::account_address::AccountAddress;
-use libra_types::crypto_proxies::ValidatorVerifier;
+use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier};
+use libra_types::proto::types::LedgerInfoWithSignatures as LedgerInfoWithSignaturesProto;
 use network::{
     proto::{
         BlockRetrievalStatus, ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock,
@@ -81,6 +82,7 @@ pub struct NetworkReceivers<T> {
     pub votes: libra_channel::Receiver<PerValidatorQueue<VoteMsg>>,
     pub block_retrieval: libra_channel::Receiver<PerValidatorQueue<BlockRetrievalRequest<T>>>,
     pub sync_info_msgs: libra_channel::Receiver<PerValidatorQueue<(SyncInfo, AccountAddress)>>,
+    pub epoch_change: libra_channel::Receiver<PerValidatorQueue<LedgerInfoWithSignatures>>,
 }
 
 /// Implements the actual networking support for all consensus messaging.
@@ -268,6 +270,14 @@ impl NetworkSender {
             );
         }
     }
+
+    /// Broadcast about epoch changes with proof to the current validator set (including self)
+    pub async fn send_epoch_change(&mut self, ledger_info: LedgerInfoWithSignatures) {
+        let msg = ConsensusMsg {
+            message: Some(ConsensusMsg_oneof::LedgerInfo(ledger_info.into())),
+        };
+        self.broadcast(msg).await
+    }
 }
 
 pub struct NetworkTask<T> {
@@ -275,6 +285,7 @@ pub struct NetworkTask<T> {
     vote_tx: libra_channel::Sender<PerValidatorQueue<VoteMsg>>,
     block_request_tx: libra_channel::Sender<PerValidatorQueue<BlockRetrievalRequest<T>>>,
     sync_info_tx: libra_channel::Sender<PerValidatorQueue<(SyncInfo, AccountAddress)>>,
+    epoch_change_tx: libra_channel::Sender<PerValidatorQueue<LedgerInfoWithSignatures>>,
     all_events: Box<dyn Stream<Item = failure::Result<Event<ConsensusMsg>>> + Send + Unpin>,
     validators: Arc<ValidatorVerifier>,
 }
@@ -322,6 +333,15 @@ impl<T: Payload> NetworkTask<T> {
                 dequeued_msgs_counter: &counters::SYNC_INFO_DEQUEUED_MSGS,
             }),
         ));
+        let (epoch_change_tx, epoch_change_rx) = libra_channel::new(PerValidatorQueue::new(
+            QueueStyle::LIFO,
+            1,
+            Some(message_queues::Counters {
+                dropped_msgs_counter: &counters::EPOCH_CHANGE_DROPPED_MSGS,
+                enqueued_msgs_counter: &counters::EPOCH_CHANGE_ENQUEUED_MSGS,
+                dequeued_msgs_counter: &counters::EPOCH_CHANGE_DEQUEUED_MSGS,
+            }),
+        ));
         let network_events = network_events.map_err(Into::<failure::Error>::into);
         let all_events = Box::new(select(network_events, self_receiver));
         (
@@ -330,6 +350,7 @@ impl<T: Payload> NetworkTask<T> {
                 vote_tx,
                 block_request_tx,
                 sync_info_tx,
+                epoch_change_tx,
                 all_events,
                 validators,
             },
@@ -338,6 +359,7 @@ impl<T: Payload> NetworkTask<T> {
                 votes: vote_rx,
                 block_retrieval: block_request_rx,
                 sync_info_msgs: sync_info_rx,
+                epoch_change: epoch_change_rx,
             },
         )
     }
@@ -367,6 +389,9 @@ impl<T: Payload> NetworkTask<T> {
                         }
                         VoteMsg(vote_msg) => self.process_vote(peer_id, vote_msg).await,
                         SyncInfo(sync_info) => self.process_sync_info(sync_info, peer_id).await,
+                        LedgerInfo(ledger_info) => {
+                            self.process_epoch_change(peer_id, ledger_info).await
+                        }
                         _ => {
                             warn!("Unexpected msg from {}: {:?}", peer_id, msg);
                             continue;
@@ -481,5 +506,19 @@ impl<T: Payload> NetworkTask<T> {
         callback
             .send(Ok(response_data))
             .map_err(|_| format_err!("handling inbound rpc call timed out"))
+    }
+
+    async fn process_epoch_change(
+        &mut self,
+        peer_id: AccountAddress,
+        ledger_info: LedgerInfoWithSignaturesProto,
+    ) -> failure::Result<()> {
+        let ledger_info = LedgerInfoWithSignatures::try_from(ledger_info)?;
+        ensure!(
+            ledger_info.ledger_info().next_validator_set().is_some(),
+            "Epoch change doesn't carry next validator set"
+        );
+        ledger_info.verify(&self.validators)?;
+        Ok(self.epoch_change_tx.put(peer_id, ledger_info))
     }
 }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -66,6 +66,11 @@ pub static ref SYNC_INFO_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("sync_in
 pub static ref SYNC_INFO_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_enqueued_msgs_count");
 pub static ref SYNC_INFO_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_dequeued_msgs_count");
 
+/// Count of number of messages dropped by epoch change channel
+pub static ref EPOCH_CHANGE_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("epoch_change_dropped_msgs_count");
+pub static ref EPOCH_CHANGE_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("epoch_change_enqueued_msgs_count");
+pub static ref EPOCH_CHANGE_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("epoch_change_dequeued_msgs_count");
+
 
 //////////////////////
 // PROPOSAL ELECTION

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -6,8 +6,6 @@ syntax = "proto3";
 package consensus;
 
 import "ledger_info.proto";
-import "transaction.proto";
-import "validator_set.proto";
 
 message ConsensusMsg {
   oneof message {
@@ -15,7 +13,8 @@ message ConsensusMsg {
     VoteMsg vote_msg = 2;
     RequestBlock request_block = 3;
     RespondBlock respond_block = 4;
-    SyncInfo sync_info = 6;
+    SyncInfo sync_info = 5;
+    types.LedgerInfoWithSignatures ledger_info = 6;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Setup initial channels for event_processor to broadcast an epoch change message which includes a LedgerInfoWithSignatures which has next_validator_set.

The channels are not used yet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
