### PR TITLE
[consensus][reconfig] dispatch network messages based on epoch

### DIFF
--- a/consensus/consensus-types/src/block_info.rs
+++ b/consensus/consensus-types/src/block_info.rs
@@ -83,7 +83,7 @@ impl BlockInfo {
 
     pub fn random(round: Round) -> Self {
         Self {
-            epoch: 0,
+            epoch: 1,
             round,
             id: HashValue::zero(),
             executed_state_id: HashValue::zero(),

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -73,6 +73,10 @@ impl<T: Payload> ProposalUncheckedSignatures<T> {
         // return proposal
         Ok(self.0)
     }
+
+    pub fn epoch(&self) -> u64 {
+        self.0.proposal.epoch()
+    }
 }
 
 impl<T: Payload> ProposalMsg<T> {

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -81,7 +81,7 @@ impl QuorumCert {
         genesis_id: HashValue,
     ) -> QuorumCert {
         let ancestor = BlockInfo::new(
-            ledger_info.epoch(),
+            ledger_info.epoch() + 1,
             0,
             genesis_id,
             ledger_info.transaction_accumulator_hash(),

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -94,6 +94,10 @@ impl SyncInfo {
             .with_context(|e| format!("Fail to verify SyncInfo: {:?}", e))?;
         Ok(())
     }
+
+    pub fn epoch(&self) -> u64 {
+        self.highest_quorum_cert.certified_block().epoch()
+    }
 }
 
 impl TryFrom<network::proto::SyncInfo> for SyncInfo {

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -101,6 +101,11 @@ impl Vote {
         )
     }
 
+    /// Return the epoch of the vote
+    pub fn epoch(&self) -> u64 {
+        self.vote_data.proposed().epoch()
+    }
+
     /// Returns the signature for the vote_data().proposed().round() that can be aggregated for
     /// TimeoutCertificate.
     pub fn timeout_signature(&self) -> Option<&Signature> {

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -22,8 +22,8 @@ impl Display for VoteData {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "VoteData: [block id: {}, round: {:02}, parent_block_id: {}, parent_block_round: {:02}]",
-            self.proposed().id(), self.proposed().round(), self.parent().id(), self.parent().round(),
+            "VoteData: [block id: {}, epoch: {}, round: {:02}, parent_block_id: {}, parent_block_round: {:02}]",
+            self.proposed().id(), self.proposed().epoch(), self.proposed().round(), self.parent().id(), self.parent().round(),
         )
     }
 }

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -44,6 +44,10 @@ impl VoteMsg {
     pub fn sync_info(&self) -> &SyncInfo {
         &self.sync_info
     }
+
+    pub fn epoch(&self) -> u64 {
+        self.vote.epoch()
+    }
 }
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -119,7 +119,7 @@ impl ChainedBftProvider {
         InitialSetup {
             author,
             // TODO: this is placeholder for now, replace with reconfiguration
-            epoch: 0,
+            epoch: 1,
             signer,
             validator,
             network_sender,

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -85,7 +85,7 @@ impl SMRNode {
         let initial_setup = InitialSetup {
             author,
             signer: signer.clone(),
-            epoch: 0,
+            epoch: 1,
             validator: validators.as_ref().clone(),
             network_sender,
             network_events,

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -131,7 +131,7 @@ impl NodeSetup {
             validators.clone(),
         );
         let (task, _receiver) =
-            NetworkTask::<TestPayload>::new(network_events, self_receiver, validators.clone());
+            NetworkTask::<TestPayload>::new(0, network_events, self_receiver, validators.clone());
         executor.spawn(task.start());
         let consensus_state = initial_data.state();
         let last_vote_sent = initial_data.last_vote();

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -354,7 +354,7 @@ fn test_network_api() {
         let (self_sender, self_receiver) = channel::new_test(8);
         let node = NetworkSender::new(*peer, network_sender, self_sender, Arc::clone(&validators));
         let (task, receiver) =
-            NetworkTask::new(network_events, self_receiver, Arc::clone(&validators));
+            NetworkTask::new(1, network_events, self_receiver, Arc::clone(&validators));
         receivers.push(receiver);
         runtime.executor().spawn(task.start());
         nodes.push(node);
@@ -421,7 +421,7 @@ fn test_rpc() {
             Arc::clone(&validators),
         );
         let (task, receiver) =
-            NetworkTask::new(network_events, self_receiver, Arc::clone(&validators));
+            NetworkTask::new(1, network_events, self_receiver, Arc::clone(&validators));
         senders.push(network_sender);
         receivers.push(receiver);
         runtime.executor().spawn(task.start());


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

With this PR, we only dispatch the same epoch message to EventProcessor and discard previous epoch messages and notify about future epoch.

Next step we'll request for EpochChange for the future epoch and verify/start new epoch based on that!

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
