### PR TITLE
[CI] Filter out aux crates in code coverage report

### DIFF
--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -96,7 +96,7 @@ fi
 
 # Generate lcov report
 echo "Generating lcov report at ${COVERAGE_DIR}/lcov.info..."
-grcov target -t lcov  --llvm --branch --ignore "/*" -o "$COVERAGE_DIR/lcov.info"
+grcov target -t lcov  --llvm --branch --ignore "/*" --ignore "x/*" --ignore "testsuite/*" -o "$COVERAGE_DIR/lcov.info"
 
 # Generate HTML report
 echo "Generating report at ${COVERAGE_DIR}..."


### PR DESCRIPTION
## Motivation
Filter out aux crates (x, testsuite) from the coverage report.

## Test Plan
Canaried 2111f31 in https://app.circleci.com/jobs/github/libra/libra/17729

Verified the aux are excluded from coverage report.
![image](https://user-images.githubusercontent.com/7528420/69200898-75532200-0af1-11ea-9a01-b0f1f7466525.png)