### PR TITLE
[consensus] adding some checks to process proposal

### DIFF
--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -68,10 +68,6 @@ impl<T: Payload> ProposalUncheckedSignatures<T> {
         // return proposal
         Ok(self.0)
     }
-
-    pub fn epoch(&self) -> u64 {
-        self.0.proposal.epoch()
-    }
 }
 
 impl<T: Payload> ProposalMsg<T> {

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -388,7 +388,7 @@ fn test_network_api() {
             let v = r.votes.next().await.unwrap();
             assert_eq!(v, vote_msg);
         }
-        nodes[4].broadcast_proposal(proposal.clone()).await;
+        nodes[0].broadcast_proposal(proposal.clone()).await;
         playground
             .wait_for_messages(4, NetworkPlayground::take_all)
             .await;


### PR DESCRIPTION
Currently, when we receive a proposal from Alice we:

* do not check if the proposal's author is Alice
* do not verify the signature if the epoch is not the current epoch

This PR fixes both.

