### PR TITLE
[cluster-test] Update timeouts, print intermediate results

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -8,9 +8,11 @@ mod reboot_random_validator;
 pub use multi_region_network_simulation::MultiRegionSimulation;
 pub use packet_loss_random_validators::PacketLossRandomValidators;
 pub use reboot_random_validator::RebootRandomValidators;
+use std::time::Duration;
 use std::{collections::HashSet, fmt::Display};
 
 pub trait Experiment: Display + Send {
     fn affected_validators(&self) -> HashSet<String>;
     fn run(&self) -> failure::Result<()>;
+    fn deadline(&self) -> Duration;
 }

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -12,7 +12,7 @@ use failure;
 use slog_scope::{info, warn};
 use std::{collections::HashSet, fmt, thread, time::Duration};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct Metrics {
     split_size: usize,
     cross_region_latency: u64,
@@ -195,6 +195,7 @@ impl Experiment for MultiRegionSimulation {
                     .single_run(*split, Duration::from_millis(*cross_region_latency))
                     .map_err(|e| warn!("{}", e))
                 {
+                    info!("metrics for this run: {:?}", metrics);
                     results.push(metrics);
                 }
                 thread::sleep(Duration::from_secs(60));
@@ -202,6 +203,10 @@ impl Experiment for MultiRegionSimulation {
         }
         print_results(results);
         Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(24 * 60 * 60)
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -53,6 +53,10 @@ impl Experiment for PacketLossRandomValidators {
         }
         Ok(())
     }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(20 * 60)
+    }
 }
 
 impl fmt::Display for PacketLossRandomValidators {

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -57,6 +57,10 @@ impl Experiment for RebootRandomValidators {
         }
         Ok(())
     }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(20 * 60)
+    }
 }
 
 impl fmt::Display for RebootRandomValidators {

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -54,7 +54,7 @@ impl Instance {
             ssh_dest.as_str(),
         ];
         let mut ssh_cmd = Command::new("timeout");
-        ssh_cmd.arg("15").args(ssh_args).args(args);
+        ssh_cmd.arg("60").args(ssh_args).args(args);
         if no_std_err {
             ssh_cmd.stderr(Stdio::null());
         }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -771,6 +771,7 @@ impl ClusterTestRunner {
             style::Reset
         );
         let affected_validators = experiment.affected_validators();
+        let deadline = experiment.deadline();
         let (exp_result_sender, exp_result_recv) = mpsc::channel();
         thread::spawn(move || {
             let result = experiment.run();
@@ -780,7 +781,7 @@ impl ClusterTestRunner {
         });
 
         // We expect experiments completes and cluster go into healthy state within timeout
-        let experiment_deadline = Instant::now() + Duration::from_secs(20 * 60);
+        let experiment_deadline = Instant::now() + deadline;
 
         loop {
             if Instant::now() > experiment_deadline {

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -234,7 +234,7 @@ impl SubmissionThread {
             if self.params.wait_committed {
                 if wait_for_accounts_sequence(&self.client, &mut self.accounts).is_err() {
                     info!(
-                        "[{}] Some transactions was not committed before expiration",
+                        "[{}] Some transactions were not committed before expiration",
                         self.instance
                     );
                 }


### PR DESCRIPTION
## Summary

* Define deadline for each experiment separately and enforce it using trait.
* Update the timeout for ssh command because during network simulation events, it times out frequently
* Set 24 hr deadline for multi-region-simulation experiment as it goes over a number of different topologies