### PR TITLE
[cluster-test] Fail cluster test if performance step failed

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -555,6 +555,18 @@ impl ClusterTestRunner {
                 return;
             }
             if let Some(hash_to_tag) = hash_to_tag.take() {
+                info!("Starting measure_performance");
+                let report = match self.measure_performance() {
+                    Ok(report) => report,
+                    Err(e) => {
+                        self.report_failure(format!("{}", e));
+                        return;
+                    }
+                };
+                let perf_msg = format!(
+                    "Performance report:\n```\n{}\n```",
+                    report.to_slack_message()
+                );
                 info!("Test suite succeed first time for `{}`", hash_to_tag);
                 let prev_commit = self
                     .deployment_manager
@@ -570,16 +582,6 @@ impl ClusterTestRunner {
                         return;
                     }
                     Ok(upstream_commit) => upstream_commit,
-                };
-                let perf_msg = match self.measure_performance() {
-                    Ok(report) => format!(
-                        "Performance report:\n```\n{}\n```",
-                        report.to_slack_message()
-                    ),
-                    Err(err) => {
-                        warn!("No performance data: {}", err);
-                        "No performance data".to_string()
-                    }
                 };
                 info!(
                     "prev_commit: {:?}, upstream_commit: {}",


### PR DESCRIPTION
Cluster test used to not fail if performance evaluation stage failed, and just reported it as 'No performance data'

This diff change it - if perf step fails, or if validators fail to recover after this step, cluster test will fail and won't tag image as nightly_tested
