### PR TITLE
[build] Use correct features even when building individually

### DIFF
--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -38,11 +38,11 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 [dev-dependencies]
 rand = "0.6.5"
 channel = { path = "../common/channel", version = "0.1.0" }
-storage-service = { path = "../storage/storage-service", version = "0.1.0", features = ["fuzzing"] }
+storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
 
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing"]
+fuzzing = ["libra-types/fuzzing", "storage-service/fuzzing"]

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -24,7 +24,7 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 rand = "0.6.5"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 executor = { path = "../executor", version = "0.1.0" }
 grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
@@ -33,4 +33,4 @@ transaction-builder = { path = "../language/transaction-builder", version = "0.1
 
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing"]
+fuzzing = ["libra-types/fuzzing", "libra-crypto/fuzzing"]


### PR DESCRIPTION
vm-validator and mempool were both getting built incorrectly when built by
themselves due to feature unification. After searching all the Cargo.tomls for
similar problems, only these two cases were found.