### PR TITLE
[easy][move] Sort errors by Loc when displaying

### DIFF
--- a/language/move-lang/src/errors/mod.rs
+++ b/language/move-lang/src/errors/mod.rs
@@ -60,8 +60,13 @@ fn render_errors<W: WriteColor>(
     writer: &mut W,
     files: &Files,
     file_mapping: &FileMapping,
-    errors: Errors,
+    mut errors: Errors,
 ) {
+    errors.sort_by(|e1, e2| {
+        let loc1: &Loc = &e1[0].0;
+        let loc2: &Loc = &e2[0].0;
+        loc1.cmp(loc2)
+    });
     let mut seen: HashSet<HashableError> = HashSet::new();
     for error in errors.into_iter() {
         let hashable_error = hashable_error(&error);

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -110,7 +110,7 @@ impl TryFrom<&[u8]> for Address {
 // Loc
 //**************************************************************************************************
 
-#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Loc {
     file: &'static str,
     span: Span,


### PR DESCRIPTION
## Motivation

- Sort errors by the initial Loc, makes reading errors a lot easier in big lists

## Test Plan

cargo test -p move-lang 