### PR TITLE
[State sync] Tmp reduce chunk size limit to 250

### DIFF
--- a/config/data/configs/single.node.config.toml
+++ b/config/data/configs/single.node.config.toml
@@ -68,7 +68,7 @@ mempool_service_port = 6182
 address = "localhost"
 
 [state_sync]
-chunk_limit = 1000
+chunk_limit = 250
 tick_interval_ms = 100
 long_poll_timeout_ms = 30000
 max_chunk_limit = 1000

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -25,7 +25,7 @@ pub struct StateSyncConfig {
 impl Default for StateSyncConfig {
     fn default() -> Self {
         Self {
-            chunk_limit: 1000,
+            chunk_limit: 250,
             tick_interval_ms: 100,
             long_poll_timeout_ms: 30000,
             max_chunk_limit: 1000,


### PR DESCRIPTION
To unblock cluster testing, issuing a tmp chunk size reduction.

ref #1782 