### PR TITLE
[consensus] adding some checks to process proposal

### DIFF
--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -388,7 +388,7 @@ fn test_network_api() {
             let v = r.votes.next().await.unwrap();
             assert_eq!(v, vote_msg);
         }
-        nodes[4].broadcast_proposal(proposal.clone()).await;
+        nodes[0].broadcast_proposal(proposal.clone()).await;
         playground
             .wait_for_messages(4, NetworkPlayground::take_all)
             .await;


### PR DESCRIPTION
Currently, when we receive a proposal from Alice we do not check if the proposal's author is Alice.
This PR fixes it.
