### PR TITLE
[cluster-test] Refactor perf benchmarks in cluster-test into Experiments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,10 +627,10 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-failure-ext 0.1.0",
  "libra-types 0.1.0",
+ "libra-util 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ec2 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ecr 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2301,6 +2301,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-util"
+version = "0.1.0"
+
+[[package]]
 name = "libra-wallet"
 version = "0.1.0"
 dependencies = [
@@ -3623,14 +3627,6 @@ dependencies = [
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "retry"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5866,7 +5862,6 @@ dependencies = [
 "checksum rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "01916ebd9fc2e81978a5dc9542a2fa47f5bb2ca3402e14c7cc42d6e3c5123e1f"
 "checksum rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82260d54cf2cbe9608df161f7e7c98e81fae702aa13af9e4d5d39dc2ffb25ab6"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
-"checksum retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ac83b31b3831aa4b07608db4170f6555ab12942197037c38570dc4c5ba5028"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rmp 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f594cb7ff8f1c5a7907f6be91f15795c8301e0d5718eb007fb5832723dd716e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "common/proptest-helpers",
     "common/prost-ext",
     "common/tools",
+    "common/util",
     "config",
     "config/config-builder",
     "config/generate-keypair",

--- a/common/util/Cargo.toml
+++ b/common/util/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libra-util"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra libra-util"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"

--- a/common/util/src/lib.rs
+++ b/common/util/src/lib.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{thread::sleep, time::Duration};
+use std::iter::Take;
+
+/// Given an operation retries it successfully sleeping everytime it fails
+/// If the operation succeeds before the iterator runs out, it returns success
+pub fn retry<I, O, T, E>(iterable: I, mut operation: O) -> Result<T, E>
+where
+    I: IntoIterator<Item = Duration>,
+    O: FnMut() -> Result<T, E>,
+{
+    let mut iterator = iterable.into_iter();
+    loop {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if let Some(delay) = iterator.next() {
+                    sleep(delay);
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+    }
+}
+
+pub fn fixed_retry_strategy(delay_ms: u64, tries: usize) -> Take<FixedDelay> {
+    FixedDelay::new(delay_ms).take(tries)
+}
+
+/// An iterator which uses a fixed delay
+pub struct FixedDelay {
+    duration: Duration,
+}
+
+impl FixedDelay {
+    /// Create a new `FixedDelay` using the given duration in milliseconds.
+    fn new(millis: u64) -> Self {
+        FixedDelay {
+            duration: Duration::from_millis(millis),
+        }
+    }
+}
+
+impl Iterator for FixedDelay {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        Some(self.duration)
+    }
+}

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -15,7 +15,6 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["pr
 itertools = "0.8.0"
 rand = "0.6.5"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
-retry = { version = "0.5.1" }
 reqwest = { version="0.9.19", features=["rustls-tls"], default_features = false }
 rusoto_core = {version = "0.41.0", features=["rustls"], default_features = false}
 rusoto_ec2 = {version = "0.41.0", features=["rustls"], default_features = false}
@@ -35,6 +34,7 @@ slog-envlogger = "2.1.0"
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
 admission-control-proto = { path = "../../admission_control/admission-control-proto", version = "0.1.0" }
+util = { path = "../../common/util", version = "0.1.0", package = "libra-util" }
 
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -3,7 +3,6 @@
 
 use crate::{aws::Aws, cluster::Cluster};
 use failure::prelude::{bail, format_err};
-use retry::{delay::Fixed, retry};
 use rusoto_core::RusotoError;
 use rusoto_ecr::{
     BatchGetImageRequest, DescribeImagesRequest, DescribeImagesResponse, Ecr, Image,
@@ -208,7 +207,7 @@ impl DeploymentManager {
         get_request.repository_name = repository.to_string();
         get_request.image_ids = vec![image_id.clone()];
         // Retry upto 10 times, waiting 10 sec between retries
-        let response = retry(Fixed::from_millis(10_000).take(10), || {
+        let response = util::retry(util::fixed_retry_strategy(10_000, 10), || {
             self.aws
                 .ecr()
                 .batch_get_image(get_request.clone())

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -7,15 +7,16 @@ mod reboot;
 mod remove_network_effects;
 mod stop_container;
 
+use crate::thread_pool_executor::ThreadPoolExecutor;
 use failure;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;
 pub use reboot::Reboot;
 pub use remove_network_effects::RemoveNetworkEffects;
+use slog_scope::info;
 use std::fmt::Display;
 pub use stop_container::StopContainer;
-
 pub trait Action: Display + Send {
     fn apply(&self) -> failure::Result<()>;
     fn is_complete(&self) -> bool;
@@ -24,4 +25,32 @@ pub trait Action: Display + Send {
 pub trait Effect: Display + Send {
     fn activate(&self) -> failure::Result<()>;
     fn deactivate(&self) -> failure::Result<()>;
+}
+
+pub fn activate_all<T: Effect>(thread_pool_executor: ThreadPoolExecutor, effects: &mut [T]) {
+    let jobs = effects
+        .iter_mut()
+        .map(|effect| {
+            move || {
+                if let Err(e) = effect.activate() {
+                    info!("Failed to activate {}: {:?}", effect, e);
+                }
+            }
+        })
+        .collect();
+    thread_pool_executor.execute_jobs(jobs);
+}
+
+pub fn deactivate_all<T: Effect>(thread_pool_executor: ThreadPoolExecutor, effects: &mut [T]) {
+    let jobs = effects
+        .iter_mut()
+        .map(|effect| {
+            move || {
+                if let Err(e) = effect.deactivate() {
+                    info!("Failed to deactivate {}: {:?}", effect, e);
+                }
+            }
+        })
+        .collect();
+    thread_pool_executor.execute_jobs(jobs);
 }

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -1,20 +1,51 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-mod multi_region_network_simulation;
-mod packet_loss_random_validators;
-mod reboot_random_validator;
+use std::time::Duration;
+use std::{collections::HashSet, fmt::Display};
 
 pub use multi_region_network_simulation::{MultiRegionSimulation, MultiRegionSimulationParams};
 pub use packet_loss_random_validators::{
     PacketLossRandomValidators, PacketLossRandomValidatorsParams,
 };
+pub use performance_benchmark_nodes_down::PerformanceBenchmarkNodesDown;
+pub use performance_benchmark_three_region_simulation::PerformanceBenchmarkThreeRegionSimulation;
 pub use reboot_random_validator::RebootRandomValidators;
-use std::time::Duration;
-use std::{collections::HashSet, fmt::Display};
+
+use crate::prometheus::Prometheus;
+use crate::thread_pool_executor::ThreadPoolExecutor;
+use crate::tx_emitter::TxEmitter;
+
+mod multi_region_network_simulation;
+mod packet_loss_random_validators;
+mod performance_benchmark_nodes_down;
+mod performance_benchmark_three_region_simulation;
+mod reboot_random_validator;
 
 pub trait Experiment: Display + Send {
-    fn affected_validators(&self) -> HashSet<String>;
-    fn run(&self) -> failure::Result<()>;
+    fn affected_validators(&self) -> HashSet<String> {
+        HashSet::new()
+    }
+    fn run(&mut self, context: &mut Context) -> failure::Result<Option<String>>;
     fn deadline(&self) -> Duration;
+}
+
+pub struct Context {
+    tx_emitter: TxEmitter,
+    prometheus: Prometheus,
+    thread_pool_executor: ThreadPoolExecutor,
+}
+
+impl Context {
+    pub fn new(
+        tx_emitter: TxEmitter,
+        prometheus: Prometheus,
+        thread_pool_executor: ThreadPoolExecutor,
+    ) -> Self {
+        Context {
+            tx_emitter,
+            prometheus,
+            thread_pool_executor,
+        }
+    }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -1,0 +1,75 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, fmt::Display};
+
+use failure::_core::fmt::{Error, Formatter};
+use failure::_core::time::Duration;
+
+use crate::cluster::Cluster;
+use crate::effects::StopContainer;
+use crate::experiments::Context;
+use crate::experiments::Experiment;
+use crate::instance::Instance;
+use crate::{effects, instance, stats};
+
+use crate::util::unix_timestamp_now;
+
+pub struct PerformanceBenchmarkNodesDown {
+    down_instances: Vec<Instance>,
+    up_instances: Vec<Instance>,
+    num_nodes_down: usize,
+}
+
+impl PerformanceBenchmarkNodesDown {
+    pub fn new(cluster: Cluster, num_nodes_down: usize) -> Self {
+        let (down_instances, up_instances) = cluster.split_n_random(num_nodes_down);
+        Self {
+            down_instances: down_instances.into_instances(),
+            up_instances: up_instances.into_instances(),
+            num_nodes_down,
+        }
+    }
+}
+
+impl Experiment for PerformanceBenchmarkNodesDown {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&self.down_instances)
+    }
+
+    fn run(&mut self, context: &mut Context) -> failure::Result<Option<String>> {
+        let mut stop_effects: Vec<_> = self
+            .down_instances
+            .clone()
+            .into_iter()
+            .map(StopContainer::new)
+            .collect();
+        effects::activate_all(context.thread_pool_executor.clone(), &mut stop_effects);
+        let window = Duration::from_secs(180);
+        context
+            .tx_emitter
+            .emit_txn_for(window + Duration::from_secs(60), self.up_instances.clone())?;
+        let end = unix_timestamp_now();
+        let start = end - window;
+        let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
+        effects::deactivate_all(context.thread_pool_executor.clone(), &mut stop_effects);
+        Ok(Some(format!(
+            "{} : {:.0} TPS, {:.1} ms latency",
+            self, avg_tps, avg_latency
+        )))
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(480)
+    }
+}
+
+impl Display for PerformanceBenchmarkNodesDown {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        if self.num_nodes_down == 0 {
+            write!(f, "all up")
+        } else {
+            write!(f, "{}% down", self.num_nodes_down)
+        }
+    }
+}

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+
+use failure::_core::fmt::{Error, Formatter};
+use failure::_core::time::Duration;
+
+use crate::cluster::Cluster;
+use crate::effects::three_region_simulation_effects;
+use crate::experiments::Context;
+use crate::experiments::Experiment;
+use crate::{effects, stats};
+
+use crate::util::unix_timestamp_now;
+
+pub struct PerformanceBenchmarkThreeRegionSimulation {
+    cluster: Cluster,
+}
+
+impl PerformanceBenchmarkThreeRegionSimulation {
+    pub fn new(cluster: Cluster) -> Self {
+        Self { cluster }
+    }
+}
+
+impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
+    fn run(&mut self, context: &mut Context) -> failure::Result<Option<String>> {
+        let (us, euro) = self.cluster.split_n_random(80);
+        let (us_west, us_east) = us.split_n_random(40);
+        let mut network_effects = three_region_simulation_effects(
+            (
+                us_west.instances().clone(),
+                us_east.instances().clone(),
+                euro.instances().clone(),
+            ),
+            (
+                Duration::from_millis(60), // us_east<->eu one way delay
+                Duration::from_millis(95), // us_west<->eu one way delay
+                Duration::from_millis(40), // us_west<->us_east one way delay
+            ),
+        );
+        effects::activate_all(context.thread_pool_executor.clone(), &mut network_effects);
+        let window = Duration::from_secs(180);
+        context.tx_emitter.emit_txn_for(
+            window + Duration::from_secs(60),
+            self.cluster.instances().clone(),
+        )?;
+        let end = unix_timestamp_now();
+        let start = end - window;
+        let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
+        effects::deactivate_all(context.thread_pool_executor.clone(), &mut network_effects);
+        Ok(Some(format!(
+            "{} : {:.0} TPS, {:.1} ms latency",
+            self, avg_tps, avg_latency
+        )))
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(420)
+    }
+}
+
+impl Display for PerformanceBenchmarkThreeRegionSimulation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "3 Region Simulation")
+    }
+}

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -1,15 +1,20 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{collections::HashSet, fmt, thread, time::Duration};
+
+use rand::Rng;
+
+use failure;
+
+use crate::experiments::Context;
 use crate::{
     cluster::Cluster,
     effects::{Action, Reboot},
     experiments::Experiment,
+    instance,
     instance::Instance,
 };
-use failure;
-use rand::Rng;
-use std::{collections::HashSet, fmt, thread, time::Duration};
 
 pub struct RebootRandomValidators {
     instances: Vec<Instance>,
@@ -38,14 +43,10 @@ impl RebootRandomValidators {
 
 impl Experiment for RebootRandomValidators {
     fn affected_validators(&self) -> HashSet<String> {
-        let mut r = HashSet::new();
-        for instance in self.instances.iter() {
-            r.insert(instance.short_hash().clone());
-        }
-        r
+        instance::instancelist_to_set(&self.instances)
     }
 
-    fn run(&self) -> failure::Result<()> {
+    fn run(&mut self, _context: &mut Context) -> failure::Result<Option<String>> {
         let mut reboots = vec![];
         for instance in self.instances.iter() {
             let reboot = Reboot::new(instance.clone());
@@ -55,7 +56,7 @@ impl Experiment for RebootRandomValidators {
         while reboots.iter().any(|r| !r.is_complete()) {
             thread::sleep(Duration::from_secs(5));
         }
-        Ok(())
+        Ok(None)
     }
 
     fn deadline(&self) -> Duration {

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use failure::{self, prelude::*};
+use std::collections::HashSet;
 use std::{
     ffi::OsStr,
     fmt,
@@ -86,4 +87,12 @@ impl fmt::Display for Instance {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}({})", self.short_hash, self.ip)
     }
+}
+
+pub fn instancelist_to_set(instances: &[Instance]) -> HashSet<String> {
+    let mut r = HashSet::new();
+    for instance in instances {
+        r.insert(instance.short_hash().clone());
+    }
+    r
 }

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -11,6 +11,7 @@ pub mod health;
 pub mod instance;
 pub mod prometheus;
 pub mod slack;
+pub mod stats;
 pub mod suite;
 pub mod thread_pool_executor;
 pub mod tx_emitter;

--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::prometheus::Prometheus;
+use failure::{self, prelude::format_err};
+use std::time::Duration;
+
+pub fn avg_tps(prometheus: &Prometheus, start: Duration, end: Duration) -> failure::Result<f64> {
+    prometheus
+        .query_range_avg(
+            "irate(libra_consensus_last_committed_version[1m])".to_string(),
+            &start,
+            &end,
+            10, /* step */
+        )
+        .map_err(|e| format_err!("No tps data: {}", e))
+}
+
+pub fn avg_latency(
+    prometheus: &Prometheus,
+    start: Duration,
+    end: Duration,
+) -> failure::Result<f64> {
+    prometheus.query_range_avg(
+        "irate(mempool_duration_sum{op='e2e.latency'}[1m])/irate(mempool_duration_count{op='e2e.latency'}[1m])"
+            .to_string(),
+        &start,
+        &end,
+        10 /* step */,
+    ).map(|x| x * 1000.).map_err(|e| format_err!("No latency data: {}", e))
+}
+
+pub fn txn_stats(
+    prometheus: &Prometheus,
+    start: Duration,
+    end: Duration,
+) -> failure::Result<(f64, f64)> {
+    Ok((
+        avg_tps(prometheus, start, end)?,
+        avg_latency(prometheus, start, end)?,
+    ))
+}

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -1,11 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cmp::min;
+
+use crate::experiments::{
+    PerformanceBenchmarkNodesDown, PerformanceBenchmarkThreeRegionSimulation,
+};
+
 use crate::{
     cluster::Cluster,
     experiments::{Experiment, RebootRandomValidators},
 };
-use std::cmp::min;
 
 pub struct ExperimentSuite {
     pub experiments: Vec<Box<dyn Experiment>>,
@@ -20,6 +25,33 @@ impl ExperimentSuite {
             let b: Box<dyn Experiment> = Box::new(RebootRandomValidators::new(count, cluster));
             experiments.push(b);
         }
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            0,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            10,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
+            cluster.clone(),
+        )));
+        Self { experiments }
+    }
+
+    pub fn new_perf_suite(cluster: &Cluster) -> Self {
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            0,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            10,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
+            cluster.clone(),
+        )));
         Self { experiments }
     }
 }


### PR DESCRIPTION
## Summary

* At a high level: As we add more and more test cases to cluster-test, it becomes hard to squeeze all of them in main.rs. At a high level, this moves individual tests into individual `Experiment`s and moves a few more functions away from main into other libraries
* We construct `ExperimentSuite`s with the list of `Experiment`s required and then run those `ExperimentSuite`

Details:
* Update experiment run to return an Option<String> which is the result of an experiment
  * Some experiments will have results like perf results, some experiments will not like reboot random validators
* Convert perf benchmarks into three separate experiments: PerformanceBenchmark, PerformanceBenchmarkNodesDown, PerformanceBenchmarkThreeRegionSimulation
  * This reduces the amount of code that we have to maintain in main.rs makes creating new experiment suites easier
* Update `new_pre_release` which adds the performance experiments as well
* Create a stats module which contains the queries for various stats like tps, latency, etc. Move code from main.rs to this module
* Move activate_all, deactivate_all logic into effects module
* Move emit_txn_for into tx_emitter module

## Test Plan

Ran on my dev cluster