### PR TITLE
[Storage] Add iterater interface for state store

### DIFF
--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use failure::prelude::*;
 use jellyfish_merkle::{
+    iterator::JellyfishMerkleIterator,
     node_type::{LeafNode, Node, NodeKey},
     JellyfishMerkleTree, TreeReader,
 };
@@ -96,6 +97,17 @@ impl StateStore {
             .collect::<Result<Vec<()>>>()?;
 
         Ok(new_root_hash_vec)
+    }
+
+    /// Returns an iterator that yields all accounts from left to right that is not less than
+    /// `starting_key`, one entry at a time, at given version.
+    #[allow(dead_code)]
+    pub fn iter_accounts<'a>(
+        &'a self,
+        version: Version,
+        starting_key: HashValue,
+    ) -> Result<JellyfishMerkleIterator<'a, Self>> {
+        JellyfishMerkleIterator::new(self, version, starting_key)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This change adds an interface that returns an iterator of accounts. The HTTP server for backup will use this iterator to send back responses.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

CI.

## Related PRs

None.
