### PR TITLE
[mempool] Change log level of raw bytes debug->trace

### DIFF
--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -164,9 +164,10 @@ async fn sync_with_peers<'a>(
                     .map(|txn| txn.try_into().unwrap())
                     .collect();
 
-                debug!(
+                trace!(
                     "MempoolNetworkSender.send_to peer {} msg {:?}",
-                    peer_id, msg
+                    peer_id,
+                    msg
                 );
                 // Since this is a direct-send, this will only error if the network
                 // module has unexpectedly crashed or shutdown.


### PR DESCRIPTION
Raw bytes sent pollutes log quite a bit even in debug mode, and unlikely to be used
