### PR TITLE
[x] skip running cargo if we have no packages to run

### DIFF
--- a/x/src/cargo.rs
+++ b/x/src/cargo.rs
@@ -136,9 +136,14 @@ impl<'a> CargoCommand<'a> {
 
     pub fn run_on_packages_together<I, S>(&self, packages: I, args: &CargoArgs) -> Result<()>
     where
-        I: IntoIterator<Item = S>,
+        I: IntoIterator<Item = S> + Clone,
         S: AsRef<OsStr>,
     {
+        // Early return if we have no packages to run
+        if packages.clone().into_iter().count() == 0 {
+            return Ok(());
+        }
+
         let mut cargo = Cargo::new(self.as_str());
         Self::apply_args(&mut cargo, args);
         cargo


### PR DESCRIPTION
Currently if an empty iterator is passed to `run_on_packages_together`,
we'll happily run the cargo command with no `--package` args. This patch
fixes this behavior and instead checks to see if we have any package
args and does an early return if the provided iterator is empty.