### PR TITLE
[mempool] commit old transactions on transaction insertion

### DIFF
--- a/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/core_mempool_test.rs
@@ -359,3 +359,17 @@ fn test_gc_ready_transaction() {
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline[0].sequence_number(), 0);
 }
+
+#[test]
+fn test_clean_stuck_transactions() {
+    let mut pool = setup_mempool().0;
+    for seq in 0..5 {
+        add_txn(&mut pool, TestTransaction::new(0, seq, 1)).unwrap();
+    }
+    let db_sequence_number = 10;
+    let txn = TestTransaction::new(0, db_sequence_number, 1).make_signed_transaction();
+    pool.add_txn(txn, 0, db_sequence_number, 100, TimelineState::NotReady);
+    let block = pool.get_block(10, HashSet::new());
+    assert_eq!(block.len(), 1);
+    assert_eq!(block[0].sequence_number(), 10);
+}


### PR DESCRIPTION
Fixes #1625
When node does state sync, transactions that are committed through this sync are not removed from mempool.
This means that even though transactions are committed, client can not use this node to submit new transactions, until they expire, which can take significant amount of time.

We do state sync quite often, so this reproduce routinely during cluster test - we had to add retry on transaction submission because of this problem
