### PR TITLE
[cluster-test] Log rotate libra.log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ name = "cluster-test"
 version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug-interface 0.1.0",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "generate-keypair 0.1.0",

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0"
 termion = "1.5.3"
 serde = { version = "1.0.89", features = ["derive"] }
 structopt = "0.3.2"
+chrono = { version = "0.4.7" }
 
 slog = { version = "2.5.0", features = ["max_level_debug", "release_max_level_debug"] }
 slog-term = "2.4.1"


### PR DESCRIPTION
This diff uses log file created in https://github.com/libra/libra/pull/1584 and rotates this log on every deploy
Why do log rotation on deploy? Since we wipe db here, we pretty much start from "clean plate", so logs can be invalidated at this point

Depends on https://github.com/libra/libra/pull/1584, please do not use `r+`, use `delegate+` instead