### PR TITLE
[RFC][language][vm] remove NativeStruct from ValueImpl & add borrow APIs for references

### DIFF
--- a/language/tools/cost-synthesis/src/main.rs
+++ b/language/tools/cost-synthesis/src/main.rs
@@ -223,7 +223,8 @@ macro_rules! bench_native {
                     let before = Instant::now();
                     let mut args = VecDeque::new();
                     args.push_front(Value::byte_array(stack_access.next_bytearray()));
-                    let _ = $function(args, &cost_table);
+                    // TODO: generate type arguments for generic native functions.
+                    let _ = $function(vec![], args, &cost_table);
                     acc + before.elapsed().as_nanos()
                 });
                 // Time per byte averaged over the number of iterations that we performed.

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -738,7 +738,11 @@ where
             for _ in 0..expected_args {
                 arguments.push_front(self.operand_stack.pop()?);
             }
-            let result = (native_function.dispatch)(arguments, self.gas_meter.cost_table())?;
+            let result = (native_function.dispatch)(
+                type_actual_tags,
+                arguments,
+                self.gas_meter.cost_table(),
+            )?;
             gas!(consume: self, result.cost)?;
             result.result.and_then(|values| {
                 for value in values {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
@@ -10,7 +10,7 @@ use libra_types::{
     account_address::AccountAddress,
     account_config,
     identifier::{IdentStr, Identifier},
-    language_storage::ModuleId,
+    language_storage::{ModuleId, TypeTag},
     vm_error::{StatusCode, VMStatus},
 };
 use std::collections::{HashMap, VecDeque};
@@ -60,7 +60,7 @@ impl NativeResult {
 /// Struct representing the expected definition for a native function.
 pub struct NativeFunction {
     /// Given the vector of aguments, it executes the native function.
-    pub dispatch: fn(VecDeque<Value>, &CostTable) -> VMResult<NativeResult>,
+    pub dispatch: fn(Vec<TypeTag>, VecDeque<Value>, &CostTable) -> VMResult<NativeResult>,
     /// The signature as defined in it's declaring module.
     /// It should NOT be generally inspected outside of it's declaring module as the various
     /// struct handle indexes are not remapped into the local context.
@@ -254,7 +254,7 @@ lazy_static! {
 
         // Event
         add!(m, addr, "Event", "write_to_event_store",
-            |_, _| {
+            |_, _, _| {
                 Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(
                             "write_to_event_store does not have a native implementation"
                                 .to_string()))
@@ -265,7 +265,7 @@ lazy_static! {
         );
         // LibraAccount
         add!(m, addr, "LibraAccount", "save_account",
-            |_, _| {
+            |_, _, _| {
                 Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(
                     "save_account does not have a native implementation".to_string()))
             },

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/hash.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/hash.rs
@@ -8,6 +8,7 @@ use crate::{
 use libra_crypto::HashValue;
 use libra_types::{
     byte_array::ByteArray,
+    language_storage::TypeTag,
     vm_error::{StatusCode, VMStatus},
 };
 use sha2::{Digest, Sha256};
@@ -18,6 +19,7 @@ use vm::{
 };
 
 pub fn native_sha2_256(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -36,6 +38,7 @@ pub fn native_sha2_256(
 }
 
 pub fn native_sha3_256(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/primitive_helpers.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/primitive_helpers.rs
@@ -8,6 +8,7 @@ use crate::{
 use libra_types::{
     account_address::AccountAddress,
     byte_array::ByteArray,
+    language_storage::TypeTag,
     vm_error::{StatusCode, VMStatus},
 };
 use std::collections::VecDeque;
@@ -17,6 +18,7 @@ use vm::{
 };
 
 pub fn native_bytearray_concat(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -42,6 +44,7 @@ pub fn native_bytearray_concat(
 }
 
 pub fn native_address_to_bytes(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -65,6 +68,7 @@ pub fn native_address_to_bytes(
 }
 
 pub fn native_u64_to_bytes(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/signature.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/signature.rs
@@ -13,6 +13,7 @@ use libra_crypto::{
 };
 use libra_types::{
     byte_array::ByteArray,
+    language_storage::TypeTag,
     vm_error::{StatusCode, VMStatus},
 };
 use std::{collections::VecDeque, convert::TryFrom};
@@ -45,6 +46,7 @@ const OVERSIZED_PUBLIC_KEY_SIZE_FAILURE: u64 = DEFAULT_ERROR_CODE + 8;
 const INVALID_PUBLIC_KEY_SIZE_FAILURE: u64 = DEFAULT_ERROR_CODE + 9;
 
 pub fn native_ed25519_signature_verification(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {
@@ -89,6 +91,7 @@ pub fn native_ed25519_signature_verification(
 
 /// Batch verify a collection of signatures using a bitmap for matching signatures to keys.
 pub fn native_ed25519_threshold_signature_verification(
+    _type_args: Vec<TypeTag>,
     mut arguments: VecDeque<Value>,
     cost_table: &CostTable,
 ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/def.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/def.rs
@@ -1,12 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    loaded_data::{struct_def::StructDef, types::Type},
-    native_structs::vector::NativeVector,
-};
-use serde::{ser, Deserialize, Serialize};
-use vm::gas_schedule::{AbstractMemorySize, GasCarrier};
+use crate::loaded_data::types::Type;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum NativeStructTag {
@@ -17,23 +13,6 @@ pub enum NativeStructTag {
 pub struct NativeStructType {
     pub tag: NativeStructTag,
     type_actuals: Vec<Type>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum NativeStructValue {
-    Vector(NativeVector),
-}
-
-// TODO(#1307)
-impl ser::Serialize for NativeStructValue {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: ser::Serializer,
-    {
-        match self {
-            NativeStructValue::Vector(v) => v.serialize(serializer),
-        }
-    }
 }
 
 impl NativeStructType {
@@ -49,27 +28,5 @@ impl NativeStructType {
 
     pub fn type_actuals(&self) -> &[Type] {
         &self.type_actuals
-    }
-}
-
-impl NativeStructValue {
-    pub fn size(&self) -> AbstractMemorySize<GasCarrier> {
-        match self {
-            NativeStructValue::Vector(v) => v.size(),
-        }
-    }
-
-    /// Normal code should always know what type this value has. This is made available only for
-    /// tests.
-    #[allow(non_snake_case)]
-    #[doc(hidden)]
-    pub(crate) fn to_struct_def_FOR_TESTING(&self) -> StructDef {
-        match self {
-            NativeStructValue::Vector(v) => StructDef::Native(NativeStructType::new_vec(
-                v.get(0)
-                    .map(|v| v.to_type_FOR_TESTING())
-                    .unwrap_or(Type::Bool),
-            )),
-        }
     }
 }

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/mod.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/mod.rs
@@ -4,4 +4,4 @@
 pub mod def;
 pub mod dispatch;
 pub mod vector;
-pub use def::{NativeStructType, NativeStructValue};
+pub use def::NativeStructType;

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
@@ -7,7 +7,10 @@ use crate::{
     pop_arg,
     value::{MutVal, ReferenceValue, Value},
 };
-use libra_types::vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, StatusType, VMStatus};
+use libra_types::{
+    language_storage::TypeTag,
+    vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, StatusType, VMStatus},
+};
 use serde::Serialize;
 use std::{collections::VecDeque, ops::Add};
 use vm::errors::VMResult;
@@ -48,7 +51,11 @@ macro_rules! get_vector_ref {
 }
 
 impl NativeVector {
-    pub fn native_empty(_args: VecDeque<Value>, cost_table: &CostTable) -> VMResult<NativeResult> {
+    pub fn native_empty(
+        _type_args: Vec<TypeTag>,
+        _args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
         Ok(NativeResult::ok(
             native_gas(cost_table, NativeCostIndex::EMPTY, 1),
             vec![Value::native_struct(NativeStructValue::Vector(
@@ -58,6 +65,7 @@ impl NativeVector {
     }
 
     pub fn native_length(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -73,6 +81,7 @@ impl NativeVector {
     }
 
     pub fn native_push_back(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -105,6 +114,7 @@ impl NativeVector {
     }
 
     pub fn native_borrow(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -136,7 +146,11 @@ impl NativeVector {
         }
     }
 
-    pub fn native_pop(mut args: VecDeque<Value>, cost_table: &CostTable) -> VMResult<NativeResult> {
+    pub fn native_pop(
+        _type_args: Vec<TypeTag>,
+        mut args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
         if args.len() != 1 {
             let msg = format!(
                 "wrong number of arguments for pop expected 1 found {}",
@@ -159,6 +173,7 @@ impl NativeVector {
     }
 
     pub fn native_destroy_empty(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
@@ -183,6 +198,7 @@ impl NativeVector {
     }
 
     pub fn native_swap(
+        _type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/vector.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    loaded_data::{struct_def::StructDef, types::Type},
     native_functions::dispatch::{native_gas, NativeResult},
-    native_structs::NativeStructValue,
+    native_structs::def::{NativeStructTag, NativeStructType},
     pop_arg,
     value::{MutVal, ReferenceValue, Value},
 };
 use libra_types::{
     language_storage::TypeTag,
-    vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, StatusType, VMStatus},
+    vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, VMStatus},
 };
 use serde::Serialize;
 use std::{collections::VecDeque, ops::Add};
@@ -25,20 +26,7 @@ pub const INDEX_OUT_OF_BOUNDS: u64 = NFE_VECTOR_ERROR_BASE + 1;
 pub const POP_EMPTY_VEC: u64 = NFE_VECTOR_ERROR_BASE + 2;
 pub const DESTROY_NON_EMPTY_VEC: u64 = NFE_VECTOR_ERROR_BASE + 3;
 
-#[allow(dead_code)]
-fn get_mut_vector(v: &mut NativeStructValue) -> VMResult<&mut NativeVector> {
-    match v {
-        NativeStructValue::Vector(v) => Ok(v),
-    }
-}
-
-fn get_vector(v: &NativeStructValue) -> VMResult<&NativeVector> {
-    match v {
-        NativeStructValue::Vector(v) => Ok(v),
-    }
-}
-
-macro_rules! get_vector_ref {
+macro_rules! pop_ref {
     ($args: expr) => {
         match $args.pop_front() {
             Some(v) => v.value_as::<ReferenceValue>()?,
@@ -50,49 +38,64 @@ macro_rules! get_vector_ref {
     };
 }
 
-impl NativeVector {
-    pub fn native_empty(
-        _type_args: Vec<TypeTag>,
-        _args: VecDeque<Value>,
-        cost_table: &CostTable,
-    ) -> VMResult<NativeResult> {
-        Ok(NativeResult::ok(
-            native_gas(cost_table, NativeCostIndex::EMPTY, 1),
-            vec![Value::native_struct(NativeStructValue::Vector(
-                NativeVector(vec![]),
-            ))],
-        ))
-    }
-
-    pub fn native_length(
-        _type_args: Vec<TypeTag>,
-        mut args: VecDeque<Value>,
-        cost_table: &CostTable,
-    ) -> VMResult<NativeResult> {
-        let reference: ReferenceValue = get_vector_ref!(args);
-        reference.read_native_struct(|struct_ref| {
-            get_vector(struct_ref).and_then(|native_vec| {
-                Ok(NativeResult::ok(
-                    native_gas(cost_table, NativeCostIndex::LENGTH, 1),
-                    vec![Value::u64(native_vec.0.len() as u64)],
-                ))
-            })
-        })
-    }
-
-    pub fn native_push_back(
-        _type_args: Vec<TypeTag>,
-        mut args: VecDeque<Value>,
-        cost_table: &CostTable,
-    ) -> VMResult<NativeResult> {
-        if args.len() != 2 {
+macro_rules! ensure_len {
+    ($v: expr, $expected_len: expr, $type: expr, $fn: expr) => {{
+        let actual_len = ($v).len();
+        let expected_len = $expected_len;
+        if actual_len != expected_len {
             let msg = format!(
-                "wrong number of arguments for push_back expected 2 found {}",
-                args.len()
+                "wrong number of {} for {} expected {} found {}",
+                ($type),
+                ($fn),
+                expected_len,
+                actual_len,
             );
             return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
         }
-        let reference: ReferenceValue = get_vector_ref!(args);
+    }};
+}
+
+impl NativeVector {
+    pub fn native_empty(
+        type_args: Vec<TypeTag>,
+        args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
+        ensure_len!(type_args, 1, "type arguments", "empty");
+        ensure_len!(args, 0, "arguments", "empty");
+
+        let cost = native_gas(cost_table, NativeCostIndex::EMPTY, 1);
+        let vec = NativeVector(vec![]);
+
+        Ok(NativeResult::ok(cost, vec![Value::native_vector(vec)]))
+    }
+
+    pub fn native_length(
+        type_args: Vec<TypeTag>,
+        mut args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
+        ensure_len!(type_args, 1, "type arguments", "length");
+        ensure_len!(args, 1, "arguments", "length");
+
+        let r = pop_ref!(args);
+        let v = r.borrow_as::<NativeVector>()?;
+
+        let v_len = v.0.len();
+        let cost = native_gas(cost_table, NativeCostIndex::LENGTH, 1);
+
+        Ok(NativeResult::ok(cost, vec![Value::u64(v_len as u64)]))
+    }
+
+    pub fn native_push_back(
+        type_args: Vec<TypeTag>,
+        mut args: VecDeque<Value>,
+        cost_table: &CostTable,
+    ) -> VMResult<NativeResult> {
+        ensure_len!(type_args, 1, "type arguments", "push back");
+        ensure_len!(args, 2, "arguments", "push back");
+
+        let r = pop_ref!(args);
         let elem = match args.pop_front() {
             Some(v) => MutVal::new(v),
             None => {
@@ -101,127 +104,104 @@ impl NativeVector {
                 ));
             }
         };
+
         let cost = cost_table
             .native_cost(NativeCostIndex::PUSH_BACK)
             .total()
             .mul(elem.size());
-        reference.mutate_native_struct(|struct_ref| {
-            get_mut_vector(struct_ref).and_then(|native_vec| {
-                native_vec.0.push(elem);
-                Ok(NativeResult::ok(cost, vec![]))
-            })
-        })
+
+        let mut v = r.borrow_mut_as::<NativeVector>()?;
+        v.0.push(elem);
+
+        Ok(NativeResult::ok(cost, vec![]))
     }
 
     pub fn native_borrow(
-        _type_args: Vec<TypeTag>,
+        type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
-        if args.len() != 2 {
-            let msg = format!(
-                "wrong number of arguments for borrow expected 2 found {}",
-                args.len()
-            );
-            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
-        }
-        let reference: ReferenceValue = get_vector_ref!(args);
+        ensure_len!(type_args, 1, "type arguments", "borrow");
+        ensure_len!(args, 2, "arguments", "borrow");
+
+        let r = pop_ref!(args);
         let idx = pop_arg!(args, u64);
         let cost = native_gas(cost_table, NativeCostIndex::BORROW, 1);
-        match reference.get_native_struct_reference(|struct_ref| {
-            get_vector(struct_ref).and_then(|native_vec| match native_vec.0.get(idx as usize) {
-                Some(val) => Ok(val.clone()),
-                None => Err(VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                    .with_sub_status(INDEX_OUT_OF_BOUNDS)),
-            })
-        }) {
-            Ok(val) => Ok(NativeResult::ok(cost, vec![val])),
-            Err(err) => {
-                if err.is(StatusType::InvariantViolation) {
-                    Ok(NativeResult::err(cost, err))
-                } else {
-                    Err(err)
-                }
+        let v = r.borrow_as::<NativeVector>()?;
+
+        match v.0.get(idx as usize) {
+            Some(val) => Ok(NativeResult::ok(cost, vec![r.extend_ref(val.clone())])),
+            None => {
+                let err = VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
+                    .with_sub_status(INDEX_OUT_OF_BOUNDS);
+                Ok(NativeResult::err(cost, err))
             }
         }
     }
 
     pub fn native_pop(
-        _type_args: Vec<TypeTag>,
+        type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
-        if args.len() != 1 {
-            let msg = format!(
-                "wrong number of arguments for pop expected 1 found {}",
-                args.len()
-            );
-            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
-        }
+        ensure_len!(type_args, 1, "type arguments", "pop");
+        ensure_len!(args, 1, "arguments", "pop");
 
-        let reference: ReferenceValue = get_vector_ref!(args);
+        let r = pop_ref!(args);
+        let mut v = r.borrow_mut_as::<NativeVector>()?;
         let cost = native_gas(cost_table, NativeCostIndex::POP_BACK, 1);
-        reference.mutate_native_struct(|struct_ref| {
-            get_mut_vector(struct_ref).and_then(|native_vec| match native_vec.0.pop() {
-                Some(val) => Ok(NativeResult::ok(cost, vec![val.into_value()?])),
-                None => Ok(NativeResult::err(
-                    cost,
-                    VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR).with_sub_status(POP_EMPTY_VEC),
-                )),
-            })
-        })
+
+        match v.0.pop() {
+            Some(val) => Ok(NativeResult::ok(cost, vec![val.into_value()?])),
+            None => Ok(NativeResult::err(
+                cost,
+                VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR).with_sub_status(POP_EMPTY_VEC),
+            )),
+        }
     }
 
     pub fn native_destroy_empty(
-        _type_args: Vec<TypeTag>,
+        type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
+        ensure_len!(type_args, 1, "type arguments", "destroy empty");
+        ensure_len!(args, 1, "arguments", "destroy empty");
+
         let cost = native_gas(cost_table, NativeCostIndex::DESTROY_EMPTY, 1);
-        if let Some(v) = args.pop_front() {
-            if let Ok(NativeStructValue::Vector(NativeVector(v))) =
-                v.value_as::<NativeStructValue>()
-            {
-                return if v.is_empty() {
-                    Ok(NativeResult::ok(cost, vec![]))
-                } else {
-                    Ok(NativeResult::err(
-                        cost,
-                        VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
-                            .with_sub_status(DESTROY_NON_EMPTY_VEC),
-                    ))
-                };
-            }
+        let v = args.pop_front().unwrap().value_as::<NativeVector>()?;
+
+        if v.0.is_empty() {
+            Ok(NativeResult::ok(cost, vec![]))
+        } else {
+            Ok(NativeResult::err(
+                cost,
+                VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
+                    .with_sub_status(DESTROY_NON_EMPTY_VEC),
+            ))
         }
-        Err(VMStatus::new(StatusCode::UNREACHABLE)
-            .with_message("bad arguments to destroy_empty".to_string()))
     }
 
     pub fn native_swap(
-        _type_args: Vec<TypeTag>,
+        type_args: Vec<TypeTag>,
         mut args: VecDeque<Value>,
         cost_table: &CostTable,
     ) -> VMResult<NativeResult> {
-        if args.len() != 3 {
-            let msg = format!(
-                "wrong number of arguments for swap expected 3 found {}",
-                args.len()
-            );
-            return Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(msg));
-        }
+        ensure_len!(type_args, 1, "type arguments", "swap");
+        ensure_len!(args, 3, "arguments", "swap");
 
-        let reference: ReferenceValue = get_vector_ref!(args);
-        let index1 = pop_arg!(args, u64);
-        let index2 = pop_arg!(args, u64);
+        let r = pop_ref!(args);
+        let idx1 = pop_arg!(args, u64) as usize;
+        let idx2 = pop_arg!(args, u64) as usize;
 
         let cost = native_gas(cost_table, NativeCostIndex::SWAP, 1);
 
         // We need to check the indices before performing the swap in order to make sure the
         // indices are within bounds.
-        let len = reference.read_native_struct(|struct_ref| {
-            get_vector(struct_ref).and_then(|native_vec| Ok(native_vec.0.len() as u64))
-        })?;
-        if index1 >= len || index2 >= len {
+        let mut v = r.borrow_mut_as::<NativeVector>()?;
+        let len = v.0.len();
+
+        if idx1 >= len || idx2 >= len {
             return Ok(NativeResult::err(
                 cost,
                 VMStatus::new(StatusCode::NATIVE_FUNCTION_ERROR)
@@ -229,21 +209,27 @@ impl NativeVector {
             ));
         }
 
-        reference.mutate_native_struct(|struct_ref| {
-            get_mut_vector(struct_ref).and_then(|native_vec| {
-                native_vec.0.swap(index1 as usize, index2 as usize);
-                Ok(NativeResult::ok(cost, vec![]))
-            })
-        })
-    }
-
-    pub(crate) fn get(&self, idx: u64) -> Option<MutVal> {
-        self.0.get(idx as usize).map(MutVal::clone)
+        v.0.swap(idx1, idx2);
+        Ok(NativeResult::ok(cost, vec![]))
     }
 
     pub fn size(&self) -> AbstractMemorySize<GasCarrier> {
         self.0
             .iter()
             .fold(*STRUCT_SIZE, |acc, vl| acc.map2(vl.size(), Add::add))
+    }
+
+    #[allow(non_snake_case)]
+    #[doc(hidden)]
+    pub(crate) fn to_struct_def_FOR_TESTING(&self) -> StructDef {
+        let elem_ty = self
+            .0
+            .get(0)
+            .map(|v| v.to_type_FOR_TESTING())
+            .unwrap_or(Type::Bool);
+        StructDef::Native(NativeStructType::new(
+            NativeStructTag::Vector,
+            vec![elem_ty],
+        ))
     }
 }


### PR DESCRIPTION
## Summary
Another preparation step for optimizing vector representation in the VM. This Pr
1) Gets rid of `NativeStructValue`, in favor of a flatter `ValueImpl`.
2) Introduces a new set of borrow APIs for references that replaces the `old read/mutate_native_struct`. The new model greatly simplifies the way we implement native functions for vector, and allow more reference or native types to be added easily.

## Test Plan
cargo test