### PR TITLE
[consensus] enforce genesis block/qc verification

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -7,7 +7,7 @@ use crate::{
     quorum_cert::QuorumCert,
     vote_data::VoteData,
 };
-use failure::{ensure, format_err};
+use failure::{bail, ensure, format_err};
 use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_types::block_info::BlockInfo;
 use libra_types::transaction::Version;
@@ -103,6 +103,23 @@ impl<T> Block<T> {
     pub fn timestamp_usecs(&self) -> u64 {
         self.block_data.timestamp_usecs()
     }
+
+    pub fn gen_block_info(
+        &self,
+        executed_state_id: HashValue,
+        version: Version,
+        next_validator_set: Option<ValidatorSet>,
+    ) -> BlockInfo {
+        BlockInfo::new(
+            self.epoch(),
+            self.round(),
+            self.id(),
+            executed_state_id,
+            version,
+            self.timestamp_usecs(),
+            next_validator_set,
+        )
+    }
 }
 
 impl<T> Block<T>
@@ -138,7 +155,7 @@ where
             ledger_info.transaction_accumulator_hash(),
             ledger_info.version(),
             ledger_info.timestamp_usecs(),
-            ledger_info.next_validator_set().cloned(),
+            None,
         );
 
         // Genesis carries a placeholder quorum certificate to its parent id with LedgerInfo
@@ -210,7 +227,7 @@ where
     /// If this is the genesis block, we skip these checks.
     pub fn validate_signatures(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
         match self.block_data.block_type() {
-            BlockType::Genesis => Ok(()),
+            BlockType::Genesis => bail!("We should not accept genesis from others"),
             BlockType::NilBlock => self.quorum_cert().verify(validator),
             BlockType::Proposal { author, .. } => {
                 let signature = self
@@ -226,38 +243,22 @@ where
     /// Makes sure that the proposal makes sense, independently of the current state.
     /// If this is the genesis block, we skip these checks.
     pub fn verify_well_formed(&self) -> failure::Result<()> {
-        if self.is_genesis_block() {
-            return Ok(());
-        }
-        debug_checked_verify_eq!(
-            self.id(),
-            self.block_data.hash(),
-            "Block id mismatch the hash"
+        ensure!(
+            !self.is_genesis_block(),
+            "We should not accept genesis from others"
         );
         ensure!(
             self.quorum_cert().certified_block().round() < self.round(),
             "Block has invalid round"
         );
+        debug_checked_verify_eq!(
+            self.id(),
+            self.block_data.hash(),
+            "Block id mismatch the hash"
+        );
 
         ensure!(!self.quorum_cert().ends_epoch(), "Block after epoch ends");
         Ok(())
-    }
-
-    pub fn gen_block_info(
-        &self,
-        executed_state_id: HashValue,
-        version: Version,
-        next_validator_set: Option<ValidatorSet>,
-    ) -> BlockInfo {
-        BlockInfo::new(
-            self.epoch(),
-            self.round(),
-            self.id(),
-            executed_state_id,
-            version,
-            self.timestamp_usecs(),
-            next_validator_set,
-        )
     }
 }
 

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block::block_test_utils::{certificate_for_genesis, placeholder_certificate_for_block};
+use crate::block::block_test_utils::certificate_for_genesis;
 use crate::{
     block::{block_test_utils::*, Block},
     quorum_cert::QuorumCert,
@@ -45,12 +45,15 @@ fn test_nil_block() {
 
     let signer = ValidatorSigner::random(None);
     let payload = 101;
-    let nil_block_qc = placeholder_certificate_for_block(
+    let parent_block_info = nil_block.quorum_cert().certified_block();
+    let nil_block_qc = gen_test_certificate(
         vec![&signer],
-        nil_block.id(),
-        nil_block.round(),
-        nil_block.quorum_cert().certified_block().id(),
-        nil_block.quorum_cert().certified_block().round(),
+        nil_block.gen_block_info(
+            parent_block_info.executed_state_id(),
+            parent_block_info.version(),
+            parent_block_info.next_validator_set().cloned(),
+        ),
+        nil_block.quorum_cert().certified_block().clone(),
         None,
     );
     println!(

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -4,6 +4,7 @@
 use crate::{block::Block, common::Round, quorum_cert::QuorumCert};
 use executor::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
 use libra_crypto::hash::HashValue;
+use libra_types::block_info::BlockInfo;
 use std::{
     fmt::{Display, Formatter},
     sync::Arc,
@@ -94,6 +95,15 @@ impl<T> ExecutedBlock<T> {
             .iter()
             .filter_map(|x| x.txn_info_hash())
             .collect()
+    }
+
+    pub fn block_info(&self) -> BlockInfo {
+        let executed_state = self.compute_result().executed_state;
+        self.block().gen_block_info(
+            executed_state.state_id,
+            executed_state.version,
+            executed_state.validators,
+        )
     }
 }
 

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -3,13 +3,10 @@
 
 use crate::vote_data::VoteData;
 use failure::prelude::*;
-use libra_crypto::{
-    hash::{CryptoHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID},
-    HashValue,
-};
+use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
     block_info::BlockInfo,
-    crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier},
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier},
     ledger_info::LedgerInfo,
 };
 use serde::{Deserialize, Serialize};
@@ -96,13 +93,10 @@ impl QuorumCert {
         let vote_data = VoteData::new(ancestor.clone(), ancestor.clone());
         let li = LedgerInfo::new(ancestor, vote_data.hash());
 
-        let signer = ValidatorSigner::genesis();
-        let signature = signer
-            .sign_message(li.hash())
-            .expect("Fail to sign genesis ledger info");
-        let mut signatures = BTreeMap::new();
-        signatures.insert(signer.author(), signature);
-        QuorumCert::new(vote_data, LedgerInfoWithSignatures::new(li, signatures))
+        QuorumCert::new(
+            vote_data,
+            LedgerInfoWithSignatures::new(li, BTreeMap::new()),
+        )
     }
 
     pub fn verify(&self, validator: &ValidatorVerifier) -> failure::Result<()> {
@@ -111,11 +105,22 @@ impl QuorumCert {
             self.ledger_info().ledger_info().consensus_data_hash() == vote_hash,
             "Quorum Cert's hash mismatch LedgerInfo"
         );
-        // Genesis is implicitly agreed upon, it doesn't have real signatures.
-        if self.certified_block().round() == 0
-            && self.certified_block().id() == *GENESIS_BLOCK_ID
-            && self.certified_block().executed_state_id() == *ACCUMULATOR_PLACEHOLDER_HASH
-        {
+        // Genesis's QC is implicitly agreed upon, it doesn't have real signatures.
+        // If someone sends us a QC on a fake genesis, it'll fail to insert into BlockStore
+        // because of the round constraint.
+        if self.certified_block().round() == 0 {
+            ensure!(
+                self.parent_block() == self.certified_block(),
+                "Genesis QC has inconsistent parent block with certified block"
+            );
+            ensure!(
+                self.certified_block() == self.ledger_info().ledger_info().commit_info(),
+                "Genesis QC has inconsistent commit block with certified block"
+            );
+            ensure!(
+                self.ledger_info().signatures().is_empty(),
+                "Genesis QC should not carry signatures"
+            );
             return Ok(());
         }
         self.ledger_info()

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -138,7 +138,7 @@ impl SafetyRules {
     /// Learn about a new quorum certificate. In normal state, this updates the preferred round,
     /// if the parent is greater than our current preferred round. This can also trigger upgrading
     /// to a new epoch.
-    /// @TODO verify signatures of the QC
+    /// @TODO verify signatures of the QC, also the special genesis QC
     /// @TODO improving signaling by stating reaction to passed in QC:
     ///     QC has older preferred round,
     ///     signatures are incorrect,

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -3,10 +3,7 @@
 
 use crate::chained_bft::block_storage::{BlockReader, BlockStore};
 use consensus_types::{
-    block::{
-        block_test_utils::{certificate_for_genesis, placeholder_certificate_for_block},
-        Block,
-    },
+    block::{block_test_utils::certificate_for_genesis, Block},
     common::Round,
     executed_block::ExecutedBlock,
     quorum_cert::QuorumCert,
@@ -24,6 +21,7 @@ mod mock_state_computer;
 mod mock_storage;
 mod mock_txn_manager;
 
+use consensus_types::block::block_test_utils::gen_test_certificate;
 use libra_types::block_info::BlockInfo;
 pub use mock_state_computer::{EmptyStateComputer, MockStateComputer};
 pub use mock_storage::{EmptyStorage, MockStorage};
@@ -163,12 +161,10 @@ impl TreeInserter {
         block: &ExecutedBlock<TestPayload>,
         consensus_block_id: Option<HashValue>,
     ) -> QuorumCert {
-        placeholder_certificate_for_block(
+        gen_test_certificate(
             vec![&self.signer],
-            block.id(),
-            block.round(),
-            block.quorum_cert().certified_block().id(),
-            block.quorum_cert().certified_block().round(),
+            block.block_info(),
+            block.quorum_cert().certified_block().clone(),
             consensus_block_id,
         )
     }

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -92,11 +92,6 @@ impl LedgerInfo {
         self.commit_info.version()
     }
 
-    /// A ledger info is nominal if it's not certifying any real version.
-    pub fn is_zero(&self) -> bool {
-        self.version() == 0
-    }
-
     pub fn timestamp_usecs(&self) -> u64 {
         self.commit_info.timestamp_usecs()
     }
@@ -226,10 +221,6 @@ impl<Sig: Signature> LedgerInfoWithSignatures<Sig> {
         &self,
         validator: &ValidatorVerifier<Sig::VerifyingKeyMaterial>,
     ) -> ::std::result::Result<(), VerifyError> {
-        if self.ledger_info.is_zero() {
-            // We're not trying to verify nominal ledger info that does not carry any information.
-            return Ok(());
-        }
         let ledger_hash = self.ledger_info().hash();
         validator.batch_verify_aggregated_signature(ledger_hash, self.signatures())
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We enforce a few things in this change:
- reject genesis block from the wire
- enforce genesis qc has the same certified, parent and committed
BlockInfo
- enforce we only insert QC with the same BlockInfo locally

Combined those checks, we're able to make sure once a node enters an
epoch, it'll not switch genesis nor accept different genesis QC.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
