### PR TITLE
[cluster-test] Limit gzip run time to 45sec

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -982,7 +982,7 @@ impl ClusterTestRunner {
                         .ok();
                     instance
                         .run_cmd_tee_err(vec![format!(
-                            "test -f {f} && sudo gzip -S {s} {f}",
+                            "! test -f {f} || (sudo timeout 45 gzip -S {s} {f} || (echo gzip failed; sudo rm -f {f}))",
                             f = log_file,
                             s = suffix
                         )])


### PR DESCRIPTION
If file is very large gzip can take insane amount of time, at this point we might as well just delete log and continue
Also fix test to not emit error when file does not exist.
