### PR TITLE
refactored state sync Prometheus metrics

### DIFF
--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -2,44 +2,80 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lazy_static;
-use libra_metrics::{DurationHistogram, OpMetrics};
-use prometheus::{IntCounter, IntGauge};
+use libra_metrics::DurationHistogram;
+use prometheus::{IntCounter, IntCounterVec, IntGauge};
 
 lazy_static::lazy_static! {
-    pub static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("state_sync");
-}
+    /// Number of sync requests sent from a node
+    pub static ref REQUESTS_SENT: IntCounterVec = register_int_counter_vec!(
+        // metric name
+        "libra_state_sync_requests_sent_total",
+        // metric description
+        "Number of sync requests sent from a node",
+        // metric labels
+        &["requested_peer_id"]
+    ).unwrap();
 
-/// Number of sync requests sent from a node
-pub const REQUESTS_SENT: &str = "requests_sent";
+    /// Number of sync responses a node received
+    pub static ref RESPONSES_RECEIVED: IntCounterVec = register_int_counter_vec!(
+        "libra_state_sync_responses_received_total",
+        "Number of sync responses a node received",
+        &["response_sender_id"]
+    ).unwrap();
 
-/// Number of sync responses a node received
-pub const RESPONSES_RECEIVED: &str = "responses_received";
+    /// Number of Success results of applying a chunk
+    pub static ref APPLY_CHUNK_SUCCESS: IntCounterVec = register_int_counter_vec!(
+        "libra_state_sync_apply_chunk_success_total",
+        "Number of Success results of applying a chunk",
+        &["chunk_sender_id"]
+    ).unwrap();
 
-/// Number of Success results of applying a chunk
-pub const APPLY_CHUNK_SUCCESS: &str = "apply_chunk_success";
+    /// Number of failed attempts to apply a chunk
+    pub static ref APPLY_CHUNK_FAILURE: IntCounterVec = register_int_counter_vec!(
+        "libra_state_sync_apply_chunk_failure_total",
+        "Number of failed attempts to apply a chunk",
+        &["chunk_sender_id"]
+    ).unwrap();
 
-/// Number of failed attempts to apply a chunk
-pub const APPLY_CHUNK_FAILURE: &str = "apply_chunk_failure";
+    /// Count the overall number of transactions state synchronizer has retrieved since last restart.
+    /// Large values mean that a node has been significantly behind and had to replay a lot of txns.
+    pub static ref STATE_SYNC_TXN_REPLAYED: IntCounter = register_int_counter!(
+        "libra_state_sync_txns_replayed_total",
+        "Number of transactions the state synchronizer has retrieved since last restart"
+    ).unwrap();
 
-lazy_static::lazy_static! {
-/// Count the overall number of transactions state synchronizer has retrieved since last restart.
-/// Large values mean that a node has been significantly behind and had to replay a lot of txns.
-pub static ref STATE_SYNC_TXN_REPLAYED: IntCounter = OP_COUNTERS.counter("state_sync_txns_replayed");
+    /// Number of peers that are currently active and upstream.
+    /// They are the set of nodes a node can make sync requests to
+    pub static ref ACTIVE_UPSTREAM_PEERS: IntGauge = register_int_gauge!(
+        "libra_state_sync_active_upstream_peers",
+        "Number of upstream peers that are currently active"
+    ).unwrap();
 
-/// Number of peers that are currently active and upstream.
-/// They are the set of nodes a node can make sync requests to
-pub static ref ACTIVE_UPSTREAM_PEERS: IntGauge = OP_COUNTERS.gauge("active_upstream_peers");
+    /// Most recent version that has been committed
+    pub static ref COMMITTED_VERSION: IntGauge = register_int_gauge!(
+        "libra_state_sync_committed_version",
+        "Most recent version that has been committed"
+    ).unwrap();
 
-/// Most recent version that has been committed
-pub static ref COMMITTED_VERSION: IntGauge = OP_COUNTERS.gauge("committed_version");
+    /// How long it takes to make progress, from requesting a chunk to processing the response and
+    /// committing the block
+    pub static ref SYNC_PROGRESS_DURATION: DurationHistogram = DurationHistogram::new(
+        register_histogram!(
+            "libra_state_sync_sync_progress_duration_s",
+            "Histogram of time it takes to sync a chunk, from requesting a chunk to processing the response and committing the block"
+        )
+        .unwrap()
+    );
 
-/// How long it takes to make progress, from requesting a chunk to processing the response and
-/// committing the block
-pub static ref SYNC_PROGRESS_DURATION: DurationHistogram = OP_COUNTERS.duration_histogram("sync_progress_duration");
+    /// Version a node is trying to catch up to
+    pub static ref TARGET_VERSION: IntGauge = register_int_gauge!(
+        "libra_state_sync_target_version",
+        "Version a node is trying to catch up to"
+    ).unwrap();
 
-/// Version a node is trying to catch up to
-pub static ref TARGET_VERSION: IntGauge = OP_COUNTERS.gauge("target_version");
-
-/// Number of timeouts that occur during sync
-pub static ref TIMEOUT: IntCounter = OP_COUNTERS.counter("timeout");
+    /// Number of timeouts that occur during sync
+    pub static ref TIMEOUT: IntCounter = register_int_counter!(
+        "libra_state_sync_timeout_total",
+        "Number of timeouts that occur during sync"
+    ).unwrap();
 }

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -3,6 +3,10 @@
 //! Used to perform catching up between nodes for committed states.
 //! Used for node restarts, network partitions, full node syncs
 #![recursion_limit = "1024"]
+
+#[macro_use]
+extern crate prometheus;
+
 use libra_types::{account_address::AccountAddress, crypto_proxies::LedgerInfoWithSignatures};
 
 pub use synchronizer::{StateSyncClient, StateSynchronizer};

--- a/terraform/templates/dashboards/state_sync.json
+++ b/terraform/templates/dashboards/state_sync.json
@@ -620,7 +620,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libra_state_sync_timeout",
+          "expr": "libra_state_sync_timeout_total",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/terraform/templates/dashboards/state_sync.json
+++ b/terraform/templates/dashboards/state_sync.json
@@ -74,7 +74,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "state_sync_gauge{op=\"active_upstream_peers\"}",
+          "expr": "libra_state_sync_active_upstream_peers",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -165,7 +165,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(state_sync{op=~'apply_chunk_success.*'}, 'chunk_sender_id', '$1', 'op', 'apply_chunk_success.(.*)')",
+          "expr": "libra_state_sync_apply_chunk_success_total",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}: {{chunk_sender_id}}",
@@ -254,7 +254,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(state_sync{op=~'apply_chunk_failure.*'}, 'chunk_sender_id', '$1', 'op', 'apply_chunk_failure.(.*)')",
+          "expr": "libra_state_sync_apply_chunk_failure_total",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}: {{chunk_sender_id}}",
@@ -355,7 +355,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "state_sync_gauge{op=\"committed_version\"}",
+          "expr": "libra_state_sync_committed_version",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -444,7 +444,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "state_sync_duration_sum{op=\"sync_progress_duration\"}",
+          "expr": "libra_state_sync_sync_progress_duration_s",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -532,7 +532,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "state_sync_gauge{op=\"target_version\"}",
+          "expr": "libra_state_sync_target_version",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -620,7 +620,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "state_sync{op=\"timeout\"}",
+          "expr": "libra_state_sync_timeout",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -709,7 +709,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "state_sync{op=\"state_sync_txns_replayed\"}",
+          "expr": "libra_state_sync_txns_replayed_total",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -810,7 +810,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(state_sync{op=~'requests_sent.*'}, 'requested_peer_id', '$1', 'op', 'requests_sent.(.*)')",
+          "expr": "libra_state_sync_requests_sent_total",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}} : {{requested_peer_id}}",
@@ -898,7 +898,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(state_sync{op=~'responses_received.*'}, 'response_sender_id', '$1', 'op', 'responses_received.(.*)')",
+          "expr": "libra_state_sync_responses_received_total",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}} : {{response_sender_id}}",


### PR DESCRIPTION
## Summary

Refactor Prometheus metrics for state sync
- follow better naming practices (https://prometheus.io/docs/practices/naming/)
- stop using `OP_COUNTERS`
- use `IntCounterVec` to better handle labels (instead of direct string manipulation)
- prefix each counter with `libra_state_sync_`
- Update all calls to state sync counters with new names

