### PR TITLE
[cluster-test] Fix TPS query and add prometheus debugging info

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -460,7 +460,7 @@ fn print_stat(prometheus: &Prometheus, window: Duration) -> failure::Result<(f64
             &end,
             step,
         )
-        .map_err(|_| format_err!("No tps data"))?;
+        .map_err(|e| format_err!("No tps data: {}", e))?;
     let avg_latency = prometheus.query_range_avg(
         "irate(mempool_duration_sum{op='e2e.latency'}[1m])/irate(mempool_duration_count{op='e2e.latency'}[1m])"
             .to_string(),

--- a/testsuite/cluster-test/src/prometheus.rs
+++ b/testsuite/cluster-test/src/prometheus.rs
@@ -52,16 +52,16 @@ impl Prometheus {
 
         let mut response = self
             .client
-            .get(url)
+            .get(url.clone())
             .send()
             .map_err(|e| format_err!("Failed to query prometheus: {:?}", e))?;
 
         // We don't check HTTP error code here
         // Prometheus supplies error status in json response along with error text
 
-        let response: PrometheusResponse = response
-            .json()
-            .map_err(|e| format_err!("Failed to parse prometheus response: {:?}", e))?;
+        let response: PrometheusResponse = response.json().map_err(|e| {
+            format_err!("Failed to parse prometheus response: {:?}. Url: {}", e, url)
+        })?;
 
         match response.data {
             Some(data) => MatrixResponse::from_prometheus(data),
@@ -158,7 +158,7 @@ struct PrometheusResult {
 
 #[derive(Debug, Deserialize)]
 struct PrometheusMetric {
-    op: String,
+    op: Option<String>,
     peer_id: String,
 }
 


### PR DESCRIPTION
Changing consensus metric for commit blocks per second broken TPS query on cluster test
Reason is that cluster test required `op` field on prometheus response, and TPS query did not have this field

This diff fixes it and also adds debug information to prometheus related errors:
 - Include details in 'No tps data' message
 - Includes prometheus URL that was used for query in error message
