### PR TITLE
[client][proof verification] add verbose mode to print out failed proofs

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -858,21 +858,14 @@ impl ClientProxy {
                     None => (0, AccountStatus::Local),
                 },
                 Err(e) => {
-                    // try downcasting error to ProofError
-                    let proof_error = e.downcast_ref::<ProofError>();
-                    if proof_error.is_some() {
-                        let proof_error = proof_error.unwrap();
-                        match proof_error {
-                            ProofError { .. } => {
-                                if verbose {
-                                    error!(
-                                        "Proof failure (msg: {:?}, failed proof: {:?})",
-                                        proof_error.msg, proof_error.proof
-                                    );
-                                } else {
-                                    error!("Proof failure (msg: {:?})", proof_error.msg,);
-                                }
-                            }
+                    if let Some(proof_error) = e.downcast_ref::<ProofError>() {
+                        if verbose {
+                            error!(
+                                "Proof failure (msg: {:?}, failed proof: {:?})",
+                                proof_error.msg, proof_error.proof
+                            );
+                        } else {
+                            error!("Proof failure (msg: {:?})", proof_error.msg,);
                         }
                     } else {
                         error!("Failed to get account state from validator, error: {:?}", e);

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -100,6 +100,7 @@ pub struct ClientProxy {
     sync_on_wallet_recovery: bool,
     /// temp files (alive for duration of program)
     temp_files: Vec<PathBuf>,
+    /// verbose client output
     verbose: bool,
 }
 
@@ -1142,7 +1143,7 @@ mod tests {
             false,
             None,
             Some(mnemonic_path),
-            false,
+            false, /* verbose mode */
         )
         .unwrap();
         for _ in 0..count {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -71,6 +71,7 @@ fn main() -> std::io::Result<()> {
         args.sync,
         args.faucet_server,
         args.mnemonic_file,
+        args.verbose,
     )
     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, &format!("{}", e)[..]))?;
 

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -168,7 +168,7 @@ impl InProcessTestClient {
                 false,
                 /* faucet server */ None,
                 Some(mnemonic_file_path.to_string()),
-                false,
+                /* verbose mode */ false,
             )
             .unwrap(),
             alias_to_cmd,

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -168,6 +168,7 @@ impl InProcessTestClient {
                 false,
                 /* faucet server */ None,
                 Some(mnemonic_file_path.to_string()),
+                false,
             )
             .unwrap(),
             alias_to_cmd,

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -118,7 +118,7 @@ impl TestEnvironment {
             false,
             /* faucet server */ None,
             Some(mnemonic_file_path),
-            false,
+            /* verbose mode */ false,
         )
         .unwrap()
     }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -118,6 +118,7 @@ impl TestEnvironment {
             false,
             /* faucet server */ None,
             Some(mnemonic_file_path),
+            false,
         )
         .unwrap()
     }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -266,7 +266,8 @@ impl SparseMerkleProof {
         element_key: HashValue,
         element_blob: Option<&AccountStateBlob>,
     ) -> Result<()> {
-        ensure!(
+        ensure_proof!(
+            self,
             self.siblings.len() <= HashValue::LENGTH_IN_BITS,
             "Sparse Merkle Tree proof has more than {} ({}) siblings.",
             HashValue::LENGTH_IN_BITS,
@@ -278,14 +279,16 @@ impl SparseMerkleProof {
                 // This is an inclusion proof, so the key and value hash provided in the proof
                 // should match element_key and element_value_hash. `siblings` should prove the
                 // route from the leaf node to the root.
-                ensure!(
+                ensure_proof!(
+                    self,
                     element_key == proof_key,
                     "Keys do not match. Key in proof: {:x}. Expected key: {:x}.",
                     proof_key,
                     element_key
                 );
                 let hash = blob.hash();
-                ensure!(
+                ensure_proof!(
+                    self,
                     hash == proof_value_hash,
                     "Value hashes do not match. Value hash in proof: {:x}. \
                      Expected value hash: {:x}",
@@ -299,15 +302,17 @@ impl SparseMerkleProof {
                 // representing `element_key` is inserted, it will break a currently existing leaf
                 // node represented by `proof_key` into a branch. `siblings` should prove the
                 // route from that leaf node to the root.
-                ensure!(
+                ensure_proof!(
+                    self,
                     element_key != proof_key,
-                    "Expected non-inclusion proof, but key exists in proof.",
+                    "Expected non-inclusion proof, but key exists in proof."
                 );
-                ensure!(
+                ensure_proof!(
+                    self,
                     element_key.common_prefix_bits_len(proof_key) >= self.siblings.len(),
                     "Key would not have ended up in the subtree where the provided key in proof \
                      is the only existing key, if it existed. So this is not a valid \
-                     non-inclusion proof.",
+                     non-inclusion proof."
                 );
             }
             (None, None) => {
@@ -338,7 +343,8 @@ impl SparseMerkleProof {
                     SparseMerkleInternalNode::new(hash, *sibling_hash).hash()
                 }
             });
-        ensure!(
+        ensure_proof!(
+            self,
             actual_root_hash == expected_root_hash,
             "Root hashes do not match. Actual root hash: {:x}. Expected root hash: {:x}.",
             actual_root_hash,

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -74,6 +74,10 @@ fn into_proto_siblings(siblings: Vec<HashValue>, placeholder: HashValue) -> Vec<
         .collect()
 }
 
+pub trait Proof {
+    fn is_proof(&self) -> bool;
+}
+
 /// A proof that can be used authenticate an element in an accumulator given trusted root hash. For
 /// example, both `LedgerInfoToTransactionInfoProof` and `TransactionInfoToEventProof` can be
 /// constructed on top of this structure.
@@ -86,8 +90,14 @@ pub struct AccumulatorProof<H> {
     phantom: PhantomData<H>,
 }
 
+impl<H> Proof for AccumulatorProof<H> {
+    fn is_proof(&self) -> bool {
+        true
+    }
+}
+
 /// Because leaves can only take half the space in the tree, any numbering of the tree leaves must
-/// not take the full width of the total space.  Thus, for a 64-bit ordering, our maximumm proof
+/// not take the full width of the total space.  Thus, for a 64-bit ordering, our maximum proof
 /// depth is limited to 63.
 pub type LeafCount = u64;
 pub const MAX_ACCUMULATOR_PROOF_DEPTH: usize = 63;
@@ -230,6 +240,12 @@ impl std::fmt::Display for SparseMerkleProof {
             "SparseMerkleProof (leaf: {:?}, siblings: {:?})",
             self.leaf, self.siblings
         )
+    }
+}
+
+impl Proof for SparseMerkleProof {
+    fn is_proof(&self) -> bool {
+        true
     }
 }
 

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::{
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfo,
+    proof::proof_error::ProofError,
     transaction::{TransactionInfo, Version},
 };
 use failure::prelude::*;
@@ -220,6 +221,16 @@ pub struct SparseMerkleProof {
     /// All siblings in this proof, including the default ones. Siblings are ordered from the bottom
     /// level to the root level.
     siblings: Vec<HashValue>,
+}
+
+impl std::fmt::Display for SparseMerkleProof {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SparseMerkleProof (leaf: {:?}, siblings: {:?})",
+            self.leaf, self.siblings
+        )
+    }
 }
 
 impl SparseMerkleProof {

--- a/types/src/proof/ensure_proof.rs
+++ b/types/src/proof/ensure_proof.rs
@@ -6,29 +6,26 @@
 //! if the proof fails.
 //! Currently, this macro only supports SparseMerkleProofs
 
-use crate::proof::definition::SparseMerkleProof;
-use crate::proof::proof_error::ProofError;
+use crate::proof::{definition::Proof, proof_error::ProofError};
 use failure::Error;
 
 macro_rules! ensure_proof {
     ($proof:ident, $cond:expr, $e:expr) => {
-        match $proof {
-            SparseMerkleProof { .. } => {
-                if !($cond) {
-                    return Err(Error::from(ProofError::new($proof.to_string(), $e.to_string())));
-                }
+        if Proof::is_proof($proof) {
+            if !($cond) {
+                return Err(Error::from(ProofError::new($proof.to_string(), $e.to_string())));
             }
+        } else {
+            ensure!($cond, $e);
         }
-        ensure!($cond, $e);
     };
     ($proof:ident, $cond:expr, $fmt:expr, $($arg:tt)+) => {
-        match $proof {
-            SparseMerkleProof { .. } => {
-                if !($cond) {
-                    return Err(Error::from(ProofError::new($proof.to_string(), format!($fmt, $($arg)+))));
-                }
+        if Proof::is_proof($proof) {
+            if !($cond) {
+                return Err(Error::from(ProofError::new($proof.to_string(), format!($fmt, $($arg)+))));
             }
+        } else {
+            ensure!($cond, $fmt, $($arg)+);
         }
-        ensure!($cond, $fmt, $($arg)+);
     };
 }

--- a/types/src/proof/ensure_proof.rs
+++ b/types/src/proof/ensure_proof.rs
@@ -16,10 +16,9 @@ macro_rules! ensure_proof {
                 if !($cond) {
                     return Err(ProofError::new($proof.to_string(), $e.to_string()))?;
                 }
-                return Ok(());
             }
         }
-        ensure!($cond, $e)
+        ensure!($cond, $e);
     };
     ($proof:ident, $cond:expr, $fmt:expr, $($arg:tt)+) => {
         match $proof {
@@ -27,9 +26,8 @@ macro_rules! ensure_proof {
                 if !($cond) {
                     return Err(ProofError::new($proof.to_string(), format!($fmt, $($arg)+)))?;
                 }
-                return Ok(());
             }
         }
-        ensure!($cond, $fmt, $($arg)+)
+        ensure!($cond, $fmt, $($arg)+);
     };
 }

--- a/types/src/proof/ensure_proof.rs
+++ b/types/src/proof/ensure_proof.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module declares the macro ensure_proof!,
+//! which checks a condition for a proof and throws a ProofError
+//! if the proof fails.
+//! Currently, this macro only supports SparseMerkleProofs
+
+use crate::proof::definition::SparseMerkleProof;
+use crate::proof::proof_error::ProofError;
+
+macro_rules! ensure_proof {
+    ($proof:ident, $cond:expr, $e:expr) => {
+        match $proof {
+            SparseMerkleProof { .. } => {
+                if !($cond) {
+                    return Err(ProofError { proof: $proof.to_string(), msg: $e.to_string() })?;
+                }
+                return Ok(());
+            }
+        }
+        ensure!($cond, $e)
+    };
+    ($proof:ident, $cond:expr, $fmt:expr, $($arg:tt)+) => {
+        match $proof {
+            SparseMerkleProof { .. } => {
+                if !($cond) {
+                    return Err(ProofError::new($proof.to_string(), format!($fmt, $($arg)+)))?;
+                }
+                return Ok(());
+            }
+        }
+        ensure!($cond, $fmt, $($arg:tt)+)
+    };
+}

--- a/types/src/proof/ensure_proof.rs
+++ b/types/src/proof/ensure_proof.rs
@@ -14,7 +14,7 @@ macro_rules! ensure_proof {
         match $proof {
             SparseMerkleProof { .. } => {
                 if !($cond) {
-                    return Err(ProofError { proof: $proof.to_string(), msg: $e.to_string() })?;
+                    return Err(ProofError::new($proof.to_string(), $e.to_string()))?;
                 }
                 return Ok(());
             }
@@ -30,6 +30,6 @@ macro_rules! ensure_proof {
                 return Ok(());
             }
         }
-        ensure!($cond, $fmt, $($arg:tt)+)
+        ensure!($cond, $fmt, $($arg)+)
     };
 }

--- a/types/src/proof/ensure_proof.rs
+++ b/types/src/proof/ensure_proof.rs
@@ -8,13 +8,14 @@
 
 use crate::proof::definition::SparseMerkleProof;
 use crate::proof::proof_error::ProofError;
+use failure::Error;
 
 macro_rules! ensure_proof {
     ($proof:ident, $cond:expr, $e:expr) => {
         match $proof {
             SparseMerkleProof { .. } => {
                 if !($cond) {
-                    return Err(ProofError::new($proof.to_string(), $e.to_string()))?;
+                    return Err(Error::from(ProofError::new($proof.to_string(), $e.to_string())));
                 }
             }
         }
@@ -24,7 +25,7 @@ macro_rules! ensure_proof {
         match $proof {
             SparseMerkleProof { .. } => {
                 if !($cond) {
-                    return Err(ProofError::new($proof.to_string(), format!($fmt, $($arg)+)))?;
+                    return Err(Error::from(ProofError::new($proof.to_string(), format!($fmt, $($arg)+))));
                 }
             }
         }

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod accumulator;
+pub mod proof_error;
+#[macro_use]
+pub mod ensure_proof;
 pub mod definition;
 pub mod position;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -3,6 +3,9 @@
 
 pub mod accumulator;
 pub mod proof_error;
+// This module actually needs and uses the imports that it complains about not using
+// (SparseMerkleProof and ProofError)
+#[allow(unused_imports)]
 #[macro_use]
 pub mod ensure_proof;
 pub mod definition;

--- a/types/src/proof/proof_error.rs
+++ b/types/src/proof/proof_error.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module declares ProofError, a failure that represents a proof failure.
+
+use failure::Fail;
+use std::fmt::{Debug, Display, Formatter, Result};
+
+// Represents an instance of proof failure
+//
+// proof is the String representation of the failed proof,
+// msg is the error message that provides context for the failed proof
+#[derive(Debug)]
+pub struct ProofError {
+    pub proof: String,
+    pub msg: String,
+}
+
+impl ProofError {
+    pub fn new(proof: String, msg: String) -> ProofError {
+        ProofError { proof, msg }
+    }
+}
+
+impl Fail for ProofError {}
+
+impl Display for ProofError {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(
+            f,
+            "ProofError (msg: {:?}, proof: {:?})",
+            self.msg, self.proof
+        )
+    }
+}

--- a/types/src/proof/proof_error.rs
+++ b/types/src/proof/proof_error.rs
@@ -26,10 +26,6 @@ impl Fail for ProofError {}
 
 impl Display for ProofError {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(
-            f,
-            "ProofError (msg: {:?}, proof: {:?})",
-            self.msg, self.proof
-        )
+        Debug::fmt(&self, f)
     }
 }


### PR DESCRIPTION
 ## Motivation

We want to support a "verbose" mode for proof verification where we print out the entire proof structure on the client CLI.

To do this, this PR achieves:
- creating `ProofError`, a custom failure for proof failures, which contains the proof structure of the failed proof
- creating a macro `ensure_proof!` that checks proofs and throws `ProofError`s when proofs fail
- creating a `Proof` trait that must be implemented for proofs that want to use the `ensure_proof!` macro

For now, actual calls to `ProofError` and `ensure_proof!` are only added in the following use cases:
- replace ensure! with ensure_proof! in `SparseMerkleProof.verify()`
- add handling `ProofError` in `ClientProxy::get_account_data_from_address()`. The includes selectively printing out the failed proof structure based on the verbose argument in the CLI. 

## Test Plan

Tested manually on client CLI (running `./scripts/cli/start_cli_testnet.sh`)
- called 'account create' to trigger proof verification on client
- checked for verbose vs non-verbose output for ProofError handling
- Existing tests (esp. types/src/proof/unit_tests/proof_test.rs) pass

Sample error output (non-verbose mode): <img width="910" alt="Screen Shot 2019-11-11 at 5 01 41 PM" src="https://user-images.githubusercontent.com/22864715/68633009-25e37500-04a5-11ea-9f15-79f13c6c256f.png">
Sample error output (verbose mode): <img width="912" alt="Screen Shot 2019-11-11 at 5 02 50 PM" src="https://user-images.githubusercontent.com/22864715/68633017-2aa82900-04a5-11ea-8c44-db09cd6a36f8.png">
