### PR TITLE
[Proof] Introduce SparseMerkleRangeProof

### DIFF
--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -186,6 +186,24 @@ impl HashValue {
         HashValueBitIterator::new(self)
     }
 
+    /// Constructs a `HashValue` from an iterator of bits.
+    pub fn from_bit_iter(iter: impl ExactSizeIterator<Item = bool>) -> Result<Self> {
+        ensure!(
+            iter.len() == Self::LENGTH_IN_BITS,
+            "The iterator should yield exactly {} bits. Actual number of bits: {}.",
+            Self::LENGTH_IN_BITS,
+            iter.len(),
+        );
+
+        let mut buf = [0; Self::LENGTH];
+        for (i, bit) in iter.enumerate() {
+            if bit {
+                buf[i / 8] |= 1 << (7 - i % 8);
+            }
+        }
+        Ok(Self::new(buf))
+    }
+
     /// Returns the length of common prefix of `self` and `other` in bits.
     pub fn common_prefix_bits_len(&self, other: HashValue) -> usize {
         self.iter_bits()

--- a/crypto/crypto/src/unit_tests/hash_test.rs
+++ b/crypto/crypto/src/unit_tests/hash_test.rs
@@ -253,4 +253,16 @@ proptest! {
         let hash2 = HashValue::from_slice(&bytes).unwrap();
         prop_assert_eq!(hash, hash2);
     }
+
+    #[test]
+    fn test_hashvalue_from_bit_iter(hash in any::<HashValue>()) {
+        let hash2 = HashValue::from_bit_iter(hash.iter_bits()).unwrap();
+        prop_assert_eq!(hash, hash2);
+
+        let bits1 = vec![false; HashValue::LENGTH_IN_BITS - 10];
+        prop_assert!(HashValue::from_bit_iter(bits1.into_iter()).is_err());
+
+        let bits2 = vec![false; HashValue::LENGTH_IN_BITS + 10];
+        prop_assert!(HashValue::from_bit_iter(bits2.into_iter()).is_err());
+    }
 }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -624,6 +624,44 @@ pub type TransactionAccumulatorRangeProof = AccumulatorRangeProof<TransactionAcc
 #[cfg(any(test, feature = "fuzzing"))]
 pub type TestAccumulatorRangeProof = AccumulatorRangeProof<TestOnlyHasher>;
 
+/// A proof that but can be used authenticate a range of consecutive leaves, from the leftmost leaf
+/// to a certain one, in a sparse Merkle tree. For example, given the following sparse Merkle tree:
+///
+/// ```text
+///                   root
+///                  /     \
+///                 /       \
+///                /         \
+///               o           o
+///              / \         / \
+///             a   o       o   h
+///                / \     / \
+///               o   d   e   X
+///              / \         / \
+///             b   c       f   g
+/// ```
+///
+/// if the proof wants show that `[a, b, c, d, e]` exists in the tree, it would need the siblings
+/// `X` and `h` on the right.
+#[derive(Debug)]
+pub struct SparseMerkleRangeProof {
+    /// The vector of siblings. The ones near the bottom are at the beginning of the vector. In the
+    /// above example, it's `[X, h]`.
+    siblings: Vec<HashValue>,
+}
+
+impl SparseMerkleRangeProof {
+    /// Constructs a new `SparseMerkleRangeProof`.
+    pub fn new(siblings: Vec<HashValue>) -> Self {
+        Self { siblings }
+    }
+
+    /// Returns the siblings.
+    pub fn siblings(&self) -> &[HashValue] {
+        &self.siblings
+    }
+}
+
 /// The complete proof used to authenticate a `Transaction` object.  This structure consists of an
 /// `AccumulatorProof` from `LedgerInfo` to `TransactionInfo` the verifier needs to verify the
 /// correctness of the `TransactionInfo` object, and the `TransactionInfo` object that is supposed

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -624,8 +624,8 @@ pub type TransactionAccumulatorRangeProof = AccumulatorRangeProof<TransactionAcc
 #[cfg(any(test, feature = "fuzzing"))]
 pub type TestAccumulatorRangeProof = AccumulatorRangeProof<TestOnlyHasher>;
 
-/// A proof that but can be used authenticate a range of consecutive leaves, from the leftmost leaf
-/// to a certain one, in a sparse Merkle tree. For example, given the following sparse Merkle tree:
+/// A proof that can be used authenticate a range of consecutive leaves, from the leftmost leaf to
+/// a certain one, in a sparse Merkle tree. For example, given the following sparse Merkle tree:
 ///
 /// ```text
 ///                   root

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -27,8 +27,9 @@ use std::marker::PhantomData;
 
 pub use self::definition::{
     AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, AccumulatorRangeProof,
-    EventAccumulatorProof, EventProof, SparseMerkleProof, TransactionAccumulatorProof,
-    TransactionAccumulatorRangeProof, TransactionListProof, TransactionProof,
+    EventAccumulatorProof, EventProof, SparseMerkleProof, SparseMerkleRangeProof,
+    TransactionAccumulatorProof, TransactionAccumulatorRangeProof, TransactionListProof,
+    TransactionProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This proof intends to prove that a range of things exist in a sparse Merkle tree. Given that when restoring the state tree, we always go from left to right, so at any point in time a list of siblings on the right is sufficient to prove the everything on the left.

The verification is a bit complex... The basic idea is that when we have the full list of leaves for a sparse Merkle tree, we can compute the common prefix length of each adjacent key pairs and find out which pair consists of the left child and right child of the same parent. Then we can compute their parent and reduce the problem. Note that we are just doing this in unit tests to test the `get_range_proof` method, the real verification will be a little bit different.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

CI.

## Related PRs

None.