### PR TITLE
[Docker][cluster_test] look up git rev in container

### DIFF
--- a/docker/cluster_test/build.sh
+++ b/docker/cluster_test/build.sh
@@ -21,7 +21,7 @@ else
   docker run --name libra_cluster_test_builder_container -d -i -t -v $DIR/../..:/libra libra_cluster_test_builder bash
 fi
 
-docker exec -i -t libra_cluster_test_builder_container bash -c 'source /root/.cargo/env; export GIT_REV=""; cargo build -p cluster-test --target-dir /target && /bin/cp /target/debug/cluster-test target/cluster_test_docker_builder/'
+docker exec -i -t libra_cluster_test_builder_container bash -c 'source /root/.cargo/env; cargo build -p cluster-test --target-dir /target && /bin/cp /target/debug/cluster-test target/cluster_test_docker_builder/'
 
 if [ "$1" = "--build-docker-image" ]; then
   ln target/cluster_test_docker_builder/cluster_test cluster_test_docker_builder_cluster_test

--- a/docker/cluster_test/cluster_test_builder.Dockerfile
+++ b/docker/cluster_test/cluster_test_builder.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
 RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang
+    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git
 #     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Install git during docker build so that we can look up git revision inside container. 
Apply this to cluster test since it's not covered in https://github.com/libra/libra/pull/1603

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`docker/cluster_test/build.sh` to build locally, verify they can build successfully.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
