### PR TITLE
[Docker] update toolchain to stable

### DIFF
--- a/docker/bench/bench.Dockerfile
+++ b/docker/bench/bench.Dockerfile
@@ -7,17 +7,13 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
 
 FROM toolchain AS builder
 
+WORKDIR /libra
 COPY . /libra
-
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 
 ### Production Image ###

--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -7,17 +7,13 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
 
 FROM toolchain AS builder
 
+WORKDIR /libra
 COPY . /libra
-
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 RUN strip target/release/client
 

--- a/docker/cluster_test/cluster_test_builder.Dockerfile
+++ b/docker/cluster_test/cluster_test_builder.Dockerfile
@@ -7,9 +7,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git
 #     && apt-get clean && rm -r /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH "$PATH:/root/.cargo/bin"
 
 WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -7,17 +7,13 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
 
 FROM toolchain AS builder
 
+WORKDIR /libra
 COPY . /libra
-
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 
 ### Production Image ###

--- a/docker/validator/validator.Dockerfile
+++ b/docker/validator/validator.Dockerfile
@@ -7,17 +7,13 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sou
     && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
 
 FROM toolchain AS builder
 
+WORKDIR /libra
 COPY . /libra
-
 RUN cargo build --release -p libra-node -p client -p benchmark && cd target/release && rm -r build deps incremental
 
 ### Production Image ###


### PR DESCRIPTION
## Motivation
We udpated rust toolchain to stable and need to keep the docker build
in sync.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
Tested validator build locally.  Will defer the rest docker builds to CircleCI to verify.
