### PR TITLE
[transaction-builder] key rotation builder takes bytes instead of add…

### DIFF
--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -120,12 +120,13 @@ pub fn encode_rotate_consensus_pubkey_script(new_key: Vec<u8>) -> Script {
     )
 }
 
-/// Encode a program that rotates the sender's authentication key to `new_key`.
-pub fn rotate_authentication_key_script(new_key: AccountAddress) -> Script {
+/// Encode a program that rotates the sender's authentication key to `new_key`. `new_key` should be
+/// a 256 bit sha3 hash of an ed25519 public key.
+pub fn rotate_authentication_key_script(new_hashed_key: Vec<u8>) -> Script {
     Script::new(
         ROTATE_AUTHENTICATION_KEY_TXN.clone(),
         vec![TransactionArgument::ByteArray(ByteArray::new(
-            new_key.as_ref().to_vec(),
+            new_hashed_key,
         ))],
     )
 }


### PR DESCRIPTION
…ress

This builder API was misleading. It took an `AccountAddress` as input, but the rotate authentication key script expects bytes encoding the hash of a public key.

## Motivation

Avoiding confusing/making the builders easier to use.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

E2E tests, should be pure refactoring given that this was unused.
