### PR TITLE
[network] Move discovery to be above the core network layer

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -69,8 +69,11 @@ lazy_static::lazy_static! {
     /// Counter of pending network events to Admission Control
     pub static ref PENDING_ADMISSION_CONTROL_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_admission_control_network_events");
 
-    /// Counter of pending network events to Admission Control
+    /// Counter of pending network events to Health Checker.
     pub static ref PENDING_HEALTH_CHECKER_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_health_checker_network_events");
+
+    /// Counter of pending network events to Discovery.
+    pub static ref PENDING_DISCOVERY_NETWORK_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_discovery_network_events");
 
     /// Counter of pending requests in Peer Manager
     pub static ref PENDING_PEER_MANAGER_REQUESTS: IntGauge = OP_COUNTERS.gauge("pending_peer_manager_requests");

--- a/network/src/utils.rs
+++ b/network/src/utils.rs
@@ -1,27 +1,4 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::NetworkError;
-use bytes::Bytes;
-use futures::{io::AsyncRead, stream::StreamExt};
 pub use libra_prost_ext::MessageExt;
-use netcore::compat::IoCompat;
-use std::io;
-use tokio::codec::{Framed, LengthDelimitedCodec};
-
-pub async fn read_proto<T, TSubstream>(
-    substream: &mut Framed<IoCompat<TSubstream>, LengthDelimitedCodec>,
-) -> Result<T, NetworkError>
-where
-    T: prost::Message + Default,
-    TSubstream: AsyncRead + Unpin,
-{
-    // Read from stream.
-    let data: Bytes = substream.next().await.map_or_else(
-        || Err(io::Error::from(io::ErrorKind::UnexpectedEof)),
-        |data| Ok(data?.freeze()),
-    )?;
-    // Parse to message.
-    let msg = T::decode(data)?;
-    Ok(msg)
-}

--- a/network/src/validator_network/discovery.rs
+++ b/network/src/validator_network/discovery.rs
@@ -1,0 +1,55 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protobuf based interface between Discovery and Network layers.
+use crate::{
+    error::NetworkError,
+    interface::NetworkRequest,
+    proto::DiscoveryMsg,
+    validator_network::{NetworkEvents, NetworkSender},
+    ProtocolId,
+};
+use libra_types::PeerId;
+
+pub const DISCOVERY_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/discovery/0.1.0";
+
+/// The interface from Network to Discovery module.
+///
+/// `DiscoveryNetworkEvents` is a `Stream` of `NetworkNotification` where the
+/// raw `Bytes` rpc messages are deserialized into
+/// `DiscoveryMsg` types. `DiscoveryNetworkEvents` is a thin wrapper
+/// around a `channel::Receiver<NetworkNotification>`.
+pub type DiscoveryNetworkEvents = NetworkEvents<DiscoveryMsg>;
+
+/// The interface from Discovery to Networking layer.
+///
+/// This is a thin wrapper around a `NetworkSender<Discoverymsg>`, which is
+/// in turn a thin wrapper around a `channel::Sender<NetworkRequest>`, so it is
+/// easy to clone and send off to a separate task. For example, the rpc requests
+/// return Futures that encapsulate the whole flow, from sending the request to
+/// remote, to finally receiving the response and deserializing. It therefore
+/// makes the most sense to make the rpc call on a separate async task, which
+/// requires the `DiscoveryNetworkSender` to be `Clone` and `Send`.
+#[derive(Clone)]
+pub struct DiscoveryNetworkSender {
+    inner: NetworkSender<DiscoveryMsg>,
+}
+
+impl DiscoveryNetworkSender {
+    pub fn new(inner: channel::Sender<NetworkRequest>) -> Self {
+        Self {
+            inner: NetworkSender::new(inner),
+        }
+    }
+
+    /// Send a DiscoveryMsg to a peer.
+    pub async fn send_to(&mut self, peer: PeerId, msg: DiscoveryMsg) -> Result<(), NetworkError> {
+        self.inner
+            .send_to(
+                peer,
+                ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
+                msg,
+            )
+            .await
+    }
+}

--- a/network/src/validator_network/health_checker.rs
+++ b/network/src/validator_network/health_checker.rs
@@ -16,7 +16,6 @@ use libra_types::PeerId;
 use std::time::Duration;
 
 /// Protocol id for HealthChecker RPC calls
-#[allow(dead_code)]
 pub const HEALTH_CHECKER_RPC_PROTOCOL: &[u8] = b"/libra/health-checker/rpc/0.1.0";
 
 /// The interface from Network to HealthChecker layer.
@@ -42,7 +41,6 @@ pub struct HealthCheckerNetworkSender {
 }
 
 impl HealthCheckerNetworkSender {
-    #[allow(dead_code)]
     pub fn new(inner: channel::Sender<NetworkRequest>) -> Self {
         Self {
             inner: NetworkSender::new(inner),
@@ -54,7 +52,6 @@ impl HealthCheckerNetworkSender {
     ///
     /// The rpc request can be canceled at any point by dropping the returned
     /// future.
-    #[allow(dead_code)]
     pub async fn ping(
         &mut self,
         recipient: PeerId,

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -29,6 +29,7 @@ pub mod network_builder;
 
 mod admission_control;
 mod consensus;
+mod discovery;
 mod health_checker;
 mod mempool;
 mod state_synchronizer;
@@ -44,6 +45,9 @@ pub use admission_control::{
 pub use consensus::{
     ConsensusNetworkEvents, ConsensusNetworkSender, CONSENSUS_DIRECT_SEND_PROTOCOL,
     CONSENSUS_RPC_PROTOCOL,
+};
+pub use discovery::{
+    DiscoveryNetworkEvents, DiscoveryNetworkSender, DISCOVERY_DIRECT_SEND_PROTOCOL,
 };
 pub use health_checker::{
     HealthCheckerNetworkEvents, HealthCheckerNetworkSender, HEALTH_CHECKER_RPC_PROTOCOL,
@@ -173,7 +177,6 @@ pub struct NetworkSender<TMessage: Message + Default> {
 }
 
 impl<TMessage: Message + Default> NetworkSender<TMessage> {
-    #[allow(dead_code)]
     pub fn new(inner: channel::Sender<NetworkRequest>) -> Self {
         Self {
             inner,
@@ -189,7 +192,6 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
     ///
     /// The Future will resolve to an `Err` if the event queue is unexpectedly
     /// shutdown.
-    #[allow(dead_code)]
     pub async fn send_to(
         &mut self,
         recipient: PeerId,
@@ -224,7 +226,6 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
     ///
     /// The Future will resolve to an `Err` if the event queue is unexpectedly
     /// shutdown.
-    #[allow(dead_code)]
     pub async fn send_to_many(
         &mut self,
         recipients: impl Iterator<Item = PeerId>,
@@ -253,7 +254,6 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
     /// Send a unary rpc request to remote peer `recipient`. Handles
     /// serialization and deserialization of the message types, assuming that the
     /// request and response both have the same message type.
-    #[allow(dead_code)]
     pub async fn unary_rpc(
         &mut self,
         recipient: PeerId,
@@ -284,7 +284,6 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
 
     /// Update the set of eligible nodes that the network should accept
     /// connections from.
-    #[allow(dead_code)]
     pub async fn update_eligible_nodes(
         &mut self,
         nodes: HashMap<PeerId, NetworkPublicKeys>,
@@ -296,7 +295,6 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
     }
 
     /// Dial the peer with the given `PeerId` at a `Multiaddr`.
-    #[allow(dead_code)]
     pub async fn dial_peer(&mut self, peer: PeerId, addr: Multiaddr) -> Result<(), NetworkError> {
         let (res_tx, res_rx) = oneshot::channel();
         self.inner
@@ -306,7 +304,6 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
     }
 
     /// Disconnect from the peer with the given `PeerId`.
-    #[allow(dead_code)]
     pub async fn disconnect_peer(&mut self, peer: PeerId) -> Result<(), NetworkError> {
         let (res_tx, res_rx) = oneshot::channel();
         self.inner
@@ -317,14 +314,12 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
 
     /// Unwrap the `NetworkSender` into the underlying
     /// `channel::Sender<NetworkRequest>`.
-    #[allow(dead_code)]
     pub fn into_inner(self) -> channel::Sender<NetworkRequest> {
         self.inner
     }
 
     /// Get a mutable reference to the underlying
     /// `channel::Sender<NetworkRequest>`.
-    #[allow(dead_code)]
     pub fn get_mut(&mut self) -> &mut channel::Sender<NetworkRequest> {
         &mut self.inner
     }

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -17,14 +17,11 @@ use crate::{
     peer_manager::{PeerManager, PeerManagerRequestSender},
     proto::PeerInfo,
     protocols::{
-        direct_send::DirectSend,
-        discovery::{Discovery, DISCOVERY_PROTOCOL_NAME},
-        health_checker::HealthChecker,
-        identity::Identity,
-        rpc::Rpc,
+        direct_send::DirectSend, discovery::Discovery, health_checker::HealthChecker,
+        identity::Identity, rpc::Rpc,
     },
     transport::*,
-    validator_network::HEALTH_CHECKER_RPC_PROTOCOL,
+    validator_network::{DISCOVERY_DIRECT_SEND_PROTOCOL, HEALTH_CHECKER_RPC_PROTOCOL},
     ProtocolId,
 };
 use channel;
@@ -123,7 +120,7 @@ impl NetworkBuilder {
             seed_peers: HashMap::new(),
             trusted_peers: Arc::new(RwLock::new(HashMap::new())),
             channel_size: NETWORK_CHANNEL_SIZE,
-            direct_send_protocols: vec![],
+            direct_send_protocols: vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
             rpc_protocols: vec![ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL)],
             transport: TransportType::Memory,
             discovery_interval_ms: DISCOVERY_INTERVAL_MS,
@@ -293,18 +290,11 @@ impl NetworkBuilder {
     }
 
     fn supported_protocols(&self) -> Vec<ProtocolId> {
-        let mut supported_protocols: Vec<ProtocolId> = self
-            .direct_send_protocols
+        self.direct_send_protocols
             .iter()
             .chain(&self.rpc_protocols)
             .cloned()
-            .collect();
-        // TODO: This check is performed at 2 places to modify how protocols are setup. Ideally we
-        // should do it at only 1 place.
-        if self.is_permissioned {
-            supported_protocols.push(ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME));
-        }
-        supported_protocols
+            .collect()
     }
 
     /// Enable or disable the health checker protocol in this network instance.
@@ -429,10 +419,9 @@ impl NetworkBuilder {
         self.executor.spawn(rpc.start());
         debug!("Started RPC actor");
 
-        let mut net_conn_mgr_reqs_tx = None;
-
-        // We start the discovery and connectivity_manager module only if the network is
+        // We start the connectivity_manager module only if the network is
         // permissioned.
+        let mut net_conn_mgr_reqs_tx = None;
         if self.is_permissioned {
             // Initialize and start connectivity manager.
             let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new(
@@ -457,38 +446,6 @@ impl NetworkBuilder {
             );
             self.executor.spawn(conn_mgr.start());
             debug!("Started connection manager");
-
-            // Initialize and start Discovery actor.
-            let (pm_discovery_notifs_tx, pm_discovery_notifs_rx) = channel::new(
-                self.channel_size,
-                &counters::PENDING_PEER_MANAGER_DISCOVERY_NOTIFICATIONS,
-            );
-            protocol_handlers.insert(
-                ProtocolId::from_static(DISCOVERY_PROTOCOL_NAME),
-                pm_discovery_notifs_tx.clone(),
-            );
-            peer_event_handlers.push(pm_discovery_notifs_tx);
-            let (signing_private_key, _signing_public_key) =
-                self.signing_keys.take().expect("Signing keys not set");
-            // Setup signer from keys.
-            let signer = ValidatorSigner::new(self.peer_id, signing_private_key);
-            let discovery = Discovery::new(
-                self.peer_id,
-                vec![self
-                    .advertised_address
-                    .clone()
-                    .unwrap_or_else(|| self.addr.clone())],
-                signer,
-                self.seed_peers.clone(),
-                self.trusted_peers.clone(),
-                Interval::new_interval(Duration::from_millis(self.discovery_interval_ms)).fuse(),
-                PeerManagerRequestSender::new(pm_reqs_tx.clone()),
-                pm_discovery_notifs_rx,
-                conn_mgr_reqs_tx.clone(),
-                Duration::from_millis(self.discovery_msg_timeout_ms),
-            );
-            self.executor.spawn(discovery.start());
-            debug!("Started discovery protocol actor");
         }
 
         let pm_net_reqs_tx = pm_reqs_tx.clone();
@@ -520,7 +477,7 @@ impl NetworkBuilder {
             rpc_net_notifs_rx,
             ds_reqs_tx,
             ds_net_notifs_rx,
-            net_conn_mgr_reqs_tx,
+            net_conn_mgr_reqs_tx.clone(),
             network_reqs_rx,
             network_reqs_tx,
             self.max_concurrent_network_reqs,
@@ -543,6 +500,37 @@ impl NetworkBuilder {
             debug!("Started health checker");
         }
 
+        // We start the discovery module only if the network is permissioned.
+        // Note: We use the `is_permissioned` flag as a proxy for whether we need to run the
+        // discovery module or not. We should make this more explicit eventually.
+        if self.is_permissioned {
+            // Initialize and start Discovery actor.
+            let (signing_private_key, _signing_public_key) =
+                self.signing_keys.take().expect("Signing keys not set");
+            // Setup signer from keys.
+            let signer = ValidatorSigner::new(self.peer_id, signing_private_key);
+            // Get handles for network events and sender.
+            let (discovery_network_tx, discovery_network_rx) = network_provider.add_discovery(
+                vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
+            );
+            let discovery = Discovery::new(
+                self.peer_id,
+                vec![self
+                    .advertised_address
+                    .clone()
+                    .unwrap_or_else(|| self.addr.clone())],
+                signer,
+                self.seed_peers.clone(),
+                self.trusted_peers.clone(),
+                Interval::new_interval(Duration::from_millis(self.discovery_interval_ms)).fuse(),
+                discovery_network_tx,
+                discovery_network_rx,
+                net_conn_mgr_reqs_tx.take().unwrap(),
+                Duration::from_millis(self.discovery_msg_timeout_ms),
+            );
+            self.executor.spawn(discovery.start());
+            debug!("Started discovery protocol actor");
+        }
         (listen_addr, Box::new(network_provider))
     }
 }


### PR DESCRIPTION
## Motivation
Discovery doesn't need to be a core network module and can function just fine using the external network API. It's also not useful in all cases - e.g. when we want to use LibraNet in a non-p2p setting.
See: #1516

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes

## Related PRs
#1706 