### PR TITLE
[Consensus] Highest ledger info processing using the new state sync flow

### DIFF
--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -49,7 +49,7 @@ impl fmt::Display for BlockRetrievalRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "[BlockRetrievalRequest starting from id {}, retrieval mode {:?}]",
+            "[BlockRetrievalRequest for id {}, retrieval mode {:?}]",
             self.block_id, self.retrieval_mode
         )
     }

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -405,48 +405,6 @@ fn test_need_fetch_for_qc() {
 }
 
 #[test]
-fn test_need_sync_for_qc() {
-    let mut inserter = TreeInserter::default();
-    let block_store = inserter.block_store();
-
-    // build a tree of the following form
-    // genesis <- a1 <- a2 <- a3
-    let genesis = block_store.root();
-    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
-    let a2 = inserter.insert_block(&a1, 2, None);
-    let a3 = inserter.insert_block(&a2, 3, None);
-    block_store.prune_tree(a3.id());
-    let qc = placeholder_certificate_for_block(
-        vec![inserter.signer()],
-        HashValue::zero(),
-        a3.round() + 3,
-        HashValue::zero(),
-        a3.round() + 2,
-        None,
-    );
-    assert_eq!(
-        block_store.need_sync_for_quorum_cert(HashValue::zero(), &qc),
-        true
-    );
-    let qc = placeholder_certificate_for_block(
-        vec![inserter.signer()],
-        HashValue::zero(),
-        a3.round() + 2,
-        HashValue::zero(),
-        a3.round() + 1,
-        None,
-    );
-    assert_eq!(
-        block_store.need_sync_for_quorum_cert(HashValue::zero(), &qc),
-        false,
-    );
-    assert_eq!(
-        block_store.need_sync_for_quorum_cert(genesis.id(), &QuorumCert::certificate_for_genesis()),
-        false
-    );
-}
-
-#[test]
 fn test_empty_reconfiguration_suffix() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::{
-    executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
+    block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert,
+    timeout_certificate::TimeoutCertificate,
 };
 use libra_crypto::HashValue;
 use std::sync::Arc;
@@ -67,4 +68,16 @@ pub trait BlockReader: Send + Sync {
 
     /// Return the highest timeout certificate if available.
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>>;
+
+    /// Retrieve the chain of ancestors starting with the given `block_id`.
+    /// Return the max possible chain up to `num_blocks` (including the starting block).
+    /// The returned vector is empty if the given block id is not found.
+    /// The vector is ordered by round in descending order (starts with the `block_id`).
+    fn get_ancestors(&self, block_id: HashValue, num_blocks: u64) -> Vec<Block<Self::Payload>>;
+
+    /// Retrieve the chain of descendants of a committed block.
+    /// The chain ends with the given block id, and includes the LedgerInfo certifying the commit of
+    /// the target block (max size of chain is constrained by the max message size constraints).
+    /// In case no such chain can be found, an empty vector is returned.
+    fn get_descendants_for_committed_id(&self, block_id: HashValue) -> Vec<Block<Self::Payload>>;
 }

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -8,7 +8,9 @@ use crate::{
     },
     counters,
 };
-use consensus_types::block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus};
+use consensus_types::block_retrieval::{
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalStatus,
+};
 use consensus_types::{
     block::Block,
     common::{Author, Payload},
@@ -249,7 +251,7 @@ impl BlockRetriever {
             let response = self
                 .network
                 .request_block(
-                    BlockRetrievalRequest::new(block_id, num_blocks),
+                    BlockRetrievalRequest::new(block_id, BlockRetrievalMode::Ancestors(num_blocks)),
                     peer,
                     timeout,
                 )

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -164,7 +164,8 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
         // Step 1
         if initial_data.need_sync() {
             // make sure we sync to the root state in case we're not
-            state_computer.sync_to_or_bail(initial_data.root_ledger_info().ledger_info().clone());
+            state_computer
+                .sync_to_or_bail_deprecated(initial_data.root_ledger_info().ledger_info().clone());
         }
 
         // Step 2 TODO: read validators from libradb instead of config

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -112,7 +112,8 @@ impl<T: Payload> EpochManager<T> {
 
     pub fn start_new_epoch(&self, ledger_info: LedgerInfoWithSignatures) -> EventProcessor<T> {
         // make sure storage is on this ledger_info too, it should be no-op if it's already committed
-        self.state_computer.sync_to_or_bail(ledger_info.clone());
+        self.state_computer
+            .sync_to_or_bail_deprecated(ledger_info.clone());
         let validators = ledger_info
             .ledger_info()
             .next_validator_set()

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -287,21 +287,6 @@ impl<T: Payload> EventProcessor<T> {
 
         if current_hqc_round < sync_info.hqc_round() {
             let deadline = self.pacemaker.current_round_deadline();
-            let now = Instant::now();
-            let deadline_repr = if deadline.gt(&now) {
-                deadline
-                    .checked_duration_since(now)
-                    .map_or("0 ms".to_string(), |v| format!("{:?}", v))
-            } else {
-                now.checked_duration_since(deadline)
-                    .map_or("0 ms".to_string(), |v| format!("Already late by {:?}", v))
-            };
-            debug!(
-                "Starting sync: current_hqc_round = {}, sync_info_hqc_round = {}, deadline = {:?}",
-                current_hqc_round,
-                sync_info.hqc_round(),
-                deadline_repr,
-            );
             self.block_store
                 .sync_to(&sync_info, self.create_block_retriever(deadline, author))
                 .await
@@ -313,7 +298,6 @@ impl<T: Payload> EventProcessor<T> {
                     );
                     e
                 })?;
-            debug!("Caught up to HQC at round {}", sync_info.hqc_round());
         }
         // Update the block store and potentially start a new round.
         self.process_certificates(

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -38,7 +38,9 @@ use mirai_annotations::{
 };
 
 use crate::chained_bft::network::IncomingBlockRetrievalRequest;
-use consensus_types::block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus};
+use consensus_types::block_retrieval::{
+    BlockRetrievalMode, BlockRetrievalResponse, BlockRetrievalStatus,
+};
 #[cfg(test)]
 use safety_rules::ConsensusState;
 use safety_rules::SafetyRules;
@@ -777,22 +779,33 @@ impl<T: Payload> EventProcessor<T> {
     /// The current version of the function is not really async, but keeping it this way for
     /// future possible changes.
     pub async fn process_block_retrieval(&self, request: IncomingBlockRetrievalRequest<T>) {
-        let mut blocks = vec![];
         let mut status = BlockRetrievalStatus::Succeeded;
-        let mut id = request.req.block_id();
-        while (blocks.len() as u64) < request.req.num_blocks() {
-            if let Some(executed_block) = self.block_store.get_block(id) {
-                id = executed_block.parent_id();
-                blocks.push(executed_block.block().clone());
-            } else {
-                status = BlockRetrievalStatus::NotEnoughBlocks;
-                break;
+        let blocks = match request.req.retrieval_mode() {
+            BlockRetrievalMode::Ancestors(num_blocks) => {
+                let blocks = self
+                    .block_store
+                    .get_ancestors(request.req.block_id(), num_blocks);
+                if blocks.is_empty() {
+                    status = BlockRetrievalStatus::IdNotFound;
+                } else if (blocks.len() as u64) < num_blocks {
+                    status = BlockRetrievalStatus::NotEnoughBlocks;
+                }
+                blocks
             }
-        }
-
-        if blocks.is_empty() {
-            status = BlockRetrievalStatus::IdNotFound;
-        }
+            BlockRetrievalMode::Descendants => {
+                let blocks = self
+                    .block_store
+                    .get_descendants_for_committed_id(request.req.block_id());
+                // In case of success the last block should have the target id.
+                if !blocks
+                    .last()
+                    .map_or(false, |b| b.id() == request.req.block_id())
+                {
+                    status = BlockRetrievalStatus::IdNotFound;
+                }
+                blocks
+            }
+        };
 
         if let Err(e) = request
             .response_sender

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -23,7 +23,9 @@ use crate::{
     util::time_service::{ClockTimeService, TimeService},
 };
 use channel;
-use consensus_types::block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus};
+use consensus_types::block_retrieval::{
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalStatus,
+};
 use consensus_types::{
     block::{
         block_test_utils::{placeholder_certificate_for_block, placeholder_ledger_info},
@@ -689,8 +691,9 @@ fn process_block_retrieval() {
 
         // first verify that we can retrieve the block if it's in the tree
         let (tx1, rx1) = oneshot::channel();
+        let req = BlockRetrievalRequest::new(block_id, BlockRetrievalMode::Ancestors(1));
         let single_block_request = IncomingBlockRetrievalRequest {
-            req: BlockRetrievalRequest::new(block_id, 1),
+            req: req.clone(),
             response_sender: tx1,
         };
         node.event_processor
@@ -698,6 +701,7 @@ fn process_block_retrieval() {
             .await;
         match rx1.await {
             Ok(response) => {
+                assert!(response.verify(&req, &node.validators).is_ok());
                 assert_eq!(response.status(), BlockRetrievalStatus::Succeeded);
                 assert_eq!(response.blocks().get(0).unwrap().id(), block_id);
             }
@@ -707,7 +711,7 @@ fn process_block_retrieval() {
         // verify that if a block is not there, return ID_NOT_FOUND
         let (tx2, rx2) = oneshot::channel();
         let missing_block_request = IncomingBlockRetrievalRequest {
-            req: BlockRetrievalRequest::new(HashValue::random(), 1),
+            req: BlockRetrievalRequest::new(HashValue::random(), BlockRetrievalMode::Ancestors(1)),
             response_sender: tx2,
         };
 
@@ -725,7 +729,7 @@ fn process_block_retrieval() {
         // if asked for many blocks, return NOT_ENOUGH_BLOCKS
         let (tx3, rx3) = oneshot::channel();
         let many_block_request = IncomingBlockRetrievalRequest {
-            req: BlockRetrievalRequest::new(block_id, 3),
+            req: BlockRetrievalRequest::new(block_id, BlockRetrievalMode::Ancestors(3)),
             response_sender: tx3,
         };
         node.event_processor
@@ -739,6 +743,66 @@ fn process_block_retrieval() {
                     node.block_store.root().id(),
                     response.blocks().get(1).unwrap().id()
                 );
+            }
+            _ => panic!("block retrieval failure"),
+        }
+    });
+}
+
+#[test]
+fn process_block_retrieval_descendants() {
+    let runtime = consensus_runtime();
+    let mut playground = NetworkPlayground::new(runtime.executor());
+    let node = NodeSetup::create_nodes(&mut playground, runtime.executor(), 1)
+        .pop()
+        .unwrap();
+
+    let genesis = node.block_store.root();
+    let mut inserter = TreeInserter::new_with_store(node.signer.clone(), node.block_store.clone());
+    let a1 = inserter.insert_block_with_qc(QuorumCert::certificate_for_genesis(), &genesis, 1);
+    let a2 = inserter.insert_block(&a1, 2, None);
+    let a3 = inserter.insert_block(&a2, 3, None);
+    let a4 = inserter.insert_block(&a3, 4, Some(a1.id()));
+
+    block_on(async move {
+        // Verify we can retrieve the descendants of a1
+        let (tx1, rx1) = oneshot::channel();
+        let req = BlockRetrievalRequest::new(a1.id(), BlockRetrievalMode::Descendants);
+        let incoming_request = IncomingBlockRetrievalRequest {
+            req: req.clone(),
+            response_sender: tx1,
+        };
+        node.event_processor
+            .process_block_retrieval(incoming_request)
+            .await;
+        match rx1.await {
+            Ok(response) => {
+                assert!(response.verify(&req, &node.validators).is_ok());
+                assert_eq!(response.status(), BlockRetrievalStatus::Succeeded);
+                let block_ids = response
+                    .blocks()
+                    .iter()
+                    .map(|b| b.id())
+                    .collect::<Vec<HashValue>>();
+                assert_eq!(block_ids, vec![a4.id(), a3.id(), a2.id(), a1.id()]);
+            }
+            _ => panic!("block retrieval failure"),
+        }
+
+        // Verify we cannot retrieve descendants of a2
+        let (tx2, rx2) = oneshot::channel();
+        let req2 = BlockRetrievalRequest::new(a2.id(), BlockRetrievalMode::Descendants);
+        let incoming_request2 = IncomingBlockRetrievalRequest {
+            req: req2.clone(),
+            response_sender: tx2,
+        };
+        node.event_processor
+            .process_block_retrieval(incoming_request2)
+            .await;
+        match rx2.await {
+            Ok(response) => {
+                assert!(response.verify(&req2, &node.validators).is_ok());
+                assert_eq!(response.status(), BlockRetrievalStatus::IdNotFound);
             }
             _ => panic!("block retrieval failure"),
         }

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -328,7 +328,7 @@ impl DropConfig {
 
 use crate::chained_bft::network::NetworkTask;
 use consensus_types::block_retrieval::{
-    BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus,
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus,
 };
 #[cfg(test)]
 use libra_types::crypto_proxies::random_validator_verifier;
@@ -449,7 +449,7 @@ fn test_rpc() {
     block_on(async move {
         let response = nodes[0]
             .request_block(
-                BlockRetrievalRequest::new(genesis.id(), 1),
+                BlockRetrievalRequest::new(genesis.id(), BlockRetrievalMode::Ancestors(1)),
                 peer,
                 Duration::from_secs(5),
             )

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -64,7 +64,7 @@ impl StateComputer for MockStateComputer {
         future::ok(()).boxed()
     }
 
-    fn sync_to(
+    fn sync_to_deprecated(
         &self,
         commit: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
@@ -80,6 +80,16 @@ impl StateComputer for MockStateComputer {
             .unbounded_send(commit.clone())
             .expect("Fail to notify about sync");
         async { Ok(true) }.boxed()
+    }
+
+    fn state_sync(
+        &self,
+        _target: LedgerInfoWithSignatures,
+    ) -> Pin<Box<dyn Future<Output = Result<LedgerInfoWithSignatures>> + Send>> {
+        async {
+            bail!("Unimplemented!");
+        }
+            .boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {
@@ -112,11 +122,21 @@ impl StateComputer for EmptyStateComputer {
         future::ok(()).boxed()
     }
 
-    fn sync_to(
+    fn sync_to_deprecated(
         &self,
         _commit: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
         async { Ok(true) }.boxed()
+    }
+
+    fn state_sync(
+        &self,
+        _target: LedgerInfoWithSignatures,
+    ) -> Pin<Box<dyn Future<Output = Result<LedgerInfoWithSignatures>> + Send>> {
+        async {
+            bail!("Unimplemented!");
+        }
+            .boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -134,12 +134,20 @@ impl StateComputer for ExecutionProxy {
     }
 
     /// Synchronize to a commit that not present locally.
-    fn sync_to(
+    fn sync_to_deprecated(
         &self,
         commit: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
         counters::STATE_SYNC_COUNT.inc();
         self.synchronizer.sync_to_deprecated(commit).boxed()
+    }
+
+    fn state_sync(
+        &self,
+        target: LedgerInfoWithSignatures,
+    ) -> Pin<Box<dyn Future<Output = Result<LedgerInfoWithSignatures>> + Send>> {
+        counters::STATE_SYNC_COUNT.inc();
+        self.synchronizer.sync_to(target).boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -95,7 +95,11 @@ impl StateSyncClient {
         }
     }
 
-    /// Sync validator's state to target
+    /// StateSynchronizer retrieves the committed transactions from the peers determined by the
+    /// target LedgerInfo. The function returns only when the local version is >= target version.
+    /// The returned LedgerInfo corresponds to the latest ledger info in storage.
+    /// StateSynchronizer maintains an invariant that the returned LedgerInfo matches the
+    /// local accumulator: i.e., the latest version in the accumulator == ledger_info.version.
     pub fn sync_to(
         &self,
         target: LedgerInfoWithSignatures,


### PR DESCRIPTION
 Summary:
In the new state sync flow we're first trying to state sync to the given target or higher,
then retrieve the ancestors of the new root and rebuild the tree.
In this change we are not using the flow yet but introduce the first pieces.
There is no proper testing and there is no proper persistency.
    
Testing:
The new feature is not in use yet, tests to be added at the level of SMR.

Issues: ref #1491