### PR TITLE
[network] Refactor health checker to be network application

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -39,6 +39,12 @@ pub enum SecurityEvent {
     /// Consensus received an invalid sync info message
     InvalidSyncInfoMsg,
 
+    /// HealthChecker received an invalid network event
+    InvalidNetworkEventHC,
+
+    /// HealthChecker received an invalid message
+    InvalidHealthCheckerMsg,
+
     /// A block being committed or executed is invalid
     InvalidBlock,
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -69,6 +69,9 @@ lazy_static::lazy_static! {
     /// Counter of pending network events to Admission Control
     pub static ref PENDING_ADMISSION_CONTROL_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_admission_control_network_events");
 
+    /// Counter of pending network events to Admission Control
+    pub static ref PENDING_HEALTH_CHECKER_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_health_checker_network_events");
+
     /// Counter of pending requests in Peer Manager
     pub static ref PENDING_PEER_MANAGER_REQUESTS: IntGauge = OP_COUNTERS.gauge("pending_peer_manager_requests");
 

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -29,13 +29,12 @@ pub use self::{
         RequestEpoch, RespondBlock, SyncInfo, VoteMsg, VoteProposal,
     },
     health_checker::{
-        health_checker_msg::Message as HealthCheckerMsg_oneof, HealthCheckerMsg, Ping as Ping2,
-        Pong as Pong2,
+        health_checker_msg::Message as HealthCheckerMsg_oneof, HealthCheckerMsg, Ping, Pong,
     },
     mempool::MempoolSyncMsg,
     network::{
         identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,
-        PeerInfo, Ping, Pong, SignedFullNodePayload, SignedPeerInfo,
+        PeerInfo, SignedFullNodePayload, SignedPeerInfo,
     },
     state_synchronizer::{
         state_synchronizer_msg::Message as StateSynchronizerMsg_oneof, GetChunkRequest,

--- a/network/src/proto/network.proto
+++ b/network/src/proto/network.proto
@@ -73,9 +73,3 @@ message IdentityMsg {
   repeated bytes supported_protocols = 2;
   Role role = 3;
 }
-
-// Ping message sent as liveness probe.
-message Ping {}
-
-// Pong message sent as response to liveness probe.
-message Pong {}

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -18,44 +18,33 @@
 //! - Use successful inbound pings as a sign of remote note being healthy
 //! - Ping a peer only in periods of no application-level communication with the peer
 use crate::{
-    error::NetworkError,
-    peer_manager::{PeerManagerNotification, PeerManagerRequestSender},
-    proto::{Ping, Pong},
-    utils::{read_proto, MessageExt},
-    ProtocolId,
+    proto::{HealthCheckerMsg, HealthCheckerMsg_oneof, Ping, Pong},
+    protocols::rpc::error::RpcError,
+    utils::MessageExt,
+    validator_network::{Event, HealthCheckerNetworkEvents, HealthCheckerNetworkSender},
 };
-use channel;
+use bytes::Bytes;
 use futures::{
-    future::{FutureExt, TryFutureExt},
-    io::{AsyncRead, AsyncWrite},
-    sink::SinkExt,
+    channel::oneshot,
     stream::{FusedStream, FuturesUnordered, Stream, StreamExt},
 };
 use libra_logger::prelude::*;
 use libra_types::PeerId;
-use netcore::compat::IoCompat;
-use rand::{rngs::SmallRng, seq::SliceRandom, FromEntropy};
-use std::{collections::HashMap, fmt::Debug, time::Duration};
-use tokio::{
-    codec::{Framed, LengthDelimitedCodec},
-    future::FutureExt as _,
-};
+use rand::{rngs::SmallRng, seq::SliceRandom, FromEntropy, Rng};
+use std::{collections::HashMap, time::Duration};
 
 #[cfg(test)]
 mod test;
 
-/// Protocol name for Ping.
-pub const PING_PROTOCOL_NAME: &[u8] = b"/libra/ping/0.1.0";
-
 /// The actor performing health checks by running the Ping protocol
-pub struct HealthChecker<TTicker, TSubstream> {
+pub struct HealthChecker<TTicker> {
     /// Ticker to trigger ping to a random peer. In production, the ticker is likely to be
     /// fixed duration interval timer.
     ticker: TTicker,
-    /// Channel to send requests to PeerManager.
-    peer_mgr_reqs_tx: PeerManagerRequestSender<TSubstream>,
-    /// Channel to receive notifications from PeerManager about new/lost connections.
-    peer_mgr_notifs_rx: channel::Receiver<PeerManagerNotification<TSubstream>>,
+    /// Channel to send requests to Network layer.
+    network_tx: HealthCheckerNetworkSender,
+    /// Channel to receive notifications from Network layer about new/lost connections.
+    network_rx: HealthCheckerNetworkEvents,
     /// Map from connected peer to last round of successful ping, and number of failures since
     /// then.
     connected: HashMap<PeerId, (u64, u64)>,
@@ -71,23 +60,22 @@ pub struct HealthChecker<TTicker, TSubstream> {
     round: u64,
 }
 
-impl<TTicker, TSubstream> HealthChecker<TTicker, TSubstream>
+impl<TTicker> HealthChecker<TTicker>
 where
     TTicker: Stream + FusedStream + Unpin,
-    TSubstream: AsyncRead + AsyncWrite + Send + Unpin + Debug + 'static,
 {
     /// Create new instance of the [`HealthChecker`] actor.
     pub fn new(
         ticker: TTicker,
-        peer_mgr_reqs_tx: PeerManagerRequestSender<TSubstream>,
-        peer_mgr_notifs_rx: channel::Receiver<PeerManagerNotification<TSubstream>>,
+        network_tx: HealthCheckerNetworkSender,
+        network_rx: HealthCheckerNetworkEvents,
         ping_timeout: Duration,
         ping_failures_tolerated: u64,
     ) -> Self {
         HealthChecker {
             ticker,
-            peer_mgr_reqs_tx,
-            peer_mgr_notifs_rx,
+            network_tx,
+            network_rx,
             connected: HashMap::new(),
             rng: SmallRng::from_entropy(),
             ping_timeout,
@@ -98,34 +86,58 @@ where
 
     pub async fn start(mut self) {
         let mut tick_handlers = FuturesUnordered::new();
-        let mut ping_handlers = FuturesUnordered::new();
         loop {
             futures::select! {
-                notif = self.peer_mgr_notifs_rx.select_next_some() => {
-                    match notif {
-                        PeerManagerNotification::NewPeer(peer_id, _) => {
+                event = self.network_rx.select_next_some() => {
+                    match event {
+                        Ok(Event::NewPeer(peer_id)) => {
                             self.connected.insert(peer_id, (self.round, 0));
-                        }
-                        PeerManagerNotification::LostPeer(peer_id, _) => {
+                        },
+                        Ok(Event::LostPeer(peer_id)) => {
                             self.connected.remove(&peer_id);
+                        },
+                        Ok(Event::RpcRequest((peer_id, msg, res_tx))) => {
+                            if let Some(HealthCheckerMsg_oneof::Ping(ping_msg)) = msg.message {
+                                self.handle_ping_request(peer_id, ping_msg, res_tx);
+                            } else {
+                                security_log(SecurityEvent::InvalidHealthCheckerMsg)
+                                    .error("Unexpected rpc message")
+                                    .data(&msg)
+                                    .data(&peer_id)
+                                    .log();
+                                debug_assert!(false, "Unexpected rpc message");
+                            }
                         }
-                        PeerManagerNotification::NewInboundSubstream(peer_id, substream) => {
-                            assert_eq!(substream.protocol, PING_PROTOCOL_NAME);
-                            ping_handlers.push(Self::handle_ping(peer_id, substream.substream));
+                        Ok(Event::Message(_)) => {
+                            security_log(SecurityEvent::InvalidNetworkEventHC)
+                                .error("Unexpected network event")
+                                .data(&event)
+                                .log();
+                            debug_assert!(false, "Unexpected network event");
+                        },
+                        Err(err) => {
+                            security_log(SecurityEvent::InvalidNetworkEventHC)
+                                .error(&err)
+                                .log();
+                            debug_assert!(false, "Unexpected network error");
                         }
                     }
                 }
                 _ = self.ticker.select_next_some() => {
                     self.round += 1;
-                    debug!("Round number: {}", self.round);
-                    match self.get_random_peer() {
+                    debug!("Tick: Round number: {}", self.round);
+                    match self.sample_random_peer() {
                         Some(peer_id) => {
                             debug!("Will ping: {}", peer_id.short_str());
+
+                            let nonce = self.sample_nonce();
+
                             tick_handlers.push(
                                 Self::ping_peer(
+                                    self.network_tx.clone(),
                                     peer_id,
                                     self.round,
-                                    self.peer_mgr_reqs_tx.clone(),
+                                    nonce,
                                     self.ping_timeout.clone()));
                         }
                         None => {
@@ -134,10 +146,9 @@ where
                     }
                 }
                 res = tick_handlers.select_next_some() => {
-                    let (peer_id, round, ping_result) = res;
-                    self.handle_ping_result(peer_id, round, ping_result).await;
+                    let (peer_id, round, nonce, ping_result) = res;
+                    self.handle_ping_response(peer_id, round, nonce, ping_result).await;
                 }
-                _ = ping_handlers.select_next_some() => {}
                 complete => {
                     crit!("Health checker actor terminated");
                     break;
@@ -146,25 +157,57 @@ where
         }
     }
 
-    async fn handle_ping_result(
+    fn handle_ping_request(
+        &mut self,
+        peer_id: PeerId,
+        ping_msg: Ping,
+        res_tx: oneshot::Sender<Result<Bytes, RpcError>>,
+    ) {
+        let nonce = ping_msg.nonce;
+        let pong_msg = Pong { nonce };
+        let res_msg = HealthCheckerMsg {
+            message: Some(HealthCheckerMsg_oneof::Pong(pong_msg)),
+        };
+        debug!(
+            "Sending Pong response to peer: {} with nonce: {}",
+            peer_id.short_str(),
+            nonce
+        );
+        let res_data = res_msg.to_bytes().unwrap();
+        let _ = res_tx.send(Ok(res_data));
+    }
+
+    async fn handle_ping_response(
         &mut self,
         peer_id: PeerId,
         round: u64,
-        ping_result: Result<(), NetworkError>,
+        req_nonce: u32,
+        ping_result: Result<Pong, RpcError>,
     ) {
         debug!("Got result for ping round: {}", round);
         match ping_result {
-            Ok(_) => {
-                debug!("Ping successful for peer: {}", peer_id.short_str());
-                // Update last successful ping to current round.
-                self.connected
-                    .entry(peer_id)
-                    .and_modify(|(ref mut r, ref mut count)| {
-                        if round > *r {
-                            *r = round;
-                            *count = 0;
-                        }
-                    });
+            Ok(pong_msg) => {
+                let res_nonce = pong_msg.nonce;
+                if res_nonce == req_nonce {
+                    debug!("Ping successful for peer: {}", peer_id.short_str());
+                    // Update last successful ping to current round.
+                    self.connected
+                        .entry(peer_id)
+                        .and_modify(|(ref mut r, ref mut count)| {
+                            if round > *r {
+                                *r = round;
+                                *count = 0;
+                            }
+                        });
+                } else {
+                    security_log(SecurityEvent::InvalidHealthCheckerMsg)
+                        .error("Pong nonce doesn't match our challenge Ping nonce")
+                        .data(&peer_id)
+                        .data(req_nonce)
+                        .data(&pong_msg)
+                        .log();
+                    debug_assert!(false, "Pong nonce doesn't match our challenge Ping nonce");
+                }
             }
             Err(err) => {
                 warn!(
@@ -189,7 +232,7 @@ where
                         *failures += 1;
                         if *failures > self.ping_failures_tolerated {
                             info!("Disonnecting from peer: {}", peer_id.short_str());
-                            if let Err(err) = self.peer_mgr_reqs_tx.disconnect_peer(peer_id).await {
+                            if let Err(err) = self.network_tx.disconnect_peer(peer_id).await {
                                 warn!(
                                     "Failed to disconnect from peer: {} with error: {:?}",
                                     peer_id.short_str(),
@@ -204,83 +247,28 @@ where
     }
 
     async fn ping_peer(
+        mut network_tx: HealthCheckerNetworkSender,
         peer_id: PeerId,
         round: u64,
-        mut peer_mgr_reqs_tx: PeerManagerRequestSender<TSubstream>,
+        nonce: u32,
         ping_timeout: Duration,
-    ) -> (PeerId, u64, Result<(), NetworkError>) {
-        let ping_result = async move {
-            // Request a new substream to peer.
-            debug!(
-                "Opening a new substream with peer: {} for Ping",
-                peer_id.short_str()
-            );
-            let substream = peer_mgr_reqs_tx
-                .open_substream(peer_id, ProtocolId::from_static(PING_PROTOCOL_NAME))
-                .await?;
-            // Messages are length-prefixed. Wrap in a framed stream.
-            let mut substream = Framed::new(IoCompat::new(substream), LengthDelimitedCodec::new());
-            // Send Ping.
-            debug!("Sending Ping to peer: {}", peer_id.short_str());
-            substream
-                .send(
-                    Ping::default()
-                        .to_bytes()
-                        .expect("Protobuf serialization fails"),
-                )
-                .await?;
-            // Read Pong.
-            debug!("Waiting for Pong from peer: {}", peer_id.short_str());
-            let _: Pong = read_proto(&mut substream).await?;
-            // Return success.
-            Ok(())
-        };
-        (
-            peer_id,
-            round,
-            ping_result
-                .timeout(ping_timeout)
-                .map_err(Into::<NetworkError>::into)
-                .map(|r| r.and_then(|x| x))
-                .await,
-        )
+    ) -> (PeerId, u64, u32, Result<Pong, RpcError>) {
+        let ping_msg = Ping { nonce };
+        debug!(
+            "Sending Ping request to peer: {} with nonce: {}",
+            peer_id.short_str(),
+            nonce
+        );
+        let res_pong_msg = network_tx.ping(peer_id, ping_msg, ping_timeout).await;
+        (peer_id, round, nonce, res_pong_msg)
     }
 
-    async fn handle_ping(peer_id: PeerId, substream: TSubstream) {
-        // Messages are length-prefixed. Wrap in a framed stream.
-        let mut substream = Framed::new(IoCompat::new(substream), LengthDelimitedCodec::new());
-        // Read ping.
-        trace!("Waiting for Ping on new substream");
-        let maybe_ping: Result<Ping, NetworkError> = read_proto(&mut substream).await;
-        if let Err(err) = maybe_ping {
-            warn!(
-                "Failed to read ping from peer: {}. Error: {:?}",
-                peer_id.short_str(),
-                err
-            );
-            return;
-        }
-        // Send Pong.
-        trace!("Sending Pong back");
-        if let Err(err) = substream
-            .send(
-                Pong::default()
-                    .to_bytes()
-                    .expect("Protobuf serialization fails"),
-            )
-            .await
-        {
-            warn!(
-                "Failed to send pong to peer: {}. Error: {:?}",
-                peer_id.short_str(),
-                err
-            );
-            return;
-        }
-    }
-
-    fn get_random_peer(&mut self) -> Option<PeerId> {
+    fn sample_random_peer(&mut self) -> Option<PeerId> {
         let peers: Vec<_> = self.connected.keys().cloned().collect();
         peers.choose(&mut self.rng).cloned()
+    }
+
+    fn sample_nonce(&mut self) -> u32 {
+        self.rng.gen::<u32>()
     }
 }

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -32,6 +32,7 @@ mod consensus;
 mod health_checker;
 mod mempool;
 mod state_synchronizer;
+
 #[cfg(test)]
 mod test;
 
@@ -44,7 +45,9 @@ pub use consensus::{
     ConsensusNetworkEvents, ConsensusNetworkSender, CONSENSUS_DIRECT_SEND_PROTOCOL,
     CONSENSUS_RPC_PROTOCOL,
 };
-pub use health_checker::HealthCheckerNetworkEvents;
+pub use health_checker::{
+    HealthCheckerNetworkEvents, HealthCheckerNetworkSender, HEALTH_CHECKER_RPC_PROTOCOL,
+};
 use libra_types::PeerId;
 pub use mempool::{MempoolNetworkEvents, MempoolNetworkSender, MEMPOOL_DIRECT_SEND_PROTOCOL};
 pub use state_synchronizer::{


### PR DESCRIPTION
Closes #1556
See also #1516

+ HealthChecker now uses `HealthCheckerNetworkSender` and
`HealthCheckerNetworkEvents` APIs introduced in #1644, instead of
network-internal APIs to the `PeerManager`. As a result, HealthChecker
can reuse network RPC logic and no longer needs to be aware of
substreams.

+ HealthChecker Ping/Pong now contains a challenge nonce to ensure
recipients are actually reading the message.

+ Remove old `Ping` and `Pong` messages in `network.proto`.

+ (For now) `NetworkBuilder` always instantiates a HealthChecker
instance for new network instances.