### PR TITLE
[Consensus] BlockRetrieval types

### DIFF
--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -1,0 +1,161 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{block::Block, common::Payload};
+use failure::prelude::*;
+use libra_crypto::hash::HashValue;
+use libra_types::crypto_proxies::ValidatorVerifier;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::fmt;
+
+/// RPC to get a chain of block of the given length starting from the given block id.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct BlockRetrievalRequest {
+    block_id: HashValue,
+    num_blocks: u64,
+}
+
+impl BlockRetrievalRequest {
+    pub fn new(block_id: HashValue, num_blocks: u64) -> Self {
+        Self {
+            block_id,
+            num_blocks,
+        }
+    }
+    pub fn block_id(&self) -> HashValue {
+        self.block_id
+    }
+    pub fn num_blocks(&self) -> u64 {
+        self.num_blocks
+    }
+}
+
+impl fmt::Display for BlockRetrievalRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "[BlockRetrievalRequest starting from id {} with {} blocks]",
+            self.block_id, self.num_blocks
+        )
+    }
+}
+
+impl TryFrom<network::proto::RequestBlock> for BlockRetrievalRequest {
+    type Error = failure::Error;
+
+    fn try_from(proto: network::proto::RequestBlock) -> failure::Result<Self> {
+        Ok(lcs::from_bytes(&proto.bytes)?)
+    }
+}
+
+impl TryFrom<BlockRetrievalRequest> for network::proto::RequestBlock {
+    type Error = failure::Error;
+
+    fn try_from(block_retrieval_request: BlockRetrievalRequest) -> failure::Result<Self> {
+        Ok(Self {
+            bytes: lcs::to_bytes(&block_retrieval_request)?,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum BlockRetrievalStatus {
+    // Successfully fill in the request.
+    Succeeded,
+    // Can not find the block corresponding to block_id.
+    IdNotFound,
+    // Can not find enough blocks but find some.
+    NotEnoughBlocks,
+}
+
+/// Carries the returned blocks and the retrieval status.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct BlockRetrievalResponse<T> {
+    status: BlockRetrievalStatus,
+    #[serde(bound(deserialize = "Block<T>: Deserialize<'de>"))]
+    blocks: Vec<Block<T>>,
+}
+
+impl<T: Payload> BlockRetrievalResponse<T> {
+    pub fn new(status: BlockRetrievalStatus, blocks: Vec<Block<T>>) -> Self {
+        Self { status, blocks }
+    }
+
+    pub fn status(&self) -> BlockRetrievalStatus {
+        self.status.clone()
+    }
+
+    pub fn blocks(&self) -> &Vec<Block<T>> {
+        &self.blocks
+    }
+
+    pub fn verify(
+        &self,
+        block_id: HashValue,
+        num_blocks: u64,
+        sig_verifier: &ValidatorVerifier,
+    ) -> failure::Result<()> {
+        ensure!(
+            self.status != BlockRetrievalStatus::Succeeded
+                || self.blocks.len() as u64 == num_blocks,
+            "not enough blocks returned, expect {}, get {}",
+            num_blocks,
+            self.blocks.len(),
+        );
+        self.blocks
+            .iter()
+            .try_fold(block_id, |expected_id, block| {
+                block.validate_signatures(sig_verifier)?;
+                block.verify_well_formed()?;
+                ensure!(
+                    block.id() == expected_id,
+                    "blocks doesn't form a chain: expect {}, get {}",
+                    expected_id,
+                    block.id()
+                );
+                Ok(block.parent_id())
+            })
+            .map(|_| ())
+    }
+}
+
+impl<T: Payload> fmt::Display for BlockRetrievalResponse<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.status() {
+            BlockRetrievalStatus::Succeeded => {
+                let block_ids = self
+                    .blocks
+                    .iter()
+                    .map(|b| b.id().short_str())
+                    .collect::<Vec<String>>();
+                write!(
+                    f,
+                    "[BlockRetrievalResponse: status: {:?}, num_blocks: {}, block_ids: {:?}]",
+                    self.status(),
+                    self.blocks().len(),
+                    block_ids
+                )
+            }
+            _ => write!(f, "[BlockRetrievalResponse: status: {:?}", self.status()),
+        }
+    }
+}
+
+impl<T: Payload> TryFrom<network::proto::RespondBlock> for BlockRetrievalResponse<T> {
+    type Error = failure::Error;
+
+    fn try_from(proto: network::proto::RespondBlock) -> failure::Result<Self> {
+        Ok(lcs::from_bytes(&proto.bytes)?)
+    }
+}
+
+impl<T: Payload> TryFrom<BlockRetrievalResponse<T>> for network::proto::RespondBlock {
+    type Error = failure::Error;
+
+    fn try_from(block_retrieval_response: BlockRetrievalResponse<T>) -> failure::Result<Self> {
+        Ok(Self {
+            bytes: lcs::to_bytes(&block_retrieval_response)?,
+        })
+    }
+}

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod block;
 pub mod block_data;
 pub mod block_info;
+pub mod block_retrieval;
 pub mod common;
 pub mod executed_block;
 pub mod proposal_msg;

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -9,7 +9,7 @@ use crate::{
             proposal_generator::ProposalGenerator,
             proposer_election::ProposerElection,
         },
-        network::{BlockRetrievalRequest, BlockRetrievalResponse, NetworkSender},
+        network::NetworkSender,
         persistent_storage::PersistentStorage,
     },
     counters,
@@ -36,7 +36,9 @@ use mirai_annotations::{
     debug_checked_precondition, debug_checked_precondition_eq, debug_checked_verify,
     debug_checked_verify_eq,
 };
-use network::proto::BlockRetrievalStatus;
+
+use crate::chained_bft::network::IncomingBlockRetrievalRequest;
+use consensus_types::block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus};
 #[cfg(test)]
 use safety_rules::ConsensusState;
 use safety_rules::SafetyRules;
@@ -776,11 +778,11 @@ impl<T: Payload> EventProcessor<T> {
     ///
     /// The current version of the function is not really async, but keeping it this way for
     /// future possible changes.
-    pub async fn process_block_retrieval(&self, request: BlockRetrievalRequest<T>) {
+    pub async fn process_block_retrieval(&self, request: IncomingBlockRetrievalRequest<T>) {
         let mut blocks = vec![];
         let mut status = BlockRetrievalStatus::Succeeded;
-        let mut id = request.block_id;
-        while (blocks.len() as u64) < request.num_blocks {
+        let mut id = request.req.block_id();
+        while (blocks.len() as u64) < request.req.num_blocks() {
             if let Some(executed_block) = self.block_store.get_block(id) {
                 id = executed_block.parent_id();
                 blocks.push(executed_block.block().clone());
@@ -796,7 +798,7 @@ impl<T: Payload> EventProcessor<T> {
 
         if let Err(e) = request
             .response_sender
-            .send(BlockRetrievalResponse { status, blocks })
+            .send(BlockRetrievalResponse::new(status, blocks))
         {
             error!("Failed to return the requested block: {:?}", e);
         }

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -7,24 +7,23 @@ use channel::{
     self, libra_channel,
     message_queues::{PerValidatorQueue, QueueStyle},
 };
+use consensus_types::block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse};
 use consensus_types::{
-    block::Block,
     common::{Author, Payload},
     proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
 };
-use failure::{self, ResultExt};
+use failure::{self};
 use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt, TryStreamExt};
-use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_prost_ext::MessageExt;
 use libra_types::account_address::AccountAddress;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use network::{
     proto::{
-        BlockRetrievalStatus, ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock,
-        RespondBlock, SyncInfo as SyncInfoProto, VoteMsg as VoteMsgProto,
+        ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock, RespondBlock,
+        SyncInfo as SyncInfoProto, VoteMsg as VoteMsgProto,
     },
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender, Event, RpcError},
 };
@@ -34,43 +33,11 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// The response sent back from EventProcessor for the BlockRetrievalRequest.
+/// The block retrieval request is used internally for implementing RPC: the callback is executed
+/// for carrying the response
 #[derive(Debug)]
-pub struct BlockRetrievalResponse<T> {
-    pub status: BlockRetrievalStatus,
-    pub blocks: Vec<Block<T>>,
-}
-
-impl<T: Payload> BlockRetrievalResponse<T> {
-    pub fn verify(&self, block_id: HashValue, num_blocks: u64) -> failure::Result<()> {
-        ensure!(
-            self.status != BlockRetrievalStatus::Succeeded
-                || self.blocks.len() as u64 == num_blocks,
-            "not enough blocks returned, expect {}, get {}",
-            num_blocks,
-            self.blocks.len(),
-        );
-        self.blocks
-            .iter()
-            .try_fold(block_id, |expected_id, block| {
-                ensure!(
-                    block.id() == expected_id,
-                    "blocks doesn't form a chain: expect {}, get {}",
-                    expected_id,
-                    block.id()
-                );
-                Ok(block.parent_id())
-            })
-            .map(|_| ())
-    }
-}
-
-/// BlockRetrievalRequest carries a block id for the requested block as well as the
-/// oneshot sender to deliver the response.
-#[derive(Debug)]
-pub struct BlockRetrievalRequest<T> {
-    pub block_id: HashValue,
-    pub num_blocks: u64,
+pub struct IncomingBlockRetrievalRequest<T> {
+    pub req: BlockRetrievalRequest,
     pub response_sender: oneshot::Sender<BlockRetrievalResponse<T>>,
 }
 
@@ -79,7 +46,8 @@ pub struct BlockRetrievalRequest<T> {
 pub struct NetworkReceivers<T> {
     pub proposals: libra_channel::Receiver<PerValidatorQueue<ProposalMsg<T>>>,
     pub votes: libra_channel::Receiver<PerValidatorQueue<VoteMsg>>,
-    pub block_retrieval: libra_channel::Receiver<PerValidatorQueue<BlockRetrievalRequest<T>>>,
+    pub block_retrieval:
+        libra_channel::Receiver<PerValidatorQueue<IncomingBlockRetrievalRequest<T>>>,
     pub sync_info_msgs: libra_channel::Receiver<PerValidatorQueue<(SyncInfo, AccountAddress)>>,
 }
 
@@ -111,43 +79,28 @@ impl NetworkSender {
     }
 
     /// Tries to retrieve num of blocks backwards starting from id from the given peer: the function
-    /// returns a future that is either fulfilled with BlockRetrievalResponse, or with a
-    /// BlockRetrievalFailure.
+    /// returns a future that is fulfilled with BlockRetrievalResponse.
     pub async fn request_block<T: Payload>(
         &mut self,
-        block_id: HashValue,
-        num_blocks: u64,
+        retrieval_request: BlockRetrievalRequest,
         from: Author,
         timeout: Duration,
     ) -> failure::Result<BlockRetrievalResponse<T>> {
         ensure!(from != self.author, "Retrieve block from self");
-        let mut req_msg = RequestBlock::default();
-        req_msg.block_id = block_id.to_vec();
-        req_msg.num_blocks = num_blocks;
-        counters::BLOCK_RETRIEVAL_COUNT.inc_by(num_blocks as i64);
+        counters::BLOCK_RETRIEVAL_COUNT.inc_by(retrieval_request.num_blocks() as i64);
         let pre_retrieval_instant = Instant::now();
-
-        let res_block = self
+        let req_msg = RequestBlock::try_from(retrieval_request.clone())?;
+        let response_msg = self
             .network_sender
             .request_block(from, req_msg, timeout)
             .await?;
-        let mut blocks = vec![];
-        let status = res_block.status();
-        for block in res_block.blocks.into_iter() {
-            match Block::try_from(block) {
-                Ok(block) => {
-                    block
-                        .validate_signatures(self.validators.as_ref())
-                        .and_then(|_| block.verify_well_formed())
-                        .with_context(|e| format_err!("Invalid block because of {:?}", e))?;
-                    blocks.push(block);
-                }
-                Err(e) => bail!("Failed to deserialize block because of {:?}", e),
-            };
-        }
         counters::BLOCK_RETRIEVAL_DURATION_S.observe_duration(pre_retrieval_instant.elapsed());
-        let response = BlockRetrievalResponse { status, blocks };
-        response.verify(block_id, num_blocks)?;
+        let response = BlockRetrievalResponse::<T>::try_from(response_msg)?;
+        response.verify(
+            retrieval_request.block_id(),
+            retrieval_request.num_blocks(),
+            self.validators.as_ref(),
+        )?;
         Ok(response)
     }
 
@@ -273,7 +226,7 @@ impl NetworkSender {
 pub struct NetworkTask<T> {
     proposal_tx: libra_channel::Sender<PerValidatorQueue<ProposalMsg<T>>>,
     vote_tx: libra_channel::Sender<PerValidatorQueue<VoteMsg>>,
-    block_request_tx: libra_channel::Sender<PerValidatorQueue<BlockRetrievalRequest<T>>>,
+    block_request_tx: libra_channel::Sender<PerValidatorQueue<IncomingBlockRetrievalRequest<T>>>,
     sync_info_tx: libra_channel::Sender<PerValidatorQueue<(SyncInfo, AccountAddress)>>,
     all_events: Box<dyn Stream<Item = failure::Result<Event<ConsensusMsg>>> + Send + Unpin>,
     validators: Arc<ValidatorVerifier>,
@@ -436,30 +389,21 @@ impl<T: Payload> NetworkTask<T> {
     async fn process_request_block(
         &mut self,
         peer_id: AccountAddress,
-        request: RequestBlock,
+        request_msg: RequestBlock,
         callback: oneshot::Sender<Result<Bytes, RpcError>>,
     ) -> failure::Result<()> {
-        let block_id = HashValue::from_slice(&request.block_id[..])?;
-        let num_blocks = request.num_blocks;
-        debug!(
-            "Received request_block RPC for {} blocks from {:?}",
-            num_blocks, block_id
-        );
+        let req = BlockRetrievalRequest::try_from(request_msg)?;
+        debug!("Received block retrieval request {}", req);
         let (tx, rx) = oneshot::channel();
-        let request = BlockRetrievalRequest {
-            block_id,
-            num_blocks,
+        let req_with_callback = IncomingBlockRetrievalRequest {
+            req,
             response_sender: tx,
         };
-        self.block_request_tx.put(peer_id, request);
-        let BlockRetrievalResponse { status, blocks } = rx.await?;
-        let mut response = RespondBlock::default();
-        response.set_status(status);
-        for b in blocks {
-            response.blocks.push(b.try_into()?);
-        }
+        self.block_request_tx.put(peer_id, req_with_callback);
+        let response = rx.await?;
+        let response_serialized = RespondBlock::try_from(response)?;
         let response_msg = ConsensusMsg {
-            message: Some(ConsensusMsg_oneof::RespondBlock(response)),
+            message: Some(ConsensusMsg_oneof::RespondBlock(response_serialized)),
         };
         let response_data = response_msg.to_bytes()?;
         callback

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -23,7 +23,7 @@ use libra_config::config::RoleType;
 use libra_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
 use libra_prost_ext::MessageExt;
 use network::{
-    proto::{Block, ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock, RespondBlock},
+    proto::{ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock, RespondBlock},
     protocols::rpc::error::RpcError,
     validator_network::{
         network_builder::{NetworkBuilder, TransportType},
@@ -329,17 +329,13 @@ async fn request_block(
 }
 
 fn compose_request_block() -> RequestBlock {
-    let mut req = RequestBlock::default();
-    req.block_id = vec![0u8; 32];
-    req
+    RequestBlock::default()
 }
 
 fn compose_respond_block(msg_len: usize) -> ConsensusMsg {
     let mut msg = ConsensusMsg::default();
     let mut res = RespondBlock::default();
-    let mut block = Block::default();
-    block.bytes = vec![0u8; msg_len];
-    res.blocks.push(block);
+    res.bytes = vec![0u8; msg_len];
     msg.message = Some(ConsensusMsg_oneof::RespondBlock(res));
     msg
 }

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -40,22 +40,9 @@ message VoteProposal {
 }
 
 message RequestBlock {
-  // The id of the requested block.
-  bytes block_id = 1;
-  uint64 num_blocks = 2;
-}
-
-enum BlockRetrievalStatus {
-  // Successfully fill in the request.
-  SUCCEEDED = 0;
-  // Can not find the block corresponding to block_id.
-  ID_NOT_FOUND = 1;
-  // Can not find enough blocks but find some.
-  NOT_ENOUGH_BLOCKS = 2;
+  bytes bytes = 1;
 }
 
 message RespondBlock {
-  BlockRetrievalStatus status = 1;
-  // The responded block.
-  repeated Block blocks = 2;
+  bytes bytes = 1;
 }

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -22,8 +22,8 @@ use ::libra_types::proto::types;
 
 pub use self::{
     consensus::{
-        consensus_msg::Message as ConsensusMsg_oneof, Block, BlockRetrievalStatus, ConsensusMsg,
-        Proposal, RequestBlock, RespondBlock, SyncInfo, VoteMsg, VoteProposal,
+        consensus_msg::Message as ConsensusMsg_oneof, Block, ConsensusMsg, Proposal, RequestBlock,
+        RespondBlock, SyncInfo, VoteMsg, VoteProposal,
     },
     mempool::MempoolSyncMsg,
     network::{

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -430,9 +430,7 @@ fn test_consensus_rpc() {
         network_provider.add_consensus(vec![rpc_protocol.clone()]);
     runtime.executor().spawn(network_provider.start());
 
-    let block_id = vec![0_u8; 32];
-    let mut req_block_msg = RequestBlock::default();
-    req_block_msg.block_id = block_id;
+    let req_block_msg = RequestBlock::default();
 
     let res_block_msg = RespondBlock::default();
 


### PR DESCRIPTION
Summary:
BlockRetrieval types used to be scattered across several network-related files.
This change is a noop from the business logic perspective: it just organizes the
BlockRetrieval related types logic in consensus types.

Testing:
unit tests

Issues:
ref #1491