### PR TITLE
[cluster-test] Move experiments params under --

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -5,8 +5,10 @@ mod multi_region_network_simulation;
 mod packet_loss_random_validators;
 mod reboot_random_validator;
 
-pub use multi_region_network_simulation::MultiRegionSimulation;
-pub use packet_loss_random_validators::PacketLossRandomValidators;
+pub use multi_region_network_simulation::{MultiRegionSimulation, MultiRegionSimulationParams};
+pub use packet_loss_random_validators::{
+    PacketLossRandomValidators, PacketLossRandomValidatorsParams,
+};
 pub use reboot_random_validator::RebootRandomValidators;
 use std::time::Duration;
 use std::{collections::HashSet, fmt::Display};


### PR DESCRIPTION
This allows to reduce amount of code in main.rs and removes experiment specific params from main structopt
New way of running experiments
```
cluster-test --workplace cluster-test --multi-region-simulation -- --splits 10 20
```