### PR TITLE
[MIRAI] Add annotations to libra-mempool crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -29,6 +29,7 @@ failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-
 grpc-helpers = { path = "../common/grpc-helpers", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+mirai-annotations = "1.5.0"
 network = { path = "../network", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

This adds documentation to the code and helps drive the diagnostics produced by MIRAI to zero so that newly introduced problems are easier to find.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo xtest libra-mempool