### PR TITLE
[terraform] Increase monitoring instance disk volume

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -64,7 +64,7 @@ resource "aws_instance" "monitoring" {
 
 resource "aws_ebs_volume" "monitoring" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  size              = 10
+  size              = var.monitoring_ebs_volume
   type              = "standard"
   snapshot_id       = var.monitoring_snapshot
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -126,3 +126,8 @@ variable "cloudwatch_logs" {
   description = "Send container logs to CloudWatch"
   default     = false
 }
+
+variable "monitoring_ebs_volume" {
+  default     = 100
+  description = "Size of monitoring instance EBS volume in GB"
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Our grafana dashboard often crashes because of not enough disk space, so increasing the monitoring instance volume to 100G.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Update my own workspace

```
# aws_ebs_volume.monitoring will be created
  + resource "aws_ebs_volume" "monitoring" {
      + arn               = (known after apply)
      + availability_zone = "us-west-2a"
      + encrypted         = (known after apply)
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 100
      + snapshot_id       = (known after apply)
      + tags              = {
          + "Name"      = "sherryx-monitoring"
          + "Role"      = "monitoring"
          + "Workspace" = "sherryx"
        }
      + type              = "standard"
```


