### PR TITLE
[cluster-test] Three region simulation

### DIFF
--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -8,6 +8,7 @@ mod remove_network_effects;
 mod stop_container;
 
 use failure;
+pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;
 pub use reboot::Reboot;

--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -12,52 +12,51 @@ use std::time::Duration;
 
 pub struct NetworkDelay {
     instance: Instance,
-    target_instances: Option<Vec<Instance>>,
-    delay: Duration,
+    // A vector of a pair of (delay, instance list)
+    // Applies delay to each instance in the instance list
+    configuration: Vec<(Vec<Instance>, Duration)>,
 }
 
 impl NetworkDelay {
-    pub fn new(
-        instance: Instance,
-        target_instances: Option<Vec<Instance>>,
-        delay: Duration,
-    ) -> Self {
+    pub fn new(instance: Instance, configuration: Vec<(Vec<Instance>, Duration)>) -> Self {
         Self {
             instance,
-            target_instances,
-            delay,
+            configuration,
         }
     }
 }
 
 impl Effect for NetworkDelay {
     fn activate(&self) -> failure::Result<()> {
-        info!(
-            "NetworkDelay {}ms for {}",
-            self.delay.as_millis(),
-            self.instance
-        );
+        info!("Injecting NetworkDelays for {}", self.instance);
         let mut command = "".to_string();
-        if let Some(target_instances) = &self.target_instances {
-            command += "sudo tc qdisc delete dev eth0 root; ";
-            // Create a HTB https://linux.die.net/man/8/tc-htb
-            command += "sudo tc qdisc add dev eth0 root handle 1: htb; ";
+        command += "sudo tc qdisc delete dev eth0 root; ";
+        // Create a HTB https://linux.die.net/man/8/tc-htb
+        command += "sudo tc qdisc add dev eth0 root handle 1: htb; ";
+        for i in 0..self.configuration.len() {
             // Create a class within the HTB https://linux.die.net/man/8/tc
-            command += "sudo tc class add dev eth0 parent 1: classid 1:1 htb rate 1tbit; ";
-            // Create u32 filters so that all the target instances are classified as class 1:1
-            // http://man7.org/linux/man-pages/man8/tc-u32.8.html
-            for target_instance in target_instances {
-                command += format!("sudo tc filter add dev eth0 parent 1: protocol ip prio 1 u32 flowid 1:1 match ip dst {}; ", target_instance.ip()).as_str();
-            }
-            // Use netem to delay packets to this class
             command += format!(
-                "sudo tc qdisc add dev eth0 parent 1:1 handle 10: netem delay {}ms; ",
-                self.delay.as_millis()
+                "sudo tc class add dev eth0 parent 1: classid 1:{} htb rate 1tbit; ",
+                i + 1
             )
             .as_str();
-        } else {
-            // If there are no target instances, add netem to the root qdisc
-            command = format!("sudo tc qdisc delete dev eth0 root; sudo tc qdisc add dev eth0 root netem delay {}ms; ", self.delay.as_millis());
+        }
+        for i in 0..self.configuration.len() {
+            // Create u32 filters so that all the target instances are classified as class 1:(i+1)
+            // http://man7.org/linux/man-pages/man8/tc-u32.8.html
+            for target_instance in &self.configuration[i].0 {
+                command += format!("sudo tc filter add dev eth0 parent 1: protocol ip prio 1 u32 flowid 1:{} match ip dst {}; ", i+1, target_instance.ip()).as_str();
+            }
+        }
+        for i in 0..self.configuration.len() {
+            // Use netem to delay packets to this class
+            command += format!(
+                "sudo tc qdisc add dev eth0 parent 1:{} handle {}0: netem delay {}ms; ",
+                i + 1,
+                i + 1,
+                self.configuration[i].1.as_millis(),
+            )
+            .as_str();
         }
         self.instance.run_cmd(vec![command])
     }
@@ -70,11 +69,40 @@ impl Effect for NetworkDelay {
 
 impl fmt::Display for NetworkDelay {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "NetworkDelay {}ms from {}",
-            self.delay.as_millis(),
-            self.instance
-        )
+        write!(f, "NetworkDelay from {}", self.instance)
     }
+}
+
+/// three_region_simulation_effects returns the list of NetworkDelays which need to be applied to
+/// all the instances in the cluster.
+/// `regions` is a 3-tuple consisting of the list of instances in each region
+/// `delays_bw_regions` is a 3-tuple consisting of the one-way delays between pairs of regions
+/// delays_bw_regions.0 is the delay b/w regions 1 & 2, delays_bw_regions.1 is the delay b/w regions 0 & 2, etc
+pub fn three_region_simulation_effects(
+    regions: (Vec<Instance>, Vec<Instance>, Vec<Instance>),
+    delays_bw_regions: (Duration, Duration, Duration),
+) -> Vec<NetworkDelay> {
+    let mut result = vec![];
+    for instance in &regions.0 {
+        let configuration = vec![
+            (regions.1.clone(), delays_bw_regions.2),
+            (regions.2.clone(), delays_bw_regions.1),
+        ];
+        result.push(NetworkDelay::new(instance.clone(), configuration));
+    }
+    for instance in &regions.1 {
+        let configuration = vec![
+            (regions.0.clone(), delays_bw_regions.2),
+            (regions.2.clone(), delays_bw_regions.0),
+        ];
+        result.push(NetworkDelay::new(instance.clone(), configuration));
+    }
+    for instance in &regions.2 {
+        let configuration = vec![
+            (regions.1.clone(), delays_bw_regions.0),
+            (regions.0.clone(), delays_bw_regions.1),
+        ];
+        result.push(NetworkDelay::new(instance.clone(), configuration));
+    }
+    result
 }

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -84,8 +84,7 @@ impl MultiRegionSimulation {
             .map(|instance| {
                 NetworkDelay::new(
                     instance.clone(),
-                    Some(larger_region.clone()),
-                    cross_region_delay,
+                    vec![(larger_region.clone(), cross_region_delay)],
                 )
             })
             .collect();


### PR DESCRIPTION
## Summary

* Simulate 3 regions in cluster-test cluster us_west(40%), us_east(40%), eu(20%)
* RTT latency b/w us_west<->eu: 190ms; us_west<->us_east: 80ms; us_east<->eu: 120ms;
* Update NetworkDelay effect so that we can apply different delays to different instances
* Create a `fn three_region_simulation_effects` which outputs the list of NetworkDelays which need to be applied to all the instances in the cluster
* Update slack message

## Test Plan

Ran it on my cluster

```
all up: 532 TPS, 1.4 s latency
10% down: 292 TPS, 2.5 s latency
3 region simulation: 394 TPS, 2.0 s latency
```