### PR TITLE
[consensus] inject BlockMetadata txn per block

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 use failure::{bail, ensure, format_err};
 use libra_crypto::hash::{CryptoHash, HashValue};
+use libra_types::account_address::{AccountAddress, ADDRESS_LENGTH};
 use libra_types::block_info::BlockInfo;
+use libra_types::block_metadata::BlockMetadata;
 use libra_types::transaction::Version;
 use libra_types::validator_set::ValidatorSet;
 use libra_types::{
@@ -308,5 +310,19 @@ impl<'de, T: DeserializeOwned + Serialize> Deserialize<'de> for Block<T> {
             block_data,
             signature,
         })
+    }
+}
+
+impl<T> From<&Block<T>> for BlockMetadata {
+    fn from(block: &Block<T>) -> Self {
+        Self::new(
+            block.id(),
+            block.timestamp_usecs(),
+            block.quorum_cert().ledger_info().signatures().clone(),
+            // For nil block, we use 0x0 which is convention for nil address in move.
+            block
+                .author()
+                .unwrap_or_else(|| AccountAddress::new([0u8; ADDRESS_LENGTH])),
+        )
     }
 }

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -175,17 +175,11 @@ impl<T: Payload> BlockStore<T> {
             .path_from_root(block_id_to_commit)
             .unwrap_or_else(Vec::new);
 
-        let payload_and_output_list = blocks_to_commit
-            .iter()
-            .map(|b| {
-                (
-                    b.payload().unwrap_or(&T::default()).clone(),
-                    Arc::clone(b.output()),
-                )
-            })
-            .collect();
         self.state_computer
-            .commit(payload_and_output_list, finality_proof)
+            .commit(
+                blocks_to_commit.iter().map(|b| b.as_ref()).collect(),
+                finality_proof,
+            )
             .await
             .unwrap_or_else(|e| panic!("Failed to persist commit due to {:?}", e));
         counters::LAST_COMMITTED_ROUND.set(block_to_commit.round() as i64);

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -6,6 +6,7 @@ use crate::{
     state_replication::StateComputer,
 };
 use consensus_types::block::Block;
+use consensus_types::executed_block::ExecutedBlock;
 use executor::{ExecutedTrees, ProcessedVMOutput};
 use failure::Result;
 use futures::{channel::mpsc, future, Future, FutureExt};
@@ -52,7 +53,7 @@ impl StateComputer for MockStateComputer {
 
     fn commit(
         &self,
-        _blocks: Vec<(Self::Payload, Arc<ProcessedVMOutput>)>,
+        _blocks: Vec<&ExecutedBlock<Self::Payload>>,
         commit: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         self.consensus_db
@@ -116,7 +117,7 @@ impl StateComputer for EmptyStateComputer {
 
     fn commit(
         &self,
-        _blocks: Vec<(Self::Payload, Arc<ProcessedVMOutput>)>,
+        _blocks: Vec<&ExecutedBlock<Self::Payload>>,
         _commit: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
         future::ok(()).boxed()

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::block::Block;
+use consensus_types::executed_block::ExecutedBlock;
 use executor::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
 use failure::Result;
 use futures::Future;
@@ -52,7 +53,7 @@ pub trait StateComputer: Send + Sync {
     /// Send a successful commit. A future is fulfilled when the state is finalized.
     fn commit(
         &self,
-        blocks: Vec<(Self::Payload, Arc<ProcessedVMOutput>)>,
+        blocks: Vec<&ExecutedBlock<Self::Payload>>,
         finality_proof: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -32,7 +32,9 @@ impl MempoolProxy {
         timestamp_usecs: u64,
     ) -> CommitTransactionsRequest {
         let mut all_updates = Vec::new();
-        assert_eq!(txns.len(), compute_result.compute_status.len());
+        // we exclude the prologue txn, we probably need a way to ensure this aligns with state_computer
+        let status = compute_result.compute_status[1..].to_vec();
+        assert_eq!(txns.len(), status.len());
         for (txn, status) in txns.iter().zip(compute_result.compute_status.iter()) {
             let mut transaction = CommittedTransaction::default();
             transaction.sender = txn.sender().as_ref().to_vec();

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -242,6 +242,19 @@ fn smoke_test_single_node() {
 }
 
 #[test]
+fn smoke_test_single_node_block_metadata() {
+    let (_swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
+    // just need an address to get the latest version
+    let address = AccountAddress::from_hex_literal("0xA550C18").unwrap();
+    // sleep 1s to commit some blocks
+    thread::sleep(time::Duration::from_secs(1));
+    let (_state, version) = client_proxy
+        .get_latest_account_state(&["q", &address.to_string()])
+        .unwrap();
+    assert!(version > 0, "BlockMetadata txn not persisted");
+}
+
+#[test]
 fn smoke_test_multi_node() {
     let (_swarm, mut client_proxy) = setup_swarm_and_client_proxy(4, 0);
     test_smoke_script(client_proxy);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We turn a Block into a special BlockMetadata txn and inject such transaction at the end of every block's payload.

This txn would record metadata, signal reconfiguration. #1383 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
