### PR TITLE
[network] Add common `NetworkSender` network interface.

### DIFF
--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -3,7 +3,7 @@
 
 use crate::peer_manager::PeerManagerError;
 use failure::{Backtrace, Context, Fail};
-use futures::channel::mpsc;
+use futures::channel::{mpsc, oneshot};
 use libra_types::validator_verifier::VerifyError;
 use std::{
     fmt::{self, Display},
@@ -33,6 +33,9 @@ pub enum NetworkErrorKind {
 
     #[fail(display = "Error sending on mpsc channel")]
     MpscSendError,
+
+    #[fail(display = "Oneshot channel unexpectedly dropped")]
+    OneshotCanceled,
 
     #[fail(display = "Error setting timeout")]
     TimerError,
@@ -122,6 +125,12 @@ impl From<parity_multiaddr::Error> for NetworkError {
 impl From<mpsc::SendError> for NetworkError {
     fn from(err: mpsc::SendError) -> NetworkError {
         err.context(NetworkErrorKind::MpscSendError).into()
+    }
+}
+
+impl From<oneshot::Canceled> for NetworkError {
+    fn from(err: oneshot::Canceled) -> NetworkError {
+        err.context(NetworkErrorKind::OneshotCanceled).into()
     }
 }
 


### PR DESCRIPTION
+ All network applications will use a wrapped `NetworkSender<TMessage>`
where `TMessage` is their own protobuf message format.

+ `NetworkSender` handles the "low-level" message-based interface to
network, so the upper network applications only see a nice async-await
API.

+ Adds a `send_to_many` method optimized for sending the same message to
many peers. Consensus currently uses something like this for their
proposal broadcast, so we will explicitly pull this into the network
interface.

+ Adds `dial_peer` and `disconnect_peer` methods to support forthcoming
work to pull out `gossip-discovery` and `connectivity-manager` into
network application modules.