### PR TITLE
[monitoring] Remove old counters and update dashboard

### DIFF
--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -122,7 +122,7 @@ impl LibraNode {
 
     pub fn check_connectivity(&self, expected_peers: i64) -> bool {
         let connected_peers = format!(
-            "libra_network_peers{{role={},state=connected}}",
+            "libra_network_peers{{role_type={},state=connected}}",
             self.role.to_string()
         );
         if let Some(num_connected_peers) = self.get_metric(&connected_peers) {

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use libra_metrics::{Histogram, IntCounter, IntGauge, OpMetrics};
+use libra_metrics::{Histogram, IntGauge, OpMetrics};
 use prometheus::{IntCounterVec, IntGaugeVec};
 
 lazy_static::lazy_static! {
@@ -12,7 +12,7 @@ lazy_static::lazy_static! {
         // metric description
         "Libra network peers counter",
         // metric labels (dimensions)
-        &["role", "state"]
+        &["role_type", "state"]
     ).unwrap();
 
     pub static ref LIBRA_NETWORK_RPC_MESSAGES: IntCounterVec = register_int_counter_vec!(
@@ -50,51 +50,6 @@ lazy_static::lazy_static! {
 }
 
 lazy_static::lazy_static! {
-    /// Counter of currently connected peers
-    pub static ref CONNECTED_PEERS: IntGauge = OP_COUNTERS.gauge("connected_peers");
-
-    /// Counter of rpc requests sent
-    pub static ref RPC_REQUESTS_SENT: IntCounter = OP_COUNTERS.counter("rpc_requests_sent");
-
-    /// Counter of rpc request bytes sent
-    pub static ref RPC_REQUEST_BYTES_SENT: IntCounter = OP_COUNTERS.counter("rpc_request_bytes_sent");
-
-    /// Counter of rpc requests failed
-    pub static ref RPC_REQUESTS_FAILED: IntCounter = OP_COUNTERS.counter("rpc_requests_failed");
-
-    /// Counter of rpc requests cancelled
-    pub static ref RPC_REQUESTS_CANCELLED: IntCounter = OP_COUNTERS.counter("rpc_requests_cancelled");
-
-    /// Counter of rpc requests received
-    pub static ref RPC_REQUESTS_RECEIVED: IntCounter = OP_COUNTERS.counter("rpc_requests_received");
-
-    /// Counter of rpc responses sent
-    pub static ref RPC_RESPONSES_SENT: IntCounter = OP_COUNTERS.counter("rpc_responses_sent");
-
-    /// Counter of rpc response bytes sent
-    pub static ref RPC_RESPONSE_BYTES_SENT: IntCounter = OP_COUNTERS.counter("rpc_response_bytes_sent");
-
-    /// Counter of rpc responses failed
-    pub static ref RPC_RESPONSES_FAILED: IntCounter = OP_COUNTERS.counter("rpc_responses_failed");
-
-    /// Histogram of rpc latency
-    pub static ref RPC_LATENCY: Histogram = OP_COUNTERS.histogram("rpc_latency");
-
-    /// Counter of messages sent via the direct send protocol
-    pub static ref DIRECT_SEND_MESSAGES_SENT: IntCounter = OP_COUNTERS.counter("direct_send_messages_sent");
-
-    /// Counter of bytes sent via the direct send protocol
-    pub static ref DIRECT_SEND_BYTES_SENT: IntCounter = OP_COUNTERS.counter("direct_send_bytes_sent");
-
-    /// Counter of messages dropped via the direct send protocol
-    pub static ref DIRECT_SEND_MESSAGES_DROPPED: IntCounter = OP_COUNTERS.counter("direct_send_messages_dropped");
-
-    /// Counter of messages received via the direct send protocol
-    pub static ref DIRECT_SEND_MESSAGES_RECEIVED: IntCounter = OP_COUNTERS.counter("direct_send_messages_received");
-
-    /// Counter of bytes received via the direct send protocol
-    pub static ref DIRECT_SEND_BYTES_RECEIVED: IntCounter = OP_COUNTERS.counter("direct_send_bytes_received");
-
     ///
     /// Channel Counters
     ///

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -298,11 +298,9 @@ where
                     .unwrap();
             }
             NetworkRequest::SendMessage(peer_id, msg) => {
-                counters::DIRECT_SEND_MESSAGES_SENT.inc();
                 counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
                     .with_label_values(&["sent"])
                     .inc();
-                counters::DIRECT_SEND_BYTES_SENT.inc_by(msg.mdata.len() as i64);
                 counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
                     .with_label_values(&["sent"])
                     .inc_by(msg.mdata.len() as i64);
@@ -330,7 +328,6 @@ where
         trace!("PeerManagerNotification::{:?}", notif);
         match notif {
             PeerManagerNotification::NewPeer(peer_id, _addr) => {
-                counters::CONNECTED_PEERS.inc();
                 for ch in upstream_handlers.values_mut() {
                     ch.send(NetworkNotification::NewPeer(peer_id))
                         .await
@@ -338,7 +335,6 @@ where
                 }
             }
             PeerManagerNotification::LostPeer(peer_id, _addr) => {
-                counters::CONNECTED_PEERS.dec();
                 for ch in upstream_handlers.values_mut() {
                     ch.send(NetworkNotification::LostPeer(peer_id))
                         .await
@@ -376,11 +372,9 @@ where
         trace!("DirectSendNotification::{:?}", notif);
         match notif {
             DirectSendNotification::RecvMessage(peer_id, msg) => {
-                counters::DIRECT_SEND_MESSAGES_RECEIVED.inc();
                 counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
                     .with_label_values(&["received"])
                     .inc();
-                counters::DIRECT_SEND_BYTES_RECEIVED.inc_by(msg.mdata.len() as i64);
                 counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
                     .with_label_values(&["received"])
                     .inc_by(msg.mdata.len() as i64);

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -246,14 +246,6 @@ where
                 );
             }
             // The messages in queue will be dropped
-            counters::DIRECT_SEND_MESSAGES_DROPPED.inc_by(
-                counters::OP_COUNTERS
-                    .peer_gauge(
-                        &counters::PENDING_DIRECT_SEND_OUTBOUND_MESSAGES,
-                        &peer_id.short_str(),
-                    )
-                    .get(),
-            );
             counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
                 .with_label_values(&["dropped"])
                 .inc_by(
@@ -312,7 +304,6 @@ where
                     .try_send_msg(peer_id, msg.clone(), self.peer_mgr_reqs_tx.clone())
                     .await
                 {
-                    counters::DIRECT_SEND_MESSAGES_DROPPED.inc();
                     counters::LIBRA_NETWORK_DIRECT_SEND_MESSAGES
                         .with_label_values(&["dropped"])
                         .inc();

--- a/terraform/templates/dashboards/network.json
+++ b/terraform/templates/dashboards/network.json
@@ -15,10 +15,12 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
+  "id": 8,
   "links": [],
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -35,7 +37,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -56,7 +60,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -67,7 +73,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(network{op='direct_send_bytes_sent'}[1m])",
+          "expr": "irate(libra_network_direct_send_bytes{state=\"sent\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -120,7 +126,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -141,7 +149,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -152,7 +162,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(network{op=\"direct_send_bytes_received\"}[1m])",
+          "expr": "irate(libra_network_direct_send_bytes{state=\"received\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -205,7 +215,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -227,7 +239,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -238,7 +252,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(network{op='rpc_requests_sent'}[1m])",
+          "expr": "irate(libra_network_rpc_messages{type=\"request\",state=\"sent\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -291,7 +305,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -312,7 +328,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -323,7 +341,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(network{op='rpc_requests_received'}[1m])",
+          "expr": "irate(libra_network_rpc_messages{type=\"request\", state=\"received\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -373,6 +391,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -389,7 +408,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -410,7 +431,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -421,7 +444,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers'}\n",
+          "expr": "libra_network_peers{role_type=\"validator\", state=\"connected\"}\n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -471,6 +494,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -487,7 +511,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -508,7 +534,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -519,7 +547,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(network{op='direct_send_messages_dropped'}[1m])",
+          "expr": "irate(libra_network_direct_send_messages{state=\"dropped\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -572,7 +600,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -593,7 +623,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -604,21 +636,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(network{op='rpc_requests_failed'}[1m])",
+          "expr": "irate(libra_network_rpc_messages{type=\"request\",state=\"failed\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
           "refId": "A"
         },
         {
-          "expr": "irate(network{op='rpc_requests_cancelled'}[1m])",
+          "expr": "irate(libra_network_rpc_messages{type=\"request\",state=\"cancelled\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
           "refId": "B"
         },
         {
-          "expr": "irate(network{op='rpc_responses_failed'}[1m])",
+          "expr": "irate(libra_network_rpc_messages{type=\"response\",state=\"failed\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -668,6 +700,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -685,7 +718,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -706,7 +741,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -771,7 +808,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -792,7 +831,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -857,7 +898,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -878,7 +921,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -939,6 +984,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -956,7 +1002,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -977,7 +1025,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1042,7 +1092,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1063,7 +1115,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1128,7 +1182,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1149,7 +1205,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1214,7 +1272,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1235,7 +1295,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1296,6 +1358,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1313,7 +1376,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1334,7 +1399,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1399,7 +1466,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1420,7 +1489,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1481,6 +1552,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1498,7 +1570,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1519,7 +1593,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1584,7 +1660,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1605,7 +1683,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1670,7 +1750,9 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -1691,7 +1773,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -1752,7 +1836,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 20,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1790,5 +1874,5 @@
   "timezone": "",
   "title": "Network",
   "uid": "5uI7S17Wk",
-  "version": 2
+  "version": 1
 }

--- a/terraform/templates/dashboards/overview_dashboard.json
+++ b/terraform/templates/dashboards/overview_dashboard.json
@@ -1922,7 +1922,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2600,7 +2600,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3278,7 +3278,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3956,7 +3956,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -4634,7 +4634,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -5312,7 +5312,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -5990,7 +5990,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -6668,7 +6668,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -7346,7 +7346,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -8024,7 +8024,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator',peer_id='$peer_id'}",
+          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,

--- a/terraform/templates/dashboards/validators.json
+++ b/terraform/templates/dashboards/validators.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 15,
+  "id": 6,
   "links": [],
   "panels": [
     {
@@ -23,7 +23,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -44,7 +46,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -108,7 +112,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -129,7 +135,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -140,7 +148,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "network_gauge{op='connected_peers',role='validator'}",
+          "expr": "libra_network_peers{role_type=\"validator\", state=\"connected\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -193,7 +201,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -214,7 +224,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -278,7 +290,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -299,7 +313,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -363,7 +379,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -384,7 +402,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -448,7 +468,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -469,7 +491,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -533,7 +557,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -554,7 +580,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -618,7 +646,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -639,7 +669,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -703,7 +735,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -724,7 +758,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
-      "options": {},
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -784,7 +820,7 @@
       }
     }
   ],
-  "schemaVersion": 18,
+  "schemaVersion": 20,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -822,5 +858,5 @@
   "timezone": "",
   "title": "Validators",
   "uid": "validators",
-  "version": 4
+  "version": 1
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

New counters are created in https://github.com/libra/libra/pull/1461
We've confirmed they're working. So cleanup the old counters now, and update the dashboard.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Launched a new environment with changes. 
Dashboard can be verified on http://prometheus.sherryxiao.aws.hlw3truzy4ls.com:9091/ by updating the queries manually.

