### PR TITLE
[network] Set TCP_NODELAY for tcp connections

### DIFF
--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -27,6 +27,16 @@ use std::{
 /// A timeout for the connection to open and complete all of the upgrade steps.
 const TRANSPORT_TIMEOUT: Duration = Duration::from_secs(30);
 
+const LIBRA_TCP_TRANSPORT: tcp::TcpTransport = tcp::TcpTransport {
+    // Use default options.
+    recv_buffer_size: None,
+    send_buffer_size: None,
+    ttl: None,
+    keepalive: None,
+    // Use TCP_NODELAY for libra tcp connections.
+    nodelay: Some(true),
+};
+
 fn identity_key_to_peer_id(
     trusted_peers: &RwLock<HashMap<PeerId, NetworkPublicKeys>>,
     remote_static_key: &[u8],
@@ -184,10 +194,9 @@ pub fn build_tcp_noise_transport(
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
 ) -> boxed::BoxedTransport<(Identity, impl StreamMultiplexer), impl ::std::error::Error> {
-    let tcp_transport = tcp::TcpTransport::default();
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
 
-    tcp_transport
+    LIBRA_TCP_TRANSPORT
         .and_then(move |socket, origin| {
             async move {
                 let (remote_static_key, socket) =
@@ -227,9 +236,8 @@ pub fn build_permissionless_tcp_noise_transport(
     own_identity: Identity,
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
 ) -> boxed::BoxedTransport<(Identity, impl StreamMultiplexer), impl ::std::error::Error> {
-    let tcp_transport = tcp::TcpTransport::default();
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
-    tcp_transport
+    LIBRA_TCP_TRANSPORT
         .and_then(move |socket, origin| {
             async move {
                 let (remote_static_key, socket) =
@@ -266,9 +274,7 @@ pub fn build_permissionless_tcp_noise_transport(
 pub fn build_tcp_transport(
     own_identity: Identity,
 ) -> boxed::BoxedTransport<(Identity, impl StreamMultiplexer), impl ::std::error::Error> {
-    let tcp_transport = tcp::TcpTransport::default();
-
-    tcp_transport
+    LIBRA_TCP_TRANSPORT
         .and_then(|socket, origin| {
             async move {
                 let muxer = Yamux::upgrade_connection(socket, origin).await?;


### PR DESCRIPTION
## Summary

With TCP_NODELAY, we are seeing improved throughput in our system when this is run on a 100-node validator cluster.

## Test Plan

* Deployed this to a 100 node validator cluster, immediately saw blocks processed per sec jump to 60 from 50. 
![image](https://user-images.githubusercontent.com/796949/68509595-21f5ef80-0226-11ea-828e-10b098ecabaf.png)

* Also noticed improvements in `Block creation to qc` time graph.
* Ran experiment by splitting 100 node cluster into 80/20 and injected 200ms delay between them.
Overall the max(block creation to qc time) was much lower with TCP_NODELAY set to true

![image](https://user-images.githubusercontent.com/796949/68509527-fd017c80-0225-11ea-9868-d37284335b53.png)

The right graph has `TCP_NODELAY` set to true and left one has it set to false
