### PR TITLE
[State synchronizer] Synchronization through epochs

### DIFF
--- a/network/src/proto/state_synchronizer.proto
+++ b/network/src/proto/state_synchronizer.proto
@@ -11,7 +11,7 @@ import "transaction.proto";
 message GetChunkRequest {
   uint64 known_version = 1;
   // Epoch the chunk response is supposed to belong to (i.e., epoch of known_version + 1)
-  uint64 chunk_epoch = 2;
+  uint64 current_epoch = 2;
   uint64 limit = 3;
   uint64 timeout = 4;
   // An optional field specifying the target.

--- a/network/src/proto/state_synchronizer.proto
+++ b/network/src/proto/state_synchronizer.proto
@@ -10,12 +10,19 @@ import "transaction.proto";
 
 message GetChunkRequest {
   uint64 known_version = 1;
-  uint64 limit = 2;
-  uint64 timeout = 3;
-  types.LedgerInfoWithSignatures ledger_info_with_sigs = 4;
+  // Epoch the chunk response is supposed to belong to (i.e., epoch of known_version + 1)
+  uint64 chunk_epoch = 2;
+  uint64 limit = 3;
+  uint64 timeout = 4;
+  // An optional field specifying the target.
+  types.LedgerInfoWithSignatures ledger_info_with_sigs = 5;
 }
 
+// The returned chunk is bounded by the end of the known_epoch of the requester (i.e., a chunk never crosses epoch
+// boundaries).
 message GetChunkResponse {
+  // Transaction proofs are built relative to this ledger info.
+  // It could either be the end of the epoch of the known version in the request, or a target / highest LI.
   types.LedgerInfoWithSignatures ledger_info_with_sigs = 1;
   // chunk of transactions with proof corresponding to version in `ledger_info_with_sigs`
   types.TransactionListWithProof txn_list_with_proof = 2;

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -336,7 +336,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
                 let request_info = PendingRequestInfo {
                     expiration_time: time,
                     known_version: request.known_version,
-                    request_epoch: request.chunk_epoch,
+                    request_epoch: request.current_epoch,
                     limit: request.limit,
                 };
                 self.subscriptions.insert(peer_id, request_info);
@@ -353,7 +353,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         self.deliver_chunk(
             peer_id,
             request.known_version,
-            request.chunk_epoch,
+            request.current_epoch,
             request.limit,
             target,
             sender,
@@ -568,7 +568,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
 
         let mut req = GetChunkRequest::default();
         req.known_version = known_version;
-        req.chunk_epoch = known_epoch;
+        req.current_epoch = known_epoch;
         req.limit = self.config.chunk_limit;
         if self.role == RoleType::Validator {
             let target = self

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -8,7 +8,7 @@ use futures::{channel::oneshot, Future, FutureExt};
 use grpcio::EnvBuilder;
 use libra_config::config::NodeConfig;
 use libra_types::{
-    crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof, ValidatorVerifier},
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof},
     transaction::TransactionListWithProof,
 };
 use std::{pin::Pin, sync::Arc};
@@ -17,7 +17,7 @@ use vm_runtime::MoveVM;
 
 /// Proxies interactions with execution and storage for state synchronization
 pub trait ExecutorProxyTrait: Sync + Send {
-    /// Latest state (ledger info and synced version) in the local storage
+    /// Sync the local state with the latest in storage.
     fn get_local_storage_state(
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<SynchronizerState>> + Send>>;
@@ -37,15 +37,12 @@ pub trait ExecutorProxyTrait: Sync + Send {
         target_version: u64,
     ) -> Pin<Box<dyn Future<Output = Result<TransactionListWithProof>> + Send>>;
 
-    fn validate_ledger_info(&self, target: &LedgerInfoWithSignatures) -> Result<()>;
-
     fn get_epoch_proof(&self, start_epoch: u64) -> Result<ValidatorChangeEventWithProof>;
 }
 
 pub(crate) struct ExecutorProxy {
     storage_read_client: Arc<StorageReadServiceClient>,
     executor: Arc<Executor<MoveVM>>,
-    validator_verifier: ValidatorVerifier,
 }
 
 impl ExecutorProxy {
@@ -56,11 +53,9 @@ impl ExecutorProxy {
             &config.storage.address,
             config.storage.port,
         ));
-        let validator_verifier = config.consensus.consensus_peers.get_validator_verifier();
         Self {
             storage_read_client,
             executor,
-            validator_verifier,
         }
     }
 }
@@ -94,10 +89,17 @@ impl ExecutorProxyTrait for ExecutorProxy {
                 storage_info.ledger_info.ledger_info().version(),
                 storage_info.synced_tree_state.map_or(0, |t| t.version),
             );
-            Ok(SynchronizerState {
-                highest_local_li: storage_info.ledger_info,
+            let current_verifier = storage_info
+                .ledger_info_with_validators
+                .ledger_info()
+                .next_validator_set()
+                .expect("No ValidatorSet found for the start of the epoch")
+                .into();
+            Ok(SynchronizerState::new(
+                storage_info.ledger_info,
                 highest_synced_version,
-            })
+                current_verifier,
+            ))
         }
             .boxed()
     }
@@ -126,11 +128,6 @@ impl ExecutorProxyTrait for ExecutorProxy {
                 .await
         }
             .boxed()
-    }
-
-    fn validate_ledger_info(&self, target: &LedgerInfoWithSignatures) -> Result<()> {
-        target.verify(&self.validator_verifier)?;
-        Ok(())
     }
 
     fn get_epoch_proof(&self, start_epoch: u64) -> Result<ValidatorChangeEventWithProof> {

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -12,10 +12,8 @@ extern crate prometheus;
 
 use libra_types::{account_address::AccountAddress, crypto_proxies::LedgerInfoWithSignatures};
 
-use libra_crypto::HashValue;
-use libra_types::block_info::BlockInfo;
-use libra_types::ledger_info::LedgerInfo;
-use std::collections::BTreeMap;
+use libra_types::crypto_proxies::ValidatorVerifier;
+
 pub use synchronizer::{StateSyncClient, StateSynchronizer};
 
 mod coordinator;
@@ -26,10 +24,18 @@ mod synchronizer;
 
 type PeerId = AccountAddress;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
+/// EpochInfo represents the highest trusted validator set: it is updated every time we're crossing
+/// the epoch boundary.
+pub struct EpochInfo {
+    pub epoch: u64,
+    pub verifier: ValidatorVerifier,
+}
+
+#[derive(Clone)]
 /// The state distinguishes between the following fields:
 /// * highest_local_li is keeping the latest certified ledger info
-/// * highest_committed_version is keeping the latest version in the transaction accumulator in case
+/// * highest_synced_version is keeping the latest version in the transaction accumulator in case
 /// the accumulator is ahead of the LedgerInfo.
 ///
 /// While `highest_local_li` can be used for helping the others (corresponding to the highest
@@ -38,26 +44,46 @@ type PeerId = AccountAddress;
 pub struct SynchronizerState {
     pub highest_local_li: LedgerInfoWithSignatures,
     pub highest_synced_version: u64,
+    // Corresponds to the current epoch if the highest local LI is in the middle of the epoch,
+    // or the next epoch if the highest local LI is the final LI in the current epoch.
+    pub trusted_epoch: EpochInfo,
 }
 
 impl SynchronizerState {
-    pub fn zero_state() -> Self {
-        let highest_local_li = LedgerInfoWithSignatures::new(
-            LedgerInfo::new(BlockInfo::empty(), HashValue::zero()),
-            BTreeMap::new(),
-        );
-        Self {
+    pub fn new(
+        highest_local_li: LedgerInfoWithSignatures,
+        highest_synced_version: u64,
+        current_verifier: ValidatorVerifier,
+    ) -> Self {
+        let current_epoch = highest_local_li.ledger_info().epoch();
+        let trusted_epoch = match highest_local_li.ledger_info().next_validator_set() {
+            Some(validator_set) => EpochInfo {
+                epoch: current_epoch + 1,
+                verifier: validator_set.into(),
+            },
+            None => EpochInfo {
+                epoch: current_epoch,
+                verifier: current_verifier,
+            },
+        };
+        SynchronizerState {
             highest_local_li,
-            highest_synced_version: 0,
+            highest_synced_version,
+            trusted_epoch,
         }
     }
 
     /// The highest available version in the local storage (even if it's not covered by the LI).
     pub fn highest_version_in_local_storage(&self) -> u64 {
-        std::cmp::max(
-            self.highest_local_li.ledger_info().version(),
-            self.highest_synced_version,
-        )
+        self.highest_synced_version
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.trusted_epoch.epoch
+    }
+
+    pub fn verifier(&self) -> &ValidatorVerifier {
+        &self.trusted_epoch.verifier
     }
 }
 

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -10,6 +10,7 @@ use executor::Executor;
 use failure::prelude::*;
 use futures::{
     channel::{mpsc, oneshot},
+    executor::block_on,
     future::Future,
     SinkExt,
 };
@@ -58,11 +59,14 @@ impl StateSynchronizer {
 
         let (coordinator_sender, coordinator_receiver) = mpsc::unbounded();
 
+        let initial_state = block_on(executor_proxy.get_local_storage_state())
+            .expect("[state sync] Start failure: cannot sync with storage.");
         let coordinator = SyncCoordinator::new(
             coordinator_receiver,
             role,
             state_sync_config.clone(),
             executor_proxy,
+            initial_state,
         );
         executor.spawn(coordinator.start(network));
 

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -1,0 +1,179 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::SynchronizerState;
+use libra_crypto::hash::CryptoHash;
+use libra_crypto::HashValue;
+use libra_types::block_info::BlockInfo;
+use libra_types::crypto_proxies::{
+    ValidatorChangeEventWithProof, ValidatorSigner, ValidatorVerifier,
+};
+use libra_types::validator_set::ValidatorSet;
+use libra_types::{
+    account_address::AccountAddress, crypto_proxies::LedgerInfoWithSignatures,
+    ledger_info::LedgerInfo, test_helpers::transaction_test_helpers::get_test_signed_txn,
+    transaction::Transaction,
+};
+use std::collections::{BTreeMap, HashMap};
+use transaction_builder::encode_transfer_script;
+use vm_genesis::GENESIS_KEYPAIR;
+
+pub struct MockStorage {
+    // some mock transactions in the storage
+    transactions: Vec<Transaction>,
+    // latest ledger info per epoch
+    ledger_infos: HashMap<u64, LedgerInfoWithSignatures>,
+    // latest epoch number (starts with 1)
+    epoch_num: u64,
+    // Validator signer of the latest epoch
+    // All epochs are built s.t. a single signature is enough for quorum cert
+    signer: ValidatorSigner,
+    // A validator verifier of the latest epoch
+    verifier: ValidatorVerifier,
+}
+
+impl MockStorage {
+    pub fn new(genesis_li: LedgerInfoWithSignatures, signer: ValidatorSigner) -> Self {
+        let verifier = genesis_li
+            .ledger_info()
+            .next_validator_set()
+            .unwrap()
+            .into();
+        let epoch_num = genesis_li.ledger_info().epoch() + 1;
+        let mut ledger_infos = HashMap::new();
+        ledger_infos.insert(0, genesis_li);
+        Self {
+            transactions: vec![],
+            ledger_infos,
+            epoch_num,
+            signer,
+            verifier,
+        }
+    }
+
+    pub fn version(&self) -> u64 {
+        self.transactions.len() as u64
+    }
+
+    pub fn epoch_num(&self) -> u64 {
+        self.epoch_num
+    }
+
+    pub fn highest_local_li(&self) -> LedgerInfoWithSignatures {
+        let cur_epoch = self.epoch_num();
+        let epoch_with_li = if self.ledger_infos.contains_key(&cur_epoch) {
+            cur_epoch
+        } else {
+            cur_epoch - 1
+        };
+        self.ledger_infos.get(&epoch_with_li).unwrap().clone()
+    }
+
+    pub fn get_local_storage_state(&self) -> SynchronizerState {
+        SynchronizerState::new(
+            self.highest_local_li(),
+            self.version(),
+            self.verifier.clone(),
+        )
+    }
+
+    pub fn get_epoch_changes(&self, known_epoch: u64) -> ValidatorChangeEventWithProof {
+        let mut epoch_change_lis = vec![];
+        for epoch_num in known_epoch..self.epoch_num() {
+            epoch_change_lis.push(self.ledger_infos.get(&epoch_num).unwrap().clone());
+        }
+        ValidatorChangeEventWithProof::new(epoch_change_lis)
+    }
+
+    pub fn get_chunk(
+        &self,
+        start_version: u64,
+        limit: u64,
+        target_version: u64,
+    ) -> Vec<Transaction> {
+        let mut version = start_version;
+        let mut res = vec![];
+        let limit = std::cmp::min(limit, target_version - start_version + 1);
+        while version - 1 < self.transactions.len() as u64 && version - start_version < limit {
+            res.push(self.transactions[(version - 1) as usize].clone());
+            version += 1;
+        }
+        res
+    }
+
+    pub fn add_txns_with_li(
+        &mut self,
+        mut transactions: Vec<Transaction>,
+        li: LedgerInfoWithSignatures,
+    ) {
+        assert_eq!(self.epoch_num, li.ledger_info().epoch());
+        self.transactions.append(&mut transactions);
+        self.ledger_infos.insert(self.epoch_num(), li.clone());
+        if let Some(next_validator_set) = li.ledger_info().next_validator_set() {
+            self.epoch_num += 1;
+            self.verifier = next_validator_set.into();
+        }
+    }
+
+    // Generate new dummy txns and updates the LI
+    // with the version corresponding to the new transactions, signed by this storage signer.
+    pub fn commit_new_txns(&mut self, num_txns: u64) {
+        for _ in 0..num_txns {
+            self.transactions.push(Self::gen_mock_user_txn());
+        }
+        self.add_li(None);
+    }
+
+    fn gen_mock_user_txn() -> Transaction {
+        let sender = AccountAddress::random();
+        let receiver = AccountAddress::random();
+        let program = encode_transfer_script(&receiver, 1);
+        Transaction::UserTransaction(get_test_signed_txn(
+            sender,
+            0, // sequence number
+            GENESIS_KEYPAIR.0.clone(),
+            GENESIS_KEYPAIR.1.clone(),
+            Some(program),
+        ))
+    }
+
+    // add the LI to the current highest version and sign it
+    fn add_li(&mut self, validator_set: Option<ValidatorSet>) {
+        let ledger_info = LedgerInfo::new(
+            BlockInfo::new(
+                self.epoch_num(),
+                self.version(),
+                HashValue::zero(),
+                HashValue::zero(),
+                self.version(),
+                0,
+                validator_set,
+            ),
+            HashValue::zero(),
+        );
+        let signature = self.signer.sign_message(ledger_info.hash()).unwrap();
+        let mut signatures = BTreeMap::new();
+        signatures.insert(self.signer.author(), signature);
+        self.ledger_infos.insert(
+            self.epoch_num(),
+            LedgerInfoWithSignatures::new(ledger_info, signatures),
+        );
+    }
+
+    // This function is applying the LedgerInfo with the next validator set to the existing version
+    // (yes, it's different from reality, we're not adding any real reconfiguration txn,
+    // just adding a new LedgerInfo).
+    // The validator set is different only in the consensus public / private keys, network data
+    // remains the same.
+    pub fn move_to_next_epoch(&mut self, signer: ValidatorSigner, validator_set: ValidatorSet) {
+        self.add_li(Some(validator_set.clone()));
+        self.epoch_num += 1;
+        self.signer = signer;
+        self.verifier = self
+            .highest_local_li()
+            .ledger_info()
+            .next_validator_set()
+            .unwrap()
+            .into();
+    }
+}

--- a/state-synchronizer/src/tests/mod.rs
+++ b/state-synchronizer/src/tests/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod integration_tests;
+mod mock_storage;
 mod unit_tests;


### PR DESCRIPTION
Summary:
In this chage state synchronization can go through epochs
* the epoch information including the verifier is part of the local state, which is synced with local storage
* the response target LI stays within the request epoch
* in case the request epoch is smaller than the target LI, the response chunk is bounded by the end of the epoch and carries the LI with the validator set for the next epoch
* the receiver of the epoch with the validator set of the next epoch updates its local state during commit processing upon syncing with local storage
* optimistic chunk requests take into account potential epoch info change

Testing: existing test coverage, new tests will be added in the followup diffs

Ref: issue #899