### PR TITLE
Support generics in the bytecode to boogie translator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "functional_tests 0.1.0",
  "goldenfile 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode 0.1.0",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/move-prover/bytecode-to-boogie/Cargo.toml
+++ b/language/move-prover/bytecode-to-boogie/Cargo.toml
@@ -16,6 +16,7 @@ ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
 stackless-bytecode-generator = { path = "../stackless-bytecode-generator", version = "0.1.0"}
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 num = "0.2.0"
+itertools = "0.8.0"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/language/move-prover/bytecode-to-boogie/src/bytecode_function_generator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/bytecode_function_generator.rs
@@ -5,7 +5,9 @@
 //! procedures.
 use crate::translator::*;
 use bytecode_verifier::VerifiedModule;
+use itertools::Itertools;
 use vm::access::ModuleAccess;
+
 impl BoogieTranslator {
     pub fn emit_stratified_functions(&self) -> String {
         let mut res = String::new();
@@ -44,22 +46,26 @@ impl BoogieTranslator {
                 update_value_str.push_str("        assert false;\n");
             } else {
                 res.push_str("        e := p#Path(p)[i];\n");
-                res.push_str("        v' := m#Map(v)[e];\n");
-                res.push_str("        if (is#Vector(v)) { v' := v#Vector(v)[e]; }\n");
+                res.push_str("        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }\n");
+                res.push_str("        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }\n");
                 res.push_str(&format!(
                     "        call v' := ReadValue{}(p, i+1, v');\n",
                     i - 1
                 ));
                 update_value_str.push_str("        e := p#Path(p)[i];\n");
-                update_value_str.push_str("        v' := m#Map(v)[e];\n");
-                update_value_str.push_str("        if (is#Vector(v)) { v' := v#Vector(v)[e]; }\n");
+                update_value_str
+                    .push_str("        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }\n");
+                update_value_str
+                    .push_str("        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }\n");
                 update_value_str.push_str(&format!(
                     "        call v' := UpdateValue{}(p, i+1, v', new_v);\n",
                     i - 1,
                 ));
-                update_value_str
-                    .push_str("        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}\n");
-                update_value_str.push_str("        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}\n");
+                update_value_str.push_str(
+                    "        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}\n",
+                );
+                update_value_str.push_str(
+                    "        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}\n");
             }
             res.push_str("    }\n}\n\n");
             update_value_str.push_str("    }\n}\n\n");
@@ -74,80 +80,70 @@ impl BoogieTranslator {
         def_idx: usize,
     ) -> String {
         let mut res = String::from("\n");
-        let field_info = get_field_info_from_def_index(module, def_idx);
+        let field_info = get_field_infos(module, &module.struct_defs()[def_idx]);
         let struct_handle_index = module.struct_defs()[def_idx].struct_handle;
         let struct_name = struct_name_from_handle_index(module, struct_handle_index);
+        let struct_type_arity = struct_type_arity_from_handle_index(module, struct_handle_index);
+        let mut type_args_str = String::new();
         let mut args_str = String::new();
         let mut typechecking_str = String::new();
         let mut fields_str = String::new();
         // pack
-        for (i, (field_name, (_, value_cons))) in field_info.iter().enumerate() {
-            if i > 0 {
+        for i in 0..struct_type_arity {
+            if !type_args_str.is_empty() {
+                type_args_str.push_str(", ");
+            }
+            type_args_str.push_str(&format!("tv{0}: TypeValue", i));
+        }
+        for (i, (field_name, field_type)) in field_info.iter().enumerate() {
+            if !args_str.is_empty() {
                 args_str.push_str(", ");
             }
             args_str.push_str(&format!("v{}: Value", i));
-            typechecking_str.push_str(&format!("    assert is#{}(v{});\n", value_cons, i));
-            fields_str.push_str(&format!(
-                "[Field({}_{}) := v{}]",
-                struct_name, field_name, i
+            typechecking_str.push_str(&format!(
+                "    assume has_type({}, v{});\n",
+                format_type_value(module, field_type),
+                i
             ));
+            fields_str.push_str(&format!("[{}_{} := v{}]", struct_name, field_name, i));
         }
         res.push_str(&format!(
             "procedure {{:inline 1}} Pack_{}({}) returns (v: Value)\n{{\n",
-            struct_name, args_str
+            struct_name,
+            if type_args_str.is_empty() {
+                args_str.clone()
+            } else {
+                format!("{}, {}", type_args_str, args_str)
+            }
         ));
         res.push_str(&typechecking_str);
-        res.push_str(&format!("    v := Map(DefaultMap{});\n}}\n\n", fields_str));
+        res.push_str(&format!(
+            "    v := Struct(ValueArray(DefaultIntMap{}, {}));\n",
+            fields_str,
+            field_info.len(),
+        ));
+        res.push_str(&format!(
+            "    assume has_type({}_type_value({}), v);\n}}\n\n",
+            struct_name,
+            (0..struct_type_arity)
+                .map(|i| format!("tv{}", i))
+                .join(", ")
+        ));
 
         // unpack
         res.push_str(&format!(
             "procedure {{:inline 1}} Unpack_{}(v: Value) returns ({})\n{{\n",
             struct_name, args_str
         ));
-        res.push_str("    assert is#Map(v);\n");
+        res.push_str("    assert is#Struct(v);\n");
         for (i, (field_name, _)) in field_info.iter().enumerate() {
             res.push_str(&format!(
-                "    v{} := m#Map(v)[Field({}_{})];\n",
+                "    v{} := smap(v)[{}_{}];\n",
                 i, struct_name, field_name
             ));
         }
         res.push_str("}\n\n");
 
-        // Eq
-        let mut bool_res_str = String::new();
-        let mut bool_assign_str = String::new();
-        res.push_str(&format!(
-            "procedure {{:inline 1}} Eq_{}(v1: Value, v2: Value) returns (res: Value)\n{{\n",
-            struct_name,
-        ));
-        for (i, (field_name, (field_type, _))) in field_info.iter().enumerate() {
-            res.push_str(&format!("    var b{}: Value;\n", i));
-            bool_res_str.push_str(&format!(" && b#Boolean(b{})", i));
-            bool_assign_str.push_str(&format!(
-                "    call b{} := Eq_{}(m#Map(v1)[Field({}_{})], m#Map(v2)[Field({}_{})]);\n",
-                i, field_type, struct_name, field_name, struct_name, field_name,
-            ));
-        }
-        res.push_str("    assert is#Map(v1) && is#Map(v2);\n");
-        res.push_str(&bool_assign_str);
-        res.push_str(&format!(
-            "    res := Boolean(true{});\n}}\n\n",
-            bool_res_str
-        ));
-
-        // Neq
-        res.push_str(&format!(
-            "procedure {{:inline 1}} Neq_{}(v1: Value, v2: Value) returns (res: Value)\n{{\n",
-            struct_name,
-        ));
-        res.push_str("    var res_val: Value;\n");
-        res.push_str("    var res_bool: bool;\n");
-        res.push_str("    assert is#Map(v1) && is#Map(v2);\n");
-        res.push_str(&format!(
-            "    call res_val := Eq_{}(v1, v2);\n",
-            struct_name,
-        ));
-        res.push_str("    res := Boolean(!b#Boolean(res_val));\n}\n\n");
         res
     }
 }

--- a/language/move-prover/bytecode-to-boogie/src/translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/translator.rs
@@ -6,6 +6,7 @@
 use bytecode_source_map::source_map::{ModuleSourceMap, SourceMap};
 use bytecode_verifier::VerifiedModule;
 use ir_to_bytecode::parser::ast::Loc;
+use itertools::Itertools;
 use libra_types::{account_address::AccountAddress, identifier::Identifier};
 use num::{BigInt, Num};
 use stackless_bytecode_generator::{
@@ -16,8 +17,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use vm::{
     access::ModuleAccess,
     file_format::{
-        FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, ModuleHandleIndex,
-        SignatureToken, StructDefinitionIndex, StructHandleIndex,
+        FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, LocalsSignatureIndex,
+        ModuleHandleIndex, SignatureToken, StructDefinition, StructDefinitionIndex,
+        StructHandleIndex,
     },
     internals::ModuleIndex,
     views::{
@@ -81,13 +83,16 @@ impl BoogieTranslator {
         self
     }
 
+    /// Returns true of this module should be ignored for output. The module will still be
+    /// processed, but all code output for it will be omitted. This is used e.g. to suppress
+    /// output for builtin modules which have special semantics in boogie, as 0x0.Vector.
     fn shall_ignore_module(&self, module: &VerifiedModule) -> bool {
-        let module_name =
-            module.identifier_at(module.module_handle_at(ModuleHandleIndex::new(0)).name);
-        match &self.target_modules {
-            Some(modules) => !modules.contains(&module_name.to_string()),
-            _ => false,
-        }
+        module.name().to_string() == "Vector"
+            && *module.address() == AccountAddress::from_hex_literal("0x0").unwrap()
+            || match &self.target_modules {
+                Some(modules) => !modules.contains(&module.name().to_string()),
+                _ => false,
+            }
     }
 
     pub fn translate(&mut self) -> String {
@@ -115,29 +120,61 @@ impl BoogieTranslator {
                 }
             };
             for (def_idx, struct_def) in module.struct_defs().iter().enumerate() {
+                // Emit TypeName
                 let struct_name = struct_name_from_handle_index(module, struct_def.struct_handle);
                 emit_str(&format!("const unique {}: TypeName;\n", struct_name));
-                let struct_definition_view = StructDefinitionView::new(module, struct_def);
-                if struct_definition_view.is_native() {
-                    continue;
-                }
-                let field_info = get_field_info_from_def_index(module, def_idx);
-                for (field_name, _) in field_info {
-                    emit_str(&format!(
-                        "const unique {}_{}: FieldName;\n",
-                        struct_name, field_name
-                    ));
-                }
-                emit_str(&self.emit_struct_specific_functions(module, def_idx));
-                let struct_handle_index = struct_def.struct_handle;
-                // calculate the max depth of a struct
-                self.max_struct_depth = std::cmp::max(
-                    self.max_struct_depth,
-                    self.get_struct_depth(
-                        module,
-                        &SignatureToken::Struct(struct_handle_index, vec![]),
-                    ),
+
+                // Emit FieldNames
+                let field_infos = get_field_infos(module, struct_def);
+                field_infos
+                    .iter()
+                    .enumerate()
+                    .for_each(|(i, (field_name, _))| {
+                        emit_str(&format!(
+                            "const {}_{}: FieldName;\naxiom {}_{} == {};\n",
+                            struct_name, field_name, struct_name, field_name, i
+                        ));
+                    });
+
+                // Emit TypeValue constructor function.
+                let struct_def_view = StructDefinitionView::new(module, struct_def);
+                let type_args = struct_def_view
+                    .type_formals()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| format!("tv{0}: TypeValue", i))
+                    .join(", ");
+                let field_type_map = field_infos
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (_, sig))| format!("[{} := {}]", i, format_type_value(module, sig)))
+                    .join("");
+
+                let type_value = format!(
+                    "StructType({}, TypeValueArray(DefaultTypeMap{}, {}))",
+                    struct_name,
+                    field_type_map,
+                    field_infos.len(),
                 );
+                emit_str(&format!(
+                    "function {}_type_value({}): TypeValue {{\n    {}\n}}\n",
+                    struct_name, type_args, type_value
+                ));
+
+                // Emit other struct specific boilerplate.
+                if !struct_def_view.is_native() {
+                    emit_str(&self.emit_struct_specific_functions(module, def_idx));
+                    let struct_handle_index = struct_def.struct_handle;
+
+                    // Calculate the max depth of a struct
+                    self.max_struct_depth = std::cmp::max(
+                        self.max_struct_depth,
+                        self.get_struct_depth(
+                            module,
+                            &SignatureToken::Struct(struct_handle_index, vec![]),
+                        ),
+                    );
+                }
             }
         }
         self.max_struct_depth += 1;
@@ -191,19 +228,12 @@ impl<'a> ModuleTranslator<'a> {
             let struct_name = struct_name_from_handle_index(module, struct_def.struct_handle);
             all_type_strs.insert(struct_name);
         }
-        let module_name =
-            module.identifier_at(module.module_handle_at(ModuleHandleIndex::new(0)).name);
-        let module_address =
-            module.address_at(module.module_handle_at(ModuleHandleIndex::new(0)).address);
-        let ignore = parent.shall_ignore_module(module)
-            || module_name.to_string() == "Vector"
-                && *module_address == AccountAddress::from_hex_literal("0x0").unwrap();
         Self {
             module,
             source_map,
             stackless_bytecode,
             all_type_strs,
-            ignore,
+            ignore: parent.shall_ignore_module(module),
         }
     }
 
@@ -285,7 +315,7 @@ impl<'a> ModuleTranslator<'a> {
                         (String::new(), String::new())
                     };
                 vec![format!(
-                    "tmp := contents#Memory(m)[old_size + {}];\nif (!b#Boolean(tmp)) {{ {}goto Label_{}; }}{}",
+                    "tmp := contents#Memory(m)[old_size + {}];\n    if (!b#Boolean(tmp)) {{ {}goto Label_{}; }}{}",
                     idx, dbg_branch_taken_str, target, dbg_branch_not_taken_str
                 )]
             }
@@ -339,14 +369,16 @@ impl<'a> ModuleTranslator<'a> {
             ],
             WriteRef(dest, src) => vec![format!("call WriteRef(t{}, contents#Memory(m)[old_size+{}]);", dest, src)],
             FreezeRef(dest, src) => vec![format!("call t{} := FreezeRef(t{});", dest, src)],
-            Call(dests, callee_index, _, args) => {
+            Call(dests, callee_index, type_actuals, args) => {
                 let callee_name = self.function_name_from_handle_index(*callee_index);
                 let mut dest_str = String::new();
                 let mut args_str = String::new();
                 let mut dest_type_assumptions = vec![];
                 let mut tmp_assignments = vec![];
-                for (i, arg) in args.iter().enumerate() {
-                    if i > 0 {
+
+                args_str.push_str(&format_type_actuals(self.module, type_actuals));
+                for arg in args.iter() {
+                    if !args_str.is_empty() {
                         args_str.push_str(", ");
                     }
                     if self.is_local_ref(*arg, func_idx) {
@@ -383,12 +415,13 @@ impl<'a> ModuleTranslator<'a> {
                 res_vec.extend(tmp_assignments);
                 res_vec
             }
-            Pack(dest, struct_def_index, _, fields) => {
+            Pack(dest, struct_def_index, type_actuals, fields) => {
                 let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 let mut fields_str = String::new();
                 let mut res_vec = vec![];
-                for (idx, field_temp) in fields.iter().enumerate() {
-                    if idx > 0 {
+                fields_str.push_str(&format_type_actuals(self.module, type_actuals));
+                for  field_temp in fields.iter() {
+                    if !fields_str.is_empty() {
                         fields_str.push_str(", ");
                     }
                     fields_str.push_str(&format!("contents#Memory(m)[old_size+{}]", field_temp));
@@ -406,8 +439,8 @@ impl<'a> ModuleTranslator<'a> {
                 let mut dests_str = String::new();
                 let mut dest_type_assumptions = vec![];
                 let mut tmp_assignments = vec![];
-                for (idx, dest) in dests.iter().enumerate() {
-                    if idx > 0 {
+                for dest in dests.iter() {
+                    if !dests_str.is_empty() {
                         dests_str.push_str(", ");
                     }
                     dests_str.push_str(&format!("t{}", dest));
@@ -438,33 +471,34 @@ impl<'a> ModuleTranslator<'a> {
                     dest, src, field_name
                 )]
             }
-            Exists(dest, addr, struct_def_index, _) => {
-                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+            Exists(dest, addr, struct_def_index, type_actuals) => {
+                let resource_type = format_struct_type_value_from_def_idx(self.module, struct_def_index, type_actuals);
                 vec![
-                    format!("call tmp := Exists(contents#Memory(m)[old_size+{}], {});", addr, struct_str),
+                    format!("call tmp := Exists(contents#Memory(m)[old_size+{}], {});", addr, resource_type),
                     format!("m := Memory(domain#Memory(m)[{}+old_size := true], contents#Memory(m)[{}+old_size := tmp]);", dest, dest),
                 ]
             }
-            BorrowGlobal(dest, addr, struct_def_index, _) => {
-                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+            BorrowGlobal(dest, addr, struct_def_index, type_actuals) => {
+                let resource_type = format_struct_type_value_from_def_idx(self.module, struct_def_index, type_actuals);
                 vec![format!(
                     "call t{} := BorrowGlobal(contents#Memory(m)[old_size+{}], {});",
-                    dest, addr, struct_str,
+                    dest, addr, resource_type,
                 )]
             }
-            MoveToSender(src, struct_def_index, _) => {
-                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+            MoveToSender(src, struct_def_index, type_actuals) => {
+                let resource_type = format_struct_type_value_from_def_idx(self.module, struct_def_index, type_actuals);
                 vec![format!(
                     "call MoveToSender({}, contents#Memory(m)[old_size+{}]);",
-                    struct_str, src,
+                    resource_type, src,
                 )]
             }
-            MoveFrom(dest, src, struct_def_index, _) => {
-                let struct_str = self.struct_name_from_definition_index(*struct_def_index);
+            MoveFrom(dest, src, struct_def_index, type_actuals) => {
+                let resource_type = format_struct_type_value_from_def_idx(self.module, struct_def_index, type_actuals);
+                // DO NOT SUBMIT let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 vec![
                     format!(
                         "call tmp := MoveFrom(contents#Memory(m)[old_size+{}], {});",
-                        src, struct_str,
+                        src, resource_type,
                     ),
                     format!("m := Memory(domain#Memory(m)[{}+old_size := true], contents#Memory(m)[{}+old_size := tmp]);", dest, dest),
                     self.format_type_checking(
@@ -587,9 +621,11 @@ impl<'a> ModuleTranslator<'a> {
                 format!("m := Memory(domain#Memory(m)[{}+old_size := true], contents#Memory(m)[{}+old_size := tmp]);", dest, dest),
             ],
             Eq(dest, op1, op2) => {
+                let sig = &self.get_local_type(*op1, func_idx);
                 vec![
                     format!(
-                        "call tmp := Eq(contents#Memory(m)[old_size+{}], contents#Memory(m)[old_size+{}]);",
+                        "tmp := Boolean(is_equal({}, contents#Memory(m)[old_size+{}], contents#Memory(m)[old_size+{}]));",
+                        format_type_value(self.module, sig),
                         op1,
                         op2
                     ),
@@ -597,9 +633,11 @@ impl<'a> ModuleTranslator<'a> {
                 ]
             }
             Neq(dest, op1, op2) => {
+                let sig = &self.get_local_type(*op1, func_idx);
                 vec![
                     format!(
-                        "call tmp := Neq(contents#Memory(m)[old_size+{}], contents#Memory(m)[old_size+{}]);",
+                        "tmp := Boolean(!is_equal({}, contents#Memory(m)[old_size+{}], contents#Memory(m)[old_size+{}]));",
+                        format_type_value(self.module, sig),
                         op1,
                         op2
                     ),
@@ -663,8 +701,14 @@ impl<'a> ModuleTranslator<'a> {
         let function_signature = self.module.function_signature_at(function_handle.signature);
         let mut args = String::new();
         let mut rets = String::new();
-        for (i, arg_type) in function_signature.arg_types.iter().enumerate() {
+        for i in 0..function_signature.type_formals.len() {
             if i > 0 {
+                args.push_str(", ");
+            }
+            args.push_str(&format!("tv{0}: TypeValue", i));
+        }
+        for (i, arg_type) in function_signature.arg_types.iter().enumerate() {
+            if i > 0 || !function_signature.type_formals.is_empty() {
                 args.push_str(", ");
             }
             args.push_str(&format!(
@@ -713,8 +757,19 @@ impl<'a> ModuleTranslator<'a> {
         let mut args = String::new(); // vector of ", argname"
         let mut rets = String::new(); // vector of ", argname"
                                       // return values are: <mutable references>, <actual returns>
+        for i in 0..self
+            .module
+            .function_signature_at(function_handle.signature)
+            .type_formals
+            .len()
+        {
+            if !args.is_empty() {
+                args.push_str(", ");
+            }
+            args.push_str(&format!("tv{}: TypeValue", i));
+        }
         for (i, _arg_type) in function_signature.arg_types.iter().enumerate() {
-            if i > 0 {
+            if !args.is_empty() {
                 args.push_str(", ");
             }
             args.push_str(&self.get_arg_name(i, arg_names).to_string());
@@ -802,7 +857,7 @@ impl<'a> ModuleTranslator<'a> {
                 "    var {}: {}; // {}\n",
                 self.get_local_name(i, arg_names),
                 self.format_value_or_ref(&local_type),
-                format_type(self.module, &local_type)
+                format_type_value(self.module, &local_type)
             ));
         }
         var_decls.push_str("\n    var tmp: Value;\n");
@@ -960,12 +1015,12 @@ impl<'a> ModuleTranslator<'a> {
 
     pub fn format_type_checking(&self, name: String, sig: &SignatureToken) -> String {
         match sig {
+            // Reference does not require type checking
             SignatureToken::Reference(_) | SignatureToken::MutableReference(_) => "".to_string(),
-            SignatureToken::TypeParameter(_) => "".to_string(),
-            _ => format!(
-                "assume is#{}({});\n",
-                format_value_cons(self.module, sig),
-                name,
+            sig => format!(
+                "assume has_type({}, {});\n",
+                format_type_value(self.module, sig),
+                name
             ),
         }
     }
@@ -977,6 +1032,15 @@ pub fn struct_name_from_handle_index(module: &VerifiedModule, idx: StructHandleI
     let module_name = module.identifier_at(struct_handle_view.module_handle().name);
     let struct_name = struct_handle_view.name();
     format!("{}_{}", module_name, struct_name)
+}
+
+pub fn struct_type_arity_from_handle_index(
+    module: &VerifiedModule,
+    idx: StructHandleIndex,
+) -> usize {
+    let struct_handle = module.struct_handle_at(idx);
+    let struct_handle_view = StructHandleView::new(module, struct_handle);
+    struct_handle_view.type_formals().len()
 }
 
 pub fn is_struct_vector(module: &VerifiedModule, idx: StructHandleIndex) -> bool {
@@ -1003,39 +1067,89 @@ pub fn format_type(module: &VerifiedModule, sig: &SignatureToken) -> String {
     }
 }
 
-pub fn format_value_cons(module: &VerifiedModule, sig: &SignatureToken) -> String {
+/// Creates the boogie representation of a TypeValue from a SignatureToken. For type
+/// parameters, this generates a reference to `tvN` (type argument N) which must be bound
+/// in the context. For structs, instead of inlining the type value (which is not possible
+/// for an imported module anyway), we call the function `<struct_name>_type_value(type_args)`.
+pub fn format_type_value(module: &VerifiedModule, sig: &SignatureToken) -> String {
     match sig {
-        SignatureToken::Bool => "Boolean",
-        SignatureToken::U64 => "Integer",
-        SignatureToken::String => "Str",
-        SignatureToken::ByteArray => "ByteArray",
-        SignatureToken::Address => "Address",
-        SignatureToken::Struct(idx, _) => {
-            if is_struct_vector(module, *idx) {
-                "Vector"
-            } else {
-                "Map"
-            }
+        SignatureToken::Bool => "BooleanType()".to_string(),
+        SignatureToken::U64 => "IntegerType()".to_string(),
+        SignatureToken::String => "StrType()".to_string(),
+        SignatureToken::ByteArray => "ByteArrayType()".to_string(),
+        SignatureToken::Address => "AddressType()".to_string(),
+        SignatureToken::Reference(t) | SignatureToken::MutableReference(t) => {
+            format!("ReferenceType({})", format_type_value(module, &*t))
         }
-        _ => "unsupported",
+        SignatureToken::TypeParameter(index) => format!("tv{}", index),
+        SignatureToken::Struct(handle_index, args) => {
+            format_struct_type_value(module, handle_index, args)
+        }
     }
-    .into()
 }
 
-pub fn get_field_info_from_def_index(
+/// Create list of type values.
+pub fn format_type_values(module: &VerifiedModule, actuals: &[SignatureToken]) -> String {
+    actuals
+        .iter()
+        .map(|sig| format_type_value(module, sig))
+        .join(", ")
+}
+
+/// Create list of actual type parameters from LocalSignatureIndex.
+pub fn format_type_actuals(
     module: &VerifiedModule,
-    def_idx: usize,
-) -> BTreeMap<String, (String, String)> {
-    let mut name_to_type = BTreeMap::new();
-    let struct_definition = &module.struct_defs()[def_idx];
-    let struct_definition_view = StructDefinitionView::new(module, struct_definition);
-    for field_definition_view in struct_definition_view.fields().unwrap() {
-        let field_name = field_definition_view.name().to_string();
-        let sig = field_definition_view.type_signature().token().as_inner();
-        name_to_type.insert(
-            field_name,
-            (format_type(module, sig), format_value_cons(module, sig)),
-        );
+    type_actuals_idx: &LocalsSignatureIndex,
+) -> String {
+    format_type_values(module, &module.locals_signature_at(*type_actuals_idx).0)
+}
+
+/// Create type value for a struct with given type actuals.
+pub fn format_struct_type_value(
+    module: &VerifiedModule,
+    struct_handle_idx: &StructHandleIndex,
+    args: &[SignatureToken],
+) -> String {
+    let struct_name = struct_name_from_handle_index(module, *struct_handle_idx);
+    format!(
+        "{}_type_value({})",
+        struct_name,
+        format_type_values(module, args)
+    )
+}
+
+/// Create type value for a struct specified by a definition index and actuals
+/// specified by LocalsSignatureIndex.
+pub fn format_struct_type_value_from_def_idx(
+    module: &VerifiedModule,
+    struct_def_index: &StructDefinitionIndex,
+    type_actuals_idx: &LocalsSignatureIndex,
+) -> String {
+    format_struct_type_value(
+        module,
+        &module.struct_def_at(*struct_def_index).struct_handle,
+        &module.locals_signature_at(*type_actuals_idx).0,
+    )
+}
+
+/// Return a vector of pairs of field name and type for a StructDefinition.
+pub fn get_field_infos(
+    module: &VerifiedModule,
+    struct_def: &StructDefinition,
+) -> Vec<(String, SignatureToken)> {
+    let struct_def_view = StructDefinitionView::new(module, struct_def);
+    if struct_def_view.is_native() {
+        vec![]
+    } else {
+        struct_def_view
+            .fields()
+            .unwrap()
+            .map(|field_def_view| {
+                (
+                    field_def_view.name().to_string(),
+                    field_def_view.type_signature().token().as_inner().clone(),
+                )
+            })
+            .collect()
     }
-    name_to_type
 }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-generics.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-generics.mvir
@@ -1,0 +1,45 @@
+module TestGenerics {
+    import 0x0.Vector;
+
+    resource R {
+        v: Vector.T<u64>
+    }
+
+    struct T<E: unrestricted> {
+         v: Vector.T<E>
+    }
+
+    public move2(x1: u64, x2: u64) {
+        let v: Vector.T<u64>;
+        let r: Self.R;
+        v = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut v, move(x1));
+        Vector.push_back<u64>(&mut v, move(x2));
+        r = R{ v: move(v) };
+        move_to_sender<R>(move(r));
+        return;
+    }
+
+    public create<E: unrestricted>(x: E): Self.T<E> {
+        let v: Vector.T<E>;
+        v = Vector.empty<E>();
+        Vector.push_back<E>(&mut v, move(x));
+        return T<E>{ v: move(v) };
+    }
+
+    public overcomplicated_equals<E: unrestricted>(x: E, y: E): bool {
+        let r: bool;
+        let x1: Self.T<E>;
+        let y1: Self.T<E>;
+        x1 = Self.create<E>(move(x));
+        y1 = Self.create<E>(move(y));
+        r = move(x1) == move(y1);
+        return move(r);
+    }
+
+    public test(): bool {
+      let r: bool;
+      r = Self.overcomplicated_equals<u64>(1, 1);
+      return move(r);
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
@@ -29,7 +29,11 @@ fn compile_files(file_names: Vec<&str>) -> (Vec<VerifiedModule>, SourceMap<Loc>)
 
         match verified_module_res {
             Err(e) => {
-                panic!("{:?}", e);
+                println!("vm verification errors!");
+                for s in &e.1 {
+                    println!("status: {:?}", s);
+                }
+                panic!("{:?}", e.0);
             }
             Ok(verified_module) => {
                 verified_modules.push(verified_module);
@@ -68,6 +72,10 @@ pub fn run_boogie(boogie_str: &str) {
     let temp_path = TempPath::new();
     temp_path.create_as_dir().unwrap();
     let boogie_file_path = temp_path.path().join("output.bpl");
+    // In order to debug errors in the output, one may uncomment below to find the output
+    // file at a stable location.
+    //    let mut boogie_file_path = std::path::PathBuf::new();
+    //    boogie_file_path.push("/tmp/output.bpl");
     fs::write(&boogie_file_path, boogie_str).unwrap();
     if let Ok(boogie_path) = env::var("BOOGIE_EXE") {
         if let Ok(z3_path) = env::var("Z3_EXE") {

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -19,8 +19,8 @@ procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue0(p, i+1, v');
     }
 }
@@ -32,8 +32,8 @@ procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue1(p, i+1, v');
     }
 }
@@ -45,8 +45,8 @@ procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue2(p, i+1, v');
     }
 }
@@ -68,11 +68,11 @@ procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue0(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -83,11 +83,11 @@ procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue1(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -98,30 +98,30 @@ procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) re
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue2(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
 procedure {:inline 1} TestControlFlow_branch_once (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // bool
-    var t1: Value; // bool
-    var t2: Value; // int
-    var t3: Value; // int
-    var t4: Value; // int
-    var t5: Value; // int
+    var t0: Value; // BooleanType()
+    var t1: Value; // BooleanType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Boolean(arg0);
+    assume has_type(BooleanType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 6;
@@ -132,7 +132,7 @@ procedure {:inline 1} TestControlFlow_branch_once (arg0: Value) returns (ret0: V
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 1];
-if (!b#Boolean(tmp)) { goto Label_6; }
+    if (!b#Boolean(tmp)) { goto Label_6; }
 
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -19,8 +19,8 @@ procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue0(p, i+1, v');
     }
 }
@@ -32,8 +32,8 @@ procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue1(p, i+1, v');
     }
 }
@@ -45,8 +45,8 @@ procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue2(p, i+1, v');
     }
 }
@@ -68,11 +68,11 @@ procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue0(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -83,11 +83,11 @@ procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue1(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -98,28 +98,28 @@ procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) re
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue2(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
 procedure {:inline 1} TestFuncCall_f (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Value; // int
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 4;
@@ -148,17 +148,17 @@ procedure TestFuncCall_f_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} TestFuncCall_g (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Value; // int
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 4;
@@ -187,37 +187,37 @@ procedure TestFuncCall_g_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} TestFuncCall_h (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // bool
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Value; // int
-    var t4: Value; // bool
-    var t5: Value; // int
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // bool
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // bool
-    var t13: Value; // bool
-    var t14: Value; // bool
-    var t15: Value; // bool
-    var t16: Value; // int
-    var t17: Value; // int
-    var t18: Value; // bool
-    var t19: Value; // bool
-    var t20: Value; // bool
-    var t21: Value; // bool
-    var t22: Value; // int
-    var t23: Value; // int
+    var t0: Value; // BooleanType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // BooleanType()
+    var t14: Value; // BooleanType()
+    var t15: Value; // BooleanType()
+    var t16: Value; // IntegerType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // BooleanType()
+    var t19: Value; // BooleanType()
+    var t20: Value; // BooleanType()
+    var t21: Value; // BooleanType()
+    var t22: Value; // IntegerType()
+    var t23: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Boolean(arg0);
+    assume has_type(BooleanType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 24;
@@ -234,13 +234,13 @@ procedure {:inline 1} TestFuncCall_h (arg0: Value) returns (ret0: Value)
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 4];
-if (!b#Boolean(tmp)) { goto Label_8; }
+    if (!b#Boolean(tmp)) { goto Label_8; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     call t6 := TestFuncCall_f(contents#Memory(m)[old_size+5]);
-    assume is#Integer(t6);
+    assume has_type(IntegerType(), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
@@ -254,7 +254,7 @@ Label_8:
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
     call t8 := TestFuncCall_g(contents#Memory(m)[old_size+7]);
-    assume is#Integer(t8);
+    assume has_type(IntegerType(), t8);
 
     m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
 
@@ -271,7 +271,7 @@ Label_11:
     call tmp := LdConst(4);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]));
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
     call tmp := And(contents#Memory(m)[old_size+9], contents#Memory(m)[old_size+12]);
@@ -289,7 +289,7 @@ Label_11:
     call tmp := LdConst(5);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+16], contents#Memory(m)[old_size+17]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+16], contents#Memory(m)[old_size+17]));
     m := Memory(domain#Memory(m)[18+old_size := true], contents#Memory(m)[18+old_size := tmp]);
 
     call tmp := And(contents#Memory(m)[old_size+15], contents#Memory(m)[old_size+18]);
@@ -302,7 +302,7 @@ Label_11:
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 21];
-if (!b#Boolean(tmp)) { goto Label_27; }
+    if (!b#Boolean(tmp)) { goto Label_27; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[22+old_size := true], contents#Memory(m)[22+old_size := tmp]);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -1,0 +1,404 @@
+
+
+// everything below is auto generated
+
+const unique TestGenerics_R: TypeName;
+const TestGenerics_R_v: FieldName;
+axiom TestGenerics_R_v == 0;
+function TestGenerics_R_type_value(): TypeValue {
+    StructType(TestGenerics_R, TypeValueArray(DefaultTypeMap[0 := Vector_T_type_value(IntegerType())], 1))
+}
+
+procedure {:inline 1} Pack_TestGenerics_R(v0: Value) returns (v: Value)
+{
+    assume has_type(Vector_T_type_value(IntegerType()), v0);
+    v := Struct(ValueArray(DefaultIntMap[TestGenerics_R_v := v0], 1));
+    assume has_type(TestGenerics_R_type_value(), v);
+}
+
+procedure {:inline 1} Unpack_TestGenerics_R(v: Value) returns (v0: Value)
+{
+    assert is#Struct(v);
+    v0 := smap(v)[TestGenerics_R_v];
+}
+
+const unique TestGenerics_T: TypeName;
+const TestGenerics_T_v: FieldName;
+axiom TestGenerics_T_v == 0;
+function TestGenerics_T_type_value(tv0: TypeValue): TypeValue {
+    StructType(TestGenerics_T, TypeValueArray(DefaultTypeMap[0 := Vector_T_type_value(tv0)], 1))
+}
+
+procedure {:inline 1} Pack_TestGenerics_T(tv0: TypeValue, v0: Value) returns (v: Value)
+{
+    assume has_type(Vector_T_type_value(tv0), v0);
+    v := Struct(ValueArray(DefaultIntMap[TestGenerics_T_v := v0], 1));
+    assume has_type(TestGenerics_T_type_value(tv0), v);
+}
+
+procedure {:inline 1} Unpack_TestGenerics_T(v: Value) returns (v0: Value)
+{
+    assert is#Struct(v);
+    v0 := smap(v)[TestGenerics_T_v];
+}
+
+procedure {:inline 1} ReadValue0(p: Path, i: int, v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := v;
+    } else {
+        assert false;
+    }
+}
+
+procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := v;
+    } else {
+        e := p#Path(p)[i];
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
+        call v' := ReadValue0(p, i+1, v');
+    }
+}
+
+procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := v;
+    } else {
+        e := p#Path(p)[i];
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
+        call v' := ReadValue1(p, i+1, v');
+    }
+}
+
+procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := v;
+    } else {
+        e := p#Path(p)[i];
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
+        call v' := ReadValue2(p, i+1, v');
+    }
+}
+
+procedure {:inline 1} UpdateValue0(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := new_v;
+    } else {
+        assert false;
+    }
+}
+
+procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := new_v;
+    } else {
+        e := p#Path(p)[i];
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
+        call v' := UpdateValue0(p, i+1, v', new_v);
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
+    }
+}
+
+procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := new_v;
+    } else {
+        e := p#Path(p)[i];
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
+        call v' := UpdateValue1(p, i+1, v', new_v);
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
+    }
+}
+
+procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) returns (v': Value)
+{
+    var e: Edge;
+    if (i == size#Path(p)) {
+        v' := new_v;
+    } else {
+        e := p#Path(p)[i];
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
+        call v' := UpdateValue2(p, i+1, v', new_v);
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
+    }
+}
+
+procedure {:inline 1} TestGenerics_move2 (arg0: Value, arg1: Value) returns ()
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // Vector_T_type_value(IntegerType())
+    var t3: Value; // TestGenerics_R_type_value()
+    var t4: Value; // Vector_T_type_value(IntegerType())
+    var t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var t6: Value; // IntegerType()
+    var t7: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var t8: Value; // IntegerType()
+    var t9: Value; // Vector_T_type_value(IntegerType())
+    var t10: Value; // TestGenerics_R_type_value()
+    var t11: Value; // TestGenerics_R_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+    assume !abort_flag;
+
+    // assume arguments are of correct types
+    assume has_type(IntegerType(), arg0);
+    assume has_type(IntegerType(), arg1);
+
+    old_size := m_size;
+    m_size := m_size + 12;
+    m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size :=  arg0]);
+    m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size :=  arg1]);
+
+    // bytecode translation starts here
+    call t4 := Vector_empty(IntegerType());
+    assume has_type(Vector_T_type_value(IntegerType()), t4);
+
+    m := Memory(domain#Memory(m)[old_size+4 := true], contents#Memory(m)[old_size+4 := t4]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+4]);
+    m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
+
+    call t5 := BorrowLoc(old_size+2);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
+    m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
+
+    call Vector_push_back(IntegerType(), t5, contents#Memory(m)[old_size+6]);
+
+    call t7 := BorrowLoc(old_size+2);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
+    m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
+
+    call Vector_push_back(IntegerType(), t7, contents#Memory(m)[old_size+8]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
+    m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
+
+    assume has_type(Vector_T_type_value(IntegerType()), contents#Memory(m)[old_size+9]);
+
+    call tmp := Pack_TestGenerics_R(contents#Memory(m)[old_size+9]);
+    m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+10]);
+    m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
+    m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
+
+    call MoveToSender(TestGenerics_R_type_value(), contents#Memory(m)[old_size+11]);
+
+    return;
+
+}
+
+procedure TestGenerics_move2_verify (arg0: Value, arg1: Value) returns ()
+{
+    call TestGenerics_move2(arg0, arg1);
+}
+
+procedure {:inline 1} TestGenerics_create (tv0: TypeValue, arg0: Value) returns (ret0: Value)
+{
+    // declare local variables
+    var t0: Value; // tv0
+    var t1: Value; // Vector_T_type_value(tv0)
+    var t2: Value; // Vector_T_type_value(tv0)
+    var t3: Reference; // ReferenceType(Vector_T_type_value(tv0))
+    var t4: Value; // tv0
+    var t5: Value; // Vector_T_type_value(tv0)
+    var t6: Value; // TestGenerics_T_type_value(tv0)
+
+    var tmp: Value;
+    var old_size: int;
+    assume !abort_flag;
+
+    // assume arguments are of correct types
+    assume has_type(tv0, arg0);
+
+    old_size := m_size;
+    m_size := m_size + 7;
+    m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size :=  arg0]);
+
+    // bytecode translation starts here
+    call t2 := Vector_empty(tv0);
+    assume has_type(Vector_T_type_value(tv0), t2);
+
+    m := Memory(domain#Memory(m)[old_size+2 := true], contents#Memory(m)[old_size+2 := t2]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
+    m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
+
+    call t3 := BorrowLoc(old_size+1);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
+    m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
+
+    call Vector_push_back(tv0, t3, contents#Memory(m)[old_size+4]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
+    m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
+
+    assume has_type(Vector_T_type_value(tv0), contents#Memory(m)[old_size+5]);
+
+    call tmp := Pack_TestGenerics_T(tv0, contents#Memory(m)[old_size+5]);
+    m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
+
+    ret0 := contents#Memory(m)[old_size+6];
+    return;
+
+}
+
+procedure TestGenerics_create_verify (tv0: TypeValue, arg0: Value) returns (ret0: Value)
+{
+    call ret0 := TestGenerics_create(tv0: TypeValue, arg0);
+}
+
+procedure {:inline 1} TestGenerics_overcomplicated_equals (tv0: TypeValue, arg0: Value, arg1: Value) returns (ret0: Value)
+{
+    // declare local variables
+    var t0: Value; // tv0
+    var t1: Value; // tv0
+    var t2: Value; // BooleanType()
+    var t3: Value; // TestGenerics_T_type_value(tv0)
+    var t4: Value; // TestGenerics_T_type_value(tv0)
+    var t5: Value; // tv0
+    var t6: Value; // TestGenerics_T_type_value(tv0)
+    var t7: Value; // tv0
+    var t8: Value; // TestGenerics_T_type_value(tv0)
+    var t9: Value; // TestGenerics_T_type_value(tv0)
+    var t10: Value; // TestGenerics_T_type_value(tv0)
+    var t11: Value; // BooleanType()
+    var t12: Value; // BooleanType()
+
+    var tmp: Value;
+    var old_size: int;
+    assume !abort_flag;
+
+    // assume arguments are of correct types
+    assume has_type(tv0, arg0);
+    assume has_type(tv0, arg1);
+
+    old_size := m_size;
+    m_size := m_size + 13;
+    m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size :=  arg0]);
+    m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size :=  arg1]);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
+    m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
+
+    call t6 := TestGenerics_create(tv0, contents#Memory(m)[old_size+5]);
+    assume has_type(TestGenerics_T_type_value(tv0), t6);
+
+    m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+6]);
+    m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
+    m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
+
+    call t8 := TestGenerics_create(tv0, contents#Memory(m)[old_size+7]);
+    assume has_type(TestGenerics_T_type_value(tv0), t8);
+
+    m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+8]);
+    m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
+    m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+4]);
+    m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
+
+    tmp := Boolean(is_equal(TestGenerics_T_type_value(tv0), contents#Memory(m)[old_size+9], contents#Memory(m)[old_size+10]));
+    m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+11]);
+    m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
+    m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
+
+    ret0 := contents#Memory(m)[old_size+12];
+    return;
+
+}
+
+procedure TestGenerics_overcomplicated_equals_verify (tv0: TypeValue, arg0: Value, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := TestGenerics_overcomplicated_equals(tv0: TypeValue, arg0, arg1);
+}
+
+procedure {:inline 1} TestGenerics_test () returns (ret0: Value)
+{
+    // declare local variables
+    var t0: Value; // BooleanType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // BooleanType()
+
+    var tmp: Value;
+    var old_size: int;
+    assume !abort_flag;
+
+    // assume arguments are of correct types
+
+    old_size := m_size;
+    m_size := m_size + 5;
+
+    // bytecode translation starts here
+    call tmp := LdConst(1);
+    m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
+
+    call tmp := LdConst(1);
+    m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
+
+    call t3 := TestGenerics_overcomplicated_equals(IntegerType(), contents#Memory(m)[old_size+1], contents#Memory(m)[old_size+2]);
+    assume has_type(BooleanType(), t3);
+
+    m := Memory(domain#Memory(m)[old_size+3 := true], contents#Memory(m)[old_size+3 := t3]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
+    m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
+
+    call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
+    m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
+
+    ret0 := contents#Memory(m)[old_size+4];
+    return;
+
+}
+
+procedure TestGenerics_test_verify () returns (ret0: Value)
+{
+    call ret0 := TestGenerics_test();
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -3,732 +3,479 @@
 // everything below is auto generated
 
 const unique LibraCoin_T: TypeName;
-const unique LibraCoin_T_value: FieldName;
+const LibraCoin_T_value: FieldName;
+axiom LibraCoin_T_value == 0;
+function LibraCoin_T_type_value(): TypeValue {
+    StructType(LibraCoin_T, TypeValueArray(DefaultTypeMap[0 := IntegerType()], 1))
+}
 
 procedure {:inline 1} Pack_LibraCoin_T(v0: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    v := Map(DefaultMap[Field(LibraCoin_T_value) := v0]);
+    assume has_type(IntegerType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[LibraCoin_T_value := v0], 1));
+    assume has_type(LibraCoin_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraCoin_T_value)];
-}
-
-procedure {:inline 1} Eq_LibraCoin_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraCoin_T_value)], m#Map(v2)[Field(LibraCoin_T_value)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_LibraCoin_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraCoin_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraCoin_T_value];
 }
 
 const unique LibraCoin_MintCapability: TypeName;
+function LibraCoin_MintCapability_type_value(): TypeValue {
+    StructType(LibraCoin_MintCapability, TypeValueArray(DefaultTypeMap, 0))
+}
 
 procedure {:inline 1} Pack_LibraCoin_MintCapability() returns (v: Value)
 {
-    v := Map(DefaultMap);
+    v := Struct(ValueArray(DefaultIntMap, 0));
+    assume has_type(LibraCoin_MintCapability_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(v: Value) returns ()
 {
-    assert is#Map(v);
-}
-
-procedure {:inline 1} Eq_LibraCoin_MintCapability(v1: Value, v2: Value) returns (res: Value)
-{
-    assert is#Map(v1) && is#Map(v2);
-    res := Boolean(true);
-}
-
-procedure {:inline 1} Neq_LibraCoin_MintCapability(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraCoin_MintCapability(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
 }
 
 const unique LibraCoin_MarketCap: TypeName;
-const unique LibraCoin_MarketCap_total_value: FieldName;
+const LibraCoin_MarketCap_total_value: FieldName;
+axiom LibraCoin_MarketCap_total_value == 0;
+function LibraCoin_MarketCap_type_value(): TypeValue {
+    StructType(LibraCoin_MarketCap, TypeValueArray(DefaultTypeMap[0 := IntegerType()], 1))
+}
 
 procedure {:inline 1} Pack_LibraCoin_MarketCap(v0: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    v := Map(DefaultMap[Field(LibraCoin_MarketCap_total_value) := v0]);
+    assume has_type(IntegerType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[LibraCoin_MarketCap_total_value := v0], 1));
+    assume has_type(LibraCoin_MarketCap_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraCoin_MarketCap_total_value)];
+    assert is#Struct(v);
+    v0 := smap(v)[LibraCoin_MarketCap_total_value];
 }
 
-procedure {:inline 1} Eq_LibraCoin_MarketCap(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraCoin_MarketCap_total_value)], m#Map(v2)[Field(LibraCoin_MarketCap_total_value)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_LibraCoin_MarketCap(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraCoin_MarketCap(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
-}
-
-const unique Vector_T: TypeName;
 const unique ValidatorConfig_Config: TypeName;
-const unique ValidatorConfig_Config_consensus_pubkey: FieldName;
-const unique ValidatorConfig_Config_network_identity_pubkey: FieldName;
-const unique ValidatorConfig_Config_network_signing_pubkey: FieldName;
+const ValidatorConfig_Config_consensus_pubkey: FieldName;
+axiom ValidatorConfig_Config_consensus_pubkey == 0;
+const ValidatorConfig_Config_network_identity_pubkey: FieldName;
+axiom ValidatorConfig_Config_network_identity_pubkey == 1;
+const ValidatorConfig_Config_network_signing_pubkey: FieldName;
+axiom ValidatorConfig_Config_network_signing_pubkey == 2;
+function ValidatorConfig_Config_type_value(): TypeValue {
+    StructType(ValidatorConfig_Config, TypeValueArray(DefaultTypeMap[0 := ByteArrayType()][1 := ByteArrayType()][2 := ByteArrayType()], 3))
+}
 
 procedure {:inline 1} Pack_ValidatorConfig_Config(v0: Value, v1: Value, v2: Value) returns (v: Value)
 {
-    assert is#ByteArray(v0);
-    assert is#ByteArray(v1);
-    assert is#ByteArray(v2);
-    v := Map(DefaultMap[Field(ValidatorConfig_Config_consensus_pubkey) := v0][Field(ValidatorConfig_Config_network_identity_pubkey) := v1][Field(ValidatorConfig_Config_network_signing_pubkey) := v2]);
+    assume has_type(ByteArrayType(), v0);
+    assume has_type(ByteArrayType(), v1);
+    assume has_type(ByteArrayType(), v2);
+    v := Struct(ValueArray(DefaultIntMap[ValidatorConfig_Config_consensus_pubkey := v0][ValidatorConfig_Config_network_identity_pubkey := v1][ValidatorConfig_Config_network_signing_pubkey := v2], 3));
+    assume has_type(ValidatorConfig_Config_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_ValidatorConfig_Config(v: Value) returns (v0: Value, v1: Value, v2: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(ValidatorConfig_Config_consensus_pubkey)];
-    v1 := m#Map(v)[Field(ValidatorConfig_Config_network_identity_pubkey)];
-    v2 := m#Map(v)[Field(ValidatorConfig_Config_network_signing_pubkey)];
-}
-
-procedure {:inline 1} Eq_ValidatorConfig_Config(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    var b2: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_bytearray(m#Map(v1)[Field(ValidatorConfig_Config_consensus_pubkey)], m#Map(v2)[Field(ValidatorConfig_Config_consensus_pubkey)]);
-    call b1 := Eq_bytearray(m#Map(v1)[Field(ValidatorConfig_Config_network_identity_pubkey)], m#Map(v2)[Field(ValidatorConfig_Config_network_identity_pubkey)]);
-    call b2 := Eq_bytearray(m#Map(v1)[Field(ValidatorConfig_Config_network_signing_pubkey)], m#Map(v2)[Field(ValidatorConfig_Config_network_signing_pubkey)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1) && b#Boolean(b2));
-}
-
-procedure {:inline 1} Neq_ValidatorConfig_Config(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_ValidatorConfig_Config(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[ValidatorConfig_Config_consensus_pubkey];
+    v1 := smap(v)[ValidatorConfig_Config_network_identity_pubkey];
+    v2 := smap(v)[ValidatorConfig_Config_network_signing_pubkey];
 }
 
 const unique ValidatorConfig_T: TypeName;
-const unique ValidatorConfig_T_config: FieldName;
+const ValidatorConfig_T_config: FieldName;
+axiom ValidatorConfig_T_config == 0;
+function ValidatorConfig_T_type_value(): TypeValue {
+    StructType(ValidatorConfig_T, TypeValueArray(DefaultTypeMap[0 := ValidatorConfig_Config_type_value()], 1))
+}
 
 procedure {:inline 1} Pack_ValidatorConfig_T(v0: Value) returns (v: Value)
 {
-    assert is#Map(v0);
-    v := Map(DefaultMap[Field(ValidatorConfig_T_config) := v0]);
+    assume has_type(ValidatorConfig_Config_type_value(), v0);
+    v := Struct(ValueArray(DefaultIntMap[ValidatorConfig_T_config := v0], 1));
+    assume has_type(ValidatorConfig_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_ValidatorConfig_T(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(ValidatorConfig_T_config)];
-}
-
-procedure {:inline 1} Eq_ValidatorConfig_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_ValidatorConfig_Config(m#Map(v1)[Field(ValidatorConfig_T_config)], m#Map(v2)[Field(ValidatorConfig_T_config)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_ValidatorConfig_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_ValidatorConfig_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[ValidatorConfig_T_config];
 }
 
 const unique GasSchedule_Cost: TypeName;
-const unique GasSchedule_Cost_cpu: FieldName;
-const unique GasSchedule_Cost_storage: FieldName;
+const GasSchedule_Cost_cpu: FieldName;
+axiom GasSchedule_Cost_cpu == 0;
+const GasSchedule_Cost_storage: FieldName;
+axiom GasSchedule_Cost_storage == 1;
+function GasSchedule_Cost_type_value(): TypeValue {
+    StructType(GasSchedule_Cost, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := IntegerType()], 2))
+}
 
 procedure {:inline 1} Pack_GasSchedule_Cost(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    assert is#Integer(v1);
-    v := Map(DefaultMap[Field(GasSchedule_Cost_cpu) := v0][Field(GasSchedule_Cost_storage) := v1]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(IntegerType(), v1);
+    v := Struct(ValueArray(DefaultIntMap[GasSchedule_Cost_cpu := v0][GasSchedule_Cost_storage := v1], 2));
+    assume has_type(GasSchedule_Cost_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_GasSchedule_Cost(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(GasSchedule_Cost_cpu)];
-    v1 := m#Map(v)[Field(GasSchedule_Cost_storage)];
-}
-
-procedure {:inline 1} Eq_GasSchedule_Cost(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(GasSchedule_Cost_cpu)], m#Map(v2)[Field(GasSchedule_Cost_cpu)]);
-    call b1 := Eq_int(m#Map(v1)[Field(GasSchedule_Cost_storage)], m#Map(v2)[Field(GasSchedule_Cost_storage)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_GasSchedule_Cost(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_GasSchedule_Cost(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[GasSchedule_Cost_cpu];
+    v1 := smap(v)[GasSchedule_Cost_storage];
 }
 
 const unique GasSchedule_T: TypeName;
-const unique GasSchedule_T_instruction_schedule: FieldName;
-const unique GasSchedule_T_native_schedule: FieldName;
+const GasSchedule_T_instruction_schedule: FieldName;
+axiom GasSchedule_T_instruction_schedule == 0;
+const GasSchedule_T_native_schedule: FieldName;
+axiom GasSchedule_T_native_schedule == 1;
+function GasSchedule_T_type_value(): TypeValue {
+    StructType(GasSchedule_T, TypeValueArray(DefaultTypeMap[0 := Vector_T_type_value(GasSchedule_Cost_type_value())][1 := Vector_T_type_value(GasSchedule_Cost_type_value())], 2))
+}
 
 procedure {:inline 1} Pack_GasSchedule_T(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Vector(v0);
-    assert is#Vector(v1);
-    v := Map(DefaultMap[Field(GasSchedule_T_instruction_schedule) := v0][Field(GasSchedule_T_native_schedule) := v1]);
+    assume has_type(Vector_T_type_value(GasSchedule_Cost_type_value()), v0);
+    assume has_type(Vector_T_type_value(GasSchedule_Cost_type_value()), v1);
+    v := Struct(ValueArray(DefaultIntMap[GasSchedule_T_instruction_schedule := v0][GasSchedule_T_native_schedule := v1], 2));
+    assume has_type(GasSchedule_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_GasSchedule_T(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(GasSchedule_T_instruction_schedule)];
-    v1 := m#Map(v)[Field(GasSchedule_T_native_schedule)];
-}
-
-procedure {:inline 1} Eq_GasSchedule_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_Vector_T(m#Map(v1)[Field(GasSchedule_T_instruction_schedule)], m#Map(v2)[Field(GasSchedule_T_instruction_schedule)]);
-    call b1 := Eq_Vector_T(m#Map(v1)[Field(GasSchedule_T_native_schedule)], m#Map(v2)[Field(GasSchedule_T_native_schedule)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_GasSchedule_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_GasSchedule_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[GasSchedule_T_instruction_schedule];
+    v1 := smap(v)[GasSchedule_T_native_schedule];
 }
 
 const unique LibraAccount_T: TypeName;
-const unique LibraAccount_T_authentication_key: FieldName;
-const unique LibraAccount_T_balance: FieldName;
-const unique LibraAccount_T_delegated_key_rotation_capability: FieldName;
-const unique LibraAccount_T_delegated_withdrawal_capability: FieldName;
-const unique LibraAccount_T_event_generator: FieldName;
-const unique LibraAccount_T_received_events: FieldName;
-const unique LibraAccount_T_sent_events: FieldName;
-const unique LibraAccount_T_sequence_number: FieldName;
+const LibraAccount_T_authentication_key: FieldName;
+axiom LibraAccount_T_authentication_key == 0;
+const LibraAccount_T_balance: FieldName;
+axiom LibraAccount_T_balance == 1;
+const LibraAccount_T_delegated_key_rotation_capability: FieldName;
+axiom LibraAccount_T_delegated_key_rotation_capability == 2;
+const LibraAccount_T_delegated_withdrawal_capability: FieldName;
+axiom LibraAccount_T_delegated_withdrawal_capability == 3;
+const LibraAccount_T_received_events: FieldName;
+axiom LibraAccount_T_received_events == 4;
+const LibraAccount_T_sent_events: FieldName;
+axiom LibraAccount_T_sent_events == 5;
+const LibraAccount_T_sequence_number: FieldName;
+axiom LibraAccount_T_sequence_number == 6;
+const LibraAccount_T_event_generator: FieldName;
+axiom LibraAccount_T_event_generator == 7;
+function LibraAccount_T_type_value(): TypeValue {
+    StructType(LibraAccount_T, TypeValueArray(DefaultTypeMap[0 := ByteArrayType()][1 := LibraCoin_T_type_value()][2 := BooleanType()][3 := BooleanType()][4 := LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())][5 := LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())][6 := IntegerType()][7 := LibraAccount_EventHandleGenerator_type_value()], 8))
+}
 
 procedure {:inline 1} Pack_LibraAccount_T(v0: Value, v1: Value, v2: Value, v3: Value, v4: Value, v5: Value, v6: Value, v7: Value) returns (v: Value)
 {
-    assert is#ByteArray(v0);
-    assert is#Map(v1);
-    assert is#Boolean(v2);
-    assert is#Boolean(v3);
-    assert is#Map(v4);
-    assert is#Map(v5);
-    assert is#Map(v6);
-    assert is#Integer(v7);
-    v := Map(DefaultMap[Field(LibraAccount_T_authentication_key) := v0][Field(LibraAccount_T_balance) := v1][Field(LibraAccount_T_delegated_key_rotation_capability) := v2][Field(LibraAccount_T_delegated_withdrawal_capability) := v3][Field(LibraAccount_T_event_generator) := v4][Field(LibraAccount_T_received_events) := v5][Field(LibraAccount_T_sent_events) := v6][Field(LibraAccount_T_sequence_number) := v7]);
+    assume has_type(ByteArrayType(), v0);
+    assume has_type(LibraCoin_T_type_value(), v1);
+    assume has_type(BooleanType(), v2);
+    assume has_type(BooleanType(), v3);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()), v4);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()), v5);
+    assume has_type(IntegerType(), v6);
+    assume has_type(LibraAccount_EventHandleGenerator_type_value(), v7);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_T_authentication_key := v0][LibraAccount_T_balance := v1][LibraAccount_T_delegated_key_rotation_capability := v2][LibraAccount_T_delegated_withdrawal_capability := v3][LibraAccount_T_received_events := v4][LibraAccount_T_sent_events := v5][LibraAccount_T_sequence_number := v6][LibraAccount_T_event_generator := v7], 8));
+    assume has_type(LibraAccount_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(v: Value) returns (v0: Value, v1: Value, v2: Value, v3: Value, v4: Value, v5: Value, v6: Value, v7: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_T_authentication_key)];
-    v1 := m#Map(v)[Field(LibraAccount_T_balance)];
-    v2 := m#Map(v)[Field(LibraAccount_T_delegated_key_rotation_capability)];
-    v3 := m#Map(v)[Field(LibraAccount_T_delegated_withdrawal_capability)];
-    v4 := m#Map(v)[Field(LibraAccount_T_event_generator)];
-    v5 := m#Map(v)[Field(LibraAccount_T_received_events)];
-    v6 := m#Map(v)[Field(LibraAccount_T_sent_events)];
-    v7 := m#Map(v)[Field(LibraAccount_T_sequence_number)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    var b2: Value;
-    var b3: Value;
-    var b4: Value;
-    var b5: Value;
-    var b6: Value;
-    var b7: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_bytearray(m#Map(v1)[Field(LibraAccount_T_authentication_key)], m#Map(v2)[Field(LibraAccount_T_authentication_key)]);
-    call b1 := Eq_LibraCoin_T(m#Map(v1)[Field(LibraAccount_T_balance)], m#Map(v2)[Field(LibraAccount_T_balance)]);
-    call b2 := Eq_bool(m#Map(v1)[Field(LibraAccount_T_delegated_key_rotation_capability)], m#Map(v2)[Field(LibraAccount_T_delegated_key_rotation_capability)]);
-    call b3 := Eq_bool(m#Map(v1)[Field(LibraAccount_T_delegated_withdrawal_capability)], m#Map(v2)[Field(LibraAccount_T_delegated_withdrawal_capability)]);
-    call b4 := Eq_LibraAccount_EventHandleGenerator(m#Map(v1)[Field(LibraAccount_T_event_generator)], m#Map(v2)[Field(LibraAccount_T_event_generator)]);
-    call b5 := Eq_LibraAccount_EventHandle(m#Map(v1)[Field(LibraAccount_T_received_events)], m#Map(v2)[Field(LibraAccount_T_received_events)]);
-    call b6 := Eq_LibraAccount_EventHandle(m#Map(v1)[Field(LibraAccount_T_sent_events)], m#Map(v2)[Field(LibraAccount_T_sent_events)]);
-    call b7 := Eq_int(m#Map(v1)[Field(LibraAccount_T_sequence_number)], m#Map(v2)[Field(LibraAccount_T_sequence_number)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1) && b#Boolean(b2) && b#Boolean(b3) && b#Boolean(b4) && b#Boolean(b5) && b#Boolean(b6) && b#Boolean(b7));
-}
-
-procedure {:inline 1} Neq_LibraAccount_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_T_authentication_key];
+    v1 := smap(v)[LibraAccount_T_balance];
+    v2 := smap(v)[LibraAccount_T_delegated_key_rotation_capability];
+    v3 := smap(v)[LibraAccount_T_delegated_withdrawal_capability];
+    v4 := smap(v)[LibraAccount_T_received_events];
+    v5 := smap(v)[LibraAccount_T_sent_events];
+    v6 := smap(v)[LibraAccount_T_sequence_number];
+    v7 := smap(v)[LibraAccount_T_event_generator];
 }
 
 const unique LibraAccount_WithdrawalCapability: TypeName;
-const unique LibraAccount_WithdrawalCapability_account_address: FieldName;
+const LibraAccount_WithdrawalCapability_account_address: FieldName;
+axiom LibraAccount_WithdrawalCapability_account_address == 0;
+function LibraAccount_WithdrawalCapability_type_value(): TypeValue {
+    StructType(LibraAccount_WithdrawalCapability, TypeValueArray(DefaultTypeMap[0 := AddressType()], 1))
+}
 
 procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(v0: Value) returns (v: Value)
 {
-    assert is#Address(v0);
-    v := Map(DefaultMap[Field(LibraAccount_WithdrawalCapability_account_address) := v0]);
+    assume has_type(AddressType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_WithdrawalCapability_account_address := v0], 1));
+    assume has_type(LibraAccount_WithdrawalCapability_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_WithdrawalCapability_account_address)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_WithdrawalCapability(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_address(m#Map(v1)[Field(LibraAccount_WithdrawalCapability_account_address)], m#Map(v2)[Field(LibraAccount_WithdrawalCapability_account_address)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_LibraAccount_WithdrawalCapability(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_WithdrawalCapability(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_WithdrawalCapability_account_address];
 }
 
 const unique LibraAccount_KeyRotationCapability: TypeName;
-const unique LibraAccount_KeyRotationCapability_account_address: FieldName;
+const LibraAccount_KeyRotationCapability_account_address: FieldName;
+axiom LibraAccount_KeyRotationCapability_account_address == 0;
+function LibraAccount_KeyRotationCapability_type_value(): TypeValue {
+    StructType(LibraAccount_KeyRotationCapability, TypeValueArray(DefaultTypeMap[0 := AddressType()], 1))
+}
 
 procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(v0: Value) returns (v: Value)
 {
-    assert is#Address(v0);
-    v := Map(DefaultMap[Field(LibraAccount_KeyRotationCapability_account_address) := v0]);
+    assume has_type(AddressType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_KeyRotationCapability_account_address := v0], 1));
+    assume has_type(LibraAccount_KeyRotationCapability_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_KeyRotationCapability_account_address)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_KeyRotationCapability(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_address(m#Map(v1)[Field(LibraAccount_KeyRotationCapability_account_address)], m#Map(v2)[Field(LibraAccount_KeyRotationCapability_account_address)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_LibraAccount_KeyRotationCapability(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_KeyRotationCapability(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_KeyRotationCapability_account_address];
 }
 
 const unique LibraAccount_SentPaymentEvent: TypeName;
-const unique LibraAccount_SentPaymentEvent_amount: FieldName;
-const unique LibraAccount_SentPaymentEvent_metadata: FieldName;
-const unique LibraAccount_SentPaymentEvent_payee: FieldName;
+const LibraAccount_SentPaymentEvent_amount: FieldName;
+axiom LibraAccount_SentPaymentEvent_amount == 0;
+const LibraAccount_SentPaymentEvent_payee: FieldName;
+axiom LibraAccount_SentPaymentEvent_payee == 1;
+const LibraAccount_SentPaymentEvent_metadata: FieldName;
+axiom LibraAccount_SentPaymentEvent_metadata == 2;
+function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
+    StructType(LibraAccount_SentPaymentEvent, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := AddressType()][2 := ByteArrayType()], 3))
+}
 
 procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(v0: Value, v1: Value, v2: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    assert is#ByteArray(v1);
-    assert is#Address(v2);
-    v := Map(DefaultMap[Field(LibraAccount_SentPaymentEvent_amount) := v0][Field(LibraAccount_SentPaymentEvent_metadata) := v1][Field(LibraAccount_SentPaymentEvent_payee) := v2]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(AddressType(), v1);
+    assume has_type(ByteArrayType(), v2);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_SentPaymentEvent_amount := v0][LibraAccount_SentPaymentEvent_payee := v1][LibraAccount_SentPaymentEvent_metadata := v2], 3));
+    assume has_type(LibraAccount_SentPaymentEvent_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(v: Value) returns (v0: Value, v1: Value, v2: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_SentPaymentEvent_amount)];
-    v1 := m#Map(v)[Field(LibraAccount_SentPaymentEvent_metadata)];
-    v2 := m#Map(v)[Field(LibraAccount_SentPaymentEvent_payee)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_SentPaymentEvent(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    var b2: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraAccount_SentPaymentEvent_amount)], m#Map(v2)[Field(LibraAccount_SentPaymentEvent_amount)]);
-    call b1 := Eq_bytearray(m#Map(v1)[Field(LibraAccount_SentPaymentEvent_metadata)], m#Map(v2)[Field(LibraAccount_SentPaymentEvent_metadata)]);
-    call b2 := Eq_address(m#Map(v1)[Field(LibraAccount_SentPaymentEvent_payee)], m#Map(v2)[Field(LibraAccount_SentPaymentEvent_payee)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1) && b#Boolean(b2));
-}
-
-procedure {:inline 1} Neq_LibraAccount_SentPaymentEvent(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_SentPaymentEvent(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_SentPaymentEvent_amount];
+    v1 := smap(v)[LibraAccount_SentPaymentEvent_payee];
+    v2 := smap(v)[LibraAccount_SentPaymentEvent_metadata];
 }
 
 const unique LibraAccount_ReceivedPaymentEvent: TypeName;
-const unique LibraAccount_ReceivedPaymentEvent_amount: FieldName;
-const unique LibraAccount_ReceivedPaymentEvent_metadata: FieldName;
-const unique LibraAccount_ReceivedPaymentEvent_payer: FieldName;
+const LibraAccount_ReceivedPaymentEvent_amount: FieldName;
+axiom LibraAccount_ReceivedPaymentEvent_amount == 0;
+const LibraAccount_ReceivedPaymentEvent_payer: FieldName;
+axiom LibraAccount_ReceivedPaymentEvent_payer == 1;
+const LibraAccount_ReceivedPaymentEvent_metadata: FieldName;
+axiom LibraAccount_ReceivedPaymentEvent_metadata == 2;
+function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
+    StructType(LibraAccount_ReceivedPaymentEvent, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := AddressType()][2 := ByteArrayType()], 3))
+}
 
 procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(v0: Value, v1: Value, v2: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    assert is#ByteArray(v1);
-    assert is#Address(v2);
-    v := Map(DefaultMap[Field(LibraAccount_ReceivedPaymentEvent_amount) := v0][Field(LibraAccount_ReceivedPaymentEvent_metadata) := v1][Field(LibraAccount_ReceivedPaymentEvent_payer) := v2]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(AddressType(), v1);
+    assume has_type(ByteArrayType(), v2);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_ReceivedPaymentEvent_amount := v0][LibraAccount_ReceivedPaymentEvent_payer := v1][LibraAccount_ReceivedPaymentEvent_metadata := v2], 3));
+    assume has_type(LibraAccount_ReceivedPaymentEvent_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(v: Value) returns (v0: Value, v1: Value, v2: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_ReceivedPaymentEvent_amount)];
-    v1 := m#Map(v)[Field(LibraAccount_ReceivedPaymentEvent_metadata)];
-    v2 := m#Map(v)[Field(LibraAccount_ReceivedPaymentEvent_payer)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_ReceivedPaymentEvent(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    var b2: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraAccount_ReceivedPaymentEvent_amount)], m#Map(v2)[Field(LibraAccount_ReceivedPaymentEvent_amount)]);
-    call b1 := Eq_bytearray(m#Map(v1)[Field(LibraAccount_ReceivedPaymentEvent_metadata)], m#Map(v2)[Field(LibraAccount_ReceivedPaymentEvent_metadata)]);
-    call b2 := Eq_address(m#Map(v1)[Field(LibraAccount_ReceivedPaymentEvent_payer)], m#Map(v2)[Field(LibraAccount_ReceivedPaymentEvent_payer)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1) && b#Boolean(b2));
-}
-
-procedure {:inline 1} Neq_LibraAccount_ReceivedPaymentEvent(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_ReceivedPaymentEvent(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_ReceivedPaymentEvent_amount];
+    v1 := smap(v)[LibraAccount_ReceivedPaymentEvent_payer];
+    v2 := smap(v)[LibraAccount_ReceivedPaymentEvent_metadata];
 }
 
 const unique LibraAccount_EventHandleGenerator: TypeName;
-const unique LibraAccount_EventHandleGenerator_counter: FieldName;
+const LibraAccount_EventHandleGenerator_counter: FieldName;
+axiom LibraAccount_EventHandleGenerator_counter == 0;
+function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
+    StructType(LibraAccount_EventHandleGenerator, TypeValueArray(DefaultTypeMap[0 := IntegerType()], 1))
+}
 
 procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(v0: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    v := Map(DefaultMap[Field(LibraAccount_EventHandleGenerator_counter) := v0]);
+    assume has_type(IntegerType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_EventHandleGenerator_counter := v0], 1));
+    assume has_type(LibraAccount_EventHandleGenerator_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_EventHandleGenerator_counter)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_EventHandleGenerator(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraAccount_EventHandleGenerator_counter)], m#Map(v2)[Field(LibraAccount_EventHandleGenerator_counter)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_LibraAccount_EventHandleGenerator(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_EventHandleGenerator(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_EventHandleGenerator_counter];
 }
 
 const unique LibraAccount_EventHandle: TypeName;
-const unique LibraAccount_EventHandle_counter: FieldName;
-const unique LibraAccount_EventHandle_guid: FieldName;
+const LibraAccount_EventHandle_counter: FieldName;
+axiom LibraAccount_EventHandle_counter == 0;
+const LibraAccount_EventHandle_guid: FieldName;
+axiom LibraAccount_EventHandle_guid == 1;
+function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
+    StructType(LibraAccount_EventHandle, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := ByteArrayType()], 2))
+}
 
-procedure {:inline 1} Pack_LibraAccount_EventHandle(v0: Value, v1: Value) returns (v: Value)
+procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    assert is#ByteArray(v1);
-    v := Map(DefaultMap[Field(LibraAccount_EventHandle_counter) := v0][Field(LibraAccount_EventHandle_guid) := v1]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(ByteArrayType(), v1);
+    v := Struct(ValueArray(DefaultIntMap[LibraAccount_EventHandle_counter := v0][LibraAccount_EventHandle_guid := v1], 2));
+    assume has_type(LibraAccount_EventHandle_type_value(tv0), v);
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraAccount_EventHandle_counter)];
-    v1 := m#Map(v)[Field(LibraAccount_EventHandle_guid)];
-}
-
-procedure {:inline 1} Eq_LibraAccount_EventHandle(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraAccount_EventHandle_counter)], m#Map(v2)[Field(LibraAccount_EventHandle_counter)]);
-    call b1 := Eq_bytearray(m#Map(v1)[Field(LibraAccount_EventHandle_guid)], m#Map(v2)[Field(LibraAccount_EventHandle_guid)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_LibraAccount_EventHandle(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraAccount_EventHandle(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraAccount_EventHandle_counter];
+    v1 := smap(v)[LibraAccount_EventHandle_guid];
 }
 
 const unique LibraSystem_ValidatorInfo: TypeName;
-const unique LibraSystem_ValidatorInfo_addr: FieldName;
-const unique LibraSystem_ValidatorInfo_consensus_pubkey: FieldName;
-const unique LibraSystem_ValidatorInfo_consensus_voting_power: FieldName;
-const unique LibraSystem_ValidatorInfo_network_identity_pubkey: FieldName;
-const unique LibraSystem_ValidatorInfo_network_signing_pubkey: FieldName;
+const LibraSystem_ValidatorInfo_addr: FieldName;
+axiom LibraSystem_ValidatorInfo_addr == 0;
+const LibraSystem_ValidatorInfo_consensus_pubkey: FieldName;
+axiom LibraSystem_ValidatorInfo_consensus_pubkey == 1;
+const LibraSystem_ValidatorInfo_consensus_voting_power: FieldName;
+axiom LibraSystem_ValidatorInfo_consensus_voting_power == 2;
+const LibraSystem_ValidatorInfo_network_signing_pubkey: FieldName;
+axiom LibraSystem_ValidatorInfo_network_signing_pubkey == 3;
+const LibraSystem_ValidatorInfo_network_identity_pubkey: FieldName;
+axiom LibraSystem_ValidatorInfo_network_identity_pubkey == 4;
+function LibraSystem_ValidatorInfo_type_value(): TypeValue {
+    StructType(LibraSystem_ValidatorInfo, TypeValueArray(DefaultTypeMap[0 := AddressType()][1 := ByteArrayType()][2 := IntegerType()][3 := ByteArrayType()][4 := ByteArrayType()], 5))
+}
 
 procedure {:inline 1} Pack_LibraSystem_ValidatorInfo(v0: Value, v1: Value, v2: Value, v3: Value, v4: Value) returns (v: Value)
 {
-    assert is#Address(v0);
-    assert is#ByteArray(v1);
-    assert is#Integer(v2);
-    assert is#ByteArray(v3);
-    assert is#ByteArray(v4);
-    v := Map(DefaultMap[Field(LibraSystem_ValidatorInfo_addr) := v0][Field(LibraSystem_ValidatorInfo_consensus_pubkey) := v1][Field(LibraSystem_ValidatorInfo_consensus_voting_power) := v2][Field(LibraSystem_ValidatorInfo_network_identity_pubkey) := v3][Field(LibraSystem_ValidatorInfo_network_signing_pubkey) := v4]);
+    assume has_type(AddressType(), v0);
+    assume has_type(ByteArrayType(), v1);
+    assume has_type(IntegerType(), v2);
+    assume has_type(ByteArrayType(), v3);
+    assume has_type(ByteArrayType(), v4);
+    v := Struct(ValueArray(DefaultIntMap[LibraSystem_ValidatorInfo_addr := v0][LibraSystem_ValidatorInfo_consensus_pubkey := v1][LibraSystem_ValidatorInfo_consensus_voting_power := v2][LibraSystem_ValidatorInfo_network_signing_pubkey := v3][LibraSystem_ValidatorInfo_network_identity_pubkey := v4], 5));
+    assume has_type(LibraSystem_ValidatorInfo_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraSystem_ValidatorInfo(v: Value) returns (v0: Value, v1: Value, v2: Value, v3: Value, v4: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraSystem_ValidatorInfo_addr)];
-    v1 := m#Map(v)[Field(LibraSystem_ValidatorInfo_consensus_pubkey)];
-    v2 := m#Map(v)[Field(LibraSystem_ValidatorInfo_consensus_voting_power)];
-    v3 := m#Map(v)[Field(LibraSystem_ValidatorInfo_network_identity_pubkey)];
-    v4 := m#Map(v)[Field(LibraSystem_ValidatorInfo_network_signing_pubkey)];
-}
-
-procedure {:inline 1} Eq_LibraSystem_ValidatorInfo(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    var b2: Value;
-    var b3: Value;
-    var b4: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_address(m#Map(v1)[Field(LibraSystem_ValidatorInfo_addr)], m#Map(v2)[Field(LibraSystem_ValidatorInfo_addr)]);
-    call b1 := Eq_bytearray(m#Map(v1)[Field(LibraSystem_ValidatorInfo_consensus_pubkey)], m#Map(v2)[Field(LibraSystem_ValidatorInfo_consensus_pubkey)]);
-    call b2 := Eq_int(m#Map(v1)[Field(LibraSystem_ValidatorInfo_consensus_voting_power)], m#Map(v2)[Field(LibraSystem_ValidatorInfo_consensus_voting_power)]);
-    call b3 := Eq_bytearray(m#Map(v1)[Field(LibraSystem_ValidatorInfo_network_identity_pubkey)], m#Map(v2)[Field(LibraSystem_ValidatorInfo_network_identity_pubkey)]);
-    call b4 := Eq_bytearray(m#Map(v1)[Field(LibraSystem_ValidatorInfo_network_signing_pubkey)], m#Map(v2)[Field(LibraSystem_ValidatorInfo_network_signing_pubkey)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1) && b#Boolean(b2) && b#Boolean(b3) && b#Boolean(b4));
-}
-
-procedure {:inline 1} Neq_LibraSystem_ValidatorInfo(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraSystem_ValidatorInfo(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraSystem_ValidatorInfo_addr];
+    v1 := smap(v)[LibraSystem_ValidatorInfo_consensus_pubkey];
+    v2 := smap(v)[LibraSystem_ValidatorInfo_consensus_voting_power];
+    v3 := smap(v)[LibraSystem_ValidatorInfo_network_signing_pubkey];
+    v4 := smap(v)[LibraSystem_ValidatorInfo_network_identity_pubkey];
 }
 
 const unique LibraSystem_ValidatorSetChangeEvent: TypeName;
-const unique LibraSystem_ValidatorSetChangeEvent_new_validator_set: FieldName;
+const LibraSystem_ValidatorSetChangeEvent_new_validator_set: FieldName;
+axiom LibraSystem_ValidatorSetChangeEvent_new_validator_set == 0;
+function LibraSystem_ValidatorSetChangeEvent_type_value(): TypeValue {
+    StructType(LibraSystem_ValidatorSetChangeEvent, TypeValueArray(DefaultTypeMap[0 := Vector_T_type_value(LibraSystem_ValidatorInfo_type_value())], 1))
+}
 
 procedure {:inline 1} Pack_LibraSystem_ValidatorSetChangeEvent(v0: Value) returns (v: Value)
 {
-    assert is#Vector(v0);
-    v := Map(DefaultMap[Field(LibraSystem_ValidatorSetChangeEvent_new_validator_set) := v0]);
+    assume has_type(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()), v0);
+    v := Struct(ValueArray(DefaultIntMap[LibraSystem_ValidatorSetChangeEvent_new_validator_set := v0], 1));
+    assume has_type(LibraSystem_ValidatorSetChangeEvent_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraSystem_ValidatorSetChangeEvent(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraSystem_ValidatorSetChangeEvent_new_validator_set)];
-}
-
-procedure {:inline 1} Eq_LibraSystem_ValidatorSetChangeEvent(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_Vector_T(m#Map(v1)[Field(LibraSystem_ValidatorSetChangeEvent_new_validator_set)], m#Map(v2)[Field(LibraSystem_ValidatorSetChangeEvent_new_validator_set)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_LibraSystem_ValidatorSetChangeEvent(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraSystem_ValidatorSetChangeEvent(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraSystem_ValidatorSetChangeEvent_new_validator_set];
 }
 
 const unique LibraSystem_ValidatorSet: TypeName;
-const unique LibraSystem_ValidatorSet_change_events: FieldName;
-const unique LibraSystem_ValidatorSet_validators: FieldName;
+const LibraSystem_ValidatorSet_validators: FieldName;
+axiom LibraSystem_ValidatorSet_validators == 0;
+const LibraSystem_ValidatorSet_change_events: FieldName;
+axiom LibraSystem_ValidatorSet_change_events == 1;
+function LibraSystem_ValidatorSet_type_value(): TypeValue {
+    StructType(LibraSystem_ValidatorSet, TypeValueArray(DefaultTypeMap[0 := Vector_T_type_value(LibraSystem_ValidatorInfo_type_value())][1 := LibraAccount_EventHandle_type_value(LibraSystem_ValidatorSetChangeEvent_type_value())], 2))
+}
 
 procedure {:inline 1} Pack_LibraSystem_ValidatorSet(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Map(v0);
-    assert is#Vector(v1);
-    v := Map(DefaultMap[Field(LibraSystem_ValidatorSet_change_events) := v0][Field(LibraSystem_ValidatorSet_validators) := v1]);
+    assume has_type(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()), v0);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraSystem_ValidatorSetChangeEvent_type_value()), v1);
+    v := Struct(ValueArray(DefaultIntMap[LibraSystem_ValidatorSet_validators := v0][LibraSystem_ValidatorSet_change_events := v1], 2));
+    assume has_type(LibraSystem_ValidatorSet_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraSystem_ValidatorSet(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraSystem_ValidatorSet_change_events)];
-    v1 := m#Map(v)[Field(LibraSystem_ValidatorSet_validators)];
-}
-
-procedure {:inline 1} Eq_LibraSystem_ValidatorSet(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_LibraAccount_EventHandle(m#Map(v1)[Field(LibraSystem_ValidatorSet_change_events)], m#Map(v2)[Field(LibraSystem_ValidatorSet_change_events)]);
-    call b1 := Eq_Vector_T(m#Map(v1)[Field(LibraSystem_ValidatorSet_validators)], m#Map(v2)[Field(LibraSystem_ValidatorSet_validators)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_LibraSystem_ValidatorSet(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraSystem_ValidatorSet(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraSystem_ValidatorSet_validators];
+    v1 := smap(v)[LibraSystem_ValidatorSet_change_events];
 }
 
 const unique LibraSystem_BlockMetadata: TypeName;
-const unique LibraSystem_BlockMetadata_height: FieldName;
-const unique LibraSystem_BlockMetadata_id: FieldName;
-const unique LibraSystem_BlockMetadata_proposer: FieldName;
-const unique LibraSystem_BlockMetadata_timestamp: FieldName;
+const LibraSystem_BlockMetadata_height: FieldName;
+axiom LibraSystem_BlockMetadata_height == 0;
+const LibraSystem_BlockMetadata_timestamp: FieldName;
+axiom LibraSystem_BlockMetadata_timestamp == 1;
+const LibraSystem_BlockMetadata_id: FieldName;
+axiom LibraSystem_BlockMetadata_id == 2;
+const LibraSystem_BlockMetadata_proposer: FieldName;
+axiom LibraSystem_BlockMetadata_proposer == 3;
+function LibraSystem_BlockMetadata_type_value(): TypeValue {
+    StructType(LibraSystem_BlockMetadata, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := IntegerType()][2 := ByteArrayType()][3 := AddressType()], 4))
+}
 
 procedure {:inline 1} Pack_LibraSystem_BlockMetadata(v0: Value, v1: Value, v2: Value, v3: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    assert is#ByteArray(v1);
-    assert is#Address(v2);
-    assert is#Integer(v3);
-    v := Map(DefaultMap[Field(LibraSystem_BlockMetadata_height) := v0][Field(LibraSystem_BlockMetadata_id) := v1][Field(LibraSystem_BlockMetadata_proposer) := v2][Field(LibraSystem_BlockMetadata_timestamp) := v3]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(IntegerType(), v1);
+    assume has_type(ByteArrayType(), v2);
+    assume has_type(AddressType(), v3);
+    v := Struct(ValueArray(DefaultIntMap[LibraSystem_BlockMetadata_height := v0][LibraSystem_BlockMetadata_timestamp := v1][LibraSystem_BlockMetadata_id := v2][LibraSystem_BlockMetadata_proposer := v3], 4));
+    assume has_type(LibraSystem_BlockMetadata_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_LibraSystem_BlockMetadata(v: Value) returns (v0: Value, v1: Value, v2: Value, v3: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(LibraSystem_BlockMetadata_height)];
-    v1 := m#Map(v)[Field(LibraSystem_BlockMetadata_id)];
-    v2 := m#Map(v)[Field(LibraSystem_BlockMetadata_proposer)];
-    v3 := m#Map(v)[Field(LibraSystem_BlockMetadata_timestamp)];
-}
-
-procedure {:inline 1} Eq_LibraSystem_BlockMetadata(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    var b2: Value;
-    var b3: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(LibraSystem_BlockMetadata_height)], m#Map(v2)[Field(LibraSystem_BlockMetadata_height)]);
-    call b1 := Eq_bytearray(m#Map(v1)[Field(LibraSystem_BlockMetadata_id)], m#Map(v2)[Field(LibraSystem_BlockMetadata_id)]);
-    call b2 := Eq_address(m#Map(v1)[Field(LibraSystem_BlockMetadata_proposer)], m#Map(v2)[Field(LibraSystem_BlockMetadata_proposer)]);
-    call b3 := Eq_int(m#Map(v1)[Field(LibraSystem_BlockMetadata_timestamp)], m#Map(v2)[Field(LibraSystem_BlockMetadata_timestamp)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1) && b#Boolean(b2) && b#Boolean(b3));
-}
-
-procedure {:inline 1} Neq_LibraSystem_BlockMetadata(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_LibraSystem_BlockMetadata(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[LibraSystem_BlockMetadata_height];
+    v1 := smap(v)[LibraSystem_BlockMetadata_timestamp];
+    v2 := smap(v)[LibraSystem_BlockMetadata_id];
+    v3 := smap(v)[LibraSystem_BlockMetadata_proposer];
 }
 
 const unique TransactionFeeDistribution_T: TypeName;
-const unique TransactionFeeDistribution_T_fee_withdrawal_capability: FieldName;
-const unique TransactionFeeDistribution_T_last_epoch_paid: FieldName;
+const TransactionFeeDistribution_T_last_epoch_paid: FieldName;
+axiom TransactionFeeDistribution_T_last_epoch_paid == 0;
+const TransactionFeeDistribution_T_fee_withdrawal_capability: FieldName;
+axiom TransactionFeeDistribution_T_fee_withdrawal_capability == 1;
+function TransactionFeeDistribution_T_type_value(): TypeValue {
+    StructType(TransactionFeeDistribution_T, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := LibraAccount_WithdrawalCapability_type_value()], 2))
+}
 
 procedure {:inline 1} Pack_TransactionFeeDistribution_T(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Map(v0);
-    assert is#Integer(v1);
-    v := Map(DefaultMap[Field(TransactionFeeDistribution_T_fee_withdrawal_capability) := v0][Field(TransactionFeeDistribution_T_last_epoch_paid) := v1]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(LibraAccount_WithdrawalCapability_type_value(), v1);
+    v := Struct(ValueArray(DefaultIntMap[TransactionFeeDistribution_T_last_epoch_paid := v0][TransactionFeeDistribution_T_fee_withdrawal_capability := v1], 2));
+    assume has_type(TransactionFeeDistribution_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_TransactionFeeDistribution_T(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(TransactionFeeDistribution_T_fee_withdrawal_capability)];
-    v1 := m#Map(v)[Field(TransactionFeeDistribution_T_last_epoch_paid)];
-}
-
-procedure {:inline 1} Eq_TransactionFeeDistribution_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_LibraAccount_WithdrawalCapability(m#Map(v1)[Field(TransactionFeeDistribution_T_fee_withdrawal_capability)], m#Map(v2)[Field(TransactionFeeDistribution_T_fee_withdrawal_capability)]);
-    call b1 := Eq_int(m#Map(v1)[Field(TransactionFeeDistribution_T_last_epoch_paid)], m#Map(v2)[Field(TransactionFeeDistribution_T_last_epoch_paid)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_TransactionFeeDistribution_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_TransactionFeeDistribution_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[TransactionFeeDistribution_T_last_epoch_paid];
+    v1 := smap(v)[TransactionFeeDistribution_T_fee_withdrawal_capability];
 }
 
 procedure {:inline 1} ReadValue0(p: Path, i: int, v: Value) returns (v': Value)
@@ -748,8 +495,8 @@ procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue0(p, i+1, v');
     }
 }
@@ -761,8 +508,8 @@ procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue1(p, i+1, v');
     }
 }
@@ -774,8 +521,8 @@ procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue2(p, i+1, v');
     }
 }
@@ -797,11 +544,11 @@ procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue0(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -812,11 +559,11 @@ procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue1(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -827,11 +574,11 @@ procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) re
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue2(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -840,18 +587,18 @@ procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) 
 procedure {:inline 1} LibraCoin_mint_with_default_capability (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Value; // address
-    var t3: Reference; // LibraCoin_MintCapability_ref
-    var t4: Value; // LibraCoin_T
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t4: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -864,10 +611,10 @@ procedure {:inline 1} LibraCoin_mint_with_default_capability (arg0: Value) retur
     call tmp := GetTxnSenderAddress();
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraCoin_MintCapability);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraCoin_MintCapability_type_value());
 
     call t4 := LibraCoin_mint(contents#Memory(m)[old_size+1], t3);
-    assume is#Map(t4);
+    assume has_type(LibraCoin_T_type_value(), t4);
 
     m := Memory(domain#Memory(m)[old_size+4 := true], contents#Memory(m)[old_size+4 := t4]);
 
@@ -884,37 +631,37 @@ procedure LibraCoin_mint_with_default_capability_verify (arg0: Value) returns (r
 procedure {:inline 1} LibraCoin_mint (arg0: Value, arg1: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Reference; // LibraCoin_MintCapability_ref
-    var t2: Reference; // LibraCoin_MarketCap_ref
-    var t3: Value; // int
-    var t4: Reference; // LibraCoin_MintCapability_ref
-    var t5: Value; // int
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // bool
-    var t10: Value; // bool
-    var t11: Value; // int
-    var t12: Value; // address
-    var t13: Reference; // LibraCoin_MarketCap_ref
-    var t14: Reference; // LibraCoin_MarketCap_ref
-    var t15: Reference; // int_ref
-    var t16: Value; // int
-    var t17: Value; // int
-    var t18: Value; // int
-    var t19: Value; // int
-    var t20: Reference; // LibraCoin_MarketCap_ref
-    var t21: Reference; // int_ref
-    var t22: Value; // int
-    var t23: Value; // LibraCoin_T
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // BooleanType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // AddressType()
+    var t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Value; // IntegerType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
+    var t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t21: Reference; // ReferenceType(IntegerType())
+    var t22: Value; // IntegerType()
+    var t23: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 24;
@@ -945,7 +692,7 @@ procedure {:inline 1} LibraCoin_mint (arg0: Value, arg1: Reference) returns (ret
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 10];
-if (!b#Boolean(tmp)) { goto Label_11; }
+    if (!b#Boolean(tmp)) { goto Label_11; }
 
     call tmp := LdConst(11);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
@@ -956,7 +703,7 @@ Label_11:
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
-    call t13 := BorrowGlobal(contents#Memory(m)[old_size+12], LibraCoin_MarketCap);
+    call t13 := BorrowGlobal(contents#Memory(m)[old_size+12], LibraCoin_MarketCap_type_value());
 
     call t2 := CopyOrMoveRef(t13);
 
@@ -965,7 +712,7 @@ Label_11:
     call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t15);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
@@ -990,7 +737,7 @@ Label_11:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[22+old_size := true], contents#Memory(m)[22+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+22]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+22]);
 
     call tmp := Pack_LibraCoin_T(contents#Memory(m)[old_size+22]);
     m := Memory(domain#Memory(m)[23+old_size := true], contents#Memory(m)[23+old_size := tmp]);
@@ -1008,14 +755,14 @@ procedure LibraCoin_mint_verify (arg0: Value, arg1: Reference) returns (ret0: Va
 procedure {:inline 1} LibraCoin_initialize () returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Value; // bool
-    var t3: Value; // bool
-    var t4: Value; // int
-    var t5: Value; // LibraCoin_MintCapability
-    var t6: Value; // int
-    var t7: Value; // LibraCoin_MarketCap
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // LibraCoin_MintCapability_type_value()
+    var t6: Value; // IntegerType()
+    var t7: Value; // LibraCoin_MarketCap_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -1033,14 +780,14 @@ procedure {:inline 1} LibraCoin_initialize () returns ()
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]));
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 3];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
@@ -1051,17 +798,17 @@ Label_7:
     call tmp := Pack_LibraCoin_MintCapability();
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call MoveToSender(LibraCoin_MintCapability, contents#Memory(m)[old_size+5]);
+    call MoveToSender(LibraCoin_MintCapability_type_value(), contents#Memory(m)[old_size+5]);
 
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+6]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+6]);
 
     call tmp := Pack_LibraCoin_MarketCap(contents#Memory(m)[old_size+6]);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
-    call MoveToSender(LibraCoin_MarketCap, contents#Memory(m)[old_size+7]);
+    call MoveToSender(LibraCoin_MarketCap_type_value(), contents#Memory(m)[old_size+7]);
 
     return;
 
@@ -1075,10 +822,10 @@ procedure LibraCoin_initialize_verify () returns ()
 procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraCoin_MarketCap_ref
-    var t2: Reference; // int_ref
-    var t3: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -1093,12 +840,12 @@ procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraCoin_MarketCap);
+    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraCoin_MarketCap_type_value());
 
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t2);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -1115,8 +862,8 @@ procedure LibraCoin_market_cap_verify () returns (ret0: Value)
 procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // LibraCoin_T
+    var t0: Value; // IntegerType()
+    var t1: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -1131,7 +878,7 @@ procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+0]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+0]);
 
     call tmp := Pack_LibraCoin_T(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
@@ -1149,10 +896,10 @@ procedure LibraCoin_zero_verify () returns (ret0: Value)
 procedure {:inline 1} LibraCoin_value (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraCoin_T_ref
-    var t1: Reference; // LibraCoin_T_ref
-    var t2: Reference; // int_ref
-    var t3: Value; // int
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -1170,7 +917,7 @@ procedure {:inline 1} LibraCoin_value (arg0: Reference) returns (ret0: Value)
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
     call tmp := ReadRef(t2);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -1187,22 +934,22 @@ procedure LibraCoin_value_verify (arg0: Reference) returns (ret0: Value)
 procedure {:inline 1} LibraCoin_split (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
 {
     // declare local variables
-    var t0: Value; // LibraCoin_T
-    var t1: Value; // int
-    var t2: Value; // LibraCoin_T
-    var t3: Reference; // LibraCoin_T_ref
-    var t4: Value; // int
-    var t5: Value; // LibraCoin_T
-    var t6: Value; // LibraCoin_T
-    var t7: Value; // LibraCoin_T
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Value; // IntegerType()
+    var t5: Value; // LibraCoin_T_type_value()
+    var t6: Value; // LibraCoin_T_type_value()
+    var t7: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
-    assume is#Integer(arg1);
+    assume has_type(LibraCoin_T_type_value(), arg0);
+    assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 8;
@@ -1216,7 +963,7 @@ procedure {:inline 1} LibraCoin_split (arg0: Value, arg1: Value) returns (ret0: 
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     call t5 := LibraCoin_withdraw(t3, contents#Memory(m)[old_size+4]);
-    assume is#Map(t5);
+    assume has_type(LibraCoin_T_type_value(), t5);
 
     m := Memory(domain#Memory(m)[old_size+5 := true], contents#Memory(m)[old_size+5 := t5]);
 
@@ -1243,31 +990,31 @@ procedure LibraCoin_split_verify (arg0: Value, arg1: Value) returns (ret0: Value
 procedure {:inline 1} LibraCoin_withdraw (arg0: Reference, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraCoin_T_ref
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Reference; // LibraCoin_T_ref
-    var t4: Reference; // int_ref
-    var t5: Value; // int
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // bool
-    var t9: Value; // bool
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // int
-    var t13: Value; // int
-    var t14: Reference; // LibraCoin_T_ref
-    var t15: Reference; // int_ref
-    var t16: Value; // int
-    var t17: Value; // LibraCoin_T
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Reference; // ReferenceType(IntegerType())
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // BooleanType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // IntegerType()
+    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#Integer(arg1);
+        assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 18;
@@ -1280,7 +1027,7 @@ procedure {:inline 1} LibraCoin_withdraw (arg0: Reference, arg1: Value) returns 
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
     call tmp := ReadRef(t4);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
@@ -1300,7 +1047,7 @@ procedure {:inline 1} LibraCoin_withdraw (arg0: Reference, arg1: Value) returns 
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 9];
-if (!b#Boolean(tmp)) { goto Label_11; }
+    if (!b#Boolean(tmp)) { goto Label_11; }
 
     call tmp := LdConst(10);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
@@ -1326,7 +1073,7 @@ Label_11:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+16]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+16]);
 
     call tmp := Pack_LibraCoin_T(contents#Memory(m)[old_size+16]);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
@@ -1344,19 +1091,19 @@ procedure LibraCoin_withdraw_verify (arg0: Reference, arg1: Value) returns (ret0
 procedure {:inline 1} LibraCoin_join (arg0: Value, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // LibraCoin_T
-    var t1: Value; // LibraCoin_T
-    var t2: Reference; // LibraCoin_T_ref
-    var t3: Value; // LibraCoin_T
-    var t4: Value; // LibraCoin_T
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t3: Value; // LibraCoin_T_type_value()
+    var t4: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
-    assume is#Map(arg1);
+    assume has_type(LibraCoin_T_type_value(), arg0);
+    assume has_type(LibraCoin_T_type_value(), arg1);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -1387,27 +1134,27 @@ procedure LibraCoin_join_verify (arg0: Value, arg1: Value) returns (ret0: Value)
 procedure {:inline 1} LibraCoin_deposit (arg0: Reference, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Reference; // LibraCoin_T_ref
-    var t1: Value; // LibraCoin_T
-    var t2: Value; // int
-    var t3: Value; // int
-    var t4: Reference; // LibraCoin_T_ref
-    var t5: Reference; // int_ref
-    var t6: Value; // int
-    var t7: Value; // LibraCoin_T
-    var t8: Value; // int
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Reference; // LibraCoin_T_ref
-    var t13: Reference; // int_ref
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t5: Reference; // ReferenceType(IntegerType())
+    var t6: Value; // IntegerType()
+    var t7: Value; // LibraCoin_T_type_value()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t13: Reference; // ReferenceType(IntegerType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#Map(arg1);
+        assume has_type(LibraCoin_T_type_value(), arg1);
 
     old_size := m_size;
     m_size := m_size + 14;
@@ -1420,7 +1167,7 @@ procedure {:inline 1} LibraCoin_deposit (arg0: Reference, arg1: Value) returns (
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
     call tmp := ReadRef(t5);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
@@ -1431,7 +1178,7 @@ procedure {:inline 1} LibraCoin_deposit (arg0: Reference, arg1: Value) returns (
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
     call t8 := Unpack_LibraCoin_T(contents#Memory(m)[old_size+7]);
-    assume is#Integer(t8);
+    assume has_type(IntegerType(), t8);
 
     m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
 
@@ -1465,22 +1212,22 @@ procedure LibraCoin_deposit_verify (arg0: Reference, arg1: Value) returns ()
 procedure {:inline 1} LibraCoin_destroy_zero (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // LibraCoin_T
-    var t1: Value; // int
-    var t2: Value; // LibraCoin_T
-    var t3: Value; // int
-    var t4: Value; // int
-    var t5: Value; // int
-    var t6: Value; // bool
-    var t7: Value; // bool
-    var t8: Value; // int
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // BooleanType()
+    var t8: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
+    assume has_type(LibraCoin_T_type_value(), arg0);
 
     old_size := m_size;
     m_size := m_size + 9;
@@ -1491,7 +1238,7 @@ procedure {:inline 1} LibraCoin_destroy_zero (arg0: Value) returns ()
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     call t3 := Unpack_LibraCoin_T(contents#Memory(m)[old_size+2]);
-    assume is#Integer(t3);
+    assume has_type(IntegerType(), t3);
 
     m := Memory(domain#Memory(m)[old_size+3 := true], contents#Memory(m)[old_size+3 := t3]);
 
@@ -1504,14 +1251,14 @@ procedure {:inline 1} LibraCoin_destroy_zero (arg0: Value) returns ()
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+4], contents#Memory(m)[old_size+5]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+4], contents#Memory(m)[old_size+5]));
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+6]);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 7];
-if (!b#Boolean(tmp)) { goto Label_10; }
+    if (!b#Boolean(tmp)) { goto Label_10; }
 
     call tmp := LdConst(11);
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
@@ -1536,16 +1283,16 @@ procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
 procedure {:inline 1} ValidatorConfig_has (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 3;
@@ -1555,7 +1302,7 @@ procedure {:inline 1} ValidatorConfig_has (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+1], ValidatorConfig_T);
+    call tmp := Exists(contents#Memory(m)[old_size+1], ValidatorConfig_T_type_value());
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     ret0 := contents#Memory(m)[old_size+2];
@@ -1571,20 +1318,20 @@ procedure ValidatorConfig_has_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} ValidatorConfig_config (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // ValidatorConfig_T_ref
-    var t2: Value; // address
-    var t3: Reference; // ValidatorConfig_T_ref
-    var t4: Reference; // ValidatorConfig_T_ref
-    var t5: Reference; // ValidatorConfig_Config_ref
-    var t6: Value; // ValidatorConfig_Config
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var t4: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var t5: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t6: Value; // ValidatorConfig_Config_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 7;
@@ -1594,7 +1341,7 @@ procedure {:inline 1} ValidatorConfig_config (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], ValidatorConfig_T);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], ValidatorConfig_T_type_value());
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -1603,7 +1350,7 @@ procedure {:inline 1} ValidatorConfig_config (arg0: Value) returns (ret0: Value)
     call t5 := BorrowField(t4, ValidatorConfig_T_config);
 
     call tmp := ReadRef(t5);
-    assume is#Map(tmp);
+    assume has_type(ValidatorConfig_Config_type_value(), tmp);
 
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
@@ -1620,10 +1367,10 @@ procedure ValidatorConfig_config_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} ValidatorConfig_consensus_pubkey (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // ValidatorConfig_Config_ref
-    var t1: Reference; // ValidatorConfig_Config_ref
-    var t2: Reference; // bytearray_ref
-    var t3: Value; // bytearray
+    var t0: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
+    var t3: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
@@ -1641,7 +1388,7 @@ procedure {:inline 1} ValidatorConfig_consensus_pubkey (arg0: Reference) returns
     call t2 := BorrowField(t1, ValidatorConfig_Config_consensus_pubkey);
 
     call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    assume has_type(ByteArrayType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -1658,10 +1405,10 @@ procedure ValidatorConfig_consensus_pubkey_verify (arg0: Reference) returns (ret
 procedure {:inline 1} ValidatorConfig_network_identity_pubkey (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // ValidatorConfig_Config_ref
-    var t1: Reference; // ValidatorConfig_Config_ref
-    var t2: Reference; // bytearray_ref
-    var t3: Value; // bytearray
+    var t0: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
+    var t3: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
@@ -1679,7 +1426,7 @@ procedure {:inline 1} ValidatorConfig_network_identity_pubkey (arg0: Reference) 
     call t2 := BorrowField(t1, ValidatorConfig_Config_network_identity_pubkey);
 
     call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    assume has_type(ByteArrayType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -1696,10 +1443,10 @@ procedure ValidatorConfig_network_identity_pubkey_verify (arg0: Reference) retur
 procedure {:inline 1} ValidatorConfig_network_signing_pubkey (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // ValidatorConfig_Config_ref
-    var t1: Reference; // ValidatorConfig_Config_ref
-    var t2: Reference; // bytearray_ref
-    var t3: Value; // bytearray
+    var t0: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
+    var t3: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
@@ -1717,7 +1464,7 @@ procedure {:inline 1} ValidatorConfig_network_signing_pubkey (arg0: Reference) r
     call t2 := BorrowField(t1, ValidatorConfig_Config_network_signing_pubkey);
 
     call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    assume has_type(ByteArrayType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -1734,23 +1481,23 @@ procedure ValidatorConfig_network_signing_pubkey_verify (arg0: Reference) return
 procedure {:inline 1} ValidatorConfig_register_candidate_validator (arg0: Value, arg1: Value, arg2: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // bytearray
-    var t1: Value; // bytearray
-    var t2: Value; // bytearray
-    var t3: Value; // bytearray
-    var t4: Value; // bytearray
-    var t5: Value; // bytearray
-    var t6: Value; // ValidatorConfig_Config
-    var t7: Value; // ValidatorConfig_T
+    var t0: Value; // ByteArrayType()
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // ByteArrayType()
+    var t4: Value; // ByteArrayType()
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // ValidatorConfig_Config_type_value()
+    var t7: Value; // ValidatorConfig_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#ByteArray(arg0);
-    assume is#ByteArray(arg1);
-    assume is#ByteArray(arg2);
+    assume has_type(ByteArrayType(), arg0);
+    assume has_type(ByteArrayType(), arg1);
+    assume has_type(ByteArrayType(), arg2);
 
     old_size := m_size;
     m_size := m_size + 8;
@@ -1768,21 +1515,21 @@ procedure {:inline 1} ValidatorConfig_register_candidate_validator (arg0: Value,
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+3]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+3]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+4]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+4]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+5]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+5]);
 
     call tmp := Pack_ValidatorConfig_Config(contents#Memory(m)[old_size+3], contents#Memory(m)[old_size+4], contents#Memory(m)[old_size+5]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
-    assume is#Map(contents#Memory(m)[old_size+6]);
+    assume has_type(ValidatorConfig_Config_type_value(), contents#Memory(m)[old_size+6]);
 
     call tmp := Pack_ValidatorConfig_T(contents#Memory(m)[old_size+6]);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
-    call MoveToSender(ValidatorConfig_T, contents#Memory(m)[old_size+7]);
+    call MoveToSender(ValidatorConfig_T_type_value(), contents#Memory(m)[old_size+7]);
 
     return;
 
@@ -1796,25 +1543,25 @@ procedure ValidatorConfig_register_candidate_validator_verify (arg0: Value, arg1
 procedure {:inline 1} ValidatorConfig_rotate_consensus_pubkey (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // bytearray
-    var t1: Reference; // ValidatorConfig_T_ref
-    var t2: Reference; // ValidatorConfig_Config_ref
-    var t3: Reference; // bytearray_ref
-    var t4: Value; // address
-    var t5: Reference; // ValidatorConfig_T_ref
-    var t6: Reference; // ValidatorConfig_T_ref
-    var t7: Reference; // ValidatorConfig_Config_ref
-    var t8: Reference; // ValidatorConfig_Config_ref
-    var t9: Reference; // bytearray_ref
-    var t10: Value; // bytearray
-    var t11: Reference; // bytearray_ref
+    var t0: Value; // ByteArrayType()
+    var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var t2: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t3: Reference; // ReferenceType(ByteArrayType())
+    var t4: Value; // AddressType()
+    var t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t9: Reference; // ReferenceType(ByteArrayType())
+    var t10: Value; // ByteArrayType()
+    var t11: Reference; // ReferenceType(ByteArrayType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#ByteArray(arg0);
+    assume has_type(ByteArrayType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 12;
@@ -1824,7 +1571,7 @@ procedure {:inline 1} ValidatorConfig_rotate_consensus_pubkey (arg0: Value) retu
     call tmp := GetTxnSenderAddress();
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
-    call t5 := BorrowGlobal(contents#Memory(m)[old_size+4], ValidatorConfig_T);
+    call t5 := BorrowGlobal(contents#Memory(m)[old_size+4], ValidatorConfig_T_type_value());
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -1859,298 +1606,298 @@ procedure ValidatorConfig_rotate_consensus_pubkey_verify (arg0: Value) returns (
 procedure {:inline 1} GasSchedule_initialize () returns ()
 {
     // declare local variables
-    var t0: Value; // Vector_T
-    var t1: Value; // Vector_T
-    var t2: Value; // address
-    var t3: Value; // address
-    var t4: Value; // bool
-    var t5: Value; // bool
-    var t6: Value; // int
-    var t7: Value; // Vector_T
-    var t8: Value; // Vector_T
-    var t9: Reference; // Vector_T_ref
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // GasSchedule_Cost
-    var t13: Reference; // Vector_T_ref
-    var t14: Value; // int
-    var t15: Value; // int
-    var t16: Value; // GasSchedule_Cost
-    var t17: Reference; // Vector_T_ref
-    var t18: Value; // int
-    var t19: Value; // int
-    var t20: Value; // GasSchedule_Cost
-    var t21: Reference; // Vector_T_ref
-    var t22: Value; // int
-    var t23: Value; // int
-    var t24: Value; // GasSchedule_Cost
-    var t25: Reference; // Vector_T_ref
-    var t26: Value; // int
-    var t27: Value; // int
-    var t28: Value; // GasSchedule_Cost
-    var t29: Reference; // Vector_T_ref
-    var t30: Value; // int
-    var t31: Value; // int
-    var t32: Value; // GasSchedule_Cost
-    var t33: Reference; // Vector_T_ref
-    var t34: Value; // int
-    var t35: Value; // int
-    var t36: Value; // GasSchedule_Cost
-    var t37: Reference; // Vector_T_ref
-    var t38: Value; // int
-    var t39: Value; // int
-    var t40: Value; // GasSchedule_Cost
-    var t41: Reference; // Vector_T_ref
-    var t42: Value; // int
-    var t43: Value; // int
-    var t44: Value; // GasSchedule_Cost
-    var t45: Reference; // Vector_T_ref
-    var t46: Value; // int
-    var t47: Value; // int
-    var t48: Value; // GasSchedule_Cost
-    var t49: Reference; // Vector_T_ref
-    var t50: Value; // int
-    var t51: Value; // int
-    var t52: Value; // GasSchedule_Cost
-    var t53: Reference; // Vector_T_ref
-    var t54: Value; // int
-    var t55: Value; // int
-    var t56: Value; // GasSchedule_Cost
-    var t57: Reference; // Vector_T_ref
-    var t58: Value; // int
-    var t59: Value; // int
-    var t60: Value; // GasSchedule_Cost
-    var t61: Reference; // Vector_T_ref
-    var t62: Value; // int
-    var t63: Value; // int
-    var t64: Value; // GasSchedule_Cost
-    var t65: Reference; // Vector_T_ref
-    var t66: Value; // int
-    var t67: Value; // int
-    var t68: Value; // GasSchedule_Cost
-    var t69: Reference; // Vector_T_ref
-    var t70: Value; // int
-    var t71: Value; // int
-    var t72: Value; // GasSchedule_Cost
-    var t73: Reference; // Vector_T_ref
-    var t74: Value; // int
-    var t75: Value; // int
-    var t76: Value; // GasSchedule_Cost
-    var t77: Reference; // Vector_T_ref
-    var t78: Value; // int
-    var t79: Value; // int
-    var t80: Value; // GasSchedule_Cost
-    var t81: Reference; // Vector_T_ref
-    var t82: Value; // int
-    var t83: Value; // int
-    var t84: Value; // GasSchedule_Cost
-    var t85: Reference; // Vector_T_ref
-    var t86: Value; // int
-    var t87: Value; // int
-    var t88: Value; // GasSchedule_Cost
-    var t89: Reference; // Vector_T_ref
-    var t90: Value; // int
-    var t91: Value; // int
-    var t92: Value; // GasSchedule_Cost
-    var t93: Reference; // Vector_T_ref
-    var t94: Value; // int
-    var t95: Value; // int
-    var t96: Value; // GasSchedule_Cost
-    var t97: Reference; // Vector_T_ref
-    var t98: Value; // int
-    var t99: Value; // int
-    var t100: Value; // GasSchedule_Cost
-    var t101: Reference; // Vector_T_ref
-    var t102: Value; // int
-    var t103: Value; // int
-    var t104: Value; // GasSchedule_Cost
-    var t105: Reference; // Vector_T_ref
-    var t106: Value; // int
-    var t107: Value; // int
-    var t108: Value; // GasSchedule_Cost
-    var t109: Reference; // Vector_T_ref
-    var t110: Value; // int
-    var t111: Value; // int
-    var t112: Value; // GasSchedule_Cost
-    var t113: Reference; // Vector_T_ref
-    var t114: Value; // int
-    var t115: Value; // int
-    var t116: Value; // GasSchedule_Cost
-    var t117: Reference; // Vector_T_ref
-    var t118: Value; // int
-    var t119: Value; // int
-    var t120: Value; // GasSchedule_Cost
-    var t121: Reference; // Vector_T_ref
-    var t122: Value; // int
-    var t123: Value; // int
-    var t124: Value; // GasSchedule_Cost
-    var t125: Reference; // Vector_T_ref
-    var t126: Value; // int
-    var t127: Value; // int
-    var t128: Value; // GasSchedule_Cost
-    var t129: Reference; // Vector_T_ref
-    var t130: Value; // int
-    var t131: Value; // int
-    var t132: Value; // GasSchedule_Cost
-    var t133: Reference; // Vector_T_ref
-    var t134: Value; // int
-    var t135: Value; // int
-    var t136: Value; // GasSchedule_Cost
-    var t137: Reference; // Vector_T_ref
-    var t138: Value; // int
-    var t139: Value; // int
-    var t140: Value; // GasSchedule_Cost
-    var t141: Reference; // Vector_T_ref
-    var t142: Value; // int
-    var t143: Value; // int
-    var t144: Value; // GasSchedule_Cost
-    var t145: Reference; // Vector_T_ref
-    var t146: Value; // int
-    var t147: Value; // int
-    var t148: Value; // GasSchedule_Cost
-    var t149: Reference; // Vector_T_ref
-    var t150: Value; // int
-    var t151: Value; // int
-    var t152: Value; // GasSchedule_Cost
-    var t153: Reference; // Vector_T_ref
-    var t154: Value; // int
-    var t155: Value; // int
-    var t156: Value; // GasSchedule_Cost
-    var t157: Reference; // Vector_T_ref
-    var t158: Value; // int
-    var t159: Value; // int
-    var t160: Value; // GasSchedule_Cost
-    var t161: Reference; // Vector_T_ref
-    var t162: Value; // int
-    var t163: Value; // int
-    var t164: Value; // GasSchedule_Cost
-    var t165: Reference; // Vector_T_ref
-    var t166: Value; // int
-    var t167: Value; // int
-    var t168: Value; // GasSchedule_Cost
-    var t169: Reference; // Vector_T_ref
-    var t170: Value; // int
-    var t171: Value; // int
-    var t172: Value; // GasSchedule_Cost
-    var t173: Reference; // Vector_T_ref
-    var t174: Value; // int
-    var t175: Value; // int
-    var t176: Value; // GasSchedule_Cost
-    var t177: Reference; // Vector_T_ref
-    var t178: Value; // int
-    var t179: Value; // int
-    var t180: Value; // GasSchedule_Cost
-    var t181: Reference; // Vector_T_ref
-    var t182: Value; // int
-    var t183: Value; // int
-    var t184: Value; // GasSchedule_Cost
-    var t185: Reference; // Vector_T_ref
-    var t186: Value; // int
-    var t187: Value; // int
-    var t188: Value; // GasSchedule_Cost
-    var t189: Reference; // Vector_T_ref
-    var t190: Value; // int
-    var t191: Value; // int
-    var t192: Value; // GasSchedule_Cost
-    var t193: Reference; // Vector_T_ref
-    var t194: Value; // int
-    var t195: Value; // int
-    var t196: Value; // GasSchedule_Cost
-    var t197: Reference; // Vector_T_ref
-    var t198: Value; // int
-    var t199: Value; // int
-    var t200: Value; // GasSchedule_Cost
-    var t201: Reference; // Vector_T_ref
-    var t202: Value; // int
-    var t203: Value; // int
-    var t204: Value; // GasSchedule_Cost
-    var t205: Reference; // Vector_T_ref
-    var t206: Value; // int
-    var t207: Value; // int
-    var t208: Value; // GasSchedule_Cost
-    var t209: Reference; // Vector_T_ref
-    var t210: Value; // int
-    var t211: Value; // int
-    var t212: Value; // GasSchedule_Cost
-    var t213: Reference; // Vector_T_ref
-    var t214: Value; // int
-    var t215: Value; // int
-    var t216: Value; // GasSchedule_Cost
-    var t217: Reference; // Vector_T_ref
-    var t218: Value; // int
-    var t219: Value; // int
-    var t220: Value; // GasSchedule_Cost
-    var t221: Reference; // Vector_T_ref
-    var t222: Value; // int
-    var t223: Value; // int
-    var t224: Value; // GasSchedule_Cost
-    var t225: Reference; // Vector_T_ref
-    var t226: Value; // int
-    var t227: Value; // int
-    var t228: Value; // GasSchedule_Cost
-    var t229: Reference; // Vector_T_ref
-    var t230: Value; // int
-    var t231: Value; // int
-    var t232: Value; // GasSchedule_Cost
-    var t233: Reference; // Vector_T_ref
-    var t234: Value; // int
-    var t235: Value; // int
-    var t236: Value; // GasSchedule_Cost
-    var t237: Reference; // Vector_T_ref
-    var t238: Value; // int
-    var t239: Value; // int
-    var t240: Value; // GasSchedule_Cost
-    var t241: Reference; // Vector_T_ref
-    var t242: Value; // int
-    var t243: Value; // int
-    var t244: Value; // GasSchedule_Cost
-    var t245: Reference; // Vector_T_ref
-    var t246: Value; // int
-    var t247: Value; // int
-    var t248: Value; // GasSchedule_Cost
-    var t249: Reference; // Vector_T_ref
-    var t250: Value; // int
-    var t251: Value; // int
-    var t252: Value; // GasSchedule_Cost
-    var t253: Reference; // Vector_T_ref
-    var t254: Value; // int
-    var t255: Value; // int
-    var t256: Value; // GasSchedule_Cost
-    var t257: Reference; // Vector_T_ref
-    var t258: Value; // int
-    var t259: Value; // int
-    var t260: Value; // GasSchedule_Cost
-    var t261: Reference; // Vector_T_ref
-    var t262: Value; // int
-    var t263: Value; // int
-    var t264: Value; // GasSchedule_Cost
-    var t265: Reference; // Vector_T_ref
-    var t266: Value; // int
-    var t267: Value; // int
-    var t268: Value; // GasSchedule_Cost
-    var t269: Reference; // Vector_T_ref
-    var t270: Value; // int
-    var t271: Value; // int
-    var t272: Value; // GasSchedule_Cost
-    var t273: Reference; // Vector_T_ref
-    var t274: Value; // int
-    var t275: Value; // int
-    var t276: Value; // GasSchedule_Cost
-    var t277: Reference; // Vector_T_ref
-    var t278: Value; // int
-    var t279: Value; // int
-    var t280: Value; // GasSchedule_Cost
-    var t281: Reference; // Vector_T_ref
-    var t282: Value; // int
-    var t283: Value; // int
-    var t284: Value; // GasSchedule_Cost
-    var t285: Reference; // Vector_T_ref
-    var t286: Value; // int
-    var t287: Value; // int
-    var t288: Value; // GasSchedule_Cost
-    var t289: Value; // Vector_T
-    var t290: Value; // Vector_T
-    var t291: Value; // GasSchedule_T
+    var t0: Value; // Vector_T_type_value(GasSchedule_Cost_type_value())
+    var t1: Value; // Vector_T_type_value(GasSchedule_Cost_type_value())
+    var t2: Value; // AddressType()
+    var t3: Value; // AddressType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // Vector_T_type_value(GasSchedule_Cost_type_value())
+    var t8: Value; // Vector_T_type_value(GasSchedule_Cost_type_value())
+    var t9: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // GasSchedule_Cost_type_value()
+    var t13: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // GasSchedule_Cost_type_value()
+    var t17: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
+    var t20: Value; // GasSchedule_Cost_type_value()
+    var t21: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t22: Value; // IntegerType()
+    var t23: Value; // IntegerType()
+    var t24: Value; // GasSchedule_Cost_type_value()
+    var t25: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t26: Value; // IntegerType()
+    var t27: Value; // IntegerType()
+    var t28: Value; // GasSchedule_Cost_type_value()
+    var t29: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t30: Value; // IntegerType()
+    var t31: Value; // IntegerType()
+    var t32: Value; // GasSchedule_Cost_type_value()
+    var t33: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t34: Value; // IntegerType()
+    var t35: Value; // IntegerType()
+    var t36: Value; // GasSchedule_Cost_type_value()
+    var t37: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t38: Value; // IntegerType()
+    var t39: Value; // IntegerType()
+    var t40: Value; // GasSchedule_Cost_type_value()
+    var t41: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t42: Value; // IntegerType()
+    var t43: Value; // IntegerType()
+    var t44: Value; // GasSchedule_Cost_type_value()
+    var t45: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t46: Value; // IntegerType()
+    var t47: Value; // IntegerType()
+    var t48: Value; // GasSchedule_Cost_type_value()
+    var t49: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t50: Value; // IntegerType()
+    var t51: Value; // IntegerType()
+    var t52: Value; // GasSchedule_Cost_type_value()
+    var t53: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t54: Value; // IntegerType()
+    var t55: Value; // IntegerType()
+    var t56: Value; // GasSchedule_Cost_type_value()
+    var t57: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t58: Value; // IntegerType()
+    var t59: Value; // IntegerType()
+    var t60: Value; // GasSchedule_Cost_type_value()
+    var t61: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t62: Value; // IntegerType()
+    var t63: Value; // IntegerType()
+    var t64: Value; // GasSchedule_Cost_type_value()
+    var t65: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t66: Value; // IntegerType()
+    var t67: Value; // IntegerType()
+    var t68: Value; // GasSchedule_Cost_type_value()
+    var t69: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t70: Value; // IntegerType()
+    var t71: Value; // IntegerType()
+    var t72: Value; // GasSchedule_Cost_type_value()
+    var t73: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t74: Value; // IntegerType()
+    var t75: Value; // IntegerType()
+    var t76: Value; // GasSchedule_Cost_type_value()
+    var t77: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t78: Value; // IntegerType()
+    var t79: Value; // IntegerType()
+    var t80: Value; // GasSchedule_Cost_type_value()
+    var t81: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t82: Value; // IntegerType()
+    var t83: Value; // IntegerType()
+    var t84: Value; // GasSchedule_Cost_type_value()
+    var t85: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t86: Value; // IntegerType()
+    var t87: Value; // IntegerType()
+    var t88: Value; // GasSchedule_Cost_type_value()
+    var t89: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t90: Value; // IntegerType()
+    var t91: Value; // IntegerType()
+    var t92: Value; // GasSchedule_Cost_type_value()
+    var t93: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t94: Value; // IntegerType()
+    var t95: Value; // IntegerType()
+    var t96: Value; // GasSchedule_Cost_type_value()
+    var t97: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t98: Value; // IntegerType()
+    var t99: Value; // IntegerType()
+    var t100: Value; // GasSchedule_Cost_type_value()
+    var t101: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t102: Value; // IntegerType()
+    var t103: Value; // IntegerType()
+    var t104: Value; // GasSchedule_Cost_type_value()
+    var t105: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t106: Value; // IntegerType()
+    var t107: Value; // IntegerType()
+    var t108: Value; // GasSchedule_Cost_type_value()
+    var t109: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t110: Value; // IntegerType()
+    var t111: Value; // IntegerType()
+    var t112: Value; // GasSchedule_Cost_type_value()
+    var t113: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t114: Value; // IntegerType()
+    var t115: Value; // IntegerType()
+    var t116: Value; // GasSchedule_Cost_type_value()
+    var t117: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t118: Value; // IntegerType()
+    var t119: Value; // IntegerType()
+    var t120: Value; // GasSchedule_Cost_type_value()
+    var t121: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t122: Value; // IntegerType()
+    var t123: Value; // IntegerType()
+    var t124: Value; // GasSchedule_Cost_type_value()
+    var t125: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t126: Value; // IntegerType()
+    var t127: Value; // IntegerType()
+    var t128: Value; // GasSchedule_Cost_type_value()
+    var t129: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t130: Value; // IntegerType()
+    var t131: Value; // IntegerType()
+    var t132: Value; // GasSchedule_Cost_type_value()
+    var t133: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t134: Value; // IntegerType()
+    var t135: Value; // IntegerType()
+    var t136: Value; // GasSchedule_Cost_type_value()
+    var t137: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t138: Value; // IntegerType()
+    var t139: Value; // IntegerType()
+    var t140: Value; // GasSchedule_Cost_type_value()
+    var t141: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t142: Value; // IntegerType()
+    var t143: Value; // IntegerType()
+    var t144: Value; // GasSchedule_Cost_type_value()
+    var t145: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t146: Value; // IntegerType()
+    var t147: Value; // IntegerType()
+    var t148: Value; // GasSchedule_Cost_type_value()
+    var t149: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t150: Value; // IntegerType()
+    var t151: Value; // IntegerType()
+    var t152: Value; // GasSchedule_Cost_type_value()
+    var t153: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t154: Value; // IntegerType()
+    var t155: Value; // IntegerType()
+    var t156: Value; // GasSchedule_Cost_type_value()
+    var t157: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t158: Value; // IntegerType()
+    var t159: Value; // IntegerType()
+    var t160: Value; // GasSchedule_Cost_type_value()
+    var t161: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t162: Value; // IntegerType()
+    var t163: Value; // IntegerType()
+    var t164: Value; // GasSchedule_Cost_type_value()
+    var t165: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t166: Value; // IntegerType()
+    var t167: Value; // IntegerType()
+    var t168: Value; // GasSchedule_Cost_type_value()
+    var t169: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t170: Value; // IntegerType()
+    var t171: Value; // IntegerType()
+    var t172: Value; // GasSchedule_Cost_type_value()
+    var t173: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t174: Value; // IntegerType()
+    var t175: Value; // IntegerType()
+    var t176: Value; // GasSchedule_Cost_type_value()
+    var t177: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t178: Value; // IntegerType()
+    var t179: Value; // IntegerType()
+    var t180: Value; // GasSchedule_Cost_type_value()
+    var t181: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t182: Value; // IntegerType()
+    var t183: Value; // IntegerType()
+    var t184: Value; // GasSchedule_Cost_type_value()
+    var t185: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t186: Value; // IntegerType()
+    var t187: Value; // IntegerType()
+    var t188: Value; // GasSchedule_Cost_type_value()
+    var t189: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t190: Value; // IntegerType()
+    var t191: Value; // IntegerType()
+    var t192: Value; // GasSchedule_Cost_type_value()
+    var t193: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t194: Value; // IntegerType()
+    var t195: Value; // IntegerType()
+    var t196: Value; // GasSchedule_Cost_type_value()
+    var t197: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t198: Value; // IntegerType()
+    var t199: Value; // IntegerType()
+    var t200: Value; // GasSchedule_Cost_type_value()
+    var t201: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t202: Value; // IntegerType()
+    var t203: Value; // IntegerType()
+    var t204: Value; // GasSchedule_Cost_type_value()
+    var t205: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t206: Value; // IntegerType()
+    var t207: Value; // IntegerType()
+    var t208: Value; // GasSchedule_Cost_type_value()
+    var t209: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t210: Value; // IntegerType()
+    var t211: Value; // IntegerType()
+    var t212: Value; // GasSchedule_Cost_type_value()
+    var t213: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t214: Value; // IntegerType()
+    var t215: Value; // IntegerType()
+    var t216: Value; // GasSchedule_Cost_type_value()
+    var t217: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t218: Value; // IntegerType()
+    var t219: Value; // IntegerType()
+    var t220: Value; // GasSchedule_Cost_type_value()
+    var t221: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t222: Value; // IntegerType()
+    var t223: Value; // IntegerType()
+    var t224: Value; // GasSchedule_Cost_type_value()
+    var t225: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t226: Value; // IntegerType()
+    var t227: Value; // IntegerType()
+    var t228: Value; // GasSchedule_Cost_type_value()
+    var t229: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t230: Value; // IntegerType()
+    var t231: Value; // IntegerType()
+    var t232: Value; // GasSchedule_Cost_type_value()
+    var t233: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t234: Value; // IntegerType()
+    var t235: Value; // IntegerType()
+    var t236: Value; // GasSchedule_Cost_type_value()
+    var t237: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t238: Value; // IntegerType()
+    var t239: Value; // IntegerType()
+    var t240: Value; // GasSchedule_Cost_type_value()
+    var t241: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t242: Value; // IntegerType()
+    var t243: Value; // IntegerType()
+    var t244: Value; // GasSchedule_Cost_type_value()
+    var t245: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t246: Value; // IntegerType()
+    var t247: Value; // IntegerType()
+    var t248: Value; // GasSchedule_Cost_type_value()
+    var t249: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t250: Value; // IntegerType()
+    var t251: Value; // IntegerType()
+    var t252: Value; // GasSchedule_Cost_type_value()
+    var t253: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t254: Value; // IntegerType()
+    var t255: Value; // IntegerType()
+    var t256: Value; // GasSchedule_Cost_type_value()
+    var t257: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t258: Value; // IntegerType()
+    var t259: Value; // IntegerType()
+    var t260: Value; // GasSchedule_Cost_type_value()
+    var t261: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t262: Value; // IntegerType()
+    var t263: Value; // IntegerType()
+    var t264: Value; // GasSchedule_Cost_type_value()
+    var t265: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t266: Value; // IntegerType()
+    var t267: Value; // IntegerType()
+    var t268: Value; // GasSchedule_Cost_type_value()
+    var t269: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t270: Value; // IntegerType()
+    var t271: Value; // IntegerType()
+    var t272: Value; // GasSchedule_Cost_type_value()
+    var t273: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t274: Value; // IntegerType()
+    var t275: Value; // IntegerType()
+    var t276: Value; // GasSchedule_Cost_type_value()
+    var t277: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t278: Value; // IntegerType()
+    var t279: Value; // IntegerType()
+    var t280: Value; // GasSchedule_Cost_type_value()
+    var t281: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t282: Value; // IntegerType()
+    var t283: Value; // IntegerType()
+    var t284: Value; // GasSchedule_Cost_type_value()
+    var t285: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t286: Value; // IntegerType()
+    var t287: Value; // IntegerType()
+    var t288: Value; // GasSchedule_Cost_type_value()
+    var t289: Value; // Vector_T_type_value(GasSchedule_Cost_type_value())
+    var t290: Value; // Vector_T_type_value(GasSchedule_Cost_type_value())
+    var t291: Value; // GasSchedule_T_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -2168,14 +1915,14 @@ procedure {:inline 1} GasSchedule_initialize () returns ()
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+2], contents#Memory(m)[old_size+3]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+2], contents#Memory(m)[old_size+3]));
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+4]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 5];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
@@ -2183,16 +1930,16 @@ if (!b#Boolean(tmp)) { goto Label_7; }
     assert false;
 
 Label_7:
-    call t7 := Vector_empty();
-    assume is#Vector(t7);
+    call t7 := Vector_empty(GasSchedule_Cost_type_value());
+    assume has_type(Vector_T_type_value(GasSchedule_Cost_type_value()), t7);
 
     m := Memory(domain#Memory(m)[old_size+7 := true], contents#Memory(m)[old_size+7 := t7]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+7]);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call t8 := Vector_empty();
-    assume is#Vector(t8);
+    call t8 := Vector_empty(GasSchedule_Cost_type_value());
+    assume has_type(Vector_T_type_value(GasSchedule_Cost_type_value()), t8);
 
     m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
 
@@ -2207,14 +1954,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+10]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+10]);
 
-    assume is#Integer(contents#Memory(m)[old_size+11]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+11]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
-    call Vector_push_back(t9, contents#Memory(m)[old_size+12]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t9, contents#Memory(m)[old_size+12]);
 
     call t13 := BorrowLoc(old_size+0);
 
@@ -2224,14 +1971,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[15+old_size := true], contents#Memory(m)[15+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+14]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+14]);
 
-    assume is#Integer(contents#Memory(m)[old_size+15]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+15]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+14], contents#Memory(m)[old_size+15]);
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
-    call Vector_push_back(t13, contents#Memory(m)[old_size+16]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t13, contents#Memory(m)[old_size+16]);
 
     call t17 := BorrowLoc(old_size+0);
 
@@ -2241,14 +1988,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[19+old_size := true], contents#Memory(m)[19+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+18]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+18]);
 
-    assume is#Integer(contents#Memory(m)[old_size+19]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+19]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+18], contents#Memory(m)[old_size+19]);
     m := Memory(domain#Memory(m)[20+old_size := true], contents#Memory(m)[20+old_size := tmp]);
 
-    call Vector_push_back(t17, contents#Memory(m)[old_size+20]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t17, contents#Memory(m)[old_size+20]);
 
     call t21 := BorrowLoc(old_size+0);
 
@@ -2258,14 +2005,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[23+old_size := true], contents#Memory(m)[23+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+22]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+22]);
 
-    assume is#Integer(contents#Memory(m)[old_size+23]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+23]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+22], contents#Memory(m)[old_size+23]);
     m := Memory(domain#Memory(m)[24+old_size := true], contents#Memory(m)[24+old_size := tmp]);
 
-    call Vector_push_back(t21, contents#Memory(m)[old_size+24]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t21, contents#Memory(m)[old_size+24]);
 
     call t25 := BorrowLoc(old_size+0);
 
@@ -2275,14 +2022,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[27+old_size := true], contents#Memory(m)[27+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+26]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+26]);
 
-    assume is#Integer(contents#Memory(m)[old_size+27]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+27]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+26], contents#Memory(m)[old_size+27]);
     m := Memory(domain#Memory(m)[28+old_size := true], contents#Memory(m)[28+old_size := tmp]);
 
-    call Vector_push_back(t25, contents#Memory(m)[old_size+28]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t25, contents#Memory(m)[old_size+28]);
 
     call t29 := BorrowLoc(old_size+0);
 
@@ -2292,14 +2039,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[31+old_size := true], contents#Memory(m)[31+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+30]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+30]);
 
-    assume is#Integer(contents#Memory(m)[old_size+31]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+31]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+30], contents#Memory(m)[old_size+31]);
     m := Memory(domain#Memory(m)[32+old_size := true], contents#Memory(m)[32+old_size := tmp]);
 
-    call Vector_push_back(t29, contents#Memory(m)[old_size+32]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t29, contents#Memory(m)[old_size+32]);
 
     call t33 := BorrowLoc(old_size+0);
 
@@ -2309,14 +2056,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[35+old_size := true], contents#Memory(m)[35+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+34]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+34]);
 
-    assume is#Integer(contents#Memory(m)[old_size+35]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+35]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+34], contents#Memory(m)[old_size+35]);
     m := Memory(domain#Memory(m)[36+old_size := true], contents#Memory(m)[36+old_size := tmp]);
 
-    call Vector_push_back(t33, contents#Memory(m)[old_size+36]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t33, contents#Memory(m)[old_size+36]);
 
     call t37 := BorrowLoc(old_size+0);
 
@@ -2326,14 +2073,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[39+old_size := true], contents#Memory(m)[39+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+38]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+38]);
 
-    assume is#Integer(contents#Memory(m)[old_size+39]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+39]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+38], contents#Memory(m)[old_size+39]);
     m := Memory(domain#Memory(m)[40+old_size := true], contents#Memory(m)[40+old_size := tmp]);
 
-    call Vector_push_back(t37, contents#Memory(m)[old_size+40]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t37, contents#Memory(m)[old_size+40]);
 
     call t41 := BorrowLoc(old_size+0);
 
@@ -2343,14 +2090,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[43+old_size := true], contents#Memory(m)[43+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+42]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+42]);
 
-    assume is#Integer(contents#Memory(m)[old_size+43]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+43]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+42], contents#Memory(m)[old_size+43]);
     m := Memory(domain#Memory(m)[44+old_size := true], contents#Memory(m)[44+old_size := tmp]);
 
-    call Vector_push_back(t41, contents#Memory(m)[old_size+44]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t41, contents#Memory(m)[old_size+44]);
 
     call t45 := BorrowLoc(old_size+0);
 
@@ -2360,14 +2107,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[47+old_size := true], contents#Memory(m)[47+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+46]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+46]);
 
-    assume is#Integer(contents#Memory(m)[old_size+47]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+47]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+46], contents#Memory(m)[old_size+47]);
     m := Memory(domain#Memory(m)[48+old_size := true], contents#Memory(m)[48+old_size := tmp]);
 
-    call Vector_push_back(t45, contents#Memory(m)[old_size+48]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t45, contents#Memory(m)[old_size+48]);
 
     call t49 := BorrowLoc(old_size+0);
 
@@ -2377,14 +2124,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[51+old_size := true], contents#Memory(m)[51+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+50]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+50]);
 
-    assume is#Integer(contents#Memory(m)[old_size+51]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+51]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+50], contents#Memory(m)[old_size+51]);
     m := Memory(domain#Memory(m)[52+old_size := true], contents#Memory(m)[52+old_size := tmp]);
 
-    call Vector_push_back(t49, contents#Memory(m)[old_size+52]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t49, contents#Memory(m)[old_size+52]);
 
     call t53 := BorrowLoc(old_size+0);
 
@@ -2394,14 +2141,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[55+old_size := true], contents#Memory(m)[55+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+54]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+54]);
 
-    assume is#Integer(contents#Memory(m)[old_size+55]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+55]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+54], contents#Memory(m)[old_size+55]);
     m := Memory(domain#Memory(m)[56+old_size := true], contents#Memory(m)[56+old_size := tmp]);
 
-    call Vector_push_back(t53, contents#Memory(m)[old_size+56]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t53, contents#Memory(m)[old_size+56]);
 
     call t57 := BorrowLoc(old_size+0);
 
@@ -2411,14 +2158,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[59+old_size := true], contents#Memory(m)[59+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+58]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+58]);
 
-    assume is#Integer(contents#Memory(m)[old_size+59]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+59]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+58], contents#Memory(m)[old_size+59]);
     m := Memory(domain#Memory(m)[60+old_size := true], contents#Memory(m)[60+old_size := tmp]);
 
-    call Vector_push_back(t57, contents#Memory(m)[old_size+60]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t57, contents#Memory(m)[old_size+60]);
 
     call t61 := BorrowLoc(old_size+0);
 
@@ -2428,14 +2175,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[63+old_size := true], contents#Memory(m)[63+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+62]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+62]);
 
-    assume is#Integer(contents#Memory(m)[old_size+63]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+63]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+62], contents#Memory(m)[old_size+63]);
     m := Memory(domain#Memory(m)[64+old_size := true], contents#Memory(m)[64+old_size := tmp]);
 
-    call Vector_push_back(t61, contents#Memory(m)[old_size+64]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t61, contents#Memory(m)[old_size+64]);
 
     call t65 := BorrowLoc(old_size+0);
 
@@ -2445,14 +2192,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[67+old_size := true], contents#Memory(m)[67+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+66]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+66]);
 
-    assume is#Integer(contents#Memory(m)[old_size+67]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+67]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+66], contents#Memory(m)[old_size+67]);
     m := Memory(domain#Memory(m)[68+old_size := true], contents#Memory(m)[68+old_size := tmp]);
 
-    call Vector_push_back(t65, contents#Memory(m)[old_size+68]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t65, contents#Memory(m)[old_size+68]);
 
     call t69 := BorrowLoc(old_size+0);
 
@@ -2462,14 +2209,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[71+old_size := true], contents#Memory(m)[71+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+70]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+70]);
 
-    assume is#Integer(contents#Memory(m)[old_size+71]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+71]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+70], contents#Memory(m)[old_size+71]);
     m := Memory(domain#Memory(m)[72+old_size := true], contents#Memory(m)[72+old_size := tmp]);
 
-    call Vector_push_back(t69, contents#Memory(m)[old_size+72]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t69, contents#Memory(m)[old_size+72]);
 
     call t73 := BorrowLoc(old_size+0);
 
@@ -2479,14 +2226,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[75+old_size := true], contents#Memory(m)[75+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+74]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+74]);
 
-    assume is#Integer(contents#Memory(m)[old_size+75]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+75]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+74], contents#Memory(m)[old_size+75]);
     m := Memory(domain#Memory(m)[76+old_size := true], contents#Memory(m)[76+old_size := tmp]);
 
-    call Vector_push_back(t73, contents#Memory(m)[old_size+76]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t73, contents#Memory(m)[old_size+76]);
 
     call t77 := BorrowLoc(old_size+0);
 
@@ -2496,14 +2243,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[79+old_size := true], contents#Memory(m)[79+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+78]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+78]);
 
-    assume is#Integer(contents#Memory(m)[old_size+79]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+79]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+78], contents#Memory(m)[old_size+79]);
     m := Memory(domain#Memory(m)[80+old_size := true], contents#Memory(m)[80+old_size := tmp]);
 
-    call Vector_push_back(t77, contents#Memory(m)[old_size+80]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t77, contents#Memory(m)[old_size+80]);
 
     call t81 := BorrowLoc(old_size+0);
 
@@ -2513,14 +2260,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[83+old_size := true], contents#Memory(m)[83+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+82]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+82]);
 
-    assume is#Integer(contents#Memory(m)[old_size+83]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+83]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+82], contents#Memory(m)[old_size+83]);
     m := Memory(domain#Memory(m)[84+old_size := true], contents#Memory(m)[84+old_size := tmp]);
 
-    call Vector_push_back(t81, contents#Memory(m)[old_size+84]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t81, contents#Memory(m)[old_size+84]);
 
     call t85 := BorrowLoc(old_size+0);
 
@@ -2530,14 +2277,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[87+old_size := true], contents#Memory(m)[87+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+86]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+86]);
 
-    assume is#Integer(contents#Memory(m)[old_size+87]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+87]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+86], contents#Memory(m)[old_size+87]);
     m := Memory(domain#Memory(m)[88+old_size := true], contents#Memory(m)[88+old_size := tmp]);
 
-    call Vector_push_back(t85, contents#Memory(m)[old_size+88]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t85, contents#Memory(m)[old_size+88]);
 
     call t89 := BorrowLoc(old_size+0);
 
@@ -2547,14 +2294,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[91+old_size := true], contents#Memory(m)[91+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+90]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+90]);
 
-    assume is#Integer(contents#Memory(m)[old_size+91]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+91]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+90], contents#Memory(m)[old_size+91]);
     m := Memory(domain#Memory(m)[92+old_size := true], contents#Memory(m)[92+old_size := tmp]);
 
-    call Vector_push_back(t89, contents#Memory(m)[old_size+92]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t89, contents#Memory(m)[old_size+92]);
 
     call t93 := BorrowLoc(old_size+0);
 
@@ -2564,14 +2311,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[95+old_size := true], contents#Memory(m)[95+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+94]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+94]);
 
-    assume is#Integer(contents#Memory(m)[old_size+95]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+95]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+94], contents#Memory(m)[old_size+95]);
     m := Memory(domain#Memory(m)[96+old_size := true], contents#Memory(m)[96+old_size := tmp]);
 
-    call Vector_push_back(t93, contents#Memory(m)[old_size+96]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t93, contents#Memory(m)[old_size+96]);
 
     call t97 := BorrowLoc(old_size+0);
 
@@ -2581,14 +2328,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[99+old_size := true], contents#Memory(m)[99+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+98]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+98]);
 
-    assume is#Integer(contents#Memory(m)[old_size+99]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+99]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+98], contents#Memory(m)[old_size+99]);
     m := Memory(domain#Memory(m)[100+old_size := true], contents#Memory(m)[100+old_size := tmp]);
 
-    call Vector_push_back(t97, contents#Memory(m)[old_size+100]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t97, contents#Memory(m)[old_size+100]);
 
     call t101 := BorrowLoc(old_size+0);
 
@@ -2598,14 +2345,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[103+old_size := true], contents#Memory(m)[103+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+102]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+102]);
 
-    assume is#Integer(contents#Memory(m)[old_size+103]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+103]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+102], contents#Memory(m)[old_size+103]);
     m := Memory(domain#Memory(m)[104+old_size := true], contents#Memory(m)[104+old_size := tmp]);
 
-    call Vector_push_back(t101, contents#Memory(m)[old_size+104]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t101, contents#Memory(m)[old_size+104]);
 
     call t105 := BorrowLoc(old_size+0);
 
@@ -2615,14 +2362,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[107+old_size := true], contents#Memory(m)[107+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+106]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+106]);
 
-    assume is#Integer(contents#Memory(m)[old_size+107]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+107]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+106], contents#Memory(m)[old_size+107]);
     m := Memory(domain#Memory(m)[108+old_size := true], contents#Memory(m)[108+old_size := tmp]);
 
-    call Vector_push_back(t105, contents#Memory(m)[old_size+108]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t105, contents#Memory(m)[old_size+108]);
 
     call t109 := BorrowLoc(old_size+0);
 
@@ -2632,14 +2379,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[111+old_size := true], contents#Memory(m)[111+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+110]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+110]);
 
-    assume is#Integer(contents#Memory(m)[old_size+111]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+111]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+110], contents#Memory(m)[old_size+111]);
     m := Memory(domain#Memory(m)[112+old_size := true], contents#Memory(m)[112+old_size := tmp]);
 
-    call Vector_push_back(t109, contents#Memory(m)[old_size+112]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t109, contents#Memory(m)[old_size+112]);
 
     call t113 := BorrowLoc(old_size+0);
 
@@ -2649,14 +2396,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[115+old_size := true], contents#Memory(m)[115+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+114]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+114]);
 
-    assume is#Integer(contents#Memory(m)[old_size+115]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+115]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+114], contents#Memory(m)[old_size+115]);
     m := Memory(domain#Memory(m)[116+old_size := true], contents#Memory(m)[116+old_size := tmp]);
 
-    call Vector_push_back(t113, contents#Memory(m)[old_size+116]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t113, contents#Memory(m)[old_size+116]);
 
     call t117 := BorrowLoc(old_size+0);
 
@@ -2666,14 +2413,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[119+old_size := true], contents#Memory(m)[119+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+118]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+118]);
 
-    assume is#Integer(contents#Memory(m)[old_size+119]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+119]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+118], contents#Memory(m)[old_size+119]);
     m := Memory(domain#Memory(m)[120+old_size := true], contents#Memory(m)[120+old_size := tmp]);
 
-    call Vector_push_back(t117, contents#Memory(m)[old_size+120]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t117, contents#Memory(m)[old_size+120]);
 
     call t121 := BorrowLoc(old_size+0);
 
@@ -2683,14 +2430,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[123+old_size := true], contents#Memory(m)[123+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+122]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+122]);
 
-    assume is#Integer(contents#Memory(m)[old_size+123]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+123]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+122], contents#Memory(m)[old_size+123]);
     m := Memory(domain#Memory(m)[124+old_size := true], contents#Memory(m)[124+old_size := tmp]);
 
-    call Vector_push_back(t121, contents#Memory(m)[old_size+124]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t121, contents#Memory(m)[old_size+124]);
 
     call t125 := BorrowLoc(old_size+0);
 
@@ -2700,14 +2447,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[127+old_size := true], contents#Memory(m)[127+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+126]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+126]);
 
-    assume is#Integer(contents#Memory(m)[old_size+127]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+127]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+126], contents#Memory(m)[old_size+127]);
     m := Memory(domain#Memory(m)[128+old_size := true], contents#Memory(m)[128+old_size := tmp]);
 
-    call Vector_push_back(t125, contents#Memory(m)[old_size+128]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t125, contents#Memory(m)[old_size+128]);
 
     call t129 := BorrowLoc(old_size+0);
 
@@ -2717,14 +2464,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[131+old_size := true], contents#Memory(m)[131+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+130]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+130]);
 
-    assume is#Integer(contents#Memory(m)[old_size+131]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+131]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+130], contents#Memory(m)[old_size+131]);
     m := Memory(domain#Memory(m)[132+old_size := true], contents#Memory(m)[132+old_size := tmp]);
 
-    call Vector_push_back(t129, contents#Memory(m)[old_size+132]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t129, contents#Memory(m)[old_size+132]);
 
     call t133 := BorrowLoc(old_size+0);
 
@@ -2734,14 +2481,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[135+old_size := true], contents#Memory(m)[135+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+134]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+134]);
 
-    assume is#Integer(contents#Memory(m)[old_size+135]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+135]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+134], contents#Memory(m)[old_size+135]);
     m := Memory(domain#Memory(m)[136+old_size := true], contents#Memory(m)[136+old_size := tmp]);
 
-    call Vector_push_back(t133, contents#Memory(m)[old_size+136]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t133, contents#Memory(m)[old_size+136]);
 
     call t137 := BorrowLoc(old_size+0);
 
@@ -2751,14 +2498,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[139+old_size := true], contents#Memory(m)[139+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+138]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+138]);
 
-    assume is#Integer(contents#Memory(m)[old_size+139]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+139]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+138], contents#Memory(m)[old_size+139]);
     m := Memory(domain#Memory(m)[140+old_size := true], contents#Memory(m)[140+old_size := tmp]);
 
-    call Vector_push_back(t137, contents#Memory(m)[old_size+140]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t137, contents#Memory(m)[old_size+140]);
 
     call t141 := BorrowLoc(old_size+0);
 
@@ -2768,14 +2515,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[143+old_size := true], contents#Memory(m)[143+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+142]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+142]);
 
-    assume is#Integer(contents#Memory(m)[old_size+143]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+143]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+142], contents#Memory(m)[old_size+143]);
     m := Memory(domain#Memory(m)[144+old_size := true], contents#Memory(m)[144+old_size := tmp]);
 
-    call Vector_push_back(t141, contents#Memory(m)[old_size+144]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t141, contents#Memory(m)[old_size+144]);
 
     call t145 := BorrowLoc(old_size+0);
 
@@ -2785,14 +2532,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[147+old_size := true], contents#Memory(m)[147+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+146]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+146]);
 
-    assume is#Integer(contents#Memory(m)[old_size+147]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+147]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+146], contents#Memory(m)[old_size+147]);
     m := Memory(domain#Memory(m)[148+old_size := true], contents#Memory(m)[148+old_size := tmp]);
 
-    call Vector_push_back(t145, contents#Memory(m)[old_size+148]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t145, contents#Memory(m)[old_size+148]);
 
     call t149 := BorrowLoc(old_size+0);
 
@@ -2802,14 +2549,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[151+old_size := true], contents#Memory(m)[151+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+150]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+150]);
 
-    assume is#Integer(contents#Memory(m)[old_size+151]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+151]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+150], contents#Memory(m)[old_size+151]);
     m := Memory(domain#Memory(m)[152+old_size := true], contents#Memory(m)[152+old_size := tmp]);
 
-    call Vector_push_back(t149, contents#Memory(m)[old_size+152]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t149, contents#Memory(m)[old_size+152]);
 
     call t153 := BorrowLoc(old_size+0);
 
@@ -2819,14 +2566,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[155+old_size := true], contents#Memory(m)[155+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+154]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+154]);
 
-    assume is#Integer(contents#Memory(m)[old_size+155]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+155]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+154], contents#Memory(m)[old_size+155]);
     m := Memory(domain#Memory(m)[156+old_size := true], contents#Memory(m)[156+old_size := tmp]);
 
-    call Vector_push_back(t153, contents#Memory(m)[old_size+156]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t153, contents#Memory(m)[old_size+156]);
 
     call t157 := BorrowLoc(old_size+0);
 
@@ -2836,14 +2583,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[159+old_size := true], contents#Memory(m)[159+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+158]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+158]);
 
-    assume is#Integer(contents#Memory(m)[old_size+159]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+159]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+158], contents#Memory(m)[old_size+159]);
     m := Memory(domain#Memory(m)[160+old_size := true], contents#Memory(m)[160+old_size := tmp]);
 
-    call Vector_push_back(t157, contents#Memory(m)[old_size+160]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t157, contents#Memory(m)[old_size+160]);
 
     call t161 := BorrowLoc(old_size+0);
 
@@ -2853,14 +2600,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[163+old_size := true], contents#Memory(m)[163+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+162]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+162]);
 
-    assume is#Integer(contents#Memory(m)[old_size+163]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+163]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+162], contents#Memory(m)[old_size+163]);
     m := Memory(domain#Memory(m)[164+old_size := true], contents#Memory(m)[164+old_size := tmp]);
 
-    call Vector_push_back(t161, contents#Memory(m)[old_size+164]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t161, contents#Memory(m)[old_size+164]);
 
     call t165 := BorrowLoc(old_size+0);
 
@@ -2870,14 +2617,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[167+old_size := true], contents#Memory(m)[167+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+166]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+166]);
 
-    assume is#Integer(contents#Memory(m)[old_size+167]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+167]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+166], contents#Memory(m)[old_size+167]);
     m := Memory(domain#Memory(m)[168+old_size := true], contents#Memory(m)[168+old_size := tmp]);
 
-    call Vector_push_back(t165, contents#Memory(m)[old_size+168]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t165, contents#Memory(m)[old_size+168]);
 
     call t169 := BorrowLoc(old_size+0);
 
@@ -2887,14 +2634,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[171+old_size := true], contents#Memory(m)[171+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+170]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+170]);
 
-    assume is#Integer(contents#Memory(m)[old_size+171]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+171]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+170], contents#Memory(m)[old_size+171]);
     m := Memory(domain#Memory(m)[172+old_size := true], contents#Memory(m)[172+old_size := tmp]);
 
-    call Vector_push_back(t169, contents#Memory(m)[old_size+172]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t169, contents#Memory(m)[old_size+172]);
 
     call t173 := BorrowLoc(old_size+0);
 
@@ -2904,14 +2651,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[175+old_size := true], contents#Memory(m)[175+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+174]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+174]);
 
-    assume is#Integer(contents#Memory(m)[old_size+175]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+175]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+174], contents#Memory(m)[old_size+175]);
     m := Memory(domain#Memory(m)[176+old_size := true], contents#Memory(m)[176+old_size := tmp]);
 
-    call Vector_push_back(t173, contents#Memory(m)[old_size+176]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t173, contents#Memory(m)[old_size+176]);
 
     call t177 := BorrowLoc(old_size+0);
 
@@ -2921,14 +2668,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[179+old_size := true], contents#Memory(m)[179+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+178]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+178]);
 
-    assume is#Integer(contents#Memory(m)[old_size+179]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+179]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+178], contents#Memory(m)[old_size+179]);
     m := Memory(domain#Memory(m)[180+old_size := true], contents#Memory(m)[180+old_size := tmp]);
 
-    call Vector_push_back(t177, contents#Memory(m)[old_size+180]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t177, contents#Memory(m)[old_size+180]);
 
     call t181 := BorrowLoc(old_size+0);
 
@@ -2938,14 +2685,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[183+old_size := true], contents#Memory(m)[183+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+182]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+182]);
 
-    assume is#Integer(contents#Memory(m)[old_size+183]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+183]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+182], contents#Memory(m)[old_size+183]);
     m := Memory(domain#Memory(m)[184+old_size := true], contents#Memory(m)[184+old_size := tmp]);
 
-    call Vector_push_back(t181, contents#Memory(m)[old_size+184]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t181, contents#Memory(m)[old_size+184]);
 
     call t185 := BorrowLoc(old_size+0);
 
@@ -2955,14 +2702,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[187+old_size := true], contents#Memory(m)[187+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+186]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+186]);
 
-    assume is#Integer(contents#Memory(m)[old_size+187]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+187]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+186], contents#Memory(m)[old_size+187]);
     m := Memory(domain#Memory(m)[188+old_size := true], contents#Memory(m)[188+old_size := tmp]);
 
-    call Vector_push_back(t185, contents#Memory(m)[old_size+188]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t185, contents#Memory(m)[old_size+188]);
 
     call t189 := BorrowLoc(old_size+0);
 
@@ -2972,14 +2719,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[191+old_size := true], contents#Memory(m)[191+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+190]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+190]);
 
-    assume is#Integer(contents#Memory(m)[old_size+191]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+191]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+190], contents#Memory(m)[old_size+191]);
     m := Memory(domain#Memory(m)[192+old_size := true], contents#Memory(m)[192+old_size := tmp]);
 
-    call Vector_push_back(t189, contents#Memory(m)[old_size+192]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t189, contents#Memory(m)[old_size+192]);
 
     call t193 := BorrowLoc(old_size+0);
 
@@ -2989,14 +2736,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[195+old_size := true], contents#Memory(m)[195+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+194]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+194]);
 
-    assume is#Integer(contents#Memory(m)[old_size+195]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+195]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+194], contents#Memory(m)[old_size+195]);
     m := Memory(domain#Memory(m)[196+old_size := true], contents#Memory(m)[196+old_size := tmp]);
 
-    call Vector_push_back(t193, contents#Memory(m)[old_size+196]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t193, contents#Memory(m)[old_size+196]);
 
     call t197 := BorrowLoc(old_size+0);
 
@@ -3006,14 +2753,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[199+old_size := true], contents#Memory(m)[199+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+198]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+198]);
 
-    assume is#Integer(contents#Memory(m)[old_size+199]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+199]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+198], contents#Memory(m)[old_size+199]);
     m := Memory(domain#Memory(m)[200+old_size := true], contents#Memory(m)[200+old_size := tmp]);
 
-    call Vector_push_back(t197, contents#Memory(m)[old_size+200]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t197, contents#Memory(m)[old_size+200]);
 
     call t201 := BorrowLoc(old_size+0);
 
@@ -3023,14 +2770,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[203+old_size := true], contents#Memory(m)[203+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+202]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+202]);
 
-    assume is#Integer(contents#Memory(m)[old_size+203]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+203]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+202], contents#Memory(m)[old_size+203]);
     m := Memory(domain#Memory(m)[204+old_size := true], contents#Memory(m)[204+old_size := tmp]);
 
-    call Vector_push_back(t201, contents#Memory(m)[old_size+204]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t201, contents#Memory(m)[old_size+204]);
 
     call t205 := BorrowLoc(old_size+0);
 
@@ -3040,14 +2787,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[207+old_size := true], contents#Memory(m)[207+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+206]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+206]);
 
-    assume is#Integer(contents#Memory(m)[old_size+207]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+207]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+206], contents#Memory(m)[old_size+207]);
     m := Memory(domain#Memory(m)[208+old_size := true], contents#Memory(m)[208+old_size := tmp]);
 
-    call Vector_push_back(t205, contents#Memory(m)[old_size+208]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t205, contents#Memory(m)[old_size+208]);
 
     call t209 := BorrowLoc(old_size+0);
 
@@ -3057,14 +2804,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[211+old_size := true], contents#Memory(m)[211+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+210]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+210]);
 
-    assume is#Integer(contents#Memory(m)[old_size+211]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+211]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+210], contents#Memory(m)[old_size+211]);
     m := Memory(domain#Memory(m)[212+old_size := true], contents#Memory(m)[212+old_size := tmp]);
 
-    call Vector_push_back(t209, contents#Memory(m)[old_size+212]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t209, contents#Memory(m)[old_size+212]);
 
     call t213 := BorrowLoc(old_size+0);
 
@@ -3074,14 +2821,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[215+old_size := true], contents#Memory(m)[215+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+214]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+214]);
 
-    assume is#Integer(contents#Memory(m)[old_size+215]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+215]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+214], contents#Memory(m)[old_size+215]);
     m := Memory(domain#Memory(m)[216+old_size := true], contents#Memory(m)[216+old_size := tmp]);
 
-    call Vector_push_back(t213, contents#Memory(m)[old_size+216]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t213, contents#Memory(m)[old_size+216]);
 
     call t217 := BorrowLoc(old_size+0);
 
@@ -3091,14 +2838,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[219+old_size := true], contents#Memory(m)[219+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+218]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+218]);
 
-    assume is#Integer(contents#Memory(m)[old_size+219]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+219]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+218], contents#Memory(m)[old_size+219]);
     m := Memory(domain#Memory(m)[220+old_size := true], contents#Memory(m)[220+old_size := tmp]);
 
-    call Vector_push_back(t217, contents#Memory(m)[old_size+220]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t217, contents#Memory(m)[old_size+220]);
 
     call t221 := BorrowLoc(old_size+1);
 
@@ -3108,14 +2855,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[223+old_size := true], contents#Memory(m)[223+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+222]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+222]);
 
-    assume is#Integer(contents#Memory(m)[old_size+223]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+223]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+222], contents#Memory(m)[old_size+223]);
     m := Memory(domain#Memory(m)[224+old_size := true], contents#Memory(m)[224+old_size := tmp]);
 
-    call Vector_push_back(t221, contents#Memory(m)[old_size+224]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t221, contents#Memory(m)[old_size+224]);
 
     call t225 := BorrowLoc(old_size+1);
 
@@ -3125,14 +2872,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[227+old_size := true], contents#Memory(m)[227+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+226]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+226]);
 
-    assume is#Integer(contents#Memory(m)[old_size+227]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+227]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+226], contents#Memory(m)[old_size+227]);
     m := Memory(domain#Memory(m)[228+old_size := true], contents#Memory(m)[228+old_size := tmp]);
 
-    call Vector_push_back(t225, contents#Memory(m)[old_size+228]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t225, contents#Memory(m)[old_size+228]);
 
     call t229 := BorrowLoc(old_size+1);
 
@@ -3142,14 +2889,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[231+old_size := true], contents#Memory(m)[231+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+230]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+230]);
 
-    assume is#Integer(contents#Memory(m)[old_size+231]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+231]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+230], contents#Memory(m)[old_size+231]);
     m := Memory(domain#Memory(m)[232+old_size := true], contents#Memory(m)[232+old_size := tmp]);
 
-    call Vector_push_back(t229, contents#Memory(m)[old_size+232]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t229, contents#Memory(m)[old_size+232]);
 
     call t233 := BorrowLoc(old_size+1);
 
@@ -3159,14 +2906,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[235+old_size := true], contents#Memory(m)[235+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+234]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+234]);
 
-    assume is#Integer(contents#Memory(m)[old_size+235]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+235]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+234], contents#Memory(m)[old_size+235]);
     m := Memory(domain#Memory(m)[236+old_size := true], contents#Memory(m)[236+old_size := tmp]);
 
-    call Vector_push_back(t233, contents#Memory(m)[old_size+236]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t233, contents#Memory(m)[old_size+236]);
 
     call t237 := BorrowLoc(old_size+1);
 
@@ -3176,14 +2923,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[239+old_size := true], contents#Memory(m)[239+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+238]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+238]);
 
-    assume is#Integer(contents#Memory(m)[old_size+239]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+239]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+238], contents#Memory(m)[old_size+239]);
     m := Memory(domain#Memory(m)[240+old_size := true], contents#Memory(m)[240+old_size := tmp]);
 
-    call Vector_push_back(t237, contents#Memory(m)[old_size+240]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t237, contents#Memory(m)[old_size+240]);
 
     call t241 := BorrowLoc(old_size+1);
 
@@ -3193,14 +2940,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[243+old_size := true], contents#Memory(m)[243+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+242]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+242]);
 
-    assume is#Integer(contents#Memory(m)[old_size+243]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+243]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+242], contents#Memory(m)[old_size+243]);
     m := Memory(domain#Memory(m)[244+old_size := true], contents#Memory(m)[244+old_size := tmp]);
 
-    call Vector_push_back(t241, contents#Memory(m)[old_size+244]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t241, contents#Memory(m)[old_size+244]);
 
     call t245 := BorrowLoc(old_size+1);
 
@@ -3210,14 +2957,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[247+old_size := true], contents#Memory(m)[247+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+246]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+246]);
 
-    assume is#Integer(contents#Memory(m)[old_size+247]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+247]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+246], contents#Memory(m)[old_size+247]);
     m := Memory(domain#Memory(m)[248+old_size := true], contents#Memory(m)[248+old_size := tmp]);
 
-    call Vector_push_back(t245, contents#Memory(m)[old_size+248]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t245, contents#Memory(m)[old_size+248]);
 
     call t249 := BorrowLoc(old_size+1);
 
@@ -3227,14 +2974,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[251+old_size := true], contents#Memory(m)[251+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+250]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+250]);
 
-    assume is#Integer(contents#Memory(m)[old_size+251]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+251]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+250], contents#Memory(m)[old_size+251]);
     m := Memory(domain#Memory(m)[252+old_size := true], contents#Memory(m)[252+old_size := tmp]);
 
-    call Vector_push_back(t249, contents#Memory(m)[old_size+252]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t249, contents#Memory(m)[old_size+252]);
 
     call t253 := BorrowLoc(old_size+1);
 
@@ -3244,14 +2991,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[255+old_size := true], contents#Memory(m)[255+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+254]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+254]);
 
-    assume is#Integer(contents#Memory(m)[old_size+255]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+255]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+254], contents#Memory(m)[old_size+255]);
     m := Memory(domain#Memory(m)[256+old_size := true], contents#Memory(m)[256+old_size := tmp]);
 
-    call Vector_push_back(t253, contents#Memory(m)[old_size+256]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t253, contents#Memory(m)[old_size+256]);
 
     call t257 := BorrowLoc(old_size+1);
 
@@ -3261,14 +3008,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[259+old_size := true], contents#Memory(m)[259+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+258]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+258]);
 
-    assume is#Integer(contents#Memory(m)[old_size+259]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+259]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+258], contents#Memory(m)[old_size+259]);
     m := Memory(domain#Memory(m)[260+old_size := true], contents#Memory(m)[260+old_size := tmp]);
 
-    call Vector_push_back(t257, contents#Memory(m)[old_size+260]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t257, contents#Memory(m)[old_size+260]);
 
     call t261 := BorrowLoc(old_size+1);
 
@@ -3278,14 +3025,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[263+old_size := true], contents#Memory(m)[263+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+262]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+262]);
 
-    assume is#Integer(contents#Memory(m)[old_size+263]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+263]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+262], contents#Memory(m)[old_size+263]);
     m := Memory(domain#Memory(m)[264+old_size := true], contents#Memory(m)[264+old_size := tmp]);
 
-    call Vector_push_back(t261, contents#Memory(m)[old_size+264]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t261, contents#Memory(m)[old_size+264]);
 
     call t265 := BorrowLoc(old_size+1);
 
@@ -3295,14 +3042,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[267+old_size := true], contents#Memory(m)[267+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+266]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+266]);
 
-    assume is#Integer(contents#Memory(m)[old_size+267]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+267]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+266], contents#Memory(m)[old_size+267]);
     m := Memory(domain#Memory(m)[268+old_size := true], contents#Memory(m)[268+old_size := tmp]);
 
-    call Vector_push_back(t265, contents#Memory(m)[old_size+268]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t265, contents#Memory(m)[old_size+268]);
 
     call t269 := BorrowLoc(old_size+1);
 
@@ -3312,14 +3059,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[271+old_size := true], contents#Memory(m)[271+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+270]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+270]);
 
-    assume is#Integer(contents#Memory(m)[old_size+271]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+271]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+270], contents#Memory(m)[old_size+271]);
     m := Memory(domain#Memory(m)[272+old_size := true], contents#Memory(m)[272+old_size := tmp]);
 
-    call Vector_push_back(t269, contents#Memory(m)[old_size+272]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t269, contents#Memory(m)[old_size+272]);
 
     call t273 := BorrowLoc(old_size+1);
 
@@ -3329,14 +3076,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[275+old_size := true], contents#Memory(m)[275+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+274]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+274]);
 
-    assume is#Integer(contents#Memory(m)[old_size+275]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+275]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+274], contents#Memory(m)[old_size+275]);
     m := Memory(domain#Memory(m)[276+old_size := true], contents#Memory(m)[276+old_size := tmp]);
 
-    call Vector_push_back(t273, contents#Memory(m)[old_size+276]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t273, contents#Memory(m)[old_size+276]);
 
     call t277 := BorrowLoc(old_size+1);
 
@@ -3346,14 +3093,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[279+old_size := true], contents#Memory(m)[279+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+278]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+278]);
 
-    assume is#Integer(contents#Memory(m)[old_size+279]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+279]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+278], contents#Memory(m)[old_size+279]);
     m := Memory(domain#Memory(m)[280+old_size := true], contents#Memory(m)[280+old_size := tmp]);
 
-    call Vector_push_back(t277, contents#Memory(m)[old_size+280]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t277, contents#Memory(m)[old_size+280]);
 
     call t281 := BorrowLoc(old_size+1);
 
@@ -3363,14 +3110,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[283+old_size := true], contents#Memory(m)[283+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+282]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+282]);
 
-    assume is#Integer(contents#Memory(m)[old_size+283]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+283]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+282], contents#Memory(m)[old_size+283]);
     m := Memory(domain#Memory(m)[284+old_size := true], contents#Memory(m)[284+old_size := tmp]);
 
-    call Vector_push_back(t281, contents#Memory(m)[old_size+284]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t281, contents#Memory(m)[old_size+284]);
 
     call t285 := BorrowLoc(old_size+1);
 
@@ -3380,14 +3127,14 @@ Label_7:
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[287+old_size := true], contents#Memory(m)[287+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+286]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+286]);
 
-    assume is#Integer(contents#Memory(m)[old_size+287]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+287]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+286], contents#Memory(m)[old_size+287]);
     m := Memory(domain#Memory(m)[288+old_size := true], contents#Memory(m)[288+old_size := tmp]);
 
-    call Vector_push_back(t285, contents#Memory(m)[old_size+288]);
+    call Vector_push_back(GasSchedule_Cost_type_value(), t285, contents#Memory(m)[old_size+288]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[289+old_size := true], contents#Memory(m)[289+old_size := tmp]);
@@ -3395,14 +3142,14 @@ Label_7:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[290+old_size := true], contents#Memory(m)[290+old_size := tmp]);
 
-    assume is#Vector(contents#Memory(m)[old_size+289]);
+    assume has_type(Vector_T_type_value(GasSchedule_Cost_type_value()), contents#Memory(m)[old_size+289]);
 
-    assume is#Vector(contents#Memory(m)[old_size+290]);
+    assume has_type(Vector_T_type_value(GasSchedule_Cost_type_value()), contents#Memory(m)[old_size+290]);
 
     call tmp := Pack_GasSchedule_T(contents#Memory(m)[old_size+289], contents#Memory(m)[old_size+290]);
     m := Memory(domain#Memory(m)[291+old_size := true], contents#Memory(m)[291+old_size := tmp]);
 
-    call MoveToSender(GasSchedule_T, contents#Memory(m)[old_size+291]);
+    call MoveToSender(GasSchedule_T_type_value(), contents#Memory(m)[old_size+291]);
 
     return;
 
@@ -3416,19 +3163,19 @@ procedure GasSchedule_initialize_verify () returns ()
 procedure {:inline 1} GasSchedule_new_cost (arg0: Value, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Value; // int
-    var t4: Value; // GasSchedule_Cost
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // GasSchedule_Cost_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
-    assume is#Integer(arg1);
+    assume has_type(IntegerType(), arg0);
+    assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -3442,9 +3189,9 @@ procedure {:inline 1} GasSchedule_new_cost (arg0: Value, arg1: Value) returns (r
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+2]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+2]);
 
-    assume is#Integer(contents#Memory(m)[old_size+3]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+3]);
 
     call tmp := Pack_GasSchedule_Cost(contents#Memory(m)[old_size+2], contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
@@ -3462,8 +3209,8 @@ procedure GasSchedule_new_cost_verify (arg0: Value, arg1: Value) returns (ret0: 
 procedure {:inline 1} GasSchedule_has_gas_schedule_resource () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
@@ -3478,7 +3225,7 @@ procedure {:inline 1} GasSchedule_has_gas_schedule_resource () returns (ret0: Va
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+0], GasSchedule_T);
+    call tmp := Exists(contents#Memory(m)[old_size+0], GasSchedule_T_type_value());
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
     ret0 := contents#Memory(m)[old_size+1];
@@ -3494,14 +3241,14 @@ procedure GasSchedule_has_gas_schedule_resource_verify () returns (ret0: Value)
 procedure {:inline 1} GasSchedule_instruction_table_size () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // GasSchedule_T_ref
-    var t1: Value; // int
-    var t2: Value; // address
-    var t3: Reference; // GasSchedule_T_ref
-    var t4: Reference; // GasSchedule_T_ref
-    var t5: Reference; // Vector_T_ref
-    var t6: Value; // int
-    var t7: Value; // int
+    var t0: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var t4: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -3516,7 +3263,7 @@ procedure {:inline 1} GasSchedule_instruction_table_size () returns (ret0: Value
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], GasSchedule_T);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], GasSchedule_T_type_value());
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -3524,8 +3271,8 @@ procedure {:inline 1} GasSchedule_instruction_table_size () returns (ret0: Value
 
     call t5 := BorrowField(t4, GasSchedule_T_instruction_schedule);
 
-    call t6 := Vector_length(t5);
-    assume is#Integer(t6);
+    call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
+    assume has_type(IntegerType(), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
@@ -3548,14 +3295,14 @@ procedure GasSchedule_instruction_table_size_verify () returns (ret0: Value)
 procedure {:inline 1} GasSchedule_native_table_size () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // GasSchedule_T_ref
-    var t1: Value; // int
-    var t2: Value; // address
-    var t3: Reference; // GasSchedule_T_ref
-    var t4: Reference; // GasSchedule_T_ref
-    var t5: Reference; // Vector_T_ref
-    var t6: Value; // int
-    var t7: Value; // int
+    var t0: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var t4: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -3570,7 +3317,7 @@ procedure {:inline 1} GasSchedule_native_table_size () returns (ret0: Value)
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], GasSchedule_T);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], GasSchedule_T_type_value());
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -3578,8 +3325,8 @@ procedure {:inline 1} GasSchedule_native_table_size () returns (ret0: Value)
 
     call t5 := BorrowField(t4, GasSchedule_T_native_schedule);
 
-    call t6 := Vector_length(t5);
-    assume is#Integer(t6);
+    call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
+    assume has_type(IntegerType(), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
@@ -3602,39 +3349,39 @@ procedure GasSchedule_native_table_size_verify () returns (ret0: Value)
 procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // LibraCoin_T
-    var t2: Value; // LibraAccount_EventHandleGenerator
-    var t3: Value; // LibraAccount_EventHandle
-    var t4: Value; // LibraAccount_EventHandle
-    var t5: Value; // bytearray
-    var t6: Value; // address
-    var t7: Value; // bytearray
-    var t8: Value; // int
-    var t9: Value; // LibraAccount_EventHandleGenerator
-    var t10: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t11: Value; // address
-    var t12: Value; // LibraAccount_EventHandle
-    var t13: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t14: Value; // address
-    var t15: Value; // LibraAccount_EventHandle
-    var t16: Value; // LibraCoin_T
-    var t17: Value; // bytearray
-    var t18: Value; // LibraCoin_T
-    var t19: Value; // bool
-    var t20: Value; // bool
-    var t21: Value; // LibraAccount_EventHandle
-    var t22: Value; // LibraAccount_EventHandle
-    var t23: Value; // int
-    var t24: Value; // LibraAccount_EventHandleGenerator
-    var t25: Value; // LibraAccount_T
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t3: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t4: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // AddressType()
+    var t7: Value; // ByteArrayType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t11: Value; // AddressType()
+    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t14: Value; // AddressType()
+    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t16: Value; // LibraCoin_T_type_value()
+    var t17: Value; // ByteArrayType()
+    var t18: Value; // LibraCoin_T_type_value()
+    var t19: Value; // BooleanType()
+    var t20: Value; // BooleanType()
+    var t21: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t22: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t23: Value; // IntegerType()
+    var t24: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t25: Value; // LibraAccount_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 26;
@@ -3645,7 +3392,7 @@ procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     call t7 := AddressUtil_address_to_bytes(contents#Memory(m)[old_size+6]);
-    assume is#ByteArray(t7);
+    assume has_type(ByteArrayType(), t7);
 
     m := Memory(domain#Memory(m)[old_size+7 := true], contents#Memory(m)[old_size+7 := t7]);
 
@@ -3655,7 +3402,7 @@ procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+8]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+8]);
 
     call tmp := Pack_LibraAccount_EventHandleGenerator(contents#Memory(m)[old_size+8]);
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
@@ -3668,8 +3415,8 @@ procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    call t12 := LibraAccount_new_event_handle_impl(t10, contents#Memory(m)[old_size+11]);
-    assume is#Map(t12);
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t10, contents#Memory(m)[old_size+11]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()), t12);
 
     m := Memory(domain#Memory(m)[old_size+12 := true], contents#Memory(m)[old_size+12 := t12]);
 
@@ -3681,8 +3428,8 @@ procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
-    call t15 := LibraAccount_new_event_handle_impl(t13, contents#Memory(m)[old_size+14]);
-    assume is#Map(t15);
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t13, contents#Memory(m)[old_size+14]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()), t15);
 
     m := Memory(domain#Memory(m)[old_size+15 := true], contents#Memory(m)[old_size+15 := t15]);
 
@@ -3690,7 +3437,7 @@ procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     call t16 := LibraCoin_zero();
-    assume is#Map(t16);
+    assume has_type(LibraCoin_T_type_value(), t16);
 
     m := Memory(domain#Memory(m)[old_size+16 := true], contents#Memory(m)[old_size+16 := t16]);
 
@@ -3721,21 +3468,21 @@ procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[24+old_size := true], contents#Memory(m)[24+old_size := tmp]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+17]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+17]);
 
-    assume is#Map(contents#Memory(m)[old_size+18]);
+    assume has_type(LibraCoin_T_type_value(), contents#Memory(m)[old_size+18]);
 
-    assume is#Boolean(contents#Memory(m)[old_size+19]);
+    assume has_type(BooleanType(), contents#Memory(m)[old_size+19]);
 
-    assume is#Boolean(contents#Memory(m)[old_size+20]);
+    assume has_type(BooleanType(), contents#Memory(m)[old_size+20]);
 
-    assume is#Map(contents#Memory(m)[old_size+21]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()), contents#Memory(m)[old_size+21]);
 
-    assume is#Map(contents#Memory(m)[old_size+22]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()), contents#Memory(m)[old_size+22]);
 
-    assume is#Integer(contents#Memory(m)[old_size+23]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+23]);
 
-    assume is#Map(contents#Memory(m)[old_size+24]);
+    assume has_type(LibraAccount_EventHandleGenerator_type_value(), contents#Memory(m)[old_size+24]);
 
     call tmp := Pack_LibraAccount_T(contents#Memory(m)[old_size+17], contents#Memory(m)[old_size+18], contents#Memory(m)[old_size+19], contents#Memory(m)[old_size+20], contents#Memory(m)[old_size+21], contents#Memory(m)[old_size+22], contents#Memory(m)[old_size+23], contents#Memory(m)[old_size+24]);
     m := Memory(domain#Memory(m)[25+old_size := true], contents#Memory(m)[25+old_size := tmp]);
@@ -3753,19 +3500,19 @@ procedure LibraAccount_make_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} LibraAccount_deposit (arg0: Value, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // LibraCoin_T
-    var t2: Value; // address
-    var t3: Value; // LibraCoin_T
-    var t4: Value; // bytearray
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // AddressType()
+    var t3: Value; // LibraCoin_T_type_value()
+    var t4: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
-    assume is#Map(arg1);
+    assume has_type(AddressType(), arg0);
+    assume has_type(LibraCoin_T_type_value(), arg1);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -3795,49 +3542,49 @@ procedure LibraAccount_deposit_verify (arg0: Value, arg1: Value) returns ()
 procedure {:inline 1} LibraAccount_deposit_with_metadata (arg0: Value, arg1: Value, arg2: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // LibraCoin_T
-    var t2: Value; // bytearray
-    var t3: Value; // int
-    var t4: Reference; // LibraAccount_T_ref
-    var t5: Value; // address
-    var t6: Reference; // LibraAccount_T_ref
-    var t7: Reference; // LibraCoin_T_ref
-    var t8: Value; // int
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // bool
-    var t12: Value; // bool
-    var t13: Value; // int
-    var t14: Value; // address
-    var t15: Value; // address
-    var t16: Reference; // LibraAccount_T_ref
-    var t17: Reference; // LibraAccount_T_ref
-    var t18: Reference; // LibraAccount_EventHandle_ref
-    var t19: Value; // int
-    var t20: Value; // address
-    var t21: Value; // bytearray
-    var t22: Value; // LibraAccount_SentPaymentEvent
-    var t23: Value; // address
-    var t24: Reference; // LibraAccount_T_ref
-    var t25: Reference; // LibraAccount_T_ref
-    var t26: Reference; // LibraCoin_T_ref
-    var t27: Value; // LibraCoin_T
-    var t28: Reference; // LibraAccount_T_ref
-    var t29: Reference; // LibraAccount_EventHandle_ref
-    var t30: Value; // int
-    var t31: Value; // address
-    var t32: Value; // bytearray
-    var t33: Value; // LibraAccount_ReceivedPaymentEvent
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // BooleanType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // IntegerType()
+    var t14: Value; // AddressType()
+    var t15: Value; // AddressType()
+    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t18: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
+    var t19: Value; // IntegerType()
+    var t20: Value; // AddressType()
+    var t21: Value; // ByteArrayType()
+    var t22: Value; // LibraAccount_SentPaymentEvent_type_value()
+    var t23: Value; // AddressType()
+    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t25: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t26: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t27: Value; // LibraCoin_T_type_value()
+    var t28: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t29: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
+    var t30: Value; // IntegerType()
+    var t31: Value; // AddressType()
+    var t32: Value; // ByteArrayType()
+    var t33: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
-    assume is#Map(arg1);
-    assume is#ByteArray(arg2);
+    assume has_type(AddressType(), arg0);
+    assume has_type(LibraCoin_T_type_value(), arg1);
+    assume has_type(ByteArrayType(), arg2);
 
     old_size := m_size;
     m_size := m_size + 34;
@@ -3849,7 +3596,7 @@ procedure {:inline 1} LibraAccount_deposit_with_metadata (arg0: Value, arg1: Val
     call t7 := BorrowLoc(old_size+1);
 
     call t8 := LibraCoin_value(t7);
-    assume is#Integer(t8);
+    assume has_type(IntegerType(), t8);
 
     m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
 
@@ -3869,7 +3616,7 @@ procedure {:inline 1} LibraAccount_deposit_with_metadata (arg0: Value, arg1: Val
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 12];
-if (!b#Boolean(tmp)) { goto Label_10; }
+    if (!b#Boolean(tmp)) { goto Label_10; }
 
     call tmp := LdConst(7);
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
@@ -3886,7 +3633,7 @@ Label_10:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+5]);
     m := Memory(domain#Memory(m)[15+old_size := true], contents#Memory(m)[15+old_size := tmp]);
 
-    call t16 := BorrowGlobal(contents#Memory(m)[old_size+15], LibraAccount_T);
+    call t16 := BorrowGlobal(contents#Memory(m)[old_size+15], LibraAccount_T_type_value());
 
     call t6 := CopyOrMoveRef(t16);
 
@@ -3903,21 +3650,21 @@ Label_10:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+19]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+19]);
 
-    assume is#Address(contents#Memory(m)[old_size+20]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+20]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+21]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+21]);
 
     call tmp := Pack_LibraAccount_SentPaymentEvent(contents#Memory(m)[old_size+19], contents#Memory(m)[old_size+20], contents#Memory(m)[old_size+21]);
     m := Memory(domain#Memory(m)[22+old_size := true], contents#Memory(m)[22+old_size := tmp]);
 
-    call LibraAccount_emit_event(t18, contents#Memory(m)[old_size+22]);
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t18, contents#Memory(m)[old_size+22]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[23+old_size := true], contents#Memory(m)[23+old_size := tmp]);
 
-    call t24 := BorrowGlobal(contents#Memory(m)[old_size+23], LibraAccount_T);
+    call t24 := BorrowGlobal(contents#Memory(m)[old_size+23], LibraAccount_T_type_value());
 
     call t4 := CopyOrMoveRef(t24);
 
@@ -3943,16 +3690,16 @@ Label_10:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[32+old_size := true], contents#Memory(m)[32+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+30]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+30]);
 
-    assume is#Address(contents#Memory(m)[old_size+31]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+31]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+32]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+32]);
 
     call tmp := Pack_LibraAccount_ReceivedPaymentEvent(contents#Memory(m)[old_size+30], contents#Memory(m)[old_size+31], contents#Memory(m)[old_size+32]);
     m := Memory(domain#Memory(m)[33+old_size := true], contents#Memory(m)[33+old_size := tmp]);
 
-    call LibraAccount_emit_event(t29, contents#Memory(m)[old_size+33]);
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t29, contents#Memory(m)[old_size+33]);
 
     return;
 
@@ -3966,23 +3713,23 @@ procedure LibraAccount_deposit_with_metadata_verify (arg0: Value, arg1: Value, a
 procedure {:inline 1} LibraAccount_mint_to_address (arg0: Value, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // int
-    var t2: Value; // address
-    var t3: Value; // bool
-    var t4: Value; // bool
-    var t5: Value; // address
-    var t6: Value; // address
-    var t7: Value; // int
-    var t8: Value; // LibraCoin_T
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // AddressType()
+    var t6: Value; // AddressType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
-    assume is#Integer(arg1);
+    assume has_type(AddressType(), arg0);
+    assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 9;
@@ -3993,14 +3740,14 @@ procedure {:inline 1} LibraAccount_mint_to_address (arg0: Value, arg1: Value) re
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+2], LibraAccount_T);
+    call tmp := Exists(contents#Memory(m)[old_size+2], LibraAccount_T_type_value());
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 4];
-if (!b#Boolean(tmp)) { goto Label_6; }
+    if (!b#Boolean(tmp)) { goto Label_6; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
@@ -4015,7 +3762,7 @@ Label_6:
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
     call t8 := LibraCoin_mint_with_default_capability(contents#Memory(m)[old_size+7]);
-    assume is#Map(t8);
+    assume has_type(LibraCoin_T_type_value(), t8);
 
     m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
 
@@ -4033,21 +3780,21 @@ procedure LibraAccount_mint_to_address_verify (arg0: Value, arg1: Value) returns
 procedure {:inline 1} LibraAccount_withdraw_from_account (arg0: Reference, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_T_ref
-    var t1: Value; // int
-    var t2: Value; // LibraCoin_T
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Reference; // LibraCoin_T_ref
-    var t5: Value; // int
-    var t6: Value; // LibraCoin_T
-    var t7: Value; // LibraCoin_T
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t5: Value; // IntegerType()
+    var t6: Value; // LibraCoin_T_type_value()
+    var t7: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#Integer(arg1);
+        assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 8;
@@ -4063,7 +3810,7 @@ procedure {:inline 1} LibraAccount_withdraw_from_account (arg0: Reference, arg1:
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     call t6 := LibraCoin_withdraw(t4, contents#Memory(m)[old_size+5]);
-    assume is#Map(t6);
+    assume has_type(LibraCoin_T_type_value(), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
@@ -4086,24 +3833,24 @@ procedure LibraAccount_withdraw_from_account_verify (arg0: Reference, arg1: Valu
 procedure {:inline 1} LibraAccount_withdraw_from_sender (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Reference; // LibraAccount_T_ref
-    var t2: Value; // address
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Reference; // LibraAccount_T_ref
-    var t5: Reference; // bool_ref
-    var t6: Value; // bool
-    var t7: Value; // int
-    var t8: Reference; // LibraAccount_T_ref
-    var t9: Value; // int
-    var t10: Value; // LibraCoin_T
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(BooleanType())
+    var t6: Value; // BooleanType()
+    var t7: Value; // IntegerType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Value; // IntegerType()
+    var t10: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 11;
@@ -4113,7 +3860,7 @@ procedure {:inline 1} LibraAccount_withdraw_from_sender (arg0: Value) returns (r
     call tmp := GetTxnSenderAddress();
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraAccount_T);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraAccount_T_type_value());
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -4122,12 +3869,12 @@ procedure {:inline 1} LibraAccount_withdraw_from_sender (arg0: Value) returns (r
     call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
 
     call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    assume has_type(BooleanType(), tmp);
 
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 6];
-if (!b#Boolean(tmp)) { goto Label_9; }
+    if (!b#Boolean(tmp)) { goto Label_9; }
 
     call tmp := LdConst(11);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
@@ -4141,7 +3888,7 @@ Label_9:
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
     call t10 := LibraAccount_withdraw_from_account(t8, contents#Memory(m)[old_size+9]);
-    assume is#Map(t10);
+    assume has_type(LibraCoin_T_type_value(), t10);
 
     m := Memory(domain#Memory(m)[old_size+10 := true], contents#Memory(m)[old_size+10 := t10]);
 
@@ -4158,23 +3905,23 @@ procedure LibraAccount_withdraw_from_sender_verify (arg0: Value) returns (ret0: 
 procedure {:inline 1} LibraAccount_withdraw_with_capability (arg0: Reference, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_WithdrawalCapability_ref
-    var t1: Value; // int
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Reference; // LibraAccount_WithdrawalCapability_ref
-    var t4: Reference; // address_ref
-    var t5: Value; // address
-    var t6: Reference; // LibraAccount_T_ref
-    var t7: Reference; // LibraAccount_T_ref
-    var t8: Value; // int
-    var t9: Value; // LibraCoin_T
+    var t0: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t4: Reference; // ReferenceType(AddressType())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#Integer(arg1);
+        assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 10;
@@ -4187,11 +3934,11 @@ procedure {:inline 1} LibraAccount_withdraw_with_capability (arg0: Reference, ar
     call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
 
     call tmp := ReadRef(t4);
-    assume is#Address(tmp);
+    assume has_type(AddressType(), tmp);
 
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraAccount_T);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraAccount_T_type_value());
 
     call t2 := CopyOrMoveRef(t6);
 
@@ -4201,7 +3948,7 @@ procedure {:inline 1} LibraAccount_withdraw_with_capability (arg0: Reference, ar
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
     call t9 := LibraAccount_withdraw_from_account(t7, contents#Memory(m)[old_size+8]);
-    assume is#Map(t9);
+    assume has_type(LibraCoin_T_type_value(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -4218,21 +3965,21 @@ procedure LibraAccount_withdraw_with_capability_verify (arg0: Reference, arg1: V
 procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraAccount_T_ref
-    var t2: Reference; // bool_ref
-    var t3: Value; // address
-    var t4: Value; // address
-    var t5: Reference; // LibraAccount_T_ref
-    var t6: Reference; // LibraAccount_T_ref
-    var t7: Reference; // bool_ref
-    var t8: Reference; // bool_ref
-    var t9: Value; // bool
-    var t10: Value; // int
-    var t11: Value; // bool
-    var t12: Reference; // bool_ref
-    var t13: Value; // address
-    var t14: Value; // LibraAccount_WithdrawalCapability
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Reference; // ReferenceType(BooleanType())
+    var t3: Value; // AddressType()
+    var t4: Value; // AddressType()
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Reference; // ReferenceType(BooleanType())
+    var t8: Reference; // ReferenceType(BooleanType())
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // BooleanType()
+    var t12: Reference; // ReferenceType(BooleanType())
+    var t13: Value; // AddressType()
+    var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -4253,7 +4000,7 @@ procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () retur
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
-    call t5 := BorrowGlobal(contents#Memory(m)[old_size+4], LibraAccount_T);
+    call t5 := BorrowGlobal(contents#Memory(m)[old_size+4], LibraAccount_T_type_value());
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -4266,12 +4013,12 @@ procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () retur
     call t8 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t8);
-    assume is#Boolean(tmp);
+    assume has_type(BooleanType(), tmp);
 
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 9];
-if (!b#Boolean(tmp)) { goto Label_13; }
+    if (!b#Boolean(tmp)) { goto Label_13; }
 
     call tmp := LdConst(11);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
@@ -4289,7 +4036,7 @@ Label_13:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
 
-    assume is#Address(contents#Memory(m)[old_size+13]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+13]);
 
     call tmp := Pack_LibraAccount_WithdrawalCapability(contents#Memory(m)[old_size+13]);
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
@@ -4307,23 +4054,23 @@ procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (r
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // LibraAccount_WithdrawalCapability
-    var t1: Value; // address
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Value; // LibraAccount_WithdrawalCapability
-    var t4: Value; // address
-    var t5: Value; // address
-    var t6: Reference; // LibraAccount_T_ref
-    var t7: Value; // bool
-    var t8: Reference; // LibraAccount_T_ref
-    var t9: Reference; // bool_ref
+    var t0: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var t4: Value; // AddressType()
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Value; // BooleanType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Reference; // ReferenceType(BooleanType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
+    assume has_type(LibraAccount_WithdrawalCapability_type_value(), arg0);
 
     old_size := m_size;
     m_size := m_size + 10;
@@ -4334,7 +4081,7 @@ procedure {:inline 1} LibraAccount_restore_withdrawal_capability (arg0: Value) r
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     call t4 := Unpack_LibraAccount_WithdrawalCapability(contents#Memory(m)[old_size+3]);
-    assume is#Address(t4);
+    assume has_type(AddressType(), t4);
 
     m := Memory(domain#Memory(m)[old_size+4 := true], contents#Memory(m)[old_size+4 := t4]);
 
@@ -4344,7 +4091,7 @@ procedure {:inline 1} LibraAccount_restore_withdrawal_capability (arg0: Value) r
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraAccount_T);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraAccount_T_type_value());
 
     call t2 := CopyOrMoveRef(t6);
 
@@ -4369,26 +4116,26 @@ procedure LibraAccount_restore_withdrawal_capability_verify (arg0: Value) return
 procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (arg0: Value, arg1: Value, arg2: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // int
-    var t2: Value; // bytearray
-    var t3: Value; // address
-    var t4: Value; // bool
-    var t5: Value; // bool
-    var t6: Value; // address
-    var t7: Value; // address
-    var t8: Value; // int
-    var t9: Value; // LibraCoin_T
-    var t10: Value; // bytearray
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // AddressType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // AddressType()
+    var t7: Value; // AddressType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraCoin_T_type_value()
+    var t10: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
-    assume is#Integer(arg1);
-    assume is#ByteArray(arg2);
+    assume has_type(AddressType(), arg0);
+    assume has_type(IntegerType(), arg1);
+    assume has_type(ByteArrayType(), arg2);
 
     old_size := m_size;
     m_size := m_size + 11;
@@ -4400,14 +4147,14 @@ procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (arg0: Value, a
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+3], LibraAccount_T);
+    call tmp := Exists(contents#Memory(m)[old_size+3], LibraAccount_T_type_value());
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+4]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 5];
-if (!b#Boolean(tmp)) { goto Label_6; }
+    if (!b#Boolean(tmp)) { goto Label_6; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
@@ -4422,7 +4169,7 @@ Label_6:
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
     call t9 := LibraAccount_withdraw_from_sender(contents#Memory(m)[old_size+8]);
-    assume is#Map(t9);
+    assume has_type(LibraCoin_T_type_value(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -4443,19 +4190,19 @@ procedure LibraAccount_pay_from_sender_with_metadata_verify (arg0: Value, arg1: 
 procedure {:inline 1} LibraAccount_pay_from_sender (arg0: Value, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // int
-    var t2: Value; // address
-    var t3: Value; // int
-    var t4: Value; // bytearray
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
-    assume is#Integer(arg1);
+    assume has_type(AddressType(), arg0);
+    assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -4485,18 +4232,18 @@ procedure LibraAccount_pay_from_sender_verify (arg0: Value, arg1: Value) returns
 procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (arg0: Reference, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_T_ref
-    var t1: Value; // bytearray
-    var t2: Value; // bytearray
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Reference; // bytearray_ref
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // ByteArrayType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(ByteArrayType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#ByteArray(arg1);
+        assume has_type(ByteArrayType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -4525,23 +4272,23 @@ procedure LibraAccount_rotate_authentication_key_for_account_verify (arg0: Refer
 procedure {:inline 1} LibraAccount_rotate_authentication_key (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // bytearray
-    var t1: Reference; // LibraAccount_T_ref
-    var t2: Value; // address
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Reference; // LibraAccount_T_ref
-    var t5: Reference; // bool_ref
-    var t6: Value; // bool
-    var t7: Value; // int
-    var t8: Reference; // LibraAccount_T_ref
-    var t9: Value; // bytearray
+    var t0: Value; // ByteArrayType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(BooleanType())
+    var t6: Value; // BooleanType()
+    var t7: Value; // IntegerType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#ByteArray(arg0);
+    assume has_type(ByteArrayType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 10;
@@ -4551,7 +4298,7 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key (arg0: Value) retur
     call tmp := GetTxnSenderAddress();
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraAccount_T);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraAccount_T_type_value());
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -4560,12 +4307,12 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key (arg0: Value) retur
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
     call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    assume has_type(BooleanType(), tmp);
 
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 6];
-if (!b#Boolean(tmp)) { goto Label_9; }
+    if (!b#Boolean(tmp)) { goto Label_9; }
 
     call tmp := LdConst(11);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
@@ -4592,20 +4339,20 @@ procedure LibraAccount_rotate_authentication_key_verify (arg0: Value) returns ()
 procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (arg0: Reference, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_KeyRotationCapability_ref
-    var t1: Value; // bytearray
-    var t2: Reference; // LibraAccount_KeyRotationCapability_ref
-    var t3: Reference; // address_ref
-    var t4: Value; // address
-    var t5: Reference; // LibraAccount_T_ref
-    var t6: Value; // bytearray
+    var t0: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t3: Reference; // ReferenceType(AddressType())
+    var t4: Value; // AddressType()
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#ByteArray(arg1);
+        assume has_type(ByteArrayType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 7;
@@ -4618,11 +4365,11 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (ar
     call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
 
     call tmp := ReadRef(t3);
-    assume is#Address(tmp);
+    assume has_type(AddressType(), tmp);
 
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
-    call t5 := BorrowGlobal(contents#Memory(m)[old_size+4], LibraAccount_T);
+    call t5 := BorrowGlobal(contents#Memory(m)[old_size+4], LibraAccount_T_type_value());
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
@@ -4641,19 +4388,19 @@ procedure LibraAccount_rotate_authentication_key_with_capability_verify (arg0: R
 procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // bool_ref
-    var t2: Value; // address
-    var t3: Value; // address
-    var t4: Reference; // LibraAccount_T_ref
-    var t5: Reference; // bool_ref
-    var t6: Reference; // bool_ref
-    var t7: Value; // bool
-    var t8: Value; // int
-    var t9: Value; // bool
-    var t10: Reference; // bool_ref
-    var t11: Value; // address
-    var t12: Value; // LibraAccount_KeyRotationCapability
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(BooleanType())
+    var t2: Value; // AddressType()
+    var t3: Value; // AddressType()
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(BooleanType())
+    var t6: Reference; // ReferenceType(BooleanType())
+    var t7: Value; // BooleanType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Reference; // ReferenceType(BooleanType())
+    var t11: Value; // AddressType()
+    var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -4674,7 +4421,7 @@ procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () ret
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
-    call t4 := BorrowGlobal(contents#Memory(m)[old_size+3], LibraAccount_T);
+    call t4 := BorrowGlobal(contents#Memory(m)[old_size+3], LibraAccount_T_type_value());
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
@@ -4683,12 +4430,12 @@ procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () ret
     call t6 := CopyOrMoveRef(t1);
 
     call tmp := ReadRef(t6);
-    assume is#Boolean(tmp);
+    assume has_type(BooleanType(), tmp);
 
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 7];
-if (!b#Boolean(tmp)) { goto Label_11; }
+    if (!b#Boolean(tmp)) { goto Label_11; }
 
     call tmp := LdConst(11);
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
@@ -4706,7 +4453,7 @@ Label_11:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    assume is#Address(contents#Memory(m)[old_size+11]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+11]);
 
     call tmp := Pack_LibraAccount_KeyRotationCapability(contents#Memory(m)[old_size+11]);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
@@ -4724,23 +4471,23 @@ procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // LibraAccount_KeyRotationCapability
-    var t1: Value; // address
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Value; // LibraAccount_KeyRotationCapability
-    var t4: Value; // address
-    var t5: Value; // address
-    var t6: Reference; // LibraAccount_T_ref
-    var t7: Value; // bool
-    var t8: Reference; // LibraAccount_T_ref
-    var t9: Reference; // bool_ref
+    var t0: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var t4: Value; // AddressType()
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Value; // BooleanType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Reference; // ReferenceType(BooleanType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
+    assume has_type(LibraAccount_KeyRotationCapability_type_value(), arg0);
 
     old_size := m_size;
     m_size := m_size + 10;
@@ -4751,7 +4498,7 @@ procedure {:inline 1} LibraAccount_restore_key_rotation_capability (arg0: Value)
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     call t4 := Unpack_LibraAccount_KeyRotationCapability(contents#Memory(m)[old_size+3]);
-    assume is#Address(t4);
+    assume has_type(AddressType(), t4);
 
     m := Memory(domain#Memory(m)[old_size+4 := true], contents#Memory(m)[old_size+4 := t4]);
 
@@ -4761,7 +4508,7 @@ procedure {:inline 1} LibraAccount_restore_key_rotation_capability (arg0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraAccount_T);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraAccount_T_type_value());
 
     call t2 := CopyOrMoveRef(t6);
 
@@ -4786,32 +4533,32 @@ procedure LibraAccount_restore_key_rotation_capability_verify (arg0: Value) retu
 procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // LibraAccount_EventHandleGenerator
-    var t2: Value; // int
-    var t3: Value; // LibraAccount_EventHandleGenerator
-    var t4: Value; // address
-    var t5: Value; // address
-    var t6: Value; // bytearray
-    var t7: Value; // LibraCoin_T
-    var t8: Value; // bool
-    var t9: Value; // bool
-    var t10: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t11: Value; // address
-    var t12: Value; // LibraAccount_EventHandle
-    var t13: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t14: Value; // address
-    var t15: Value; // LibraAccount_EventHandle
-    var t16: Value; // int
-    var t17: Value; // LibraAccount_EventHandleGenerator
-    var t18: Value; // LibraAccount_T
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t2: Value; // IntegerType()
+    var t3: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t4: Value; // AddressType()
+    var t5: Value; // AddressType()
+    var t6: Value; // ByteArrayType()
+    var t7: Value; // LibraCoin_T_type_value()
+    var t8: Value; // BooleanType()
+    var t9: Value; // BooleanType()
+    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t11: Value; // AddressType()
+    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t14: Value; // AddressType()
+    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t18: Value; // LibraAccount_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 19;
@@ -4821,7 +4568,7 @@ procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+2]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+2]);
 
     call tmp := Pack_LibraAccount_EventHandleGenerator(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
@@ -4836,12 +4583,12 @@ procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     call t6 := AddressUtil_address_to_bytes(contents#Memory(m)[old_size+5]);
-    assume is#ByteArray(t6);
+    assume has_type(ByteArrayType(), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
     call t7 := LibraCoin_zero();
-    assume is#Map(t7);
+    assume has_type(LibraCoin_T_type_value(), t7);
 
     m := Memory(domain#Memory(m)[old_size+7 := true], contents#Memory(m)[old_size+7 := t7]);
 
@@ -4856,8 +4603,8 @@ procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    call t12 := LibraAccount_new_event_handle_impl(t10, contents#Memory(m)[old_size+11]);
-    assume is#Map(t12);
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, contents#Memory(m)[old_size+11]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()), t12);
 
     m := Memory(domain#Memory(m)[old_size+12 := true], contents#Memory(m)[old_size+12 := t12]);
 
@@ -4866,8 +4613,8 @@ procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
-    call t15 := LibraAccount_new_event_handle_impl(t13, contents#Memory(m)[old_size+14]);
-    assume is#Map(t15);
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, contents#Memory(m)[old_size+14]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()), t15);
 
     m := Memory(domain#Memory(m)[old_size+15 := true], contents#Memory(m)[old_size+15 := t15]);
 
@@ -4877,21 +4624,21 @@ procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+6]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+6]);
 
-    assume is#Map(contents#Memory(m)[old_size+7]);
+    assume has_type(LibraCoin_T_type_value(), contents#Memory(m)[old_size+7]);
 
-    assume is#Boolean(contents#Memory(m)[old_size+8]);
+    assume has_type(BooleanType(), contents#Memory(m)[old_size+8]);
 
-    assume is#Boolean(contents#Memory(m)[old_size+9]);
+    assume has_type(BooleanType(), contents#Memory(m)[old_size+9]);
 
-    assume is#Map(contents#Memory(m)[old_size+12]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()), contents#Memory(m)[old_size+12]);
 
-    assume is#Map(contents#Memory(m)[old_size+15]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()), contents#Memory(m)[old_size+15]);
 
-    assume is#Integer(contents#Memory(m)[old_size+16]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+16]);
 
-    assume is#Map(contents#Memory(m)[old_size+17]);
+    assume has_type(LibraAccount_EventHandleGenerator_type_value(), contents#Memory(m)[old_size+17]);
 
     call tmp := Pack_LibraAccount_T(contents#Memory(m)[old_size+6], contents#Memory(m)[old_size+7], contents#Memory(m)[old_size+8], contents#Memory(m)[old_size+9], contents#Memory(m)[old_size+12], contents#Memory(m)[old_size+15], contents#Memory(m)[old_size+16], contents#Memory(m)[old_size+17]);
     m := Memory(domain#Memory(m)[18+old_size := true], contents#Memory(m)[18+old_size := tmp]);
@@ -4910,22 +4657,22 @@ procedure LibraAccount_create_account_verify (arg0: Value) returns ()
 procedure {:inline 1} LibraAccount_create_new_account (arg0: Value, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // int
-    var t2: Value; // address
-    var t3: Value; // int
-    var t4: Value; // int
-    var t5: Value; // bool
-    var t6: Value; // address
-    var t7: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // AddressType()
+    var t7: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
-    assume is#Integer(arg1);
+    assume has_type(AddressType(), arg0);
+    assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 8;
@@ -4948,7 +4695,7 @@ procedure {:inline 1} LibraAccount_create_new_account (arg0: Value, arg1: Value)
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 5];
-if (!b#Boolean(tmp)) { goto Label_9; }
+    if (!b#Boolean(tmp)) { goto Label_9; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
@@ -4972,12 +4719,12 @@ procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) retur
 procedure {:inline 1} LibraAccount_balance_for_account (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_T_ref
-    var t1: Value; // int
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Reference; // LibraCoin_T_ref
-    var t4: Value; // int
-    var t5: Value; // int
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -4995,7 +4742,7 @@ procedure {:inline 1} LibraAccount_balance_for_account (arg0: Reference) returns
     call t3 := BorrowField(t2, LibraAccount_T_balance);
 
     call t4 := LibraCoin_value(t3);
-    assume is#Integer(t4);
+    assume has_type(IntegerType(), t4);
 
     m := Memory(domain#Memory(m)[old_size+4 := true], contents#Memory(m)[old_size+4 := t4]);
 
@@ -5018,17 +4765,17 @@ procedure LibraAccount_balance_for_account_verify (arg0: Reference) returns (ret
 procedure {:inline 1} LibraAccount_balance (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 4;
@@ -5038,10 +4785,10 @@ procedure {:inline 1} LibraAccount_balance (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T);
+    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T_type_value());
 
     call t3 := LibraAccount_balance_for_account(t2);
-    assume is#Integer(t3);
+    assume has_type(IntegerType(), t3);
 
     m := Memory(domain#Memory(m)[old_size+3 := true], contents#Memory(m)[old_size+3 := t3]);
 
@@ -5058,10 +4805,10 @@ procedure LibraAccount_balance_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} LibraAccount_sequence_number_for_account (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_T_ref
-    var t1: Reference; // LibraAccount_T_ref
-    var t2: Reference; // int_ref
-    var t3: Value; // int
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -5079,7 +4826,7 @@ procedure {:inline 1} LibraAccount_sequence_number_for_account (arg0: Reference)
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t2);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -5096,17 +4843,17 @@ procedure LibraAccount_sequence_number_for_account_verify (arg0: Reference) retu
 procedure {:inline 1} LibraAccount_sequence_number (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 4;
@@ -5116,10 +4863,10 @@ procedure {:inline 1} LibraAccount_sequence_number (arg0: Value) returns (ret0: 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T);
+    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T_type_value());
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
-    assume is#Integer(t3);
+    assume has_type(IntegerType(), t3);
 
     m := Memory(domain#Memory(m)[old_size+3 := true], contents#Memory(m)[old_size+3 := t3]);
 
@@ -5136,18 +4883,18 @@ procedure LibraAccount_sequence_number_verify (arg0: Value) returns (ret0: Value
 procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Reference; // bool_ref
-    var t4: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(BooleanType())
+    var t4: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -5157,12 +4904,12 @@ procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (arg0: Valu
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T);
+    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T_type_value());
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
 
     call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    assume has_type(BooleanType(), tmp);
 
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
@@ -5179,18 +4926,18 @@ procedure LibraAccount_delegated_key_rotation_capability_verify (arg0: Value) re
 procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Reference; // bool_ref
-    var t4: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(BooleanType())
+    var t4: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 5;
@@ -5200,12 +4947,12 @@ procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (arg0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T);
+    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraAccount_T_type_value());
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
 
     call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    assume has_type(BooleanType(), tmp);
 
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
@@ -5222,9 +4969,9 @@ procedure LibraAccount_delegated_withdrawal_capability_verify (arg0: Value) retu
 procedure {:inline 1} LibraAccount_withdrawal_capability_address (arg0: Reference) returns (ret0: Reference)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_WithdrawalCapability_ref
-    var t1: Reference; // LibraAccount_WithdrawalCapability_ref
-    var t2: Reference; // address_ref
+    var t0: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t2: Reference; // ReferenceType(AddressType())
 
     var tmp: Value;
     var old_size: int;
@@ -5254,9 +5001,9 @@ procedure LibraAccount_withdrawal_capability_address_verify (arg0: Reference) re
 procedure {:inline 1} LibraAccount_key_rotation_capability_address (arg0: Reference) returns (ret0: Reference)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_KeyRotationCapability_ref
-    var t1: Reference; // LibraAccount_KeyRotationCapability_ref
-    var t2: Reference; // address_ref
+    var t0: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t2: Reference; // ReferenceType(AddressType())
 
     var tmp: Value;
     var old_size: int;
@@ -5286,16 +5033,16 @@ procedure LibraAccount_key_rotation_capability_address_verify (arg0: Reference) 
 procedure {:inline 1} LibraAccount_exists (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 3;
@@ -5305,7 +5052,7 @@ procedure {:inline 1} LibraAccount_exists (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+1], LibraAccount_T);
+    call tmp := Exists(contents#Memory(m)[old_size+1], LibraAccount_T_type_value());
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     ret0 := contents#Memory(m)[old_size+2];
@@ -5321,64 +5068,64 @@ procedure LibraAccount_exists_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} LibraAccount_prologue () returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // bool
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Value; // bytearray
-    var t5: Value; // bytearray
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // address
-    var t13: Value; // address
-    var t14: Value; // bool
-    var t15: Value; // bool
-    var t16: Value; // bool
-    var t17: Value; // int
-    var t18: Value; // address
-    var t19: Reference; // LibraAccount_T_ref
-    var t20: Value; // bytearray
-    var t21: Value; // bytearray
-    var t22: Value; // bytearray
-    var t23: Value; // bytearray
-    var t24: Reference; // LibraAccount_T_ref
-    var t25: Reference; // bytearray_ref
-    var t26: Value; // bytearray
-    var t27: Value; // bool
-    var t28: Value; // bool
-    var t29: Value; // int
-    var t30: Value; // int
-    var t31: Value; // int
-    var t32: Value; // int
-    var t33: Value; // int
-    var t34: Value; // int
-    var t35: Reference; // LibraAccount_T_ref
-    var t36: Reference; // LibraAccount_T_ref
-    var t37: Reference; // LibraAccount_T_ref
-    var t38: Value; // int
-    var t39: Value; // int
-    var t40: Value; // int
-    var t41: Value; // bool
-    var t42: Value; // bool
-    var t43: Value; // int
-    var t44: Reference; // LibraAccount_T_ref
-    var t45: Reference; // int_ref
-    var t46: Value; // int
-    var t47: Value; // int
-    var t48: Value; // int
-    var t49: Value; // int
-    var t50: Value; // bool
-    var t51: Value; // bool
-    var t52: Value; // int
-    var t53: Value; // int
-    var t54: Value; // int
-    var t55: Value; // bool
-    var t56: Value; // bool
-    var t57: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Value; // BooleanType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Value; // ByteArrayType()
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // AddressType()
+    var t13: Value; // AddressType()
+    var t14: Value; // BooleanType()
+    var t15: Value; // BooleanType()
+    var t16: Value; // BooleanType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // AddressType()
+    var t19: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t20: Value; // ByteArrayType()
+    var t21: Value; // ByteArrayType()
+    var t22: Value; // ByteArrayType()
+    var t23: Value; // ByteArrayType()
+    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t25: Reference; // ReferenceType(ByteArrayType())
+    var t26: Value; // ByteArrayType()
+    var t27: Value; // BooleanType()
+    var t28: Value; // BooleanType()
+    var t29: Value; // IntegerType()
+    var t30: Value; // IntegerType()
+    var t31: Value; // IntegerType()
+    var t32: Value; // IntegerType()
+    var t33: Value; // IntegerType()
+    var t34: Value; // IntegerType()
+    var t35: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t36: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t37: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t38: Value; // IntegerType()
+    var t39: Value; // IntegerType()
+    var t40: Value; // IntegerType()
+    var t41: Value; // BooleanType()
+    var t42: Value; // BooleanType()
+    var t43: Value; // IntegerType()
+    var t44: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t45: Reference; // ReferenceType(IntegerType())
+    var t46: Value; // IntegerType()
+    var t47: Value; // IntegerType()
+    var t48: Value; // IntegerType()
+    var t49: Value; // IntegerType()
+    var t50: Value; // BooleanType()
+    var t51: Value; // BooleanType()
+    var t52: Value; // IntegerType()
+    var t53: Value; // IntegerType()
+    var t54: Value; // IntegerType()
+    var t55: Value; // BooleanType()
+    var t56: Value; // BooleanType()
+    var t57: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -5399,7 +5146,7 @@ procedure {:inline 1} LibraAccount_prologue () returns ()
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+13], LibraAccount_T);
+    call tmp := Exists(contents#Memory(m)[old_size+13], LibraAccount_T_type_value());
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+14]);
@@ -5412,7 +5159,7 @@ procedure {:inline 1} LibraAccount_prologue () returns ()
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 16];
-if (!b#Boolean(tmp)) { goto Label_10; }
+    if (!b#Boolean(tmp)) { goto Label_10; }
 
     call tmp := LdConst(5);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
@@ -5423,7 +5170,7 @@ Label_10:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[18+old_size := true], contents#Memory(m)[18+old_size := tmp]);
 
-    call t19 := BorrowGlobal(contents#Memory(m)[old_size+18], LibraAccount_T);
+    call t19 := BorrowGlobal(contents#Memory(m)[old_size+18], LibraAccount_T_type_value());
 
     call t2 := CopyOrMoveRef(t19);
 
@@ -5437,7 +5184,7 @@ Label_10:
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
     call t22 := Hash_sha3_256(contents#Memory(m)[old_size+21]);
-    assume is#ByteArray(t22);
+    assume has_type(ByteArrayType(), t22);
 
     m := Memory(domain#Memory(m)[old_size+22 := true], contents#Memory(m)[old_size+22 := t22]);
 
@@ -5452,18 +5199,18 @@ Label_10:
     call t25 := BorrowField(t24, LibraAccount_T_authentication_key);
 
     call tmp := ReadRef(t25);
-    assume is#ByteArray(tmp);
+    assume has_type(ByteArrayType(), tmp);
 
     m := Memory(domain#Memory(m)[26+old_size := true], contents#Memory(m)[26+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+23], contents#Memory(m)[old_size+26]);
+    tmp := Boolean(is_equal(ByteArrayType(), contents#Memory(m)[old_size+23], contents#Memory(m)[old_size+26]));
     m := Memory(domain#Memory(m)[27+old_size := true], contents#Memory(m)[27+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+27]);
     m := Memory(domain#Memory(m)[28+old_size := true], contents#Memory(m)[28+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 28];
-if (!b#Boolean(tmp)) { goto Label_27; }
+    if (!b#Boolean(tmp)) { goto Label_27; }
 
     call tmp := LdConst(2);
     m := Memory(domain#Memory(m)[29+old_size := true], contents#Memory(m)[29+old_size := tmp]);
@@ -5504,7 +5251,7 @@ Label_27:
     call t37 := CopyOrMoveRef(t3);
 
     call t38 := LibraAccount_balance_for_account(t37);
-    assume is#Integer(t38);
+    assume has_type(IntegerType(), t38);
 
     m := Memory(domain#Memory(m)[old_size+38 := true], contents#Memory(m)[old_size+38 := t38]);
 
@@ -5524,7 +5271,7 @@ Label_27:
     m := Memory(domain#Memory(m)[42+old_size := true], contents#Memory(m)[42+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 42];
-if (!b#Boolean(tmp)) { goto Label_48; }
+    if (!b#Boolean(tmp)) { goto Label_48; }
 
     call tmp := LdConst(6);
     m := Memory(domain#Memory(m)[43+old_size := true], contents#Memory(m)[43+old_size := tmp]);
@@ -5537,7 +5284,7 @@ Label_48:
     call t45 := BorrowField(t44, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t45);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[46+old_size := true], contents#Memory(m)[46+old_size := tmp]);
 
@@ -5563,7 +5310,7 @@ Label_48:
     m := Memory(domain#Memory(m)[51+old_size := true], contents#Memory(m)[51+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 51];
-if (!b#Boolean(tmp)) { goto Label_61; }
+    if (!b#Boolean(tmp)) { goto Label_61; }
 
     call tmp := LdConst(3);
     m := Memory(domain#Memory(m)[52+old_size := true], contents#Memory(m)[52+old_size := tmp]);
@@ -5577,14 +5324,14 @@ Label_61:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+10]);
     m := Memory(domain#Memory(m)[54+old_size := true], contents#Memory(m)[54+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+53], contents#Memory(m)[old_size+54]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+53], contents#Memory(m)[old_size+54]));
     m := Memory(domain#Memory(m)[55+old_size := true], contents#Memory(m)[55+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+55]);
     m := Memory(domain#Memory(m)[56+old_size := true], contents#Memory(m)[56+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 56];
-if (!b#Boolean(tmp)) { goto Label_68; }
+    if (!b#Boolean(tmp)) { goto Label_68; }
 
     call tmp := LdConst(4);
     m := Memory(domain#Memory(m)[57+old_size := true], contents#Memory(m)[57+old_size := tmp]);
@@ -5604,51 +5351,51 @@ procedure LibraAccount_prologue_verify () returns ()
 procedure {:inline 1} LibraAccount_epilogue () returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraAccount_T_ref
-    var t2: Reference; // LibraAccount_T_ref
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Value; // int
-    var t5: Value; // int
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // LibraCoin_T
-    var t10: Value; // int
-    var t11: Value; // address
-    var t12: Value; // address
-    var t13: Reference; // LibraAccount_T_ref
-    var t14: Value; // int
-    var t15: Value; // int
-    var t16: Value; // int
-    var t17: Value; // int
-    var t18: Value; // int
-    var t19: Value; // int
-    var t20: Value; // int
-    var t21: Value; // int
-    var t22: Reference; // LibraAccount_T_ref
-    var t23: Reference; // LibraAccount_T_ref
-    var t24: Reference; // LibraAccount_T_ref
-    var t25: Value; // int
-    var t26: Value; // int
-    var t27: Value; // int
-    var t28: Value; // bool
-    var t29: Value; // bool
-    var t30: Value; // int
-    var t31: Reference; // LibraAccount_T_ref
-    var t32: Value; // int
-    var t33: Value; // LibraCoin_T
-    var t34: Value; // int
-    var t35: Value; // int
-    var t36: Value; // int
-    var t37: Value; // int
-    var t38: Reference; // LibraAccount_T_ref
-    var t39: Reference; // int_ref
-    var t40: Value; // address
-    var t41: Reference; // LibraAccount_T_ref
-    var t42: Reference; // LibraAccount_T_ref
-    var t43: Reference; // LibraCoin_T_ref
-    var t44: Value; // LibraCoin_T
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraCoin_T_type_value()
+    var t10: Value; // IntegerType()
+    var t11: Value; // AddressType()
+    var t12: Value; // AddressType()
+    var t13: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
+    var t20: Value; // IntegerType()
+    var t21: Value; // IntegerType()
+    var t22: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t23: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t25: Value; // IntegerType()
+    var t26: Value; // IntegerType()
+    var t27: Value; // IntegerType()
+    var t28: Value; // BooleanType()
+    var t29: Value; // BooleanType()
+    var t30: Value; // IntegerType()
+    var t31: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t32: Value; // IntegerType()
+    var t33: Value; // LibraCoin_T_type_value()
+    var t34: Value; // IntegerType()
+    var t35: Value; // IntegerType()
+    var t36: Value; // IntegerType()
+    var t37: Value; // IntegerType()
+    var t38: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t39: Reference; // ReferenceType(IntegerType())
+    var t40: Value; // AddressType()
+    var t41: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t42: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t43: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t44: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -5669,7 +5416,7 @@ procedure {:inline 1} LibraAccount_epilogue () returns ()
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
-    call t13 := BorrowGlobal(contents#Memory(m)[old_size+12], LibraAccount_T);
+    call t13 := BorrowGlobal(contents#Memory(m)[old_size+12], LibraAccount_T_type_value());
 
     call t1 := CopyOrMoveRef(t13);
 
@@ -5718,7 +5465,7 @@ procedure {:inline 1} LibraAccount_epilogue () returns ()
     call t24 := CopyOrMoveRef(t3);
 
     call t25 := LibraAccount_balance_for_account(t24);
-    assume is#Integer(t25);
+    assume has_type(IntegerType(), t25);
 
     m := Memory(domain#Memory(m)[old_size+25 := true], contents#Memory(m)[old_size+25 := t25]);
 
@@ -5738,7 +5485,7 @@ procedure {:inline 1} LibraAccount_epilogue () returns ()
     m := Memory(domain#Memory(m)[29+old_size := true], contents#Memory(m)[29+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 29];
-if (!b#Boolean(tmp)) { goto Label_30; }
+    if (!b#Boolean(tmp)) { goto Label_30; }
 
     call tmp := LdConst(6);
     m := Memory(domain#Memory(m)[30+old_size := true], contents#Memory(m)[30+old_size := tmp]);
@@ -5752,7 +5499,7 @@ Label_30:
     m := Memory(domain#Memory(m)[32+old_size := true], contents#Memory(m)[32+old_size := tmp]);
 
     call t33 := LibraAccount_withdraw_from_account(t31, contents#Memory(m)[old_size+32]);
-    assume is#Map(t33);
+    assume has_type(LibraCoin_T_type_value(), t33);
 
     m := Memory(domain#Memory(m)[old_size+33 := true], contents#Memory(m)[old_size+33 := t33]);
 
@@ -5783,7 +5530,7 @@ Label_30:
     call tmp := LdAddr(4078);
     m := Memory(domain#Memory(m)[40+old_size := true], contents#Memory(m)[40+old_size := tmp]);
 
-    call t41 := BorrowGlobal(contents#Memory(m)[old_size+40], LibraAccount_T);
+    call t41 := BorrowGlobal(contents#Memory(m)[old_size+40], LibraAccount_T_type_value());
 
     call t2 := CopyOrMoveRef(t41);
 
@@ -5808,35 +5555,35 @@ procedure LibraAccount_epilogue_verify () returns ()
 procedure {:inline 1} LibraAccount_fresh_guid (arg0: Reference, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t1: Value; // address
-    var t2: Reference; // int_ref
-    var t3: Value; // bytearray
-    var t4: Value; // bytearray
-    var t5: Value; // bytearray
-    var t6: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t7: Reference; // int_ref
-    var t8: Value; // address
-    var t9: Value; // bytearray
-    var t10: Reference; // int_ref
-    var t11: Value; // int
-    var t12: Value; // bytearray
-    var t13: Reference; // int_ref
-    var t14: Value; // int
-    var t15: Value; // int
-    var t16: Value; // int
-    var t17: Reference; // int_ref
-    var t18: Value; // bytearray
-    var t19: Value; // bytearray
-    var t20: Value; // bytearray
-    var t21: Value; // bytearray
+    var t0: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // ByteArrayType()
+    var t4: Value; // ByteArrayType()
+    var t5: Value; // ByteArrayType()
+    var t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t7: Reference; // ReferenceType(IntegerType())
+    var t8: Value; // AddressType()
+    var t9: Value; // ByteArrayType()
+    var t10: Reference; // ReferenceType(IntegerType())
+    var t11: Value; // IntegerType()
+    var t12: Value; // ByteArrayType()
+    var t13: Reference; // ReferenceType(IntegerType())
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(IntegerType())
+    var t18: Value; // ByteArrayType()
+    var t19: Value; // ByteArrayType()
+    var t20: Value; // ByteArrayType()
+    var t21: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#Address(arg1);
+        assume has_type(AddressType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 22;
@@ -5854,7 +5601,7 @@ procedure {:inline 1} LibraAccount_fresh_guid (arg0: Reference, arg1: Value) ret
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
     call t9 := AddressUtil_address_to_bytes(contents#Memory(m)[old_size+8]);
-    assume is#ByteArray(t9);
+    assume has_type(ByteArrayType(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -5864,12 +5611,12 @@ procedure {:inline 1} LibraAccount_fresh_guid (arg0: Reference, arg1: Value) ret
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
     call t12 := U64Util_u64_to_bytes(contents#Memory(m)[old_size+11]);
-    assume is#ByteArray(t12);
+    assume has_type(ByteArrayType(), t12);
 
     m := Memory(domain#Memory(m)[old_size+12 := true], contents#Memory(m)[old_size+12 := t12]);
 
@@ -5879,7 +5626,7 @@ procedure {:inline 1} LibraAccount_fresh_guid (arg0: Reference, arg1: Value) ret
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
@@ -5900,7 +5647,7 @@ procedure {:inline 1} LibraAccount_fresh_guid (arg0: Reference, arg1: Value) ret
     m := Memory(domain#Memory(m)[19+old_size := true], contents#Memory(m)[19+old_size := tmp]);
 
     call t20 := BytearrayUtil_bytearray_concat(contents#Memory(m)[old_size+18], contents#Memory(m)[old_size+19]);
-    assume is#ByteArray(t20);
+    assume has_type(ByteArrayType(), t20);
 
     m := Memory(domain#Memory(m)[old_size+20 := true], contents#Memory(m)[old_size+20 := t20]);
 
@@ -5920,23 +5667,23 @@ procedure LibraAccount_fresh_guid_verify (arg0: Reference, arg1: Value) returns 
     call ret0 := LibraAccount_fresh_guid(arg0, arg1);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle_impl (arg0: Reference, arg1: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, arg0: Reference, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t1: Value; // address
-    var t2: Value; // int
-    var t3: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t4: Value; // address
-    var t5: Value; // bytearray
-    var t6: Value; // LibraAccount_EventHandle
+    var t0: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t1: Value; // AddressType()
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t4: Value; // AddressType()
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-        assume is#Address(arg1);
+        assume has_type(AddressType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 7;
@@ -5953,15 +5700,15 @@ procedure {:inline 1} LibraAccount_new_event_handle_impl (arg0: Reference, arg1:
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     call t5 := LibraAccount_fresh_guid(t3, contents#Memory(m)[old_size+4]);
-    assume is#ByteArray(t5);
+    assume has_type(ByteArrayType(), t5);
 
     m := Memory(domain#Memory(m)[old_size+5 := true], contents#Memory(m)[old_size+5 := t5]);
 
-    assume is#Integer(contents#Memory(m)[old_size+2]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+2]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+5]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+5]);
 
-    call tmp := Pack_LibraAccount_EventHandle(contents#Memory(m)[old_size+2], contents#Memory(m)[old_size+5]);
+    call tmp := Pack_LibraAccount_EventHandle(tv0, contents#Memory(m)[old_size+2], contents#Memory(m)[old_size+5]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     ret0 := contents#Memory(m)[old_size+6];
@@ -5969,22 +5716,22 @@ procedure {:inline 1} LibraAccount_new_event_handle_impl (arg0: Reference, arg1:
 
 }
 
-procedure LibraAccount_new_event_handle_impl_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, arg0: Reference, arg1: Value) returns (ret0: Value)
 {
-    call ret0 := LibraAccount_new_event_handle_impl(arg0, arg1);
+    call ret0 := LibraAccount_new_event_handle_impl(tv0: TypeValue, arg0, arg1);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_T_ref
-    var t1: Value; // bytearray
-    var t2: Value; // address
-    var t3: Reference; // LibraAccount_T_ref
-    var t4: Reference; // LibraAccount_T_ref
-    var t5: Reference; // LibraAccount_EventHandleGenerator_ref
-    var t6: Value; // address
-    var t7: Value; // LibraAccount_EventHandle
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t6: Value; // AddressType()
+    var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
 
     var tmp: Value;
     var old_size: int;
@@ -5999,7 +5746,7 @@ procedure {:inline 1} LibraAccount_new_event_handle () returns (ret0: Value)
     call tmp := GetTxnSenderAddress();
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraAccount_T);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraAccount_T_type_value());
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -6010,8 +5757,8 @@ procedure {:inline 1} LibraAccount_new_event_handle () returns (ret0: Value)
     call tmp := GetTxnSenderAddress();
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
-    call t7 := LibraAccount_new_event_handle_impl(t5, contents#Memory(m)[old_size+6]);
-    assume is#Map(t7);
+    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, contents#Memory(m)[old_size+6]);
+    assume has_type(LibraAccount_EventHandle_type_value(tv0), t7);
 
     m := Memory(domain#Memory(m)[old_size+7 := true], contents#Memory(m)[old_size+7 := t7]);
 
@@ -6020,38 +5767,39 @@ procedure {:inline 1} LibraAccount_new_event_handle () returns (ret0: Value)
 
 }
 
-procedure LibraAccount_new_event_handle_verify () returns (ret0: Value)
+procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
 {
-    call ret0 := LibraAccount_new_event_handle();
+    call ret0 := LibraAccount_new_event_handle(tv0: TypeValue);
 }
 
-procedure {:inline 1} LibraAccount_emit_event (arg0: Reference, arg1: Value) returns ()
+procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, arg0: Reference, arg1: Value) returns ()
 {
     // declare local variables
-    var t0: Reference; // LibraAccount_EventHandle_ref
-    var t1: Value; // typeparam
-    var t2: Reference; // int_ref
-    var t3: Value; // bytearray
-    var t4: Reference; // LibraAccount_EventHandle_ref
-    var t5: Reference; // bytearray_ref
-    var t6: Value; // bytearray
-    var t7: Reference; // LibraAccount_EventHandle_ref
-    var t8: Reference; // int_ref
-    var t9: Value; // bytearray
-    var t10: Reference; // int_ref
-    var t11: Value; // int
-    var t12: Value; // typeparam
-    var t13: Reference; // int_ref
-    var t14: Value; // int
-    var t15: Value; // int
-    var t16: Value; // int
-    var t17: Reference; // int_ref
+    var t0: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var t1: Value; // tv0
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // ByteArrayType()
+    var t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var t5: Reference; // ReferenceType(ByteArrayType())
+    var t6: Value; // ByteArrayType()
+    var t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var t8: Reference; // ReferenceType(IntegerType())
+    var t9: Value; // ByteArrayType()
+    var t10: Reference; // ReferenceType(IntegerType())
+    var t11: Value; // IntegerType()
+    var t12: Value; // tv0
+    var t13: Reference; // ReferenceType(IntegerType())
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(IntegerType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
+        assume has_type(tv0, arg1);
 
     old_size := m_size;
     m_size := m_size + 18;
@@ -6064,7 +5812,7 @@ procedure {:inline 1} LibraAccount_emit_event (arg0: Reference, arg1: Value) ret
     call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
 
     call tmp := ReadRef(t5);
-    assume is#ByteArray(tmp);
+    assume has_type(ByteArrayType(), tmp);
 
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
@@ -6083,19 +5831,19 @@ procedure {:inline 1} LibraAccount_emit_event (arg0: Reference, arg1: Value) ret
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
-    call LibraAccount_write_to_event_store(contents#Memory(m)[old_size+9], contents#Memory(m)[old_size+11], contents#Memory(m)[old_size+12]);
+    call LibraAccount_write_to_event_store(tv0, contents#Memory(m)[old_size+9], contents#Memory(m)[old_size+11], contents#Memory(m)[old_size+12]);
 
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
@@ -6113,28 +5861,28 @@ procedure {:inline 1} LibraAccount_emit_event (arg0: Reference, arg1: Value) ret
 
 }
 
-procedure LibraAccount_emit_event_verify (arg0: Reference, arg1: Value) returns ()
+procedure LibraAccount_emit_event_verify (tv0: TypeValue, arg0: Reference, arg1: Value) returns ()
 {
-    call LibraAccount_emit_event(arg0, arg1);
+    call LibraAccount_emit_event(tv0: TypeValue, arg0, arg1);
 }
 
-procedure {:inline 1} LibraAccount_write_to_event_store (arg0: Value, arg1: Value, arg2: Value) returns ();
-procedure {:inline 1} LibraAccount_destroy_handle (arg0: Value) returns ()
+procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
+procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // LibraAccount_EventHandle
-    var t1: Value; // bytearray
-    var t2: Value; // int
-    var t3: Value; // LibraAccount_EventHandle
-    var t4: Value; // int
-    var t5: Value; // bytearray
+    var t0: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var t4: Value; // IntegerType()
+    var t5: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
+    assume has_type(LibraAccount_EventHandle_type_value(tv0), arg0);
 
     old_size := m_size;
     m_size := m_size + 6;
@@ -6145,9 +5893,9 @@ procedure {:inline 1} LibraAccount_destroy_handle (arg0: Value) returns ()
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     call t4, t5 := Unpack_LibraAccount_EventHandle(contents#Memory(m)[old_size+3]);
-    assume is#Integer(t4);
+    assume has_type(IntegerType(), t4);
 
-    assume is#ByteArray(t5);
+    assume has_type(ByteArrayType(), t5);
 
     m := Memory(domain#Memory(m)[old_size+4 := true], contents#Memory(m)[old_size+4 := t4]);
     m := Memory(domain#Memory(m)[old_size+5 := true], contents#Memory(m)[old_size+5 := t5]);
@@ -6162,22 +5910,22 @@ procedure {:inline 1} LibraAccount_destroy_handle (arg0: Value) returns ()
 
 }
 
-procedure LibraAccount_destroy_handle_verify (arg0: Value) returns ()
+procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, arg0: Value) returns ()
 {
-    call LibraAccount_destroy_handle(arg0);
+    call LibraAccount_destroy_handle(tv0: TypeValue, arg0);
 }
 
 procedure {:inline 1} LibraSystem_initialize_validator_set () returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Value; // bool
-    var t3: Value; // bool
-    var t4: Value; // int
-    var t5: Value; // Vector_T
-    var t6: Value; // LibraAccount_EventHandle
-    var t7: Value; // LibraSystem_ValidatorSet
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // Vector_T_type_value(LibraSystem_ValidatorInfo_type_value())
+    var t6: Value; // LibraAccount_EventHandle_type_value(LibraSystem_ValidatorSetChangeEvent_type_value())
+    var t7: Value; // LibraSystem_ValidatorSet_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -6195,14 +5943,14 @@ procedure {:inline 1} LibraSystem_initialize_validator_set () returns ()
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]));
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 3];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
@@ -6210,24 +5958,24 @@ if (!b#Boolean(tmp)) { goto Label_7; }
     assert false;
 
 Label_7:
-    call t5 := Vector_empty();
-    assume is#Vector(t5);
+    call t5 := Vector_empty(LibraSystem_ValidatorInfo_type_value());
+    assume has_type(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()), t5);
 
     m := Memory(domain#Memory(m)[old_size+5 := true], contents#Memory(m)[old_size+5 := t5]);
 
-    call t6 := LibraAccount_new_event_handle();
-    assume is#Map(t6);
+    call t6 := LibraAccount_new_event_handle(LibraSystem_ValidatorSetChangeEvent_type_value());
+    assume has_type(LibraAccount_EventHandle_type_value(LibraSystem_ValidatorSetChangeEvent_type_value()), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
-    assume is#Vector(contents#Memory(m)[old_size+5]);
+    assume has_type(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()), contents#Memory(m)[old_size+5]);
 
-    assume is#Map(contents#Memory(m)[old_size+6]);
+    assume has_type(LibraAccount_EventHandle_type_value(LibraSystem_ValidatorSetChangeEvent_type_value()), contents#Memory(m)[old_size+6]);
 
     call tmp := Pack_LibraSystem_ValidatorSet(contents#Memory(m)[old_size+5], contents#Memory(m)[old_size+6]);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
-    call MoveToSender(LibraSystem_ValidatorSet, contents#Memory(m)[old_size+7]);
+    call MoveToSender(LibraSystem_ValidatorSet_type_value(), contents#Memory(m)[old_size+7]);
 
     return;
 
@@ -6241,16 +5989,16 @@ procedure LibraSystem_initialize_validator_set_verify () returns ()
 procedure {:inline 1} LibraSystem_initialize_block_metadata () returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Value; // bool
-    var t3: Value; // bool
-    var t4: Value; // int
-    var t5: Value; // int
-    var t6: Value; // int
-    var t7: Value; // bytearray
-    var t8: Value; // address
-    var t9: Value; // LibraSystem_BlockMetadata
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // ByteArrayType()
+    var t8: Value; // AddressType()
+    var t9: Value; // LibraSystem_BlockMetadata_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -6268,14 +6016,14 @@ procedure {:inline 1} LibraSystem_initialize_block_metadata () returns ()
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]));
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 3];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
@@ -6294,18 +6042,18 @@ Label_7:
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+5]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+5]);
 
-    assume is#Integer(contents#Memory(m)[old_size+6]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+6]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+7]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+7]);
 
-    assume is#Address(contents#Memory(m)[old_size+8]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+8]);
 
     call tmp := Pack_LibraSystem_BlockMetadata(contents#Memory(m)[old_size+5], contents#Memory(m)[old_size+6], contents#Memory(m)[old_size+7], contents#Memory(m)[old_size+8]);
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
-    call MoveToSender(LibraSystem_BlockMetadata, contents#Memory(m)[old_size+9]);
+    call MoveToSender(LibraSystem_BlockMetadata_type_value(), contents#Memory(m)[old_size+9]);
 
     return;
 
@@ -6319,9 +6067,9 @@ procedure LibraSystem_initialize_block_metadata_verify () returns ()
 procedure {:inline 1} LibraSystem_get_consensus_pubkey (arg0: Reference) returns (ret0: Reference)
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorInfo_ref
-    var t1: Reference; // LibraSystem_ValidatorInfo_ref
-    var t2: Reference; // bytearray_ref
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t1: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
 
     var tmp: Value;
     var old_size: int;
@@ -6351,9 +6099,9 @@ procedure LibraSystem_get_consensus_pubkey_verify (arg0: Reference) returns (ret
 procedure {:inline 1} LibraSystem_get_consensus_voting_power (arg0: Reference) returns (ret0: Reference)
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorInfo_ref
-    var t1: Reference; // LibraSystem_ValidatorInfo_ref
-    var t2: Reference; // int_ref
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t1: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
 
     var tmp: Value;
     var old_size: int;
@@ -6383,9 +6131,9 @@ procedure LibraSystem_get_consensus_voting_power_verify (arg0: Reference) return
 procedure {:inline 1} LibraSystem_get_network_signing_pubkey (arg0: Reference) returns (ret0: Reference)
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorInfo_ref
-    var t1: Reference; // LibraSystem_ValidatorInfo_ref
-    var t2: Reference; // bytearray_ref
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t1: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
 
     var tmp: Value;
     var old_size: int;
@@ -6415,9 +6163,9 @@ procedure LibraSystem_get_network_signing_pubkey_verify (arg0: Reference) return
 procedure {:inline 1} LibraSystem_get_network_identity_pubkey (arg0: Reference) returns (ret0: Reference)
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorInfo_ref
-    var t1: Reference; // LibraSystem_ValidatorInfo_ref
-    var t2: Reference; // bytearray_ref
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t1: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
 
     var tmp: Value;
     var old_size: int;
@@ -6447,24 +6195,24 @@ procedure LibraSystem_get_network_identity_pubkey_verify (arg0: Reference) retur
 procedure {:inline 1} LibraSystem_block_prologue (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // bytearray
-    var t2: Value; // bytearray
-    var t3: Value; // address
-    var t4: Value; // int
-    var t5: Value; // bytearray
-    var t6: Value; // bytearray
-    var t7: Value; // address
+    var t0: Value; // IntegerType()
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // AddressType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // ByteArrayType()
+    var t7: Value; // AddressType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
-    assume is#ByteArray(arg1);
-    assume is#ByteArray(arg2);
-    assume is#Address(arg3);
+    assume has_type(IntegerType(), arg0);
+    assume has_type(ByteArrayType(), arg1);
+    assume has_type(ByteArrayType(), arg2);
+    assume has_type(AddressType(), arg3);
 
     old_size := m_size;
     m_size := m_size + 8;
@@ -6502,50 +6250,50 @@ procedure LibraSystem_block_prologue_verify (arg0: Value, arg1: Value, arg2: Val
 procedure {:inline 1} LibraSystem_process_block_prologue (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // bytearray
-    var t2: Value; // bytearray
-    var t3: Value; // address
-    var t4: Reference; // LibraSystem_BlockMetadata_ref
-    var t5: Value; // address
-    var t6: Reference; // LibraSystem_BlockMetadata_ref
-    var t7: Value; // int
-    var t8: Reference; // LibraSystem_BlockMetadata_ref
-    var t9: Reference; // int_ref
-    var t10: Value; // int
-    var t11: Value; // bool
-    var t12: Value; // bool
-    var t13: Value; // int
-    var t14: Value; // address
-    var t15: Value; // bool
-    var t16: Value; // bool
-    var t17: Value; // int
-    var t18: Value; // bytearray
-    var t19: Reference; // LibraSystem_BlockMetadata_ref
-    var t20: Reference; // bytearray_ref
-    var t21: Value; // int
-    var t22: Reference; // LibraSystem_BlockMetadata_ref
-    var t23: Reference; // int_ref
-    var t24: Value; // address
-    var t25: Reference; // LibraSystem_BlockMetadata_ref
-    var t26: Reference; // address_ref
-    var t27: Reference; // LibraSystem_BlockMetadata_ref
-    var t28: Reference; // int_ref
-    var t29: Value; // int
-    var t30: Value; // int
-    var t31: Value; // int
-    var t32: Reference; // LibraSystem_BlockMetadata_ref
-    var t33: Reference; // int_ref
+    var t0: Value; // IntegerType()
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // AddressType()
+    var t4: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t7: Value; // IntegerType()
+    var t8: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t9: Reference; // ReferenceType(IntegerType())
+    var t10: Value; // IntegerType()
+    var t11: Value; // BooleanType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // IntegerType()
+    var t14: Value; // AddressType()
+    var t15: Value; // BooleanType()
+    var t16: Value; // BooleanType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // ByteArrayType()
+    var t19: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t20: Reference; // ReferenceType(ByteArrayType())
+    var t21: Value; // IntegerType()
+    var t22: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t23: Reference; // ReferenceType(IntegerType())
+    var t24: Value; // AddressType()
+    var t25: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t26: Reference; // ReferenceType(AddressType())
+    var t27: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t28: Reference; // ReferenceType(IntegerType())
+    var t29: Value; // IntegerType()
+    var t30: Value; // IntegerType()
+    var t31: Value; // IntegerType()
+    var t32: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t33: Reference; // ReferenceType(IntegerType())
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
-    assume is#ByteArray(arg1);
-    assume is#ByteArray(arg2);
-    assume is#Address(arg3);
+    assume has_type(IntegerType(), arg0);
+    assume has_type(ByteArrayType(), arg1);
+    assume has_type(ByteArrayType(), arg2);
+    assume has_type(AddressType(), arg3);
 
     old_size := m_size;
     m_size := m_size + 34;
@@ -6558,7 +6306,7 @@ procedure {:inline 1} LibraSystem_process_block_prologue (arg0: Value, arg1: Val
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraSystem_BlockMetadata);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraSystem_BlockMetadata_type_value());
 
     call t4 := CopyOrMoveRef(t6);
 
@@ -6570,7 +6318,7 @@ procedure {:inline 1} LibraSystem_process_block_prologue (arg0: Value, arg1: Val
     call t9 := BorrowField(t8, LibraSystem_BlockMetadata_timestamp);
 
     call tmp := ReadRef(t9);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
 
@@ -6581,7 +6329,7 @@ procedure {:inline 1} LibraSystem_process_block_prologue (arg0: Value, arg1: Val
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 12];
-if (!b#Boolean(tmp)) { goto Label_12; }
+    if (!b#Boolean(tmp)) { goto Label_12; }
 
     call tmp := LdConst(5001);
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
@@ -6593,7 +6341,7 @@ Label_12:
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
     call t15 := LibraSystem_is_validator(contents#Memory(m)[old_size+14]);
-    assume is#Boolean(t15);
+    assume has_type(BooleanType(), t15);
 
     m := Memory(domain#Memory(m)[old_size+15 := true], contents#Memory(m)[old_size+15 := t15]);
 
@@ -6601,7 +6349,7 @@ Label_12:
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 16];
-if (!b#Boolean(tmp)) { goto Label_18; }
+    if (!b#Boolean(tmp)) { goto Label_18; }
 
     call tmp := LdConst(5002);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
@@ -6641,7 +6389,7 @@ Label_18:
     call t28 := BorrowField(t27, LibraSystem_BlockMetadata_height);
 
     call tmp := ReadRef(t28);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[29+old_size := true], contents#Memory(m)[29+old_size := tmp]);
 
@@ -6669,10 +6417,10 @@ procedure LibraSystem_process_block_prologue_verify (arg0: Value, arg1: Value, a
 procedure {:inline 1} LibraSystem_get_current_block_height () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraSystem_BlockMetadata_ref
-    var t2: Reference; // int_ref
-    var t3: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -6687,12 +6435,12 @@ procedure {:inline 1} LibraSystem_get_current_block_height () returns (ret0: Val
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata);
+    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata_type_value());
 
     call t2 := BorrowField(t1, LibraSystem_BlockMetadata_height);
 
     call tmp := ReadRef(t2);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -6709,10 +6457,10 @@ procedure LibraSystem_get_current_block_height_verify () returns (ret0: Value)
 procedure {:inline 1} LibraSystem_get_current_block_id () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraSystem_BlockMetadata_ref
-    var t2: Reference; // bytearray_ref
-    var t3: Value; // bytearray
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t2: Reference; // ReferenceType(ByteArrayType())
+    var t3: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
@@ -6727,12 +6475,12 @@ procedure {:inline 1} LibraSystem_get_current_block_id () returns (ret0: Value)
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata);
+    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata_type_value());
 
     call t2 := BorrowField(t1, LibraSystem_BlockMetadata_id);
 
     call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    assume has_type(ByteArrayType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -6749,10 +6497,10 @@ procedure LibraSystem_get_current_block_id_verify () returns (ret0: Value)
 procedure {:inline 1} LibraSystem_get_current_timestamp () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraSystem_BlockMetadata_ref
-    var t2: Reference; // int_ref
-    var t3: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -6767,12 +6515,12 @@ procedure {:inline 1} LibraSystem_get_current_timestamp () returns (ret0: Value)
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata);
+    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata_type_value());
 
     call t2 := BorrowField(t1, LibraSystem_BlockMetadata_timestamp);
 
     call tmp := ReadRef(t2);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -6789,10 +6537,10 @@ procedure LibraSystem_get_current_timestamp_verify () returns (ret0: Value)
 procedure {:inline 1} LibraSystem_get_current_proposer () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraSystem_BlockMetadata_ref
-    var t2: Reference; // address_ref
-    var t3: Value; // address
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraSystem_BlockMetadata_type_value())
+    var t2: Reference; // ReferenceType(AddressType())
+    var t3: Value; // AddressType()
 
     var tmp: Value;
     var old_size: int;
@@ -6807,12 +6555,12 @@ procedure {:inline 1} LibraSystem_get_current_proposer () returns (ret0: Value)
     call tmp := LdAddr(173345816);
     m := Memory(domain#Memory(m)[0+old_size := true], contents#Memory(m)[0+old_size := tmp]);
 
-    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata);
+    call t1 := BorrowGlobal(contents#Memory(m)[old_size+0], LibraSystem_BlockMetadata_type_value());
 
     call t2 := BorrowField(t1, LibraSystem_BlockMetadata_proposer);
 
     call tmp := ReadRef(t2);
-    assume is#Address(tmp);
+    assume has_type(AddressType(), tmp);
 
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
@@ -6829,12 +6577,12 @@ procedure LibraSystem_get_current_proposer_verify () returns (ret0: Value)
 procedure {:inline 1} LibraSystem_validator_set_size () returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorSet_ref
-    var t1: Value; // address
-    var t2: Reference; // LibraSystem_ValidatorSet_ref
-    var t3: Reference; // LibraSystem_ValidatorSet_ref
-    var t4: Reference; // Vector_T_ref
-    var t5: Value; // int
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t3: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t4: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t5: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -6849,7 +6597,7 @@ procedure {:inline 1} LibraSystem_validator_set_size () returns (ret0: Value)
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraSystem_ValidatorSet);
+    call t2 := BorrowGlobal(contents#Memory(m)[old_size+1], LibraSystem_ValidatorSet_type_value());
 
     call t0 := CopyOrMoveRef(t2);
 
@@ -6857,8 +6605,8 @@ procedure {:inline 1} LibraSystem_validator_set_size () returns (ret0: Value)
 
     call t4 := BorrowField(t3, LibraSystem_ValidatorSet_validators);
 
-    call t5 := Vector_length(t4);
-    assume is#Integer(t5);
+    call t5 := Vector_length(LibraSystem_ValidatorInfo_type_value(), t4);
+    assume has_type(IntegerType(), t5);
 
     m := Memory(domain#Memory(m)[old_size+5 := true], contents#Memory(m)[old_size+5 := t5]);
 
@@ -6875,47 +6623,47 @@ procedure LibraSystem_validator_set_size_verify () returns (ret0: Value)
 procedure {:inline 1} LibraSystem_is_validator (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Reference; // Vector_T_ref
-    var t4: Reference; // LibraSystem_ValidatorInfo_ref
-    var t5: Value; // address
-    var t6: Reference; // LibraSystem_ValidatorSet_ref
-    var t7: Reference; // Vector_T_ref
-    var t8: Reference; // Vector_T_ref
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // bool
-    var t13: Value; // bool
-    var t14: Value; // int
-    var t15: Reference; // Vector_T_ref
-    var t16: Value; // int
-    var t17: Reference; // LibraSystem_ValidatorInfo_ref
-    var t18: Reference; // LibraSystem_ValidatorInfo_ref
-    var t19: Reference; // address_ref
-    var t20: Value; // address
-    var t21: Value; // address
-    var t22: Value; // bool
-    var t23: Value; // bool
-    var t24: Value; // int
-    var t25: Value; // int
-    var t26: Value; // int
-    var t27: Value; // int
-    var t28: Value; // int
-    var t29: Value; // bool
-    var t30: Reference; // Vector_T_ref
-    var t31: Value; // int
-    var t32: Reference; // LibraSystem_ValidatorInfo_ref
-    var t33: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t4: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t7: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t8: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // BooleanType()
+    var t14: Value; // IntegerType()
+    var t15: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t18: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t19: Reference; // ReferenceType(AddressType())
+    var t20: Value; // AddressType()
+    var t21: Value; // AddressType()
+    var t22: Value; // BooleanType()
+    var t23: Value; // BooleanType()
+    var t24: Value; // IntegerType()
+    var t25: Value; // IntegerType()
+    var t26: Value; // IntegerType()
+    var t27: Value; // IntegerType()
+    var t28: Value; // IntegerType()
+    var t29: Value; // BooleanType()
+    var t30: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t31: Value; // IntegerType()
+    var t32: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t33: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 34;
@@ -6925,7 +6673,7 @@ procedure {:inline 1} LibraSystem_is_validator (arg0: Value) returns (ret0: Valu
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraSystem_ValidatorSet);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraSystem_ValidatorSet_type_value());
 
     call t7 := BorrowField(t6, LibraSystem_ValidatorSet_validators);
 
@@ -6933,8 +6681,8 @@ procedure {:inline 1} LibraSystem_is_validator (arg0: Value) returns (ret0: Valu
 
     call t8 := CopyOrMoveRef(t3);
 
-    call t9 := Vector_length(t8);
-    assume is#Integer(t9);
+    call t9 := Vector_length(LibraSystem_ValidatorInfo_type_value(), t8);
+    assume has_type(IntegerType(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -6947,11 +6695,11 @@ procedure {:inline 1} LibraSystem_is_validator (arg0: Value) returns (ret0: Valu
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]));
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 12];
-if (!b#Boolean(tmp)) { goto Label_13; }
+    if (!b#Boolean(tmp)) { goto Label_13; }
 
     call tmp := LdFalse();
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
@@ -6971,7 +6719,7 @@ Label_13:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
-    call t17 := Vector_borrow(t15, contents#Memory(m)[old_size+16]);
+    call t17 := Vector_borrow(LibraSystem_ValidatorInfo_type_value(), t15, contents#Memory(m)[old_size+16]);
 
 
     call t4 := CopyOrMoveRef(t17);
@@ -6982,18 +6730,18 @@ Label_19:
     call t19 := BorrowField(t18, LibraSystem_ValidatorInfo_addr);
 
     call tmp := ReadRef(t19);
-    assume is#Address(tmp);
+    assume has_type(AddressType(), tmp);
 
     m := Memory(domain#Memory(m)[20+old_size := true], contents#Memory(m)[20+old_size := tmp]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+20], contents#Memory(m)[old_size+21]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+20], contents#Memory(m)[old_size+21]));
     m := Memory(domain#Memory(m)[22+old_size := true], contents#Memory(m)[22+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 22];
-if (!b#Boolean(tmp)) { goto Label_27; }
+    if (!b#Boolean(tmp)) { goto Label_27; }
 
     call tmp := LdTrue();
     m := Memory(domain#Memory(m)[23+old_size := true], contents#Memory(m)[23+old_size := tmp]);
@@ -7024,7 +6772,7 @@ Label_27:
     m := Memory(domain#Memory(m)[29+old_size := true], contents#Memory(m)[29+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 29];
-if (!b#Boolean(tmp)) { goto Label_36; }
+    if (!b#Boolean(tmp)) { goto Label_36; }
 
     goto Label_41;
 
@@ -7034,7 +6782,7 @@ Label_36:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[31+old_size := true], contents#Memory(m)[31+old_size := tmp]);
 
-    call t32 := Vector_borrow(t30, contents#Memory(m)[old_size+31]);
+    call t32 := Vector_borrow(LibraSystem_ValidatorInfo_type_value(), t30, contents#Memory(m)[old_size+31]);
 
 
     call t4 := CopyOrMoveRef(t32);
@@ -7058,29 +6806,29 @@ procedure LibraSystem_is_validator_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} LibraSystem_add_validator (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Reference; // LibraSystem_ValidatorSet_ref
-    var t2: Value; // address
-    var t3: Value; // bool
-    var t4: Value; // bool
-    var t5: Value; // int
-    var t6: Value; // address
-    var t7: Reference; // LibraSystem_ValidatorSet_ref
-    var t8: Reference; // LibraSystem_ValidatorSet_ref
-    var t9: Reference; // Vector_T_ref
-    var t10: Value; // address
-    var t11: Value; // bytearray
-    var t12: Value; // int
-    var t13: Value; // bytearray
-    var t14: Value; // bytearray
-    var t15: Value; // LibraSystem_ValidatorInfo
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t2: Value; // AddressType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // AddressType()
+    var t7: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t8: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t9: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t10: Value; // AddressType()
+    var t11: Value; // ByteArrayType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // ByteArrayType()
+    var t14: Value; // ByteArrayType()
+    var t15: Value; // LibraSystem_ValidatorInfo_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 16;
@@ -7091,7 +6839,7 @@ procedure {:inline 1} LibraSystem_add_validator (arg0: Value) returns ()
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     call t3 := ValidatorConfig_has(contents#Memory(m)[old_size+2]);
-    assume is#Boolean(t3);
+    assume has_type(BooleanType(), t3);
 
     m := Memory(domain#Memory(m)[old_size+3 := true], contents#Memory(m)[old_size+3 := t3]);
 
@@ -7099,7 +6847,7 @@ procedure {:inline 1} LibraSystem_add_validator (arg0: Value) returns ()
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 4];
-if (!b#Boolean(tmp)) { goto Label_6; }
+    if (!b#Boolean(tmp)) { goto Label_6; }
 
     call tmp := LdConst(17);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
@@ -7110,7 +6858,7 @@ Label_6:
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
-    call t7 := BorrowGlobal(contents#Memory(m)[old_size+6], LibraSystem_ValidatorSet);
+    call t7 := BorrowGlobal(contents#Memory(m)[old_size+6], LibraSystem_ValidatorSet_type_value());
 
     call t1 := CopyOrMoveRef(t7);
 
@@ -7130,20 +6878,20 @@ Label_6:
 
     // unimplemented instruction
 
-    assume is#Address(contents#Memory(m)[old_size+10]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+10]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+11]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+11]);
 
-    assume is#Integer(contents#Memory(m)[old_size+12]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+12]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+13]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+13]);
 
-    assume is#ByteArray(contents#Memory(m)[old_size+14]);
+    assume has_type(ByteArrayType(), contents#Memory(m)[old_size+14]);
 
     call tmp := Pack_LibraSystem_ValidatorInfo(contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11], contents#Memory(m)[old_size+12], contents#Memory(m)[old_size+13], contents#Memory(m)[old_size+14]);
     m := Memory(domain#Memory(m)[15+old_size := true], contents#Memory(m)[15+old_size := tmp]);
 
-    call Vector_push_back(t9, contents#Memory(m)[old_size+15]);
+    call Vector_push_back(LibraSystem_ValidatorInfo_type_value(), t9, contents#Memory(m)[old_size+15]);
 
     return;
 
@@ -7157,48 +6905,48 @@ procedure LibraSystem_add_validator_verify (arg0: Value) returns ()
 procedure {:inline 1} LibraSystem_copy_validator_info (arg0: Reference) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorInfo_ref
-    var t1: Value; // bytearray
-    var t2: Value; // bytearray
-    var t3: Value; // bytearray
-    var t4: Value; // ValidatorConfig_Config
-    var t5: Value; // bool
-    var t6: Reference; // LibraSystem_ValidatorInfo_ref
-    var t7: Reference; // address_ref
-    var t8: Value; // address
-    var t9: Value; // ValidatorConfig_Config
-    var t10: Reference; // ValidatorConfig_Config_ref
-    var t11: Value; // bytearray
-    var t12: Reference; // ValidatorConfig_Config_ref
-    var t13: Value; // bytearray
-    var t14: Reference; // ValidatorConfig_Config_ref
-    var t15: Value; // bytearray
-    var t16: Value; // bool
-    var t17: Reference; // bytearray_ref
-    var t18: Reference; // LibraSystem_ValidatorInfo_ref
-    var t19: Reference; // bytearray_ref
-    var t20: Value; // bool
-    var t21: Value; // bytearray
-    var t22: Reference; // LibraSystem_ValidatorInfo_ref
-    var t23: Reference; // bytearray_ref
-    var t24: Value; // bool
-    var t25: Reference; // bytearray_ref
-    var t26: Reference; // LibraSystem_ValidatorInfo_ref
-    var t27: Reference; // bytearray_ref
-    var t28: Value; // bool
-    var t29: Value; // bytearray
-    var t30: Reference; // LibraSystem_ValidatorInfo_ref
-    var t31: Reference; // bytearray_ref
-    var t32: Value; // bool
-    var t33: Reference; // bytearray_ref
-    var t34: Reference; // LibraSystem_ValidatorInfo_ref
-    var t35: Reference; // bytearray_ref
-    var t36: Value; // bool
-    var t37: Value; // bytearray
-    var t38: Reference; // LibraSystem_ValidatorInfo_ref
-    var t39: Reference; // bytearray_ref
-    var t40: Value; // bool
-    var t41: Value; // bool
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // ByteArrayType()
+    var t4: Value; // ValidatorConfig_Config_type_value()
+    var t5: Value; // BooleanType()
+    var t6: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t7: Reference; // ReferenceType(AddressType())
+    var t8: Value; // AddressType()
+    var t9: Value; // ValidatorConfig_Config_type_value()
+    var t10: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t11: Value; // ByteArrayType()
+    var t12: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t13: Value; // ByteArrayType()
+    var t14: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var t15: Value; // ByteArrayType()
+    var t16: Value; // BooleanType()
+    var t17: Reference; // ReferenceType(ByteArrayType())
+    var t18: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t19: Reference; // ReferenceType(ByteArrayType())
+    var t20: Value; // BooleanType()
+    var t21: Value; // ByteArrayType()
+    var t22: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t23: Reference; // ReferenceType(ByteArrayType())
+    var t24: Value; // BooleanType()
+    var t25: Reference; // ReferenceType(ByteArrayType())
+    var t26: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t27: Reference; // ReferenceType(ByteArrayType())
+    var t28: Value; // BooleanType()
+    var t29: Value; // ByteArrayType()
+    var t30: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t31: Reference; // ReferenceType(ByteArrayType())
+    var t32: Value; // BooleanType()
+    var t33: Reference; // ReferenceType(ByteArrayType())
+    var t34: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t35: Reference; // ReferenceType(ByteArrayType())
+    var t36: Value; // BooleanType()
+    var t37: Value; // ByteArrayType()
+    var t38: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t39: Reference; // ReferenceType(ByteArrayType())
+    var t40: Value; // BooleanType()
+    var t41: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
@@ -7216,12 +6964,12 @@ procedure {:inline 1} LibraSystem_copy_validator_info (arg0: Reference) returns 
     call t7 := BorrowField(t6, LibraSystem_ValidatorInfo_addr);
 
     call tmp := ReadRef(t7);
-    assume is#Address(tmp);
+    assume has_type(AddressType(), tmp);
 
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
     call t9 := ValidatorConfig_config(contents#Memory(m)[old_size+8]);
-    assume is#Map(t9);
+    assume has_type(ValidatorConfig_Config_type_value(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -7231,7 +6979,7 @@ procedure {:inline 1} LibraSystem_copy_validator_info (arg0: Reference) returns 
     call t10 := BorrowLoc(old_size+4);
 
     call t11 := ValidatorConfig_consensus_pubkey(t10);
-    assume is#ByteArray(t11);
+    assume has_type(ByteArrayType(), t11);
 
     m := Memory(domain#Memory(m)[old_size+11 := true], contents#Memory(m)[old_size+11 := t11]);
 
@@ -7241,7 +6989,7 @@ procedure {:inline 1} LibraSystem_copy_validator_info (arg0: Reference) returns 
     call t12 := BorrowLoc(old_size+4);
 
     call t13 := ValidatorConfig_network_signing_pubkey(t12);
-    assume is#ByteArray(t13);
+    assume has_type(ByteArrayType(), t13);
 
     m := Memory(domain#Memory(m)[old_size+13 := true], contents#Memory(m)[old_size+13 := t13]);
 
@@ -7251,7 +6999,7 @@ procedure {:inline 1} LibraSystem_copy_validator_info (arg0: Reference) returns 
     call t14 := BorrowLoc(old_size+4);
 
     call t15 := ValidatorConfig_network_identity_pubkey(t14);
-    assume is#ByteArray(t15);
+    assume has_type(ByteArrayType(), t15);
 
     m := Memory(domain#Memory(m)[old_size+15 := true], contents#Memory(m)[old_size+15 := t15]);
 
@@ -7270,11 +7018,11 @@ procedure {:inline 1} LibraSystem_copy_validator_info (arg0: Reference) returns 
 
     call t19 := BorrowField(t18, LibraSystem_ValidatorInfo_consensus_pubkey);
 
-    call tmp := Neq(contents#Memory(m)[old_size+17], contents#Memory(m)[old_size+19]);
+    tmp := Boolean(!is_equal(ReferenceType(ByteArrayType()), contents#Memory(m)[old_size+17], contents#Memory(m)[old_size+19]));
     m := Memory(domain#Memory(m)[20+old_size := true], contents#Memory(m)[20+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 20];
-if (!b#Boolean(tmp)) { goto Label_27; }
+    if (!b#Boolean(tmp)) { goto Label_27; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
@@ -7298,11 +7046,11 @@ Label_27:
 
     call t27 := BorrowField(t26, LibraSystem_ValidatorInfo_network_signing_pubkey);
 
-    call tmp := Neq(contents#Memory(m)[old_size+25], contents#Memory(m)[old_size+27]);
+    tmp := Boolean(!is_equal(ReferenceType(ByteArrayType()), contents#Memory(m)[old_size+25], contents#Memory(m)[old_size+27]));
     m := Memory(domain#Memory(m)[28+old_size := true], contents#Memory(m)[28+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 28];
-if (!b#Boolean(tmp)) { goto Label_38; }
+    if (!b#Boolean(tmp)) { goto Label_38; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[29+old_size := true], contents#Memory(m)[29+old_size := tmp]);
@@ -7326,11 +7074,11 @@ Label_38:
 
     call t35 := BorrowField(t34, LibraSystem_ValidatorInfo_network_identity_pubkey);
 
-    call tmp := Neq(contents#Memory(m)[old_size+33], contents#Memory(m)[old_size+35]);
+    tmp := Boolean(!is_equal(ReferenceType(ByteArrayType()), contents#Memory(m)[old_size+33], contents#Memory(m)[old_size+35]));
     m := Memory(domain#Memory(m)[36+old_size := true], contents#Memory(m)[36+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 36];
-if (!b#Boolean(tmp)) { goto Label_49; }
+    if (!b#Boolean(tmp)) { goto Label_49; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[37+old_size := true], contents#Memory(m)[37+old_size := tmp]);
@@ -7364,42 +7112,42 @@ procedure LibraSystem_copy_validator_info_verify (arg0: Reference) returns (ret0
 procedure {:inline 1} LibraSystem_reconfigure () returns ()
 {
     // declare local variables
-    var t0: Reference; // LibraSystem_ValidatorSet_ref
-    var t1: Reference; // Vector_T_ref
-    var t2: Reference; // LibraSystem_ValidatorInfo_ref
-    var t3: Value; // int
-    var t4: Value; // int
-    var t5: Value; // bool
-    var t6: Value; // address
-    var t7: Reference; // LibraSystem_ValidatorSet_ref
-    var t8: Reference; // LibraSystem_ValidatorSet_ref
-    var t9: Reference; // Vector_T_ref
-    var t10: Value; // int
-    var t11: Reference; // Vector_T_ref
-    var t12: Reference; // Vector_T_ref
-    var t13: Value; // int
-    var t14: Value; // bool
-    var t15: Reference; // Vector_T_ref
-    var t16: Value; // int
-    var t17: Reference; // LibraSystem_ValidatorInfo_ref
-    var t18: Reference; // LibraSystem_ValidatorInfo_ref
-    var t19: Value; // bool
-    var t20: Value; // bool
-    var t21: Value; // int
-    var t22: Value; // int
-    var t23: Value; // int
-    var t24: Value; // int
-    var t25: Value; // int
-    var t26: Value; // bool
-    var t27: Reference; // Vector_T_ref
-    var t28: Value; // int
-    var t29: Reference; // LibraSystem_ValidatorInfo_ref
-    var t30: Value; // bool
-    var t31: Reference; // LibraSystem_ValidatorSet_ref
-    var t32: Reference; // LibraAccount_EventHandle_ref
-    var t33: Reference; // Vector_T_ref
-    var t34: Value; // Vector_T
-    var t35: Value; // LibraSystem_ValidatorSetChangeEvent
+    var t0: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t1: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t2: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // AddressType()
+    var t7: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t8: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t9: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t10: Value; // IntegerType()
+    var t11: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t12: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t13: Value; // IntegerType()
+    var t14: Value; // BooleanType()
+    var t15: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t18: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t19: Value; // BooleanType()
+    var t20: Value; // BooleanType()
+    var t21: Value; // IntegerType()
+    var t22: Value; // IntegerType()
+    var t23: Value; // IntegerType()
+    var t24: Value; // IntegerType()
+    var t25: Value; // IntegerType()
+    var t26: Value; // BooleanType()
+    var t27: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t28: Value; // IntegerType()
+    var t29: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t30: Value; // BooleanType()
+    var t31: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t32: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraSystem_ValidatorSetChangeEvent_type_value()))
+    var t33: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t34: Value; // Vector_T_type_value(LibraSystem_ValidatorInfo_type_value())
+    var t35: Value; // LibraSystem_ValidatorSetChangeEvent_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -7414,7 +7162,7 @@ procedure {:inline 1} LibraSystem_reconfigure () returns ()
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
-    call t7 := BorrowGlobal(contents#Memory(m)[old_size+6], LibraSystem_ValidatorSet);
+    call t7 := BorrowGlobal(contents#Memory(m)[old_size+6], LibraSystem_ValidatorSet_type_value());
 
     call t0 := CopyOrMoveRef(t7);
 
@@ -7434,8 +7182,8 @@ procedure {:inline 1} LibraSystem_reconfigure () returns ()
 
     call t12 := FreezeRef(t11);
 
-    call t13 := Vector_length(t12);
-    assume is#Integer(t13);
+    call t13 := Vector_length(LibraSystem_ValidatorInfo_type_value(), t12);
+    assume has_type(IntegerType(), t13);
 
     m := Memory(domain#Memory(m)[old_size+13 := true], contents#Memory(m)[old_size+13 := t13]);
 
@@ -7453,7 +7201,7 @@ procedure {:inline 1} LibraSystem_reconfigure () returns ()
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
-    call t17 := Vector_borrow_mut(t15, contents#Memory(m)[old_size+16]);
+    call t17 := Vector_borrow_mut(LibraSystem_ValidatorInfo_type_value(), t15, contents#Memory(m)[old_size+16]);
 
 
     call t2 := CopyOrMoveRef(t17);
@@ -7462,12 +7210,12 @@ Label_18:
     call t18 := CopyOrMoveRef(t2);
 
     call t19 := LibraSystem_copy_validator_info(t18);
-    assume is#Boolean(t19);
+    assume has_type(BooleanType(), t19);
 
     m := Memory(domain#Memory(m)[old_size+19 := true], contents#Memory(m)[old_size+19 := t19]);
 
     tmp := contents#Memory(m)[old_size + 19];
-if (!b#Boolean(tmp)) { goto Label_23; }
+    if (!b#Boolean(tmp)) { goto Label_23; }
 
     call tmp := LdTrue();
     m := Memory(domain#Memory(m)[20+old_size := true], contents#Memory(m)[20+old_size := tmp]);
@@ -7498,7 +7246,7 @@ Label_23:
     m := Memory(domain#Memory(m)[26+old_size := true], contents#Memory(m)[26+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 26];
-if (!b#Boolean(tmp)) { goto Label_32; }
+    if (!b#Boolean(tmp)) { goto Label_32; }
 
     goto Label_37;
 
@@ -7508,7 +7256,7 @@ Label_32:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[28+old_size := true], contents#Memory(m)[28+old_size := tmp]);
 
-    call t29 := Vector_borrow_mut(t27, contents#Memory(m)[old_size+28]);
+    call t29 := Vector_borrow_mut(LibraSystem_ValidatorInfo_type_value(), t27, contents#Memory(m)[old_size+28]);
 
 
     call t2 := CopyOrMoveRef(t29);
@@ -7520,7 +7268,7 @@ Label_37:
     m := Memory(domain#Memory(m)[30+old_size := true], contents#Memory(m)[30+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 30];
-if (!b#Boolean(tmp)) { goto Label_46; }
+    if (!b#Boolean(tmp)) { goto Label_46; }
 
     call t31 := CopyOrMoveRef(t0);
 
@@ -7529,16 +7277,16 @@ if (!b#Boolean(tmp)) { goto Label_46; }
     call t33 := CopyOrMoveRef(t1);
 
     call tmp := ReadRef(t33);
-    assume is#Vector(tmp);
+    assume has_type(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()), tmp);
 
     m := Memory(domain#Memory(m)[34+old_size := true], contents#Memory(m)[34+old_size := tmp]);
 
-    assume is#Vector(contents#Memory(m)[old_size+34]);
+    assume has_type(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()), contents#Memory(m)[old_size+34]);
 
     call tmp := Pack_LibraSystem_ValidatorSetChangeEvent(contents#Memory(m)[old_size+34]);
     m := Memory(domain#Memory(m)[35+old_size := true], contents#Memory(m)[35+old_size := tmp]);
 
-    call LibraAccount_emit_event(t32, contents#Memory(m)[old_size+35]);
+    call LibraAccount_emit_event(LibraSystem_ValidatorSetChangeEvent_type_value(), t32, contents#Memory(m)[old_size+35]);
 
     return;
 
@@ -7555,28 +7303,28 @@ procedure LibraSystem_reconfigure_verify () returns ()
 procedure {:inline 1} LibraSystem_get_ith_validator_info (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Reference; // Vector_T_ref
-    var t2: Value; // address
-    var t3: Reference; // LibraSystem_ValidatorSet_ref
-    var t4: Reference; // Vector_T_ref
-    var t5: Value; // int
-    var t6: Reference; // Vector_T_ref
-    var t7: Value; // int
-    var t8: Value; // bool
-    var t9: Value; // bool
-    var t10: Value; // int
-    var t11: Reference; // Vector_T_ref
-    var t12: Value; // int
-    var t13: Reference; // LibraSystem_ValidatorInfo_ref
-    var t14: Value; // LibraSystem_ValidatorInfo
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t4: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t5: Value; // IntegerType()
+    var t6: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t7: Value; // IntegerType()
+    var t8: Value; // BooleanType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t12: Value; // IntegerType()
+    var t13: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t14: Value; // LibraSystem_ValidatorInfo_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 15;
@@ -7586,7 +7334,7 @@ procedure {:inline 1} LibraSystem_get_ith_validator_info (arg0: Value) returns (
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
-    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraSystem_ValidatorSet);
+    call t3 := BorrowGlobal(contents#Memory(m)[old_size+2], LibraSystem_ValidatorSet_type_value());
 
     call t4 := BorrowField(t3, LibraSystem_ValidatorSet_validators);
 
@@ -7597,8 +7345,8 @@ procedure {:inline 1} LibraSystem_get_ith_validator_info (arg0: Value) returns (
 
     call t6 := CopyOrMoveRef(t1);
 
-    call t7 := Vector_length(t6);
-    assume is#Integer(t7);
+    call t7 := Vector_length(LibraSystem_ValidatorInfo_type_value(), t6);
+    assume has_type(IntegerType(), t7);
 
     m := Memory(domain#Memory(m)[old_size+7 := true], contents#Memory(m)[old_size+7 := t7]);
 
@@ -7609,7 +7357,7 @@ procedure {:inline 1} LibraSystem_get_ith_validator_info (arg0: Value) returns (
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 9];
-if (!b#Boolean(tmp)) { goto Label_12; }
+    if (!b#Boolean(tmp)) { goto Label_12; }
 
     call tmp := LdConst(3);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
@@ -7622,11 +7370,11 @@ Label_12:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
-    call t13 := Vector_borrow(t11, contents#Memory(m)[old_size+12]);
+    call t13 := Vector_borrow(LibraSystem_ValidatorInfo_type_value(), t11, contents#Memory(m)[old_size+12]);
 
 
     call tmp := ReadRef(t13);
-    assume is#Map(tmp);
+    assume has_type(LibraSystem_ValidatorInfo_type_value(), tmp);
 
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
 
@@ -7643,36 +7391,36 @@ procedure LibraSystem_get_ith_validator_info_verify (arg0: Value) returns (ret0:
 procedure {:inline 1} LibraSystem_get_ith_validator_address (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Reference; // LibraSystem_ValidatorSet_ref
-    var t3: Value; // address
-    var t4: Reference; // LibraSystem_ValidatorInfo_ref
-    var t5: Value; // address
-    var t6: Reference; // LibraSystem_ValidatorSet_ref
-    var t7: Reference; // LibraSystem_ValidatorSet_ref
-    var t8: Reference; // Vector_T_ref
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // bool
-    var t13: Value; // bool
-    var t14: Value; // int
-    var t15: Reference; // LibraSystem_ValidatorSet_ref
-    var t16: Reference; // Vector_T_ref
-    var t17: Value; // int
-    var t18: Reference; // LibraSystem_ValidatorInfo_ref
-    var t19: Reference; // LibraSystem_ValidatorInfo_ref
-    var t20: Reference; // address_ref
-    var t21: Value; // address
-    var t22: Value; // address
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t3: Value; // AddressType()
+    var t4: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t7: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t8: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // BooleanType()
+    var t14: Value; // IntegerType()
+    var t15: Reference; // ReferenceType(LibraSystem_ValidatorSet_type_value())
+    var t16: Reference; // ReferenceType(Vector_T_type_value(LibraSystem_ValidatorInfo_type_value()))
+    var t17: Value; // IntegerType()
+    var t18: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t19: Reference; // ReferenceType(LibraSystem_ValidatorInfo_type_value())
+    var t20: Reference; // ReferenceType(AddressType())
+    var t21: Value; // AddressType()
+    var t22: Value; // AddressType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
+    assume has_type(IntegerType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 23;
@@ -7682,7 +7430,7 @@ procedure {:inline 1} LibraSystem_get_ith_validator_address (arg0: Value) return
     call tmp := LdAddr(472);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraSystem_ValidatorSet);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], LibraSystem_ValidatorSet_type_value());
 
     call t2 := CopyOrMoveRef(t6);
 
@@ -7690,8 +7438,8 @@ procedure {:inline 1} LibraSystem_get_ith_validator_address (arg0: Value) return
 
     call t8 := BorrowField(t7, LibraSystem_ValidatorSet_validators);
 
-    call t9 := Vector_length(t8);
-    assume is#Integer(t9);
+    call t9 := Vector_length(LibraSystem_ValidatorInfo_type_value(), t8);
+    assume has_type(IntegerType(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -7711,7 +7459,7 @@ procedure {:inline 1} LibraSystem_get_ith_validator_address (arg0: Value) return
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 13];
-if (!b#Boolean(tmp)) { goto Label_14; }
+    if (!b#Boolean(tmp)) { goto Label_14; }
 
     call tmp := LdConst(3);
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);
@@ -7726,7 +7474,7 @@ Label_14:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
 
-    call t18 := Vector_borrow(t16, contents#Memory(m)[old_size+17]);
+    call t18 := Vector_borrow(LibraSystem_ValidatorInfo_type_value(), t16, contents#Memory(m)[old_size+17]);
 
 
     call t4 := CopyOrMoveRef(t18);
@@ -7736,7 +7484,7 @@ Label_14:
     call t20 := BorrowField(t19, LibraSystem_ValidatorInfo_addr);
 
     call tmp := ReadRef(t20);
-    assume is#Address(tmp);
+    assume has_type(AddressType(), tmp);
 
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
@@ -7759,26 +7507,26 @@ procedure LibraSystem_get_ith_validator_address_verify (arg0: Value) returns (re
 procedure {:inline 1} TransactionFeeDistribution_distribute_transaction_fees () returns ()
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Value; // LibraCoin_T
-    var t3: Value; // int
-    var t4: Reference; // TransactionFeeDistribution_T_ref
-    var t5: Value; // address
-    var t6: Reference; // TransactionFeeDistribution_T_ref
-    var t7: Value; // int
-    var t8: Value; // address
-    var t9: Value; // int
-    var t10: Reference; // TransactionFeeDistribution_T_ref
-    var t11: Reference; // LibraAccount_WithdrawalCapability_ref
-    var t12: Value; // int
-    var t13: Value; // LibraCoin_T
-    var t14: Value; // int
-    var t15: Value; // int
-    var t16: Value; // int
-    var t17: Value; // LibraCoin_T
-    var t18: Value; // int
-    var t19: Value; // int
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(TransactionFeeDistribution_T_type_value())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(TransactionFeeDistribution_T_type_value())
+    var t7: Value; // IntegerType()
+    var t8: Value; // AddressType()
+    var t9: Value; // IntegerType()
+    var t10: Reference; // ReferenceType(TransactionFeeDistribution_T_type_value())
+    var t11: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t12: Value; // IntegerType()
+    var t13: Value; // LibraCoin_T_type_value()
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraCoin_T_type_value()
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -7793,12 +7541,12 @@ procedure {:inline 1} TransactionFeeDistribution_distribute_transaction_fees () 
     call tmp := LdAddr(4078);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], TransactionFeeDistribution_T);
+    call t6 := BorrowGlobal(contents#Memory(m)[old_size+5], TransactionFeeDistribution_T_type_value());
 
     call t4 := CopyOrMoveRef(t6);
 
     call t7 := LibraSystem_validator_set_size();
-    assume is#Integer(t7);
+    assume has_type(IntegerType(), t7);
 
     m := Memory(domain#Memory(m)[old_size+7 := true], contents#Memory(m)[old_size+7 := t7]);
 
@@ -7809,7 +7557,7 @@ procedure {:inline 1} TransactionFeeDistribution_distribute_transaction_fees () 
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
     call t9 := LibraAccount_balance(contents#Memory(m)[old_size+8]);
-    assume is#Integer(t9);
+    assume has_type(IntegerType(), t9);
 
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
 
@@ -7824,7 +7572,7 @@ procedure {:inline 1} TransactionFeeDistribution_distribute_transaction_fees () 
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
     call t13 := LibraAccount_withdraw_with_capability(t11, contents#Memory(m)[old_size+12]);
-    assume is#Map(t13);
+    assume has_type(LibraCoin_T_type_value(), t13);
 
     m := Memory(domain#Memory(m)[old_size+13 := true], contents#Memory(m)[old_size+13 := t13]);
 
@@ -7838,7 +7586,7 @@ procedure {:inline 1} TransactionFeeDistribution_distribute_transaction_fees () 
     m := Memory(domain#Memory(m)[15+old_size := true], contents#Memory(m)[15+old_size := tmp]);
 
     call t16 := TransactionFeeDistribution_per_validator_distribution_amount(contents#Memory(m)[old_size+14], contents#Memory(m)[old_size+15]);
-    assume is#Integer(t16);
+    assume has_type(IntegerType(), t16);
 
     m := Memory(domain#Memory(m)[old_size+16 := true], contents#Memory(m)[old_size+16 := t16]);
 
@@ -7868,14 +7616,14 @@ procedure TransactionFeeDistribution_distribute_transaction_fees_verify () retur
 procedure {:inline 1} TransactionFeeDistribution_initialize () returns ()
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // address
-    var t2: Value; // bool
-    var t3: Value; // bool
-    var t4: Value; // int
-    var t5: Value; // int
-    var t6: Value; // LibraAccount_WithdrawalCapability
-    var t7: Value; // TransactionFeeDistribution_T
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var t7: Value; // TransactionFeeDistribution_T_type_value()
 
     var tmp: Value;
     var old_size: int;
@@ -7893,14 +7641,14 @@ procedure {:inline 1} TransactionFeeDistribution_initialize () returns ()
     call tmp := LdAddr(4078);
     m := Memory(domain#Memory(m)[1+old_size := true], contents#Memory(m)[1+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+0], contents#Memory(m)[old_size+1]));
     m := Memory(domain#Memory(m)[2+old_size := true], contents#Memory(m)[2+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+2]);
     m := Memory(domain#Memory(m)[3+old_size := true], contents#Memory(m)[3+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 3];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
@@ -7912,18 +7660,18 @@ Label_7:
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     call t6 := LibraAccount_extract_sender_withdrawal_capability();
-    assume is#Map(t6);
+    assume has_type(LibraAccount_WithdrawalCapability_type_value(), t6);
 
     m := Memory(domain#Memory(m)[old_size+6 := true], contents#Memory(m)[old_size+6 := t6]);
 
-    assume is#Integer(contents#Memory(m)[old_size+5]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+5]);
 
-    assume is#Map(contents#Memory(m)[old_size+6]);
+    assume has_type(LibraAccount_WithdrawalCapability_type_value(), contents#Memory(m)[old_size+6]);
 
     call tmp := Pack_TransactionFeeDistribution_T(contents#Memory(m)[old_size+5], contents#Memory(m)[old_size+6]);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
-    call MoveToSender(TransactionFeeDistribution_T, contents#Memory(m)[old_size+7]);
+    call MoveToSender(TransactionFeeDistribution_T_type_value(), contents#Memory(m)[old_size+7]);
 
     return;
 
@@ -7937,43 +7685,43 @@ procedure TransactionFeeDistribution_initialize_verify () returns ()
 procedure {:inline 1} TransactionFeeDistribution_distribute_transaction_fees_internal (arg0: Value, arg1: Value, arg2: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // LibraCoin_T
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Value; // int
-    var t4: Value; // address
-    var t5: Value; // LibraCoin_T
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // bool
-    var t10: Value; // int
-    var t11: Value; // address
-    var t12: Value; // int
-    var t13: Value; // int
-    var t14: Value; // int
-    var t15: Value; // LibraCoin_T
-    var t16: Value; // int
-    var t17: Value; // LibraCoin_T
-    var t18: Value; // LibraCoin_T
-    var t19: Value; // address
-    var t20: Value; // LibraCoin_T
-    var t21: Reference; // LibraCoin_T_ref
-    var t22: Value; // int
-    var t23: Value; // int
-    var t24: Value; // bool
-    var t25: Value; // LibraCoin_T
-    var t26: Value; // address
-    var t27: Value; // LibraCoin_T
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // AddressType()
+    var t5: Value; // LibraCoin_T_type_value()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // AddressType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // IntegerType()
+    var t14: Value; // IntegerType()
+    var t15: Value; // LibraCoin_T_type_value()
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraCoin_T_type_value()
+    var t18: Value; // LibraCoin_T_type_value()
+    var t19: Value; // AddressType()
+    var t20: Value; // LibraCoin_T_type_value()
+    var t21: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t22: Value; // IntegerType()
+    var t23: Value; // IntegerType()
+    var t24: Value; // BooleanType()
+    var t25: Value; // LibraCoin_T_type_value()
+    var t26: Value; // AddressType()
+    var t27: Value; // LibraCoin_T_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
-    assume is#Integer(arg1);
-    assume is#Integer(arg2);
+    assume has_type(LibraCoin_T_type_value(), arg0);
+    assume has_type(IntegerType(), arg1);
+    assume has_type(IntegerType(), arg2);
 
     old_size := m_size;
     m_size := m_size + 28;
@@ -7999,13 +7747,13 @@ Label_2:
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 9];
-if (!b#Boolean(tmp)) { goto Label_22; }
+    if (!b#Boolean(tmp)) { goto Label_22; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
 
     call t11 := LibraSystem_get_ith_validator_address(contents#Memory(m)[old_size+10]);
-    assume is#Address(t11);
+    assume has_type(AddressType(), t11);
 
     m := Memory(domain#Memory(m)[old_size+11 := true], contents#Memory(m)[old_size+11 := t11]);
 
@@ -8031,9 +7779,9 @@ if (!b#Boolean(tmp)) { goto Label_22; }
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
     call t18, t17 := LibraCoin_split(contents#Memory(m)[old_size+15], contents#Memory(m)[old_size+16]);
-    assume is#Map(t18);
+    assume has_type(LibraCoin_T_type_value(), t18);
 
-    assume is#Map(t17);
+    assume has_type(LibraCoin_T_type_value(), t17);
 
     m := Memory(domain#Memory(m)[old_size+18 := true], contents#Memory(m)[old_size+18 := t18]);
     m := Memory(domain#Memory(m)[old_size+17 := true], contents#Memory(m)[old_size+17 := t17]);
@@ -8058,18 +7806,18 @@ Label_22:
     call t21 := BorrowLoc(old_size+0);
 
     call t22 := LibraCoin_value(t21);
-    assume is#Integer(t22);
+    assume has_type(IntegerType(), t22);
 
     m := Memory(domain#Memory(m)[old_size+22 := true], contents#Memory(m)[old_size+22 := t22]);
 
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[23+old_size := true], contents#Memory(m)[23+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+22], contents#Memory(m)[old_size+23]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+22], contents#Memory(m)[old_size+23]));
     m := Memory(domain#Memory(m)[24+old_size := true], contents#Memory(m)[24+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 24];
-if (!b#Boolean(tmp)) { goto Label_30; }
+    if (!b#Boolean(tmp)) { goto Label_30; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[25+old_size := true], contents#Memory(m)[25+old_size := tmp]);
@@ -8100,33 +7848,33 @@ procedure TransactionFeeDistribution_distribute_transaction_fees_internal_verify
 procedure {:inline 1} TransactionFeeDistribution_per_validator_distribution_amount (arg0: Value, arg1: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Value; // int
-    var t2: Value; // int
-    var t3: Value; // int
-    var t4: Value; // int
-    var t5: Value; // bool
-    var t6: Value; // bool
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // int
-    var t12: Value; // int
-    var t13: Value; // int
-    var t14: Value; // int
-    var t15: Value; // bool
-    var t16: Value; // bool
-    var t17: Value; // int
-    var t18: Value; // int
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // IntegerType()
+    var t14: Value; // IntegerType()
+    var t15: Value; // BooleanType()
+    var t16: Value; // BooleanType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Integer(arg0);
-    assume is#Integer(arg1);
+    assume has_type(IntegerType(), arg0);
+    assume has_type(IntegerType(), arg1);
 
     old_size := m_size;
     m_size := m_size + 19;
@@ -8140,14 +7888,14 @@ procedure {:inline 1} TransactionFeeDistribution_per_validator_distribution_amou
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[4+old_size := true], contents#Memory(m)[4+old_size := tmp]);
 
-    call tmp := Neq(contents#Memory(m)[old_size+3], contents#Memory(m)[old_size+4]);
+    tmp := Boolean(!is_equal(IntegerType(), contents#Memory(m)[old_size+3], contents#Memory(m)[old_size+4]));
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+5]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 6];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
@@ -8186,7 +7934,7 @@ Label_7:
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 16];
-if (!b#Boolean(tmp)) { goto Label_20; }
+    if (!b#Boolean(tmp)) { goto Label_20; }
 
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -3,35 +3,23 @@
 // everything below is auto generated
 
 const unique TestReference_T: TypeName;
-const unique TestReference_T_value: FieldName;
+const TestReference_T_value: FieldName;
+axiom TestReference_T_value == 0;
+function TestReference_T_type_value(): TypeValue {
+    StructType(TestReference_T, TypeValueArray(DefaultTypeMap[0 := IntegerType()], 1))
+}
 
 procedure {:inline 1} Pack_TestReference_T(v0: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    v := Map(DefaultMap[Field(TestReference_T_value) := v0]);
+    assume has_type(IntegerType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[TestReference_T_value := v0], 1));
+    assume has_type(TestReference_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_TestReference_T(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(TestReference_T_value)];
-}
-
-procedure {:inline 1} Eq_TestReference_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(TestReference_T_value)], m#Map(v2)[Field(TestReference_T_value)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_TestReference_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_TestReference_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[TestReference_T_value];
 }
 
 procedure {:inline 1} ReadValue0(p: Path, i: int, v: Value) returns (v': Value)
@@ -51,8 +39,8 @@ procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue0(p, i+1, v');
     }
 }
@@ -64,8 +52,8 @@ procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue1(p, i+1, v');
     }
 }
@@ -77,8 +65,8 @@ procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue2(p, i+1, v');
     }
 }
@@ -100,11 +88,11 @@ procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue0(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -115,11 +103,11 @@ procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue1(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -130,20 +118,20 @@ procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) re
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue2(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
 procedure {:inline 1} TestReference_mut_b (arg0: Reference) returns ()
 {
     // declare local variables
-    var t0: Reference; // int_ref
-    var t1: Value; // int
-    var t2: Reference; // int_ref
+    var t0: Reference; // ReferenceType(IntegerType())
+    var t1: Value; // IntegerType()
+    var t2: Reference; // ReferenceType(IntegerType())
 
     var tmp: Value;
     var old_size: int;
@@ -175,18 +163,18 @@ procedure TestReference_mut_b_verify (arg0: Reference) returns ()
 procedure {:inline 1} TestReference_mut_ref () returns ()
 {
     // declare local variables
-    var t0: Value; // int
-    var t1: Reference; // int_ref
-    var t2: Value; // int
-    var t3: Reference; // int_ref
-    var t4: Reference; // int_ref
-    var t5: Reference; // int_ref
-    var t6: Value; // int
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // bool
-    var t10: Value; // bool
-    var t11: Value; // int
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(IntegerType())
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(IntegerType())
+    var t4: Reference; // ReferenceType(IntegerType())
+    var t5: Reference; // ReferenceType(IntegerType())
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // BooleanType()
+    var t11: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
@@ -215,7 +203,7 @@ procedure {:inline 1} TestReference_mut_ref () returns ()
     call t5 := CopyOrMoveRef(t1);
 
     call tmp := ReadRef(t5);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
@@ -228,14 +216,14 @@ procedure {:inline 1} TestReference_mut_ref () returns ()
     call tmp := LdConst(10);
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+7], contents#Memory(m)[old_size+8]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+7], contents#Memory(m)[old_size+8]));
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+9]);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 10];
-if (!b#Boolean(tmp)) { goto Label_16; }
+    if (!b#Boolean(tmp)) { goto Label_16; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -3,146 +3,95 @@
 // everything below is auto generated
 
 const unique TestStruct_B: TypeName;
-const unique TestStruct_B_addr: FieldName;
-const unique TestStruct_B_val: FieldName;
+const TestStruct_B_addr: FieldName;
+axiom TestStruct_B_addr == 0;
+const TestStruct_B_val: FieldName;
+axiom TestStruct_B_val == 1;
+function TestStruct_B_type_value(): TypeValue {
+    StructType(TestStruct_B, TypeValueArray(DefaultTypeMap[0 := AddressType()][1 := IntegerType()], 2))
+}
 
 procedure {:inline 1} Pack_TestStruct_B(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Address(v0);
-    assert is#Integer(v1);
-    v := Map(DefaultMap[Field(TestStruct_B_addr) := v0][Field(TestStruct_B_val) := v1]);
+    assume has_type(AddressType(), v0);
+    assume has_type(IntegerType(), v1);
+    v := Struct(ValueArray(DefaultIntMap[TestStruct_B_addr := v0][TestStruct_B_val := v1], 2));
+    assume has_type(TestStruct_B_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_TestStruct_B(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(TestStruct_B_addr)];
-    v1 := m#Map(v)[Field(TestStruct_B_val)];
-}
-
-procedure {:inline 1} Eq_TestStruct_B(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_address(m#Map(v1)[Field(TestStruct_B_addr)], m#Map(v2)[Field(TestStruct_B_addr)]);
-    call b1 := Eq_int(m#Map(v1)[Field(TestStruct_B_val)], m#Map(v2)[Field(TestStruct_B_val)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_TestStruct_B(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_TestStruct_B(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[TestStruct_B_addr];
+    v1 := smap(v)[TestStruct_B_val];
 }
 
 const unique TestStruct_A: TypeName;
-const unique TestStruct_A_b: FieldName;
-const unique TestStruct_A_val: FieldName;
+const TestStruct_A_val: FieldName;
+axiom TestStruct_A_val == 0;
+const TestStruct_A_b: FieldName;
+axiom TestStruct_A_b == 1;
+function TestStruct_A_type_value(): TypeValue {
+    StructType(TestStruct_A, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := TestStruct_B_type_value()], 2))
+}
 
 procedure {:inline 1} Pack_TestStruct_A(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Map(v0);
-    assert is#Integer(v1);
-    v := Map(DefaultMap[Field(TestStruct_A_b) := v0][Field(TestStruct_A_val) := v1]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(TestStruct_B_type_value(), v1);
+    v := Struct(ValueArray(DefaultIntMap[TestStruct_A_val := v0][TestStruct_A_b := v1], 2));
+    assume has_type(TestStruct_A_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_TestStruct_A(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(TestStruct_A_b)];
-    v1 := m#Map(v)[Field(TestStruct_A_val)];
-}
-
-procedure {:inline 1} Eq_TestStruct_A(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_TestStruct_B(m#Map(v1)[Field(TestStruct_A_b)], m#Map(v2)[Field(TestStruct_A_b)]);
-    call b1 := Eq_int(m#Map(v1)[Field(TestStruct_A_val)], m#Map(v2)[Field(TestStruct_A_val)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_TestStruct_A(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_TestStruct_A(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[TestStruct_A_val];
+    v1 := smap(v)[TestStruct_A_b];
 }
 
 const unique TestStruct_C: TypeName;
-const unique TestStruct_C_b: FieldName;
-const unique TestStruct_C_val: FieldName;
+const TestStruct_C_val: FieldName;
+axiom TestStruct_C_val == 0;
+const TestStruct_C_b: FieldName;
+axiom TestStruct_C_b == 1;
+function TestStruct_C_type_value(): TypeValue {
+    StructType(TestStruct_C, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := TestStruct_A_type_value()], 2))
+}
 
 procedure {:inline 1} Pack_TestStruct_C(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Map(v0);
-    assert is#Integer(v1);
-    v := Map(DefaultMap[Field(TestStruct_C_b) := v0][Field(TestStruct_C_val) := v1]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(TestStruct_A_type_value(), v1);
+    v := Struct(ValueArray(DefaultIntMap[TestStruct_C_val := v0][TestStruct_C_b := v1], 2));
+    assume has_type(TestStruct_C_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_TestStruct_C(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(TestStruct_C_b)];
-    v1 := m#Map(v)[Field(TestStruct_C_val)];
-}
-
-procedure {:inline 1} Eq_TestStruct_C(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_TestStruct_A(m#Map(v1)[Field(TestStruct_C_b)], m#Map(v2)[Field(TestStruct_C_b)]);
-    call b1 := Eq_int(m#Map(v1)[Field(TestStruct_C_val)], m#Map(v2)[Field(TestStruct_C_val)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_TestStruct_C(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_TestStruct_C(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[TestStruct_C_val];
+    v1 := smap(v)[TestStruct_C_b];
 }
 
 const unique TestStruct_T: TypeName;
-const unique TestStruct_T_x: FieldName;
+const TestStruct_T_x: FieldName;
+axiom TestStruct_T_x == 0;
+function TestStruct_T_type_value(): TypeValue {
+    StructType(TestStruct_T, TypeValueArray(DefaultTypeMap[0 := IntegerType()], 1))
+}
 
 procedure {:inline 1} Pack_TestStruct_T(v0: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    v := Map(DefaultMap[Field(TestStruct_T_x) := v0]);
+    assume has_type(IntegerType(), v0);
+    v := Struct(ValueArray(DefaultIntMap[TestStruct_T_x := v0], 1));
+    assume has_type(TestStruct_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_TestStruct_T(v: Value) returns (v0: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(TestStruct_T_x)];
-}
-
-procedure {:inline 1} Eq_TestStruct_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(TestStruct_T_x)], m#Map(v2)[Field(TestStruct_T_x)]);
-    res := Boolean(true && b#Boolean(b0));
-}
-
-procedure {:inline 1} Neq_TestStruct_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_TestStruct_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[TestStruct_T_x];
 }
 
 procedure {:inline 1} ReadValue0(p: Path, i: int, v: Value) returns (v': Value)
@@ -162,8 +111,8 @@ procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue0(p, i+1, v');
     }
 }
@@ -175,8 +124,8 @@ procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue1(p, i+1, v');
     }
 }
@@ -188,8 +137,8 @@ procedure {:inline 1} ReadValue3(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue2(p, i+1, v');
     }
 }
@@ -201,8 +150,8 @@ procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue3(p, i+1, v');
     }
 }
@@ -224,11 +173,11 @@ procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue0(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -239,11 +188,11 @@ procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue1(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -254,11 +203,11 @@ procedure {:inline 1} UpdateValue3(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue2(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -269,29 +218,29 @@ procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) re
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue3(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
 procedure {:inline 1} TestStruct_identity (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
 {
     // declare local variables
-    var t0: Value; // TestStruct_A
-    var t1: Value; // TestStruct_C
-    var t2: Value; // TestStruct_A
-    var t3: Value; // TestStruct_C
+    var t0: Value; // TestStruct_A_type_value()
+    var t1: Value; // TestStruct_C_type_value()
+    var t2: Value; // TestStruct_A_type_value()
+    var t3: Value; // TestStruct_C_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Map(arg0);
-    assume is#Map(arg1);
+    assume has_type(TestStruct_A_type_value(), arg0);
+    assume has_type(TestStruct_C_type_value(), arg1);
 
     old_size := m_size;
     m_size := m_size + 4;
@@ -319,33 +268,33 @@ procedure TestStruct_identity_verify (arg0: Value, arg1: Value) returns (ret0: V
 procedure {:inline 1} TestStruct_module_builtins (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // TestStruct_T
-    var t2: Reference; // TestStruct_T_ref
-    var t3: Reference; // TestStruct_T_ref
-    var t4: Value; // bool
-    var t5: Value; // address
-    var t6: Value; // bool
-    var t7: Value; // bool
-    var t8: Value; // bool
-    var t9: Value; // int
-    var t10: Value; // address
-    var t11: Reference; // TestStruct_T_ref
-    var t12: Reference; // TestStruct_T_ref
-    var t13: Value; // address
-    var t14: Reference; // TestStruct_T_ref
-    var t15: Reference; // TestStruct_T_ref
-    var t16: Value; // address
-    var t17: Value; // TestStruct_T
-    var t18: Value; // TestStruct_T
-    var t19: Value; // bool
+    var t0: Value; // AddressType()
+    var t1: Value; // TestStruct_T_type_value()
+    var t2: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t3: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t4: Value; // BooleanType()
+    var t5: Value; // AddressType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // BooleanType()
+    var t8: Value; // BooleanType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // AddressType()
+    var t11: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t12: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t13: Value; // AddressType()
+    var t14: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t15: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t16: Value; // AddressType()
+    var t17: Value; // TestStruct_T_type_value()
+    var t18: Value; // TestStruct_T_type_value()
+    var t19: Value; // BooleanType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 20;
@@ -355,7 +304,7 @@ procedure {:inline 1} TestStruct_module_builtins (arg0: Value) returns (ret0: Va
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    call tmp := Exists(contents#Memory(m)[old_size+5], TestStruct_T);
+    call tmp := Exists(contents#Memory(m)[old_size+5], TestStruct_T_type_value());
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+6]);
@@ -368,7 +317,7 @@ procedure {:inline 1} TestStruct_module_builtins (arg0: Value) returns (ret0: Va
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 8];
-if (!b#Boolean(tmp)) { goto Label_8; }
+    if (!b#Boolean(tmp)) { goto Label_8; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
@@ -379,7 +328,7 @@ Label_8:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
 
-    call t11 := BorrowGlobal(contents#Memory(m)[old_size+10], TestStruct_T);
+    call t11 := BorrowGlobal(contents#Memory(m)[old_size+10], TestStruct_T_type_value());
 
     call t2 := CopyOrMoveRef(t11);
 
@@ -390,7 +339,7 @@ Label_8:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
 
-    call t14 := BorrowGlobal(contents#Memory(m)[old_size+13], TestStruct_T);
+    call t14 := BorrowGlobal(contents#Memory(m)[old_size+13], TestStruct_T_type_value());
 
     call t3 := CopyOrMoveRef(t14);
 
@@ -401,9 +350,9 @@ Label_8:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[16+old_size := true], contents#Memory(m)[16+old_size := tmp]);
 
-    call tmp := MoveFrom(contents#Memory(m)[old_size+16], TestStruct_T);
+    call tmp := MoveFrom(contents#Memory(m)[old_size+16], TestStruct_T_type_value());
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
-    assume is#Map(t17);
+    assume has_type(TestStruct_T_type_value(), t17);
 
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+17]);
@@ -412,7 +361,7 @@ Label_8:
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+1]);
     m := Memory(domain#Memory(m)[18+old_size := true], contents#Memory(m)[18+old_size := tmp]);
 
-    call MoveToSender(TestStruct_T, contents#Memory(m)[old_size+18]);
+    call MoveToSender(TestStruct_T_type_value(), contents#Memory(m)[old_size+18]);
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+4]);
     m := Memory(domain#Memory(m)[19+old_size := true], contents#Memory(m)[19+old_size := tmp]);
@@ -430,37 +379,37 @@ procedure TestStruct_module_builtins_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} TestStruct_nested_struct (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // TestStruct_A
-    var t2: Value; // TestStruct_B
-    var t3: Reference; // TestStruct_B_ref
-    var t4: Reference; // int_ref
-    var t5: Value; // int
-    var t6: Value; // bool
-    var t7: Value; // address
-    var t8: Value; // int
-    var t9: Value; // TestStruct_B
-    var t10: Value; // address
-    var t11: Value; // int
-    var t12: Value; // TestStruct_B
-    var t13: Reference; // TestStruct_B_ref
-    var t14: Reference; // TestStruct_B_ref
-    var t15: Reference; // int_ref
-    var t16: Reference; // int_ref
-    var t17: Value; // int
-    var t18: Value; // int
-    var t19: Value; // int
-    var t20: Value; // bool
-    var t21: Value; // bool
-    var t22: Value; // int
-    var t23: Value; // TestStruct_B
+    var t0: Value; // AddressType()
+    var t1: Value; // TestStruct_A_type_value()
+    var t2: Value; // TestStruct_B_type_value()
+    var t3: Reference; // ReferenceType(TestStruct_B_type_value())
+    var t4: Reference; // ReferenceType(IntegerType())
+    var t5: Value; // IntegerType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // AddressType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // TestStruct_B_type_value()
+    var t10: Value; // AddressType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // TestStruct_B_type_value()
+    var t13: Reference; // ReferenceType(TestStruct_B_type_value())
+    var t14: Reference; // ReferenceType(TestStruct_B_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Reference; // ReferenceType(IntegerType())
+    var t17: Value; // IntegerType()
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
+    var t20: Value; // BooleanType()
+    var t21: Value; // BooleanType()
+    var t22: Value; // IntegerType()
+    var t23: Value; // TestStruct_B_type_value()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 24;
@@ -471,7 +420,7 @@ procedure {:inline 1} TestStruct_nested_struct (arg0: Value) returns (ret0: Valu
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 6];
-if (!b#Boolean(tmp)) { goto Label_7; }
+    if (!b#Boolean(tmp)) { goto Label_7; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+0]);
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
@@ -479,9 +428,9 @@ if (!b#Boolean(tmp)) { goto Label_7; }
     call tmp := LdConst(1);
     m := Memory(domain#Memory(m)[8+old_size := true], contents#Memory(m)[8+old_size := tmp]);
 
-    assume is#Address(contents#Memory(m)[old_size+7]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+7]);
 
-    assume is#Integer(contents#Memory(m)[old_size+8]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+8]);
 
     call tmp := Pack_TestStruct_B(contents#Memory(m)[old_size+7], contents#Memory(m)[old_size+8]);
     m := Memory(domain#Memory(m)[9+old_size := true], contents#Memory(m)[9+old_size := tmp]);
@@ -498,9 +447,9 @@ Label_7:
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    assume is#Address(contents#Memory(m)[old_size+10]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+10]);
 
-    assume is#Integer(contents#Memory(m)[old_size+11]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+11]);
 
     call tmp := Pack_TestStruct_B(contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]);
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
@@ -522,7 +471,7 @@ Label_11:
     call t16 := CopyOrMoveRef(t4);
 
     call tmp := ReadRef(t16);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[17+old_size := true], contents#Memory(m)[17+old_size := tmp]);
 
@@ -535,14 +484,14 @@ Label_11:
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[19+old_size := true], contents#Memory(m)[19+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+18], contents#Memory(m)[old_size+19]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+18], contents#Memory(m)[old_size+19]));
     m := Memory(domain#Memory(m)[20+old_size := true], contents#Memory(m)[20+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+20]);
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 21];
-if (!b#Boolean(tmp)) { goto Label_26; }
+    if (!b#Boolean(tmp)) { goto Label_26; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[22+old_size := true], contents#Memory(m)[22+old_size := tmp]);
@@ -566,29 +515,29 @@ procedure TestStruct_nested_struct_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} TestStruct_try_unpack (arg0: Value) returns (ret0: Value)
 {
     // declare local variables
-    var t0: Value; // address
-    var t1: Value; // int
-    var t2: Value; // TestStruct_B
-    var t3: Value; // address
-    var t4: Value; // address
-    var t5: Value; // int
-    var t6: Value; // TestStruct_B
-    var t7: Value; // TestStruct_B
-    var t8: Value; // address
-    var t9: Value; // int
-    var t10: Value; // address
-    var t11: Value; // address
-    var t12: Value; // bool
-    var t13: Value; // bool
-    var t14: Value; // int
-    var t15: Value; // int
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // TestStruct_B_type_value()
+    var t3: Value; // AddressType()
+    var t4: Value; // AddressType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // TestStruct_B_type_value()
+    var t7: Value; // TestStruct_B_type_value()
+    var t8: Value; // AddressType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // AddressType()
+    var t11: Value; // AddressType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // BooleanType()
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Address(arg0);
+    assume has_type(AddressType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 16;
@@ -601,9 +550,9 @@ procedure {:inline 1} TestStruct_try_unpack (arg0: Value) returns (ret0: Value)
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[5+old_size := true], contents#Memory(m)[5+old_size := tmp]);
 
-    assume is#Address(contents#Memory(m)[old_size+4]);
+    assume has_type(AddressType(), contents#Memory(m)[old_size+4]);
 
-    assume is#Integer(contents#Memory(m)[old_size+5]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+5]);
 
     call tmp := Pack_TestStruct_B(contents#Memory(m)[old_size+4], contents#Memory(m)[old_size+5]);
     m := Memory(domain#Memory(m)[6+old_size := true], contents#Memory(m)[6+old_size := tmp]);
@@ -615,9 +564,9 @@ procedure {:inline 1} TestStruct_try_unpack (arg0: Value) returns (ret0: Value)
     m := Memory(domain#Memory(m)[7+old_size := true], contents#Memory(m)[7+old_size := tmp]);
 
     call t8, t9 := Unpack_TestStruct_B(contents#Memory(m)[old_size+7]);
-    assume is#Address(t8);
+    assume has_type(AddressType(), t8);
 
-    assume is#Integer(t9);
+    assume has_type(IntegerType(), t9);
 
     m := Memory(domain#Memory(m)[old_size+8 := true], contents#Memory(m)[old_size+8 := t8]);
     m := Memory(domain#Memory(m)[old_size+9 := true], contents#Memory(m)[old_size+9 := t9]);
@@ -634,14 +583,14 @@ procedure {:inline 1} TestStruct_try_unpack (arg0: Value) returns (ret0: Value)
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+3]);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]);
+    tmp := Boolean(is_equal(AddressType(), contents#Memory(m)[old_size+10], contents#Memory(m)[old_size+11]));
     m := Memory(domain#Memory(m)[12+old_size := true], contents#Memory(m)[12+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+12]);
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 13];
-if (!b#Boolean(tmp)) { goto Label_15; }
+    if (!b#Boolean(tmp)) { goto Label_15; }
 
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[14+old_size := true], contents#Memory(m)[14+old_size := tmp]);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -3,40 +3,27 @@
 // everything below is auto generated
 
 const unique Test3_T: TypeName;
-const unique Test3_T_f: FieldName;
-const unique Test3_T_g: FieldName;
+const Test3_T_f: FieldName;
+axiom Test3_T_f == 0;
+const Test3_T_g: FieldName;
+axiom Test3_T_g == 1;
+function Test3_T_type_value(): TypeValue {
+    StructType(Test3_T, TypeValueArray(DefaultTypeMap[0 := IntegerType()][1 := IntegerType()], 2))
+}
 
 procedure {:inline 1} Pack_Test3_T(v0: Value, v1: Value) returns (v: Value)
 {
-    assert is#Integer(v0);
-    assert is#Integer(v1);
-    v := Map(DefaultMap[Field(Test3_T_f) := v0][Field(Test3_T_g) := v1]);
+    assume has_type(IntegerType(), v0);
+    assume has_type(IntegerType(), v1);
+    v := Struct(ValueArray(DefaultIntMap[Test3_T_f := v0][Test3_T_g := v1], 2));
+    assume has_type(Test3_T_type_value(), v);
 }
 
 procedure {:inline 1} Unpack_Test3_T(v: Value) returns (v0: Value, v1: Value)
 {
-    assert is#Map(v);
-    v0 := m#Map(v)[Field(Test3_T_f)];
-    v1 := m#Map(v)[Field(Test3_T_g)];
-}
-
-procedure {:inline 1} Eq_Test3_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var b0: Value;
-    var b1: Value;
-    assert is#Map(v1) && is#Map(v2);
-    call b0 := Eq_int(m#Map(v1)[Field(Test3_T_f)], m#Map(v2)[Field(Test3_T_f)]);
-    call b1 := Eq_int(m#Map(v1)[Field(Test3_T_g)], m#Map(v2)[Field(Test3_T_g)]);
-    res := Boolean(true && b#Boolean(b0) && b#Boolean(b1));
-}
-
-procedure {:inline 1} Neq_Test3_T(v1: Value, v2: Value) returns (res: Value)
-{
-    var res_val: Value;
-    var res_bool: bool;
-    assert is#Map(v1) && is#Map(v2);
-    call res_val := Eq_Test3_T(v1, v2);
-    res := Boolean(!b#Boolean(res_val));
+    assert is#Struct(v);
+    v0 := smap(v)[Test3_T_f];
+    v1 := smap(v)[Test3_T_g];
 }
 
 procedure {:inline 1} ReadValue0(p: Path, i: int, v: Value) returns (v': Value)
@@ -56,8 +43,8 @@ procedure {:inline 1} ReadValue1(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue0(p, i+1, v');
     }
 }
@@ -69,8 +56,8 @@ procedure {:inline 1} ReadValue2(p: Path, i: int, v: Value) returns (v': Value)
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue1(p, i+1, v');
     }
 }
@@ -82,8 +69,8 @@ procedure {:inline 1} ReadValueMax(p: Path, i: int, v: Value) returns (v': Value
         v' := v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := ReadValue2(p, i+1, v');
     }
 }
@@ -105,11 +92,11 @@ procedure {:inline 1} UpdateValue1(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue0(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -120,11 +107,11 @@ procedure {:inline 1} UpdateValue2(p: Path, i: int, v: Value, new_v: Value) retu
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue1(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
@@ -135,81 +122,81 @@ procedure {:inline 1} UpdateValueMax(p: Path, i: int, v: Value, new_v: Value) re
         v' := new_v;
     } else {
         e := p#Path(p)[i];
-        v' := m#Map(v)[e];
-        if (is#Vector(v)) { v' := v#Vector(v)[e]; }
+        if (is#Struct(v)) { v' := smap(v)[f#Field(e)]; }
+        if (is#Vector(v)) { v' := vmap(v)[i#Index(e)]; }
         call v' := UpdateValue2(p, i+1, v', new_v);
-        if (is#Map(v)) { v' := Map(m#Map(v)[e := v']);}
-        if (is#Vector(v)) { v' := Vector(v#Vector(v)[e := v'], l#Vector(v));}
+        if (is#Struct(v)) { v' := mk_struct(smap(v)[f#Field(e) := v'], slen(v));}
+        if (is#Vector(v)) { v' := mk_vector(vmap(v)[i#Index(e) := v'], vlen(v));}
     }
 }
 
 procedure {:inline 1} Test3_test3 (arg0: Value) returns ()
 {
     // declare local variables
-    var t0: Value; // bool
-    var t1: Value; // Test3_T
-    var t2: Reference; // Test3_T_ref
-    var t3: Reference; // int_ref
-    var t4: Reference; // int_ref
-    var t5: Reference; // int_ref
-    var t6: Reference; // int_ref
-    var t7: Value; // int
-    var t8: Value; // int
-    var t9: Value; // int
-    var t10: Value; // int
-    var t11: Value; // Test3_T
-    var t12: Reference; // Test3_T_ref
-    var t13: Value; // bool
-    var t14: Reference; // Test3_T_ref
-    var t15: Reference; // int_ref
-    var t16: Reference; // Test3_T_ref
-    var t17: Reference; // int_ref
-    var t18: Value; // int
-    var t19: Reference; // int_ref
-    var t20: Value; // bool
-    var t21: Value; // bool
-    var t22: Reference; // Test3_T_ref
-    var t23: Reference; // int_ref
-    var t24: Reference; // Test3_T_ref
-    var t25: Reference; // int_ref
-    var t26: Value; // int
-    var t27: Reference; // int_ref
-    var t28: Reference; // Test3_T_ref
-    var t29: Reference; // int_ref
-    var t30: Reference; // Test3_T_ref
-    var t31: Reference; // int_ref
-    var t32: Reference; // int_ref
-    var t33: Value; // int
-    var t34: Reference; // int_ref
-    var t35: Value; // int
-    var t36: Value; // bool
-    var t37: Value; // int
-    var t38: Value; // int
-    var t39: Value; // bool
-    var t40: Value; // bool
-    var t41: Value; // int
-    var t42: Value; // int
-    var t43: Value; // int
-    var t44: Value; // bool
-    var t45: Value; // bool
-    var t46: Value; // int
-    var t47: Value; // int
-    var t48: Value; // int
-    var t49: Value; // bool
-    var t50: Value; // bool
-    var t51: Value; // int
-    var t52: Value; // int
-    var t53: Value; // int
-    var t54: Value; // bool
-    var t55: Value; // bool
-    var t56: Value; // int
+    var t0: Value; // BooleanType()
+    var t1: Value; // Test3_T_type_value()
+    var t2: Reference; // ReferenceType(Test3_T_type_value())
+    var t3: Reference; // ReferenceType(IntegerType())
+    var t4: Reference; // ReferenceType(IntegerType())
+    var t5: Reference; // ReferenceType(IntegerType())
+    var t6: Reference; // ReferenceType(IntegerType())
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // Test3_T_type_value()
+    var t12: Reference; // ReferenceType(Test3_T_type_value())
+    var t13: Value; // BooleanType()
+    var t14: Reference; // ReferenceType(Test3_T_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Reference; // ReferenceType(Test3_T_type_value())
+    var t17: Reference; // ReferenceType(IntegerType())
+    var t18: Value; // IntegerType()
+    var t19: Reference; // ReferenceType(IntegerType())
+    var t20: Value; // BooleanType()
+    var t21: Value; // BooleanType()
+    var t22: Reference; // ReferenceType(Test3_T_type_value())
+    var t23: Reference; // ReferenceType(IntegerType())
+    var t24: Reference; // ReferenceType(Test3_T_type_value())
+    var t25: Reference; // ReferenceType(IntegerType())
+    var t26: Value; // IntegerType()
+    var t27: Reference; // ReferenceType(IntegerType())
+    var t28: Reference; // ReferenceType(Test3_T_type_value())
+    var t29: Reference; // ReferenceType(IntegerType())
+    var t30: Reference; // ReferenceType(Test3_T_type_value())
+    var t31: Reference; // ReferenceType(IntegerType())
+    var t32: Reference; // ReferenceType(IntegerType())
+    var t33: Value; // IntegerType()
+    var t34: Reference; // ReferenceType(IntegerType())
+    var t35: Value; // IntegerType()
+    var t36: Value; // BooleanType()
+    var t37: Value; // IntegerType()
+    var t38: Value; // IntegerType()
+    var t39: Value; // BooleanType()
+    var t40: Value; // BooleanType()
+    var t41: Value; // IntegerType()
+    var t42: Value; // IntegerType()
+    var t43: Value; // IntegerType()
+    var t44: Value; // BooleanType()
+    var t45: Value; // BooleanType()
+    var t46: Value; // IntegerType()
+    var t47: Value; // IntegerType()
+    var t48: Value; // IntegerType()
+    var t49: Value; // BooleanType()
+    var t50: Value; // BooleanType()
+    var t51: Value; // IntegerType()
+    var t52: Value; // IntegerType()
+    var t53: Value; // IntegerType()
+    var t54: Value; // BooleanType()
+    var t55: Value; // BooleanType()
+    var t56: Value; // IntegerType()
 
     var tmp: Value;
     var old_size: int;
     assume !abort_flag;
 
     // assume arguments are of correct types
-    assume is#Boolean(arg0);
+    assume has_type(BooleanType(), arg0);
 
     old_size := m_size;
     m_size := m_size + 57;
@@ -222,9 +209,9 @@ procedure {:inline 1} Test3_test3 (arg0: Value) returns ()
     call tmp := LdConst(0);
     m := Memory(domain#Memory(m)[10+old_size := true], contents#Memory(m)[10+old_size := tmp]);
 
-    assume is#Integer(contents#Memory(m)[old_size+9]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+9]);
 
-    assume is#Integer(contents#Memory(m)[old_size+10]);
+    assume has_type(IntegerType(), contents#Memory(m)[old_size+10]);
 
     call tmp := Pack_Test3_T(contents#Memory(m)[old_size+9], contents#Memory(m)[old_size+10]);
     m := Memory(domain#Memory(m)[11+old_size := true], contents#Memory(m)[11+old_size := tmp]);
@@ -240,7 +227,7 @@ procedure {:inline 1} Test3_test3 (arg0: Value) returns ()
     m := Memory(domain#Memory(m)[13+old_size := true], contents#Memory(m)[13+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 13];
-if (!b#Boolean(tmp)) { goto Label_12; }
+    if (!b#Boolean(tmp)) { goto Label_12; }
 
     call t14 := CopyOrMoveRef(t2);
 
@@ -272,7 +259,7 @@ Label_15:
     m := Memory(domain#Memory(m)[21+old_size := true], contents#Memory(m)[21+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 21];
-if (!b#Boolean(tmp)) { goto Label_25; }
+    if (!b#Boolean(tmp)) { goto Label_25; }
 
     call t22 := CopyOrMoveRef(t2);
 
@@ -312,7 +299,7 @@ Label_28:
     call t32 := CopyOrMoveRef(t5);
 
     call tmp := ReadRef(t32);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[33+old_size := true], contents#Memory(m)[33+old_size := tmp]);
 
@@ -322,7 +309,7 @@ Label_28:
     call t34 := CopyOrMoveRef(t6);
 
     call tmp := ReadRef(t34);
-    assume is#Integer(tmp);
+    assume has_type(IntegerType(), tmp);
 
     m := Memory(domain#Memory(m)[35+old_size := true], contents#Memory(m)[35+old_size := tmp]);
 
@@ -333,7 +320,7 @@ Label_28:
     m := Memory(domain#Memory(m)[36+old_size := true], contents#Memory(m)[36+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 36];
-if (!b#Boolean(tmp)) { goto Label_60; }
+    if (!b#Boolean(tmp)) { goto Label_60; }
 
     call tmp := CopyOrMoveValue(contents#Memory(m)[old_size+7]);
     m := Memory(domain#Memory(m)[37+old_size := true], contents#Memory(m)[37+old_size := tmp]);
@@ -341,14 +328,14 @@ if (!b#Boolean(tmp)) { goto Label_60; }
     call tmp := LdConst(10);
     m := Memory(domain#Memory(m)[38+old_size := true], contents#Memory(m)[38+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+37], contents#Memory(m)[old_size+38]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+37], contents#Memory(m)[old_size+38]));
     m := Memory(domain#Memory(m)[39+old_size := true], contents#Memory(m)[39+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+39]);
     m := Memory(domain#Memory(m)[40+old_size := true], contents#Memory(m)[40+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 40];
-if (!b#Boolean(tmp)) { goto Label_52; }
+    if (!b#Boolean(tmp)) { goto Label_52; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[41+old_size := true], contents#Memory(m)[41+old_size := tmp]);
@@ -362,14 +349,14 @@ Label_52:
     call tmp := LdConst(20);
     m := Memory(domain#Memory(m)[43+old_size := true], contents#Memory(m)[43+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+42], contents#Memory(m)[old_size+43]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+42], contents#Memory(m)[old_size+43]));
     m := Memory(domain#Memory(m)[44+old_size := true], contents#Memory(m)[44+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+44]);
     m := Memory(domain#Memory(m)[45+old_size := true], contents#Memory(m)[45+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 45];
-if (!b#Boolean(tmp)) { goto Label_59; }
+    if (!b#Boolean(tmp)) { goto Label_59; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[46+old_size := true], contents#Memory(m)[46+old_size := tmp]);
@@ -386,14 +373,14 @@ Label_60:
     call tmp := LdConst(20);
     m := Memory(domain#Memory(m)[48+old_size := true], contents#Memory(m)[48+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+47], contents#Memory(m)[old_size+48]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+47], contents#Memory(m)[old_size+48]));
     m := Memory(domain#Memory(m)[49+old_size := true], contents#Memory(m)[49+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+49]);
     m := Memory(domain#Memory(m)[50+old_size := true], contents#Memory(m)[50+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 50];
-if (!b#Boolean(tmp)) { goto Label_67; }
+    if (!b#Boolean(tmp)) { goto Label_67; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[51+old_size := true], contents#Memory(m)[51+old_size := tmp]);
@@ -407,14 +394,14 @@ Label_67:
     call tmp := LdConst(10);
     m := Memory(domain#Memory(m)[53+old_size := true], contents#Memory(m)[53+old_size := tmp]);
 
-    call tmp := Eq(contents#Memory(m)[old_size+52], contents#Memory(m)[old_size+53]);
+    tmp := Boolean(is_equal(IntegerType(), contents#Memory(m)[old_size+52], contents#Memory(m)[old_size+53]));
     m := Memory(domain#Memory(m)[54+old_size := true], contents#Memory(m)[54+old_size := tmp]);
 
     call tmp := Not(contents#Memory(m)[old_size+54]);
     m := Memory(domain#Memory(m)[55+old_size := true], contents#Memory(m)[55+old_size := tmp]);
 
     tmp := contents#Memory(m)[old_size + 55];
-if (!b#Boolean(tmp)) { goto Label_74; }
+    if (!b#Boolean(tmp)) { goto Label_74; }
 
     call tmp := LdConst(42);
     m := Memory(domain#Memory(m)[56+old_size := true], contents#Memory(m)[56+old_size := tmp]);

--- a/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
@@ -56,3 +56,11 @@ fn test_lib() {
         &[], // empty here means include all deps in output
     ));
 }
+
+#[test]
+fn test_generics() {
+    run_boogie(&generate_boogie(
+        "test_mvir/test-generics.mvir",
+        &["TestGenerics"],
+    ));
+}


### PR DESCRIPTION
#  Motivation

The bytecode-to-boogie translator until now did not support generics in its encoding. First class support for generics, implying types as values, is needed for two purposes:

1. To support resource storage operations like `move_to_sender<T>(...)`.
2. To support certain built-in operations like equality on values which depend on generic types. E.g.
     currently it is allowed in MoveIR to write 
    ```
    public eq<T: unrestricted>(x: T, y: T): bool {
      let r: bool;
      r = move(x) == move(y);
      return r;
    }
    ```

This PR adds supports for first class generics. The design is roughly as follows:

- We introduce a boogie datatype `TypeValue` which represents a type. 
- The type comes with two axiomatized functions `has_type(tv, v)` and `is_equal(tv, v1, v2)` which
   work for every type and value. 
- Each generated method gets passed additional parameters `tv0: TypeValue, tv1: TypeValue, ...` 
   depending on the number of type parameters it takes. (This includes special struct functions
   pack/unpack). In each call, we pass the actual type parameters, which might in turn be
   based on type parameters from the context.

This approach exploits the parametric type discipline of MoveIR by avoiding to store any runtime type information in values. Instead, we have the full runtime type information, if needed, available via automatically added method parameters.

There are a few technical changes coming with this:

- In order to efficiently quantify vector and struct ranges, we directly use ints as keys  instead
  of the Edge type. This allows us to specify a range `i where i >=0 && i < n` with `n` the bound
  is all we need to store in a term. Supposedly this will work easier for Z3 to reason about this stuff,
  but it is not yet backed by evidence.
- Consequently, `Map` was renamed to `Struct` with `v#Struct(s) : [FieldName]Value`, where `FieldName` is an int contiguously assigned.
- Equality is now handled generically, so the type specific `Eq_X` implementations in prelude
   and translator have been removed. I mostly made the above changes to the encoding to gain
   confidence that a generic implementation of equality w.r.t. a certain type can be very
   efficient.

For a review, I suggest to start with the example in `test_mvir/test-generics.mvir` and 
the generated output in `tests/goldenfiles/test-generics.bpl`.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

Added new test `test-generics`. Regenerated and reviewed golden files for all other tests (including
standard library), and ensured they all compile under boogie.

## Related PRs

NA
