### PR TITLE
[monitoring] change public metric whitelist to be a constant

### DIFF
--- a/common/metrics/src/json_metrics.rs
+++ b/common/metrics/src/json_metrics.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 pub fn get_json_metrics() -> HashMap<String, String> {
     let mut json_metrics: HashMap<String, String> = HashMap::new();
     json_metrics = add_revision_hash(json_metrics);
-    serde_json::to_string(&json_metrics).unwrap();
     json_metrics
 }
 

--- a/common/metrics/src/public_metrics.rs
+++ b/common/metrics/src/public_metrics.rs
@@ -1,10 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use lazy_static::lazy_static;
-
 // A list of metrics which will be made public to all the partners
-lazy_static! {
-    pub static ref PUBLIC_METRICS: Vec<String> =
-        vec!["libra_network_peers".to_string(), "revision".to_string()];
-}
+pub const PUBLIC_METRICS: &[&str] = &["libra_network_peers", "revision"];


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make the public metric whitelist to be constant so that it can't be changed during runtime.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Start local network and make sure whitelist works as expected
```
[sherryxiao@devvm1881.prn3 ~] curl localhost:33357/metrics
# HELP libra_network_peers Libra network peers counter
# TYPE libra_network_peers gauge
libra_network_peers{role="validator",state="connected"} 3
```
```
[sherryxiao@devvm1881.prn3 ~/libra] curl localhost:43347/json_metrics
{"revision":"995e4df3"}
```
