### PR TITLE
[cluster-test] Bump liveness health check timeout 1m->2m

### DIFF
--- a/testsuite/cluster-test/src/health/liveness_check.rs
+++ b/testsuite/cluster-test/src/health/liveness_check.rs
@@ -11,7 +11,7 @@ pub struct LivenessHealthCheck {
     last_committed: HashMap<String, LastCommitInfo>,
 }
 
-const MAX_BEHIND: Duration = Duration::from_secs(60);
+const MAX_BEHIND: Duration = Duration::from_secs(120);
 
 #[derive(Default)]
 struct LastCommitInfo {


### PR DESCRIPTION
We have intermittent failures with 1m timeout, this diff will double it
