### PR TITLE
[consensus] removing the `terminate` in chained_bft_smr loop

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -136,9 +136,6 @@ impl<T: Payload> ChainedBftSMR<T> {
                         idle_duration = pre_select_instant.elapsed();
                         epoch_manager.process_epoch_retrieval(epoch_retrieval_and_peer.0, epoch_retrieval_and_peer.1).await
                     }
-                    complete => {
-                        break;
-                    }
                 }
                 counters::EVENT_PROCESSING_LOOP_BUSY_DURATION_S
                     .observe_duration(pre_select_instant.elapsed() - idle_duration);


### PR DESCRIPTION
The consensus loop/select has a `terminate` that should not be reachable as the loop should run forever.
This commit removes it.