### PR TITLE
[language][verifier] disallow generic resources in storage

### DIFF
--- a/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_global.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_global.mvir
@@ -14,3 +14,5 @@ module M {
         return;
     }
 }
+
+// check: TYPE_ERROR

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_global_mut.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/borrow_global_mut.mvir
@@ -1,0 +1,12 @@
+module M {
+    resource Foo<T: unrestricted> { x: T }
+
+    f(): u64 {
+        let foo_ref: &mut Self.Foo<u64>;
+        foo_ref = borrow_global_mut<Foo<u64>>(0x100);
+        _ = move(foo_ref);
+        return;
+    }
+}
+
+// check: TYPE_ERROR

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/exists.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/exists.mvir
@@ -1,0 +1,11 @@
+module M {
+    resource Foo<T> { x: T }
+
+    exists_foo_u64(): bool {
+        let b: bool;
+        b = exists<Foo<u64>>();
+        return move(b);
+    }
+}
+
+// check: TYPE_ERROR

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/move_from.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/move_from.mvir
@@ -8,4 +8,4 @@ module M {
     }
 }
 
-// check: RET_UNSAFE_TO_DESTROY_ERROR
+// check: TYPE_ERROR

--- a/language/functional_tests/tests/testsuite/generics/resource_safety/move_to_sender.mvir
+++ b/language/functional_tests/tests/testsuite/generics/resource_safety/move_to_sender.mvir
@@ -1,0 +1,10 @@
+module M {
+    resource Foo<T> { x: T }
+
+    f()  {
+        move_to_sender<Foo<u64>>(Foo<u64> { x: 42 });
+        return;
+    }
+}
+
+// check: TYPE_ERROR

--- a/language/functional_tests/tests/testsuite/payments/print_counterfeit_money.mvir
+++ b/language/functional_tests/tests/testsuite/payments/print_counterfeit_money.mvir
@@ -1,0 +1,53 @@
+//! account: default, 100000
+
+module M {
+    import 0x0.LibraCoin;
+    import 0x0.LibraAccount;
+
+    resource R<T: resource> { x: T }
+    resource FakeCoin { value: u64 }
+
+    fetch<T: resource>(): T acquires R {
+        let r: Self.R<T>;
+        let t: T;
+        r = move_from<R<T>>(get_txn_sender());
+        R<T> { x: t } = move(r);
+        return move(t);
+    }
+
+    store<T: resource>(x: T) {
+        move_to_sender<R<T>>(R<T> { x: move(x) });
+        return;
+    }
+
+    transmute<T1: resource, T2: resource>(x: T1): T2 acquires R {
+        Self.store<T1>(move(x));
+        return Self.fetch<T2>();
+    }
+
+    public become_rich() acquires R {
+        let fake: Self.FakeCoin;
+        let real: LibraCoin.T;
+
+        fake = FakeCoin { value: 400000 };
+        real = Self.transmute<Self.FakeCoin, LibraCoin.T>(move(fake));
+
+        LibraAccount.deposit(get_txn_sender(), move(real));
+
+        return;
+    }
+}
+
+//! new-transaction
+import {{default}}.M;
+import 0x0.LibraAccount;
+
+main() {
+    M.become_rich();
+    assert(LibraAccount.balance(get_txn_sender()) == 500000, 42);
+    return;
+}
+
+// check: TYPE_ERROR
+// check: TYPE_ERROR
+// check: LINKER_ERROR


### PR DESCRIPTION
## Summary
Right now we don't support generic resources in storage and this PR makes the verifier error on such cases. 

## Test Plan
New test added. 
```
cargo test
```