### PR TITLE
[cluster-test] Add a cleanup method for performing cleanups

### DIFF
--- a/testsuite/cluster-test/src/effects/remove_network_effects.rs
+++ b/testsuite/cluster-test/src/effects/remove_network_effects.rs
@@ -18,7 +18,7 @@ impl Action for RemoveNetworkEffects {
     fn apply(&self) -> failure::Result<()> {
         info!("RemoveNetworkEffects for {}", self.instance);
         self.instance
-            .run_cmd(vec!["sudo tc qdisc delete dev eth0 root".to_string()])
+            .run_cmd(vec!["sudo tc qdisc delete dev eth0 root; true".to_string()])
     }
 
     fn is_complete(&self) -> bool {


### PR DESCRIPTION
## Summary

The cleanup method is intended to cleanup effects of experiments which might have crashed mid way. We run this before we run experiments. 

There is also a standalone flag for running cleanup.

## Test Plan

```
[ec2-user:validator@ip-10-0-0-212 ~]$ ~/libra/target/cluster_test_docker_builder/cluster-test --workplace=kush --cleanup
Oct 29 00:15:27.334 INFO Discovered 4 peers
Oct 29 00:15:27.555 INFO Log tail thread started in 220 ms
Oct 29 00:15:27.556 INFO RemoveNetworkEffects for 1e5d5a74(10.0.6.55)
Oct 29 00:15:27.556 INFO RemoveNetworkEffects for 8deeeaed(10.0.1.66)
Oct 29 00:15:27.556 INFO RemoveNetworkEffects for ab0d6a54(10.0.10.92)
Oct 29 00:15:27.557 INFO RemoveNetworkEffects for 57ff8374(10.0.3.130)
```