### PR TITLE
[cluster-test] Use sync log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,6 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -30,7 +30,6 @@ chrono = { version = "0.4.7" }
 slog = { version = "2.5.0", features = ["max_level_debug", "release_max_level_debug"] }
 slog-term = "2.4.1"
 slog-scope = "4.0"
-slog-async = "2.3"
 slog-envlogger = "2.1.0"
 
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -240,7 +240,7 @@ fn setup_log() {
     let decorator = slog_term::PlainDecorator::new(std::io::stdout());
     let drain = slog_term::CompactFormat::new(decorator).build().fuse();
     let drain = slog_envlogger::new(drain);
-    let drain = slog_async::Async::new(drain).build().fuse();
+    let drain = std::sync::Mutex::new(drain).fuse();
     let logger = slog::Logger::root(drain, o!());
     let logger_guard = slog_scope::set_global_logger(logger);
     std::mem::forget(logger_guard);


### PR DESCRIPTION
Instead of using async drain, using sync.
Mainly two reasons:

- Some parts of cluster test use println! for better UX, but when async drain is used output of println! and log! macro is mixed in a bad way
- if program uses log! macro and terminates quickly, part of output can disappear because async thread did not process log

There is no intense log output in cluster test so sync log is not an issue
