### PR TITLE
[Docker] look up git rev in build container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 *~
-.git/
 **/.terraform/
 terraform/
 target/

--- a/docker/bench/bench.Dockerfile
+++ b/docker/bench/bench.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster AS toolchain
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang \
+    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
@@ -17,10 +17,6 @@ RUN rustup install $(cat rust-toolchain)
 FROM toolchain AS builder
 
 COPY . /libra
-
-ARG BUILD_DATE
-ARG GIT_REV
-ARG GIT_UPSTREAM
 
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 
@@ -38,6 +34,10 @@ EXPOSE 9101
 
 # Define MINT_KEY, AC_HOST and AC_DEBUG environment variables when running
 ENTRYPOINT ["/opt/libra/bin/bench_init.sh"]
+
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster AS toolchain
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang \
+    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
@@ -17,10 +17,6 @@ RUN rustup install $(cat rust-toolchain)
 FROM toolchain AS builder
 
 COPY . /libra
-
-ARG BUILD_DATE
-ARG GIT_REV
-ARG GIT_UPSTREAM
 
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 
@@ -51,6 +47,10 @@ CMD cd /opt/libra/etc && echo "$MINT_KEY" | \
     base64 -d > mint.key && \
     cd /opt/libra/bin && \
     exec gunicorn --bind 0.0.0.0:8000 --access-logfile - --error-logfile - --log-level $LOG_LEVEL server
+
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE

--- a/docker/validator/validator.Dockerfile
+++ b/docker/validator/validator.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster AS toolchain
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang \
+    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
@@ -17,10 +17,6 @@ RUN rustup install $(cat rust-toolchain)
 FROM toolchain AS builder
 
 COPY . /libra
-
-ARG BUILD_DATE
-ARG GIT_REV
-ARG GIT_UPSTREAM
 
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 
@@ -44,6 +40,10 @@ ENV RUST_BACKTRACE 1
 # Define SEED_PEERS, NODE_CONFIG, NETWORK_KEYPAIRS, CONSENSUS_KEYPAIR, GENESIS_BLOB and PEER_ID environment variables when running
 COPY docker/validator/docker-run.sh /
 CMD /docker-run.sh
+
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE


### PR DESCRIPTION
## Motivation
Building the libra-metrics crate needs to look up the git rev it was
built with.  Currently we pass in the git rev as docker build arg
when building inside the container.  Putting these args before the
rust build cmd also causes layer cache miss for the build layer.  We
can try look up the git rev inside the container.

The docker setup is updated such that the .git directory is copied
inside the container. The rust build process can then look up git rev.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
- Tested nightly build work flow on local machine
build builder --> build validator --> build faucet --> build client --> build bench
- Verified all images are built
- Verified all the target images (validator, mint etc) hit layer cache
- Canaried with nightly build in Circle

## Related PRs
#1572 