### PR TITLE
[cluster-test] Introduce ct - shortcut to run cluster test docker

### DIFF
--- a/testsuite/cluster-test/ct
+++ b/testsuite/cluster-test/ct
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+DOCKER_IMAGE="cluster-test:latest"
+WAIT_TO="45m"
+CONTAINER="cluster-test-$RANDOM"
+WORKPLACE="cluster-test"
+
+while (( "$#" )); do
+  case "$1" in
+    -c|--container)
+      CONTAINER=$2
+      shift 2
+      ;;
+    -P|--prune)
+      docker image prune -a -f
+      shift 1
+      ;;
+    -i|--image)
+      DOCKER_IMAGE=$2
+      shift 2
+      ;;
+    -T|--wait-timeout)
+      WAIT_TO=$2
+      shift 2
+      ;;
+    -w|--workplace)
+      WORKPLACE=$2
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    *) # end argument parsing
+      break
+      ;;
+  esac
+done
+
+# Waiting for other runs to finish
+timeout $WAIT_TO bash -c 'while [ $(docker ps --quiet --filter name=$CONTAINER) ]; do echo "Another container is running, waiting..."; sleep 1m; done'
+
+# Cleanup container in case it was terminated but not removed (no -f flags to avoid killing alive container)
+docker rm $CONTAINER 2>/dev/null >/dev/null || :
+
+trap "echo Terminating on signal; docker rm -f $CONTAINER >/dev/null" SIGINT SIGTERM
+
+# This could in theory fail due to concurrency, but it seem unlikely
+docker run -v /libra_rsa:/libra_rsa --name $CONTAINER --rm $DOCKER_IMAGE --workplace $WORKPLACE $* &
+
+wait


### PR DESCRIPTION
* ct runs cluster test inside docker container
* locally built image is used by default, but can be overwritten with `--image`

Running from Circle CI will look something like that:

```
ct --prune --container cluster-test-ci --image <RUNNER_IMAGE> --
   --deploy <upstream_xxx> --run_ci_suite
```