### PR TITLE
Change AC to point to fullnodes

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -16,7 +16,7 @@ use structopt::StructOpt;
 )]
 struct Args {
     /// Admission Control port to connect to.
-    #[structopt(short = "p", long, default_value = "8000")]
+    #[structopt(short = "p", long, default_value = "8001")]
     pub port: NonZeroU16,
     /// Host address/name to connect to.
     #[structopt(short = "a", long)]
@@ -160,8 +160,8 @@ mod tests {
     #[test]
     fn test_args_port() {
         let args = Args::from_iter(&["test", "--host=h", "--validator-set-file=vsf"]);
-        assert_eq!(args.port.get(), 8000);
-        assert_eq!(format!("{}:{}", args.host, args.port.get()), "h:8000");
+        assert_eq!(args.port.get(), 8001);
+        assert_eq!(format!("{}:{}", args.host, args.port.get()), "h:8001");
         let args = Args::from_iter(&[
             "test",
             "--port=65535",

--- a/config/data/configs/single.node.config.toml
+++ b/config/data/configs/single.node.config.toml
@@ -12,7 +12,7 @@ genesis_file_location = "genesis.blob"
 
 [admission_control]
 address = "0.0.0.0"
-admission_control_service_port = 8000
+admission_control_service_port = 8001
 need_to_check_mempool_before_validation = false
 max_concurrent_inbound_syncs = 100
 

--- a/config/src/config/admission_control_config.rs
+++ b/config/src/config/admission_control_config.rs
@@ -18,7 +18,7 @@ impl Default for AdmissionControlConfig {
     fn default() -> AdmissionControlConfig {
         AdmissionControlConfig {
             address: "0.0.0.0".to_string(),
-            admission_control_service_port: 8000,
+            admission_control_service_port: 8001,
             need_to_check_mempool_before_validation: false,
             max_concurrent_inbound_syncs: 100,
             upstream_proxy_timeout: Duration::from_secs(1),

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,4 +10,4 @@ This directory contains [Docker](https://www.docker.com/) configuration and scri
 4. To test the validator image locally, run `docker/validator/run.sh`
 5. To test the faucet server image locally, run `docker/mint/run.sh`
 6. Run the client as follows:
-   `cargo run -p client --bin client -- -a localhost -p 8000 -f localhost:8080 -s terraform/validator-sets/dev/consensus_peers.config.toml`
+   `cargo run -p client --bin client -- -a localhost -p 8001 -f localhost:8080 -s terraform/validator-sets/dev/consensus_peers.config.toml`

--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -29,7 +29,7 @@ COPY --from=builder /libra/target/release/client /opt/libra/bin/libra_client
 COPY scripts/cli/consensus_peers.config.toml /opt/libra/etc/consensus_peers.config.toml
 
 ENTRYPOINT ["/opt/libra/bin/libra_client"]
-CMD ["--host", "ac.testnet.libra.org", "--port", "8000", "-s", "/opt/libra/etc/consensus_peers.config.toml"]
+CMD ["--host", "ac.testnet.libra.org", "--port", "8001", "-s", "/opt/libra/etc/consensus_peers.config.toml"]
 
 ARG BUILD_DATE
 ARG GIT_REV

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host ac.testnet.libra.org --port 8000 -s $SCRIPT_PATH/consensus_peers.config.toml"
+RUN_PARAMS="--host ac.testnet.libra.org --port 8001 -s $SCRIPT_PATH/consensus_peers.config.toml"
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since now fullnodes are deployed, switch AC to point to fullnodes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Fullnodes already deployed in our workspaces, start client and connect to fullnodes:
```
cargo run -p client --bin client -- -a ac.dev.aws.hlw3truzy4ls.com -p 8001 -f faucet.dev.aws.hlw3truzy4ls.com -s terraform/validator-sets/dev/consensus_peers.config.toml
```
Successfully connected to the nodes:
```
     Running `target/debug/client -a ac.dev.aws.hlw3truzy4ls.com -p 8001 -f faucet.dev.aws.hlw3truzy4ls.com -s terraform/validator-sets/dev/consensus_peers.config.toml`
Connected to validator at: ac.dev.aws.hlw3truzy4ls.com:8001
usage: <command> <args>

Use the following commands:

account | a
        Account operations
query | q
        Query operations
transfer | transferb | t | tb
        <sender_account_address>|<sender_account_ref_id> <receiver_account_address>|<receiver_account_ref_id> <number_of_coins> [gas_unit_price_in_micro_libras (default=0)] [max_gas_amount_in_micro_libras (default 140000)] Suffix 'b' is for blocking.
        Transfer coins (in libra) from account to another.
help | h
        Prints this help
quit | q!
        Exit this client


Please, input commands:

libra%
```