### PR TITLE
[cluster-test] Multi region simulation

### DIFF
--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -1,9 +1,11 @@
+mod network_delay;
 mod packet_loss;
 mod reboot;
 mod remove_network_effects;
 mod stop_container;
 
 use failure;
+pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;
 pub use reboot::Reboot;
 pub use remove_network_effects::RemoveNetworkEffects;

--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -1,0 +1,75 @@
+/// NetworkDelay introduces network delay from a given instance to a provided list of instances
+/// If no instances are provided, network delay is introduced on all outgoing packets
+use crate::{effects::Action, instance::Instance};
+use failure;
+use slog_scope::info;
+use std::fmt;
+use std::time::Duration;
+
+pub struct NetworkDelay {
+    instance: Instance,
+    target_instances: Option<Vec<Instance>>,
+    delay: Duration,
+}
+
+impl NetworkDelay {
+    pub fn new(
+        instance: Instance,
+        target_instances: Option<Vec<Instance>>,
+        delay: Duration,
+    ) -> Self {
+        Self {
+            instance,
+            target_instances,
+            delay,
+        }
+    }
+}
+
+impl Action for NetworkDelay {
+    fn apply(&self) -> failure::Result<()> {
+        info!(
+            "NetworkDelay {}ms for {}",
+            self.delay.as_millis(),
+            self.instance
+        );
+        let mut command = "".to_string();
+        if let Some(target_instances) = &self.target_instances {
+            command += "sudo tc qdisc delete dev eth0 root; ";
+            // Create a HTB https://linux.die.net/man/8/tc-htb
+            command += "sudo tc qdisc add dev eth0 root handle 1: htb; ";
+            // Create a class within the HTB https://linux.die.net/man/8/tc
+            command += "sudo tc class add dev eth0 parent 1: classid 1:1 htb rate 1tbit; ";
+            // Create u32 filters so that all the target instances are classified as class 1:1
+            // http://man7.org/linux/man-pages/man8/tc-u32.8.html
+            for target_instance in target_instances {
+                command += format!("sudo tc filter add dev eth0 parent 1: protocol ip prio 1 u32 flowid 1:1 match ip dst {}; ", target_instance.ip()).as_str();
+            }
+            // Use netem to delay packets to this class
+            command += format!(
+                "sudo tc qdisc add dev eth0 parent 1:1 handle 10: netem delay {}ms; ",
+                self.delay.as_millis()
+            )
+            .as_str();
+        } else {
+            // If there are no target instances, add netem to the root qdisc
+            command = format!("sudo tc qdisc delete dev eth0 root; sudo tc qdisc add dev eth0 root netem delay {}ms; ", self.delay.as_millis());
+        }
+        self.instance.run_cmd(vec![command])
+    }
+
+    fn is_complete(&self) -> bool {
+        true
+    }
+}
+
+impl fmt::Display for NetworkDelay {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "NetworkDelay {}ms from {}",
+            self.delay.as_millis(),
+            self.instance
+        )
+    }
+}

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -1,6 +1,8 @@
+mod multi_region_network_simulation;
 mod packet_loss_random_validators;
 mod reboot_random_validator;
 
+pub use multi_region_network_simulation::MultiRegionSimulation;
 pub use packet_loss_random_validators::PacketLossRandomValidators;
 pub use reboot_random_validator::RebootRandomValidators;
 use std::{collections::HashSet, fmt::Display};

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -1,0 +1,99 @@
+/// This module provides an experiment which simulates a multi-region environment.
+/// It undoes the simulation in the cluster after the given duration
+use crate::effects::NetworkDelay;
+use crate::{
+    cluster::Cluster,
+    effects::{Action, RemoveNetworkEffects},
+    experiments::Experiment,
+    instance::Instance,
+    thread_pool_executor::ThreadPoolExecutor,
+};
+use failure;
+use std::{collections::HashSet, fmt, thread, time::Duration};
+
+pub struct MultiRegionSimulation {
+    // Instances in region1
+    region1: Vec<Instance>,
+    // Instances in region2
+    region2: Vec<Instance>,
+    cross_region_delay: Duration,
+    experiment_duration: Duration,
+    thread_pool_executor: ThreadPoolExecutor,
+}
+
+impl MultiRegionSimulation {
+    pub fn new(
+        count: usize,
+        cross_region_delay: Duration,
+        experiment_duration: Duration,
+        cluster: &Cluster,
+        thread_pool_executor: ThreadPoolExecutor,
+    ) -> Self {
+        let (region1, region2) = cluster.split_n_random(count);
+        Self {
+            region1: region1.into_instances(),
+            region2: region2.into_instances(),
+            cross_region_delay,
+            experiment_duration,
+            thread_pool_executor,
+        }
+    }
+}
+
+impl Experiment for MultiRegionSimulation {
+    fn affected_validators(&self) -> HashSet<String> {
+        let mut r = HashSet::new();
+        for instance in self.region1.iter().chain(self.region2.iter()) {
+            r.insert(instance.short_hash().clone());
+        }
+        r
+    }
+
+    fn run(&self) -> failure::Result<()> {
+        let (smaller_region, larger_region);
+        if self.region1.len() < self.region2.len() {
+            smaller_region = &self.region1;
+            larger_region = &self.region2;
+        } else {
+            smaller_region = &self.region2;
+            larger_region = &self.region1;
+        }
+        // Add network delay commands only to the instances of the smaller
+        // region because we have to run fewer ssh commands.
+        let jobs: Vec<_> = smaller_region
+            .iter()
+            .map(|instance| {
+                let instance = instance.clone();
+                let larger_region = larger_region.clone();
+                let cross_region_delay = self.cross_region_delay;
+                move || {
+                    let network_delay = NetworkDelay::new(
+                        instance.clone(),
+                        Some(larger_region.clone()),
+                        cross_region_delay,
+                    );
+                    network_delay.apply()
+                }
+            })
+            .collect();
+        self.thread_pool_executor.execute_jobs(jobs);
+
+        thread::sleep(self.experiment_duration);
+        for instance in smaller_region {
+            let remove_network_effects = RemoveNetworkEffects::new(instance.clone());
+            remove_network_effects.apply()?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for MultiRegionSimulation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Multi Region Simulation with a split of  {}/{}",
+            self.region1.len(),
+            self.region2.len()
+        )
+    }
+}


### PR DESCRIPTION
## Summary

* Create a `NetworkDelay` action which adds network delay to a single instance using `tc`.
* Create a `MultiRegionSimulation` experiment which simulates a two region split among the instances
  * Creates a virtual region1 and region2
  * Adds delay to all packets which go from region1 to region2
  * We dont need to do the vice versa because region1 will be delaying all its responses to region2

* Depends on PR #1560


## Test Plan

* Ran `~/libra/target/cluster_test_docker_builder/cluster-test --workplace=kush --multi-region-simulation --multi-region-split=1 --multi-region-exp-duration-secs=30` on my test cluster.

![image](https://user-images.githubusercontent.com/796949/67817811-2115ce80-fa6c-11e9-8175-19d8c6be48b4.png)
