### PR TITLE
[docker] Move docker CMD into docker-run.sh

### DIFF
--- a/docker/validator/docker-run.sh
+++ b/docker/validator/docker-run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -ex
+
+cd /opt/libra/etc
+echo "$NODE_CONFIG" > node.config.toml
+echo "$SEED_PEERS" > seed_peers.config.toml
+echo "$NETWORK_KEYPAIRS" > network_keypairs.config.toml
+echo "$CONSENSUS_KEYPAIR" > consensus_keypair.config.toml
+echo "$FULLNODE_KEYPAIRS" > fullnode_keypairs.config.toml
+exec /opt/libra/bin/libra-node -f node.config.toml

--- a/docker/validator/validator.Dockerfile
+++ b/docker/validator/validator.Dockerfile
@@ -42,13 +42,8 @@ EXPOSE 9101
 ENV RUST_BACKTRACE 1
 
 # Define SEED_PEERS, NODE_CONFIG, NETWORK_KEYPAIRS, CONSENSUS_KEYPAIR, GENESIS_BLOB and PEER_ID environment variables when running
-CMD cd /opt/libra/etc \
-    && echo "$NODE_CONFIG" > node.config.toml \
-    && echo "$SEED_PEERS" > seed_peers.config.toml \
-    && echo "$NETWORK_KEYPAIRS" > network_keypairs.config.toml \
-    && echo "$CONSENSUS_KEYPAIR" > consensus_keypair.config.toml \
-    && echo "$FULLNODE_KEYPAIRS" > fullnode_keypairs.config.toml \
-    && exec /opt/libra/bin/libra-node -f node.config.toml
+COPY docker/validator/docker-run.sh /
+CMD /docker-run.sh
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE


### PR DESCRIPTION
Instead of having complicated command in docker CMD, this diff moves setting up environment into `docker-run.sh` file and sets CMD to this shell file.

*Test plan:*
Building docker image and will try it on my workplace (doing this now, if diff looks good please use delegate+, not r+)