### PR TITLE
[reconfig] refactor ValidatorChangeEventWithProof

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -33,7 +33,6 @@ use libra_config::config::ConsensusProposerType::{
 use libra_types::crypto_proxies::{
     random_validator_verifier, LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
 };
-use libra_types::validator_public_keys::ValidatorPublicKeys;
 use libra_types::validator_set::ValidatorSet;
 use std::time::Duration;
 use tokio::runtime;
@@ -151,18 +150,7 @@ impl SMRNode {
         let (mut signers, validator_verifier) =
             random_validator_verifier(num_nodes, Some(quorum_voting_power), true);
         let validator_set = if executor_with_reconfig {
-            let addr = validator_verifier.get_ordered_account_addresses();
-            Some(ValidatorSet::new(
-                addr.into_iter()
-                    .map(|addr| {
-                        ValidatorPublicKeys::new_with_random_network_keys(
-                            addr,
-                            validator_verifier.get_public_key(&addr).unwrap(),
-                            validator_verifier.get_voting_power(&addr).unwrap(),
-                        )
-                    })
-                    .collect(),
-            ))
+            Some((&validator_verifier).into())
         } else {
             None
         };

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -455,7 +455,7 @@ impl LibraDB {
     ) -> Result<(
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        ValidatorChangeEventWithProof,
         AccumulatorConsistencyProof,
     )> {
         error_if_too_many_requested(request_items.len() as u64, MAX_REQUEST_ITEMS)?;
@@ -543,7 +543,7 @@ impl LibraDB {
         Ok((
             response_items,
             ledger_info_with_sigs,
-            vec![], /* TODO: validator_change_events */
+            ValidatorChangeEventWithProof::new(vec![]),
             ledger_consistency_proof,
         ))
     }

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -98,7 +98,7 @@ impl StorageRead for StorageReadServiceClient {
     ) -> Result<(
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        ValidatorChangeEventWithProof,
         AccumulatorConsistencyProof,
     )> {
         block_on(self.update_to_latest_ledger_async(client_known_version, requested_items))
@@ -114,7 +114,7 @@ impl StorageRead for StorageReadServiceClient {
                     Output = Result<(
                         Vec<ResponseItem>,
                         LedgerInfoWithSignatures,
-                        Vec<ValidatorChangeEventWithProof>,
+                        ValidatorChangeEventWithProof,
                         AccumulatorConsistencyProof,
                     )>,
                 > + Send,
@@ -299,7 +299,7 @@ pub trait StorageRead: Send + Sync {
     ) -> Result<(
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        ValidatorChangeEventWithProof,
         AccumulatorConsistencyProof,
     )>;
 
@@ -317,7 +317,7 @@ pub trait StorageRead: Send + Sync {
                     Output = Result<(
                         Vec<ResponseItem>,
                         LedgerInfoWithSignatures,
-                        Vec<ValidatorChangeEventWithProof>,
+                        ValidatorChangeEventWithProof,
                         AccumulatorConsistencyProof,
                     )>,
                 > + Send,

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -48,7 +48,7 @@ impl StorageRead for MockStorageReadClient {
     ) -> Result<(
         Vec<ResponseItem>,
         LedgerInfoWithSignatures,
-        Vec<ValidatorChangeEventWithProof>,
+        ValidatorChangeEventWithProof,
         AccumulatorConsistencyProof,
     )> {
         let request = libra_types::get_with_proof::UpdateToLatestLedgerRequest::new(
@@ -77,7 +77,7 @@ impl StorageRead for MockStorageReadClient {
                     Output = Result<(
                         Vec<ResponseItem>,
                         LedgerInfoWithSignatures,
-                        Vec<ValidatorChangeEventWithProof>,
+                        ValidatorChangeEventWithProof,
                         AccumulatorConsistencyProof,
                     )>,
                 > + Send,

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -78,7 +78,7 @@ impl From<UpdateToLatestLedgerRequest> for crate::proto::types::UpdateToLatestLe
 pub struct UpdateToLatestLedgerResponse<Sig> {
     pub response_items: Vec<ResponseItem>,
     pub ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
-    pub validator_change_events: Vec<ValidatorChangeEventWithProof<Sig>>,
+    pub validator_change_events: ValidatorChangeEventWithProof<Sig>,
     pub ledger_consistency_proof: AccumulatorConsistencyProof,
 }
 
@@ -99,9 +99,8 @@ impl<Sig: Signature> TryFrom<crate::proto::types::UpdateToLatestLedgerResponse>
             .try_into()?;
         let validator_change_events = proto
             .validator_change_events
-            .into_iter()
-            .map(TryInto::try_into)
-            .collect::<Result<Vec<_>>>()?;
+            .unwrap_or_else(Default::default)
+            .try_into()?;
         let ledger_consistency_proof = proto
             .ledger_consistency_proof
             .unwrap_or_else(Default::default)
@@ -126,11 +125,7 @@ impl<Sig: Signature> From<UpdateToLatestLedgerResponse<Sig>>
             .map(Into::into)
             .collect();
         let ledger_info_with_sigs = Some(response.ledger_info_with_sigs.into());
-        let validator_change_events = response
-            .validator_change_events
-            .into_iter()
-            .map(Into::into)
-            .collect();
+        let validator_change_events = Some(response.validator_change_events.into());
         let ledger_consistency_proof = Some(response.ledger_consistency_proof.into());
 
         Self {
@@ -147,7 +142,7 @@ impl<Sig: Signature> UpdateToLatestLedgerResponse<Sig> {
     pub fn new(
         response_items: Vec<ResponseItem>,
         ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
-        validator_change_events: Vec<ValidatorChangeEventWithProof<Sig>>,
+        validator_change_events: ValidatorChangeEventWithProof<Sig>,
         ledger_consistency_proof: AccumulatorConsistencyProof,
     ) -> Self {
         UpdateToLatestLedgerResponse {

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1,6 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-
 use crate::transaction::Transaction;
 use crate::{
     access_path::AccessPath,
@@ -559,7 +558,7 @@ prop_compose! {
     fn arb_update_to_latest_ledger_response()(
         response_items in vec(any::<ResponseItem>(), 0..10),
         ledger_info_with_sigs in any::<LedgerInfoWithSignatures<Ed25519Signature>>(),
-        validator_change_events in vec(any::<ValidatorChangeEventWithProof<Ed25519Signature>>(), 0..10),
+        validator_change_events in any::<ValidatorChangeEventWithProof<Ed25519Signature>>(),
         ledger_consistency_proof in any::<AccumulatorConsistencyProof>(),
     ) -> UpdateToLatestLedgerResponse<Ed25519Signature> {
         UpdateToLatestLedgerResponse::new(

--- a/types/src/proto/get_with_proof.proto
+++ b/types/src/proto/get_with_proof.proto
@@ -171,7 +171,7 @@ message UpdateToLatestLedgerResponse {
     // Validator change events from what the client last knew.  This is used to
     // inform the client of validator changes from the client's last known version
     // until the current version
-    repeated ValidatorChangeEventWithProof validator_change_events = 3;
+    ValidatorChangeEventWithProof validator_change_events = 3;
 
     // A proof that shows the latest ledger accumulator is consistent with the
     // old accumulator at "client_known_version".

--- a/types/src/proto/validator_change.proto
+++ b/types/src/proto/validator_change.proto
@@ -18,10 +18,6 @@ import "ledger_info.proto";
 // proof.  The client can then verify that these events were under the current
 // tree and that the changes were signed by the old validators (and that the
 // events correctly show which validators are the new validators).
-//
-// This message represents a single validator change event and the proof that
-// corresponds to it
 message ValidatorChangeEventWithProof {
-  LedgerInfoWithSignatures ledger_info_with_sigs = 1;
-  EventWithProof event_with_proof = 2;
+  repeated LedgerInfoWithSignatures ledger_info_with_sigs = 1;
 }

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -1,15 +1,125 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{contract_event::EventWithProof, ledger_info::LedgerInfoWithSignatures};
+use crate::crypto_proxies::ValidatorVerifier;
+use crate::ledger_info::LedgerInfoWithSignatures;
 use failure::*;
+use libra_crypto::ed25519::*;
 use libra_crypto::*;
 use std::convert::{TryFrom, TryInto};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValidatorChangeEventWithProof<Sig> {
-    ledger_info_with_sigs: LedgerInfoWithSignatures<Sig>,
-    event_with_proof: EventWithProof,
+    ledger_info_with_sigs: Vec<LedgerInfoWithSignatures<Sig>>,
+}
+
+impl<Sig: Signature> ValidatorChangeEventWithProof<Sig> {
+    pub fn new(ledger_info_with_sigs: Vec<LedgerInfoWithSignatures<Sig>>) -> Self {
+        Self {
+            ledger_info_with_sigs,
+        }
+    }
+}
+impl ValidatorChangeEventWithProof<Ed25519Signature> {
+    /// Verify the proof is correctly chained with known epoch and validator verifier
+    pub fn verify(&self, epoch: u64, validator_verifier: &ValidatorVerifier) -> Result<()> {
+        ensure!(
+            !self.ledger_info_with_sigs.is_empty(),
+            "Empty ValidatorChangeEventWithProof"
+        );
+        self.ledger_info_with_sigs
+            .iter()
+            .try_fold(
+                (epoch, validator_verifier.clone()),
+                |(epoch, validator_verifier), ledger_info| {
+                    ensure!(
+                        epoch == ledger_info.ledger_info().epoch(),
+                        "LedgerInfo has unexpected epoch"
+                    );
+                    ledger_info.verify(&validator_verifier)?;
+                    ledger_info
+                        .ledger_info()
+                        .next_validator_set()
+                        .map(|v| (epoch + 1, v.into()))
+                        .ok_or_else(|| format_err!("LedgerInfo doesn't carry ValidatorSet"))
+                },
+            )
+            .map(|_| ())
+    }
+}
+
+#[test]
+fn verify_validator_set_change_proof() {
+    use crate::crypto_proxies::random_validator_verifier;
+    use crate::ledger_info::LedgerInfo;
+    use libra_crypto::hash::CryptoHash;
+    use std::collections::BTreeMap;
+
+    let all_epoch: Vec<u64> = (1..=10).collect();
+    let mut valid_ledger_info = vec![];
+    let mut validator_verifier = vec![];
+    // We generate end-epoch ledger info for epoch 1 to 10, each signed by the current validator set and carries next validator set.
+    let (mut current_signers, mut current_verifier) = random_validator_verifier(1, None, true);
+    for epoch in &all_epoch {
+        validator_verifier.push(current_verifier.clone());
+        let (next_signers, next_verifier) =
+            random_validator_verifier((*epoch + 1) as usize, None, true);
+        let validator_set = Some((&next_verifier).into());
+        let ledger_info = LedgerInfo::new(
+            42,
+            HashValue::zero(),
+            HashValue::zero(),
+            HashValue::zero(),
+            *epoch,
+            0,
+            validator_set,
+        );
+        let signatures = current_signers
+            .iter()
+            .map(|s| (s.author(), s.sign_message(ledger_info.hash()).unwrap()))
+            .collect();
+        valid_ledger_info.push(LedgerInfoWithSignatures::new(ledger_info, signatures));
+        current_signers = next_signers;
+        current_verifier = next_verifier;
+    }
+
+    // Test well-formed proof will succeed
+    let proof_1 = ValidatorChangeEventWithProof::new(valid_ledger_info.clone());
+    assert!(proof_1.verify(all_epoch[0], &validator_verifier[0]).is_ok());
+
+    let proof_2 = ValidatorChangeEventWithProof::new(valid_ledger_info[2..5].to_vec());
+    assert!(proof_2.verify(all_epoch[2], &validator_verifier[2]).is_ok());
+
+    // Test empty proof will fail verification
+    let proof_3 = ValidatorChangeEventWithProof::new(vec![]);
+    assert!(proof_3
+        .verify(all_epoch[0], &validator_verifier[0])
+        .is_err());
+
+    // Test non contiguous proof will fail
+    let mut list = valid_ledger_info[3..5].to_vec();
+    list.extend_from_slice(&valid_ledger_info[8..9]);
+    let proof_4 = ValidatorChangeEventWithProof::new(list);
+    assert!(proof_4
+        .verify(all_epoch[3], &validator_verifier[3])
+        .is_err());
+
+    // Test non increasing proof will fail
+    let mut list = valid_ledger_info.clone();
+    list.reverse();
+    let proof_5 = ValidatorChangeEventWithProof::new(list);
+    assert!(proof_5
+        .verify(all_epoch[9], &validator_verifier[9])
+        .is_err());
+
+    // Test proof with invalid signatures will fail
+    let proof_6 = ValidatorChangeEventWithProof::new(vec![LedgerInfoWithSignatures::new(
+        valid_ledger_info[0].ledger_info().clone(),
+        BTreeMap::new(),
+    )]);
+    assert!(proof_6
+        .verify(all_epoch[0], &validator_verifier[0])
+        .is_err());
 }
 
 impl<Sig: Signature> TryFrom<crate::proto::types::ValidatorChangeEventWithProof>
@@ -20,15 +130,11 @@ impl<Sig: Signature> TryFrom<crate::proto::types::ValidatorChangeEventWithProof>
     fn try_from(proto: crate::proto::types::ValidatorChangeEventWithProof) -> Result<Self> {
         let ledger_info_with_sigs = proto
             .ledger_info_with_sigs
-            .ok_or_else(|| format_err!("Missing ledger_info_with_sigs"))?
-            .try_into()?;
-        let event_with_proof = proto
-            .event_with_proof
-            .ok_or_else(|| format_err!("Missing event_with_proof"))?
-            .try_into()?;
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>>>()?;
         Ok(ValidatorChangeEventWithProof {
             ledger_info_with_sigs,
-            event_with_proof,
         })
     }
 }
@@ -38,25 +144,27 @@ impl<Sig: Signature> From<ValidatorChangeEventWithProof<Sig>>
 {
     fn from(change: ValidatorChangeEventWithProof<Sig>) -> Self {
         Self {
-            ledger_info_with_sigs: Some(change.ledger_info_with_sigs.into()),
-            event_with_proof: Some(change.event_with_proof.into()),
+            ledger_info_with_sigs: change
+                .ledger_info_with_sigs
+                .into_iter()
+                .map(Into::into)
+                .collect(),
         }
     }
 }
 
 #[cfg(any(test, feature = "fuzzing"))]
-use libra_crypto::ed25519::*;
+use proptest::collection::vec;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 
 #[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
     fn arb_validator_change_event_with_proof()(
-        ledger_info_with_sigs in any::<LedgerInfoWithSignatures<Ed25519Signature>>(),
-        event_with_proof in any::<EventWithProof>(),
+        ledger_info_with_sigs in vec(any::<LedgerInfoWithSignatures<Ed25519Signature>>(), 0..10),
     ) -> ValidatorChangeEventWithProof<Ed25519Signature> {
         ValidatorChangeEventWithProof{
-            ledger_info_with_sigs, event_with_proof
+            ledger_info_with_sigs
         }
     }
 }

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -306,6 +306,26 @@ impl From<&ValidatorSet> for ValidatorVerifier<Ed25519PublicKey> {
     }
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
+impl From<&ValidatorVerifier<Ed25519PublicKey>> for ValidatorSet {
+    fn from(verifier: &ValidatorVerifier<Ed25519PublicKey>) -> Self {
+        use crate::validator_public_keys::ValidatorPublicKeys;
+        ValidatorSet::new(
+            verifier
+                .get_ordered_account_addresses()
+                .into_iter()
+                .map(|addr| {
+                    ValidatorPublicKeys::new_with_random_network_keys(
+                        addr,
+                        verifier.get_public_key(&addr).unwrap(),
+                        verifier.get_voting_power(&addr).unwrap(),
+                    )
+                })
+                .collect(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::crypto_proxies::random_validator_verifier;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We change the ValidatorChangeEventWithProof struct to prepare for usage,
it carries a list of LedgerInfo that has validator set for corresponding
epoch and we implement the function to verify it given a known validator
 set.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
