### PR TITLE
[language] Instantiate interpreter for different parts of txn flow

### DIFF
--- a/language/stdlib/modules/gas_schedule.mvir
+++ b/language/stdlib/modules/gas_schedule.mvir
@@ -246,7 +246,8 @@ module GasSchedule {
           Cost { cpu: 10, storage: 1 }
         );
 
-        // Native table. Do not change the order of these
+        // Native table. Each of these represent a cost that is used by a
+        // native function. Do not change the order of these.
         Vector.push_back<Self.Cost>(
           &mut native_table,
           Cost { cpu: 30, storage: 1 }

--- a/language/tools/cost-synthesis/src/main.rs
+++ b/language/tools/cost-synthesis/src/main.rs
@@ -36,7 +36,6 @@ use vm::{
 use vm_cache_map::Arena;
 use vm_runtime::{
     code_cache::module_cache::{ModuleCache, VMModuleCache},
-    data_cache::TransactionDataCache,
     interpreter::InterpreterForCostSynthesis,
     loaded_data::function::{FunctionRef, FunctionReference},
 };

--- a/language/tools/cost-synthesis/src/vm_runner.rs
+++ b/language/tools/cost-synthesis/src/vm_runner.rs
@@ -40,10 +40,8 @@ macro_rules! with_loaded_vm {
         }
         let gas_schedule = CostTable::zero();
         let txn_data = TransactionMetadata::default();
-        let data_cache = TransactionDataCache::new(&data_cache);
         let mut $vm =
-            InterpreterForCostSynthesis::new(&$module_cache, txn_data, data_cache, &gas_schedule);
-        $vm.turn_off_gas_metering();
+            InterpreterForCostSynthesis::new(&$module_cache, &txn_data, &data_cache, &gas_schedule);
         $vm.push_frame(entry_func, vec![]);
     };
 }

--- a/language/vm/vm-runtime/src/execution_context.rs
+++ b/language/vm/vm-runtime/src/execution_context.rs
@@ -1,0 +1,146 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data_cache::{RemoteCache, TransactionDataCache};
+use libra_types::{
+    access_path::AccessPath,
+    contract_event::ContractEvent,
+    language_storage::ModuleId,
+    vm_error::{StatusCode, VMStatus},
+    write_set::WriteSet,
+};
+use vm::{
+    errors::*,
+    gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasUnits},
+};
+use vm_runtime_types::{
+    loaded_data::struct_def::StructDef,
+    value::{GlobalRef, Struct, Value},
+};
+
+/// A TransactionExecutionContext holds the mutable data that needs to be persisted from one
+/// section of the transaction flow to another. Because of this, this is the _only_ data that can
+/// both be mutated, and persist between interpretation instances.
+pub struct TransactionExecutionContext<'txn> {
+    /// Gas metering to track cost of execution.
+    gas_left: GasUnits<GasCarrier>,
+    /// List of events "fired" during the course of an execution.
+    event_data: Vec<ContractEvent>,
+    /// Data store
+    data_view: TransactionDataCache<'txn>,
+}
+
+/// The transaction
+impl<'txn> TransactionExecutionContext<'txn> {
+    pub fn new(gas_left: GasUnits<GasCarrier>, data_cache: &'txn dyn RemoteCache) -> Self {
+        Self {
+            gas_left,
+            event_data: Vec::new(),
+            data_view: TransactionDataCache::new(data_cache),
+        }
+    }
+
+    pub fn exists_module(&self, m: &ModuleId) -> bool {
+        self.data_view.exists_module(m)
+    }
+
+    /// Clear all the writes local to this execution.
+    pub fn clear(&mut self) {
+        self.data_view.clear();
+        self.event_data.clear();
+    }
+
+    /// Return the list of events emitted during execution.
+    pub fn events(&self) -> &[ContractEvent] {
+        &self.event_data
+    }
+
+    /// Return the gas remaining
+    pub fn gas_left(&self) -> GasUnits<GasCarrier> {
+        self.gas_left
+    }
+
+    /// Generate a `WriteSet` as a result of an execution.
+    pub fn make_write_set(
+        &mut self,
+        to_be_published_modules: Vec<(ModuleId, Vec<u8>)>,
+    ) -> VMResult<WriteSet> {
+        self.data_view.make_write_set(to_be_published_modules)
+    }
+}
+
+/// The InterpreterContext context trait speficies the mutations that are allowed to the
+/// TransactionExecutionContext within the interpreter.
+pub trait InterpreterContext {
+    fn move_resource_to(
+        &mut self,
+        ap: &AccessPath,
+        def: StructDef,
+        resource: Struct,
+    ) -> VMResult<()>;
+
+    fn move_resource_from(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<Value>;
+
+    fn resource_exists(
+        &mut self,
+        ap: &AccessPath,
+        def: StructDef,
+    ) -> VMResult<(bool, AbstractMemorySize<GasCarrier>)>;
+
+    fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<GlobalRef>;
+
+    fn push_event(&mut self, event: ContractEvent);
+
+    fn deduct_gas(&mut self, amount: GasUnits<GasCarrier>) -> VMResult<()>;
+
+    fn remaining_gas(&self) -> GasUnits<GasCarrier>;
+}
+
+impl<'txn> InterpreterContext for TransactionExecutionContext<'txn> {
+    fn move_resource_to(
+        &mut self,
+        ap: &AccessPath,
+        def: StructDef,
+        resource: Struct,
+    ) -> VMResult<()> {
+        self.data_view.move_resource_to(&ap, def, resource)
+    }
+
+    fn move_resource_from(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<Value> {
+        self.data_view.move_resource_from(&ap, def)
+    }
+
+    fn resource_exists(
+        &mut self,
+        ap: &AccessPath,
+        def: StructDef,
+    ) -> VMResult<(bool, AbstractMemorySize<GasCarrier>)> {
+        self.data_view.resource_exists(&ap, def)
+    }
+
+    fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<GlobalRef> {
+        self.data_view.borrow_global(&ap, def)
+    }
+
+    fn push_event(&mut self, event: ContractEvent) {
+        self.event_data.push(event)
+    }
+
+    fn remaining_gas(&self) -> GasUnits<GasCarrier> {
+        self.gas_left()
+    }
+
+    fn deduct_gas(&mut self, amount: GasUnits<GasCarrier>) -> VMResult<()> {
+        if self
+            .gas_left
+            .app(&amount, |curr_gas, gas_amt| curr_gas >= gas_amt)
+        {
+            self.gas_left = self.gas_left.sub(amount);
+            Ok(())
+        } else {
+            // Zero out the internal gas state
+            self.gas_left = GasUnits::new(0);
+            Err(VMStatus::new(StatusCode::OUT_OF_GAS))
+        }
+    }
+}

--- a/language/vm/vm-runtime/src/gas_meter.rs
+++ b/language/vm/vm-runtime/src/gas_meter.rs
@@ -11,7 +11,6 @@ use libra_types::{
     account_config,
     identifier::Identifier,
     language_storage::ModuleId,
-    transaction::MAX_TRANSACTION_SIZE_IN_BYTES,
     vm_error::{sub_status, StatusCode, VMStatus},
 };
 use vm::{errors::VMResult, gas_schedule::*};
@@ -65,128 +64,19 @@ pub(crate) fn load_gas_schedule<'alloc>(
 
 #[macro_export]
 macro_rules! gas {
-    (instr: $self:ident, $opcode:path, $mem_size:expr) => {
-        $self.gas_meter.consume_instruction_gas($opcode, $mem_size)
+    (instr: $context:ident, $self:ident, $opcode:path, $mem_size:expr) => {
+        $context.deduct_gas(
+            $self
+                .gas_schedule
+                .instruction_cost($opcode as u8)
+                .total()
+                .mul($mem_size),
+        )
     };
-    (const_instr: $self:ident, $opcode:path) => {
-        $self
-            .gas_meter
-            .consume_instruction_gas($opcode, *CONST_SIZE)
+    (const_instr: $context:ident, $self:ident, $opcode:path) => {
+        $context.deduct_gas($self.gas_schedule.instruction_cost($opcode as u8).total())
     };
-    (consume: $self:ident, $expr:expr) => {
-        $self.gas_meter.consume_gas($expr)
+    (consume: $context:ident, $expr:expr) => {
+        $context.deduct_gas($expr)
     };
-}
-
-/// Holds the state of the gas meter.
-pub struct GasMeter<'txn> {
-    // The current amount of gas that is left ("unburnt gas") in the gas meter.
-    current_gas_left: GasUnits<GasCarrier>,
-
-    // The gas schedule used for computing the gas cost per bytecode instruction.
-    gas_schedule: &'txn CostTable,
-
-    // We need to disable and enable gas metering for both the prologue and epilogue of the Account
-    // contract. The VM will then internally unset/set this flag before executing either of them.
-    meter_on: bool,
-}
-
-// NB: A number of the functions/methods in this struct will return a VMResult<T>
-// since we will need to access stack and memory states, and we need to be able
-// to report errors properly from these accesses.
-impl<'txn> GasMeter<'txn> {
-    /// Create a new gas meter with starting gas amount `gas_amount`
-    pub fn new(gas_amount: GasUnits<GasCarrier>, gas_schedule: &'txn CostTable) -> Self {
-        GasMeter {
-            current_gas_left: gas_amount,
-            gas_schedule,
-            meter_on: true,
-        }
-    }
-
-    pub fn cost_table(&self) -> &'txn CostTable {
-        &self.gas_schedule
-    }
-
-    /// Charges additional gas for the transaction based upon the total size (in bytes) of the
-    /// submitted transaction. It is important that we charge for the transaction size since a
-    /// transaction can contain arbitrary amounts of bytes in the `note` field. We also want to
-    /// disinsentivize large transactions with large notes, so we charge the same amount up to a
-    /// cutoff, after which we start charging at a greater rate.
-    pub fn charge_transaction_gas(
-        &mut self,
-        transaction_size: AbstractMemorySize<GasCarrier>,
-    ) -> VMResult<()> {
-        precondition!(transaction_size.get() <= (MAX_TRANSACTION_SIZE_IN_BYTES as u64));
-        let cost = calculate_intrinsic_gas(transaction_size);
-        self.consume_gas(cost)
-    }
-
-    /// Queries the internal state of the gas meter to determine if it has at
-    /// least `needed_gas` amount of gas.
-    pub fn has_gas(&self, needed_gas: GasUnits<GasCarrier>) -> bool {
-        self.current_gas_left
-            .app(&needed_gas, |curr_gas, needed_gas| curr_gas >= needed_gas)
-    }
-
-    /// Disables metering of gas.
-    ///
-    /// We need to disable and enable gas metering for both the prologue and epilogue of the
-    /// Account contract. The VM will then internally turn off gas metering before executing either
-    /// of them using this method.
-    pub fn disable_metering(&mut self) {
-        self.meter_on = false;
-    }
-
-    /// Re-enables metering of gas.
-    ///
-    /// After executing the prologue and epilogue in the Account contract gas metering is re-enabled
-    /// using this method. The VM is responsible for internally calling this method after disabling
-    /// gas metering.
-    pub fn enable_metering(&mut self) {
-        self.meter_on = true;
-    }
-
-    /// Get the amount of gas that remains (that has _not_ been consumed) in the gas meter.
-    ///
-    /// This method is used by the `GetGasRemaining` bytecode instruction to get the current
-    /// amount of gas remaining at the point of call.
-    pub fn remaining_gas(&self) -> GasUnits<GasCarrier> {
-        self.current_gas_left
-    }
-
-    /// A wrapper that calculates and then consumes the gas unless metering is disabled.
-    #[inline]
-    pub fn consume_instruction_gas(
-        &mut self,
-        instruction_key: Opcodes,
-        memory_size: AbstractMemorySize<GasCarrier>,
-    ) -> VMResult<()> {
-        if self.meter_on {
-            let gas_cost = self.gas_schedule.instruction_cost(instruction_key as u8);
-            let gas = gas_cost.total().mul(memory_size);
-            self.consume_gas(gas)
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Consume the amount of gas given by `gas_amount`. If there is not enough gas
-    /// left in the internal state, an `OutOfGasError` is returned.
-    pub fn consume_gas(&mut self, gas_amount: GasUnits<GasCarrier>) -> VMResult<()> {
-        if !self.meter_on {
-            return Ok(());
-        }
-        if self
-            .current_gas_left
-            .app(&gas_amount, |curr_gas, gas_amt| curr_gas >= gas_amt)
-        {
-            self.current_gas_left = self.current_gas_left.sub(gas_amount);
-            Ok(())
-        } else {
-            // Zero out the internal gas state
-            self.current_gas_left = GasUnits::new(0);
-            Err(VMStatus::new(StatusCode::OUT_OF_GAS))
-        }
-    }
 }

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -1,12 +1,15 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(any(test, feature = "instruction_synthesis"))]
+use crate::data_cache::RemoteCache;
+#[cfg(any(test, feature = "instruction_synthesis"))]
+use crate::execution_context::TransactionExecutionContext;
 use crate::{
     code_cache::module_cache::ModuleCache,
     counters::*,
-    data_cache::TransactionDataCache,
+    execution_context::InterpreterContext,
     gas,
-    gas_meter::GasMeter,
     identifier::{create_access_path, resource_storage_key},
     loaded_data::{
         function::{FunctionRef, FunctionReference},
@@ -25,13 +28,12 @@ use libra_types::{
     language_storage::{ModuleId, StructTag, TypeTag},
     transaction::MAX_TRANSACTION_SIZE_IN_BYTES,
     vm_error::{StatusCode, StatusType, VMStatus},
-    write_set::WriteSet,
 };
 #[cfg(any(test, feature = "instruction_synthesis"))]
 use std::collections::HashMap;
 use std::{collections::VecDeque, convert::TryFrom, marker::PhantomData};
 #[cfg(any(test, feature = "instruction_synthesis"))]
-use vm::gas_schedule::{CostTable, MAXIMUM_NUMBER_OF_GAS_UNITS};
+use vm::gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS;
 use vm::{
     access::ModuleAccess,
     errors::*,
@@ -40,7 +42,8 @@ use vm::{
         StructDefinitionIndex,
     },
     gas_schedule::{
-        AbstractMemorySize, GasAlgebra, GasCarrier, NativeCostIndex, Opcodes, CONST_SIZE,
+        calculate_intrinsic_gas, AbstractMemorySize, CostTable, GasAlgebra, GasCarrier,
+        NativeCostIndex, Opcodes,
     },
     transaction_metadata::TransactionMetadata,
 };
@@ -58,7 +61,6 @@ lazy_static! {
     /// The ModuleId for the Event
     pub static ref EVENT_MODULE: ModuleId =
         { ModuleId::new(account_config::core_code_address(), Identifier::new("Event").unwrap()) };
-
 }
 
 // Names for special functions and structs
@@ -67,42 +69,6 @@ lazy_static! {
     static ref ACCOUNT_STRUCT_NAME: Identifier = Identifier::new("T").unwrap();
     static ref EMIT_EVENT_NAME: Identifier = Identifier::new("write_to_event_store").unwrap();
     static ref SAVE_ACCOUNT_NAME: Identifier = Identifier::new("save_account").unwrap();
-}
-
-/// `Interpreter` instances can execute Move functions.
-///
-/// An `Interpreter` instance is a stand alone execution context for a function.
-/// It mimics execution on a single thread, with an call stack and an operand stack.
-/// The `Interpreter` receives a reference to a data store used by certain opcodes
-/// to do operations on data on chain and a `TransactionMetadata` which is also used to resolve
-/// specific opcodes.
-/// A `ModuleCache` is also provided to resolve external references to code.
-// REVIEW: abstract the data store better (maybe a single Trait for both data and event?)
-// The ModuleCache should be a Loader with a proper API.
-// Resolve where GasMeter should live.
-pub struct Interpreter<'alloc, 'txn, P>
-where
-    'alloc: 'txn,
-    P: ModuleCache<'alloc>,
-{
-    /// Operand stack, where Move `Value`s are stored for stack operations.
-    operand_stack: Stack,
-    /// The stack of active functions.
-    call_stack: CallStack<'txn>,
-    /// Gas metering to track cost of execution.
-    gas_meter: GasMeter<'txn>,
-    /// Transaction data to resolve special bytecodes (e.g. GetTxnSequenceNumber, GetTxnPublicKey,
-    /// GetTxnSenderAddress, ...)
-    txn_data: TransactionMetadata,
-    /// List of events "fired" during the course of an execution.
-    // REVIEW: should this live outside the Interpreter?
-    event_data: Vec<ContractEvent>,
-    /// Data store
-    // REVIEW: maybe this and the event should go together as some kind of external context?
-    data_view: TransactionDataCache<'txn>,
-    /// Code cache, this is effectively the loader.
-    module_cache: P,
-    phantom: PhantomData<&'alloc ()>,
 }
 
 fn derive_type_tag(
@@ -151,92 +117,135 @@ fn derive_type_tag(
     }
 }
 
+/// `Interpreter` instances can execute Move functions.
+///
+/// An `Interpreter` instance is a stand alone execution context for a function.
+/// It mimics execution on a single thread, with an call stack and an operand stack.
+/// The `Interpreter` receives a reference to a data store used by certain opcodes
+/// to do operations on data on chain and a `TransactionMetadata` which is also used to resolve
+/// specific opcodes.
+/// A `ModuleCache` is also provided to resolve external references to code.
+// REVIEW: abstract the data store better (maybe a single Trait for both data and event?)
+// The ModuleCache should be a Loader with a proper API.
+// Resolve where GasMeter should live.
+pub struct Interpreter<'alloc, 'txn, P>
+where
+    'alloc: 'txn,
+    P: ModuleCache<'alloc>,
+{
+    /// Operand stack, where Move `Value`s are stored for stack operations.
+    operand_stack: Stack,
+    /// The stack of active functions.
+    call_stack: CallStack<'txn>,
+    /// Transaction data to resolve special bytecodes (e.g. GetTxnSequenceNumber, GetTxnPublicKey,
+    /// GetTxnSenderAddress, ...)
+    txn_data: &'txn TransactionMetadata,
+    /// Code cache, this is effectively the loader.
+    module_cache: &'txn P,
+    gas_schedule: &'txn CostTable,
+    phantom: PhantomData<&'alloc ()>,
+}
+
 impl<'alloc, 'txn, P> Interpreter<'alloc, 'txn, P>
 where
     'alloc: 'txn,
     P: ModuleCache<'alloc>,
 {
+    /// Execute a function.
+    /// `module` is an identifier for the name the module is stored in. `function_name` is the name
+    /// of the function. If such function is found, the VM will execute this function with arguments
+    /// `args`. The return value will be placed on the top of the value stack and abort if an error
+    /// occurs.
+    // REVIEW: this should probably disappear or at the very least only one between
+    // `execute_function` and `entrypoint` should exist. It's a bit messy at
+    // the moment given tooling and testing. Once we remove Program transactions and we
+    // clean up the loader we will have a better time cleaning this up.
+    pub fn execute_function(
+        context: &mut dyn InterpreterContext,
+        module_cache: &'txn P,
+        txn_data: &'txn TransactionMetadata,
+        gas_schedule: &'txn CostTable,
+        module: &ModuleId,
+        function_name: &IdentStr,
+        args: Vec<Value>,
+    ) -> VMResult<()> {
+        let mut interp = Self::new(module_cache, txn_data, gas_schedule);
+        let loaded_module = interp.module_cache.get_loaded_module(module)?;
+        let func_idx = loaded_module
+            .function_defs_table
+            .get(function_name)
+            .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
+        let func = FunctionRef::new(loaded_module, *func_idx);
+
+        interp.execute(context, func, args)
+    }
+
+    /// Entrypoint into the interpreter. All external calls need to be routed through this
+    /// function.
+    pub(crate) fn entrypoint(
+        context: &mut dyn InterpreterContext,
+        module_cache: &'txn P,
+        txn_data: &'txn TransactionMetadata,
+        gas_schedule: &'txn CostTable,
+        func: FunctionRef<'txn>,
+        args: Vec<Value>,
+    ) -> VMResult<()> {
+        // We charge an intrinsic amount of gas based upon the size of the transaction submitted
+        // (in raw bytes).
+        let txn_size = txn_data.transaction_size();
+        // The callers of this function verify the transaction before executing it. Transaction
+        // verification ensures the following condition.
+        assume!(txn_size.get() <= (MAX_TRANSACTION_SIZE_IN_BYTES as u64));
+        // We count the intrinsic cost of the transaction here, since that needs to also cover the
+        // setup of the function.
+        let mut interp = Self::new(module_cache, txn_data, gas_schedule);
+        let starting_gas = context.remaining_gas();
+        gas!(consume: context, calculate_intrinsic_gas(txn_size))?;
+        let ret = interp.execute(context, func, args);
+        record_stats!(
+            observe | TXN_EXECUTION_GAS_USAGE | starting_gas.sub(context.remaining_gas()).get()
+        );
+        ret
+    }
+
+    /// Create an account on the blockchain by calling into `CREATE_ACCOUNT_NAME` function stored
+    /// in the `ACCOUNT_MODULE` on chain.
+    // REVIEW: this should not live here
+    pub(crate) fn create_account_entry(
+        context: &mut dyn InterpreterContext,
+        module_cache: &'txn P,
+        txn_data: &'txn TransactionMetadata,
+        gas_schedule: &'txn CostTable,
+        addr: AccountAddress,
+    ) -> VMResult<()> {
+        let account_module = module_cache.get_loaded_module(&ACCOUNT_MODULE)?;
+        let mut interp = Self::new(module_cache, txn_data, gas_schedule);
+        interp.execute_function_call(
+            context,
+            &ACCOUNT_MODULE,
+            &CREATE_ACCOUNT_NAME,
+            vec![Value::byte_array(ByteArray::new(addr.to_vec()))],
+        )?;
+
+        let account_resource = interp.operand_stack.pop_as::<Struct>()?;
+        interp.save_account(context, account_module, addr, account_resource)
+    }
+
     /// Create a new instance of an `Interpreter` in the context of a transaction with a
-    /// given module cache (loader) and a data store.
-    // REVIEW: it's not clear the responsibilities between the Interpreter and the outside
-    // context are well defined. Obviously certain opcodes require a given context, but
-    // we may be doing better here...
-    pub fn new(
-        module_cache: P,
-        txn_data: TransactionMetadata,
-        data_view: TransactionDataCache<'txn>,
-        gas_meter: GasMeter<'txn>,
+    /// given module cache and gas schedule.
+    fn new(
+        module_cache: &'txn P,
+        txn_data: &'txn TransactionMetadata,
+        gas_schedule: &'txn CostTable,
     ) -> Self {
         Interpreter {
             operand_stack: Stack::new(),
             call_stack: CallStack::new(),
-            gas_meter,
+            gas_schedule,
             txn_data,
-            event_data: vec![],
-            data_view,
             module_cache,
             phantom: PhantomData,
         }
-    }
-
-    //
-    // The functions below should be reviewed once we clean up the Loader and the
-    // transaction flow. It's not clear whether they are leaking internal of the Interpreter
-    // that would be better exposed via a more proper API.
-    //
-
-    /// Returns the module cache for this interpreter.
-    pub fn module_cache(&self) -> &P {
-        &self.module_cache
-    }
-
-    /// Disables metering of gas.
-    pub fn disable_metering(&mut self) {
-        self.gas_meter.disable_metering();
-    }
-
-    /// Re-enables metering of gas.
-    pub(crate) fn enable_metering(&mut self) {
-        self.gas_meter.enable_metering();
-    }
-
-    /// Returns the gas used by an execution in the `Interpreter`.
-    pub(crate) fn gas_used(&self) -> u64 {
-        self.txn_data
-            .max_gas_amount
-            .sub(self.gas_meter.remaining_gas())
-            .mul(self.txn_data.gas_unit_price)
-            .get()
-    }
-
-    // This is used by the genesis tool and must be deleted and re-worked
-    pub(crate) fn swap_sender(&mut self, address: AccountAddress) -> AccountAddress {
-        let old_sender = self.txn_data.sender;
-        self.txn_data.sender = address;
-        old_sender
-    }
-
-    /// Clear all the writes local to this execution.
-    pub(crate) fn clear(&mut self) {
-        self.data_view.clear();
-        self.event_data.clear();
-    }
-
-    /// Return the list of events emitted during execution.
-    pub(crate) fn events(&self) -> &[ContractEvent] {
-        &self.event_data
-    }
-
-    /// Generate a `WriteSet` as a result of an execution.
-    pub(crate) fn make_write_set(
-        &mut self,
-        to_be_published_modules: Vec<(ModuleId, Vec<u8>)>,
-    ) -> VMResult<WriteSet> {
-        self.data_view.make_write_set(to_be_published_modules)
-    }
-
-    pub(crate) fn exists_module(&self, m: &ModuleId) -> bool {
-        self.data_view.exists_module(m)
     }
 
     /// Execute a function.
@@ -245,11 +254,12 @@ where
     /// `args`. The return value will be placed on the top of the value stack and abort if an error
     /// occurs.
     // REVIEW: this should probably disappear or at the very least only one between
-    // `execute_function` and `interpeter_entrypoint` should exist. It's a bit messy at
+    // `execute_function` and `entrypoint` should exist. It's a bit messy at
     // the moment given tooling and testing. Once we remove Program transactions and we
     // clean up the loader we will have a better time cleaning this up.
-    pub fn execute_function(
+    fn execute_function_call(
         &mut self,
+        context: &mut dyn InterpreterContext,
         module: &ModuleId,
         function_name: &IdentStr,
         args: Vec<Value>,
@@ -261,40 +271,19 @@ where
             .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
         let func = FunctionRef::new(loaded_module, *func_idx);
 
-        self.execute(func, args)
-    }
-
-    /// Entrypoint into the interpreter. All external calls need to be routed through this
-    /// function.
-    pub(crate) fn interpeter_entrypoint(
-        &mut self,
-        func: FunctionRef<'txn>,
-        args: Vec<Value>,
-    ) -> VMResult<()> {
-        // We charge an intrinsic amount of gas based upon the size of the transaction submitted
-        // (in raw bytes).
-        let txn_size = self.txn_data.transaction_size;
-        // The callers of this function verify the transaction before executing it. Transaction
-        // verification ensures the following condition.
-        assume!(txn_size.get() <= (MAX_TRANSACTION_SIZE_IN_BYTES as u64));
-        // We count the intrinsic cost of the transaction here, since that needs to also cover the
-        // setup of the function.
-        let starting_gas = self.gas_meter.remaining_gas().get();
-        self.gas_meter.charge_transaction_gas(txn_size)?;
-        let ret = self.execute(func, args);
-        record_stats!(observe | TXN_EXECUTION_GAS_USAGE | starting_gas);
-        ret
+        self.execute(context, func, args)
     }
 
     /// Internal execution entry point.
-    fn execute(&mut self, function: FunctionRef<'txn>, args: Vec<Value>) -> VMResult<()> {
-        self.execute_main(function, args, 0).or_else(|err| {
-            self.operand_stack.0.clear();
-            self.call_stack.0.clear();
-            Err(err)
-        })?;
-        // TODO: assert invariants: empty operand stack, ...
-        Ok(())
+    fn execute(
+        &mut self,
+        context: &mut dyn InterpreterContext,
+        function: FunctionRef<'txn>,
+        args: Vec<Value>,
+    ) -> VMResult<()> {
+        // No unwinding of the call stack and value stack need to be done here -- the context will
+        // take care of that.
+        self.execute_main(context, function, args, 0)
     }
 
     /// Main loop for the execution of a function.
@@ -307,6 +296,7 @@ where
     // we can simplify this code quite a bit.
     fn execute_main(
         &mut self,
+        context: &mut dyn InterpreterContext,
         function: FunctionRef<'txn>,
         args: Vec<Value>,
         create_account_marker: usize,
@@ -320,7 +310,7 @@ where
         loop {
             let code = current_frame.code_definition();
             let exit_code = self
-                .execute_code_unit(&mut current_frame, code)
+                .execute_code_unit(context, &mut current_frame, code)
                 .or_else(|err| Err(self.maybe_core_dump(err, &current_frame)))?;
             match exit_code {
                 ExitCode::Return => {
@@ -340,7 +330,8 @@ where
                         .locals_signature_at(type_actuals_idx)
                         .0;
                     gas!(
-                        instr: self,
+                        instr: context,
+                        self,
                         Opcodes::CALL,
                         AbstractMemorySize::new((type_actuals.len() + 1) as GasCarrier)
                     )?;
@@ -356,7 +347,7 @@ where
                         .collect::<VMResult<Vec<_>>>()?;
 
                     let opt_frame = self
-                        .make_call_frame(current_frame.module(), idx, type_actual_tags)
+                        .make_call_frame(context, current_frame.module(), idx, type_actual_tags)
                         .or_else(|err| Err(self.maybe_core_dump(err, &current_frame)))?;
                     if let Some(frame) = opt_frame {
                         self.call_stack.push(current_frame).or_else(|frame| {
@@ -371,9 +362,9 @@ where
     }
 
     /// Execute a Move function until a return or a call opcode is found.
-    #[allow(clippy::cognitive_complexity)]
     fn execute_code_unit(
         &mut self,
+        context: &mut dyn InterpreterContext,
         frame: &mut Frame<'txn, FunctionRef<'txn>>,
         code: &[Bytecode],
     ) -> VMResult<ExitCode> {
@@ -385,45 +376,46 @@ where
 
                 match instruction {
                     Bytecode::Pop => {
-                        gas!(const_instr: self, Opcodes::POP)?;
+                        gas!(const_instr: context, self, Opcodes::POP)?;
                         self.operand_stack.pop()?;
                     }
                     Bytecode::Ret => {
-                        gas!(const_instr: self, Opcodes::RET)?;
+                        gas!(const_instr: context, self, Opcodes::RET)?;
                         return Ok(ExitCode::Return);
                     }
                     Bytecode::BrTrue(offset) => {
-                        gas!(const_instr: self, Opcodes::BR_TRUE)?;
+                        gas!(const_instr: context, self, Opcodes::BR_TRUE)?;
                         if self.operand_stack.pop_as::<bool>()? {
                             frame.pc = *offset;
                             break;
                         }
                     }
                     Bytecode::BrFalse(offset) => {
-                        gas!(const_instr: self, Opcodes::BR_FALSE)?;
+                        gas!(const_instr: context, self, Opcodes::BR_FALSE)?;
                         if !self.operand_stack.pop_as::<bool>()? {
                             frame.pc = *offset;
                             break;
                         }
                     }
                     Bytecode::Branch(offset) => {
-                        gas!(const_instr: self, Opcodes::BRANCH)?;
+                        gas!(const_instr: context, self, Opcodes::BRANCH)?;
                         frame.pc = *offset;
                         break;
                     }
                     Bytecode::LdConst(int_const) => {
-                        gas!(const_instr: self, Opcodes::LD_CONST)?;
+                        gas!(const_instr: context, self, Opcodes::LD_CONST)?;
                         self.operand_stack.push(Value::u64(*int_const))?;
                     }
                     Bytecode::LdAddr(idx) => {
-                        gas!(const_instr: self, Opcodes::LD_ADDR)?;
+                        gas!(const_instr: context, self, Opcodes::LD_ADDR)?;
                         self.operand_stack
                             .push(Value::address(*frame.module().address_at(*idx)))?;
                     }
                     Bytecode::LdStr(idx) => {
                         let string = frame.module().user_string_at(*idx);
                         gas!(
-                            instr: self,
+                            instr: context,
+                            self,
                             Opcodes::LD_STR,
                             AbstractMemorySize::new(string.len() as GasCarrier)
                         )?;
@@ -432,7 +424,8 @@ where
                     Bytecode::LdByteArray(idx) => {
                         let byte_array = frame.module().byte_array_at(*idx);
                         gas!(
-                            instr: self,
+                            instr: context,
+                            self,
                             Opcodes::LD_STR,
                             AbstractMemorySize::new(byte_array.len() as GasCarrier)
                         )?;
@@ -440,26 +433,26 @@ where
                             .push(Value::byte_array(byte_array.clone()))?;
                     }
                     Bytecode::LdTrue => {
-                        gas!(const_instr: self, Opcodes::LD_TRUE)?;
+                        gas!(const_instr: context, self, Opcodes::LD_TRUE)?;
                         self.operand_stack.push(Value::bool(true))?;
                     }
                     Bytecode::LdFalse => {
-                        gas!(const_instr: self, Opcodes::LD_TRUE)?;
+                        gas!(const_instr: context, self, Opcodes::LD_TRUE)?;
                         self.operand_stack.push(Value::bool(false))?;
                     }
                     Bytecode::CopyLoc(idx) => {
                         let local = frame.copy_loc(*idx)?;
-                        gas!(instr: self, Opcodes::COPY_LOC, local.size())?;
+                        gas!(instr: context, self, Opcodes::COPY_LOC, local.size())?;
                         self.operand_stack.push(local)?;
                     }
                     Bytecode::MoveLoc(idx) => {
                         let local = frame.move_loc(*idx)?;
-                        gas!(instr: self, Opcodes::MOVE_LOC, local.size())?;
+                        gas!(instr: context, self, Opcodes::MOVE_LOC, local.size())?;
                         self.operand_stack.push(local)?;
                     }
                     Bytecode::StLoc(idx) => {
                         let value_to_store = self.operand_stack.pop()?;
-                        gas!(instr: self, Opcodes::ST_LOC, value_to_store.size())?;
+                        gas!(instr: context, self, Opcodes::ST_LOC, value_to_store.size())?;
                         frame.store_loc(*idx, value_to_store)?;
                     }
                     Bytecode::Call(idx, type_actuals_idx) => {
@@ -470,7 +463,7 @@ where
                             Bytecode::MutBorrowLoc(_) => Opcodes::MUT_BORROW_LOC,
                             _ => Opcodes::IMM_BORROW_LOC,
                         };
-                        gas!(const_instr: self, opcode)?;
+                        gas!(const_instr: context, self, opcode)?;
                         self.operand_stack.push(frame.borrow_loc(*idx)?)?;
                     }
                     Bytecode::ImmBorrowField(fd_idx) | Bytecode::MutBorrowField(fd_idx) => {
@@ -478,7 +471,7 @@ where
                             Bytecode::MutBorrowField(_) => Opcodes::MUT_BORROW_FIELD,
                             _ => Opcodes::IMM_BORROW_FIELD,
                         };
-                        gas!(const_instr: self, opcode)?;
+                        gas!(const_instr: context, self, opcode)?;
                         let field_offset = frame.module().get_field_offset(*fd_idx)?;
                         let reference = self.operand_stack.pop_as::<ReferenceValue>()?;
                         let field_ref = reference.borrow_field(field_offset as usize)?;
@@ -492,7 +485,7 @@ where
                             AbstractMemorySize::new(GasCarrier::from(field_count)),
                             |acc, arg| acc.add(arg.size()),
                         );
-                        gas!(instr: self, Opcodes::PACK, size)?;
+                        gas!(instr: context, self, Opcodes::PACK, size)?;
                         self.operand_stack.push(Value::struct_(Struct::new(args)))?;
                     }
                     Bytecode::Unpack(sd_idx, _) => {
@@ -500,7 +493,8 @@ where
                         let field_count = struct_def.declared_field_count()?;
                         let struct_ = self.operand_stack.pop_as::<Struct>()?;
                         gas!(
-                            instr: self,
+                            instr: context,
+                            self,
                             Opcodes::UNPACK,
                             AbstractMemorySize::new(GasCarrier::from(field_count))
                         )?;
@@ -509,160 +503,186 @@ where
                         // doing a fair bit of work before charging for it.
                         for idx in 0..field_count {
                             let value = struct_.get_field_value(idx as usize)?;
-                            gas!(instr: self, Opcodes::UNPACK, value.size())?;
+                            gas!(instr: context, self, Opcodes::UNPACK, value.size())?;
                             self.operand_stack.push(value)?;
                         }
                     }
                     Bytecode::ReadRef => {
                         let reference = self.operand_stack.pop_as::<ReferenceValue>()?;
                         let value = reference.read_ref()?;
-                        gas!(instr: self, Opcodes::READ_REF, value.size())?;
+                        gas!(instr: context, self, Opcodes::READ_REF, value.size())?;
                         self.operand_stack.push(value)?;
                     }
                     Bytecode::WriteRef => {
                         let reference = self.operand_stack.pop_as::<ReferenceValue>()?;
                         let value = self.operand_stack.pop()?;
-                        gas!(instr: self, Opcodes::WRITE_REF, value.size())?;
+                        gas!(instr: context, self, Opcodes::WRITE_REF, value.size())?;
                         reference.write_ref(value);
                     }
                     // Arithmetic Operations
                     Bytecode::Add => {
-                        gas!(const_instr: self, Opcodes::ADD)?;
+                        gas!(const_instr: context, self, Opcodes::ADD)?;
                         self.binop_int(u64::checked_add)?
                     }
                     Bytecode::Sub => {
-                        gas!(const_instr: self, Opcodes::SUB)?;
+                        gas!(const_instr: context, self, Opcodes::SUB)?;
                         self.binop_int(u64::checked_sub)?
                     }
                     Bytecode::Mul => {
-                        gas!(const_instr: self, Opcodes::MUL)?;
+                        gas!(const_instr: context, self, Opcodes::MUL)?;
                         self.binop_int(u64::checked_mul)?
                     }
                     Bytecode::Mod => {
-                        gas!(const_instr: self, Opcodes::MOD)?;
+                        gas!(const_instr: context, self, Opcodes::MOD)?;
                         self.binop_int(u64::checked_rem)?
                     }
                     Bytecode::Div => {
-                        gas!(const_instr: self, Opcodes::DIV)?;
+                        gas!(const_instr: context, self, Opcodes::DIV)?;
                         self.binop_int(u64::checked_div)?
                     }
                     Bytecode::BitOr => {
-                        gas!(const_instr: self, Opcodes::BIT_OR)?;
+                        gas!(const_instr: context, self, Opcodes::BIT_OR)?;
                         self.binop_int(|l: u64, r| Some(l | r))?
                     }
                     Bytecode::BitAnd => {
-                        gas!(const_instr: self, Opcodes::BIT_AND)?;
+                        gas!(const_instr: context, self, Opcodes::BIT_AND)?;
                         self.binop_int(|l: u64, r| Some(l & r))?
                     }
                     Bytecode::Xor => {
-                        gas!(const_instr: self, Opcodes::XOR)?;
+                        gas!(const_instr: context, self, Opcodes::XOR)?;
                         self.binop_int(|l: u64, r| Some(l ^ r))?
                     }
                     Bytecode::Or => {
-                        gas!(const_instr: self, Opcodes::OR)?;
+                        gas!(const_instr: context, self, Opcodes::OR)?;
                         self.binop_bool(|l, r| l || r)?
                     }
                     Bytecode::And => {
-                        gas!(const_instr: self, Opcodes::AND)?;
+                        gas!(const_instr: context, self, Opcodes::AND)?;
                         self.binop_bool(|l, r| l && r)?
                     }
                     Bytecode::Lt => {
-                        gas!(const_instr: self, Opcodes::LT)?;
+                        gas!(const_instr: context, self, Opcodes::LT)?;
                         self.binop_bool(|l: u64, r| l < r)?
                     }
                     Bytecode::Gt => {
-                        gas!(const_instr: self, Opcodes::GT)?;
+                        gas!(const_instr: context, self, Opcodes::GT)?;
                         self.binop_bool(|l: u64, r| l > r)?
                     }
                     Bytecode::Le => {
-                        gas!(const_instr: self, Opcodes::LE)?;
+                        gas!(const_instr: context, self, Opcodes::LE)?;
                         self.binop_bool(|l: u64, r| l <= r)?
                     }
                     Bytecode::Ge => {
-                        gas!(const_instr: self, Opcodes::GE)?;
+                        gas!(const_instr: context, self, Opcodes::GE)?;
                         self.binop_bool(|l: u64, r| l >= r)?
                     }
                     Bytecode::Abort => {
-                        gas!(const_instr: self, Opcodes::ABORT)?;
+                        gas!(const_instr: context, self, Opcodes::ABORT)?;
                         let error_code = self.operand_stack.pop_as::<u64>()?;
                         return Err(VMStatus::new(StatusCode::ABORTED).with_sub_status(error_code));
                     }
                     Bytecode::Eq => {
                         let lhs = self.operand_stack.pop()?;
                         let rhs = self.operand_stack.pop()?;
-                        gas!(instr: self, Opcodes::EQ, lhs.size().add(rhs.size()))?;
+                        gas!(
+                            instr: context,
+                            self,
+                            Opcodes::EQ,
+                            lhs.size().add(rhs.size())
+                        )?;
                         self.operand_stack.push(Value::bool(lhs.equals(&rhs)?))?;
                     }
                     Bytecode::Neq => {
                         let lhs = self.operand_stack.pop()?;
                         let rhs = self.operand_stack.pop()?;
-                        gas!(instr: self, Opcodes::NEQ, lhs.size().add(rhs.size()))?;
+                        gas!(
+                            instr: context,
+                            self,
+                            Opcodes::NEQ,
+                            lhs.size().add(rhs.size())
+                        )?;
                         self.operand_stack
                             .push(Value::bool(lhs.not_equals(&rhs)?))?;
                     }
                     Bytecode::GetTxnGasUnitPrice => {
-                        gas!(const_instr: self, Opcodes::GET_TXN_GAS_UNIT_PRICE)?;
+                        gas!(const_instr: context, self, Opcodes::GET_TXN_GAS_UNIT_PRICE)?;
                         self.operand_stack
                             .push(Value::u64(self.txn_data.gas_unit_price().get()))?;
                     }
                     Bytecode::GetTxnMaxGasUnits => {
-                        gas!(const_instr: self, Opcodes::GET_TXN_MAX_GAS_UNITS)?;
+                        gas!(const_instr: context, self, Opcodes::GET_TXN_MAX_GAS_UNITS)?;
                         self.operand_stack
                             .push(Value::u64(self.txn_data.max_gas_amount().get()))?;
                     }
                     Bytecode::GetTxnSequenceNumber => {
-                        gas!(const_instr: self, Opcodes::GET_TXN_SEQUENCE_NUMBER)?;
+                        gas!(const_instr: context, self, Opcodes::GET_TXN_SEQUENCE_NUMBER)?;
                         self.operand_stack
                             .push(Value::u64(self.txn_data.sequence_number()))?;
                     }
                     Bytecode::GetTxnSenderAddress => {
-                        gas!(const_instr: self, Opcodes::GET_TXN_SENDER)?;
+                        gas!(const_instr: context, self, Opcodes::GET_TXN_SENDER)?;
                         self.operand_stack
                             .push(Value::address(self.txn_data.sender()))?;
                     }
                     Bytecode::GetTxnPublicKey => {
-                        gas!(const_instr: self, Opcodes::GET_TXN_PUBLIC_KEY)?;
+                        gas!(const_instr: context, self, Opcodes::GET_TXN_PUBLIC_KEY)?;
                         let byte_array =
                             ByteArray::new(self.txn_data.public_key().to_bytes().to_vec());
                         self.operand_stack.push(Value::byte_array(byte_array))?;
                     }
                     Bytecode::MutBorrowGlobal(idx, _) | Bytecode::ImmBorrowGlobal(idx, _) => {
                         let addr = self.operand_stack.pop_as::<AccountAddress>()?;
-                        let size =
-                            self.global_data_op(addr, *idx, frame.module(), Self::borrow_global)?;
-                        gas!(instr: self, Opcodes::MUT_BORROW_GLOBAL, size)?;
+                        let size = self.global_data_op(
+                            context,
+                            addr,
+                            *idx,
+                            frame.module(),
+                            Self::borrow_global,
+                        )?;
+                        gas!(instr: context, self, Opcodes::MUT_BORROW_GLOBAL, size)?;
                     }
                     Bytecode::Exists(idx, _) => {
                         let addr = self.operand_stack.pop_as::<AccountAddress>()?;
-                        let size = self.global_data_op(addr, *idx, frame.module(), Self::exists)?;
-                        gas!(instr: self, Opcodes::EXISTS, size)?;
+                        let size =
+                            self.global_data_op(context, addr, *idx, frame.module(), Self::exists)?;
+                        gas!(instr: context, self, Opcodes::EXISTS, size)?;
                     }
                     Bytecode::MoveFrom(idx, _) => {
                         let addr = self.operand_stack.pop_as::<AccountAddress>()?;
-                        let size =
-                            self.global_data_op(addr, *idx, frame.module(), Self::move_from)?;
+                        let size = self.global_data_op(
+                            context,
+                            addr,
+                            *idx,
+                            frame.module(),
+                            Self::move_from,
+                        )?;
                         // TODO: Have this calculate before pulling in the data based upon
                         // the size of the data that we are about to read in.
-                        gas!(instr: self, Opcodes::MOVE_FROM, size)?;
+                        gas!(instr: context, self, Opcodes::MOVE_FROM, size)?;
                     }
                     Bytecode::MoveToSender(idx, _) => {
                         let addr = self.txn_data.sender();
-                        let size =
-                            self.global_data_op(addr, *idx, frame.module(), Self::move_to_sender)?;
-                        gas!(instr: self, Opcodes::MOVE_TO, size)?;
+                        let size = self.global_data_op(
+                            context,
+                            addr,
+                            *idx,
+                            frame.module(),
+                            Self::move_to_sender,
+                        )?;
+                        gas!(instr: context, self, Opcodes::MOVE_TO, size)?;
                     }
                     Bytecode::FreezeRef => {
                         // FreezeRef should just be a null op as we don't distinguish between mut
                         // and immut ref at runtime.
                     }
                     Bytecode::Not => {
-                        gas!(const_instr: self, Opcodes::NOT)?;
+                        gas!(const_instr: context, self, Opcodes::NOT)?;
                         let value = !self.operand_stack.pop_as::<bool>()?;
                         self.operand_stack.push(Value::bool(value))?;
                     }
                     Bytecode::GetGasRemaining => {
-                        gas!(const_instr: self, Opcodes::GET_GAS_REMAINING)?;
-                        let remaining_gas = self.gas_meter.remaining_gas().get();
+                        gas!(const_instr: context, self, Opcodes::GET_GAS_REMAINING)?;
+                        let remaining_gas = context.remaining_gas().get();
                         self.operand_stack.push(Value::u64(remaining_gas))?;
                     }
                 }
@@ -690,13 +710,14 @@ where
     /// function are incorrectly attributed to the caller.
     fn make_call_frame(
         &mut self,
+        context: &mut dyn InterpreterContext,
         module: &LoadedModule,
         idx: FunctionHandleIndex,
         type_actual_tags: Vec<TypeTag>,
     ) -> VMResult<Option<Frame<'txn, FunctionRef<'txn>>>> {
         let func = self.module_cache.resolve_function_ref(module, idx)?;
         if func.is_native() {
-            self.call_native(func, type_actual_tags)?;
+            self.call_native(context, func, type_actual_tags)?;
             Ok(None)
         } else {
             let mut locals = Locals::new(func.local_count());
@@ -711,6 +732,7 @@ where
     /// Call a native functions.
     fn call_native(
         &mut self,
+        context: &mut dyn InterpreterContext,
         function: FunctionRef<'txn>,
         type_actual_tags: Vec<TypeTag>,
     ) -> VMResult<()> {
@@ -720,10 +742,10 @@ where
         let native_function = resolve_native_function(&module_id, function_name)
             .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
         if module_id == *EVENT_MODULE && function_name == EMIT_EVENT_NAME.as_ident_str() {
-            self.call_emit_event(type_actual_tags)
+            self.call_emit_event(context, type_actual_tags)
         } else if module_id == *ACCOUNT_MODULE && function_name == SAVE_ACCOUNT_NAME.as_ident_str()
         {
-            self.call_save_account()
+            self.call_save_account(context)
         } else {
             let mut arguments = VecDeque::new();
             let expected_args = native_function.num_args();
@@ -738,8 +760,8 @@ where
             for _ in 0..expected_args {
                 arguments.push_front(self.operand_stack.pop()?);
             }
-            let result = (native_function.dispatch)(arguments, self.gas_meter.cost_table())?;
-            gas!(consume: self, result.cost)?;
+            let result = (native_function.dispatch)(arguments, self.gas_schedule)?;
+            gas!(consume: context, result.cost)?;
             result.result.and_then(|values| {
                 for value in values {
                     self.operand_stack.push(value)?;
@@ -750,7 +772,11 @@ where
     }
 
     /// Emit an event if the native function was `write_to_event_store`.
-    fn call_emit_event(&mut self, mut type_actual_tags: Vec<TypeTag>) -> VMResult<()> {
+    fn call_emit_event(
+        &mut self,
+        context: &mut dyn InterpreterContext,
+        mut type_actual_tags: Vec<TypeTag>,
+    ) -> VMResult<()> {
         if type_actual_tags.len() != 1 {
             return Err(
                 VMStatus::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(format!(
@@ -770,18 +796,16 @@ where
         let key = self.operand_stack.pop_as::<ByteArray>()?;
         let guid = EventKey::try_from(key.as_bytes())
             .map_err(|_| VMStatus::new(StatusCode::EVENT_KEY_MISMATCH))?;
-        self.event_data
-            .push(ContractEvent::new(guid, count, type_tag, msg));
+        context.push_event(ContractEvent::new(guid, count, type_tag, msg));
         Ok(())
     }
 
     /// Save an account into the data store.
-    fn call_save_account(&mut self) -> VMResult<()> {
+    fn call_save_account(&mut self, context: &mut dyn InterpreterContext) -> VMResult<()> {
         let account_module = self.module_cache.get_loaded_module(&ACCOUNT_MODULE)?;
-
         let account_resource = self.operand_stack.pop_as::<Struct>()?;
         let address = self.operand_stack.pop_as::<AccountAddress>()?;
-        self.save_account(account_module, address, account_resource)
+        self.save_account(context, account_module, address, account_resource)
     }
 
     /// Perform a binary operation to two values at the top of the stack.
@@ -825,28 +849,33 @@ where
     /// opcode.
     fn global_data_op<F>(
         &mut self,
+        context: &mut dyn InterpreterContext,
         address: AccountAddress,
         idx: StructDefinitionIndex,
         module: &LoadedModule,
         op: F,
     ) -> VMResult<AbstractMemorySize<GasCarrier>>
     where
-        F: FnOnce(&mut Self, AccessPath, StructDef) -> VMResult<AbstractMemorySize<GasCarrier>>,
+        F: FnOnce(
+            &mut Self,
+            &mut dyn InterpreterContext,
+            AccessPath,
+            StructDef,
+        ) -> VMResult<AbstractMemorySize<GasCarrier>>,
     {
         let ap = Self::make_access_path(module, idx, address);
-        let struct_def = self
-            .module_cache
-            .resolve_struct_def(module, idx, &self.gas_meter)?;
-        op(self, ap, struct_def)
+        let struct_def = self.module_cache.resolve_struct_def(module, idx, context)?;
+        op(self, context, ap, struct_def)
     }
 
     /// BorrowGlobal (mutable and not) opcode.
     fn borrow_global(
         &mut self,
+        context: &mut dyn InterpreterContext,
         ap: AccessPath,
         struct_def: StructDef,
     ) -> VMResult<AbstractMemorySize<GasCarrier>> {
-        let global_ref = self.data_view.borrow_global(&ap, struct_def)?;
+        let global_ref = context.borrow_global(&ap, struct_def)?;
         let size = global_ref.size();
         self.operand_stack.push(Value::global_ref(global_ref))?;
         Ok(size)
@@ -855,10 +884,11 @@ where
     /// Exists opcode.
     fn exists(
         &mut self,
+        context: &mut dyn InterpreterContext,
         ap: AccessPath,
         struct_def: StructDef,
     ) -> VMResult<AbstractMemorySize<GasCarrier>> {
-        let (exists, mem_size) = self.data_view.resource_exists(&ap, struct_def)?;
+        let (exists, mem_size) = context.resource_exists(&ap, struct_def)?;
         self.operand_stack.push(Value::bool(exists))?;
         Ok(mem_size)
     }
@@ -866,10 +896,11 @@ where
     /// MoveFrom opcode.
     fn move_from(
         &mut self,
+        context: &mut dyn InterpreterContext,
         ap: AccessPath,
         struct_def: StructDef,
     ) -> VMResult<AbstractMemorySize<GasCarrier>> {
-        let resource = self.data_view.move_resource_from(&ap, struct_def)?;
+        let resource = context.move_resource_from(&ap, struct_def)?;
         let size = resource.size();
         self.operand_stack.push(resource)?;
         Ok(size)
@@ -878,12 +909,13 @@ where
     /// MoveToSender opcode.
     fn move_to_sender(
         &mut self,
+        context: &mut dyn InterpreterContext,
         ap: AccessPath,
         struct_def: StructDef,
     ) -> VMResult<AbstractMemorySize<GasCarrier>> {
         let resource = self.operand_stack.pop_as::<Struct>()?;
         let size = resource.size();
-        self.data_view.move_resource_to(&ap, struct_def, resource)?;
+        context.move_resource_to(&ap, struct_def, resource)?;
         Ok(size)
     }
 
@@ -899,14 +931,14 @@ where
 
     fn save_account(
         &mut self,
+        context: &mut dyn InterpreterContext,
         account_module: &LoadedModule,
         addr: AccountAddress,
         account_resource: Struct,
     ) -> VMResult<()> {
         gas!(
-            consume: self,
-            self.gas_meter
-                .cost_table()
+            consume: context,
+            self.gas_schedule
                 .native_cost(NativeCostIndex::SAVE_ACCOUNT)
                 .total()
         )?;
@@ -914,38 +946,13 @@ where
             .struct_defs_table
             .get(&*ACCOUNT_STRUCT_NAME)
             .ok_or_else(|| VMStatus::new(StatusCode::LINKER_ERROR))?;
-        let account_struct_def = self.module_cache.resolve_struct_def(
-            account_module,
-            *account_struct_id,
-            &self.gas_meter,
-        )?;
+        let account_struct_def =
+            self.module_cache
+                .resolve_struct_def(account_module, *account_struct_id, context)?;
 
         // TODO: Adding the freshly created account's expiration date to the TransactionOutput here.
         let account_path = Self::make_access_path(account_module, *account_struct_id, addr);
-        self.data_view
-            .move_resource_to(&account_path, account_struct_def, account_resource)
-    }
-
-    /// Create an account on the blockchain by calling into `CREATE_ACCOUNT_NAME` function stored
-    /// in the `ACCOUNT_MODULE` on chain.
-    // REVIEW: this should not live here
-    pub fn create_account_entry(&mut self, addr: AccountAddress) -> VMResult<()> {
-        let account_module = self.module_cache.get_loaded_module(&ACCOUNT_MODULE)?;
-
-        // TODO: Currently the event counter will cause the gas cost for create account be flexible.
-        //       We either need to fix the gas stability test cases in tests or we need to come up
-        //       with some better ideas for the event counter creation.
-        self.gas_meter.disable_metering();
-        // Address will be used as the initial authentication key.
-        self.execute_function(
-            &ACCOUNT_MODULE,
-            &CREATE_ACCOUNT_NAME,
-            vec![Value::byte_array(ByteArray::new(addr.to_vec()))],
-        )?;
-        self.gas_meter.enable_metering();
-
-        let account_resource = self.operand_stack.pop_as::<Struct>()?;
-        self.save_account(account_module, addr, account_resource)
+        context.move_resource_to(&account_path, account_struct_def, account_resource)
     }
 
     //
@@ -1187,10 +1194,14 @@ where
 // to determine what the needs of gas logic has to be.
 //
 #[cfg(any(test, feature = "instruction_synthesis"))]
-pub struct InterpreterForCostSynthesis<'alloc, 'txn, P>(Interpreter<'alloc, 'txn, P>)
+pub struct InterpreterForCostSynthesis<'alloc, 'txn, P>
 where
     'alloc: 'txn,
-    P: ModuleCache<'alloc>;
+    P: ModuleCache<'alloc>,
+{
+    interpreter: Interpreter<'alloc, 'txn, P>,
+    context: TransactionExecutionContext<'txn>,
+}
 
 #[cfg(any(test, feature = "instruction_synthesis"))]
 impl<'alloc, 'txn, P> InterpreterForCostSynthesis<'alloc, 'txn, P>
@@ -1199,34 +1210,33 @@ where
     P: ModuleCache<'alloc>,
 {
     pub fn new(
-        module_cache: P,
-        txn_data: TransactionMetadata,
-        data_view: TransactionDataCache<'txn>,
+        module_cache: &'txn P,
+        txn_data: &'txn TransactionMetadata,
+        data_cache: &'txn dyn RemoteCache,
         gas_schedule: &'txn CostTable,
     ) -> Self {
-        let gas_meter = GasMeter::new(*MAXIMUM_NUMBER_OF_GAS_UNITS, gas_schedule);
-        let interpreter = Interpreter::new(module_cache, txn_data, data_view, gas_meter);
-        InterpreterForCostSynthesis(interpreter)
-    }
-
-    pub fn turn_off_gas_metering(&mut self) {
-        self.0.gas_meter.disable_metering();
+        let interpreter = Interpreter::new(module_cache, txn_data, gas_schedule);
+        let context = TransactionExecutionContext::new(*MAXIMUM_NUMBER_OF_GAS_UNITS, data_cache);
+        InterpreterForCostSynthesis {
+            interpreter,
+            context,
+        }
     }
 
     pub fn clear_writes(&mut self) {
-        self.0.clear();
+        self.context.clear();
     }
 
     pub fn set_stack(&mut self, stack: Vec<Value>) {
-        self.0.operand_stack.0 = stack;
+        self.interpreter.operand_stack.0 = stack;
     }
 
     pub fn call_stack_height(&self) -> usize {
-        self.0.call_stack.0.len()
+        self.interpreter.call_stack.0.len()
     }
 
     pub fn pop_call(&mut self) {
-        self.0
+        self.interpreter
             .call_stack
             .pop()
             .expect("call stack must not be empty");
@@ -1234,29 +1244,30 @@ where
 
     pub fn push_frame(&mut self, func: FunctionRef<'txn>, type_actual_tags: Vec<TypeTag>) {
         let count = func.local_count();
-        self.0
+        self.interpreter
             .call_stack
             .push(Frame::new(func, type_actual_tags, Locals::new(count)))
             .expect("Call stack limit reached");
     }
 
     pub fn load_call(&mut self, args: HashMap<LocalIndex, Value>) {
-        let mut current_frame = self.0.call_stack.pop().expect("frame must exist");
+        let mut current_frame = self.interpreter.call_stack.pop().expect("frame must exist");
         for (local_index, local) in args.into_iter() {
             current_frame
                 .store_loc(local_index, local)
                 .expect("local must exist");
         }
-        self.0
+        self.interpreter
             .call_stack
             .push(current_frame)
             .expect("Call stack limit reached");
     }
 
     pub fn execute_code_snippet(&mut self, code: &[Bytecode]) -> VMResult<()> {
-        let mut current_frame = self.0.call_stack.pop().expect("frame must exist");
-        self.0.execute_code_unit(&mut current_frame, code)?;
-        self.0
+        let mut current_frame = self.interpreter.call_stack.pop().expect("frame must exist");
+        self.interpreter
+            .execute_code_unit(&mut self.context, &mut current_frame, code)?;
+        self.interpreter
             .call_stack
             .push(current_frame)
             .expect("Call stack limit reached");

--- a/language/vm/vm-runtime/src/lib.rs
+++ b/language/vm/vm-runtime/src/lib.rs
@@ -124,6 +124,7 @@ mod unit_tests;
 
 pub mod code_cache;
 pub mod data_cache;
+pub mod execution_context;
 pub mod identifier;
 pub mod interpreter;
 pub mod loaded_data;

--- a/language/vm/vm-runtime/src/system_txn/block_metadata_processor.rs
+++ b/language/vm/vm-runtime/src/system_txn/block_metadata_processor.rs
@@ -45,6 +45,7 @@ where
     //       time by a reasonable amount.
     let gas_schedule = CostTable::zero();
 
+    // The transaction executor failed to start
     let mut txn_executor =
         TransactionExecutor::new(&module_cache, &gas_schedule, data_cache, txn_data);
     let result = if let Ok((id, timestamp, previous_vote, proposer)) = block_metadata.into_inner() {


### PR DESCRIPTION
PR where the mutable context is passed in to the interpreter. **Only look at the top commit!**

This has a number of consequences, but some of the major ones are:
* We don't need to worry about cleanup within the interpreter after execution(!!)
* We remove all of the non-interpreter methods (e.g. `clear`, `events`, `make_write_set`) out of the interpreter and into the context where the mutable fields persisted across interpretation steps are.
* Pretty much the entirety of the gas meter goes away (and some of the functionality gets moved to the context). Also, branching statements to see if the meter has been disabled are removed entirely.
* The interpreter is now one-shot; you cannot grab an instance of the interpreter.

This is just a diff for now -- there is still some cleanup to do. I'm generally liking the way this is coming out, but I'm wondering about whether or not the `module_cache` (and _maybe_ the `gas_schedule`) should be held in the context as well. What are your thoughts?
