### PR TITLE
[language] Change binary operator precedence to match Rust

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -240,7 +240,11 @@ fn parse_copyable_val_<'input>(
     Ok(spanned(start_loc, end_loc, val))
 }
 
-// Get the precedence of a binary operator.
+// Get the precedence of a binary operator. The minimum precedence value
+// is 1, and larger values have higher precedence. For tokens that are not
+// binary operators, this returns a value of zero so that they will be
+// below the minimum value and will mark the end of the binary expression
+// for the code in parse_rhs_of_binary_exp.
 fn get_precedence(token: &Tok) -> u32 {
     match token {
         // Reserved minimum precedence value is 1 (specified in parse_exp_)

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -240,34 +240,26 @@ fn parse_copyable_val_<'input>(
     Ok(spanned(start_loc, end_loc, val))
 }
 
-// Exp = BinopExp = CmpOpExp
-// CmpOpExp = (OrExp CmpOp OrExp) || OrExp
-// OrExp = (AndExp OrOp AndExp) || AndExp
-// AndExp = (XorExp AndOp XorExp) || XorExp
-// XorExp = (BinOrExp XorOp BinOrExp) || BinOrExp
-// BinOrExp = (BinAndExp BinOrOp BinAndExp) || BinAndExp
-// BinAndExp = (AddSubExp BinAndOp AddSubExp) || AddSubExp
-// AddSubExp = (FactorExp AddSubOp FactorExp) || FactorExp
-// FactorExp = (UnaryExp FactorOp UnaryExp) || UnaryExp
-
+// Get the precedence of a binary operator.
 fn get_precedence(token: &Tok) -> u32 {
     match token {
-        Tok::EqualEqual => 1,
-        Tok::ExclaimEqual => 1,
-        Tok::Less => 1,
-        Tok::Greater => 1,
-        Tok::LessEqual => 1,
-        Tok::GreaterEqual => 1,
+        // Reserved minimum precedence value is 1 (specified in parse_exp_)
         Tok::PipePipe => 2,
         Tok::AmpAmp => 3,
-        Tok::Caret => 4,
+        Tok::EqualEqual => 4,
+        Tok::ExclaimEqual => 4,
+        Tok::Less => 4,
+        Tok::Greater => 4,
+        Tok::LessEqual => 4,
+        Tok::GreaterEqual => 4,
         Tok::Pipe => 5,
-        Tok::Amp => 6,
-        Tok::Plus => 7,
-        Tok::Minus => 7,
-        Tok::Star => 8,
-        Tok::Slash => 8,
-        Tok::Percent => 8,
+        Tok::Caret => 6,
+        Tok::Amp => 7,
+        Tok::Plus => 8,
+        Tok::Minus => 8,
+        Tok::Star => 9,
+        Tok::Slash => 9,
+        Tok::Percent => 9,
         _ => 0, // anything else is not a binary operator
     }
 }
@@ -276,7 +268,7 @@ fn parse_exp_<'input>(
     tokens: &mut Lexer<'input>,
 ) -> Result<Exp_, ParseError<usize, Token<'input>, failure::Error>> {
     let lhs = parse_unary_exp_(tokens)?;
-    parse_rhs_of_binary_exp(tokens, lhs, get_precedence(&Tok::EqualEqual))
+    parse_rhs_of_binary_exp(tokens, lhs, /* min_prec */ 1)
 }
 
 fn parse_rhs_of_binary_exp<'input>(

--- a/language/functional_tests/tests/testsuite/operators/boolean_operators.mvir
+++ b/language/functional_tests/tests/testsuite/operators/boolean_operators.mvir
@@ -1,6 +1,6 @@
 main() {
-  assert(true && false == false, 99);
-  assert(true || false == true, 100);
+  assert((true && false) == false, 99);
+  assert((true || false) == true, 100);
   assert(!true == false, 101);
   assert(!false == true, 102);
   assert(!!true == true, 103);

--- a/language/functional_tests/tests/testsuite/operators/precedence.mvir
+++ b/language/functional_tests/tests/testsuite/operators/precedence.mvir
@@ -1,0 +1,9 @@
+main() {
+  assert(true || true && false, 99); // "&&" has precedence over "||"
+  assert(true != false && false != true, 100); // "&&" has precedence over comparisons
+  assert(1 | 3 ^ 1 == 3, 101); // binary XOR has precedence over OR
+  assert(2 ^ 3 & 1 == 3, 102); // binary AND has precedence over XOR
+  assert(3 & 3 + 1 == 0, 103); // addition has precedence over binary AND
+  assert(1 + 2 * 3 == 7, 104); // multiplication has precedence over addition
+  return;
+}

--- a/language/stackless-bytecode/generator/tests/stack_elim_tests.rs
+++ b/language/stackless-bytecode/generator/tests/stack_elim_tests.rs
@@ -96,7 +96,7 @@ fn transform_code_with_arithmetic_ops() {
 
             public arithmetic_ops(a: u64, b: u64): u64 * u64 {
                 let c: u64;
-                c = (copy(a) + move(b) - 1) * 2 / 3 % 4 | 5 & 6 ^ 7;
+                c = ((copy(a) + move(b) - 1) * 2 / 3 % 4 | 5 & 6) ^ 7;
                 return move(c), move(a);
             }
         }


### PR DESCRIPTION
Swap the priority of binary XOR and binary OR operators, so that XOR has a higher precedence. Change the precedence of comparison operators to be higher than logical AND/OR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a new functional test for binary operator precedence. I confirmed that all the assertions in that test fail without the code change from this PR.