### PR TITLE
[CI] add conditional docker build to commit verify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,11 +139,43 @@ jobs:
           name: Terraform validate
           command: terraform validate
           working_directory: terraform/
+  build-docker:
+    machine:
+      image: ubuntu-1604:201903-01
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Check if the docker build job should run
+          command: .circleci/should_build_docker.sh
+      - run:
+          name: Get the list of updated docker files
+          command: |
+            echo 'export DOCKER_FILES=$(
+              for commit in $(git rev-list origin/master..HEAD) ; do
+                git diff-tree --no-commit-id --name-only -r "$commit" -- "*.Dockerfile";
+              done
+            )' >> $BASH_ENV
+      - run:
+          name: Build each of the updated docker files
+          command: |
+            # Use the dockerfile own build.sh script if it has one.
+            for docker_file in $DOCKER_FILES; do
+              build_script=$(dirname $docker_file)/build.sh
+              if [ -f "$build_script" ]; then
+                $build_script
+              else
+                file_no_ext=$(basename $docker_file)
+                module=${file_no_ext%.Dockerfile}
+                docker build -f $docker_file --tag commit_verify_${CIRCLE_BUILD_NUM}_$module .
+              fi
+            done
 
 workflows:
   commit-workflow:
     jobs:
       - build
+      - build-docker
       - validate-config
       - terraform
 

--- a/.circleci/should_build_docker.sh
+++ b/.circleci/should_build_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -eo pipefail
+
+oldrev="origin/master"
+newrev="HEAD"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR=$SCRIPT_DIR/..
+
+# Look for updated Dockerfiles in the PR
+cd "$PROJECT_DIR"
+COMMITS=$(git rev-list $oldrev..$newrev)
+DOCKER_FILES=$(
+  for commit in $COMMITS; do
+    git diff-tree --no-commit-id --name-only -r "$commit" -- "*.Dockerfile";
+  done
+)
+
+if [ "$DOCKER_FILES" ]; then
+  echo "Will build docker containers."
+else
+  echo "Will skip building docker containers."
+  circleci step halt
+fi


### PR DESCRIPTION
## Motivation
When we make changes to these docker files, we want to verify them in
the commit work flow.  Or we end up breaking nightly. This is a
follow-up to 243f535.

Here we added a conditional docker build job to the commit verify work
flow.  The docker build job will kick off iff the PR contains change in
any file matches `*.Dockerfile`.  Once triggered, the work flow will
build each of the updated docker files.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
- Canary with 006e5ea (where the mint and validator dockerfiles are modified) https://app.circleci.com/jobs/github/libra/libra/13208
Verified both mint and validator's docker images are built.
![image](https://user-images.githubusercontent.com/7528420/67738901-9a121900-f9cd-11e9-970a-b14c87732372.png)
![image](https://user-images.githubusercontent.com/7528420/67738909-a302ea80-f9cd-11e9-9876-4c6d091317f0.png)

- Canary with fb95b87 (where the mint dockerfile has an intentional typo) https://app.circleci.com/jobs/github/libra/libra/13233
Verified the docker build is triggered but failed due to the typo
![image](https://user-images.githubusercontent.com/7528420/67738960-e3faff00-f9cd-11e9-963b-27e1d541d1f5.png)

- Canary with 0a1ec77 (where there is no change in any dockerfile) https://app.circleci.com/jobs/github/libra/libra/13236
Verified the docker build step is skipped.
![image](https://user-images.githubusercontent.com/7528420/67739007-1ad11500-f9ce-11e9-9f22-6d543990e2fa.png)
 
## Related PRs
#1296 