### PR TITLE
Added support for running Boogie/Z3 on move-prover tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "functional_tests 0.1.0",
  "ir-to-bytecode 0.1.0",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/move-prover/bytecode-to-boogie/Cargo.toml
+++ b/language/move-prover/bytecode-to-boogie/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 functional_tests = { path = "../../functional_tests", version = "0.1.0" }
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
+libra-tools = { path = "../../../common/tools", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }

--- a/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
@@ -5,12 +5,13 @@ use bytecode_source_map::source_map::SourceMap;
 use bytecode_to_boogie::translator::BoogieTranslator;
 use bytecode_verifier::VerifiedModule;
 use ir_to_bytecode::{compiler::compile_module, parser::ast::Loc, parser::parse_module};
+use libra_tools::tempdir::TempPath;
 use libra_types::account_address::AccountAddress;
-use std::fs;
+use std::{env, fs, process::Command};
 use stdlib::{stdlib_modules, stdlib_source_map};
 
 // mod translator;
-fn compile_files(file_names: Vec<String>) -> (Vec<VerifiedModule>, SourceMap<Loc>) {
+fn compile_files(file_names: Vec<&str>) -> (Vec<VerifiedModule>, SourceMap<Loc>) {
     let mut verified_modules = stdlib_modules().to_vec();
     let mut source_maps = stdlib_source_map().to_vec();
     let files_len = file_names.len();
@@ -38,11 +39,9 @@ fn compile_files(file_names: Vec<String>) -> (Vec<VerifiedModule>, SourceMap<Loc
     (verified_modules, source_maps)
 }
 
-#[test]
-fn test3() {
+fn generate_boogie(file_name: &str) -> String {
     let mut file_names = vec![];
-    let name = "test_mvir/test3.mvir".to_string();
-    file_names.push(name);
+    file_names.push(file_name);
     let (modules, source_maps) = compile_files(file_names.to_vec());
 
     let mut ts = BoogieTranslator::new(&modules, &source_maps);
@@ -52,87 +51,57 @@ fn test3() {
     let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
     res.push_str(&written_code);
     res.push_str(&ts.translate());
-    // This is probably too sensitive to minor changes in libra; commenting for now.
-    //    let expected_code = fs::read_to_string("test_mvir/test3.bpl.expect").unwrap();
-    //    assert_eq!(res, expected_code);
+    res
+}
+
+fn run_boogie(boogie_str: &str) {
+    let temp_path = TempPath::new();
+    temp_path.create_as_dir().unwrap();
+    let boogie_file_path = temp_path.path().join("output.bpl");
+    fs::write(&boogie_file_path, boogie_str).unwrap();
+    if let Ok(boogie_path) = env::var("BOOGIE_EXE") {
+        if let Ok(z3_path) = env::var("Z3_EXE") {
+            let status = Command::new(boogie_path)
+                .args(&[
+                    &format!("{}{}", "-z3exe:", z3_path).as_str(),
+                    "-doModSetAnalysis",
+                    "-noinfer",
+                    "-noVerify",
+                    boogie_file_path.to_str().unwrap(),
+                ])
+                .status()
+                .expect("failed to execute Boogie");
+            assert!(status.success());
+        }
+    }
+}
+
+#[test]
+fn test3() {
+    run_boogie(&generate_boogie("test_mvir/test3.mvir"));
 }
 
 #[test]
 fn test_arithmetic() {
-    let mut file_names = vec![];
-    let name = "test_mvir/test-arithmetic.mvir".to_string();
-    file_names.push(name);
-    let (modules, source_maps) = compile_files(file_names.to_vec());
-
-    let mut ts = BoogieTranslator::new(&modules, &source_maps);
-    let mut res = String::new();
-
-    // handwritten boogie code
-    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
-    res.push_str(&written_code);
-    res.push_str(&ts.translate());
+    run_boogie(&generate_boogie("test_mvir/test-arithmetic.mvir"));
 }
 
 #[test]
 fn test_control_flow() {
-    let mut file_names = vec![];
-    let name = "test_mvir/test-control-flow.mvir".to_string();
-    file_names.push(name);
-    let (modules, source_maps) = compile_files(file_names.to_vec());
-
-    let mut ts = BoogieTranslator::new(&modules, &source_maps);
-    let mut res = String::new();
-
-    // handwritten boogie code
-    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
-    res.push_str(&written_code);
-    res.push_str(&ts.translate());
+    run_boogie(&generate_boogie("test_mvir/test-control-flow.mvir"));
 }
 
 #[test]
 fn test_func_call() {
-    let mut file_names = vec![];
-    let name = "test_mvir/test-func-call.mvir".to_string();
-    file_names.push(name);
-    let (modules, source_maps) = compile_files(file_names.to_vec());
-
-    let mut ts = BoogieTranslator::new(&modules, &source_maps);
-    let mut res = String::new();
-
-    // handwritten boogie code
-    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
-    res.push_str(&written_code);
-    res.push_str(&ts.translate());
+    run_boogie(&generate_boogie("test_mvir/test-func-call.mvir"));
 }
 
 #[test]
 fn test_reference() {
-    let mut file_names = vec![];
-    let name = "test_mvir/test-reference.mvir".to_string();
-    file_names.push(name);
-    let (modules, source_maps) = compile_files(file_names.to_vec());
-
-    let mut ts = BoogieTranslator::new(&modules, &source_maps);
-    let mut res = String::new();
-
-    // handwritten boogie code
-    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
-    res.push_str(&written_code);
-    res.push_str(&ts.translate());
+    run_boogie(&generate_boogie("test_mvir/test-reference.mvir"));
 }
 
 #[test]
 fn test_struct() {
-    let mut file_names = vec![];
-    let name = "test_mvir/test-struct.mvir".to_string();
-    file_names.push(name);
-    let (modules, source_maps) = compile_files(file_names.to_vec());
-
-    let mut ts = BoogieTranslator::new(&modules, &source_maps);
-    let mut res = String::new();
-
-    // handwritten boogie code
-    let written_code = fs::read_to_string("src/bytecode_instrs.bpl").unwrap();
-    res.push_str(&written_code);
-    res.push_str(&ts.translate());
+    run_boogie(&generate_boogie("test_mvir/test-struct.mvir"));
 }


### PR DESCRIPTION
##  Motivation
This PR adds preliminary support for running the Boogie/Z3 on the output of bytecode to Boogie translator.  To run with Boogie/Z3, set BOOGIE_EXE and Z3_EXE to the path to Boogie and Z3 executables, respectively.  If either of these paths is not found, the generated output is not verified.  Currently, Boogie is run with -noVerify option which means that only type checking is done.  The test fails if Boogie does not return success status. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.  Manually verified that Boogie/Z3 run as expected.

## Related PRs