### PR TITLE
[network][bug] Always advertise discovery and HealthChecker protocols

### DIFF
--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -274,12 +274,16 @@ impl NetworkBuilder {
     /// Set the protocol IDs that DirectSend actor subscribes.
     pub fn direct_send_protocols(&mut self, protocols: Vec<ProtocolId>) -> &mut Self {
         self.direct_send_protocols = protocols;
+        self.direct_send_protocols
+            .push(ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL));
         self
     }
 
     /// Set the protocol IDs that RPC actor subscribes.
     pub fn rpc_protocols(&mut self, protocols: Vec<ProtocolId>) -> &mut Self {
         self.rpc_protocols = protocols;
+        self.rpc_protocols
+            .push(ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL));
         self
     }
 


### PR DESCRIPTION

## Motivation
After the refactoring to move Discovery and HealthChecker to application layer, we were no longer advertising them in our PeerManager supported protocols, causing requests to open substreams for these protocols to fail.

This PR always adds Discovery and HealthChecker protocols to advertised DirectSend and RPC protocols lists respectively. This is a temporary hack while we simplify the process of adding protocols to the network layer.