### PR TITLE
[consensus] enforce epoch consistency of messages

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -238,6 +238,8 @@ where
             self.quorum_cert().certified_block().round() < self.round(),
             "Block has invalid round"
         );
+
+        ensure!(!self.quorum_cert().ends_epoch(), "Block after epoch ends");
         Ok(())
     }
 

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -64,10 +64,9 @@ impl<T: Payload> ProposalUncheckedSignatures<T> {
         if let Some(tc) = self.0.sync_info.highest_timeout_certificate() {
             tc.verify(validator).map_err(|e| format_err!("{:?}", e))?;
         }
-        // verify the QC signatures of highest_ledger_info
+        // verify the QC signatures of sync_info
         self.0
             .sync_info
-            .highest_ledger_info()
             .verify(validator)
             .map_err(|e| format_err!("{:?}", e))?;
         // return proposal
@@ -102,6 +101,10 @@ impl<T: Payload> ProposalMsg<T> {
             self.proposal.round() > 0,
             "Proposal for {} has an incorrect round of 0",
             self.proposal,
+        );
+        ensure!(
+            self.proposal.epoch() == self.sync_info.epoch(),
+            "ProposalMsg has different epoch number from SyncInfo"
         );
         ensure!(
             self.proposal.parent_id()

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -67,6 +67,14 @@ impl QuorumCert {
         }
     }
 
+    /// If the QC commits reconfiguration and starts a new epoch
+    pub fn ends_epoch(&self) -> bool {
+        self.signed_ledger_info
+            .ledger_info()
+            .next_validator_set()
+            .is_some()
+    }
+
     /// QuorumCert for the genesis block deterministically generated from end-epoch LedgerInfo:
     /// - the ID of the block is determined by the generated genesis block.
     /// - the accumulator root hash of the LedgerInfo is set to the last executed state of previous

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{common::Round, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate};
-use failure::ResultExt;
+use failure::{ensure, ResultExt};
 use libra_types::crypto_proxies::ValidatorVerifier;
 use network;
 use serde::{Deserialize, Serialize};
@@ -82,6 +82,24 @@ impl SyncInfo {
     }
 
     pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
+        let epoch = self.highest_quorum_cert.certified_block().epoch();
+        ensure!(
+            epoch == self.highest_ledger_info.certified_block().epoch(),
+            "Multi epoch in SyncInfo - HLI and HQC"
+        );
+        if let Some(tc) = &self.highest_timeout_cert {
+            ensure!(epoch == tc.epoch(), "Multi epoch in SyncInfo - TC and HQC");
+        }
+
+        ensure!(
+            self.highest_quorum_cert.certified_block().round()
+                >= self.highest_ledger_info.certified_block().round(),
+            "HQC has lower round than HLI"
+        );
+        ensure!(
+            self.highest_ledger_info.committed_block_id().is_some(),
+            "HLI has no committed block"
+        );
         self.highest_quorum_cert
             .verify(validator)
             .and_then(|_| self.highest_ledger_info.verify(validator))

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -4,6 +4,8 @@
 use crate::{sync_info::SyncInfo, vote::Vote};
 #[cfg(any(test, feature = "fuzzing"))]
 use failure::bail;
+use failure::ensure;
+use libra_types::crypto_proxies::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
 #[cfg(any(test, feature = "fuzzing"))]
 use std::convert::TryInto;
@@ -47,6 +49,15 @@ impl VoteMsg {
 
     pub fn epoch(&self) -> u64 {
         self.vote.epoch()
+    }
+
+    pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
+        ensure!(
+            self.vote().epoch() == self.sync_info.epoch(),
+            "VoteMsg has different epoch"
+        );
+        self.vote().verify(validator)?;
+        self.sync_info.verify(validator)
     }
 }
 

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -103,6 +103,11 @@ impl<T: Payload> ProposalGenerator<T> {
 
         let hqc = self.ensure_highest_quorum_cert(round)?;
 
+        ensure!(
+            !hqc.ends_epoch(),
+            "The epoch has already ended,a proposal is not allowed to generated"
+        );
+
         // One needs to hold the blocks with the references to the payloads while get_block is
         // being executed: pending blocks vector keeps all the pending ancestors of the extended
         // branch.
@@ -177,7 +182,6 @@ impl<T: Payload> ProposalGenerator<T> {
                 }
             }
         };
-
         // Reconfiguration rule - we propose empty blocks after reconfiguration until it's committed
         let txns = if self.block_store.root().id() != hqc.certified_block().id()
             && hqc.certified_block().has_reconfiguration()

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -439,16 +439,13 @@ impl<T: Payload> NetworkTask<T> {
         match vote_msg.epoch().cmp(&self.epoch) {
             Ordering::Equal => {
                 debug!("Received {}", vote_msg);
-                vote_msg
-                    .vote()
-                    .verify(self.validators.as_ref())
-                    .map_err(|e| {
-                        security_log(SecurityEvent::InvalidConsensusVote)
-                            .error(&e)
-                            .data(&vote_msg)
-                            .log();
-                        e
-                    })?;
+                vote_msg.verify(self.validators.as_ref()).map_err(|e| {
+                    security_log(SecurityEvent::InvalidConsensusVote)
+                        .error(&e)
+                        .data(&vote_msg)
+                        .log();
+                    e
+                })?;
                 self.vote_tx.push(peer_id, vote_msg)
             }
             Ordering::Less | Ordering::Greater => self


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We enforce every messages contain the information about the same epoch.
(Fix a few missing verification too)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests, Idk if we want to add tests for every error cases, it's probably worth it's own PR if so.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
