### PR TITLE
[cluster-test] Resolve tag in --deploy

### DIFF
--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -58,7 +58,6 @@ impl DeploymentManager {
             .image_digest_by_tag(TESTED_TAG)
             .expect("Failed to get image digest for TESTED_TAG");
         if hash == last_tested {
-            info!("Last deployed digest matches latest digest we expect, not doing redeploy");
             return None;
         }
         Some(hash)

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -196,9 +196,13 @@ pub fn main() {
 
     let mut runner = ClusterTestRunner::setup(&args);
 
-    if let Some(ref deploy_hash) = args.deploy {
+    if let Some(ref hash_or_tag) = args.deploy {
         // Deploy deploy_hash before running whatever command
-        exit_on_error(runner.redeploy(deploy_hash));
+        let hash = runner
+            .deployment_manager
+            .resolve(hash_or_tag)
+            .expect("Failed to resolve tag");
+        exit_on_error(runner.redeploy(&hash));
     }
 
     if args.run {


### PR DESCRIPTION
Currently `deploy` requires hash of image, with this change it can accept either hash or tag
