### PR TITLE
[CI] set errexit in config validate

### DIFF
--- a/scripts/circle_validate_configs.sh
+++ b/scripts/circle_validate_configs.sh
@@ -10,6 +10,8 @@
 # - Script is running inside the git repository, with git command available
 # - Script is run from repo's top level folder
 
+set -e
+
 # Generate Configs
 echo "--- Generating all the configs ---"
 cd terraform/validator-sets


### PR DESCRIPTION
## Motivation
The config validate wordflow relies on re-building the configs in
place and diff-ing them in git. There is a loophole where the diff-ing
doesn't detect changes because the config fails to re-build.  Ex
https://circleci.com/gh/libra/libra/18360

Switch on errexit so that it detects when config fails to re-build.

## Test Plan
Tested locally by rebasing on top of #1802 
