### PR TITLE
[consensus] update safety rules documentation and add TODOs

### DIFF
--- a/consensus/safety-rules/src/persistent_storage.rs
+++ b/consensus/safety-rules/src/persistent_storage.rs
@@ -11,6 +11,8 @@ use tempfile::NamedTempFile;
 /// SafetyRules needs an abstract storage interface to act as a common utility for storing
 /// persistent data to local disk, cloud, secrets managers, or even memory (for tests)
 /// Any set function is expected to sync to the remote system before returning.
+/// @TODO add access to private key from persistent store
+/// @TODO add retrieval of private key based upon public key to persistent store
 pub trait PersistentStorage: Send + Sync {
     fn epoch(&self) -> u64;
     fn set_epoch(&mut self, epoch: u64);


### PR DESCRIPTION
The documentation had fallen out of date as the code moved from within
consensus, to its own file, to its own crate.
In addition, there were race conditions due to concurrent work happening
in the code base. Listing TODOs to better help track these. So ideally
if a PR were to hit on a TODO it would either be addressed or updated
to reflect the new world order.