### PR TITLE
[terraform] Allow to redirect output to a file

### DIFF
--- a/terraform/fullnodes.tf
+++ b/terraform/fullnodes.tf
@@ -96,6 +96,7 @@ data "template_file" "fullnode_ecs_task_definition" {
     log_region       = var.region
     log_prefix       = "fullnode-${substr(var.fullnode_ids[count.index], 0, 8)}"
     capabilities     = jsonencode(var.validator_linux_capabilities)
+    command          = local.validator_command
   }
 }
 

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -3,6 +3,9 @@
         "name": "validator",
         "image": "${image}${image_version}",
         "cpu": ${cpu},
+        %{ if command != "" }
+            "command": ${command},
+        %{ endif }
         "memory": ${mem},
         "essential": true,
         "portMappings": [

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -251,6 +251,16 @@ data "template_file" "seed_peers" {
   }
 }
 
+variable "log_to_file" {
+  type        = bool
+  default     = false
+  description = "Set to true to log to /opt/libra/data/libra.log (in container) and /data/libra/libra.log (on host). This file won't be log rotated, you need to handle log rotation on your own if you choose this option"
+}
+
+locals {
+  validator_command = var.log_to_file ? jsonencode(["bash", "-c", "/docker-run.sh >> /opt/libra/data/libra.log 2>&1"]) : ""
+}
+
 data "template_file" "ecs_task_definition" {
   count    = length(var.peer_ids)
   template = file("templates/validator.json")
@@ -272,6 +282,7 @@ data "template_file" "ecs_task_definition" {
     log_region       = var.region
     log_prefix       = "validator-${substr(var.peer_ids[count.index], 0, 8)}"
     capabilities     = jsonencode(var.validator_linux_capabilities)
+    command          = local.validator_command
   }
 }
 


### PR DESCRIPTION
This diff introduces log_to_file variable, when set to true log output will be redirected to  /opt/libra/data/libra.log (in container) and /data/libra/libra.log (on host)

Tested that with `-var "log_to_file=true"` log is printed to a file on host, and without this var `docker log` still works as it should
Also checked that with `log_to_file=true` iostat on host is still at 0% disk util