### PR TITLE
[cluster-test] Use split_n_random for PacketLoss experiment

### DIFF
--- a/testsuite/cluster-test/src/effects/remove_network_effects.rs
+++ b/testsuite/cluster-test/src/effects/remove_network_effects.rs
@@ -1,7 +1,7 @@
 /// RemoveNetworkEffect deletes all network effects introduced on an instance
 use crate::{effects::Action, instance::Instance};
 use failure;
-use slog_scope::info;
+use slog_scope::debug;
 use std::fmt;
 
 pub struct RemoveNetworkEffects {
@@ -16,7 +16,7 @@ impl RemoveNetworkEffects {
 
 impl Action for RemoveNetworkEffects {
     fn apply(&self) -> failure::Result<()> {
-        info!("RemoveNetworkEffects for {}", self.instance);
+        debug!("RemoveNetworkEffects for {}", self.instance);
         self.instance
             .run_cmd(vec!["sudo tc qdisc delete dev eth0 root; true".to_string()])
     }

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -8,7 +8,6 @@ use crate::{
     instance::Instance,
 };
 use failure;
-use rand::Rng;
 use std::{collections::HashSet, fmt, thread, time::Duration};
 
 pub struct PacketLossRandomValidators {
@@ -19,23 +18,9 @@ pub struct PacketLossRandomValidators {
 
 impl PacketLossRandomValidators {
     pub fn new(count: usize, percent: f32, duration: Duration, cluster: &Cluster) -> Self {
-        if count > cluster.instances().len() {
-            panic!(
-                "count {} should be <= number of instances {}",
-                count,
-                cluster.instances().len()
-            );
-        }
-        let mut instances = Vec::with_capacity(count);
-        let mut all_instances = cluster.instances().clone();
-        let mut rnd = rand::thread_rng();
-        for _i in 0..count {
-            let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));
-            instances.push(instance);
-        }
-
+        let (test_cluster, _) = cluster.split_n_random(count);
         Self {
-            instances,
+            instances: test_cluster.into_instances(),
             percent,
             duration,
         }


### PR DESCRIPTION
## Summary

* `fn split_n_random` provides the functionality of splitting a cluster's instances randomly. Re-using that logic in PacketLoss experiment
* Use debug level instead of info level in `RemoveNetworkEffects`

## Test Plan
 
Ran it on my test cluster

```
[ec2-user:validator@ip-10-0-0-212 ~]$ ~/libra/target/cluster_test_docker_builder/cluster-test --workplace=kush --packet-loss-experiment --packet-loss-percent-instances=50 --packet-loss-percent=20 --packet-loss-duration-secs=10
Oct 29 19:16:29.709 INFO Discovered 4 peers
Oct 29 19:16:29.930 INFO Log tail thread started in 220 ms
Oct 29 19:16:30.193 INFO Starting experiment Packet Loss 20.00% [1e5d5a74(10.0.6.55), ab0d6a54(10.0.10.92), ]
Oct 29 19:16:30.193 INFO PacketLoss 20.00% for 1e5d5a74(10.0.6.55)
Oct 29 19:16:30.585 INFO PacketLoss 20.00% for ab0d6a54(10.0.10.92)
Oct 29 19:17:05.207 INFO Experiment finished, waiting until all affected validators recover
Oct 29 19:17:10.211 INFO Experiment completed
```

Related issue: #1198