### PR TITLE
[fuzzing] Adding tool to investigate crashes

### DIFF
--- a/testsuite/libra-fuzzer/README.md
+++ b/testsuite/libra-fuzzer/README.md
@@ -64,3 +64,14 @@ To test coverage of our fuzzers you can run the following command with [tarpauli
 ```
 CORPUS_PATH=fuzz/corpus cargo tarpaulin -p libra-fuzzer -- coverage
 ```
+### Investigating an artifact
+
+Running the following command (with your own artifact contained in a similar path)
+will run the fuzzer with your input.
+
+```
+cargo run investigate -- -i artifacts/compiled_module/crash-5d7f403f
+```
+
+This is helpful to investigate and debug a binary in order to find the root cause
+of a bug.

--- a/testsuite/libra-fuzzer/src/bin/investigate.rs
+++ b/testsuite/libra-fuzzer/src/bin/investigate.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_fuzzer::FuzzTarget;
+use std::{fs, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Libra-Fuzzer Investigator",
+    author = "The Libra Association",
+    about = "Utility tool to investigate fuzzing artifacts"
+)]
+struct Args {
+    /// Admission Control port to connect to.
+    #[structopt(short = "i", long)]
+    pub input_file: Option<String>,
+}
+
+fn main() {
+    // args
+    let args = Args::from_args();
+
+    // check if it exists
+    let input_file = PathBuf::from(args.input_file.expect("input file must be set via -i"));
+    if !input_file.exists() {
+        println!("usage: cargo run investigate -i <artifacts/.../corpus_input>");
+        return;
+    }
+
+    // get target from path (input_file = .../<target>/<corpus_input>)
+    let mut ancestors = input_file.ancestors();
+    ancestors.next(); // skip full path
+    let target_name = ancestors
+        .next()
+        .expect("input file should be inside target directory")
+        .iter()
+        .last()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let target = FuzzTarget::by_name(target_name)
+        .unwrap_or_else(|| panic!("unknown fuzz target: {}", target_name));
+
+    // run the target fuzzer on the file
+    let data = fs::read(input_file).expect("failed to read artifact");
+    target.fuzz(&data);
+}


### PR DESCRIPTION
Currently we do not have good tools to use with debuggers to investigate crashes found by the fuzzer.
This adds a utility tool that can be called like this:

```
cargo run investigate -- -i artifacts/compiled_module/crash-5d7f403f
```

This utility can be ran from lldb/gdb to investigate an artifact.
