### PR TITLE
[x] Run most of the unit tests first before running integration tests

### DIFF
--- a/x/src/test.rs
+++ b/x/src/test.rs
@@ -58,15 +58,15 @@ pub fn run(args: Args, config: Config) -> Result<()> {
     } else if utils::project_is_root()? {
         // TODO Maybe only run a subest of tests if we're not inside
         // a package but not at the project root (e.g. language)
+        run_cargo_test_with_exclusions(
+            config.package_exceptions().iter().map(|(p, _)| p.as_str()),
+            pass_through_args.clone(),
+        )?;
         run_cargo_test_on_packages_separate(
             config
                 .package_exceptions()
                 .iter()
                 .map(|(p, pkg)| (p.as_str(), pkg)),
-            pass_through_args.clone(),
-        )?;
-        run_cargo_test_with_exclusions(
-            config.package_exceptions().iter().map(|(p, _)| p.as_str()),
             pass_through_args,
         )?;
         Ok(())


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It seems like the current setup runs the integration tests before most of the other unit tests. This makes debugging less intuitive because debugging smaller unit tests is often much easier than debugging integration tests. So just re-order the commands.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

Run `cargo xtest`.

## Related PRs

None.
