### PR TITLE
[network] Add benchmark for transport with TCP_NODELAY set

### DIFF
--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -25,16 +25,16 @@ use tokio::net::tcp::{TcpListener, TcpStream};
 #[derive(Debug, Clone, Default)]
 pub struct TcpTransport {
     /// Size of the recv buffer size to set for opened sockets, or `None` to keep default.
-    recv_buffer_size: Option<usize>,
+    pub recv_buffer_size: Option<usize>,
     /// Size of the send buffer size to set for opened sockets, or `None` to keep default.
-    send_buffer_size: Option<usize>,
+    pub send_buffer_size: Option<usize>,
     /// TTL to set for opened sockets, or `None` to keep default.
-    ttl: Option<u32>,
+    pub ttl: Option<u32>,
     /// Keep alive duration to set for opened sockets, or `None` to keep default.
     #[allow(clippy::option_option)]
-    keepalive: Option<Option<Duration>>,
+    pub keepalive: Option<Option<Duration>>,
     /// `TCP_NODELAY` to set for opened sockets, or `None` to keep default.
-    nodelay: Option<bool>,
+    pub nodelay: Option<bool>,
 }
 
 impl TcpTransport {


### PR DESCRIPTION
## Motivation

Motivation was to explore the effect of setting `TCP_NODELAY` on our TCP connections and exploring avenues for perf improvements.

This line chart compares performance b/w Memsocket, TCP and TCP with TCP_NODELAY set:
![image](https://user-images.githubusercontent.com/877038/68355319-bac02a00-00c3-11ea-9d3e-56d9b44ff61f.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes