### PR TITLE
[network][consensus] `ConsensusNetworkSender` now wraps `NetworkSender`

### DIFF
--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -262,6 +262,11 @@ impl<PublicKey: VerifyingKey> ValidatorVerifier<PublicKey> {
         account_addresses
     }
 
+    /// Returns an ordered list of account addresses as an `Iterator`.
+    pub fn get_account_addresses_iter(&self) -> impl Iterator<Item = AccountAddress> + '_ {
+        self.address_to_validator_info.keys().copied()
+    }
+
     /// Returns the number of authors to be validated.
     pub fn len(&self) -> usize {
         self.address_to_validator_info.len()


### PR DESCRIPTION
+ Refactored `chained_bft::NetworkSender` so it uses
`ConsensusNetworkSender::send_to_many` instead of the previous
`send_bytes` method, which no longer needs to exist.

+ Added `ValidatorVerifier::get_account_addresses_iter()`. We should be
able to remove `get_ordered_account_addresses()` in a subsequent commit,
since it does an unnecessary sort (`BTreeMap` already sorts on insertion).