### PR TITLE
[Build] cargo audit should fail at warning level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
           name: Cargo Audit
           command: |
             cargo install --force cargo-audit
-            cargo audit
+            cargo audit --deny-warnings
       - build_teardown
   terraform:
     executor: terraform-executor


### PR DESCRIPTION
## Motivation
cargo-audit should exit with an error if any warning advisories are found.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

Tested locally with `cargo-audit 0.10.0`

## Related PRs
#1535 