### PR TITLE
[StateSynchronizer] sync to a specified target only

### DIFF
--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -67,7 +67,7 @@ impl StateComputer for MockStateComputer {
     fn sync_to(
         &self,
         commit: LedgerInfoWithSignatures,
-    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         debug!(
             "{}Fake sync{} to block id {}",
             Fg(Blue),
@@ -79,7 +79,7 @@ impl StateComputer for MockStateComputer {
         self.commit_callback
             .unbounded_send(commit.clone())
             .expect("Fail to notify about sync");
-        async { Ok(true) }.boxed()
+        async { Ok(()) }.boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {
@@ -115,8 +115,8 @@ impl StateComputer for EmptyStateComputer {
     fn sync_to(
         &self,
         _commit: LedgerInfoWithSignatures,
-    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
-        async { Ok(true) }.boxed()
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+        async { Ok(()) }.boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -136,10 +136,10 @@ impl StateComputer for ExecutionProxy {
     /// Synchronize to a commit that not present locally.
     fn sync_to(
         &self,
-        commit: LedgerInfoWithSignatures,
-    ) -> Pin<Box<dyn Future<Output = Result<bool>> + Send>> {
+        target: LedgerInfoWithSignatures,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         counters::STATE_SYNC_COUNT.inc();
-        self.synchronizer.sync_to_deprecated(commit).boxed()
+        self.synchronizer.sync_to(target).boxed()
     }
 
     fn committed_trees(&self) -> ExecutedTrees {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -252,15 +252,9 @@ impl SynchronizerEnv {
         Box::new(|resp| -> Result<GetChunkResponse> { Ok(resp) })
     }
 
-    fn sync_to(&self, peer_id: usize, version: u64) -> bool {
+    fn sync_to(&self, peer_id: usize, version: u64) {
         let target = MockExecutorProxy::mock_ledger_info(self.peers[1], version);
-        block_on(self.clients[peer_id].sync_to_deprecated(target)).unwrap()
-    }
-
-    fn sync_to_new_flow(&self, peer_id: usize, version: u64) -> bool {
-        let target = MockExecutorProxy::mock_ledger_info(self.peers[1], version);
-        let li = block_on(self.clients[peer_id].sync_to(target)).unwrap();
-        li.ledger_info().version() == version
+        block_on(self.clients[peer_id].sync_to(target)).unwrap()
     }
 
     fn commit(&self, peer_id: usize, version: u64) {
@@ -286,18 +280,10 @@ fn test_basic_catch_up() {
 
     // test small sequential syncs
     for version in 1..5 {
-        assert!(env.sync_to(0, version));
+        env.sync_to(0, version);
     }
     // test batch sync for multiple transactions
-    assert!(env.sync_to(0, 10));
-}
-
-#[test]
-fn test_basic_catch_up_new_flow() {
-    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::Validator);
-    for version in 1..5 {
-        assert!(env.sync_to_new_flow(0, version));
-    }
+    env.sync_to(0, 10);
 }
 
 #[test]
@@ -314,7 +300,7 @@ fn test_flaky_peer_sync() {
         }
     });
     let env = SynchronizerEnv::new(handler, RoleType::Validator);
-    assert!(env.sync_to(0, 1));
+    env.sync_to(0, 1);
 }
 
 #[test]


### PR DESCRIPTION
Summary:
We were trying to come up with a simplified solution that would allow both the validators and the full nodes
operate in a similar fashion by trying to state sync to the highest possible ledger info.

Unfortunately this flow significantly complicates the logic in consensus due to the new reconfiguration design
because it opens a possibility for an EventProcessor to accidentally state sync to another epoch. The basic
paradigm is for the EventProcessor to operate in one epoch only, hence complicating that logic is not worth the
effort.

In addition to that we realized that the new flow did not really solve the liveness attack of non-reachable
state sync. Instead, we are planning to update storage to support idempotent commits, which would mean that
in future state sync should be able to just "give up" and return without changing the visible storage state.

Testing: existing unit test coverage
