### PR TITLE
[Coverage] remove duplicated llvm profiling pass

### DIFF
--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -72,18 +72,19 @@ then
 fi
 
 # Set the flags necessary for coverage output
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Zno-landing-pads -Cpasses=insert-gcov-profiling"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Zno-landing-pads"
+export RUSTC_BOOTSTRAP=1
 export CARGO_INCREMENTAL=0
 
 # Clean the project
 echo "Cleaning project..."
-(cd "$TEST_DIR"; cargo +nightly clean)
+(cd "$TEST_DIR"; cargo clean)
 
 # Run tests
 echo "Running tests..."
 while read -r line; do
         dirline=$(realpath $(dirname "$line"));
-        (cd "$dirline"; cargo +nightly xtest)
+        (cd "$dirline" && pwd && cargo xtest)
 done < <(find "$TEST_DIR" -name 'Cargo.toml')
 
 # Make the coverage directory if it doesn't exist


### PR DESCRIPTION
## Motivation
After we worked around Cargo's feature unification issue, we ended up
running the profiling pass twice.  The second pass messes up the
checksum llvm gcov was expecting.  Specifically, the checksum in .gcno 
is different from those in the test binary and the .gcda it generates.

Also added RUSTC_BOOTSTRAP=1 env var to the coverage script to use
the rustc nightly toolchain without mucking with cargo option everywhere.

## Test Plan
Tested locally with `$ scripts/coverage_report.sh client codecov --batch` 
- [Before] checksum mismatch.  Cannot compute coverage.
```
...
Generating lcov report at codecov/lcov.info...
Error in computing counters:
File checksums do not match: 1538952050 != 270294155 in debug/deps/grpcio_compiler-9e3af28a7eada719
...
...
Error in computing counters:
File checksums do not match: 1521245141 != 1162947021 in debug/deps/bindgen-d1c8b9634e53d038
...
Writing directory view page.  Coverage is computed.
Overall coverage rate:
  lines......: 0.0% (0 of 3381 lines)
  functions..: 0.0% (0 of 536 functions)
Done. Please view report at codecov/index.html
```
- [After] no checksum mismatched.  C
```
...
Reading data file codecov/lcov.info
Resolved relative source file path "language/stdlib/src/stdlib.rs" with CWD to "/Users/youngyl/workp/libra/language/stdlib/src/stdlib.rs".
Found 155 entries.
Found common filename prefix "/Users/youngyl/workp"
Writing .css and .png files.
Generating output.
...
...
Writing directory view page.
Overall coverage rate:
  lines......: 4.1% (571 of 14078 lines)
  functions..: 2.9% (120 of 4118 functions)
```