### PR TITLE
[admission-control] Add service test into lib

### DIFF
--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -11,6 +11,10 @@
 //! 1. SubmitTransaction, to submit transaction to associated validator.
 //! 2. UpdateToLatestLedger, to query storage, e.g. account state, transaction log, and proofs.
 
+#[cfg(test)]
+#[path = "unit_tests/admission_control_service_test.rs"]
+mod admission_control_service_test;
+
 #[cfg(feature = "fuzzing")]
 /// Fuzzer for admission control
 pub mod admission_control_fuzzing;


### PR DESCRIPTION
## Motivation

Adding AC service test into service lib so that cargo x test command can pick it up. 

## Test Plan

Test now runs with either: 
`cargo x test -p admission-control-service` or `cargo xtest` in admission-control/admission-control-service directory 

