### PR TITLE
[cluster-test] Add ConnectTimeout and ConnectionAttempts to ssh

### DIFF
--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -51,6 +51,8 @@ impl Instance {
             "-i",
             "/libra_rsa",
             "-oStrictHostKeyChecking=no",
+            "-oConnectTimeout=3",
+            "-oConnectionAttempts=10",
             ssh_dest.as_str(),
         ];
         let mut ssh_cmd = Command::new("timeout");


### PR DESCRIPTION
## Summary

I've frequently seen ssh fail with connection timeouts. This adds 10 Connection Attempts with a ConnectTimeout of 3 seconds on every attempt.

## Test Plan

Ran on my dev cluster