### PR TITLE
[Storage] return ValidatorChangeEventWithProof in LibraDB::update_to_latest_ledger

### DIFF
--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -150,16 +150,9 @@ impl ExecutorProxyTrait for ExecutorProxy {
     }
 
     fn get_epoch_proof(&self, start_epoch: u64) -> Result<ValidatorChangeEventWithProof> {
-        let mut ledger_info_per_epoch = self
+        let ledger_info_per_epoch = self
             .storage_read_client
-            .get_latest_ledger_infos_per_epoch(start_epoch)?;
-        // The latest ledger info may not carry the validator set.
-        match ledger_info_per_epoch.pop() {
-            Some(li) if li.ledger_info().next_validator_set().is_some() => {
-                ledger_info_per_epoch.push(li);
-            }
-            _ => (),
-        }
+            .get_epoch_change_ledger_infos(start_epoch)?;
         Ok(ValidatorChangeEventWithProof::new(ledger_info_per_epoch))
     }
 }

--- a/storage/libradb/src/errors.rs
+++ b/storage/libradb/src/errors.rs
@@ -12,6 +12,9 @@ pub enum LibraDbError {
     #[fail(display = "{} not found.", _0)]
     NotFound(String),
     /// Requested too many items.
-    #[fail(display = "Too many items requested: {}, max is {}", _0, _1)]
+    #[fail(
+        display = "Too many items requested: at least {} requested, max is {}",
+        _0, _1
+    )]
     TooManyRequested(u64, u64),
 }

--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -4,74 +4,19 @@
 use super::*;
 use crate::{change_set::ChangeSet, LibraDB};
 use libra_tools::tempdir::TempPath;
-use libra_types::block_info::BlockInfo;
-use libra_types::ledger_info::LedgerInfo;
-use libra_types::validator_set::ValidatorSet;
+use libra_types::proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen};
 use proptest::{collection::vec, prelude::*};
-use std::collections::BTreeMap;
 
-fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<(LedgerInfoWithSignatures, bool)>> {
+fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<LedgerInfoWithSignatures>> {
     (
-        vec(
-            (
-                any::<HashValue>(),
-                any::<HashValue>(),
-                any::<HashValue>(),
-                any::<u64>(),
-                0..10u64,
-                any::<bool>(),
-            ),
-            1..100,
-        ),
-        vec(0..100_000_000u64, 3),
+        any_with::<AccountInfoUniverse>(3),
+        vec((any::<LedgerInfoWithSignaturesGen>(), 0..10usize), 1..100),
     )
-        .prop_map(|(block_params, mut ledger_params)| {
-            ledger_params.sort_unstable();
-            let mut epoch = ledger_params[0];
-            let mut round = ledger_params[1];
-            let mut version = ledger_params[2];
-
-            block_params
-                .into_iter()
-                .map(
-                    |(
-                        block_id,
-                        accu_hash,
-                        consensus_data_hash,
-                        timestamp,
-                        block_size,
-                        new_epoch_if_possible,
-                    )| {
-                        round += 1;
-                        version += block_size;
-                        let is_new_epoch = new_epoch_if_possible && block_size != 0;
-                        let next_validator_set = if is_new_epoch {
-                            Some(ValidatorSet::new(Vec::new()))
-                        } else {
-                            None
-                        };
-
-                        let li = LedgerInfoWithSignatures::new(
-                            LedgerInfo::new(
-                                BlockInfo::new(
-                                    epoch,
-                                    round,
-                                    block_id,
-                                    accu_hash,
-                                    version,
-                                    timestamp,
-                                    next_validator_set,
-                                ),
-                                consensus_data_hash,
-                            ),
-                            BTreeMap::default(),
-                        );
-                        if is_new_epoch {
-                            epoch += 1;
-                        }
-                        (li, is_new_epoch)
-                    },
-                )
+        .prop_map(|(mut universe, gens)| {
+            gens.into_iter()
+                .map(|(ledger_info_gen, block_size)| {
+                    ledger_info_gen.materialize(&mut universe, block_size)
+                })
                 .collect()
         })
 }
@@ -81,7 +26,7 @@ proptest! {
 
     #[test]
     fn test_ledger_info_put_get_verify(
-        inputs in arb_ledger_infos_with_sigs()
+        ledger_infos_with_sigs in arb_ledger_infos_with_sigs()
     ) {
         // set up
         let tmp_dir = TempPath::new();
@@ -90,25 +35,25 @@ proptest! {
 
         // write to DB
         let mut cs = ChangeSet::new();
-        inputs
+        ledger_infos_with_sigs
             .iter()
-            .map(|(info, _)| store.put_ledger_info(info, &mut cs))
+            .map(|info| store.put_ledger_info(info, &mut cs))
             .collect::<Result<Vec<_>>>()
             .unwrap();
         store.db.write_schemas(cs.batch).unwrap();
 
         // verify get_latest_ledger_infos_per_epoch()
-        let mut epoch_ledgers: Vec<_> = inputs
+        let mut epoch_ledgers: Vec<_> = ledger_infos_with_sigs
             .iter()
-            .filter(|(_, is_new_epoch)| *is_new_epoch)
-            .map(|(li, _)| li.clone())
+            .filter(|info| info.ledger_info().next_validator_set().is_some())
+            .map(|info| info.clone())
             .collect();
-        let last = inputs.last().unwrap();
-        let last_is_new_epoch = last.1;
+        let last = ledger_infos_with_sigs.last().unwrap();
+        let last_is_new_epoch = last.ledger_info().next_validator_set().is_some();
         if !last_is_new_epoch {
-            epoch_ledgers.push(last.0.clone());
+            epoch_ledgers.push(last.clone());
         }
-        let start_epoch = inputs.first().unwrap().0.ledger_info().epoch();
+        let start_epoch = ledger_infos_with_sigs.first().unwrap().ledger_info().epoch();
         prop_assert_eq!(
             &store.get_latest_ledger_infos_per_epoch(start_epoch).unwrap(),
             &epoch_ledgers
@@ -129,6 +74,7 @@ proptest! {
             let this = pair[1];
             let this_epoch = this.0;
             let this_ver = this.1;
+            prop_assert_eq!(prev_epoch + 1, this_epoch);
 
             let mid_ver = (prev_ver + this_ver) / 2;
             prop_assert_eq!(store.get_epoch(mid_ver).unwrap(), prev_epoch, "{}", mid_ver);

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -63,7 +63,6 @@ impl LedgerStore {
         }
     }
 
-    #[allow(dead_code)]
     pub fn get_epoch(&self, version: Version) -> Result<u64> {
         let mut iter = self
             .db

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -305,10 +305,6 @@ impl LibraDB {
     }
 
     /// Returns ledger infos reflecting epoch bumps starting with the given epoch.
-    ///
-    /// Returns error in case `start_epoch` is higher than the currently known epoch.
-    /// The returned vector is not necessarily sorted: the client should make sure to sort it
-    /// by epoch number.
     pub fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -304,18 +304,17 @@ impl LibraDB {
             .version())
     }
 
-    /// Returns the latest ledger infos per epoch starting with the given epoch num:
-    /// - the latest ledger info of the current epoch is just the last ledger info in the system
-    /// - the latest ledger infos of previous epochs contain reconfiguration validator sets.
+    /// Returns ledger infos reflecting epoch bumps starting with the given epoch.
+    ///
     /// Returns error in case `start_epoch` is higher than the currently known epoch.
     /// The returned vector is not necessarily sorted: the client should make sure to sort it
     /// by epoch number.
-    pub fn get_latest_ledger_infos_per_epoch(
+    pub fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures>> {
         self.ledger_store
-            .get_latest_ledger_infos_per_epoch(start_epoch)
+            .get_epoch_change_ledger_infos(start_epoch, self.get_latest_version()?)
     }
 
     /// Persist transactions. Called by the executor module when either syncing nodes or committing
@@ -547,19 +546,8 @@ impl LibraDB {
             ledger_info.epoch()
         };
         let validator_change_proof = if client_epoch < current_epoch {
-            let mut ledger_infos = self
-                .ledger_store
-                .get_latest_ledger_infos_per_epoch(client_epoch)?;
-            if ledger_infos
-                .last()
-                .ok_or_else(|| LibraDbError::NotFound(String::from("Latest epoch LedgerInfo")))?
-                .ledger_info()
-                .next_validator_set()
-                .is_none()
-            {
-                ledger_infos.pop();
-            }
-            ledger_infos
+            self.ledger_store
+                .get_epoch_change_ledger_infos(client_epoch, ledger_info.version())?
         } else {
             Vec::new()
         };

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -20,7 +20,7 @@ fn verify_epochs(db: &LibraDB, ledger_infos_with_sigs: &[LedgerInfoWithSignature
     let epoch_change_lis: Vec<_> = ledger_infos_with_sigs
         .iter()
         .filter(|info| info.ledger_info().next_validator_set().is_some())
-        .map(|info| info.clone())
+        .cloned()
         .collect();
 
     let (_, _, proof, _) = db.update_to_latest_ledger(0, Vec::new())?;

--- a/storage/libradb/src/mock_genesis/mod.rs
+++ b/storage/libradb/src/mock_genesis/mod.rs
@@ -12,6 +12,7 @@ use libra_crypto::{
     HashValue,
 };
 use libra_types::block_info::BlockInfo;
+use libra_types::validator_set::ValidatorSet;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -77,7 +78,15 @@ fn gen_mock_genesis() -> (
     );
 
     let ledger_info = LedgerInfo::new(
-        BlockInfo::new(0, 0, *GENESIS_BLOCK_ID, txn_info.hash(), 0, 0, None),
+        BlockInfo::new(
+            0,
+            0,
+            *GENESIS_BLOCK_ID,
+            txn_info.hash(),
+            0,
+            0,
+            Some(ValidatorSet::new(Vec::new())),
+        ),
         HashValue::random(),
     );
     let ledger_info_with_sigs =

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -30,9 +30,8 @@ use std::{pin::Pin, sync::Arc};
 use storage_proto::{
     proto::storage::{GetStartupInfoRequest, StorageClient},
     GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
-    GetEpochChangeLedgerInfosRequest, GetEpochChangeLedgerInfosResponse,
-    GetStartupInfoResponse, GetTransactionsRequest, GetTransactionsResponse,
-    SaveTransactionsRequest, StartupInfo,
+    GetEpochChangeLedgerInfosRequest, GetEpochChangeLedgerInfosResponse, GetStartupInfoResponse,
+    GetTransactionsRequest, GetTransactionsResponse, SaveTransactionsRequest, StartupInfo,
 };
 
 pub use crate::state_view::VerifiedStateView;

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -30,7 +30,7 @@ use std::{pin::Pin, sync::Arc};
 use storage_proto::{
     proto::storage::{GetStartupInfoRequest, StorageClient},
     GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
-    GetLatestLedgerInfosPerEpochRequest, GetLatestLedgerInfosPerEpochResponse,
+    GetEpochChangeLedgerInfosRequest, GetEpochChangeLedgerInfosResponse,
     GetStartupInfoResponse, GetTransactionsRequest, GetTransactionsResponse,
     SaveTransactionsRequest, StartupInfo,
 };
@@ -211,24 +211,24 @@ impl StorageRead for StorageReadServiceClient {
             .boxed()
     }
 
-    fn get_latest_ledger_infos_per_epoch(
+    fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures>> {
-        block_on(self.get_latest_ledger_infos_per_epoch_async(start_epoch))
+        block_on(self.get_epoch_change_ledger_infos_async(start_epoch))
     }
 
-    fn get_latest_ledger_infos_per_epoch_async(
+    fn get_epoch_change_ledger_infos_async(
         &self,
         start_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {
-        let proto_req = GetLatestLedgerInfosPerEpochRequest::new(start_epoch);
+        let proto_req = GetEpochChangeLedgerInfosRequest::new(start_epoch);
         convert_grpc_response(
             self.client()
-                .get_latest_ledger_infos_per_epoch_async(&proto_req.into()),
+                .get_epoch_change_ledger_infos_async(&proto_req.into()),
         )
         .map(|resp| {
-            let resp = GetLatestLedgerInfosPerEpochResponse::try_from(resp?)?;
+            let resp = GetEpochChangeLedgerInfosResponse::try_from(resp?)?;
             Ok(resp.into())
         })
         .boxed()
@@ -380,20 +380,20 @@ pub trait StorageRead: Send + Sync {
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Option<StartupInfo>>> + Send>>;
 
-    /// See [`LibraDB::get_latest_ledger_infos_per_epoch`].
+    /// See [`LibraDB::get_epoch_change_ledger_infos`].
     ///
-    /// [`LibraDB::get_latest_ledger_infos_per_epoch`]:
-    /// ../libradb/struct.LibraDB.html#method.get_latest_ledger_infos_per_epoch
-    fn get_latest_ledger_infos_per_epoch(
+    /// [`LibraDB::get_epoch_change_ledger_infos`]:
+    /// ../libradb/struct.LibraDB.html#method.get_epoch_change_ledger_infos
+    fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures>>;
 
-    /// See [`LibraDB::get_latest_ledger_infos_per_epoch`].
+    /// See [`LibraDB::get_epoch_change_ledger_infos`].
     ///
-    /// [`LibraDB::get_latest_ledger_infos_per_epoch`]:
-    /// ../libradb/struct.LibraDB.html#method.get_latest_ledger_infos_per_epoch
-    fn get_latest_ledger_infos_per_epoch_async(
+    /// [`LibraDB::get_epoch_change_ledger_infos`]:
+    /// ../libradb/struct.LibraDB.html#method.get_epoch_change_ledger_infos
+    fn get_epoch_change_ledger_infos_async(
         &self,
         start_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>>;

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -428,68 +428,68 @@ impl From<GetStartupInfoResponse> for crate::proto::storage::GetStartupInfoRespo
     }
 }
 
-/// Helper to construct and parse [`proto::storage::GetLatestLedgerInfosPerEpochRequest`]
+/// Helper to construct and parse [`proto::storage::GetEpochChangeLedgerInfosRequest`]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct GetLatestLedgerInfosPerEpochRequest {
+pub struct GetEpochChangeLedgerInfosRequest {
     pub start_epoch: u64,
 }
 
-impl GetLatestLedgerInfosPerEpochRequest {
+impl GetEpochChangeLedgerInfosRequest {
     /// Constructor.
     pub fn new(start_epoch: u64) -> Self {
         Self { start_epoch }
     }
 }
 
-impl TryFrom<crate::proto::storage::GetLatestLedgerInfosPerEpochRequest>
-    for GetLatestLedgerInfosPerEpochRequest
+impl TryFrom<crate::proto::storage::GetEpochChangeLedgerInfosRequest>
+    for GetEpochChangeLedgerInfosRequest
 {
     type Error = Error;
 
-    fn try_from(proto: crate::proto::storage::GetLatestLedgerInfosPerEpochRequest) -> Result<Self> {
+    fn try_from(proto: crate::proto::storage::GetEpochChangeLedgerInfosRequest) -> Result<Self> {
         Ok(Self {
             start_epoch: proto.start_epoch,
         })
     }
 }
 
-impl From<GetLatestLedgerInfosPerEpochRequest>
-    for crate::proto::storage::GetLatestLedgerInfosPerEpochRequest
+impl From<GetEpochChangeLedgerInfosRequest>
+    for crate::proto::storage::GetEpochChangeLedgerInfosRequest
 {
-    fn from(request: GetLatestLedgerInfosPerEpochRequest) -> Self {
+    fn from(request: GetEpochChangeLedgerInfosRequest) -> Self {
         Self {
             start_epoch: request.start_epoch,
         }
     }
 }
 
-/// Helper to construct and parse [`proto::storage::GetLatestLedgerInfosPerEpochResponse`]
+/// Helper to construct and parse [`proto::storage::GetEpochChangeLedgerInfosResponse`]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct GetLatestLedgerInfosPerEpochResponse {
-    pub latest_ledger_infos: Vec<LedgerInfoWithSignatures>,
+pub struct GetEpochChangeLedgerInfosResponse {
+    pub ledger_infos_with_sigs: Vec<LedgerInfoWithSignatures>,
 }
 
-impl GetLatestLedgerInfosPerEpochResponse {
+impl GetEpochChangeLedgerInfosResponse {
     /// Constructor.
     pub fn new(latest_ledger_infos: Vec<LedgerInfoWithSignatures>) -> Self {
         Self {
-            latest_ledger_infos,
+            ledger_infos_with_sigs: latest_ledger_infos,
         }
     }
 }
 
-impl TryFrom<crate::proto::storage::GetLatestLedgerInfosPerEpochResponse>
-    for GetLatestLedgerInfosPerEpochResponse
+impl TryFrom<crate::proto::storage::GetEpochChangeLedgerInfosResponse>
+    for GetEpochChangeLedgerInfosResponse
 {
     type Error = Error;
 
     fn try_from(
-        proto: crate::proto::storage::GetLatestLedgerInfosPerEpochResponse,
+        proto: crate::proto::storage::GetEpochChangeLedgerInfosResponse,
     ) -> Result<Self> {
         Ok(Self {
-            latest_ledger_infos: proto
+            ledger_infos_with_sigs: proto
                 .latest_ledger_infos
                 .into_iter()
                 .map(TryFrom::try_from)
@@ -498,13 +498,13 @@ impl TryFrom<crate::proto::storage::GetLatestLedgerInfosPerEpochResponse>
     }
 }
 
-impl From<GetLatestLedgerInfosPerEpochResponse>
-    for crate::proto::storage::GetLatestLedgerInfosPerEpochResponse
+impl From<GetEpochChangeLedgerInfosResponse>
+    for crate::proto::storage::GetEpochChangeLedgerInfosResponse
 {
-    fn from(response: GetLatestLedgerInfosPerEpochResponse) -> Self {
+    fn from(response: GetEpochChangeLedgerInfosResponse) -> Self {
         Self {
             latest_ledger_infos: response
-                .latest_ledger_infos
+                .ledger_infos_with_sigs
                 .into_iter()
                 .map(Into::into)
                 .collect(),
@@ -512,9 +512,9 @@ impl From<GetLatestLedgerInfosPerEpochResponse>
     }
 }
 
-impl Into<Vec<LedgerInfoWithSignatures>> for GetLatestLedgerInfosPerEpochResponse {
+impl Into<Vec<LedgerInfoWithSignatures>> for GetEpochChangeLedgerInfosResponse {
     fn into(self) -> Vec<LedgerInfoWithSignatures> {
-        self.latest_ledger_infos
+        self.ledger_infos_with_sigs
     }
 }
 

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -485,9 +485,7 @@ impl TryFrom<crate::proto::storage::GetEpochChangeLedgerInfosResponse>
 {
     type Error = Error;
 
-    fn try_from(
-        proto: crate::proto::storage::GetEpochChangeLedgerInfosResponse,
-    ) -> Result<Self> {
+    fn try_from(proto: crate::proto::storage::GetEpochChangeLedgerInfosResponse) -> Result<Self> {
         Ok(Self {
             ledger_infos_with_sigs: proto
                 .latest_ledger_infos

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -47,8 +47,8 @@ service Storage {
     returns (GetStartupInfoResponse);
 
     // Returns latest ledger infos per epoch.
-    rpc GetLatestLedgerInfosPerEpoch(GetLatestLedgerInfosPerEpochRequest)
-    returns (GetLatestLedgerInfosPerEpochResponse);
+    rpc GetEpochChangeLedgerInfos(GetEpochChangeLedgerInfosRequest)
+    returns (GetEpochChangeLedgerInfosResponse);
 }
 
 message SaveTransactionsRequest {
@@ -128,12 +128,12 @@ message StartupInfo {
     TreeState synced_tree_state = 3;
 }
 
-message GetLatestLedgerInfosPerEpochRequest {
+message GetEpochChangeLedgerInfosRequest {
     /// The last epoch number with available information to the client.
     uint64 start_epoch = 1;
 }
 
-message GetLatestLedgerInfosPerEpochResponse {
+message GetEpochChangeLedgerInfosResponse {
     /// Vector of latest ledger infos per epoch (not sorted)
     repeated types.LedgerInfoWithSignatures latest_ledger_infos = 1;
 }

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -25,8 +25,8 @@ use std::{
 };
 use storage_proto::proto::storage::{
     create_storage, GetAccountStateWithProofByVersionRequest,
-    GetAccountStateWithProofByVersionResponse, GetLatestLedgerInfosPerEpochRequest,
-    GetLatestLedgerInfosPerEpochResponse, GetStartupInfoRequest, GetStartupInfoResponse,
+    GetAccountStateWithProofByVersionResponse, GetEpochChangeLedgerInfosRequest,
+    GetEpochChangeLedgerInfosResponse, GetStartupInfoRequest, GetStartupInfoResponse,
     GetTransactionsRequest, GetTransactionsResponse, SaveTransactionsRequest,
     SaveTransactionsResponse, Storage,
 };
@@ -217,15 +217,15 @@ impl StorageService {
         Ok(rust_resp.into())
     }
 
-    fn get_latest_ledger_infos_per_epoch_inner(
+    fn get_epoch_change_ledger_infos_inner(
         &self,
-        req: GetLatestLedgerInfosPerEpochRequest,
-    ) -> Result<GetLatestLedgerInfosPerEpochResponse> {
-        let rust_req = storage_proto::GetLatestLedgerInfosPerEpochRequest::try_from(req)?;
+        req: GetEpochChangeLedgerInfosRequest,
+    ) -> Result<GetEpochChangeLedgerInfosResponse> {
+        let rust_req = storage_proto::GetEpochChangeLedgerInfosRequest::try_from(req)?;
         let ledger_infos = self
             .db
-            .get_latest_ledger_infos_per_epoch(rust_req.start_epoch)?;
-        let rust_resp = storage_proto::GetLatestLedgerInfosPerEpochResponse::new(ledger_infos);
+            .get_epoch_change_ledger_infos(rust_req.start_epoch)?;
+        let rust_resp = storage_proto::GetEpochChangeLedgerInfosResponse::new(ledger_infos);
         Ok(rust_resp.into())
     }
 }
@@ -291,15 +291,15 @@ impl Storage for StorageService {
         provide_grpc_response(resp, ctx, sink);
     }
 
-    fn get_latest_ledger_infos_per_epoch(
+    fn get_epoch_change_ledger_infos(
         &mut self,
         ctx: grpcio::RpcContext,
-        req: GetLatestLedgerInfosPerEpochRequest,
-        sink: grpcio::UnarySink<GetLatestLedgerInfosPerEpochResponse>,
+        req: GetEpochChangeLedgerInfosRequest,
+        sink: grpcio::UnarySink<GetEpochChangeLedgerInfosResponse>,
     ) {
-        debug!("[GRPC] Storage::get_latest_ledger_infos_per_epoch");
+        debug!("[GRPC] Storage::get_epoch_change_ledger_infos");
         let _timer = SVC_COUNTERS.req(&ctx);
-        let resp = self.get_latest_ledger_infos_per_epoch_inner(req);
+        let resp = self.get_epoch_change_ledger_infos_inner(req);
         provide_grpc_response(resp, ctx, sink);
     }
 }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -139,14 +139,14 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
-    fn get_latest_ledger_infos_per_epoch(
+    fn get_epoch_change_ledger_infos(
         &self,
         _start_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures>> {
         unimplemented!()
     }
 
-    fn get_latest_ledger_infos_per_epoch_async(
+    fn get_epoch_change_ledger_infos_async(
         &self,
         _start_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -12,7 +12,7 @@ use std::convert::{TryFrom, TryInto};
 /// A vector of LedgerInfo with contiguous increasing epoch numbers to prove a sequence of
 /// validator changes from the first LedgerInfo's epoch.
 pub struct ValidatorChangeEventWithProof<Sig> {
-    ledger_info_with_sigs: Vec<LedgerInfoWithSignatures<Sig>>,
+    pub ledger_info_with_sigs: Vec<LedgerInfoWithSignatures<Sig>>,
 }
 
 impl<Sig: Signature> ValidatorChangeEventWithProof<Sig> {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As requested by consensus side. Also refactored LibraDB::get_latest_ledger_info_per_epoch to skip returning the latest ledger info if it's not an epoch bump, because on both call sites of it we filter that out.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

unit tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
