### PR TITLE
[cost-synthesis & test-generation] Update creation of identifiers and fix bit rot

### DIFF
--- a/language/tools/cost-synthesis/src/common.rs
+++ b/language/tools/cost-synthesis/src/common.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Defines constants and types that are used throughout cost synthesis.
+use rand::{distributions::Alphanumeric, rngs::StdRng, Rng};
 use vm::file_format::TableIndex;
 use vm_runtime_types::value::Value;
 
@@ -31,3 +32,13 @@ pub const DEFAULT_FUNCTION_IDX: TableIndex = 0;
 
 /// The type of the value stack.
 pub type Stack = Vec<Value>;
+
+pub fn random_string(rng: &mut StdRng, len: usize) -> String {
+    if len == 0 {
+        "".to_string()
+    } else {
+        let mut string = "a".to_string();
+        (1..len).for_each(|_| string.push(rng.sample(Alphanumeric)));
+        string
+    }
+}

--- a/language/tools/cost-synthesis/src/global_state/inhabitor.rs
+++ b/language/tools/cost-synthesis/src/global_state/inhabitor.rs
@@ -87,7 +87,7 @@ where
 
     fn next_str(&mut self) -> String {
         let len: usize = self.gen.gen_range(1, MAX_STRING_SIZE);
-        (0..len).map(|_| self.gen.gen::<char>()).collect::<String>()
+        random_string(&mut self.gen, len)
     }
 
     fn next_vm_string(&mut self) -> VMString {

--- a/language/tools/test-generation/src/bytecode_generator.rs
+++ b/language/tools/test-generation/src/bytecode_generator.rs
@@ -292,9 +292,11 @@ impl BytecodeGenerator {
                         StructDefinitionIndex::new(
                             self.rng.gen_range(0, module.struct_defs.len()) as TableIndex
                         ),
-                        LocalsSignatureIndex::new(
-                            self.rng.gen_range(0, module.locals_signatures.len()) as TableIndex,
-                        ),
+                        // TODO: Need to generate a proper generic call eventually
+                        LocalsSignatureIndex::new(0),
+                        //LocalsSignatureIndex::new(
+                        //self.rng.gen_range(0, module.locals_signatures.len()) as TableIndex,
+                        //),
                     )
                 }
                 BytecodeType::FieldDefinitionIndex(instruction) => {
@@ -309,9 +311,11 @@ impl BytecodeGenerator {
                         FunctionHandleIndex::new(
                             self.rng.gen_range(0, module.function_handles.len()) as TableIndex,
                         ),
-                        LocalsSignatureIndex::new(
-                            self.rng.gen_range(0, module.locals_signatures.len()) as TableIndex,
-                        ),
+                        // TODO: Need to generate a proper generic call eventually
+                        LocalsSignatureIndex::new(0),
+                        //LocalsSignatureIndex::new(
+                        //self.rng.gen_range(0, module.locals_signatures.len()) as TableIndex,
+                        //),
                     )
                 }
             };


### PR DESCRIPTION
Previously we could create invalid identifiers which would cause the
generation to crash. We now make sure that all strings and identifiers
conform to the identifier specification in types.

Also generated modules were previously not representing empty type
parameter info previously. This fixes this as well.

Note that the test generator every one in a while creates some invalid modules due to "NEGATIVE_STACK_SIZE_WITHIN_BLOCK` but this doesn't seem to be coming from the module generation so I'm not going to try and fix this for now.
