### PR TITLE
[consensus] derive ValidatorSet from genesis txn instead of config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-failure-ext 0.1.0",

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -8,7 +8,6 @@ use crate::{
         persistent_storage::{PersistentStorage, StorageWriteProxy},
     },
     consensus_provider::ConsensusProvider,
-    counters,
     state_computer::ExecutionProxy,
     state_replication::StateMachineReplication,
     txn_manager::MempoolProxy,
@@ -20,8 +19,7 @@ use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_mempool::proto::mempool::MempoolClient;
 use libra_types::{
-    account_address::AccountAddress,
-    crypto_proxies::{ValidatorSigner, ValidatorVerifier},
+    account_address::AccountAddress, crypto_proxies::ValidatorSigner,
     transaction::SignedTransaction,
 };
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};
@@ -34,7 +32,6 @@ use vm_runtime::MoveVM;
 pub struct InitialSetup {
     pub author: Author,
     pub signer: ValidatorSigner,
-    pub validator: ValidatorVerifier,
     pub network_sender: ConsensusNetworkSender,
     pub network_events: ConsensusNetworkEvents,
 }
@@ -97,22 +94,9 @@ impl ChainedBftProvider {
             "Failed to move a Consensus private key from a NodeConfig, key absent or already read",
         );
         let signer = ValidatorSigner::new(author, private_key);
-        // Keeping the initial set of validators in a node config is embarrassing and we should
-        // all feel bad about it.
-        let validator = node_config
-            .consensus
-            .consensus_peers
-            .get_validator_verifier();
-        counters::CURRENT_EPOCH_VALIDATORS.set(validator.len() as i64);
-        counters::CURRENT_EPOCH_QUORUM_SIZE.set(validator.quorum_voting_power() as i64);
-        debug!(
-            "[Consensus]: quorum_size = {:?}",
-            validator.quorum_voting_power()
-        );
         InitialSetup {
             author,
             signer,
-            validator,
             network_sender,
             network_events,
         }

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -63,12 +63,8 @@ impl ChainedBftProvider {
         let initial_setup = Self::initialize_setup(network_sender, network_events, node_config);
         debug!("[Consensus] My peer: {:?}", initial_setup.author);
         let config = ChainedBftSMRConfig::from_node_config(&node_config.consensus);
-        let (storage, initial_data) = StorageWriteProxy::start(node_config);
-        info!(
-            "Starting up the consensus state machine with recovery data - [last_vote {}], [highest timeout certificate: {}]",
-            initial_data.last_vote().map_or("None".to_string(), |v| v.to_string()),
-            initial_data.highest_timeout_certificate().map_or("None".to_string(), |v| v.to_string()),
-        );
+        let storage = Arc::new(StorageWriteProxy::new(node_config));
+        let initial_data = storage.start();
         let txn_manager = Arc::new(MempoolProxy::new(mempool_client.clone()));
         let state_computer = Arc::new(ExecutionProxy::new(executor, synchronizer_client.clone()));
         let smr = ChainedBftSMR::new(initial_setup, runtime, config, storage, initial_data);

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -139,7 +139,7 @@ impl SMRNode {
         self.smr.stop();
         let recover_data = self
             .storage
-            .get_recovery_data()
+            .try_start()
             .unwrap_or_else(|e| panic!("fail to restart due to: {}", e));
         Self::start(
             playground,
@@ -171,7 +171,7 @@ impl SMRNode {
         let validators = Arc::new(validator_verifier);
         let mut nodes = vec![];
         for smr_id in 0..num_nodes {
-            let (storage, initial_data) = MockStorage::start_for_testing();
+            let (initial_data, storage) = MockStorage::start_for_testing();
             let safety_rules_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
             OnDiskStorage::default_storage(safety_rules_path.clone());
             nodes.push(Self::start(

--- a/consensus/src/chained_bft/consensusdb/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/mod.rs
@@ -157,10 +157,23 @@ impl ConsensusDB {
             .get::<SingleEntrySchema>(&SingleEntryKey::HighestTimeoutCertificate)
     }
 
+    /// Delete the timeout certificates
+    pub fn delete_highest_timeout_certificate(&self) -> Result<()> {
+        let mut batch = SchemaBatch::new();
+        batch.delete::<SingleEntrySchema>(&SingleEntryKey::HighestTimeoutCertificate)?;
+        self.commit(batch)
+    }
+
     /// Get latest vote message data (if available)
     fn get_last_vote_msg_data(&self) -> Result<Option<Vec<u8>>> {
         self.db
             .get::<SingleEntrySchema>(&SingleEntryKey::LastVoteMsg)
+    }
+
+    pub fn delete_last_vote_msg(&self) -> Result<()> {
+        let mut batch = SchemaBatch::new();
+        batch.delete::<SingleEntrySchema>(&SingleEntryKey::LastVoteMsg)?;
+        self.commit(batch)
     }
 
     /// Get all consensus blocks.

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -173,8 +173,7 @@ impl<T: Payload> EpochManager<T> {
             .into();
         // make sure storage is on this ledger_info too, it should be no-op if it's already committed
         self.state_computer.sync_to_or_bail(ledger_info.clone());
-        let initial_data = RecoveryData::new(None, vec![], vec![], ledger_info.ledger_info(), None)
-            .expect("should be able to build new epoch RecoveryData");
+        let initial_data = self.storage.start();
         self.epoch = initial_data.epoch();
         info!(
             "Start new epoch {} with genesis {}, validators {}",

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -85,13 +85,10 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     let signer = FUZZING_SIGNER.clone();
 
     // TODO: remove
-    let validator = Arc::new(ValidatorVerifier::new_single(
-        signer.author(),
-        signer.public_key(),
-    ));
+    let validator = ValidatorVerifier::new_single(signer.author(), signer.public_key());
 
     // TODO: EmptyStorage
-    let (initial_data, storage) = MockStorage::<TestPayload>::start_for_testing();
+    let (initial_data, storage) = MockStorage::<TestPayload>::start_for_testing(validator);
 
     // TODO: remove
     let safety_rules =
@@ -105,8 +102,10 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         signer.author(),
         network_sender,
         self_sender,
-        Arc::clone(&validator),
+        initial_data.validators(),
     );
+
+    let validators = initial_data.validators();
 
     // TODO: mock
     let block_store = build_empty_store(storage.clone(), initial_data);
@@ -141,7 +140,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         network,
         storage.clone(),
         time_service,
-        validator,
+        validators,
     )
 }
 

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -91,7 +91,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     ));
 
     // TODO: EmptyStorage
-    let (storage, initial_data) = MockStorage::<TestPayload>::start_for_testing();
+    let (initial_data, storage) = MockStorage::<TestPayload>::start_for_testing();
 
     // TODO: remove
     let safety_rules =

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -96,7 +96,7 @@ impl NodeSetup {
         let validators = Arc::new(validator_verifier);
         let mut nodes = vec![];
         for signer in signers.iter().take(num_nodes) {
-            let (storage, initial_data) = MockStorage::<TestPayload>::start_for_testing();
+            let (initial_data, storage) = MockStorage::<TestPayload>::start_for_testing();
 
             let safety_rules_file = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
             OnDiskStorage::default_storage(safety_rules_file.clone());
@@ -205,7 +205,7 @@ impl NodeSetup {
     pub fn restart(self, playground: &mut NetworkPlayground, executor: TaskExecutor) -> Self {
         let recover_data = self
             .storage
-            .get_recovery_data()
+            .try_start()
             .unwrap_or_else(|e| panic!("fail to restart due to: {}", e));
         Self::new(
             playground,

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -1,16 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chained_bft::persistent_storage::{
-    PersistentLivenessStorage, PersistentStorage, RecoveryData,
-};
+use crate::chained_bft::persistent_storage::{PersistentStorage, RecoveryData};
 
 use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
 use failure::Result;
-use libra_config::config::{NodeConfig, NodeConfigHelpers};
 use libra_crypto::HashValue;
 use libra_types::ledger_info::LedgerInfo;
 use std::{
@@ -43,7 +40,15 @@ impl<T: Payload> MockStorage<T> {
         }
     }
 
-    pub fn get_recovery_data(&self) -> Result<RecoveryData<T>> {
+    pub fn commit_to_storage(&self, ledger: LedgerInfo) {
+        *self.storage_ledger.lock().unwrap() = ledger;
+
+        if let Err(e) = self.verify_consistency() {
+            panic!("invalid db after commit: {}", e);
+        }
+    }
+
+    pub fn try_start(&self) -> Result<RecoveryData<T>> {
         let mut blocks: Vec<_> = self
             .shared_storage
             .block
@@ -76,43 +81,25 @@ impl<T: Payload> MockStorage<T> {
         )
     }
 
-    pub fn commit_to_storage(&self, ledger: LedgerInfo) {
-        *self.storage_ledger.lock().unwrap() = ledger;
-
-        if let Err(e) = self.verify_consistency() {
-            panic!("invalid db after commit: {}", e);
-        }
-    }
-
     pub fn verify_consistency(&self) -> Result<()> {
-        self.get_recovery_data().map(|_| ())
+        self.try_start().map(|_| ())
     }
 
-    pub fn start_for_testing() -> (Arc<Self>, RecoveryData<T>) {
-        Self::start(&NodeConfigHelpers::get_single_node_test_config(false))
-    }
-}
+    pub fn start_for_testing() -> (RecoveryData<T>, Arc<Self>) {
+        let shared_storage = Arc::new(MockSharedStorage {
+            block: Mutex::new(HashMap::new()),
+            qc: Mutex::new(HashMap::new()),
+            last_vote: Mutex::new(None),
+            highest_timeout_certificate: Mutex::new(None),
+        });
+        let storage = Arc::new(MockStorage::new(Arc::clone(&shared_storage)));
 
-impl<T: Payload> PersistentLivenessStorage for MockStorage<T> {
-    fn save_highest_timeout_cert(
-        &self,
-        highest_timeout_certificate: TimeoutCertificate,
-    ) -> Result<()> {
-        self.shared_storage
-            .highest_timeout_certificate
-            .lock()
-            .unwrap()
-            .replace(highest_timeout_certificate);
-        Ok(())
+        (storage.start(), storage)
     }
 }
 
 // A impl that always start from genesis.
 impl<T: Payload> PersistentStorage<T> for MockStorage<T> {
-    fn persistent_liveness_storage(&self) -> Box<dyn PersistentLivenessStorage> {
-        Box::new(MockStorage::new(Arc::clone(&self.shared_storage)))
-    }
-
     fn save_tree(&self, blocks: Vec<Block<T>>, quorum_certs: Vec<QuorumCert>) -> Result<()> {
         for block in blocks {
             self.shared_storage
@@ -154,19 +141,20 @@ impl<T: Payload> PersistentStorage<T> for MockStorage<T> {
         Ok(())
     }
 
-    fn start(_config: &NodeConfig) -> (Arc<Self>, RecoveryData<T>) {
-        let shared_storage = Arc::new(MockSharedStorage {
-            block: Mutex::new(HashMap::new()),
-            qc: Mutex::new(HashMap::new()),
-            last_vote: Mutex::new(None),
-            highest_timeout_certificate: Mutex::new(None),
-        });
-        let storage = MockStorage::new(Arc::clone(&shared_storage));
+    fn start(&self) -> RecoveryData<T> {
+        self.try_start().unwrap()
+    }
 
-        (
-            Arc::new(Self::new(shared_storage)),
-            storage.get_recovery_data().unwrap(),
-        )
+    fn save_highest_timeout_cert(
+        &self,
+        highest_timeout_certificate: TimeoutCertificate,
+    ) -> Result<()> {
+        self.shared_storage
+            .highest_timeout_certificate
+            .lock()
+            .unwrap()
+            .replace(highest_timeout_certificate);
+        Ok(())
     }
 }
 
@@ -174,22 +162,13 @@ impl<T: Payload> PersistentStorage<T> for MockStorage<T> {
 pub struct EmptyStorage;
 
 impl EmptyStorage {
-    pub fn start_for_testing<T: Payload>() -> (Arc<Self>, RecoveryData<T>) {
-        Self::start(&NodeConfigHelpers::get_single_node_test_config(false))
-    }
-}
-
-impl PersistentLivenessStorage for EmptyStorage {
-    fn save_highest_timeout_cert(&self, _: TimeoutCertificate) -> Result<()> {
-        Ok(())
+    pub fn start_for_testing<T: Payload>() -> (RecoveryData<T>, Arc<Self>) {
+        let storage = Arc::new(EmptyStorage);
+        (storage.start(), storage)
     }
 }
 
 impl<T: Payload> PersistentStorage<T> for EmptyStorage {
-    fn persistent_liveness_storage(&self) -> Box<dyn PersistentLivenessStorage> {
-        Box::new(EmptyStorage)
-    }
-
     fn save_tree(&self, _: Vec<Block<T>>, _: Vec<QuorumCert>) -> Result<()> {
         Ok(())
     }
@@ -202,10 +181,10 @@ impl<T: Payload> PersistentStorage<T> for EmptyStorage {
         Ok(())
     }
 
-    fn start(_: &NodeConfig) -> (Arc<Self>, RecoveryData<T>) {
-        (
-            Arc::new(EmptyStorage),
-            RecoveryData::new(None, vec![], vec![], &LedgerInfo::genesis(), None).unwrap(),
-        )
+    fn start(&self) -> RecoveryData<T> {
+        RecoveryData::new(None, vec![], vec![], &LedgerInfo::genesis(), None).unwrap()
+    }
+    fn save_highest_timeout_cert(&self, _: TimeoutCertificate) -> Result<()> {
+        Ok(())
     }
 }

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -75,7 +75,7 @@ pub fn build_chain() -> Vec<Arc<ExecutedBlock<TestPayload>>> {
 }
 
 pub fn build_empty_tree() -> Arc<BlockStore<TestPayload>> {
-    let (storage, initial_data) = EmptyStorage::start_for_testing();
+    let (initial_data, storage) = EmptyStorage::start_for_testing();
     Arc::new(block_on(BlockStore::new(
         storage,
         initial_data,

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -24,6 +24,7 @@ failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
+lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -141,7 +141,7 @@ where
                 root_hash,
                 0,
                 0,
-                Some(ValidatorSet::new(vec![])),
+                output.validators().clone(),
             ),
             HashValue::zero(),
         );

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -180,7 +180,7 @@ fn gen_ledger_info(
 ) -> LedgerInfoWithSignatures {
     let ledger_info = LedgerInfo::new(
         BlockInfo::new(
-            0,
+            1,
             0,
             commit_block_id,
             root_hash,

--- a/executor/src/mock_vm/mod.rs
+++ b/executor/src/mock_vm/mod.rs
@@ -8,6 +8,7 @@ use lazy_static::lazy_static;
 use libra_config::config::VMConfig;
 use libra_crypto::ed25519::compat;
 use libra_state_view::StateView;
+use libra_types::validator_set::ValidatorSet;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
@@ -60,8 +61,18 @@ impl VMExecutor for MockVM {
                 1,
                 "Genesis block should have only one transaction."
             );
-            let output =
-                TransactionOutput::new(gen_genesis_writeset(), vec![], 0, KEEP_STATUS.clone());
+            let output = TransactionOutput::new(
+                gen_genesis_writeset(),
+                // mock the validator set event
+                vec![ContractEvent::new(
+                    ValidatorSet::change_event_key(),
+                    0,
+                    TypeTag::Bool,
+                    lcs::to_bytes(&ValidatorSet::new(vec![])).unwrap(),
+                )],
+                0,
+                KEEP_STATUS.clone(),
+            );
             return Ok(vec![output]);
         }
 

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -359,6 +359,7 @@ impl From<TreeState> for crate::proto::storage::TreeState {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StartupInfo {
     pub ledger_info: LedgerInfoWithSignatures,
+    pub ledger_info_with_validators: LedgerInfoWithSignatures,
     pub committed_tree_state: TreeState,
     pub synced_tree_state: Option<TreeState>,
 }
@@ -369,6 +370,10 @@ impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
     fn try_from(proto: crate::proto::storage::StartupInfo) -> Result<Self> {
         let ledger_info = proto
             .ledger_info
+            .ok_or_else(|| format_err!("Missing ledger_info"))?
+            .try_into()?;
+        let ledger_info_with_validators = proto
+            .ledger_info_with_validators
             .ok_or_else(|| format_err!("Missing ledger_info"))?
             .try_into()?;
         let committed_tree_state = proto
@@ -382,6 +387,7 @@ impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
 
         Ok(Self {
             ledger_info,
+            ledger_info_with_validators,
             committed_tree_state,
             synced_tree_state,
         })
@@ -391,11 +397,13 @@ impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
 impl From<StartupInfo> for crate::proto::storage::StartupInfo {
     fn from(info: StartupInfo) -> Self {
         let ledger_info = Some(info.ledger_info.into());
+        let ledger_info_with_validators = Some(info.ledger_info_with_validators.into());
         let committed_tree_state = Some(info.committed_tree_state.into());
         let synced_tree_state = info.synced_tree_state.map(Into::into);
 
         Self {
             ledger_info,
+            ledger_info_with_validators,
             committed_tree_state,
             synced_tree_state,
         }

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -120,12 +120,15 @@ message StartupInfo {
     // start up sync.
     types.LedgerInfoWithSignatures ledger_info = 1;
 
+    // The latest LedgerInfo that carries a ValidatorSet
+    types.LedgerInfoWithSignatures ledger_info_with_validators = 2;
+
     // The latest committed tree state matching the ledger info above.
-    TreeState committed_tree_state = 2;
+    TreeState committed_tree_state = 3;
 
     // The latest synced tree state when the number of transactions is more than ledger_info
     // indicates.
-    TreeState synced_tree_state = 3;
+    TreeState synced_tree_state = 4;
 }
 
 message GetEpochChangeLedgerInfosRequest {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This changes enable us move away from reading ValidatorVerifier from config, instead we unified with how reconfiguration works.

Genesis blob will have the ValidatorSet, the LedgerInfo commits that would include it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
