### PR TITLE
[State Synchronizer] Use a single storage request when syncing local …

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -325,7 +325,7 @@ where
                             state.version + 1,
                         )
                     }),
-                    ledger_info.timestamp_usecs(),
+                    ledger_info.ledger_info().timestamp_usecs(),
                 )
             }
             None => {

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -30,11 +30,11 @@ type PeerId = AccountAddress;
 /// the accumulator is ahead of the LedgerInfo.
 ///
 /// While `highest_local_li` can be used for helping the others (corresponding to the highest
-/// version we have a proof for), `highest_committed_version` is used for retrieving missing chunks
+/// version we have a proof for), `highest_synced_version` is used for retrieving missing chunks
 /// for the local storage.
 pub struct SynchronizerState {
     pub highest_local_li: LedgerInfoWithSignatures,
-    pub highest_committed_version: u64,
+    pub highest_synced_version: u64,
 }
 
 impl SynchronizerState {
@@ -45,7 +45,7 @@ impl SynchronizerState {
         );
         Self {
             highest_local_li,
-            highest_committed_version: 0,
+            highest_synced_version: 0,
         }
     }
 
@@ -53,7 +53,7 @@ impl SynchronizerState {
     pub fn highest_version_in_local_storage(&self) -> u64 {
         std::cmp::max(
             self.highest_local_li.ledger_info().version(),
-            self.highest_committed_version,
+            self.highest_synced_version,
         )
     }
 }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -111,12 +111,12 @@ impl ExecutorProxyTrait for MockExecutorProxy {
     fn get_local_storage_state(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<SynchronizerState>> + Send>> {
-        let highest_committed_version = self.storage.read().unwrap().version;
-        let highest_local_li = Self::mock_ledger_info(self.peer_id, highest_committed_version);
+        let highest_synced_version = self.storage.read().unwrap().version;
+        let highest_local_li = Self::mock_ledger_info(self.peer_id, highest_synced_version);
         async move {
             Ok(SynchronizerState {
                 highest_local_li,
-                highest_committed_version,
+                highest_synced_version,
             })
         }
             .boxed()
@@ -291,7 +291,7 @@ impl SynchronizerEnv {
         let max_retries = 30;
         for _ in 0..max_retries {
             let state = block_on(self.clients[peer_id].get_state()).unwrap();
-            if state.highest_committed_version == target_version {
+            if state.highest_synced_version == target_version {
                 return true;
             }
             std::thread::sleep(std::time::Duration::from_millis(1000));

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -31,7 +31,6 @@ use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
     crypto_proxies::LedgerInfoWithSignatures,
-    ledger_info::LedgerInfo,
     proof::SparseMerkleProof,
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
@@ -359,7 +358,7 @@ impl From<TreeState> for crate::proto::storage::TreeState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StartupInfo {
-    pub ledger_info: LedgerInfo,
+    pub ledger_info: LedgerInfoWithSignatures,
     pub committed_tree_state: TreeState,
     pub synced_tree_state: Option<TreeState>,
 }

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -118,7 +118,7 @@ message StartupInfo {
     // The latest committed LedgerInfo. Note that at start up storage can have more
     // transactions than the latest committed LedgerInfo indicates due to an incomplete
     // start up sync.
-    types.LedgerInfo ledger_info = 1;
+    types.LedgerInfoWithSignatures ledger_info = 1;
 
     // The latest committed tree state matching the ledger info above.
     TreeState committed_tree_state = 2;


### PR DESCRIPTION
…state with storage

Summary:
The only reason state synchronizer could not use `StartupInfo` for syncing its local state was becase
`StartupInfo` didn't keep the signatures of the `LedgerInfo`.
In this change we're adding the signatures to `StartupInfo` and changing the `get_local_storage_state()` functionality to have a single storage call.

Testing: existing unit test coverage

Issues: ref #899