### PR TITLE
[consensus] Update all consensus counters to new format

### DIFF
--- a/common/channel/src/libra_channel.rs
+++ b/common/channel/src/libra_channel.rs
@@ -11,12 +11,13 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::Waker;
 
-use crate::message_queues::{Counters, PerKeyQueue, QueueStyle};
+use crate::message_queues::{PerKeyQueue, QueueStyle};
 use failure::prelude::*;
 use futures::async_await::FusedStream;
 use futures::stream::Stream;
 use futures::task::Context;
 use futures::Poll;
+use libra_metrics::IntCounterVec;
 use std::hash::Hash;
 
 /// SharedState is a data structure private to this module which is
@@ -121,7 +122,7 @@ impl<K: Eq + Hash + Clone, M> FusedStream for Receiver<K, M> {
 pub fn new<K: Eq + Hash + Clone, M>(
     queue_style: QueueStyle,
     max_queue_size_per_key: usize,
-    counters: Option<Counters>,
+    counters: Option<&'static IntCounterVec>,
 ) -> (Sender<K, M>, Receiver<K, M>) {
     let shared_state = Arc::new(Mutex::new(SharedState {
         internal_queue: PerKeyQueue::new(queue_style, max_queue_size_per_key, counters),

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -537,11 +537,15 @@ impl<T: Payload> EventProcessor<T> {
                 match waiting_success {
                     WaitingSuccess::WaitWasRequired { wait_duration, .. } => {
                         counters::VOTE_SUCCESS_WAIT_S.observe_duration(wait_duration);
-                        counters::VOTE_WAIT_WAS_REQUIRED_COUNT.inc();
+                        counters::VOTES_COUNT
+                            .with_label_values(&["wait_was_required"])
+                            .inc();
                     }
                     WaitingSuccess::NoWaitRequired { .. } => {
                         counters::VOTE_SUCCESS_WAIT_S.observe_duration(Duration::new(0, 0));
-                        counters::VOTE_NO_WAIT_REQUIRED_COUNT.inc();
+                        counters::VOTES_COUNT
+                            .with_label_values(&["no_wait_required"])
+                            .inc();
                     }
                 }
             }
@@ -553,7 +557,9 @@ impl<T: Payload> EventProcessor<T> {
                                 block_timestamp_us,
                                 current_round_deadline);
                         counters::VOTE_FAILURE_WAIT_S.observe_duration(Duration::new(0, 0));
-                        counters::VOTE_MAX_WAIT_EXCEEDED_COUNT.inc();
+                        counters::VOTES_COUNT
+                            .with_label_values(&["max_wait_exceeded"])
+                            .inc();
                     }
                     WaitingError::WaitFailed {
                         current_duration_since_epoch,
@@ -565,7 +571,9 @@ impl<T: Payload> EventProcessor<T> {
                                 block_timestamp_us,
                                 current_duration_since_epoch);
                         counters::VOTE_FAILURE_WAIT_S.observe_duration(wait_duration);
-                        counters::VOTE_WAIT_FAILED_COUNT.inc();
+                        counters::VOTES_COUNT
+                            .with_label_values(&["wait_failed"])
+                            .inc();
                     }
                 };
                 return Err(waiting_error);

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -143,7 +143,9 @@ impl<T: Payload> ProposalGenerator<T> {
                             wait_duration,
                         } => {
                             counters::PROPOSAL_SUCCESS_WAIT_S.observe_duration(wait_duration);
-                            counters::PROPOSAL_WAIT_WAS_REQUIRED_COUNT.inc();
+                            counters::PROPOSALS_GENERATED_COUNT
+                                .with_label_values(&["wait_was_required"])
+                                .inc();
                             current_duration_since_epoch
                         }
                         WaitingSuccess::NoWaitRequired {
@@ -151,7 +153,9 @@ impl<T: Payload> ProposalGenerator<T> {
                             ..
                         } => {
                             counters::PROPOSAL_SUCCESS_WAIT_S.observe_duration(Duration::new(0, 0));
-                            counters::PROPOSAL_NO_WAIT_REQUIRED_COUNT.inc();
+                            counters::PROPOSALS_GENERATED_COUNT
+                                .with_label_values(&["no_wait_required"])
+                                .inc();
                             current_duration_since_epoch
                         }
                     }
@@ -160,7 +164,9 @@ impl<T: Payload> ProposalGenerator<T> {
                     match waiting_error {
                         WaitingError::MaxWaitExceeded => {
                             counters::PROPOSAL_FAILURE_WAIT_S.observe_duration(Duration::new(0, 0));
-                            counters::PROPOSAL_MAX_WAIT_EXCEEDED_COUNT.inc();
+                            counters::PROPOSALS_GENERATED_COUNT
+                                .with_label_values(&["max_wait_exceeded"])
+                                .inc();
                             bail!(
                                 "Waiting until parent block timestamp usecs {:?} would exceed the round duration {:?}, hence will not create a proposal for this round",
                                 hqc.certified_block().timestamp_usecs(),
@@ -171,7 +177,9 @@ impl<T: Payload> ProposalGenerator<T> {
                             wait_duration,
                         } => {
                             counters::PROPOSAL_FAILURE_WAIT_S.observe_duration(wait_duration);
-                            counters::PROPOSAL_WAIT_FAILED_COUNT.inc();
+                            counters::PROPOSALS_GENERATED_COUNT
+                                .with_label_values(&["wait_failed"])
+                                .inc();
                             bail!(
                                 "Even after waiting for {:?}, parent block timestamp usecs {:?} >= current timestamp usecs {:?}, will not create a proposal for this round",
                                 wait_duration,

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -3,10 +3,7 @@
 
 use crate::counters;
 use bytes::Bytes;
-use channel::{
-    self, libra_channel,
-    message_queues::{self, QueueStyle},
-};
+use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse};
 use consensus_types::epoch_retrieval::EpochRetrievalRequest;
 use consensus_types::{
@@ -274,50 +271,21 @@ impl<T: Payload> NetworkTask<T> {
         self_receiver: channel::Receiver<failure::Result<Event<ConsensusMsg>>>,
         validators: Arc<ValidatorVerifier>,
     ) -> (NetworkTask<T>, NetworkReceivers<T>) {
-        let (proposal_tx, proposal_rx) = libra_channel::new(
-            QueueStyle::LIFO,
-            1,
-            Some(message_queues::Counters {
-                dropped_msgs_counter: &counters::PROPOSAL_DROPPED_MSGS,
-                enqueued_msgs_counter: &counters::PROPOSAL_ENQUEUED_MSGS,
-                dequeued_msgs_counter: &counters::PROPOSAL_DEQUEUED_MSGS,
-            }),
-        );
-        let (vote_tx, vote_rx) = libra_channel::new(
-            QueueStyle::LIFO,
-            1,
-            Some(message_queues::Counters {
-                dropped_msgs_counter: &counters::VOTES_DROPPED_MSGS,
-                enqueued_msgs_counter: &counters::VOTES_ENQUEUED_MSGS,
-                dequeued_msgs_counter: &counters::VOTES_DEQUEUED_MSGS,
-            }),
-        );
+        let (proposal_tx, proposal_rx) =
+            libra_channel::new(QueueStyle::LIFO, 1, Some(&counters::PROPOSAL_CHANNEL_MSGS));
+        let (vote_tx, vote_rx) =
+            libra_channel::new(QueueStyle::LIFO, 1, Some(&counters::VOTES_CHANNEL_MSGS));
         let (block_request_tx, block_request_rx) = libra_channel::new(
             QueueStyle::LIFO,
             1,
-            Some(message_queues::Counters {
-                dropped_msgs_counter: &counters::BLOCK_RETRIEVAL_DROPPED_MSGS,
-                enqueued_msgs_counter: &counters::BLOCK_RETRIEVAL_ENQUEUED_MSGS,
-                dequeued_msgs_counter: &counters::BLOCK_RETRIEVAL_DEQUEUED_MSGS,
-            }),
+            Some(&counters::BLOCK_RETRIEVAL_CHANNEL_MSGS),
         );
-        let (sync_info_tx, sync_info_rx) = libra_channel::new(
-            QueueStyle::LIFO,
-            1,
-            Some(message_queues::Counters {
-                dropped_msgs_counter: &counters::SYNC_INFO_DROPPED_MSGS,
-                enqueued_msgs_counter: &counters::SYNC_INFO_ENQUEUED_MSGS,
-                dequeued_msgs_counter: &counters::SYNC_INFO_DEQUEUED_MSGS,
-            }),
-        );
+        let (sync_info_tx, sync_info_rx) =
+            libra_channel::new(QueueStyle::LIFO, 1, Some(&counters::SYNC_INFO_CHANNEL_MSGS));
         let (epoch_change_tx, epoch_change_rx) = libra_channel::new(
             QueueStyle::LIFO,
             1,
-            Some(message_queues::Counters {
-                dropped_msgs_counter: &counters::EPOCH_CHANGE_DROPPED_MSGS,
-                enqueued_msgs_counter: &counters::EPOCH_CHANGE_ENQUEUED_MSGS,
-                dequeued_msgs_counter: &counters::EPOCH_CHANGE_DEQUEUED_MSGS,
-            }),
+            Some(&counters::EPOCH_CHANGE_CHANNEL_MSGS),
         );
         let (different_epoch_tx, different_epoch_rx) =
             libra_channel::new(QueueStyle::LIFO, 1, None);

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -2,74 +2,54 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use libra_metrics::{DurationHistogram, OpMetrics};
-use prometheus::{Histogram, IntCounter, IntGauge};
-
-lazy_static::lazy_static! {
-    pub static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("consensus");
-}
+use libra_metrics::DurationHistogram;
+use prometheus::{Histogram, IntCounter, IntCounterVec, IntGauge};
 
 lazy_static::lazy_static! {
 //////////////////////
 // HEALTH COUNTERS
 //////////////////////
 /// This counter is set to the round of the highest committed block.
-pub static ref LAST_COMMITTED_ROUND: IntGauge = OP_COUNTERS.gauge("last_committed_round");
+pub static ref LAST_COMMITTED_ROUND: IntGauge = register_int_gauge!("libra_consensus_last_committed_round","This counter is set to the round of the highest committed block.").unwrap();
 
 /// The counter corresponds to the version of the last committed ledger info.
-pub static ref LAST_COMMITTED_VERSION: IntGauge = OP_COUNTERS.gauge("last_committed_version");
+pub static ref LAST_COMMITTED_VERSION: IntGauge = register_int_gauge!("libra_consensus_last_committed_version", "The counter corresponds to the version of the last committed ledger info.").unwrap();
 
 /// This counter is set to the round of the highest voted block.
-pub static ref LAST_VOTE_ROUND: IntGauge = OP_COUNTERS.gauge("last_vote_round");
+pub static ref LAST_VOTE_ROUND: IntGauge = register_int_gauge!("libra_consensus_last_vote_round", "This counter is set to the round of the highest voted block.").unwrap();
 
 /// This counter is set to the round of the preferred block (highest 2-chain head).
-pub static ref PREFERRED_BLOCK_ROUND: IntGauge = OP_COUNTERS.gauge("preferred_block_round");
+pub static ref PREFERRED_BLOCK_ROUND: IntGauge = register_int_gauge!("libra_consensus_preferred_block_round", "This counter is set to the round of the preferred block (highest 2-chain head).").unwrap();
 
 /// This counter is set to the last round reported by the local pacemaker.
-pub static ref CURRENT_ROUND: IntGauge = OP_COUNTERS.gauge("current_round");
+pub static ref CURRENT_ROUND: IntGauge = register_int_gauge!("libra_consensus_current_round", "This counter is set to the last round reported by the local pacemaker.").unwrap();
 
 /// Count of the committed blocks since last restart.
-pub static ref COMMITTED_BLOCKS_COUNT: IntCounter = OP_COUNTERS.counter("committed_blocks_count");
+pub static ref COMMITTED_BLOCKS_COUNT: IntCounter = register_int_counter!("libra_consensus_committed_blocks_count", "Count of the committed blocks since last restart.").unwrap();
 
 /// Count of the committed transactions since last restart.
-pub static ref COMMITTED_TXNS_COUNT: IntCounter = OP_COUNTERS.counter("committed_txns_count");
+pub static ref COMMITTED_TXNS_COUNT: IntCounterVec = register_int_counter_vec!("libra_consensus_committed_txns_count", "Count of the transactions since last restart. state is success or failed", &["state"]).unwrap();
 
-/// Count of success txns in the blocks committed by this validator since last restart.
-pub static ref SUCCESS_TXNS_COUNT: IntCounter = OP_COUNTERS.counter("success_txns_count");
+/// Histogram of idle time of spent in event processing loop
+pub static ref EVENT_PROCESSING_LOOP_IDLE_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_event_processing_loop_idle_duration_s", "Histogram of idle time of spent in event processing loop").unwrap());
 
-/// Count of failed txns in the committed blocks since last restart.
-/// FAILED_TXNS_COUNT + SUCCESS_TXN_COUNT == COMMITTED_TXNS_COUNT
-pub static ref FAILED_TXNS_COUNT: IntCounter = OP_COUNTERS.counter("failed_txns_count");
-
-/// Histogram of idle time (ms) of spent in event processing loop
-pub static ref EVENT_PROCESSING_LOOP_IDLE_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("event_processing_loop_idle_duration_s");
-/// Histogram of busy time (ms) of spent in event processing loop
-pub static ref EVENT_PROCESSING_LOOP_BUSY_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("event_processing_loop_busy_duration_s");
+/// Histogram of busy time of spent in event processing loop
+pub static ref EVENT_PROCESSING_LOOP_BUSY_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_event_processing_loop_busy_duration_s", "Histogram of busy time of spent in event processing loop").unwrap());
 
 /// Counters(queued,dequeued,dropped) related to proposals channel
-pub static ref PROPOSAL_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("proposal_dropped_msgs_count");
-pub static ref PROPOSAL_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("proposal_enqueued_msgs_count");
-pub static ref PROPOSAL_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("proposal_dequeued_msgs_count");
+pub static ref PROPOSAL_CHANNEL_MSGS: IntCounterVec = register_int_counter_vec!("libra_consensus_proposal_channel_msgs_count", "Counters(queued,dequeued,dropped) related to proposals channel", &["state"]).unwrap();
 
 /// Counters(queued,dequeued,dropped) related to votes channel
-pub static ref VOTES_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("votes_dropped_msgs_count");
-pub static ref VOTES_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("votes_enqueued_msgs_count");
-pub static ref VOTES_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("votes_dequeued_msgs_count");
+pub static ref VOTES_CHANNEL_MSGS: IntCounterVec = register_int_counter_vec!("libra_consensus_votes_channel_msgs_count", "Counters(queued,dequeued,dropped) related to votes channel", &["state"]).unwrap();
 
 /// Counters(queued,dequeued,dropped) related to block retrieval channel
-pub static ref BLOCK_RETRIEVAL_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("block_retrieval_dropped_msgs_count");
-pub static ref BLOCK_RETRIEVAL_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("block_retrieval_enqueued_msgs_count");
-pub static ref BLOCK_RETRIEVAL_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("block_retrieval_dequeued_msgs_count");
+pub static ref BLOCK_RETRIEVAL_CHANNEL_MSGS: IntCounterVec = register_int_counter_vec!("libra_consensus_block_retrieval_channel_msgs_count", "Counters(queued,dequeued,dropped) related to block retrieval channel", &["state"]).unwrap();
 
 /// Counters(queued,dequeued,dropped) related to sync info channel
-pub static ref SYNC_INFO_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_dropped_msgs_count");
-pub static ref SYNC_INFO_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_enqueued_msgs_count");
-pub static ref SYNC_INFO_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("sync_info_dequeued_msgs_count");
+pub static ref SYNC_INFO_CHANNEL_MSGS: IntCounterVec = register_int_counter_vec!("libra_consensus_sync_info_dropped_channel_msgs_count", "Counters(queued,dequeued,dropped) related to sync info channel", &["state"]).unwrap();
 
-/// Count of number of messages dropped by epoch change channel
-pub static ref EPOCH_CHANGE_DROPPED_MSGS: IntCounter = OP_COUNTERS.counter("epoch_change_dropped_msgs_count");
-pub static ref EPOCH_CHANGE_ENQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("epoch_change_enqueued_msgs_count");
-pub static ref EPOCH_CHANGE_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("epoch_change_dequeued_msgs_count");
+/// Counters(queued,dequeued,dropped) related to epoch change channel
+pub static ref EPOCH_CHANGE_CHANNEL_MSGS: IntCounterVec = register_int_counter_vec!("libra_consensus_epoch_change_dropped_channel_msgs_count", "Counters(queued,dequeued,dropped) related to epoch change channel", &["state"]).unwrap();
 
 
 //////////////////////
@@ -78,63 +58,63 @@ pub static ref EPOCH_CHANGE_DEQUEUED_MSGS: IntCounter = OP_COUNTERS.counter("epo
 
 /// Count of the block proposals sent by this validator since last restart
 /// (both primary and secondary)
-pub static ref PROPOSALS_COUNT: IntCounter = OP_COUNTERS.counter("proposals_count");
+pub static ref PROPOSALS_COUNT: IntCounter = register_int_counter!("libra_consensus_proposals_count", "Count of the block proposals sent by this validator since last restart (both primary and secondary)").unwrap();
 
 /// Count the number of times a validator voted for secondary proposals (upon timeout) since
 /// last restart.
-pub static ref VOTE_SECONDARY_PROPOSAL_COUNT: IntCounter = OP_COUNTERS.counter("vote_secondary_proposal_count");
+pub static ref VOTE_SECONDARY_PROPOSAL_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_secondary_proposal_count", "Count the number of times a validator voted for secondary proposals (upon timeout) since last restart.").unwrap();
 
 /// Count the number of times a validator voted for a nil block since last restart.
-pub static ref VOTE_NIL_COUNT: IntCounter = OP_COUNTERS.counter("vote_nil_count");
+pub static ref VOTE_NIL_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_nil_count", "Count the number of times a validator voted for a nil block since last restart.").unwrap();
 
 //////////////////////
 // PACEMAKER COUNTERS
 //////////////////////
 /// Count of the rounds that gathered QC since last restart.
-pub static ref QC_ROUNDS_COUNT: IntCounter = OP_COUNTERS.counter("qc_rounds_count");
+pub static ref QC_ROUNDS_COUNT: IntCounter = register_int_counter!("libra_consensus_qc_rounds_count", "Count of the rounds that gathered QC since last restart.").unwrap();
 
 /// Count of the timeout rounds since last restart (close to 0 in happy path).
-pub static ref TIMEOUT_ROUNDS_COUNT: IntCounter = OP_COUNTERS.counter("timeout_rounds_count");
+pub static ref TIMEOUT_ROUNDS_COUNT: IntCounter = register_int_counter!("libra_consensus_timeout_rounds_count", "Count of the timeout rounds since last restart (close to 0 in happy path).").unwrap();
 
 /// Count the number of timeouts a node experienced since last restart (close to 0 in happy path).
 /// This count is different from `TIMEOUT_ROUNDS_COUNT`, because not every time a node has
 /// a timeout there is an ultimate decision to move to the next round (it might take multiple
 /// timeouts to get the timeout certificate).
-pub static ref TIMEOUT_COUNT: IntCounter = OP_COUNTERS.counter("timeout_count");
+pub static ref TIMEOUT_COUNT: IntCounter = register_int_counter!("libra_consensus_timeout_count", "Count the number of timeouts a node experienced since last restart (close to 0 in happy path).").unwrap();
 
 /// The timeout of the current round.
-pub static ref ROUND_TIMEOUT_MS: IntGauge = OP_COUNTERS.gauge("round_timeout_ms");
+pub static ref ROUND_TIMEOUT_MS: IntGauge = register_int_gauge!("libra_consensus_round_timeout_s", "The timeout of the current round.").unwrap();
 
 ////////////////////////
 // SYNCMANAGER COUNTERS
 ////////////////////////
 /// Count the number of times we invoked state synchronization since last restart.
-pub static ref STATE_SYNC_COUNT: IntCounter = OP_COUNTERS.counter("state_sync_count");
+pub static ref STATE_SYNC_COUNT: IntCounter = register_int_counter!("libra_consensus_state_sync_count", "Count the number of times we invoked state synchronization since last restart.").unwrap();
 
 /// Count the number of block retrieval requests issued since last restart.
-pub static ref BLOCK_RETRIEVAL_COUNT: IntCounter = OP_COUNTERS.counter("block_retrieval_count");
+pub static ref BLOCK_RETRIEVAL_COUNT: IntCounter = register_int_counter!("libra_consensus_block_retrieval_count", "Count the number of block retrieval requests issued since last restart.").unwrap();
 
 /// Histogram of block retrieval duration.
-pub static ref BLOCK_RETRIEVAL_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("block_retrieval_duration_s");
+pub static ref BLOCK_RETRIEVAL_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_block_retrieval_duration_s", "Histogram of block retrieval duration.").unwrap());
 
 /// Histogram of state sync duration.
-pub static ref STATE_SYNC_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("state_sync_duration_s");
+pub static ref STATE_SYNC_DURATION_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_state_sync_duration_s", "Histogram of state sync duration.").unwrap());
 
 /// Counts the number of times the sync info message has been set since last restart.
-pub static ref SYNC_INFO_MSGS_SENT_COUNT: IntCounter = OP_COUNTERS.counter("sync_info_msg_sent_count");
+pub static ref SYNC_INFO_MSGS_SENT_COUNT: IntCounter = register_int_counter!("libra_consensus_sync_info_msg_sent_count", "Counts the number of times the sync info message has been set since last restart.").unwrap();
 
 /// Counts the number of times the sync info message has been received since last restart.
-pub static ref SYNC_INFO_MSGS_RECEIVED_COUNT: IntCounter = OP_COUNTERS.counter("sync_info_msg_received_count");
+pub static ref SYNC_INFO_MSGS_RECEIVED_COUNT: IntCounter = register_int_counter!("libra_consensus_sync_info_msg_received_count", "Counts the number of times the sync info message has been received since last restart.").unwrap();
 
 //////////////////////
 // RECONFIGURATION COUNTERS
 //////////////////////
 /// Current epoch num
-pub static ref EPOCH: IntGauge = OP_COUNTERS.gauge("epoch");
+pub static ref EPOCH: IntGauge = register_int_gauge!("libra_consensus_epoch", "Current epoch num").unwrap();
 /// The number of validators in the current epoch
-pub static ref CURRENT_EPOCH_VALIDATORS: IntGauge = OP_COUNTERS.gauge("current_epoch_validators");
+pub static ref CURRENT_EPOCH_VALIDATORS: IntGauge = register_int_gauge!("libra_consensus_current_epoch_validators", "The number of validators in the current epoch").unwrap();
 /// Quorum size in the current epoch
-pub static ref CURRENT_EPOCH_QUORUM_SIZE: IntGauge = OP_COUNTERS.gauge("current_epoch_quorum_size");
+pub static ref CURRENT_EPOCH_QUORUM_SIZE: IntGauge = register_int_gauge!("libra_consensus_current_epoch_quorum_size", "Quorum size in the current epoch").unwrap();
 
 
 //////////////////////
@@ -142,102 +122,103 @@ pub static ref CURRENT_EPOCH_QUORUM_SIZE: IntGauge = OP_COUNTERS.gauge("current_
 //////////////////////
 /// Counter for the number of blocks in the block tree (including the root).
 /// In a "happy path" with no collisions and timeouts, should be equal to 3 or 4.
-pub static ref NUM_BLOCKS_IN_TREE: IntGauge = OP_COUNTERS.gauge("num_blocks_in_tree");
+pub static ref NUM_BLOCKS_IN_TREE: IntGauge = register_int_gauge!("libra_consensus_num_blocks_in_tree", "Counter for the number of blocks in the block tree (including the root).").unwrap();
 
 //////////////////////
 // PERFORMANCE COUNTERS
 //////////////////////
-/// Histogram of execution time (ms) of non-empty blocks.
-pub static ref BLOCK_EXECUTION_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("block_execution_duration_s");
+/// Histogram of execution time of non-empty blocks.
+pub static ref BLOCK_EXECUTION_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_block_execution_duration_s", "Histogram of execution time of non-empty blocks.").unwrap());
 
 /// Histogram of duration of a commit procedure (the time it takes for the execution / storage to
 /// commit a block once we decide to do so).
-pub static ref BLOCK_COMMIT_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("block_commit_duration_s");
+pub static ref BLOCK_COMMIT_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_block_commit_duration_s", "Histogram of duration of a commit procedure (the time it takes for the execution / storage to commit a block once we decide to do so).").unwrap());
 
 /// Histogram for the number of txns per (committed) blocks.
-pub static ref NUM_TXNS_PER_BLOCK: Histogram = OP_COUNTERS.histogram("num_txns_per_block");
+pub static ref NUM_TXNS_PER_BLOCK: Histogram = register_histogram!("libra_consensus_num_txns_per_block", "Histogram for the number of txns per (committed) blocks.").unwrap();
 
-/// Histogram of per-transaction execution time (ms) of non-empty blocks
+/// Histogram of per-transaction execution time of non-empty blocks
 /// (calculated as the overall execution time of a block divided by the number of transactions).
-pub static ref TXN_EXECUTION_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("txn_execution_duration_s");
+pub static ref TXN_EXECUTION_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_txn_execution_duration_s", "Histogram of per-transaction execution time of non-empty blocks (calculated as the overall execution time of a block divided by the number of transactions).").unwrap());
 
-/// Histogram of execution time (ms) of empty blocks.
-pub static ref EMPTY_BLOCK_EXECUTION_DURATION_S: DurationHistogram = OP_COUNTERS.duration_histogram("empty_block_execution_duration_s");
+/// Histogram of execution time of empty blocks.
+pub static ref EMPTY_BLOCK_EXECUTION_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_empty_block_execution_duration_s", "Histogram of execution time of empty blocks.").unwrap());
 
 /// Histogram of the time it takes for a block to get committed.
 /// Measured as the commit time minus block's timestamp.
-pub static ref CREATION_TO_COMMIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("creation_to_commit_s");
+pub static ref CREATION_TO_COMMIT_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_creation_to_commit_s", "Histogram of the time it takes for a block to get committed. Measured as the commit time minus block's timestamp.").unwrap());
 
 /// Duration between block generation time until the moment it gathers full QC
-pub static ref CREATION_TO_QC_S: DurationHistogram = OP_COUNTERS.duration_histogram("creation_to_qc_s");
+pub static ref CREATION_TO_QC_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_creation_to_qc_s", "Duration between block generation time until the moment it gathers full QC").unwrap());
 
 /// Duration between block generation time until the moment it is received and ready for execution.
-pub static ref CREATION_TO_RECEIVAL_S: DurationHistogram = OP_COUNTERS.duration_histogram("creation_to_receival_s");
+pub static ref CREATION_TO_RECEIVAL_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_creation_to_receival_s", "Duration between block generation time until the moment it is received and ready for execution.").unwrap());
 
 ////////////////////////////////////
 // PROPSOSAL/VOTE TIMESTAMP COUNTERS
 ////////////////////////////////////
 /// Count of the proposals that passed the timestamp rules and did not have to wait
-pub static ref PROPOSAL_NO_WAIT_REQUIRED_COUNT: IntCounter = OP_COUNTERS.counter("proposal_no_wait_required_count");
+pub static ref PROPOSAL_NO_WAIT_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_no_wait_required_count", "Count of the proposals that passed the timestamp rules and did not have to wait").unwrap();
 
 /// Count of the proposals where passing the timestamp rules required waiting
-pub static ref PROPOSAL_WAIT_WAS_REQUIRED_COUNT: IntCounter = OP_COUNTERS.counter("proposal_wait_was_required_count");
+pub static ref PROPOSAL_WAIT_WAS_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_wait_was_required_count", "Count of the proposals where passing the timestamp rules required waiting").unwrap();
 
 /// Count of the proposals that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules
-pub static ref PROPOSAL_MAX_WAIT_EXCEEDED_COUNT: IntCounter = OP_COUNTERS.counter("proposal_max_wait_exceeded_count");
+pub static ref PROPOSAL_MAX_WAIT_EXCEEDED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_max_wait_exceeded_count", "Count of the proposals that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules").unwrap();
 
 /// Count of the proposals that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules
-pub static ref PROPOSAL_WAIT_FAILED_COUNT: IntCounter = OP_COUNTERS.counter("proposal_wait_failed_count");
+pub static ref PROPOSAL_WAIT_FAILED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_wait_failed_count", "Count of the proposals that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules").unwrap();
 
 /// Histogram of time waited for successfully proposing a proposal (both those that waited and didn't wait) after following timestamp rules
-pub static ref PROPOSAL_SUCCESS_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("proposal_success_wait_s");
+pub static ref PROPOSAL_SUCCESS_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_proposal_success_wait_s", "Histogram of time waited for successfully proposing a proposal (both those that waited and didn't wait) after following timestamp rules").unwrap());
 
 /// Histogram of time waited for failing to propose a proposal (both those that waited and didn't wait) while trying to follow timestamp rules
-pub static ref PROPOSAL_FAILURE_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("proposal_failure_wait_s");
+pub static ref PROPOSAL_FAILURE_WAIT_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_proposal_failure_wait_s", "Histogram of time waited for failing to propose a proposal (both those that waited and didn't wait) while trying to follow timestamp rules").unwrap());
 
 /// Count of the votes that passed the timestamp rules and did not have to wait
-pub static ref VOTE_NO_WAIT_REQUIRED_COUNT: IntCounter = OP_COUNTERS.counter("vote_no_wait_required_count");
+pub static ref VOTE_NO_WAIT_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_no_wait_required_count", "Count of the votes that passed the timestamp rules and did not have to wait").unwrap();
 
 /// Count of the votes where passing the timestamp rules required waiting
-pub static ref VOTE_WAIT_WAS_REQUIRED_COUNT: IntCounter = OP_COUNTERS.counter("vote_wait_was_required_count");
+pub static ref VOTE_WAIT_WAS_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_wait_was_required_count", "Count of the votes where passing the timestamp rules required waiting").unwrap();
 
 /// Count of the votes that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules
-pub static ref VOTE_MAX_WAIT_EXCEEDED_COUNT: IntCounter = OP_COUNTERS.counter("vote_max_wait_exceeded_count");
+pub static ref VOTE_MAX_WAIT_EXCEEDED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_max_wait_exceeded_count", "Count of the votes that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules").unwrap();
 
 /// Count of the votes that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules
-pub static ref VOTE_WAIT_FAILED_COUNT: IntCounter = OP_COUNTERS.counter("vote_wait_failed_count");
+pub static ref VOTE_WAIT_FAILED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_wait_failed_count", "Count of the votes that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules").unwrap();
 
 /// Histogram of time waited for successfully having the ability to vote (both those that waited and didn't wait) after following timestamp rules.
 /// A success only means that a replica has an opportunity to vote.  It may not vote if it doesn't pass the voting rules.
-pub static ref VOTE_SUCCESS_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("vote_success_wait_s");
+pub static ref VOTE_SUCCESS_WAIT_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_vote_success_wait_s", "Histogram of time waited for successfully having the ability to vote (both those that waited and didn't wait) after following timestamp rules.").unwrap());
 
 /// Histogram of time waited for failing to have the ability to vote (both those that waited and didn't wait) while trying to follow timestamp rules
-pub static ref VOTE_FAILURE_WAIT_S: DurationHistogram = OP_COUNTERS.duration_histogram("vote_failure_wait_s");
+pub static ref VOTE_FAILURE_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_vote_success_wait_s", "Histogram of time waited for failing to have the ability to vote (both those that waited and didn't wait) while trying to follow timestamp rules").unwrap());
+
 
 ///////////////////
 // CHANNEL COUNTERS
 ///////////////////
 /// Count of the pending messages sent to itself in the channel
-pub static ref PENDING_SELF_MESSAGES: IntGauge = OP_COUNTERS.gauge("pending_self_messages");
+pub static ref PENDING_SELF_MESSAGES: IntGauge = register_int_gauge!("libra_consensus_pending_self_messages", "Count of the pending messages sent to itself in the channel").unwrap();
 
 /// Count of the pending inbound proposals
-pub static ref PENDING_PROPOSAL: IntGauge = OP_COUNTERS.gauge("pending_proposal");
+pub static ref PENDING_PROPOSAL: IntGauge = register_int_gauge!("libra_consensus_pending_proposal", "Count of the pending inbound proposals").unwrap();
 
 /// Count of the pending inbound votes
-pub static ref PENDING_VOTES: IntGauge = OP_COUNTERS.gauge("pending_votes");
+pub static ref PENDING_VOTES: IntGauge = register_int_gauge!("libra_consensus_pending_votes", "Count of the pending inbound votes").unwrap();
 
 /// Count of the pending inbound block requests
-pub static ref PENDING_BLOCK_REQUESTS: IntGauge = OP_COUNTERS.gauge("pending_block_requests");
+pub static ref PENDING_BLOCK_REQUESTS: IntGauge = register_int_gauge!("libra_consensus_pending_block_requests", "Count of the pending inbound block requests").unwrap();
 
 /// Count of the pending outbound pacemaker timeouts
-pub static ref PENDING_PACEMAKER_TIMEOUTS: IntGauge = OP_COUNTERS.gauge("pending_pacemaker_timeouts");
+pub static ref PENDING_PACEMAKER_TIMEOUTS: IntGauge = register_int_gauge!("libra_consensus_pending_pacemaker_timeouts", "Count of the pending outbound pacemaker timeouts").unwrap();
 
 /// Count of the pending new round events.
-pub static ref PENDING_NEW_ROUND_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_new_round_events");
+pub static ref PENDING_NEW_ROUND_EVENTS: IntGauge = register_int_gauge!("libra_consensus_pending_new_round_events", "Count of the pending new round events.").unwrap();
 
 /// Count of the pending sync info messages.
-pub static ref PENDING_SYNC_INFO_MSGS: IntGauge = OP_COUNTERS.gauge("pending_sync_info_msgs");
+pub static ref PENDING_SYNC_INFO_MSGS: IntGauge = register_int_gauge!("libra_consensus_pending_sync_info_msgs", "Count of the pending sync info messages.").unwrap();
 
 /// Count of the pending winning proposals.
-pub static ref PENDING_WINNING_PROPOSALS: IntGauge = OP_COUNTERS.gauge("pending_winning_proposals");
+pub static ref PENDING_WINNING_PROPOSALS: IntGauge = register_int_gauge!("libra_consensus_pending_winning_proposals", "Count of the pending winning proposals.").unwrap();
 }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -157,17 +157,13 @@ pub static ref CREATION_TO_RECEIVAL_S: DurationHistogram = DurationHistogram::ne
 ////////////////////////////////////
 // PROPSOSAL/VOTE TIMESTAMP COUNTERS
 ////////////////////////////////////
-/// Count of the proposals that passed the timestamp rules and did not have to wait
-pub static ref PROPOSAL_NO_WAIT_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_no_wait_required_count", "Count of the proposals that passed the timestamp rules and did not have to wait").unwrap();
 
-/// Count of the proposals where passing the timestamp rules required waiting
-pub static ref PROPOSAL_WAIT_WAS_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_wait_was_required_count", "Count of the proposals where passing the timestamp rules required waiting").unwrap();
-
-/// Count of the proposals that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules
-pub static ref PROPOSAL_MAX_WAIT_EXCEEDED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_max_wait_exceeded_count", "Count of the proposals that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules").unwrap();
-
-/// Count of the proposals that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules
-pub static ref PROPOSAL_WAIT_FAILED_COUNT: IntCounter = register_int_counter!("libra_consensus_proposal_wait_failed_count", "Count of the proposals that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules").unwrap();
+/// Total count of the proposals generated. state can be:
+/// no_wait_required: Count of the proposals that passed the timestamp rules and did not have to wait
+/// wait_was_required: Count of the proposals where passing the timestamp rules required waiting
+/// max_wait_exceeded: Count of the proposals that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules
+/// wait_failed: Count of the proposals that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules
+pub static ref PROPOSALS_GENERATED_COUNT: IntCounterVec = register_int_counter_vec!("libra_consensus_proposals_generated_count", "Count of all the proposals generated", &["state"]).unwrap();
 
 /// Histogram of time waited for successfully proposing a proposal (both those that waited and didn't wait) after following timestamp rules
 pub static ref PROPOSAL_SUCCESS_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_proposal_success_wait_s", "Histogram of time waited for successfully proposing a proposal (both those that waited and didn't wait) after following timestamp rules").unwrap());

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -98,7 +98,7 @@ pub static ref BLOCK_RETRIEVAL_COUNT: IntCounter = register_int_counter!("libra_
 pub static ref BLOCK_RETRIEVAL_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_block_retrieval_duration_s", "Histogram of block retrieval duration.").unwrap());
 
 /// Histogram of state sync duration.
-pub static ref STATE_SYNC_DURATION_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_state_sync_duration_s", "Histogram of state sync duration.").unwrap());
+pub static ref STATE_SYNC_DURATION_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_state_sync_duration_s", "Histogram of state sync duration.").unwrap());
 
 /// Counts the number of times the sync info message has been set since last restart.
 pub static ref SYNC_INFO_MSGS_SENT_COUNT: IntCounter = register_int_counter!("libra_consensus_sync_info_msg_sent_count", "Counts the number of times the sync info message has been set since last restart.").unwrap();
@@ -146,7 +146,7 @@ pub static ref EMPTY_BLOCK_EXECUTION_DURATION_S: DurationHistogram = DurationHis
 
 /// Histogram of the time it takes for a block to get committed.
 /// Measured as the commit time minus block's timestamp.
-pub static ref CREATION_TO_COMMIT_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_creation_to_commit_s", "Histogram of the time it takes for a block to get committed. Measured as the commit time minus block's timestamp.").unwrap());
+pub static ref CREATION_TO_COMMIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_creation_to_commit_s", "Histogram of the time it takes for a block to get committed. Measured as the commit time minus block's timestamp.").unwrap());
 
 /// Duration between block generation time until the moment it gathers full QC
 pub static ref CREATION_TO_QC_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_creation_to_qc_s", "Duration between block generation time until the moment it gathers full QC").unwrap());
@@ -169,23 +169,18 @@ pub static ref PROPOSALS_GENERATED_COUNT: IntCounterVec = register_int_counter_v
 pub static ref PROPOSAL_SUCCESS_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_proposal_success_wait_s", "Histogram of time waited for successfully proposing a proposal (both those that waited and didn't wait) after following timestamp rules").unwrap());
 
 /// Histogram of time waited for failing to propose a proposal (both those that waited and didn't wait) while trying to follow timestamp rules
-pub static ref PROPOSAL_FAILURE_WAIT_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_proposal_failure_wait_s", "Histogram of time waited for failing to propose a proposal (both those that waited and didn't wait) while trying to follow timestamp rules").unwrap());
+pub static ref PROPOSAL_FAILURE_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_proposal_failure_wait_s", "Histogram of time waited for failing to propose a proposal (both those that waited and didn't wait) while trying to follow timestamp rules").unwrap());
 
-/// Count of the votes that passed the timestamp rules and did not have to wait
-pub static ref VOTE_NO_WAIT_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_no_wait_required_count", "Count of the votes that passed the timestamp rules and did not have to wait").unwrap();
-
-/// Count of the votes where passing the timestamp rules required waiting
-pub static ref VOTE_WAIT_WAS_REQUIRED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_wait_was_required_count", "Count of the votes where passing the timestamp rules required waiting").unwrap();
-
-/// Count of the votes that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules
-pub static ref VOTE_MAX_WAIT_EXCEEDED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_max_wait_exceeded_count", "Count of the votes that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules").unwrap();
-
-/// Count of the votes that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules
-pub static ref VOTE_WAIT_FAILED_COUNT: IntCounter = register_int_counter!("libra_consensus_vote_wait_failed_count", "Count of the votes that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules").unwrap();
+/// Total count of the votes. state can be:
+/// no_wait_required: Count of the votes that passed the timestamp rules and did not have to wait
+/// wait_was_required: Count of the votes where passing the timestamp rules required waiting
+/// max_wait_exceeded: Count of the votes that were not made due to the waiting period exceeding the maximum allowed duration, breaking timestamp rules
+/// wait_failed: Count of the votes that were not made due to waiting to ensure the current time exceeds min_duration_since_epoch failed, breaking timestamp rules
+pub static ref VOTES_COUNT: IntCounterVec = register_int_counter_vec!("libra_consensus_votes_count", "Count of all the votes", &["state"]).unwrap();
 
 /// Histogram of time waited for successfully having the ability to vote (both those that waited and didn't wait) after following timestamp rules.
 /// A success only means that a replica has an opportunity to vote.  It may not vote if it doesn't pass the voting rules.
-pub static ref VOTE_SUCCESS_WAIT_S: DurationHistogram =DurationHistogram::new(register_histogram!("libra_consensus_vote_success_wait_s", "Histogram of time waited for successfully having the ability to vote (both those that waited and didn't wait) after following timestamp rules.").unwrap());
+pub static ref VOTE_SUCCESS_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_vote_success_wait_s", "Histogram of time waited for successfully having the ability to vote (both those that waited and didn't wait) after following timestamp rules.").unwrap());
 
 /// Histogram of time waited for failing to have the ability to vote (both those that waited and didn't wait) while trying to follow timestamp rules
 pub static ref VOTE_FAILURE_WAIT_S: DurationHistogram = DurationHistogram::new(register_histogram!("libra_consensus_vote_success_wait_s", "Histogram of time waited for failing to have the ability to vote (both those that waited and didn't wait) while trying to follow timestamp rules").unwrap());

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -16,6 +16,9 @@ extern crate failure;
 #[macro_use]
 extern crate debug_interface;
 
+#[macro_use]
+extern crate prometheus;
+
 mod chained_bft;
 
 mod util;

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -410,7 +410,7 @@ impl LibraSwarm {
     /// function are now available at all the nodes.
     pub fn wait_for_all_nodes_to_catchup(&mut self) -> bool {
         let num_attempts = 60;
-        let last_committed_round_str = "consensus{op=committed_blocks_count}";
+        let last_committed_round_str = "libra_consensus_committed_blocks_count{}";
         let mut done = vec![false; self.nodes.len()];
 
         let mut last_committed_round = 0;

--- a/terraform/templates/dashboards/analytics.json
+++ b/terraform/templates/dashboards/analytics.json
@@ -83,7 +83,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(consensus{op='committed_txns_count'})",
+          "expr": "max(libra_consensus_committed_txns_count)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -232,7 +232,7 @@
       "pluginVersion": "6.2.2",
       "targets": [
         {
-          "expr": "max(rate(consensus{op='committed_txns_count'}[5m]))",
+          "expr": "max(rate(libra_consensus_committed_txns_count[5m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -345,7 +345,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(consensus{op='committed_txns_count'}[5m]))",
+          "expr": "max(rate(libra_consensus_committed_txns_count[5m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -520,7 +520,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='committed_txns_count'}",
+          "expr": "libra_consensus_committed_txns_count",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/terraform/templates/dashboards/consensus.json
+++ b/terraform/templates/dashboards/consensus.json
@@ -1405,7 +1405,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_proposal_no_wait_required_count",
+          "expr": "libra_consensus_proposals_generated_count{state='no_wait_required'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1491,7 +1491,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_proposal_wait_was_required_count",
+          "expr": "libra_consensus_proposals_generated_count{state='wait_was_required'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1577,7 +1577,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_proposal_max_wait_exceeded_count",
+          "expr": "libra_consensus_proposals_generated_count{state='max_wait_exceeded'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1663,7 +1663,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_proposal_wait_failed_count",
+          "expr": "libra_consensus_proposals_generated_count{state='wait_failed'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/terraform/templates/dashboards/consensus.json
+++ b/terraform/templates/dashboards/consensus.json
@@ -1921,7 +1921,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_vote_no_wait_required_count",
+          "expr": "libra_consensus_votes_count{state='no_wait_required'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2007,7 +2007,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_vote_wait_was_required_count",
+          "expr": "libra_consensus_votes_count{state='wait_was_required'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2093,7 +2093,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_vote_max_wait_exceeded_count",
+          "expr": "libra_consensus_votes_count{state='max_wait_exceeded'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2179,7 +2179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_consensus_vote_wait_failed_count",
+          "expr": "libra_consensus_votes_count{state='wait_failed'}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/terraform/templates/dashboards/consensus.json
+++ b/terraform/templates/dashboards/consensus.json
@@ -67,7 +67,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_round'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_round[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -162,7 +162,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_version'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_version[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -248,7 +248,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus_gauge{op='num_blocks_in_tree'} - 1",
+          "expr": "libra_consensus_num_blocks_in_tree - 1",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -334,7 +334,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='creation_to_qc_s'}[1m])/irate(consensus_duration_count{op='creation_to_qc_s'}[1m])",
+          "expr": "irate(libra_consensus_creation_to_qc_s_sum[1m])/irate(libra_consensus_creation_to_qc_s_count[1m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -342,7 +342,7 @@
           "refId": "A"
         },
         {
-          "expr": "irate(consensus_duration_sum{op='creation_to_receival_s'}[1m])/irate(consensus_duration_count{op='creation_to_receival_s'}[1m])",
+          "expr": "irate(libra_consensus_creation_to_receival_s_sum[1m])/irate(libra_consensus_creation_to_receival_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}: vote",
@@ -432,7 +432,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='event_processing_loop_idle_duration_s'}[1m]) / ignoring(op) (irate(consensus_duration_sum{op='event_processing_loop_idle_duration_s'}[1m]) + ignoring(op) irate(consensus_duration_sum{op='event_processing_loop_busy_duration_s'}[1m]))",
+          "expr": "irate(libra_consensus_event_processing_loop_idle_duration_s_sum[1m]) /  (irate(libra_consensus_event_processing_loop_idle_duration_s_sum[1m]) +  irate(libra_consensus_event_processing_loop_busy_duration_s_sum[1m]))",
           "legendFormat": "{{peer_id}} Idle",
           "refId": "A"
         }
@@ -528,7 +528,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus{op='qc_rounds_count'}[1m])",
+          "expr": "irate(libra_consensus_qc_rounds_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -613,7 +613,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='timeout_rounds_count'}",
+          "expr": "libra_consensus_timeout_rounds_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -698,7 +698,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='timeout_count'}",
+          "expr": "libra_consensus_timeout_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -783,7 +783,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus_gauge{op='round_timeout_ms'}",
+          "expr": "libra_consensus_round_timeout_s",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -868,7 +868,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus{op='proposals_count'}[1m])",
+          "expr": "irate(libra_consensus_proposals_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -966,7 +966,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='state_sync_count'}",
+          "expr": "libra_consensus_state_sync_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1051,7 +1051,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='state_sync_txns_replayed'}",
+          "expr": "libra_consensus_state_sync_txns_replayed",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1136,7 +1136,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus_duration_sum{op='state_sync_duration_s'}",
+          "expr": "libra_consensus_state_sync_duration_s_sum",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1221,7 +1221,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='block_retrieval_count'}",
+          "expr": "libra_consensus_block_retrieval_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1306,7 +1306,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus_duration_sum{op='block_retrieval_duration_s'}",
+          "expr": "libra_consensus_block_retrieval_duration_s_sum",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1405,7 +1405,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='proposal_no_wait_required_count'}",
+          "expr": "libra_consensus_proposal_no_wait_required_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1491,7 +1491,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='proposal_wait_was_required_count'}",
+          "expr": "libra_consensus_proposal_wait_was_required_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1577,7 +1577,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='proposal_max_wait_exceeded_count'}",
+          "expr": "libra_consensus_proposal_max_wait_exceeded_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1663,7 +1663,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='proposal_wait_failed_count'}",
+          "expr": "libra_consensus_proposal_wait_failed_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1749,7 +1749,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='proposal_success_wait_s'}[1m])/irate(consensus_duration_count{op='proposal_success_wait_s'}[1m])",
+          "expr": "irate(libra_consensus_proposal_success_wait_s_sum[1m])/irate(libra_consensus_proposal_success_wait_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1835,7 +1835,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='proposal_failure_wait_s'}[1m])/irate(consensus_duration_count{op='proposal_failure_wait_s'}[1m])",
+          "expr": "irate(libra_consensus_proposal_failure_wait_s_sum[1m])/irate(libra_consensus_proposal_failure_wait_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1921,7 +1921,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='vote_no_wait_required_count'}",
+          "expr": "libra_consensus_vote_no_wait_required_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2007,7 +2007,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='vote_wait_was_required_count'}",
+          "expr": "libra_consensus_vote_wait_was_required_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2093,7 +2093,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='vote_max_wait_exceeded_count'}",
+          "expr": "libra_consensus_vote_max_wait_exceeded_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2179,7 +2179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "consensus{op='vote_wait_failed_count'}",
+          "expr": "libra_consensus_vote_wait_failed_count",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2265,7 +2265,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='vote_success_wait_s'}[1m])/irate(consensus_duration_count{op='vote_success_wait_s'}[1m])",
+          "expr": "irate(libra_consensus_vote_success_wait_s_sum[1m])/irate(libra_consensus_vote_success_wait_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -2351,7 +2351,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='vote_failure_wait_s'}[1m])/irate(consensus_duration_count{op='vote_failure_wait_s'}[1m])",
+          "expr": "irate(libra_consensus_vote_failure_wait_s_sum[1m])/irate(libra_consensus_vote_failure_wait_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/terraform/templates/dashboards/overview_dashboard.json
+++ b/terraform/templates/dashboards/overview_dashboard.json
@@ -436,7 +436,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_round'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_round[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -524,7 +524,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_version'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_version[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -700,7 +700,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "100 * irate(consensus{op=\"failed_txns_count\"}[1m]) / irate(consensus{op=\"committed_txns_count\"}[1m])",
+          "expr": "100 * irate(libra_consensus_committed_txns_count{state=\"failed\"}[1m]) / irate(libra_consensus_committed_txns_count[1m])",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/terraform/templates/dashboards/performance.json
+++ b/terraform/templates/dashboards/performance.json
@@ -152,7 +152,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_version'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_version[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -237,7 +237,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='num_txns_per_block'}[1m])/irate(consensus_duration_count{op='num_txns_per_block'}[1m])",
+          "expr": "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -335,7 +335,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='txn_execution_duration_s'}[1m])/irate(consensus_duration_count{op='txn_execution_duration_s'}[1m])",
+          "expr": "irate(libra_consensus_txn_execution_duration_s_sum[1m])/irate(libra_consensus_txn_execution_duration_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -420,7 +420,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='txn_execution_duration_s'}[1m])/irate(consensus_duration_count{op='txn_execution_duration_s'}[1m])",
+          "expr": "irate(libra_consensus_txn_execution_duration_s_sum[1m])/irate(libra_consensus_txn_execution_duration_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -505,7 +505,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='vm_execute_block_time_s'}[1m])/irate(consensus_duration_count{op='vm_execute_block_time_s'}[1m])",
+          "expr": "irate(libra_consensus_vm_execute_block_time_s_sum[1m])/irate(libra_consensus_vm_execute_block_time_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -701,7 +701,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='creation_to_commit_s'}[1m])/irate(consensus_duration_count{op='creation_to_commit_s'}[1m])",
+          "expr": "irate(libra_consensus_creation_to_commit_s_sum[1m])/irate(libra_consensus_creation_to_commit_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -786,7 +786,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_duration_sum{op='creation_to_qc_s'}[1m])/irate(consensus_duration_count{op='creation_to_qc_s'}[1m])",
+          "expr": "irate(libra_consensus_creation_to_qc_s_sum[1m])/irate(libra_consensus_creation_to_qc_s_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/terraform/templates/dashboards/validators.json
+++ b/terraform/templates/dashboards/validators.json
@@ -237,7 +237,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='current_round',role='validator'}[1m])",
+          "expr": "irate(libra_consensus_current_round{role='validator'}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -326,7 +326,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_version',role='validator'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_version{role='validator'}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -504,7 +504,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus_gauge{op='last_committed_round',role='validator'}[1m])",
+          "expr": "irate(libra_consensus_last_committed_round{role='validator'}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -593,7 +593,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(consensus{op=\"failed_txns_count\"}[1m]) / irate(consensus{op=\"committed_txns_count\"}[1m])",
+          "expr": "irate(libra_consensus_committed_txns_count{state=\"failed\"}[1m]) / irate(libra_consensus_committed_txns_count[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -455,7 +455,7 @@ fn print_stat(prometheus: &Prometheus, window: Duration) -> failure::Result<(f64
     let start = end - window;
     let avg_tps = prometheus
         .query_range_avg(
-            "irate(consensus_gauge{op='last_committed_version'}[1m])".to_string(),
+            "irate(libra_consensus_last_committed_version[1m])".to_string(),
             &start,
             &end,
             step,


### PR DESCRIPTION
## Summary

* Stop using OP_COUNTERS
* Create a separate metric for each counter prefixed by "libra_consensus_"
* Use promethus macros directly for creating counters
* Update all usages of consensus counters to new names

## Testing

* Deployed this to my cluster and verified that all charts show up in Grafana Dashboards