### PR TITLE
[consensus] multi proposer election with SHA-3

### DIFF
--- a/consensus/src/chained_bft/liveness/multi_proposer_test.rs
+++ b/consensus/src/chained_bft/liveness/multi_proposer_test.rs
@@ -19,11 +19,12 @@ fn test_multi_proposer() {
         signers.push(signer);
     }
     let mut pe: Box<dyn ProposerElection<u32>> = Box::new(MultiProposer::new(proposers.clone(), 2));
-    let round = 1;
-    let first_hash = multi_proposer_election::hash(round);
-    let primary_idx = (first_hash % 8) as usize;
-    let second_hash = multi_proposer_election::hash(first_hash);
-    let secondary_idx = (second_hash % 7) as usize; // assuming no collisions in this case
+    let round = 1u64;
+    let mut state = round.to_le_bytes().to_vec();
+    let primary_idx = multi_proposer_election::next(&mut state);
+    let primary_idx = (primary_idx % 8) as usize;
+    let secondary_idx = multi_proposer_election::next(&mut state);
+    let secondary_idx = (secondary_idx % 7) as usize; // assuming no collisions in this case
 
     let primary_proposer = proposers[primary_idx];
     let secondary_proposer = proposers[secondary_idx];
@@ -87,8 +88,9 @@ fn test_multi_proposer_hash() {
     // Verify that the hash distributes primary proposers in a "reasonable" fashion
     let mut counts = vec![0; 10];
     for round in 0..10000 {
-        let idx = (multi_proposer_election::hash(round) % counts.len() as u64) as usize;
-        counts[idx] += 1;
+        let mut state = (round as u64).to_le_bytes().to_vec();
+        let idx = multi_proposer_election::next(&mut state) % (counts.len() as u64);
+        counts[idx as usize] += 1;
     }
     for c in counts {
         assert!(c > 900);


### PR DESCRIPTION
**1. Multi proposer election** currently uses the siphash PRF, this is not super uber cool because the rest of the codebase uses SHA-3 and this adds a cryptographic dependency that we don't really need. So I changed it to SHA-3.

**2. there's a bias in the modular reduction** of the operation that computes a round's proposers. It is not worth being fixed as the bias is negligible in practice, I've added a comment to indicate this.
