### PR TITLE
[Consensus] Block retrieval of descendants of a committed id

### DIFF
--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::{
-    executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
+    block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert,
+    timeout_certificate::TimeoutCertificate,
 };
 use libra_crypto::HashValue;
 use std::sync::Arc;
@@ -67,4 +68,16 @@ pub trait BlockReader: Send + Sync {
 
     /// Return the highest timeout certificate if available.
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>>;
+
+    /// Retrieve the chain of ancestors starting with the given `block_id`.
+    /// Return the max possible chain up to `num_blocks` (including the starting block).
+    /// The returned vector is empty if the given block id is not found.
+    /// The vector is ordered by round in descending order (starts with the `block_id`).
+    fn get_ancestors(&self, block_id: HashValue, num_blocks: u64) -> Vec<Block<Self::Payload>>;
+
+    /// Retrieve the chain of descendants of a committed block.
+    /// The chain ends with the given block id, and includes the LedgerInfo certifying the commit of
+    /// the target block (max size of chain is constrained by the max message size constraints).
+    /// In case no such chain can be found, an empty vector is returned.
+    fn get_descendants_for_committed_id(&self, block_id: HashValue) -> Vec<Block<Self::Payload>>;
 }

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -8,7 +8,9 @@ use crate::{
     },
     counters,
 };
-use consensus_types::block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus};
+use consensus_types::block_retrieval::{
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalStatus,
+};
 use consensus_types::{
     block::Block,
     common::{Author, Payload},
@@ -249,7 +251,7 @@ impl BlockRetriever {
             let response = self
                 .network
                 .request_block(
-                    BlockRetrievalRequest::new(block_id, num_blocks),
+                    BlockRetrievalRequest::new(block_id, BlockRetrievalMode::Ancestors(num_blocks)),
                     peer,
                     timeout,
                 )

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -87,7 +87,6 @@ impl NetworkSender {
         timeout: Duration,
     ) -> failure::Result<BlockRetrievalResponse<T>> {
         ensure!(from != self.author, "Retrieve block from self");
-        counters::BLOCK_RETRIEVAL_COUNT.inc_by(retrieval_request.num_blocks() as i64);
         let pre_retrieval_instant = Instant::now();
         let req_msg = RequestBlock::try_from(retrieval_request.clone())?;
         let response_msg = self
@@ -96,11 +95,8 @@ impl NetworkSender {
             .await?;
         counters::BLOCK_RETRIEVAL_DURATION_S.observe_duration(pre_retrieval_instant.elapsed());
         let response = BlockRetrievalResponse::<T>::try_from(response_msg)?;
-        response.verify(
-            retrieval_request.block_id(),
-            retrieval_request.num_blocks(),
-            self.validators.as_ref(),
-        )?;
+        response.verify(&retrieval_request, self.validators.as_ref())?;
+        counters::BLOCK_RETRIEVAL_COUNT.inc_by(response.blocks().len() as i64);
         Ok(response)
     }
 

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -320,7 +320,7 @@ impl DropConfig {
 
 use crate::chained_bft::network::NetworkTask;
 use consensus_types::block_retrieval::{
-    BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus,
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus,
 };
 #[cfg(test)]
 use libra_types::crypto_proxies::random_validator_verifier;
@@ -441,7 +441,7 @@ fn test_rpc() {
     block_on(async move {
         let response = nodes[0]
             .request_block(
-                BlockRetrievalRequest::new(genesis.id(), 1),
+                BlockRetrievalRequest::new(genesis.id(), BlockRetrievalMode::Ancestors(1)),
                 peer,
                 Duration::from_secs(5),
             )


### PR DESCRIPTION
Summary:
This diff introduces a new type of block retrieval: retrieval of the descendants of a committed id.
The idea is to return the chain that starts with the highest round, end at a given target id,
and contains a ledger info that proves a commit of a given target id.

We thus introduce two types of BlockRetrievalMode (Ancestors and Descendants).
Most of the business logic is in the BlockTree, which is running DFS in order to find the chain that would fit the request.

Tests:
Added unit tests for the retrieval of the descendants of the committed id both at the leve of BlockTree and EventProcessor.

Ref issue #1491