### PR TITLE
[cluster-test] Test if file exists before log rotate

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -926,6 +926,7 @@ impl ClusterTestRunner {
             now.second()
         );
         let suffix = &suffix;
+        let log_file = "/data/libra/libra.log";
         info!("Will use suffix {} for log rotation", suffix);
         let jobs = self
             .cluster
@@ -939,13 +940,11 @@ impl ClusterTestRunner {
                         .map_err(|e| info!("Failed to wipe {}: {:?}", instance, e))
                         .ok();
                     instance
-                        .run_cmd_tee_err(vec![
-                            "sudo",
-                            "gzip",
-                            "-S",
-                            suffix,
-                            "/data/libra/libra.log",
-                        ])
+                        .run_cmd_tee_err(vec![format!(
+                            "test -f {f} && sudo gzip -S {s} {f}",
+                            f = log_file,
+                            s = suffix
+                        )])
                         .map_err(|e| info!("Failed to gzip log file {}: {:?}", instance, e))
                         .ok();
                 }


### PR DESCRIPTION
When cluster test fails to setup cluster(for example, failed to cp genesis.blob), then there is no log file on host - previous was log rotate, and new one was not created.

In this case attempt to log rotate it on next run produces a lot of noise.

This checks if file exists before attempting to log rotate it
