### PR TITLE
[executor] refactor executor with synced_trees

### DIFF
--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -89,7 +89,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
         let client = Arc::clone(&self.storage_read_client);
         async move {
             let resp = client.get_startup_info_async().await?;
-            resp.map(|r| r.latest_version)
+            resp.map(|r| r.ledger_info.version())
                 .ok_or_else(|| format_err!("failed to fetch startup info"))
         }
             .boxed()

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -105,17 +105,27 @@ message GetStartupInfoResponse {
     StartupInfo info = 1;
 }
 
-message StartupInfo {
-    // The latest LedgerInfo. Note that at start up storage can have more
-    // transactions than the latest LedgerInfo indicates due to an incomplete
-    // start up sync.
-    types.LedgerInfo ledger_info = 1;
-    // The latest version. All fields below are based on this version.
-    uint64 latest_version = 2;
+message TreeState {
+    // The version of the tree state. All fields below are based on this version.
+    uint64 version = 1;
+    // From left to right, root hashes of all frozen subtrees.
+    repeated bytes ledger_frozen_subtree_hashes = 2;
     // The latest account state root hash.
     bytes account_state_root_hash = 3;
-    // From left to right, root hashes of all frozen subtrees.
-    repeated bytes ledger_frozen_subtree_hashes = 4;
+}
+
+message StartupInfo {
+    // The latest committed LedgerInfo. Note that at start up storage can have more
+    // transactions than the latest committed LedgerInfo indicates due to an incomplete
+    // start up sync.
+    types.LedgerInfo ledger_info = 1;
+
+    // The latest committed tree state matching the ledger info above.
+    TreeState committed_tree_state = 2;
+
+    // The latest synced tree state when the number of transactions is more than ledger_info
+    // indicates.
+    TreeState synced_tree_state = 3;
 }
 
 message GetLatestLedgerInfosPerEpochRequest {


### PR DESCRIPTION
## Motivation

Refactor the executor and introduce `synced_tree` that is necessary for idempotent commits.

Currently, when executor is in `sync` mode. It cannot accept new `execution` requests and commit blocks that are even consistent with data synced. But we have to be able to do this since the node we are syncing to may be not honest node and we have to run consensus to recover from this `sync-and-stuck` case.

Now executor stores two `tree state`, one for committed state backed by the latest ledger info, one for committed state with the highest version number no matter whether matched with the latest ledger info. If the latter doesn't match the former, it is caused by unfinished state sync.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

## Issues

cc: https://github.com/libra/libra/issues/1590
