### PR TITLE
[language][vm] pass type arguments to native functions

### DIFF
--- a/language/tools/cost-synthesis/src/main.rs
+++ b/language/tools/cost-synthesis/src/main.rs
@@ -223,7 +223,8 @@ macro_rules! bench_native {
                     let before = Instant::now();
                     let mut args = VecDeque::new();
                     args.push_front(Value::byte_array(stack_access.next_bytearray()));
-                    let _ = $function(args, &cost_table);
+                    // TODO: generate type arguments for generic native functions.
+                    let _ = $function(vec![], args, &cost_table);
                     acc + before.elapsed().as_nanos()
                 });
                 // Time per byte averaged over the number of iterations that we performed.

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -738,7 +738,11 @@ where
             for _ in 0..expected_args {
                 arguments.push_front(self.operand_stack.pop()?);
             }
-            let result = (native_function.dispatch)(arguments, self.gas_meter.cost_table())?;
+            let result = (native_function.dispatch)(
+                type_actual_tags,
+                arguments,
+                self.gas_meter.cost_table(),
+            )?;
             gas!(consume: self, result.cost)?;
             result.result.and_then(|values| {
                 for value in values {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
@@ -10,7 +10,7 @@ use libra_types::{
     account_address::AccountAddress,
     account_config,
     identifier::{IdentStr, Identifier},
-    language_storage::ModuleId,
+    language_storage::{ModuleId, TypeTag},
     vm_error::{StatusCode, VMStatus},
 };
 use std::collections::{HashMap, VecDeque};
@@ -60,7 +60,7 @@ impl NativeResult {
 /// Struct representing the expected definition for a native function.
 pub struct NativeFunction {
     /// Given the vector of aguments, it executes the native function.
-    pub dispatch: fn(VecDeque<Value>, &CostTable) -> VMResult<NativeResult>,
+    pub dispatch: fn(Vec<TypeTag>, VecDeque<Value>, &CostTable) -> VMResult<NativeResult>,
     /// The signature as defined in it's declaring module.
     /// It should NOT be generally inspected outside of it's declaring module as the various
     /// struct handle indexes are not remapped into the local context.
@@ -254,7 +254,7 @@ lazy_static! {
 
         // Event
         add!(m, addr, "Event", "write_to_event_store",
-            |_, _| {
+            |_, _, _| {
                 Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(
                             "write_to_event_store does not have a native implementation"
                                 .to_string()))
@@ -265,7 +265,7 @@ lazy_static! {
         );
         // LibraAccount
         add!(m, addr, "LibraAccount", "save_account",
-            |_, _| {
+            |_, _, _| {
                 Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(
                     "save_account does not have a native implementation".to_string()))
             },

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/hash.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/hash.rs
@@ -8,6 +8,7 @@ use crate::{
 use libra_crypto::HashValue;
 use libra_types::{
     byte_array::ByteArray,
+    language_storage::TypeTag,
     vm_error::{StatusCode, VMStatus},
 };
 use sha2::{Digest, Sha256};
@@ -18,6 +19,7 @@ use vm::{
 };
 
 pub fn native_sha2_256(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -36,6 +38,7 @@ pub fn native_sha2_256(
 }
 
 pub fn native_sha3_256(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/primitive_helpers.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/primitive_helpers.rs
@@ -8,6 +8,7 @@ use crate::{
 use libra_types::{
     account_address::AccountAddress,
     byte_array::ByteArray,
+    language_storage::TypeTag,
     vm_error::{StatusCode, VMStatus},
 };
 use std::collections::VecDeque;
@@ -17,6 +18,7 @@ use vm::{
 };
 
 pub fn native_bytearray_concat(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -42,6 +44,7 @@ pub fn native_bytearray_concat(
 }
 
 pub fn native_address_to_bytes(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -65,6 +68,7 @@ pub fn native_address_to_bytes(
 }
 
 pub fn native_u64_to_bytes(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/signature.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/signature.rs
@@ -13,6 +13,7 @@ use libra_crypto::{
 };
 use libra_types::{
     byte_array::ByteArray,
+    language_storage::TypeTag,
     vm_error::{StatusCode, VMStatus},
 };
 use std::{collections::VecDeque, convert::TryFrom};
@@ -45,6 +46,7 @@ const OVERSIZED_PUBLIC_KEY_SIZE_FAILURE: u64 = DEFAULT_ERROR_CODE + 8;
 const INVALID_PUBLIC_KEY_SIZE_FAILURE: u64 = DEFAULT_ERROR_CODE + 9;
 
 pub fn native_ed25519_signature_verification(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -89,6 +91,7 @@ pub fn native_ed25519_signature_verification(
 
 /// Batch verify a collection of signatures using a bitmap for matching signatures to keys.
 pub fn native_ed25519_threshold_signature_verification(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
@@ -7,7 +7,10 @@ use crate::{
     pop_arg,
     value::{MutVal, ReferenceValue, Value},
 };
-use libra_types::vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, StatusType, VMStatus};
+use libra_types::{
+    language_storage::TypeTag,
+    vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, StatusType, VMStatus},
+};
 use serde::Serialize;
 use std::{collections::VecDeque, ops::Add};
 use vm::errors::VMResult;
@@ -48,7 +51,11 @@ macro_rules! get_vector_ref {
 }
 
 impl NativeVector {
-    pub fn native_empty(_args: VecDeque<Value>, cost_table: &CostTable) -> VMResult<NativeResult> {
+    pub fn native_empty(
+        _type_args: Vec<TypeTag>,
+        _args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
         Ok(NativeResult::ok(
             native_gas(cost_table, NativeCostIndex::EMPTY, 1),
             vec![Value::native_struct(NativeStructValue::Vector(
@@ -58,6 +65,7 @@ impl NativeVector {
     }
 
     pub fn native_length(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -73,6 +81,7 @@ impl NativeVector {
     }
 
     pub fn native_push_back(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -105,6 +114,7 @@ impl NativeVector {
     }
 
     pub fn native_borrow(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -136,7 +146,11 @@ impl NativeVector {
         }
     }
 
-    pub fn native_pop(mut args: VecDeque<Value>, cost_table: &CostTable) -> VMResult<NativeResult> {
+    pub fn native_pop(
+        _type_args: Vec<TypeTag>,
+        mut args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
         if args.len() != 1 {
             let msg = format!(
                 "wrong number of arguments for pop expected 1 found {}",
@@ -159,6 +173,7 @@ impl NativeVector {
     }
 
     pub fn native_destroy_empty(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -183,6 +198,7 @@ impl NativeVector {
     }
 
     pub fn native_swap(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {


### PR DESCRIPTION
## Summary
This is a preparation for the planned attempt to optimize in-memory representation of move native vectors. It passes the type arguments to the native functions so they can have specialized behaviors based on them.

## Test Plan
cargo test

## Note
Right now `libra_types::language_storage::TypeTag` is used to represent types at runtime. This is temporary and will be replaced when we figure out the VM types story.