### PR TITLE
[CI] check genesis blob in commit verify

### DIFF
--- a/scripts/circle_validate_configs.sh
+++ b/scripts/circle_validate_configs.sh
@@ -19,11 +19,11 @@ cd terraform/validator-sets
 # Notice: This is not comparing all configs yet.
 
 # Cleanup files we do compare yet
-git checkout -- '**/seed_peers.config.toml' '**/genesis.blob'
+git checkout -- '**/seed_peers.config.toml'
 git update-index --refresh
 
 echo "--- Compare configs ---"
-changes=$(git diff-index HEAD -- '**/consensus_peers.config.toml' '**/node.consensus.keys.toml' '**/network_peers.config.toml' '**/node.network.keys.toml')
+changes=$(git diff-index HEAD -- '**/consensus_peers.config.toml' '**/node.consensus.keys.toml' '**/network_peers.config.toml' '**/node.network.keys.toml' '**/genesis.blob')
 if [ -z "$changes" ];
 then
 	# nothing to do


### PR DESCRIPTION
## Motivation
Check the genensis blob consistenchy as part of commit verify.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
- Canaried in 3b5676c when rebasing off a breaking change.  Commit verify failed.
https://circleci.com/gh/libra/libra/16090?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link
![image](https://user-images.githubusercontent.com/7528420/68719731-bc756c00-0561-11ea-8556-ca2b7f97fcf2.png)

- Canaried in 65976ad without breaking change. Commit verify passed.
https://circleci.com/gh/libra/libra/16069?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link