### PR TITLE
[cluster-test] Add experiment to simulate multi-region environment and report result

### DIFF
--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::effects::Effect;
 /// NetworkDelay introduces network delay from a given instance to a provided list of instances
 /// If no instances are provided, network delay is introduced on all outgoing packets
-use crate::{effects::Action, instance::Instance};
+use crate::instance::Instance;
 use failure;
 use slog_scope::info;
 use std::fmt;
@@ -29,8 +30,8 @@ impl NetworkDelay {
     }
 }
 
-impl Action for NetworkDelay {
-    fn apply(&self) -> failure::Result<()> {
+impl Effect for NetworkDelay {
+    fn activate(&self) -> failure::Result<()> {
         info!(
             "NetworkDelay {}ms for {}",
             self.delay.as_millis(),
@@ -61,8 +62,9 @@ impl Action for NetworkDelay {
         self.instance.run_cmd(vec![command])
     }
 
-    fn is_complete(&self) -> bool {
-        true
+    fn deactivate(&self) -> failure::Result<()> {
+        self.instance
+            .run_cmd(vec!["sudo tc qdisc delete dev eth0 root; true".to_string()])
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -3,89 +3,204 @@
 
 /// This module provides an experiment which simulates a multi-region environment.
 /// It undoes the simulation in the cluster after the given duration
+use crate::effects::Effect;
 use crate::effects::NetworkDelay;
-use crate::{
-    cluster::Cluster,
-    effects::{Action, RemoveNetworkEffects},
-    experiments::Experiment,
-    instance::Instance,
-    thread_pool_executor::ThreadPoolExecutor,
-};
+use crate::prometheus::Prometheus;
+use crate::util::unix_timestamp_now;
+use crate::{cluster::Cluster, experiments::Experiment, thread_pool_executor::ThreadPoolExecutor};
 use failure;
+use slog_scope::{info, warn};
 use std::{collections::HashSet, fmt, thread, time::Duration};
 
+#[derive(Default)]
+struct Metrics {
+    split_size: usize,
+    cross_region_latency: u64,
+    txn_per_sec: Option<f64>,
+    blocks_per_sec: Option<f64>,
+    avg_vote_time: Option<f64>,
+    avg_qc_time: Option<f64>,
+}
+
 pub struct MultiRegionSimulation {
-    // Instances in region1
-    region1: Vec<Instance>,
-    // Instances in region2
-    region2: Vec<Instance>,
-    cross_region_delay: Duration,
-    experiment_duration: Duration,
+    splits: Vec<usize>,
+    cross_region_latencies: Vec<u64>,
+    exp_duration_per_config: Duration,
     thread_pool_executor: ThreadPoolExecutor,
+    cluster: Cluster,
+    prometheus: Prometheus,
 }
 
 impl MultiRegionSimulation {
     pub fn new(
-        count: usize,
-        cross_region_delay: Duration,
-        experiment_duration: Duration,
-        cluster: &Cluster,
+        splits: Vec<usize>,
+        cross_region_latencies: Vec<u64>,
+        exp_duration_per_config: Duration,
+        cluster: Cluster,
         thread_pool_executor: ThreadPoolExecutor,
+        prometheus: Prometheus,
     ) -> Self {
-        let (region1, region2) = cluster.split_n_random(count);
         Self {
-            region1: region1.into_instances(),
-            region2: region2.into_instances(),
-            cross_region_delay,
-            experiment_duration,
+            splits,
+            cross_region_latencies,
+            exp_duration_per_config,
             thread_pool_executor,
+            cluster,
+            prometheus,
         }
+    }
+
+    fn single_run(&self, count: usize, cross_region_delay: Duration) -> failure::Result<Metrics> {
+        let (cluster1, cluster2) = self.cluster.split_n_random(count);
+        let (region1, region2) = (cluster1.into_instances(), cluster2.into_instances());
+        let (smaller_region, larger_region);
+        if region1.len() < region2.len() {
+            smaller_region = &region1;
+            larger_region = &region2;
+        } else {
+            smaller_region = &region2;
+            larger_region = &region1;
+        }
+        let network_delays_effects: Vec<_> = smaller_region
+            .iter()
+            .map(|instance| {
+                NetworkDelay::new(
+                    instance.clone(),
+                    Some(larger_region.clone()),
+                    cross_region_delay,
+                )
+            })
+            .collect();
+        // Add network delay commands only to the instances of the smaller
+        // region because we have to run fewer ssh commands.
+        let start_effects: Vec<_> = network_delays_effects
+            .iter()
+            .map(|effect| {
+                move || {
+                    effect.activate().unwrap();
+                }
+            })
+            .collect();
+        self.thread_pool_executor.execute_jobs(start_effects);
+
+        thread::sleep(self.exp_duration_per_config);
+        let metrics = self.get_metrics(count, cross_region_delay.as_millis() as u64);
+        let stop_effects: Vec<_> = network_delays_effects
+            .iter()
+            .map(|effect| {
+                move || {
+                    effect.deactivate().unwrap();
+                }
+            })
+            .collect();
+        self.thread_pool_executor.execute_jobs(stop_effects);
+        Ok(metrics)
+    }
+
+    fn get_metrics(&self, split_size: usize, cross_region_latency: u64) -> Metrics {
+        let mut metrics: Metrics = Default::default();
+        metrics.split_size = split_size;
+        metrics.cross_region_latency = cross_region_latency;
+        let step = 10;
+        let end = unix_timestamp_now();
+        // Measure metrics 30s after the experiment started to ignore initial warmup metrics
+        let start = end - self.exp_duration_per_config + Duration::from_secs(30);
+        metrics.txn_per_sec = self
+            .prometheus
+            .query_range_avg(
+                "irate(consensus_gauge{op='last_committed_version'}[1m])".to_string(),
+                &start,
+                &end,
+                step,
+            )
+            .map_err(|e| warn!("{}", e))
+            .ok();
+        metrics.blocks_per_sec = self
+            .prometheus
+            .query_range_avg(
+                "irate(consensus_gauge{op='last_committed_round'}[1m])".to_string(),
+                &start,
+                &end,
+                step,
+            )
+            .map_err(|e| warn!("{}", e))
+            .ok();
+        metrics.avg_vote_time = self
+            .prometheus
+            .query_range_avg(
+                "irate(consensus_duration_sum{op='creation_to_receival_s'}[1m])/irate(consensus_duration_count{op='creation_to_receival_s'}[1m])".to_string(),
+                &start,
+                &end,
+                step,
+            )
+            .map_err(|e| warn!("{}", e))
+            .ok().map(|x| x * 1000f64);
+        metrics.avg_qc_time = self
+            .prometheus
+            .query_range_avg(
+                "irate(consensus_duration_sum{op='creation_to_qc_s'}[1m])/irate(consensus_duration_count{op='creation_to_qc_s'}[1m])".to_string(),
+                &start,
+                &end,
+                step,
+            )
+            .map_err(|e| warn!("{}", e))
+            .ok().map(|x| x * 1000f64);
+        metrics
+    }
+}
+
+fn print_results(metrics: Vec<Metrics>) {
+    info!("Results:");
+    println!(
+        "split_size, cross_region_latency, txn_per_sec, blocks_per_sec, avg_vote_time, avg_qc_time"
+    );
+    let to_str = |x: &Option<f64>| -> String {
+        if let Some(val) = x {
+            format!("{:.2}", val)
+        } else {
+            "".to_string()
+        }
+    };
+    for metric in metrics {
+        println!(
+            "{}, {}, {}, {}, {}, {}",
+            metric.split_size,
+            metric.cross_region_latency,
+            to_str(&metric.txn_per_sec),
+            to_str(&metric.blocks_per_sec),
+            to_str(&metric.avg_vote_time),
+            to_str(&metric.avg_qc_time),
+        );
     }
 }
 
 impl Experiment for MultiRegionSimulation {
     fn affected_validators(&self) -> HashSet<String> {
         let mut r = HashSet::new();
-        for instance in self.region1.iter().chain(self.region2.iter()) {
+        for instance in self.cluster.clone().into_instances() {
             r.insert(instance.short_hash().clone());
         }
         r
     }
 
     fn run(&self) -> failure::Result<()> {
-        let (smaller_region, larger_region);
-        if self.region1.len() < self.region2.len() {
-            smaller_region = &self.region1;
-            larger_region = &self.region2;
-        } else {
-            smaller_region = &self.region2;
-            larger_region = &self.region1;
-        }
-        // Add network delay commands only to the instances of the smaller
-        // region because we have to run fewer ssh commands.
-        let jobs: Vec<_> = smaller_region
-            .iter()
-            .map(|instance| {
-                let instance = instance.clone();
-                let larger_region = larger_region.clone();
-                let cross_region_delay = self.cross_region_delay;
-                move || {
-                    let network_delay = NetworkDelay::new(
-                        instance.clone(),
-                        Some(larger_region.clone()),
-                        cross_region_delay,
-                    );
-                    network_delay.apply()
+        let mut results = vec![];
+        for split in &self.splits {
+            for cross_region_latency in &self.cross_region_latencies {
+                info!(
+                    "Running multi region simulation: split: {}, cross region latency: {}ms",
+                    split, cross_region_latency
+                );
+                if let Ok(metrics) = self
+                    .single_run(*split, Duration::from_millis(*cross_region_latency))
+                    .map_err(|e| warn!("{}", e))
+                {
+                    results.push(metrics);
                 }
-            })
-            .collect();
-        self.thread_pool_executor.execute_jobs(jobs);
-
-        thread::sleep(self.experiment_duration);
-        for instance in smaller_region {
-            let remove_network_effects = RemoveNetworkEffects::new(instance.clone());
-            remove_network_effects.apply()?;
+                thread::sleep(Duration::from_secs(60));
+            }
         }
+        print_results(results);
         Ok(())
     }
 }
@@ -94,9 +209,8 @@ impl fmt::Display for MultiRegionSimulation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Multi Region Simulation with a split of  {}/{}",
-            self.region1.len(),
-            self.region2.len()
+            "Multi Region Simulation splits: {:?} cross region latencies: {:?}",
+            self.splits, self.cross_region_latencies
         )
     }
 }

--- a/testsuite/cluster-test/src/prometheus.rs
+++ b/testsuite/cluster-test/src/prometheus.rs
@@ -9,6 +9,7 @@ use reqwest::Url;
 use serde::Deserialize;
 use std::{collections::HashMap, time::Duration};
 
+#[derive(Clone)]
 pub struct Prometheus {
     url: Url,
     client: reqwest::Client,
@@ -31,7 +32,7 @@ impl Prometheus {
         Self { url, client }
     }
 
-    pub fn query_range(
+    fn query_range(
         &self,
         query: String,
         start: &Duration,
@@ -70,6 +71,18 @@ impl Prometheus {
                 response.error
             ),
         }
+    }
+    pub fn query_range_avg(
+        &self,
+        query: String,
+        start: &Duration,
+        end: &Duration,
+        step: u64,
+    ) -> failure::Result<f64> {
+        let response = self.query_range(query, start, end, step)?;
+        response
+            .avg()
+            .ok_or_else(|| format_err!("Failed to compute avg"))
     }
 }
 


### PR DESCRIPTION
## Summary

* This is the code which is used to run experiments with introducing network delays between nodes and simulation of multi-region
* With this we can specify a list of split sizes and delays and we will run the simulation for every combination of these two parameters
* Update NetworkDelay to be an `Effect` instead of `Action`
* Update flags for multi-region simulation because now we can run simulations with a variety of split sizes and delays instead of just one
* Complete rewrite of multi_region_network_simulation.rs to handle running simulations with a variety of configs
* Print a list of all metrics in a csv format at the end of the experiment

## Test Plan

Tested this on my cluster