### PR TITLE
[cluster-test] Update genesis.blob on deploy

### DIFF
--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -162,7 +162,7 @@ impl DeploymentManager {
         Ok(upstream_commit)
     }
 
-    fn get_upstream_tag(&self, digest: &str) -> failure::Result<String> {
+    pub fn get_upstream_tag(&self, digest: &str) -> failure::Result<String> {
         let image_id = ImageIdentifier {
             image_digest: Some(digest.to_string()),
             image_tag: None,


### PR DESCRIPTION
This will fetch genesis.blob generated by circle during deploy
We need this because genesis.blob is updated relatively frequently and it breaks cluster test every time

Fixes #1224
