### PR TITLE
[metrics] Convert RPC bytes and DirectSend bytes metrics to histogram

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -3,7 +3,7 @@
 
 use lazy_static;
 use libra_metrics::{Histogram, IntGauge, OpMetrics};
-use prometheus::{IntCounterVec, IntGaugeVec};
+use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
 
 lazy_static::lazy_static! {
     pub static ref LIBRA_NETWORK_PEERS: IntGaugeVec = register_int_gauge_vec!(
@@ -17,13 +17,13 @@ lazy_static::lazy_static! {
 
     pub static ref LIBRA_NETWORK_RPC_MESSAGES: IntCounterVec = register_int_counter_vec!(
         "libra_network_rpc_messages",
-        "Libra network rpc messages counters",
+        "Libra network rpc messages counter",
         &["type", "state"]
     ).unwrap();
 
-    pub static ref LIBRA_NETWORK_RPC_BYTES: IntCounterVec = register_int_counter_vec!(
+    pub static ref LIBRA_NETWORK_RPC_BYTES: HistogramVec = register_histogram_vec!(
         "libra_network_rpc_bytes",
-        "Libra network rpc bytes counters",
+        "Libra network rpc bytes histogram",
         &["type", "state"]
     ).unwrap();
 
@@ -34,13 +34,13 @@ lazy_static::lazy_static! {
 
     pub static ref LIBRA_NETWORK_DIRECT_SEND_MESSAGES: IntCounterVec = register_int_counter_vec!(
         "libra_network_direct_send_messages",
-        "Libra network direct send protocol counters, measured by messages",
+        "Libra network direct send messages counter",
         &["state"]
     ).unwrap();
 
-    pub static ref LIBRA_NETWORK_DIRECT_SEND_BYTES: IntCounterVec = register_int_counter_vec!(
+    pub static ref LIBRA_NETWORK_DIRECT_SEND_BYTES: HistogramVec = register_histogram_vec!(
         "libra_network_direct_send_bytes",
-        "Libra network direct send protocol counters, measured by bytes",
+        "Libra network direct send bytes histogram",
         &["state"]
     ).unwrap();
 }

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -326,7 +326,7 @@ where
                     .inc();
                 counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
                     .with_label_values(&["sent"])
-                    .inc_by(msg.mdata.len() as i64);
+                    .observe(msg.mdata.len() as f64);
                 ds_reqs_tx
                     .send(DirectSendRequest::SendMessage(peer_id, msg))
                     .await
@@ -411,7 +411,7 @@ where
                     .inc();
                 counters::LIBRA_NETWORK_DIRECT_SEND_BYTES
                     .with_label_values(&["received"])
-                    .inc_by(msg.mdata.len() as i64);
+                    .observe(msg.mdata.len() as f64);
                 let ch = upstream_handlers
                     .get_mut(&msg.protocol)
                     .expect("DirectSend protocol not registered");

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -371,7 +371,7 @@ where
         .inc();
     counters::LIBRA_NETWORK_RPC_BYTES
         .with_label_values(&["request", "sent"])
-        .inc_by(req_len as i64);
+        .observe(req_len as f64);
 
     // Wait for listener's response.
     let res_data = match substream.next().await {
@@ -488,7 +488,7 @@ where
         .inc();
     counters::LIBRA_NETWORK_RPC_BYTES
         .with_label_values(&["response", "sent"])
-        .inc_by(res_len as i64);
+        .observe(res_len as f64);
 
     Ok(())
 }

--- a/terraform/templates/dashboards/network.json
+++ b/terraform/templates/dashboards/network.json
@@ -73,7 +73,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(libra_network_direct_send_bytes{state=\"sent\"}[1m])",
+          "expr": "irate(libra_network_direct_send_bytes_sum{state=\"sent\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -162,7 +162,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(libra_network_direct_send_bytes{state=\"received\"}[1m])",
+          "expr": "irate(libra_network_direct_send_bytes_sum{state=\"received\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",


### PR DESCRIPTION
## Motivation

From network benchmarks (e.g. #1592), it can be seen that the message size greatly affects the network performance. As such, it will be good to track the size of messages being shuttled across the network. The metrics being converted were previously counters, but will not be histogram. To get throughput metrics, we will now need to use `libra_network_rpc_bytes_rate` instead of just `libra_network_rpc_bytes`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes