### PR TITLE
[vm] Clean up the code cache api.

### DIFF
--- a/language/tools/cost-synthesis/src/global_state/inhabitor.rs
+++ b/language/tools/cost-synthesis/src/global_state/inhabitor.rs
@@ -113,8 +113,7 @@ where
         let module = self
             .module_cache
             .get_loaded_module(&module_id)
-            .expect("[Module Lookup] Runtime error while looking up module")
-            .expect("[Module Lookup] Unable to find module");
+            .expect("[Module Lookup] Runtime error while looking up module");
         let struct_def_idx = self
             .struct_handle_table
             .entry(module_id)

--- a/language/tools/cost-synthesis/src/stack_generator.rs
+++ b/language/tools/cost-synthesis/src/stack_generator.rs
@@ -407,8 +407,7 @@ where
         let module = self
             .module_cache
             .get_loaded_module(&module_id)
-            .expect("[Module Lookup] Runtime error while looking up module")
-            .expect("[Module Lookup] Unable to find module");
+            .expect("[Module Lookup] Runtime error while looking up module");
         let struct_def_idx = self
             .struct_handle_table
             .entry(module_id)
@@ -453,8 +452,7 @@ where
         let module = self
             .module_cache
             .get_loaded_module(&module_id)
-            .expect("[Module Lookup] Runtime error while looking up module")
-            .expect("[Module Lookup] Unable to find module");
+            .expect("[Module Lookup] Runtime error while looking up module");
         let function_def_idx = *self
             .function_handle_table
             .entry(module_id)

--- a/language/tools/cost-synthesis/src/vm_runner.rs
+++ b/language/tools/cost-synthesis/src/vm_runner.rs
@@ -27,8 +27,7 @@ macro_rules! with_loaded_vm {
         $module_cache.cache_module(root_module.clone());
         let $mod = $module_cache
             .get_loaded_module(&module_id)
-            .expect("[Module Lookup] Runtime error while looking up module")
-            .expect("[Module Cache] Unable to find module in module cache.");
+            .expect("[Module Lookup] Runtime error while looking up module");
         for m in modules.clone() {
             $module_cache.cache_module(m);
         }

--- a/language/vm/vm-runtime/src/block_processor.rs
+++ b/language/vm/vm-runtime/src/block_processor.rs
@@ -12,13 +12,12 @@ use libra_config::config::VMPublishingOption;
 use libra_logger::prelude::*;
 use libra_types::{
     transaction::{
-        SignatureCheckedTransaction, SignedTransaction, TransactionOutput, TransactionStatus,
+        SignatureCheckedTransaction, SignedTransaction, TransactionOutput,
     },
     vm_error::{sub_status, StatusCode, VMStatus},
 };
 use rayon::prelude::*;
 use vm::gas_schedule::CostTable;
-use vm_cache_map::Arena;
 
 pub fn execute_user_transaction_block<'alloc, P>(
     txn_block: Vec<SignedTransaction>,
@@ -120,8 +119,7 @@ fn transaction_flow<'alloc, P>(
 where
     P: ModuleCache<'alloc>,
 {
-    let arena = Arena::new();
-    let process_txn = ProcessTransaction::new(txn, gas_schedule, &module_cache, data_cache, &arena);
+    let process_txn = ProcessTransaction::new(txn, gas_schedule, &module_cache, data_cache);
 
     let validated_txn = record_stats! {time_hist | TXN_VALIDATION_TIME_TAKEN | {
     match process_txn.validate(mode, publishing_option) {
@@ -150,12 +148,5 @@ where
 
     // On success, publish the modules into the cache so that future transactions can refer to them
     // directly.
-    let output = executed_txn.into_output();
-    match output.status() {
-        TransactionStatus::Keep(status) if status.major_status == StatusCode::EXECUTED => {
-            module_cache.reclaim_cached_module(arena.into_vec());
-        }
-        _ => (),
-    };
-    output
+    executed_txn.into_output()
 }

--- a/language/vm/vm-runtime/src/block_processor.rs
+++ b/language/vm/vm-runtime/src/block_processor.rs
@@ -11,9 +11,7 @@ use crate::{
 use libra_config::config::VMPublishingOption;
 use libra_logger::prelude::*;
 use libra_types::{
-    transaction::{
-        SignatureCheckedTransaction, SignedTransaction, TransactionOutput,
-    },
+    transaction::{SignatureCheckedTransaction, SignedTransaction, TransactionOutput},
     vm_error::{sub_status, StatusCode, VMStatus},
 };
 use rayon::prelude::*;

--- a/language/vm/vm-runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm-runtime/src/code_cache/module_cache.rs
@@ -201,7 +201,7 @@ impl<'alloc> VMModuleCache<'alloc> {
                     .get(callee_name)
                     .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
                 Ok(FunctionRef::new(callee_module, *callee_func_id))
-            },
+            }
             Err(errors) => Err(errors),
         }
     }
@@ -221,7 +221,7 @@ impl<'alloc> VMModuleCache<'alloc> {
             Ok(module) => {
                 let struct_def_idx = module.get_struct_def_index(struct_name)?;
                 self.resolve_struct_def_with_fetcher(module, *struct_def_idx, gas_meter, fetcher)
-            },
+            }
             Err(errors) => Err(errors),
         }
     }
@@ -257,8 +257,10 @@ impl<'alloc> VMModuleCache<'alloc> {
                     }
                     TypeContext::new(ctx)
                 };
-                let struct_def = ctx.subst_struct_def(&self
-                    .resolve_struct_handle_with_fetcher(module, *sh_idx, gas_meter, fetcher)?)?;
+                let struct_def = ctx
+                    .subst_struct_def(&self.resolve_struct_handle_with_fetcher(
+                        module, *sh_idx, gas_meter, fetcher,
+                    )?)?;
                 Ok(Type::Struct(struct_def))
             }
             SignatureToken::Reference(sub_tok) => {
@@ -327,13 +329,13 @@ impl<'alloc> VMModuleCache<'alloc> {
                             gas_meter,
                             fetcher,
                         )?;
-                            // `field_types` is initally empty, a single element is pushed
-                            // per loop iteration and the number of iterations is bound to
-                            // the max size of `module.field_def_range()`.
-                            // MIRAI cannot currently check this bound in terms of
-                            // `field_count`.
-                            assume!(field_types.len() < usize::max_value());
-                            field_types.push(ty);
+                        // `field_types` is initally empty, a single element is pushed
+                        // per loop iteration and the number of iterations is bound to
+                        // the max size of `module.field_def_range()`.
+                        // MIRAI cannot currently check this bound in terms of
+                        // `field_count`.
+                        assume!(field_types.len() < usize::max_value());
+                        field_types.push(ty);
                     }
                     StructDef::new(field_types)
                 }
@@ -366,7 +368,9 @@ impl<'alloc> ModuleCache<'alloc> for VMModuleCache<'alloc> {
     }
 
     fn get_loaded_module(&self, id: &ModuleId) -> VMResult<&'alloc LoadedModule> {
-        self.map.get(id).ok_or_else(||VMStatus::new(StatusCode::LINKER_ERROR))
+        self.map
+            .get(id)
+            .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))
     }
 
     fn cache_module(&self, module: VerifiedModule) {

--- a/language/vm/vm-runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm-runtime/src/code_cache/module_cache.rs
@@ -42,9 +42,9 @@ pub trait ModuleCache<'alloc> {
     ///
     /// Returns:
     ///
-    /// * `Ok(Some(FunctionRef))` if such function exists.
-    /// * `Ok(None)` if such function doesn't exists.
-    /// * `Err(...)` for a verification issue in a resolved dependency or VM invariant violation.
+    /// * `Ok(FunctionRef)` if such function exists.
+    /// * `Err(...)` for a verification issue in a resolved dependency, VM invariant violation, or
+    ///   function not found.
     fn resolve_function_ref(
         &self,
         caller_module: &LoadedModule,
@@ -56,8 +56,7 @@ pub trait ModuleCache<'alloc> {
     ///
     /// Returns:
     ///
-    /// * `Ok(Some(StructDef))` if such struct exists.
-    /// * `Ok(None)` if such function doesn't exists.
+    /// * `Ok(StructDef)` if such struct exists.
     /// * `Err(...)` for a verification or other issue in a resolved dependency, out of gas, or for
     ///   a VM invariant violation.
     fn resolve_struct_def(
@@ -71,8 +70,7 @@ pub trait ModuleCache<'alloc> {
     ///
     /// Returns:
     ///
-    /// * `Ok(Some(LoadedModule))` if such module exists.
-    /// * `Ok(None)` if such module doesn't exists.
+    /// * `Ok(LoadedModule)` if such module exists.
     /// * `Err(...)` for a verification issue in the module or for a VM invariant violation.
     fn get_loaded_module(&self, id: &ModuleId) -> VMResult<&'alloc LoadedModule>;
 

--- a/language/vm/vm-runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm-runtime/src/code_cache/module_cache.rs
@@ -140,6 +140,7 @@ impl<'alloc> VMModuleCache<'alloc> {
         if let Some(m) = self.map.get(id) {
             return Ok(&*m);
         }
+        // TODO: Add a better error message for what failed to be loaded.
         let module = match fetcher.get_module(id) {
             Some(module) => module,
             None => return Err(VMStatus::new(StatusCode::LINKER_ERROR)),

--- a/language/vm/vm-runtime/src/code_cache/module_cache.rs
+++ b/language/vm/vm-runtime/src/code_cache/module_cache.rs
@@ -15,7 +15,6 @@ use libra_types::{
     language_storage::ModuleId,
     vm_error::{StatusCode, VMStatus},
 };
-use std::marker::PhantomData;
 use vm::{
     access::ModuleAccess,
     errors::*,
@@ -50,7 +49,7 @@ pub trait ModuleCache<'alloc> {
         &self,
         caller_module: &LoadedModule,
         idx: FunctionHandleIndex,
-    ) -> VMResult<Option<FunctionRef<'alloc>>>;
+    ) -> VMResult<FunctionRef<'alloc>>;
 
     /// Resolve a StructDefinitionIndex into a StructDef. This process will be recursive so we may
     /// charge gas on each recursive step.
@@ -66,7 +65,7 @@ pub trait ModuleCache<'alloc> {
         module: &LoadedModule,
         idx: StructDefinitionIndex,
         gas_meter: &GasMeter,
-    ) -> VMResult<Option<StructDef>>;
+    ) -> VMResult<StructDef>;
 
     /// Resolve a ModuleId into a LoadedModule if the module has been cached already.
     ///
@@ -75,13 +74,9 @@ pub trait ModuleCache<'alloc> {
     /// * `Ok(Some(LoadedModule))` if such module exists.
     /// * `Ok(None)` if such module doesn't exists.
     /// * `Err(...)` for a verification issue in the module or for a VM invariant violation.
-    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<Option<&'alloc LoadedModule>>;
+    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<&'alloc LoadedModule>;
 
     fn cache_module(&self, module: VerifiedModule);
-
-    /// Recache the list of previously resolved modules. Think of the cache as a generational
-    /// cache and we need to move modules across generations.
-    fn reclaim_cached_module(&self, v: Vec<LoadedModule>);
 }
 
 /// `ModuleCache` is also implemented for references.
@@ -93,7 +88,7 @@ where
         &self,
         caller_module: &LoadedModule,
         idx: FunctionHandleIndex,
-    ) -> VMResult<Option<FunctionRef<'alloc>>> {
+    ) -> VMResult<FunctionRef<'alloc>> {
         (*self).resolve_function_ref(caller_module, idx)
     }
 
@@ -102,20 +97,16 @@ where
         module: &LoadedModule,
         idx: StructDefinitionIndex,
         gas_meter: &GasMeter,
-    ) -> VMResult<Option<StructDef>> {
+    ) -> VMResult<StructDef> {
         (*self).resolve_struct_def(module, idx, gas_meter)
     }
 
-    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<Option<&'alloc LoadedModule>> {
+    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<&'alloc LoadedModule> {
         (*self).get_loaded_module(id)
     }
 
     fn cache_module(&self, module: VerifiedModule) {
         (*self).cache_module(module)
-    }
-
-    fn reclaim_cached_module(&self, v: Vec<LoadedModule>) {
-        (*self).reclaim_cached_module(v)
     }
 }
 
@@ -144,16 +135,16 @@ impl<'alloc> VMModuleCache<'alloc> {
         &self,
         id: &ModuleId,
         fetcher: &F,
-    ) -> VMResult<Option<&'alloc LoadedModule>> {
+    ) -> VMResult<&'alloc LoadedModule> {
         // Currently it is still possible for a script to invoke a nonsense module id function.
         // However, once we have the verifier that checks the well-formedness of the all the linked
         // module id, we should get rid of that ok_or_else case here.
         if let Some(m) = self.map.get(id) {
-            return Ok(Some(&*m));
+            return Ok(&*m);
         }
         let module = match fetcher.get_module(id) {
             Some(module) => module,
-            None => return Ok(None),
+            None => return Err(VMStatus::new(StatusCode::LINKER_ERROR)),
         };
 
         // Verify the module before using it.
@@ -173,7 +164,7 @@ impl<'alloc> VMModuleCache<'alloc> {
         };
 
         let loaded_module = LoadedModule::new(module);
-        Ok(Some(self.map.or_insert(id.clone(), loaded_module)))
+        Ok(self.map.or_insert(id.clone(), loaded_module))
     }
 
     #[cfg(test)]
@@ -195,7 +186,7 @@ impl<'alloc> VMModuleCache<'alloc> {
         caller_module: &LoadedModule,
         idx: FunctionHandleIndex,
         fetcher: &F,
-    ) -> VMResult<Option<FunctionRef<'alloc>>>
+    ) -> VMResult<FunctionRef<'alloc>>
     where
         F: ModuleFetcher,
     {
@@ -204,14 +195,13 @@ impl<'alloc> VMModuleCache<'alloc> {
         let callee_module_id = FunctionHandleView::new(caller_module, function_handle).module_id();
 
         match self.get_loaded_module_with_fetcher(&callee_module_id, fetcher) {
-            Ok(Some(callee_module)) => {
+            Ok(callee_module) => {
                 let callee_func_id = callee_module
                     .function_defs_table
                     .get(callee_name)
                     .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
-                Ok(Some(FunctionRef::new(callee_module, *callee_func_id)))
-            }
-            Ok(None) => Ok(None),
+                Ok(FunctionRef::new(callee_module, *callee_func_id))
+            },
             Err(errors) => Err(errors),
         }
     }
@@ -223,16 +213,15 @@ impl<'alloc> VMModuleCache<'alloc> {
         idx: StructHandleIndex,
         gas_meter: &GasMeter,
         fetcher: &F,
-    ) -> VMResult<Option<StructDef>> {
+    ) -> VMResult<StructDef> {
         let struct_handle = module.struct_handle_at(idx);
         let struct_name = module.identifier_at(struct_handle.name);
         let struct_def_module_id = StructHandleView::new(module, struct_handle).module_id();
         match self.get_loaded_module_with_fetcher(&struct_def_module_id, fetcher) {
-            Ok(Some(module)) => {
+            Ok(module) => {
                 let struct_def_idx = module.get_struct_def_index(struct_name)?;
                 self.resolve_struct_def_with_fetcher(module, *struct_def_idx, gas_meter, fetcher)
-            }
-            Ok(None) => Ok(None),
+            },
             Err(errors) => Err(errors),
         }
     }
@@ -245,14 +234,14 @@ impl<'alloc> VMModuleCache<'alloc> {
         type_context: &TypeContext,
         gas_meter: &GasMeter,
         fetcher: &F,
-    ) -> VMResult<Option<Type>> {
+    ) -> VMResult<Type> {
         match tok {
-            SignatureToken::Bool => Ok(Some(Type::Bool)),
-            SignatureToken::U64 => Ok(Some(Type::U64)),
-            SignatureToken::String => Ok(Some(Type::String)),
-            SignatureToken::ByteArray => Ok(Some(Type::ByteArray)),
-            SignatureToken::Address => Ok(Some(Type::Address)),
-            SignatureToken::TypeParameter(idx) => Ok(Some(type_context.get_type(*idx)?)),
+            SignatureToken::Bool => Ok(Type::Bool),
+            SignatureToken::U64 => Ok(Type::U64),
+            SignatureToken::String => Ok(Type::String),
+            SignatureToken::ByteArray => Ok(Type::ByteArray),
+            SignatureToken::Address => Ok(Type::Address),
+            SignatureToken::TypeParameter(idx) => Ok(type_context.get_type(*idx)?),
             SignatureToken::Struct(sh_idx, tys) => {
                 let ctx = {
                     let mut ctx = vec![];
@@ -264,19 +253,13 @@ impl<'alloc> VMModuleCache<'alloc> {
                             gas_meter,
                             fetcher,
                         )?;
-                        if let Some(t) = resolved_type {
-                            ctx.push(t);
-                        } else {
-                            return Ok(None);
-                        }
+                        ctx.push(resolved_type);
                     }
                     TypeContext::new(ctx)
                 };
-                let struct_def = self
-                    .resolve_struct_handle_with_fetcher(module, *sh_idx, gas_meter, fetcher)?
-                    .map(|def| ctx.subst_struct_def(&def))
-                    .transpose()?;
-                Ok(struct_def.map(Type::Struct))
+                let struct_def = ctx.subst_struct_def(&self
+                    .resolve_struct_handle_with_fetcher(module, *sh_idx, gas_meter, fetcher)?)?;
+                Ok(Type::Struct(struct_def))
             }
             SignatureToken::Reference(sub_tok) => {
                 let inner_ty = self.resolve_signature_token_with_fetcher(
@@ -286,7 +269,7 @@ impl<'alloc> VMModuleCache<'alloc> {
                     gas_meter,
                     fetcher,
                 )?;
-                Ok(inner_ty.map(|t| Type::Reference(Box::new(t))))
+                Ok(Type::Reference(Box::new(inner_ty)))
             }
             SignatureToken::MutableReference(sub_tok) => {
                 let inner_ty = self.resolve_signature_token_with_fetcher(
@@ -296,7 +279,7 @@ impl<'alloc> VMModuleCache<'alloc> {
                     gas_meter,
                     fetcher,
                 )?;
-                Ok(inner_ty.map(|t| Type::MutableReference(Box::new(t))))
+                Ok(Type::MutableReference(Box::new(inner_ty)))
             }
         }
     }
@@ -309,9 +292,9 @@ impl<'alloc> VMModuleCache<'alloc> {
         idx: StructDefinitionIndex,
         gas_meter: &GasMeter,
         fetcher: &F,
-    ) -> VMResult<Option<StructDef>> {
+    ) -> VMResult<StructDef> {
         if let Some(def) = module.cached_struct_def_at(idx) {
-            return Ok(Some(def));
+            return Ok(def);
         }
         let def = {
             let struct_def = module.struct_def_at(idx);
@@ -344,17 +327,13 @@ impl<'alloc> VMModuleCache<'alloc> {
                             gas_meter,
                             fetcher,
                         )?;
-                        if let Some(t) = ty {
                             // `field_types` is initally empty, a single element is pushed
                             // per loop iteration and the number of iterations is bound to
                             // the max size of `module.field_def_range()`.
                             // MIRAI cannot currently check this bound in terms of
                             // `field_count`.
                             assume!(field_types.len() < usize::max_value());
-                            field_types.push(t);
-                        } else {
-                            return Ok(None);
-                        }
+                            field_types.push(ty);
                     }
                     StructDef::new(field_types)
                 }
@@ -364,7 +343,7 @@ impl<'alloc> VMModuleCache<'alloc> {
         // to have multiple copies of a struct def floating around, but that probably isn't going
         // to be a big deal.
         module.cache_struct_def(idx, def.clone());
-        Ok(Some(def))
+        Ok(def)
     }
 }
 
@@ -373,7 +352,7 @@ impl<'alloc> ModuleCache<'alloc> for VMModuleCache<'alloc> {
         &self,
         caller_module: &LoadedModule,
         idx: FunctionHandleIndex,
-    ) -> VMResult<Option<FunctionRef<'alloc>>> {
+    ) -> VMResult<FunctionRef<'alloc>> {
         self.resolve_function_ref_with_fetcher(caller_module, idx, &NullFetcher())
     }
 
@@ -382,15 +361,12 @@ impl<'alloc> ModuleCache<'alloc> for VMModuleCache<'alloc> {
         module: &LoadedModule,
         idx: StructDefinitionIndex,
         gas_meter: &GasMeter,
-    ) -> VMResult<Option<StructDef>> {
+    ) -> VMResult<StructDef> {
         self.resolve_struct_def_with_fetcher(module, idx, gas_meter, &NullFetcher())
     }
 
-    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<Option<&'alloc LoadedModule>> {
-        // Currently it is still possible for a script to invoke a nonsense module id function.
-        // However, once we have the verifier that checks the well-formedness of the all the linked
-        // module id, we should get rid of that ok_or case here.
-        Ok(self.map.get(id))
+    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<&'alloc LoadedModule> {
+        self.map.get(id).ok_or_else(||VMStatus::new(StatusCode::LINKER_ERROR))
     }
 
     fn cache_module(&self, module: VerifiedModule) {
@@ -398,13 +374,6 @@ impl<'alloc> ModuleCache<'alloc> for VMModuleCache<'alloc> {
         // TODO: Check ModuleId duplication in statedb
         let loaded_module = LoadedModule::new(module);
         self.map.or_insert(module_id, loaded_module);
-    }
-
-    fn reclaim_cached_module(&self, v: Vec<LoadedModule>) {
-        for m in v.into_iter() {
-            let module_id = m.self_id();
-            self.map.or_insert(module_id, m);
-        }
     }
 }
 
@@ -447,7 +416,7 @@ impl<'alloc, 'blk, F: ModuleFetcher> ModuleCache<'alloc> for BlockModuleCache<'a
         &self,
         caller_module: &LoadedModule,
         idx: FunctionHandleIndex,
-    ) -> VMResult<Option<FunctionRef<'alloc>>> {
+    ) -> VMResult<FunctionRef<'alloc>> {
         self.vm_cache
             .resolve_function_ref_with_fetcher(caller_module, idx, &self.storage)
     }
@@ -457,100 +426,17 @@ impl<'alloc, 'blk, F: ModuleFetcher> ModuleCache<'alloc> for BlockModuleCache<'a
         module: &LoadedModule,
         idx: StructDefinitionIndex,
         gas_meter: &GasMeter,
-    ) -> VMResult<Option<StructDef>> {
+    ) -> VMResult<StructDef> {
         self.vm_cache
             .resolve_struct_def_with_fetcher(module, idx, gas_meter, &self.storage)
     }
 
-    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<Option<&'alloc LoadedModule>> {
+    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<&'alloc LoadedModule> {
         self.vm_cache
             .get_loaded_module_with_fetcher(id, &self.storage)
     }
 
     fn cache_module(&self, module: VerifiedModule) {
         self.vm_cache.cache_module(module)
-    }
-
-    fn reclaim_cached_module(&self, v: Vec<LoadedModule>) {
-        self.vm_cache.reclaim_cached_module(v)
-    }
-}
-
-/// A temporary cache for module published by a single transaction. This cache allows the
-/// transaction script to refer to either those newly published modules in `local_cache` or those
-/// existing on chain modules in `block_cache`. VM can choose to discard those newly published
-/// modules if there is an error during execution.
-pub struct TransactionModuleCache<'alloc, 'txn, P>
-where
-    'alloc: 'txn,
-    P: ModuleCache<'alloc>,
-{
-    block_cache: P,
-    local_cache: VMModuleCache<'txn>,
-
-    phantom: PhantomData<&'alloc ()>,
-}
-
-impl<'alloc, 'txn, P> TransactionModuleCache<'alloc, 'txn, P>
-where
-    'alloc: 'txn,
-    P: ModuleCache<'alloc>,
-{
-    pub fn new(block_cache: P, allocator: &'txn Arena<LoadedModule>) -> Self {
-        TransactionModuleCache {
-            block_cache,
-            local_cache: VMModuleCache::new(allocator),
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<'alloc, 'txn, P> ModuleCache<'txn> for TransactionModuleCache<'alloc, 'txn, P>
-where
-    'alloc: 'txn,
-    P: ModuleCache<'alloc>,
-{
-    fn resolve_function_ref(
-        &self,
-        caller_module: &LoadedModule,
-        idx: FunctionHandleIndex,
-    ) -> VMResult<Option<FunctionRef<'txn>>> {
-        if let Some(f) = self.local_cache.resolve_function_ref(caller_module, idx)? {
-            Ok(Some(f))
-        } else {
-            self.block_cache.resolve_function_ref(caller_module, idx)
-        }
-    }
-
-    fn resolve_struct_def(
-        &self,
-        module: &LoadedModule,
-        idx: StructDefinitionIndex,
-        gas_meter: &GasMeter,
-    ) -> VMResult<Option<StructDef>> {
-        if let Some(f) = self
-            .local_cache
-            .resolve_struct_def(module, idx, gas_meter)?
-        {
-            Ok(Some(f))
-        } else {
-            self.block_cache.resolve_struct_def(module, idx, gas_meter)
-        }
-    }
-
-    fn get_loaded_module(&self, id: &ModuleId) -> VMResult<Option<&'txn LoadedModule>> {
-        if let Some(m) = self.local_cache.get_loaded_module(id)? {
-            Ok(Some(m))
-        } else {
-            self.block_cache.get_loaded_module(id)
-        }
-    }
-
-    fn cache_module(&self, module: VerifiedModule) {
-        self.local_cache.cache_module(module)
-    }
-
-    fn reclaim_cached_module(&self, _v: Vec<LoadedModule>) {
-        panic!("reclaim_cached_module should never be called on TransactionModuleCache");
     }
 }

--- a/language/vm/vm-runtime/src/data_cache.rs
+++ b/language/vm/vm-runtime/src/data_cache.rs
@@ -104,6 +104,16 @@ impl<'txn> TransactionDataCache<'txn> {
         }
     }
 
+    pub fn exists_module(&self, m: &ModuleId) -> bool {
+        let ap = AccessPath::from(m);
+        self.data_map.contains_key(&ap) || {
+            match self.data_cache.get(&ap) {
+                Ok(Some(_)) => true,
+                _ => false,
+            }
+        }
+    }
+
     // Retrieve data from the local cache or loads it from the remote cache into the local cache.
     // All operations on the global data are based on this API and they all load the data
     // into the cache.

--- a/language/vm/vm-runtime/src/gas_meter.rs
+++ b/language/vm/vm-runtime/src/gas_meter.rs
@@ -38,8 +38,8 @@ where
 {
     let address = account_config::association_address();
     let gas_module = module_cache
-        .get_loaded_module(&GAS_SCHEDULE_MODULE)?
-        .ok_or_else(|| {
+        .get_loaded_module(&GAS_SCHEDULE_MODULE)
+        .map_err(|_| {
             VMStatus::new(StatusCode::GAS_SCHEDULE_ERROR)
                 .with_sub_status(sub_status::GSE_UNABLE_TO_LOAD_MODULE)
         })?;
@@ -254,8 +254,7 @@ impl<'txn> GasMeter<'txn> {
             Bytecode::Call(call_idx, _) => {
                 let function_ref = interpreter
                     .module_cache()
-                    .resolve_function_ref(interpreter.module(), *call_idx)?
-                    .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
+                    .resolve_function_ref(interpreter.module(), *call_idx)?;
                 if function_ref.is_native() {
                     GasUnits::new(0) // This will be costed at the call site/by the native function
                 } else {

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -231,7 +231,9 @@ where
         self.data_view.make_write_set(to_be_published_modules)
     }
 
-    pub(crate) fn exists_module(&self, m: &ModuleId) -> bool { self.data_view.exists_module(m) }
+    pub(crate) fn exists_module(&self, m: &ModuleId) -> bool {
+        self.data_view.exists_module(m)
+    }
 
     /// Execute a function.
     /// `module` is an identifier for the name the module is stored in. `function_name` is the name
@@ -248,9 +250,7 @@ where
         function_name: &IdentStr,
         args: Vec<Value>,
     ) -> VMResult<()> {
-        let loaded_module = self
-            .module_cache
-            .get_loaded_module(module)?;
+        let loaded_module = self.module_cache.get_loaded_module(module)?;
         let func_idx = loaded_module
             .function_defs_table
             .get(function_name)
@@ -618,9 +618,7 @@ where
         idx: FunctionHandleIndex,
         type_actual_tags: Vec<TypeTag>,
     ) -> VMResult<Option<Frame<'txn, FunctionRef<'txn>>>> {
-        let func = self
-            .module_cache
-            .resolve_function_ref(module, idx)?;
+        let func = self.module_cache.resolve_function_ref(module, idx)?;
         if func.is_native() {
             self.call_native(func, type_actual_tags)?;
             Ok(None)
@@ -703,9 +701,7 @@ where
 
     /// Save an account into the data store.
     fn call_save_account(&mut self) -> VMResult<()> {
-        let account_module = self
-            .module_cache
-            .get_loaded_module(&ACCOUNT_MODULE)?;
+        let account_module = self.module_cache.get_loaded_module(&ACCOUNT_MODULE)?;
 
         let account_resource = self.operand_stack.pop_as::<Struct>()?;
         let address = self.operand_stack.pop_as::<AccountAddress>()?;
@@ -762,9 +758,9 @@ where
         F: FnOnce(&mut Self, AccessPath, StructDef) -> VMResult<AbstractMemorySize<GasCarrier>>,
     {
         let ap = Self::make_access_path(module, idx, address);
-        let struct_def =
-            self.module_cache
-                .resolve_struct_def(module, idx, &self.gas_meter)?;
+        let struct_def = self
+            .module_cache
+            .resolve_struct_def(module, idx, &self.gas_meter)?;
         op(self, ap, struct_def)
     }
 
@@ -835,9 +831,11 @@ where
             .struct_defs_table
             .get(&*ACCOUNT_STRUCT_NAME)
             .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
-        let account_struct_def = self
-            .module_cache
-            .resolve_struct_def(account_module, *account_struct_id, &self.gas_meter)?;
+        let account_struct_def = self.module_cache.resolve_struct_def(
+            account_module,
+            *account_struct_id,
+            &self.gas_meter,
+        )?;
 
         // TODO: Adding the freshly created account's expiration date to the TransactionOutput here.
         let account_path = Self::make_access_path(account_module, *account_struct_id, addr);
@@ -849,9 +847,7 @@ where
     /// in the `ACCOUNT_MODULE` on chain.
     // REVIEW: this should not live here
     pub fn create_account_entry(&mut self, addr: AccountAddress) -> VMResult<()> {
-        let account_module = self
-            .module_cache
-            .get_loaded_module(&ACCOUNT_MODULE)?;
+        let account_module = self.module_cache.get_loaded_module(&ACCOUNT_MODULE)?;
 
         // TODO: Currently the event counter will cause the gas cost for create account be flexible.
         //       We either need to fix the gas stability test cases in tests or we need to come up

--- a/language/vm/vm-runtime/src/process_txn/execute.rs
+++ b/language/vm/vm-runtime/src/process_txn/execute.rs
@@ -78,10 +78,10 @@ where
             //       global storage or from the local data cache (which means that this module is
             //       published within the same block).
             if txn_executor.exists_module(&module_id) {
-               return txn_executor.failed_transaction_cleanup(Err(vm_error(
-                        Location::default(),
-                        StatusCode::DUPLICATE_MODULE_NAME,
-                    )));
+                return txn_executor.failed_transaction_cleanup(Err(vm_error(
+                    Location::default(),
+                    StatusCode::DUPLICATE_MODULE_NAME,
+                )));
             };
             let module_bytes = module.into_inner();
             let output = txn_executor.transaction_cleanup(vec![(module_id, module_bytes)]);

--- a/language/vm/vm-runtime/src/process_txn/mod.rs
+++ b/language/vm/vm-runtime/src/process_txn/mod.rs
@@ -3,13 +3,11 @@
 
 use crate::{
     code_cache::module_cache::ModuleCache, data_cache::RemoteCache,
-    loaded_data::loaded_module::LoadedModule,
 };
 use libra_config::config::VMPublishingOption;
 use libra_types::transaction::SignatureCheckedTransaction;
 use std::marker::PhantomData;
 use vm::{errors::VMResult, gas_schedule::CostTable};
-use vm_cache_map::Arena;
 
 pub mod execute;
 pub mod validate;
@@ -28,7 +26,6 @@ where
     gas_schedule: &'txn CostTable,
     module_cache: P,
     data_cache: &'txn dyn RemoteCache,
-    allocator: &'txn Arena<LoadedModule>,
     phantom: PhantomData<&'alloc ()>,
 }
 
@@ -43,14 +40,12 @@ where
         gas_schedule: &'txn CostTable,
         module_cache: P,
         data_cache: &'txn dyn RemoteCache,
-        allocator: &'txn Arena<LoadedModule>,
     ) -> Self {
         Self {
             txn,
             gas_schedule,
             module_cache,
             data_cache,
-            allocator,
             phantom: PhantomData,
         }
     }

--- a/language/vm/vm-runtime/src/process_txn/mod.rs
+++ b/language/vm/vm-runtime/src/process_txn/mod.rs
@@ -1,9 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    code_cache::module_cache::ModuleCache, data_cache::RemoteCache,
-};
+use crate::{code_cache::module_cache::ModuleCache, data_cache::RemoteCache};
 use libra_config::config::VMPublishingOption;
 use libra_types::transaction::SignatureCheckedTransaction;
 use std::marker::PhantomData;

--- a/language/vm/vm-runtime/src/process_txn/validate.rs
+++ b/language/vm/vm-runtime/src/process_txn/validate.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    code_cache::{
-        module_cache::ModuleCache,
-        script_cache::ScriptCache,
-    },
+    code_cache::{module_cache::ModuleCache, script_cache::ScriptCache},
     data_cache::RemoteCache,
     process_txn::{verify::VerifiedTransaction, ProcessTransaction},
     txn_executor::TransactionExecutor,
@@ -277,12 +274,8 @@ where
         payload_check()?;
 
         let metadata = TransactionMetadata::new(&txn);
-        let mut txn_state = ValidatedTransactionState::new(
-            metadata,
-            gas_schedule,
-            module_cache,
-            data_cache,
-        );
+        let mut txn_state =
+            ValidatedTransactionState::new(metadata, gas_schedule, module_cache, data_cache);
 
         // Run the prologue to ensure that clients have enough gas and aren't tricking us by
         // sending us garbage.
@@ -316,8 +309,7 @@ where
     'alloc: 'txn,
     P: ModuleCache<'alloc>,
 {
-    pub(super) txn_executor:
-        TransactionExecutor<'alloc, 'txn, P>,
+    pub(super) txn_executor: TransactionExecutor<'alloc, 'txn, P>,
 }
 
 impl<'alloc, 'txn, P> ValidatedTransactionState<'alloc, 'txn, P>

--- a/language/vm/vm-runtime/src/process_txn/verify.rs
+++ b/language/vm/vm-runtime/src/process_txn/verify.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    code_cache::{
-        module_cache::ModuleCache,
-        script_cache::ScriptCache,
-    },
+    code_cache::{module_cache::ModuleCache, script_cache::ScriptCache},
     loaded_data::function::{FunctionRef, FunctionReference},
     process_txn::{execute::ExecutedTransaction, validate::ValidatedTransaction},
     txn_executor::TransactionExecutor,
@@ -168,8 +165,7 @@ where
     'alloc: 'txn,
     P: ModuleCache<'alloc>,
 {
-    pub(super) txn_executor:
-        TransactionExecutor<'alloc, 'txn, P>,
+    pub(super) txn_executor: TransactionExecutor<'alloc, 'txn, P>,
     pub(super) verified_txn: VerTxn<'alloc>,
 }
 

--- a/language/vm/vm-runtime/src/process_txn/verify.rs
+++ b/language/vm/vm-runtime/src/process_txn/verify.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     code_cache::{
-        module_cache::{ModuleCache, TransactionModuleCache},
+        module_cache::ModuleCache,
         script_cache::ScriptCache,
     },
     loaded_data::function::{FunctionRef, FunctionReference},
@@ -169,7 +169,7 @@ where
     P: ModuleCache<'alloc>,
 {
     pub(super) txn_executor:
-        TransactionExecutor<'txn, 'txn, TransactionModuleCache<'alloc, 'txn, P>>,
+        TransactionExecutor<'alloc, 'txn, P>,
     pub(super) verified_txn: VerTxn<'alloc>,
 }
 
@@ -177,7 +177,6 @@ where
 ///
 /// It can be a program, a script or a module. A transaction script gets executed by the VM.
 /// A module script publishes the module provided.
-// TODO: A Script will be a FunctionRef once we remove the ability to publish in scripts.
 pub enum VerTxn<'alloc> {
     Script(FunctionRef<'alloc>),
     Module(Box<VerifiedModule>),

--- a/language/vm/vm-runtime/src/runtime.rs
+++ b/language/vm/vm-runtime/src/runtime.rs
@@ -91,7 +91,6 @@ impl<'alloc> VMRuntime<'alloc> {
             }
         };
 
-        let arena = Arena::new();
         let signature_verified_txn = match txn.check_signature() {
             Ok(t) => t,
             Err(_) => return Some(VMStatus::new(StatusCode::INVALID_SIGNATURE)),
@@ -102,7 +101,6 @@ impl<'alloc> VMRuntime<'alloc> {
             &gas_schedule,
             module_cache,
             &data_cache,
-            &arena,
         );
         let mode = if data_view.is_genesis() {
             ValidationMode::Genesis

--- a/language/vm/vm-runtime/src/txn_executor.rs
+++ b/language/vm/vm-runtime/src/txn_executor.rs
@@ -250,7 +250,9 @@ where
         ))
     }
 
-    pub fn exists_module(&self, m: &ModuleId) -> bool { self.interpreter.exists_module(m) }
+    pub fn exists_module(&self, m: &ModuleId) -> bool {
+        self.interpreter.exists_module(m)
+    }
 }
 
 #[inline]

--- a/language/vm/vm-runtime/src/txn_executor.rs
+++ b/language/vm/vm-runtime/src/txn_executor.rs
@@ -249,6 +249,8 @@ where
             },
         ))
     }
+
+    pub fn exists_module(&self, m: &ModuleId) -> bool { self.interpreter.exists_module(m) }
 }
 
 #[inline]

--- a/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
@@ -521,9 +521,7 @@ fn test_multi_module_struct_resolution() {
     let gas_schedule = CostTable::zero();
     {
         let module_id_2 = ModuleId::new(AccountAddress::default(), ident("M2"));
-        let module2_ref = block_cache
-            .get_loaded_module(&module_id_2)
-            .unwrap();
+        let module2_ref = block_cache.get_loaded_module(&module_id_2).unwrap();
 
         let gas = GasMeter::new(GasUnits::new(100_000_000), &gas_schedule);
         let struct_t = block_cache

--- a/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
@@ -175,16 +175,14 @@ fn test_loader_one_module() {
     let allocator = Arena::new();
     let loaded_program = VMModuleCache::new(&allocator);
     loaded_program.cache_module(module);
-    let module_ref = loaded_program.get_loaded_module(&mod_id).unwrap().unwrap();
+    let module_ref = loaded_program.get_loaded_module(&mod_id).unwrap();
 
     // Get the function reference of the first two function handles.
     let func1_ref = loaded_program
         .resolve_function_ref(module_ref, FunctionHandleIndex::new(0))
-        .unwrap()
         .unwrap();
     let func2_ref = loaded_program
         .resolve_function_ref(module_ref, FunctionHandleIndex::new(1))
-        .unwrap()
         .unwrap();
 
     // The two references should refer to the same module
@@ -220,11 +218,9 @@ fn test_loader_cross_modules() {
     let entry_module = entry_func.module();
     let func1 = loaded_program
         .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))
-        .unwrap()
         .unwrap();
     let func2 = loaded_program
         .resolve_function_ref(entry_module, FunctionHandleIndex::new(2))
-        .unwrap()
         .unwrap();
 
     assert_eq!(
@@ -259,9 +255,7 @@ fn test_cache_with_storage() {
     // Function is not defined locally.
     assert!(vm_cache
         .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))
-        .unwrap()
-        .is_none());
-
+        .is_err());
     {
         let fetcher = FakeFetcher::new(vec![test_module("module").into_inner()]);
         let mut block_cache = BlockModuleCache::new(&vm_cache, fetcher);
@@ -269,11 +263,9 @@ fn test_cache_with_storage() {
         // Make sure the block cache fetches the code from the view.
         let func1 = block_cache
             .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))
-            .unwrap()
             .unwrap();
         let func2 = block_cache
             .resolve_function_ref(entry_module, FunctionHandleIndex::new(2))
-            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -297,11 +289,9 @@ fn test_cache_with_storage() {
 
         let func1 = block_cache
             .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))
-            .unwrap()
             .unwrap();
         let func2 = block_cache
             .resolve_function_ref(entry_module, FunctionHandleIndex::new(2))
-            .unwrap()
             .unwrap();
 
         assert_eq!(
@@ -325,11 +315,9 @@ fn test_cache_with_storage() {
     // definition
     let func1 = vm_cache
         .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))
-        .unwrap()
         .unwrap();
     let func2 = vm_cache
         .resolve_function_ref(entry_module, FunctionHandleIndex::new(2))
-        .unwrap()
         .unwrap();
 
     assert_eq!(
@@ -448,7 +436,6 @@ fn test_multi_level_cache_write_back() {
     // After reclaiming we should see it from the
     let func2_ref = vm_cache
         .resolve_function_ref(entry_module, FunctionHandleIndex::new(1))
-        .unwrap()
         .unwrap();
     assert_eq!(func2_ref.arg_count(), 1);
     assert_eq!(func2_ref.return_count(), 0);
@@ -488,16 +475,14 @@ fn test_same_module_struct_resolution() {
     let block_cache = BlockModuleCache::new(&vm_cache, fetcher);
     {
         let module_id = ModuleId::new(AccountAddress::default(), ident("M1"));
-        let module_ref = block_cache.get_loaded_module(&module_id).unwrap().unwrap();
+        let module_ref = block_cache.get_loaded_module(&module_id).unwrap();
         let gas_schedule = CostTable::zero();
         let gas = GasMeter::new(GasUnits::new(100_000_000), &gas_schedule);
         let struct_x = block_cache
             .resolve_struct_def(module_ref, StructDefinitionIndex::new(0), &gas)
-            .unwrap()
             .unwrap();
         let struct_t = block_cache
             .resolve_struct_def(module_ref, StructDefinitionIndex::new(1), &gas)
-            .unwrap()
             .unwrap();
         assert_eq!(struct_x, StructDef::new(vec![]));
         assert_eq!(
@@ -538,13 +523,11 @@ fn test_multi_module_struct_resolution() {
         let module_id_2 = ModuleId::new(AccountAddress::default(), ident("M2"));
         let module2_ref = block_cache
             .get_loaded_module(&module_id_2)
-            .unwrap()
             .unwrap();
 
         let gas = GasMeter::new(GasUnits::new(100_000_000), &gas_schedule);
         let struct_t = block_cache
             .resolve_struct_def(module2_ref, StructDefinitionIndex::new(0), &gas)
-            .unwrap()
             .unwrap();
         assert_eq!(
             struct_t,
@@ -575,7 +558,7 @@ fn test_field_offset_resolution() {
     let block_cache = BlockModuleCache::new(&vm_cache, fetcher);
     {
         let module_id = ModuleId::new(AccountAddress::default(), ident("M1"));
-        let module_ref = block_cache.get_loaded_module(&module_id).unwrap().unwrap();
+        let module_ref = block_cache.get_loaded_module(&module_id).unwrap();
 
         let f_idx = module_ref.field_defs_table.get(&ident("f")).unwrap();
         assert_eq!(module_ref.get_field_offset(*f_idx).unwrap(), 0);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a follow up for #1626. With the new transaction logic, one can only publish a module within a transaction and not run anything in the module. As a result, we won't need the multi generation code cache to support running a temporary module.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
