### PR TITLE
[enhancement] Refactor libra_channel and remove MessageQueue trait

### DIFF
--- a/common/channel/src/message_queues.rs
+++ b/common/channel/src/message_queues.rs
@@ -1,10 +1,9 @@
-use crate::libra_channel::MessageQueue;
 use libra_metrics::IntCounter;
-use libra_types::account_address::AccountAddress;
 use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
 
 /// QueueStyle is an enum which can be used as a configuration option for
-/// PerValidatorQueue. Since the queue per validator is going to be bounded,
+/// PerValidatorQueue. Since the queue per key is going to be bounded,
 /// QueueStyle also determines the policy for dropping messages.
 /// With LIFO, oldest messages are dropped.
 /// With FIFO, newest messages are dropped.
@@ -20,57 +19,57 @@ pub struct Counters {
     pub dequeued_msgs_counter: &'static IntCounter,
 }
 
-/// PerValidatorQueue maintains a queue of messages per validator. It
-/// is a bounded queue per validator and the style (FIFO, LIFO) is
+/// PerKeyQueue maintains a queue of messages per key. It
+/// is a bounded queue of messages per Key and the style (FIFO, LIFO) is
 /// configurable. When a new message is added using `push`, it is added to
-/// the validator's queue.
+/// the key's queue.
 /// When `pop` is called, the next message is picked from one
-/// of the validator's queue and returned. This happens in a round-robin
-/// fashion among validators.
+/// of the key's queue and returned. This happens in a round-robin
+/// fashion among keys.
 /// If there are no messages, in any of the queues, `None` is returned.
-pub struct PerValidatorQueue<T> {
-    /// QueueStyle for the messages stored per validator
+pub(crate) struct PerKeyQueue<K: Eq + Hash + Clone, T> {
+    /// QueueStyle for the messages stored per key
     queue_style: QueueStyle,
-    /// per_validator_queue maintains a map from a Validator to a queue
-    /// of all the messages from that Validator. A Validator is
+    /// per_key_queue maintains a map from a Key to a queue
+    /// of all the messages from that Key. A Key is
     /// represented by AccountAddress
-    per_validator_queue: HashMap<AccountAddress, VecDeque<T>>,
-    /// This is a (round-robin)queue of Validators which have pending messages
+    per_key_queue: HashMap<K, VecDeque<T>>,
+    /// This is a (round-robin)queue of Keys which have pending messages
     /// This queue will be used for performing round robin among
-    /// Validators for choosing the next message
-    round_robin_queue: VecDeque<AccountAddress>,
-    /// Maximum number of messages to store per validator
+    /// Keys for choosing the next message
+    round_robin_queue: VecDeque<K>,
+    /// Maximum number of messages to store per key
     max_queue_size: usize,
     counters: Option<Counters>,
 }
 
-impl<T> PerValidatorQueue<T> {
-    /// Create a new PerValidatorQueue with the provided QueueStyle and
-    /// max_queue_size_per_validator
-    pub fn new(
+impl<K: Eq + Hash + Clone, T> PerKeyQueue<K, T> {
+    /// Create a new PerKeyQueue with the provided QueueStyle and
+    /// max_queue_size_per_key
+    pub(crate) fn new(
         queue_style: QueueStyle,
-        max_queue_size_per_validator: usize,
+        max_queue_size_per_key: usize,
         counters: Option<Counters>,
     ) -> Self {
         assert!(
-            max_queue_size_per_validator > 0,
-            "max_queue_size_per_validator should be > 0"
+            max_queue_size_per_key > 0,
+            "max_queue_size_per_key should be > 0"
         );
         Self {
             queue_style,
-            max_queue_size: max_queue_size_per_validator,
-            per_validator_queue: HashMap::new(),
+            max_queue_size: max_queue_size_per_key,
+            per_key_queue: HashMap::new(),
             round_robin_queue: VecDeque::new(),
             counters,
         }
     }
 
-    /// Given a validator, pops the message from its queue and returns the message
-    /// It also returns a boolean indicating whether the validators queue is empty
+    /// Given a key, pops the message from its queue and returns the message
+    /// It also returns a boolean indicating whether the keys queue is empty
     /// after popping the message
-    fn pop_from_validator_queue(&mut self, validator: AccountAddress) -> (Option<T>, bool) {
-        if let Some(q) = self.per_validator_queue.get_mut(&validator) {
-            // Extract message from the validator's queue
+    fn pop_from_key_queue(&mut self, key: &K) -> (Option<T>, bool) {
+        if let Some(q) = self.per_key_queue.get_mut(key) {
+            // Extract message from the key's queue
             let retval = match self.queue_style {
                 QueueStyle::FIFO => q.pop_front(),
                 QueueStyle::LIFO => q.pop_back(),
@@ -80,29 +79,24 @@ impl<T> PerValidatorQueue<T> {
             (None, true)
         }
     }
-}
 
-impl<T> MessageQueue for PerValidatorQueue<T> {
-    type Key = AccountAddress;
-    type Message = T;
-
-    /// push a message to the appropriate queue in per_validator_queue
-    /// add the validator to round_robin_queue if it didnt already exist
-    fn push(&mut self, key: Self::Key, message: Self::Message) {
+    /// push a message to the appropriate queue in per_key_queue
+    /// add the key to round_robin_queue if it didnt already exist
+    pub(crate) fn push(&mut self, key: K, message: T) {
         if let Some(c) = self.counters.as_ref() {
             c.enqueued_msgs_counter.inc();
         }
         let max_queue_size = self.max_queue_size;
-        let validator_message_queue = self
-            .per_validator_queue
-            .entry(key)
+        let key_message_queue = self
+            .per_key_queue
+            .entry(key.clone())
             .or_insert_with(|| VecDeque::with_capacity(max_queue_size));
-        // Add the validator to our round-robin queue if it's not already there
-        if validator_message_queue.is_empty() {
+        // Add the key to our round-robin queue if it's not already there
+        if key_message_queue.is_empty() {
             self.round_robin_queue.push_back(key);
         }
-        // Push the message to the actual validator message queue
-        if validator_message_queue.len() == max_queue_size {
+        // Push the message to the actual key message queue
+        if key_message_queue.len() == max_queue_size {
             if let Some(c) = self.counters.as_ref() {
                 c.dropped_msgs_counter.inc()
             }
@@ -111,27 +105,27 @@ impl<T> MessageQueue for PerValidatorQueue<T> {
                 QueueStyle::FIFO => (),
                 // Drop the oldest message for LIFO
                 QueueStyle::LIFO => {
-                    validator_message_queue.pop_front();
-                    validator_message_queue.push_back(message);
+                    key_message_queue.pop_front();
+                    key_message_queue.push_back(message);
                 }
             };
         } else {
-            validator_message_queue.push_back(message);
+            key_message_queue.push_back(message);
         }
     }
 
-    /// pop a message from the appropriate queue in per_validator_queue
-    /// remove the validator from the round_robin_queue if it has no more messages
-    fn pop(&mut self) -> Option<Self::Message> {
-        let validator = match self.round_robin_queue.pop_front() {
+    /// pop a message from the appropriate queue in per_key_queue
+    /// remove the key from the round_robin_queue if it has no more messages
+    pub(crate) fn pop(&mut self) -> Option<T> {
+        let key = match self.round_robin_queue.pop_front() {
             Some(v) => v,
             _ => {
                 return None;
             }
         };
-        let (message, is_q_empty) = self.pop_from_validator_queue(validator);
+        let (message, is_q_empty) = self.pop_from_key_queue(&key);
         if !is_q_empty {
-            self.round_robin_queue.push_back(validator);
+            self.round_robin_queue.push_back(key);
         }
         if message.is_some() {
             if let Some(c) = self.counters.as_ref() {

--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -1,5 +1,4 @@
-use crate::libra_channel::MessageQueue;
-use crate::message_queues::{PerValidatorQueue, QueueStyle};
+use crate::message_queues::{PerKeyQueue, QueueStyle};
 use libra_types::account_address::AccountAddress;
 use libra_types::account_address::ADDRESS_LENGTH;
 
@@ -17,7 +16,7 @@ struct VoteMsg {
 
 #[test]
 fn test_fifo() {
-    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3, None);
+    let mut q = PerKeyQueue::new(QueueStyle::FIFO, 3, None);
     let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
 
     // Test order
@@ -76,7 +75,7 @@ fn test_fifo() {
 
 #[test]
 fn test_lifo() {
-    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3, None);
+    let mut q = PerKeyQueue::new(QueueStyle::LIFO, 3, None);
     let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
 
     // Test order
@@ -135,7 +134,7 @@ fn test_lifo() {
 
 #[test]
 fn test_fifo_round_robin() {
-    let mut q = PerValidatorQueue::new(QueueStyle::FIFO, 3, None);
+    let mut q = PerKeyQueue::new(QueueStyle::FIFO, 3, None);
     let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
     let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
     let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
@@ -206,7 +205,7 @@ fn test_fifo_round_robin() {
 
 #[test]
 fn test_lifo_round_robin() {
-    let mut q = PerValidatorQueue::new(QueueStyle::LIFO, 3, None);
+    let mut q = PerKeyQueue::new(QueueStyle::LIFO, 3, None);
     let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
     let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
     let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);


### PR DESCRIPTION
## Summary

* Follow up PR for @phlip9's suggestions in PR #1490
* Rename `PerValidatorQueue` to `PerKeyQueue` because the `Key` is now a generic type
* Remove `MessageQueue` trait and make `PerKeyQueue` a part of `libra_channel`
* Reduce the visibility of `PerKeyQueue` to crate

This depends on PR #1490, so it contains that PRs commit as well.

## Test Plan

* Updated existing unit tests