### PR TITLE
[state sync] enforce chunk_size = 1 in smoke tests

### DIFF
--- a/testsuite/tests/libratest/configs/node.config.toml
+++ b/testsuite/tests/libratest/configs/node.config.toml
@@ -1,0 +1,14 @@
+# Defaults are now set in config.rs
+[[networks]]
+seed_peers_file = ""  # For direct validation of this file
+network_keypairs_file = ""  # For direct validation of this file
+network_peers_file = ""  # For direct validation of this file
+role = "validator"
+
+[consensus]
+consensus_keypair_file = "" # For direct validation of this file
+consensus_peers_file = ""  # For direct validation of this file
+
+[state_sync]
+chunk_limit = 1
+upstream_peers = []

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -30,12 +30,13 @@ impl TestEnvironment {
     fn new(num_validators: usize) -> Self {
         ::libra_logger::init_for_e2e_testing();
         let faucet_key = generate_keypair::load_faucet_key_or_create_default(None);
+        let template_path = "testsuite/tests/libratest/configs/node.config.toml".to_string();
         let validator_swarm = LibraSwarm::configure_swarm(
             num_validators,
             RoleType::Validator,
             faucet_key.0.clone(),
             None,
-            None,
+            Some(template_path),
             None,
         )
         .unwrap();


### PR DESCRIPTION
## Motivation

follow up on https://github.com/libra/libra/issues/1720
it's quite tricky to catch it in state sync unit-tests because tests there use executor mock
our smoke_test coverage is sufficient, except it uses default chunk size of 1000
this PR introduces separate default configuration for smoke tests,
that enforces chunk_size for state sync to be set to 1


### Have you read the [Contributing Guidelines on pull requests]
Yes

## Test Plan
Existing coverage
Manually added print statements to state synchronizer to verify it actually performs multiple chunk requests during `test_basic_state_synchronization` test

