### PR TITLE
[cluster-test] Remove dependency on external dependency : retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,10 +641,10 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-failure-ext 0.1.0",
  "libra-types 0.1.0",
+ "libra-util 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ec2 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ecr 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2335,6 +2335,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-util"
+version = "0.1.0"
+
+[[package]]
 name = "libra-wallet"
 version = "0.1.0"
 dependencies = [
@@ -3681,14 +3685,6 @@ dependencies = [
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "retry"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5950,7 +5946,6 @@ dependencies = [
 "checksum rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "01916ebd9fc2e81978a5dc9542a2fa47f5bb2ca3402e14c7cc42d6e3c5123e1f"
 "checksum rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82260d54cf2cbe9608df161f7e7c98e81fae702aa13af9e4d5d39dc2ffb25ab6"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
-"checksum retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ac83b31b3831aa4b07608db4170f6555ab12942197037c38570dc4c5ba5028"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rmp 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f594cb7ff8f1c5a7907f6be91f15795c8301e0d5718eb007fb5832723dd716e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "common/proptest-helpers",
     "common/prost-ext",
     "common/tools",
+    "common/util",
     "config",
     "config/config-builder",
     "config/generate-keypair",

--- a/common/util/Cargo.toml
+++ b/common/util/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libra-util"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra libra-util"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"

--- a/common/util/src/lib.rs
+++ b/common/util/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod retry;

--- a/common/util/src/retry.rs
+++ b/common/util/src/retry.rs
@@ -1,0 +1,80 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{thread, time::Duration};
+
+/// Given an operation retries it successfully sleeping everytime it fails
+/// If the operation succeeds before the iterator runs out, it returns success
+pub fn retry<I, O, T, E>(iterable: I, mut operation: O) -> Result<T, E>
+where
+    I: IntoIterator<Item = Duration>,
+    O: FnMut() -> Result<T, E>,
+{
+    let mut iterator = iterable.into_iter();
+    loop {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if let Some(delay) = iterator.next() {
+                    thread::sleep(delay);
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+    }
+}
+
+pub fn fixed_retry_strategy(delay_ms: u64, tries: usize) -> impl Iterator<Item = Duration> {
+    FixedDelay::new(delay_ms).take(tries)
+}
+
+/// An iterator which uses a fixed delay
+pub struct FixedDelay {
+    duration: Duration,
+}
+
+impl FixedDelay {
+    /// Create a new `FixedDelay` using the given duration in milliseconds.
+    fn new(millis: u64) -> Self {
+        FixedDelay {
+            duration: Duration::from_millis(millis),
+        }
+    }
+}
+
+impl Iterator for FixedDelay {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        Some(self.duration)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fixed_retry_strategy_success() {
+        let mut collection = vec![1, 2, 3, 4, 5].into_iter();
+        let result = retry(fixed_retry_strategy(0, 10), || match collection.next() {
+            Some(n) if n == 5 => Ok(n),
+            Some(_) => Err("not 5"),
+            None => Err("not 5"),
+        })
+        .unwrap();
+        assert_eq!(result, 5);
+    }
+
+    #[test]
+    fn test_fixed_retry_strategy_error() {
+        let mut collection = vec![1, 2, 3, 4, 5].into_iter();
+        let result = retry(fixed_retry_strategy(0, 3), || match collection.next() {
+            Some(n) if n == 5 => Ok(n),
+            Some(_) => Err("not 5"),
+            None => Err("not 5"),
+        });
+        assert_eq!(result, Err("not 5"));
+    }
+}

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -15,7 +15,6 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["pr
 itertools = "0.8.0"
 rand = "0.6.5"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
-retry = { version = "0.5.1" }
 reqwest = { version="0.9.19", features=["rustls-tls"], default_features = false }
 rusoto_core = {version = "0.41.0", features=["rustls"], default_features = false}
 rusoto_ec2 = {version = "0.41.0", features=["rustls"], default_features = false}
@@ -35,6 +34,7 @@ slog-envlogger = "2.1.0"
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
 admission-control-proto = { path = "../../admission_control/admission-control-proto", version = "0.1.0" }
+util = { path = "../../common/util", version = "0.1.0", package = "libra-util" }
 
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -3,7 +3,6 @@
 
 use crate::{aws::Aws, cluster::Cluster};
 use failure::prelude::{bail, format_err};
-use retry::{delay::Fixed, retry};
 use rusoto_core::RusotoError;
 use rusoto_ecr::{
     BatchGetImageRequest, DescribeImagesRequest, DescribeImagesResponse, Ecr, Image,
@@ -12,6 +11,7 @@ use rusoto_ecr::{
 use rusoto_ecs::{Ecs, UpdateServiceRequest};
 use slog_scope::{info, warn};
 use std::{env, thread, time::Duration};
+use util::retry;
 
 #[derive(Clone)]
 pub struct DeploymentManager {
@@ -208,7 +208,7 @@ impl DeploymentManager {
         get_request.repository_name = repository.to_string();
         get_request.image_ids = vec![image_id.clone()];
         // Retry upto 10 times, waiting 10 sec between retries
-        let response = retry(Fixed::from_millis(10_000).take(10), || {
+        let response = retry::retry(retry::fixed_retry_strategy(10_000, 10), || {
             self.aws
                 .ecr()
                 .batch_get_image(get_request.clone())


### PR DESCRIPTION
## Summary

Get rid of external dependency `retry`. Add a simple implementation of retry under `common/util`.

## Test Plan

Added unit tests