### PR TITLE
[cluster-test] Don't set RUST_BACKTRACE by default in container

### DIFF
--- a/docker/cluster-test/cluster-test.Dockerfile
+++ b/docker/cluster-test/cluster-test.Dockerfile
@@ -23,8 +23,6 @@ RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY --from=builder /target/release/cluster-test /usr/local/bin/cluster-test
 COPY terraform/validator-sets/100/mint.key /etc/cluster-test/
-## Capture backtrace on error
-ENV RUST_BACKTRACE 1
 ENTRYPOINT ["cluster-test"]
 ARG BUILD_DATE
 ARG GIT_REV

--- a/docker/cluster-test/cluster-test.Dockerfile.template
+++ b/docker/cluster-test/cluster-test.Dockerfile.template
@@ -18,12 +18,13 @@ RUN docker/cluster-test/compile.sh
 FROM debian:buster
 
 RUN apt-get update && apt-get install -y openssh-client
+RUN mkdir /etc/cluster-test
+WORKDIR /etc/cluster-test
 
 #ifdef INCREMENTAL_IMAGE
 COPY cluster_test_docker_builder_cluster_test /usr/local/bin/cluster-test
+
 #else
-RUN mkdir /etc/cluster-test
-WORKDIR /etc/cluster-test
 
 COPY --from=builder /target/release/cluster-test /usr/local/bin/cluster-test
 #endif

--- a/docker/cluster-test/cluster-test.Dockerfile.template
+++ b/docker/cluster-test/cluster-test.Dockerfile.template
@@ -30,9 +30,6 @@ COPY --from=builder /target/release/cluster-test /usr/local/bin/cluster-test
 
 COPY terraform/validator-sets/100/mint.key /etc/cluster-test/
 
-## Capture backtrace on error
-ENV RUST_BACKTRACE 1
-
 ENTRYPOINT ["cluster-test"]
 
 ARG BUILD_DATE

--- a/docker/cluster-test/cluster-test.container.Dockerfile
+++ b/docker/cluster-test/cluster-test.container.Dockerfile
@@ -8,6 +8,8 @@
 ## -
 FROM debian:buster
 RUN apt-get update && apt-get install -y openssh-client
+RUN mkdir /etc/cluster-test
+WORKDIR /etc/cluster-test
 COPY cluster_test_docker_builder_cluster_test /usr/local/bin/cluster-test
 COPY terraform/validator-sets/100/mint.key /etc/cluster-test/
 ENTRYPOINT ["cluster-test"]

--- a/docker/cluster-test/cluster-test.container.Dockerfile
+++ b/docker/cluster-test/cluster-test.container.Dockerfile
@@ -10,8 +10,6 @@ FROM debian:buster
 RUN apt-get update && apt-get install -y openssh-client
 COPY cluster_test_docker_builder_cluster_test /usr/local/bin/cluster-test
 COPY terraform/validator-sets/100/mint.key /etc/cluster-test/
-## Capture backtrace on error
-ENV RUST_BACKTRACE 1
 ENTRYPOINT ["cluster-test"]
 ARG BUILD_DATE
 ARG GIT_REV


### PR DESCRIPTION
It pollutes log quite a bit when set.
In case debugging is needed one can always override it with `docker run -e RUST_BACKTRACE=1`
