### PR TITLE
[full node] add metrics for full node dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "libra-types 0.1.0",
  "network 0.1.0",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -18,6 +18,7 @@ num_cpus = "1.10.1"
 lazy_static = "1.3.0"
 rand = "0.6.5"
 tokio = "=0.2.0-alpha.6"
+prometheus = { version = "0.7.0", default-features = false }
 
 admission-control-proto = { path = "../admission-control-proto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/admission_control/admission-control-service/src/counters.rs
+++ b/admission_control/admission-control-service/src/counters.rs
@@ -1,0 +1,72 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use lazy_static;
+use prometheus::{HistogramVec, IntCounterVec};
+
+lazy_static::lazy_static! {
+    // Number of transactions that admission control proxied up to upstream peer
+    //
+    // The 'success' of a transaction proxy is defined from a networking perspective, where the
+    // transaction is submitted to the upstream peer, receives a valid SubmitTransactionResponse,
+    // and callback to the downstream peer that initially sent this transaction submission request
+    // is also successful (i.e. no timeout)
+    //
+    // Thus, a transaction submission response from the upstream peer that states that
+    // the transaction was rejected by the upstream peer, would still be considered a
+    // successful transaction proxy
+    pub static ref TRANSACTION_PROXY: IntCounterVec = register_int_counter_vec!(
+        "libra_admission_control_transaction_proxy_count",
+        "Number of transactions a full node proxied up to upstream peer",
+        &[
+            // role of this node
+            "role",
+            // role of the node that sent the txn submission request to this node: client or FN
+            "sender_role",
+            // result of the txn proxy: success, failure
+            "state",
+        ]
+    ).unwrap();
+
+    // Number of transactions that admission control submits to mempool
+    pub static ref TRANSACTION_SUBMISSION: IntCounterVec = register_int_counter_vec!(
+        "libra_admission_control_transaction_submission_count",
+        "Number of transactions AC in validator node tries to submit to mempool",
+        &[
+            // state of the transaction: accepted, rejected
+            "state",
+            // if the txn submission failed, the cause of rejection. "" for successful txn submission
+            "rejection_cause",
+        ]
+    ).unwrap();
+
+    // Number of timeouts that happen when admission control handles transaction submission
+    // requests. Timeout can happen while waiting for a response from upstream peer
+    // or callback to the node that sent the submission request to this node
+    pub static ref TIMEOUT: IntCounterVec = register_int_counter_vec!(
+        "libra_admission_control_timeout_count",
+        "Number of timeouts that happen when AC handles transaction submissions",
+        &[
+            // role of this node: validator, full_node
+            "role",
+            // role of the node that sent the txn submission request to this node: client or FN
+            "sender_role",
+            // type of timeout: "timeout", "callback_timeout"
+            "state",
+        ]
+    ).unwrap();
+
+    // The time it takes for admission control to handle a transaction submission request, from when
+    // it sends the transaction to mempool or upstream peer (depending on its role), to when the
+    // callback to the downstream peer finishes
+    pub static ref TRANSACTION_LATENCY: HistogramVec = register_histogram_vec!(
+        "libra_admission_control_transaction_submission_latency_s",
+        "Histogram of time it takes for admission control to handle a transaction submission request",
+        &[
+            // role of this node: validator, full_node
+            "role",
+            // result of the transaction handling: success, failure
+            "state",
+        ]
+    ).unwrap();
+}

--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -11,6 +11,9 @@
 //! 1. SubmitTransaction, to submit transaction to associated validator.
 //! 2. UpdateToLatestLedger, to query storage, e.g. account state, transaction log, and proofs.
 
+#[macro_use]
+extern crate prometheus;
+
 #[cfg(test)]
 #[path = "unit_tests/admission_control_service_test.rs"]
 mod admission_control_service_test;
@@ -20,6 +23,7 @@ mod admission_control_service_test;
 pub mod admission_control_fuzzing;
 /// AC gRPC service.
 pub mod admission_control_service;
+mod counters;
 #[cfg(feature = "fuzzing")]
 /// Useful Mocks
 pub mod mocks;
@@ -27,12 +31,6 @@ pub mod mocks;
 pub mod runtime;
 /// Handler for sending transaction write requests upstream if needed
 mod upstream_proxy;
-use lazy_static::lazy_static;
-use libra_metrics::OpMetrics;
 
 use libra_types::account_address::AccountAddress;
 type PeerId = AccountAddress;
-
-lazy_static! {
-    static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("admission_control");
-}


### PR DESCRIPTION
## Summary

Adding new metrics to be used for full node grafana dashboard. In the process, also refactored and pulled in old admission control metrics using `OP_COUNTERS` to new metrics prefixed with `libra_admission_control_`

Some existing metrics can be used for FN dashboard. New counters were added to track metrics not handled by existing metrics. 

**New metrics:**
- `libra_admission_control_` metrics are for tracking the success/failure/timeout/latency of handling txn submission requests in AC

**Existing metrics:** 
- use existing `SVC_COUNTER` to track read/write qps in admission control service (https://github.com/libra/libra/blob/master/admission_control/admission-control-service/src/admission_control_service.rs#L86)
- use existing `LIBRA_NETWORK_PEERS` counter to track number of connected FN peers (https://github.com/libra/libra/blob/master/network/src/peer_manager/mod.rs#L285)
- use existing `libra_state_sync_committed_version` to track version of FN (for read queries) (https://github.com/libra/libra/blob/master/state-synchronizer/src/counters.rs#L56)
