### PR TITLE
[MIRAI] Annotate panics as either unreachable or as todos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
  "libra-failure-ext 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
+ "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -99,6 +99,7 @@ pub struct ClientProxy {
     sync_on_wallet_recovery: bool,
     /// temp files (alive for duration of program)
     temp_files: Vec<PathBuf>,
+    // invariant self.address_to_ref_id.values().iter().all(|i| i < self.accounts.len())
 }
 
 impl ClientProxy {
@@ -807,8 +808,9 @@ impl ClientProxy {
                 .address_to_ref_id
                 .get(&address)
                 .expect("Should have the key");
+            // assumption follows from invariant
             let mut account_data: &mut AccountData =
-                self.accounts.get_mut(*account_ref_id).unwrap_or_else(|| panic!("Local cache not consistent, reference id {} not available in local accounts", account_ref_id));
+                self.accounts.get_mut(*account_ref_id).unwrap_or_else(|| unreachable!("Local cache not consistent, reference id {} not available in local accounts", account_ref_id));
             if account_state.0.is_some() {
                 account_data.status = AccountStatus::Persisted;
             }

--- a/common/failure-ext/failure-macros/src/lib.rs
+++ b/common/failure-ext/failure-macros/src/lib.rs
@@ -13,3 +13,13 @@ macro_rules! bail_err {
         return Err(From::from($e));
     };
 }
+
+/// Terminates the program with a panic that is tagged as being an unrecoverable error.
+/// Use this for errors that arise in correct programs due to external factors.
+/// For example, if a file that is essential for running cannot be found for some reason.
+#[macro_export]
+macro_rules! unrecoverable {
+    ($fmt:expr, $($arg:tt)+) => {{
+        panic!(concat!("unrecoverable: ", stringify!($fmt)), $($arg)+);
+    }};
+}

--- a/common/failure-ext/src/lib.rs
+++ b/common/failure-ext/src/lib.rs
@@ -19,7 +19,7 @@ pub use failure::{
 // Custom error handling macros are placed in the failure-macros crate. Due to
 // the way intra-crate macro exports currently work, macros can't be exported
 // from anywhere but the top level when they are defined in the same crate.
-pub use libra_failure_macros::bail_err;
+pub use libra_failure_macros::{bail_err, unrecoverable};
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 
@@ -27,5 +27,5 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub mod prelude {
     pub use crate::Result;
     pub use failure::{bail, ensure, err_msg, format_err, Error, Fail, ResultExt};
-    pub use libra_failure_macros::bail_err;
+    pub use libra_failure_macros::{bail_err, unrecoverable};
 }

--- a/common/metrics/src/metric_server.rs
+++ b/common/metrics/src/metric_server.rs
@@ -111,9 +111,10 @@ fn serve_public_metrics(
 }
 
 pub fn start_server(host: String, port: u16, public_metric: bool) {
+    // Only called from places that guarantee that host is parsable, but this must be assumed.
     let addr: SocketAddr = (host.as_str(), port)
         .to_socket_addrs()
-        .unwrap_or_else(|_| panic!("Failed to parse {}:{} as address", host, port))
+        .unwrap_or_else(|_| unreachable!("Failed to parse {}:{} as address", host, port))
         .next()
         .unwrap();
 

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -180,7 +180,7 @@ impl SwarmConfig {
                 network_identity_private_key,
             } = private_keys
                 .remove_entry(&peer_id)
-                .unwrap_or_else(|| panic!("Key not found for peer: {}", node_id))
+                .unwrap_or_else(|| unreachable!("Key not found for peer: {}", node_id))
                 .1;
             let network_keypairs =
                 NetworkKeyPairs::load(network_signing_private_key, network_identity_private_key);

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -240,7 +240,7 @@ impl NodeConfig {
             .iter()
             .map(|peer_id_str| {
                 (PeerId::from_str(peer_id_str).unwrap_or_else(|_| {
-                    panic!("Failed to parse peer_id from string: {}", peer_id_str)
+                    unreachable!("Failed to parse peer_id from string: {}", peer_id_str)
                 }))
             })
             .collect()

--- a/config/src/trusted_peers.rs
+++ b/config/src/trusted_peers.rs
@@ -13,7 +13,7 @@ use libra_types::{
     validator_set::ValidatorSet,
     PeerId,
 };
-use mirai_annotations::postcondition;
+use mirai_annotations::*;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
@@ -81,6 +81,7 @@ pub struct ConsensusPeersConfig {
 pub struct UpstreamPeersConfig {
     /// List of PeerIds serialized as string.
     pub upstream_peers: Vec<String>,
+    // invariant self.upstream_peers.all(|peer_id_str| { PeerId::from_str(peer_id_str) })
 }
 
 impl ConsensusPeersConfig {
@@ -123,7 +124,7 @@ impl ConsensusPeersConfig {
                 .map(|(peer_id_str, peer_info)| {
                     (
                         PeerId::from_str(peer_id_str).unwrap_or_else(|_| {
-                            panic!(
+                            unreachable!(
                                 "Failed to deserialize PeerId: {} from consensus peers config: ",
                                 peer_id_str
                             )

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -181,7 +181,7 @@ impl<T: Payload> BlockStore<T> {
                 finality_proof,
             )
             .await
-            .unwrap_or_else(|e| panic!("Failed to persist commit due to {:?}", e));
+            .unwrap_or_else(|e| unrecoverable!("Failed to persist commit due to {:?}", e));
         counters::LAST_COMMITTED_ROUND.set(block_to_commit.round() as i64);
         debug!("{}Committed{} {}", Fg(Blue), Fg(Reset), *block_to_commit);
         event!("committed",

--- a/consensus/src/chained_bft/consensusdb/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/mod.rs
@@ -45,7 +45,7 @@ impl ConsensusDB {
         let path = db_root_path.as_ref().join("consensusdb");
         let instant = Instant::now();
         let db = DB::open(path.clone(), cf_opts_map).unwrap_or_else(|e| {
-            panic!("ConsensusDB open failed due to {:?}, unable to continue", e)
+            unrecoverable!("ConsensusDB open failed due to {:?}, unable to continue", e)
         });
 
         info!(

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -311,7 +311,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
                     .into(),
             ),
         )
-        .unwrap_or_else(|e| panic!("Can not construct recovery data due to {}", e));
+        .unwrap_or_else(|e| unrecoverable!("Can not construct recovery data due to {}", e));
 
         (self as &dyn PersistentStorage<T>)
             .prune_tree(initial_data.take_blocks_to_prune())

--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -186,7 +186,7 @@ Error handling suggestions follow the [Rust book guidance](https://doc.rust-lang
 
 *Panic*
 
-* `panic!()` - Runtime panic! should only be used when the resulting state cannot be processed going forward.  It should not be used for any recoverable errors.
+* `unrecoverable!()` - Causes a panic. Should only be used when the resulting state cannot be processed going forward.
 * `unwrap()` - Unwrap should only be used for mutexes (e.g. `lock().unwrap()`) and test code.  For all other use cases, prefer `expect()`. The only exception is if the error message is custom-generated, in which case use `.unwrap_or_else(|| panic!("error: {}", foo))`
 * `expect()` - Expect should be invoked when a system invariant is expected to be preserved.  `expect()` is preferred over `unwrap()` and should contain a detailed error message on failure in most cases.
 * `assert!()` - This macro is kept in both debug/release and should be used to protect invariants of the system as necessary

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -114,7 +114,8 @@ fn parse_account_address<'input>(
         });
     }
     let addr = AccountAddress::from_hex_literal(&tokens.content()).unwrap_or_else(|_| {
-        panic!(
+        // The lexer guarantees this, but tracking it all the way to here is tedious.
+        unreachable!(
             "The address {:?} is of invalid length. Addresses are at most 32-bytes long",
             tokens.content()
         )
@@ -186,7 +187,8 @@ fn parse_copyable_val_<'input>(
         Tok::ByteArrayValue => {
             let s = tokens.content();
             let buf = ByteArray::new(hex::decode(&s[2..s.len() - 1]).unwrap_or_else(|_| {
-                panic!("The string {:?} is not a valid hex-encoded byte array", s)
+                // The lexer guarantees this, but tracking this knowledge all the way to here is tedious
+                unreachable!("The string {:?} is not a valid hex-encoded byte array", s)
             }));
             tokens.advance()?;
             CopyableVal::ByteArray(buf)

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -6,6 +6,7 @@ use bytecode_verifier::{
     VerifiedModule,
 };
 use compiler::{util, Compiler};
+use failure::prelude::*;
 use ir_to_bytecode::parser::{parse_module, parse_script};
 use libra_types::{
     access_path::AccessPath,
@@ -73,9 +74,9 @@ fn do_verify_module(module: CompiledModule, dependencies: &[VerifiedModule]) -> 
 
 fn write_output(path: &PathBuf, buf: &[u8]) {
     let mut f = fs::File::create(path)
-        .unwrap_or_else(|err| panic!("Unable to open output file {:?}: {}", path, err));
+        .unwrap_or_else(|err| unrecoverable!("Unable to open output file {:?}: {}", path, err));
     f.write_all(&buf)
-        .unwrap_or_else(|err| panic!("Unable to write to output file {:?}: {}", path, err));
+        .unwrap_or_else(|err| unrecoverable!("Unable to write to output file {:?}: {}", path, err));
 }
 
 fn main() {

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_source_map::source_map::ModuleSourceMap;
+use failure::prelude::*;
 use ir_to_bytecode::{
     compiler::compile_module,
     parser::{ast::Loc, parse_module},
@@ -16,7 +17,7 @@ pub fn do_compile_module<T: ModuleAccess>(
     dependencies: &[T],
 ) -> (CompiledModule, ModuleSourceMap<Loc>) {
     let source = fs::read_to_string(source_path)
-        .unwrap_or_else(|_| panic!("Unable to read file: {:?}", source_path));
+        .unwrap_or_else(|_| unrecoverable!("Unable to read file: {:?}", source_path));
     let parsed_module = parse_module(&source).unwrap();
     compile_module(address, parsed_module, dependencies).unwrap()
 }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -38,6 +38,7 @@ use libra_types::{
     language_storage::ModuleId,
     vm_error::{StatusCode, VMStatus},
 };
+use mirai_annotations::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 #[cfg(any(test, feature = "fuzzing"))]
@@ -1608,7 +1609,9 @@ impl CompiledModuleMut {
             // XXX these two don't seem to belong here
             other @ IndexKind::LocalPool
             | other @ IndexKind::CodeDefinition
-            | other @ IndexKind::TypeParameter => panic!("invalid kind for count: {:?}", other),
+            | other @ IndexKind::TypeParameter => {
+                unreachable!("invalid kind for count: {:?}", other)
+            }
         }
     }
 

--- a/language/vm/src/views.rs
+++ b/language/vm/src/views.rs
@@ -218,10 +218,6 @@ impl<'a, T: ModuleAccess> StructHandleView<'a, T> {
         &self.struct_handle.type_formals
     }
 
-    pub fn definition(&self) -> StructDefinitionView<'a, T> {
-        unimplemented!("this requires linking")
-    }
-
     pub fn module_handle(&self) -> &ModuleHandle {
         self.module.module_handle_at(self.struct_handle.module)
     }

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -100,7 +100,8 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             .iter()
             .map(|peer_id_str| {
                 PeerId::from_str(peer_id_str).unwrap_or_else(|_| {
-                    panic!("Failed to parse peer_id from string: {}", peer_id_str)
+                    // invariant of UpstreamPeersConfig
+                    unreachable!("Failed to parse peer_id from string: {}", peer_id_str)
                 })
             })
             .collect();

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -380,7 +380,7 @@ impl InternalNode {
             let only_child_index = Nibble::from(range_existence_bitmap.trailing_zeros() as u8);
             self.child(only_child_index)
                 .unwrap_or_else(|| {
-                    panic!(
+                    unrecoverable!(
                         "Corrupted internal node: existence_bitmap indicates \
                          the existence of a non-exist child at index {:x}",
                         only_child_index
@@ -458,7 +458,8 @@ impl InternalNode {
                         let only_child_version = self
                             .child(only_child_index)
                             .unwrap_or_else(|| {
-                                panic!(
+                                // Should be guaranteed by the self invariants, but these are not easy to express at the moment
+                                unrecoverable!(
                                     "Corrupted internal node: child_bitmap indicates \
                                      the existence of a non-exist child at index {:x}",
                                     only_child_index

--- a/storage/jellyfish-merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/mod.rs
@@ -213,7 +213,7 @@ where
         let root_node_key = self.get_root_node_key();
         let root_hash = self
             .get_node(root_node_key)
-            .unwrap_or_else(|_| panic!("Root node with key {:?} must exist", root_node_key))
+            .unwrap_or_else(|_| unreachable!("Root node with key {:?} must exist", root_node_key))
             .hash();
         self.frozen_cache.root_hashes.push(root_hash);
         self.frozen_cache.node_cache.extend(self.node_cache.drain());

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -136,7 +136,7 @@ impl LibraDB {
         let instant = Instant::now();
         let db = Arc::new(
             DB::open(path.clone(), cf_opts_map)
-                .unwrap_or_else(|e| panic!("LibraDB open failed: {:?}", e)),
+                .unwrap_or_else(|e| unrecoverable!("LibraDB open failed: {:?}", e)),
         );
 
         info!(

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -148,7 +148,8 @@ impl SparseMerkleTree {
         loop {
             let next_node = if let Node::Internal(node) = &*current_node.read_lock() {
                 let bit = bits.next().unwrap_or_else(|| {
-                    panic!("Tree is deeper than {} levels.", HashValue::LENGTH_IN_BITS)
+                    // invariant of HashValueBitIterator
+                    unreachable!("Tree is deeper than {} levels.", HashValue::LENGTH_IN_BITS)
                 });
                 bits_on_path.push(bit);
                 if bit {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4.7", default-features = false, features = ["clock"] }
 hex = { version = "0.3.2", default-features = false }
 itertools = { version = "0.8.0", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
+mirai-annotations = "1.5.0"
 proptest = { version = "0.9.4", default-features = false, optional = true }
 proptest-derive = { version = "0.1.2", default-features = false, optional = true }
 prost = "0.5.0"

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -49,6 +49,7 @@ use failure::prelude::*;
 use hex;
 use lazy_static::lazy_static;
 use libra_crypto::hash::{CryptoHash, HashValue};
+use mirai_annotations::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use radix_trie::TrieKey;
@@ -102,6 +103,7 @@ impl fmt::Display for Access {
 /// Non-empty sequence of field accesses
 #[derive(Eq, Hash, Serialize, Deserialize, Debug, Clone, PartialEq, Ord, PartialOrd)]
 pub struct Accesses(Vec<Access>);
+// invariant self.0.len() == 1
 
 /// SEPARATOR is used as a delimiter between fields. It should not be a legal part of any identifier
 /// in the language
@@ -137,6 +139,7 @@ impl Accesses {
 
     /// Return the last access in the sequence
     pub fn last(&self) -> &Access {
+        assume!(self.0.last().is_some()); // follows from invariant
         self.0.last().unwrap() // guaranteed not to fail because sequence is non-empty
     }
 

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -24,6 +24,7 @@
 //! Note3: The leaf index starting from left-most leaf, starts from 0
 
 use crate::proof::definition::{LeafCount, MAX_ACCUMULATOR_LEAVES, MAX_ACCUMULATOR_PROOF_DEPTH};
+use mirai_annotations::*;
 use std::fmt;
 
 #[cfg(test)]
@@ -89,11 +90,13 @@ impl Position {
 
     /// What is the left node of this node? Will overflow if the node is a leaf
     pub fn left_child(self) -> Self {
+        checked_precondition!(!self.is_leaf());
         Self::child(self, NodeDirection::Left)
     }
 
     /// What is the right node of this node? Will overflow if the node is a leaf
     pub fn right_child(self) -> Self {
+        checked_precondition!(!self.is_leaf());
         Self::child(self, NodeDirection::Right)
     }
 


### PR DESCRIPTION
## Motivation

MIRAI complains about reachable panics. There a good reasons for this because panics are pretty pervasive and are often unexpected and indicate programming mistakes if they are reached.

This PR fixes some calls to panic! to instead be calls to unreachable!, as already suggested in the coding guidelines.

The remaining panics are replaced by a new macro unrecoverable! which just calls panic but prepends the tag "unrecoverable: " to the message. This makes it possible for MIRAI to not warn about these panics and should also make it easier to make sense of panics that show up in logs.

This PR only addressed panics that are currently complained about by MIRAI. There are many more, but I want to keep this PR as small as possible.

There a small number of additional annotations to satisfy MIRAI as well as some comments to help the reader understand why certain panics are in fact unreachable.

I've also removed an unimplemented method. It is not used and keeping it around is both a trap and another cause for a MIRAI message.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo xtest
