### PR TITLE
[Consensus] Verify SyncInfo on demand

### DIFF
--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -64,11 +64,7 @@ impl<T: Payload> ProposalUncheckedSignatures<T> {
         if let Some(tc) = self.0.sync_info.highest_timeout_certificate() {
             tc.verify(validator).map_err(|e| format_err!("{:?}", e))?;
         }
-        // verify the QC signatures of sync_info
-        self.0
-            .sync_info
-            .verify(validator)
-            .map_err(|e| format_err!("{:?}", e))?;
+        // Note that we postpone the verification of SyncInfo until it's being used.
         // return proposal
         Ok(self.0)
     }

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -56,8 +56,10 @@ impl VoteMsg {
             self.vote().epoch() == self.sync_info.epoch(),
             "VoteMsg has different epoch"
         );
-        self.vote().verify(validator)?;
-        self.sync_info.verify(validator)
+        // We're not verifying SyncInfo here yet: we are going to verify it only in case we need
+        // it. This way we avoid verifying O(n) SyncInfo messages while aggregating the votes
+        // (O(n^2) signature verifications).
+        self.vote().verify(validator)
     }
 }
 

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -602,7 +602,11 @@ fn process_timeout_certificate_test() {
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(vec![1], 1, 1, genesis_qc.clone(), &node.signer);
     let block_skip_round = Block::new_proposal(vec![1], 2, 2, genesis_qc.clone(), &node.signer);
-    let tc = TimeoutCertificate::new(Timeout::new(1, 1), HashMap::new());
+    let timeout = Timeout::new(1, 1);
+    let timeout_signature = timeout.sign(&node.signer);
+
+    let mut tc = TimeoutCertificate::new(timeout, HashMap::new());
+    tc.add_signature(node.author, timeout_signature);
 
     block_on(async move {
         let skip_round_proposal = ProposalMsg::<TestPayload>::new(

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -429,13 +429,7 @@ impl<T: Payload> NetworkTask<T> {
         let sync_info = SyncInfo::try_from(sync_info)?;
         match sync_info.epoch().cmp(&self.epoch) {
             Ordering::Equal => {
-                sync_info.verify(self.validators.as_ref()).map_err(|e| {
-                    security_log(SecurityEvent::InvalidSyncInfoMsg)
-                        .error(&e)
-                        .data(&sync_info)
-                        .log();
-                    e
-                })?;
+                // SyncInfo verification is postponed to the moment it's actually used.
                 self.sync_info_tx.push(peer_id, (sync_info, peer_id))
             }
             Ordering::Less | Ordering::Greater => self


### PR DESCRIPTION
Summary:
We used to verify SyncInfo for every incoming messages.
That would incur O(n^2) signature verifications for the vote aggregators in every round, because every vote would carry a SyncInfo with the QCs.
The performance cost of such verification was high and had a visible impact on throughput and latency.

In this diff we're postponing the verification of SyncInfo to a later stage in `EventProcessor::sync_up()` function.
One "unintended" change in this commit is the more explicit way of resetting consensus state during the epoch change.
We used to call the `process_certificate()` function indiscriminatory, and when I changed it to be called only for QCs that are higher than the local,
the epoch transition stopped working: it needed the `SafetyRules::update()` call. Moved the epoch change code of SafetyRules to a separate `start_new_epoch()` function,
but in general I find it kinda fragile. May be we should make consensus state epoch aware (keep a pair of (epoch, round) instead of just round)? That way we wouldn't depend on these reset functions.

Testing: unit tests
