### PR TITLE
[consensus] Eliminate the field enforce_increasing_timestamps

### DIFF
--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -116,7 +116,6 @@ impl<T: Payload> EpochManager<T> {
             Arc::clone(&self.storage),
             initial_data,
             Arc::clone(&self.state_computer),
-            true,
             self.config.max_pruned_blocks_in_mem,
         )));
 
@@ -128,7 +127,6 @@ impl<T: Payload> EpochManager<T> {
             Arc::clone(&self.txn_manager),
             self.time_service.clone(),
             self.config.max_block_size,
-            true,
         );
 
         let pacemaker =
@@ -153,7 +151,6 @@ impl<T: Payload> EpochManager<T> {
             network_sender,
             self.storage.clone(),
             self.time_service.clone(),
-            true,
             validators,
         )
     }

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -63,7 +63,6 @@ fn build_empty_store(
         storage,
         initial_data,
         Arc::new(EmptyStateComputer),
-        true,
         10, // max pruned blocks in mem
     )))
 }
@@ -119,7 +118,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         Arc::new(MockTransactionManager::new()),
         time_service.clone(),
         1,
-        true,
     );
 
     //
@@ -127,9 +125,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
 
     // TODO: have two different nodes, one for proposing, one for accepting a proposal
     let proposer_election = Box::new(RotatingProposer::new(vec![signer.author()], 1));
-
-    // We do not want to care about the time
-    let enforce_increasing_timestamps = false;
 
     // event processor
     EventProcessor::new(
@@ -143,7 +138,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         network,
         storage.clone(),
         time_service,
-        enforce_increasing_timestamps,
         validator,
     )
 }

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -144,7 +144,6 @@ impl NodeSetup {
             storage.clone(),
             initial_data,
             state_computer.clone(),
-            true,
             10, // max pruned blocks in mem
         )));
 
@@ -156,7 +155,6 @@ impl NodeSetup {
             Arc::new(MockTransactionManager::new()),
             time_service.clone(),
             1,
-            true,
         );
 
         let safety_rules = SafetyRules::new(consensus_state, signer.clone());
@@ -175,7 +173,6 @@ impl NodeSetup {
             network,
             storage.clone(),
             time_service,
-            true,
             validators.clone(),
         );
         block_on(event_processor.start());

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -32,7 +32,6 @@ fn test_proposal_generation_empty_tree() {
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
-        true,
     );
     let genesis = block_store.root();
 
@@ -59,7 +58,6 @@ fn test_proposal_generation_parent() {
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
-        true,
     );
     let genesis = block_store.root();
     let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
@@ -101,7 +99,6 @@ fn test_old_proposal_generation() {
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
-        true,
     );
     let genesis = block_store.root();
     let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
@@ -121,7 +118,6 @@ fn test_empty_proposal_after_reconfiguration() {
         Arc::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
-        true,
     );
     let genesis = block_store.root();
     let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -80,7 +80,6 @@ pub fn build_empty_tree() -> Arc<BlockStore<TestPayload>> {
         storage,
         initial_data,
         Arc::new(EmptyStateComputer),
-        true,
         10, // max pruned blocks in mem
     )))
 }


### PR DESCRIPTION
This is true everywhere (except fuzzing). Discussed many times on how
this should be deleted... this is an easy cleanup as I ponder ways to
make the code slightly easier to navigate and test.