### PR TITLE
[consensus] fix potential problems of reconfig

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -156,7 +156,7 @@ where
             HashValue::zero(),
             ledger_info.transaction_accumulator_hash(),
             ledger_info.version(),
-            ledger_info.timestamp_usecs(),
+            0,
             None,
         );
 
@@ -170,7 +170,7 @@ where
             ),
         );
 
-        let block_data = BlockData::new_genesis(ledger_info.timestamp_usecs(), genesis_quorum_cert);
+        let block_data = BlockData::new_genesis(0, genesis_quorum_cert);
 
         Block {
             id: block_data.hash(),

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -18,6 +18,7 @@ use consensus_types::{
 use failure;
 use libra_logger::prelude::*;
 use libra_types::account_address::AccountAddress;
+use libra_types::validator_change::ValidatorChangeEventWithProof;
 use mirai_annotations::checked_precondition;
 use rand::{prelude::*, Rng};
 use std::{
@@ -173,6 +174,14 @@ impl<T: Payload> BlockStore<T> {
         // ensure it's [b1, b2]
         blocks.reverse();
         self.rebuild(root, blocks, quorum_certs).await;
+        if highest_ledger_info.ends_epoch() {
+            retriever
+                .network
+                .broadcast_epoch_change(ValidatorChangeEventWithProof::new(vec![
+                    highest_ledger_info.ledger_info().clone(),
+                ]))
+                .await;
+        }
         Ok(())
     }
 }

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -123,7 +123,10 @@ impl<T: Payload> RecoveryData<T> {
     }
 
     pub fn last_vote(&self) -> Option<Vote> {
-        self.last_vote.clone()
+        match &self.last_vote {
+            Some(v) if v.epoch() == self.epoch => Some(v.clone()),
+            _ => None,
+        }
     }
 
     pub fn take(
@@ -143,7 +146,10 @@ impl<T: Payload> RecoveryData<T> {
     }
 
     pub fn highest_timeout_certificate(&self) -> Option<TimeoutCertificate> {
-        self.highest_timeout_certificate.clone()
+        match &self.highest_timeout_certificate {
+            Some(tc) if tc.epoch() == self.epoch => Some(tc.clone()),
+            _ => None,
+        }
     }
 
     /// Finds the root (last committed block) and returns the root block, the QC to the root block


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
This change fixes three problems:
- non-deterministic genesis deriviation due to block timestamp
- not advance epoch if sync up to the boundary
- RecoveryData potentially exposes different epoch data

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests, I need to figure out a systematic way to test such cases.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
