### PR TITLE
[vm] Fix caching rule for block prologue

### DIFF
--- a/language/vm/vm-runtime/src/system_txn/block_metadata_processor.rs
+++ b/language/vm/vm-runtime/src/system_txn/block_metadata_processor.rs
@@ -58,8 +58,11 @@ where
     } else {
         Err(VMStatus::new(StatusCode::MALFORMED))
     };
-    match result {
-        Ok(_) => txn_executor.transaction_cleanup(vec![]),
+    match result.and_then(|_| txn_executor.make_write_set(vec![], Ok(()))) {
+        Ok(output) => {
+            data_cache.push_write_set(output.write_set());
+            output
+        }
         Err(err) => ExecutedTransaction::discard_error_output(err),
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix the caching bug for the block prologue transaction processor: Previously after execute one block, the writeset wasn't applied to the local data cache of the VM, which resulted in some inconsistent state in the state synchronizer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This will fix the test for #1739.
