### PR TITLE
[network] Refactor out common `NetworkEvents` implementations

### DIFF
--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -28,8 +28,7 @@ use crate::{
     ProtocolId,
 };
 use channel;
-use futures::channel::oneshot;
-use futures::{future::BoxFuture, FutureExt, SinkExt, StreamExt};
+use futures::{channel::oneshot, future::BoxFuture, FutureExt, SinkExt, StreamExt};
 use libra_logger::prelude::*;
 use libra_types::PeerId;
 use parity_multiaddr::Multiaddr;


### PR DESCRIPTION
See #1516, #1556 

+ There was a lot of code duplication from implementing many wrappers
around a `channel::Receiver<NetworkNotification>` that would just
deserialize inbound rpc and direct-send messages.

+ Initially, we only had `mempool` and `consensus` interfaces, so the
code duplication was not a problem. Today, however, we have more and so
the code duplication is getting to be a problem.

+ This change adds a `NetworkEvents<T: prost::Message>`, which is a
`Stream` that reads messages from a `channel::Receiver<NetworkNotification>`
and deserializes them into `T: prost::Message`.

+ Next, we can try to refactor out some common parts for the
`NetworkSender` interface.