### PR TITLE
[consensus][reconfig] adopt ValidatorChangeEventWithProof in consensus

### DIFF
--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -33,7 +33,9 @@ use consensus_types::{
 use failure::ResultExt;
 use libra_crypto::hash::TransactionAccumulatorHasher;
 use libra_logger::prelude::*;
-use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier};
+use libra_types::crypto_proxies::{
+    LedgerInfoWithSignatures, ValidatorChangeEventWithProof, ValidatorVerifier,
+};
 use mirai_annotations::{
     debug_checked_precondition, debug_checked_precondition_eq, debug_checked_verify,
     debug_checked_verify_eq,
@@ -782,7 +784,9 @@ impl<T: Payload> EventProcessor<T> {
             }
         }
         if finality_proof.ledger_info().next_validator_set().is_some() {
-            self.network.send_epoch_change(finality_proof).await
+            self.network
+                .send_epoch_change(ValidatorChangeEventWithProof::new(vec![finality_proof]))
+                .await
         }
     }
 

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -276,7 +276,7 @@ impl NetworkPlayground {
     }
 
     pub fn epoch_change_only(msg_copy: &(Author, ConsensusMsg)) -> bool {
-        if let Some(ConsensusMsg_oneof::LedgerInfo(_)) = msg_copy.1.message {
+        if let Some(ConsensusMsg_oneof::EpochChange(_)) = msg_copy.1.message {
             true
         } else {
             false

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package consensus;
 
-import "ledger_info.proto";
+import "validator_change.proto";
 
 message ConsensusMsg {
   oneof message {
@@ -14,7 +14,7 @@ message ConsensusMsg {
     RequestBlock request_block = 3;
     RespondBlock respond_block = 4;
     SyncInfo sync_info = 5;
-    types.LedgerInfoWithSignatures ledger_info = 6;
+    types.ValidatorChangeEventWithProof epoch_change = 6;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We adopt the new ValidatorChangeEventWithProof structure to broadcast new epoch change and process it correspondingly.

Next PR we'll introduce EpochRetrieval to proactively fetch the proof.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
