### PR TITLE
[consensus][reconfig] complete support of epoch change upon receiving ledger info

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -49,9 +49,10 @@ impl<T: PartialEq> Display for Block<T> {
         let nil_marker = if self.is_nil_block() { " (NIL)" } else { "" };
         write!(
             f,
-            "[id: {}{}, round: {:02}, parent_id: {}]",
+            "[id: {}{}, epoch: {}, round: {:02}, parent_id: {}]",
             self.id,
             nil_marker,
+            self.epoch(),
             self.round(),
             self.quorum_cert().certified_block().id(),
         )

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -20,6 +20,7 @@ use libra_types::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 #[cfg(test)]
 #[path = "safety_rules_test.rs"]
@@ -125,12 +126,12 @@ impl ConsensusState {
 pub struct SafetyRules {
     // Keeps the state.
     state: ConsensusState,
-    validator_signer: ValidatorSigner,
+    validator_signer: Arc<ValidatorSigner>,
 }
 
 impl SafetyRules {
     /// Constructs a new instance of SafetyRules given the BlockTree and ConsensusState.
-    pub fn new(state: ConsensusState, validator_signer: ValidatorSigner) -> Self {
+    pub fn new(state: ConsensusState, validator_signer: Arc<ValidatorSigner>) -> Self {
         Self {
             state,
             validator_signer,

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -11,6 +11,7 @@ use libra_types::{
     crypto_proxies::ValidatorSigner,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
 };
+use std::sync::Arc;
 use std::{
     collections::BTreeMap,
     time::{SystemTime, UNIX_EPOCH},
@@ -94,7 +95,10 @@ fn test_initial_state() {
     // Start from scratch, verify the state
     let block = Block::<Round>::make_genesis_block();
 
-    let safety_rules = SafetyRules::new(ConsensusState::default(), ValidatorSigner::from_int(0));
+    let safety_rules = SafetyRules::new(
+        ConsensusState::default(),
+        Arc::new(ValidatorSigner::from_int(0)),
+    );
     let state = safety_rules.consensus_state();
     assert_eq!(state.last_vote_round(), block.round());
     assert_eq!(state.preferred_block_round(), block.round());
@@ -104,7 +108,10 @@ fn test_initial_state() {
 fn test_preferred_block_rule() {
     // Preferred block is the highest 2-chain head.
     let validator_signer = ValidatorSigner::from_int(0);
-    let mut safety_rules = SafetyRules::new(ConsensusState::default(), validator_signer.clone());
+    let mut safety_rules = SafetyRules::new(
+        ConsensusState::default(),
+        Arc::new(validator_signer.clone()),
+    );
 
     // build a tree of the following form:
     //             _____    _____
@@ -172,7 +179,10 @@ fn test_preferred_block_rule() {
 /// Test the potential ledger info that we're going to use in case of voting
 fn test_voting_potential_commit_id() {
     let validator_signer = ValidatorSigner::from_int(0);
-    let mut safety_rules = SafetyRules::new(ConsensusState::default(), validator_signer.clone());
+    let mut safety_rules = SafetyRules::new(
+        ConsensusState::default(),
+        Arc::new(validator_signer.clone()),
+    );
 
     // build a tree of the following form:
     //            _____
@@ -223,7 +233,10 @@ fn test_voting_potential_commit_id() {
 #[test]
 fn test_voting() {
     let validator_signer = ValidatorSigner::from_int(0);
-    let mut safety_rules = SafetyRules::new(ConsensusState::default(), validator_signer.clone());
+    let mut safety_rules = SafetyRules::new(
+        ConsensusState::default(),
+        Arc::new(validator_signer.clone()),
+    );
 
     // build a tree of the following form:
     //             _____    __________
@@ -309,7 +322,10 @@ fn test_voting() {
 #[test]
 fn test_commit_rule_consecutive_rounds() {
     let validator_signer = ValidatorSigner::from_int(0);
-    let safety_rules = SafetyRules::new(ConsensusState::default(), validator_signer.clone());
+    let safety_rules = SafetyRules::new(
+        ConsensusState::default(),
+        Arc::new(validator_signer.clone()),
+    );
 
     // build a tree of the following form:
     //             ___________

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -172,7 +172,7 @@ impl<T: Payload> BlockStore<T> {
             .save_tree(blocks.clone(), quorum_certs.clone())?;
         let pre_sync_instance = Instant::now();
         self.state_computer
-            .sync_to_or_bail(highest_ledger_info.clone());
+            .sync_to_or_bail(highest_ledger_info.ledger_info().clone());
         counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());
         let root = (
             blocks.pop().expect("should have 3-chain"),

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -92,7 +92,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     let consensus_state = initial_data.state();
 
     // TODO: remove
-    let safety_rules = SafetyRules::new(consensus_state, signer.clone());
+    let safety_rules = SafetyRules::new(consensus_state, Arc::new(signer.clone()));
 
     // TODO: mock channels
     let (network_reqs_tx, _network_reqs_rx) = channel::new_test(8);

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -139,6 +139,7 @@ impl NodeSetup {
         let state_computer = Arc::new(MockStateComputer::new(
             commit_cb_sender,
             Arc::clone(&storage),
+            None,
         ));
 
         let block_store = Arc::new(block_on(BlockStore::new(

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -158,7 +158,7 @@ impl NodeSetup {
             1,
         );
 
-        let safety_rules = SafetyRules::new(consensus_state, signer.clone());
+        let safety_rules = SafetyRules::new(consensus_state, Arc::new(signer.clone()));
 
         let pacemaker = Self::create_pacemaker(time_service.clone());
 

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -458,11 +458,12 @@ impl<T: Payload> NetworkTask<T> {
         ledger_info: LedgerInfoWithSignaturesProto,
     ) -> failure::Result<()> {
         let ledger_info = LedgerInfoWithSignatures::try_from(ledger_info)?;
-        ensure!(
-            ledger_info.ledger_info().next_validator_set().is_some(),
-            "Epoch change doesn't carry next validator set"
-        );
         ledger_info.verify(&self.validators)?;
+        let validators = match ledger_info.ledger_info().next_validator_set() {
+            Some(v) => v.into(),
+            None => bail!("Epoch change doesn't carry next validator set"),
+        };
+        self.validators = Arc::new(validators);
         Ok(self.epoch_change_tx.put(peer_id, ledger_info))
     }
 }

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -275,6 +275,14 @@ impl NetworkPlayground {
         }
     }
 
+    pub fn epoch_change_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
+        if let Some(ConsensusMsg_oneof::LedgerInfo(_)) = msg_copy.1.message {
+            true
+        } else {
+            false
+        }
+    }
+
     fn is_message_dropped(&self, src: &Author, net_req: &NetworkRequest) -> bool {
         self.drop_config
             .read()

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -11,22 +11,26 @@ use failure::Result;
 use futures::{channel::mpsc, future, Future, FutureExt};
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
+use libra_types::validator_set::ValidatorSet;
 use std::{pin::Pin, sync::Arc};
 use termion::color::*;
 
 pub struct MockStateComputer {
     commit_callback: mpsc::UnboundedSender<LedgerInfoWithSignatures>,
     consensus_db: Arc<MockStorage<TestPayload>>,
+    reconfig: Option<ValidatorSet>,
 }
 
 impl MockStateComputer {
     pub fn new(
         commit_callback: mpsc::UnboundedSender<LedgerInfoWithSignatures>,
         consensus_db: Arc<MockStorage<TestPayload>>,
+        reconfig: Option<ValidatorSet>,
     ) -> Self {
         MockStateComputer {
             commit_callback,
             consensus_db,
+            reconfig,
         }
     }
 }
@@ -41,7 +45,7 @@ impl StateComputer for MockStateComputer {
         future::ok(ProcessedVMOutput::new(
             vec![],
             ExecutedTrees::new_empty(),
-            None,
+            self.reconfig.clone(),
         ))
         .boxed()
     }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -3,7 +3,6 @@
 
 use crate::{counters, state_replication::StateComputer};
 use consensus_types::block::Block;
-use consensus_types::quorum_cert::QuorumCert;
 use executor::{CommittableBlock, ExecutedTrees, Executor, ProcessedVMOutput};
 use failure::Result;
 use futures::{Future, FutureExt};
@@ -135,11 +134,12 @@ impl StateComputer for ExecutionProxy {
     }
 
     /// Synchronize to a commit that not present locally.
-    fn sync_to(&self, commit: QuorumCert) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
+    fn sync_to(
+        &self,
+        commit: LedgerInfoWithSignatures,
+    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
         counters::STATE_SYNC_COUNT.inc();
-        self.synchronizer
-            .sync_to_deprecated(commit.ledger_info().clone())
-            .boxed()
+        self.synchronizer.sync_to_deprecated(commit).boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::block::Block;
-use consensus_types::quorum_cert::QuorumCert;
 use executor::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
 use failure::Result;
 use futures::Future;
@@ -57,11 +56,14 @@ pub trait StateComputer: Send + Sync {
         finality_proof: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 
-    fn sync_to(&self, commit: QuorumCert) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>>;
+    fn sync_to(
+        &self,
+        commit: LedgerInfoWithSignatures,
+    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>>;
 
     fn committed_trees(&self) -> ExecutedTrees;
 
-    fn sync_to_or_bail(&self, commit: QuorumCert) {
+    fn sync_to_or_bail(&self, commit: LedgerInfoWithSignatures) {
         let status = futures::executor::block_on(self.sync_to(commit));
         match status {
             Ok(true) => (),

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -64,6 +64,11 @@ impl ValidatorPublicKeys {
         &self.consensus_public_key
     }
 
+    /// Returns the voting power for this validator
+    pub fn consensus_voting_power(&self) -> u64 {
+        self.consensus_voting_power
+    }
+
     /// Returns the key for validating signed messages at the network layers
     pub fn network_signing_public_key(&self) -> &Ed25519PublicKey {
         &self.network_signing_public_key

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -3,6 +3,10 @@
 
 use crate::account_address::AccountAddress;
 use failure::Result;
+#[cfg(any(test, feature = "fuzzing"))]
+use libra_crypto::ed25519::compat::generate_keypair as generate_ed25519_keypair;
+#[cfg(any(test, feature = "fuzzing"))]
+use libra_crypto::x25519::compat::generate_keypair as generate_x25519_keypair;
 use libra_crypto::{ed25519::*, traits::ValidKey, x25519::X25519StaticPublicKey};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -44,6 +48,23 @@ impl ValidatorPublicKeys {
         network_signing_public_key: Ed25519PublicKey,
         network_identity_public_key: X25519StaticPublicKey,
     ) -> Self {
+        ValidatorPublicKeys {
+            account_address,
+            consensus_public_key,
+            consensus_voting_power,
+            network_signing_public_key,
+            network_identity_public_key,
+        }
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn new_with_random_network_keys(
+        account_address: AccountAddress,
+        consensus_public_key: Ed25519PublicKey,
+        consensus_voting_power: u64,
+    ) -> Self {
+        let (_, network_signing_public_key) = generate_ed25519_keypair(None);
+        let (_, network_identity_public_key) = generate_x25519_keypair(None);
         ValidatorPublicKeys {
             account_address,
             consensus_public_key,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR completes the processing of an epoch change upon new ledger info:
- change validators in network
- sync to end-epoch ledger info
- start new epoch event processor with derived genesis

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Will add tests in stacked commit, send out for review first.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
