### PR TITLE
Forbid unsafe code throughout the codebase, with a few exceptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,7 +2244,6 @@ dependencies = [
  "network 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0",
  "storage-client 0.1.0",
  "storage-service 0.1.0",

--- a/admission_control/admission-control-proto/src/lib.rs
+++ b/admission_control/admission-control-proto/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod proto;
 
 use failure::prelude::*;

--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 

--- a/admission_control/admission-control-service/src/lib.rs
+++ b/admission_control/admission-control-service/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-
 #![deny(missing_docs)]
 #![recursion_limit = "1024"]
 

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use admission_control_proto::proto::{
     admission_control::AdmissionControlClient,
     admission_control::SubmitTransactionResponse as ProtoSubmitTransactionResponse,

--- a/client/libra_wallet/src/lib.rs
+++ b/client/libra_wallet/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 /// Error crate
 pub mod error;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #![deny(missing_docs)]
 //! Libra Client
 //!

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-
 #![deny(missing_docs)]
+
 //! Libra Client
 //!
 //! Client (binary) is the CLI tool to interact with Libra validator.
 //! It supposes all public APIs.
+
 pub use libra_crypto::{ed25519::*, test_utils::KeyPair, traits::ValidKeyStringExt};
 pub use libra_types::{
     account_address::AccountAddress,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use chrono::prelude::{SecondsFormat, Utc};
 use client::{client_proxy::ClientProxy, commands::*};
 use libra_logger::set_default_global_logger;

--- a/common/bounded-executor/src/lib.rs
+++ b/common/bounded-executor/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! A bounded tokio [`TaskExecutor`]. Only a bounded number of tasks can run
 //! concurrently when spawned through this executor, defined by the initial
 //! `capacity`.

--- a/common/channel/src/lib.rs
+++ b/common/channel/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Provides an mpsc (multi-producer single-consumer) channel wrapped in an
 //! [`IntGauge`](libra_metrics::IntGauge)
 

--- a/common/crash-handler/src/lib.rs
+++ b/common/crash-handler/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use backtrace::Backtrace;
 use libra_logger::prelude::*;
 use serde::Serialize;

--- a/common/datatest-stable/src/lib.rs
+++ b/common/datatest-stable/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! `datatest-stable` is a very simple test harness intended to meet some of the needs provided by
 //! the `datatest` crate when using a stable rust compiler without using the `RUSTC_BOOTSTRAP` hack
 //! to use nightly features on the stable track.

--- a/common/debug-interface/src/lib.rs
+++ b/common/debug-interface/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::proto::{GetNodeDetailsRequest, NodeDebugInterfaceClient};
 use failure::prelude::*;
 use grpcio::{ChannelBuilder, EnvBuilder};

--- a/common/executable-helpers/src/lib.rs
+++ b/common/executable-helpers/src/lib.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod helpers;

--- a/common/failure-ext/failure-macros/src/lib.rs
+++ b/common/failure-ext/failure-macros/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Collection of convenience macros for error handling
 
 /// Exits a function early with an `Error`.

--- a/common/failure-ext/src/lib.rs
+++ b/common/failure-ext/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! A common error handling library for the Libra project.
 //!
 //! ## Usage

--- a/common/futures-semaphore/src/lib.rs
+++ b/common/futures-semaphore/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! `Semaphore` holds a set of permits. Permits are used to synchronize access
 //! to a shared resource. Before accessing the shared resource, callers must
 //! acquire a permit from the semaphore. Once the permit is acquired, the caller

--- a/common/grpc-helpers/src/lib.rs
+++ b/common/grpc-helpers/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::{prelude::*, Result};
 use futures::{compat::Future01CompatExt, future::Future, prelude::*};
 use futures_01::future::Future as Future01;

--- a/common/lcs/src/lib.rs
+++ b/common/lcs/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! # Libra Canonical Serialization (LCS)
 //!
 //! LCS defines a deterministic means for translating a message or data structure into bytes

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! A default logger for Libra project.
 //!
 //! ## Usage

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-
 #![recursion_limit = "128"]
 
 #[macro_use]

--- a/common/nibble/src/lib.rs
+++ b/common/nibble/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! `Nibble` represents a four-bit unsigned integer.
 
 #[cfg(feature = "fuzzing")]

--- a/common/proptest-helpers/src/lib.rs
+++ b/common/proptest-helpers/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #[cfg(test)]
 mod unit_tests;
 

--- a/common/prost-ext/src/lib.rs
+++ b/common/prost-ext/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use bytes::{Bytes, BytesMut};
 use prost::{EncodeError, Message};
 

--- a/common/tools/src/lib.rs
+++ b/common/tools/src/lib.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod tempdir;

--- a/common/util/src/lib.rs
+++ b/common/util/src/lib.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod retry;

--- a/config/config-builder/src/bin/libra-config.rs
+++ b/config/config-builder/src/bin/libra-config.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use config_builder::swarm_config::SwarmConfigBuilder;
 use libra_config::config::RoleType;
 use std::convert::TryInto;

--- a/config/config-builder/src/lib.rs
+++ b/config/config-builder/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod swarm_config;
 pub mod util;

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::prelude::*;
 use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_tools::tempdir::TempPath;

--- a/config/generate-keypair/src/main.rs
+++ b/config/generate-keypair/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use generate_keypair::create_faucet_key_file;
 use structopt::StructOpt;
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod config;
 pub mod keys;
 pub mod seed_peers;

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod accumulator_extension_proof;
 pub mod block;
 pub mod block_data;

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 mod persistent_storage;
 mod safety_rules;
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Consensus for the Libra Core blockchain
 //!
 //! Encapsulates public consensus traits and any implementations of those traits.

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! # Derive macros for crypto operations
 //! This crate contains four types of derive macros:
 //!
@@ -93,6 +95,8 @@
 //!     BLS(BLS12381Signature),
 //! }
 //! ```
+
+#![forbid(unsafe_code)]
 
 extern crate proc_macro;
 

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-
-//! A library supplying various cryptographic primitives
-
-#![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+//! A library supplying various cryptographic primitives
 
 pub mod bls12381;
 pub mod ed25519;

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -1,8 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! A library supplying various cryptographic primitives
+
+#![forbid(unsafe_code)]
 #![deny(missing_docs)]
+
 
 pub mod bls12381;
 pub mod ed25519;

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
 #![allow(dead_code)]
 
 mod block_processor;

--- a/language/benchmarks/src/lib.rs
+++ b/language/benchmarks/src/lib.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod transactions;

--- a/language/borrow-graph/src/lib.rs
+++ b/language/borrow-graph/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod graph;
 mod paths;
 pub mod references;

--- a/language/bytecode-verifier/bytecode_verifier_tests/src/lib.rs
+++ b/language/bytecode-verifier/bytecode_verifier_tests/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #[cfg(test)]
 pub mod unit_tests;

--- a/language/bytecode-verifier/invalid-mutations/src/lib.rs
+++ b/language/bytecode-verifier/invalid-mutations/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod bounds;
 pub mod signature;

--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Verifies bytecode sanity.
 
 // Bounds checks are implemented in the `vm` crate.

--- a/language/compiler/bytecode-source-map/src/lib.rs
+++ b/language/compiler/bytecode-source-map/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod disassembler;
 pub mod mapping;
 pub mod marking;

--- a/language/compiler/bytecode-source-map/src/main.rs
+++ b/language/compiler/bytecode-source-map/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use bytecode_source_map::disassembler::{Disassembler, DisassemblerOptions};
 use bytecode_source_map::mapping::SourceMapping;
 use bytecode_source_map::source_map::ModuleSourceMap;

--- a/language/compiler/ir-to-bytecode/src/lib.rs
+++ b/language/compiler/ir-to-bytecode/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 extern crate log;
 
 pub mod compiler;

--- a/language/compiler/ir-to-bytecode/syntax/src/lib.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! # Grammar
 //! ## Identifiers
 //! ```text

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod util;
 
 #[cfg(test)]

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use bytecode_verifier::{
     verifier::{verify_module_dependencies, VerifiedProgram},
     VerifiedModule,

--- a/language/e2e-tests/src/lib.rs
+++ b/language/e2e-tests/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Test infrastructure for the Libra VM.
 //!
 //! This crate contains helpers for executing tests against the Libra VM.

--- a/language/functional_tests/src/lib.rs
+++ b/language/functional_tests/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #[macro_use]
 extern crate lazy_static;
 

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use move_lang::command_line::{self as cli};
 use move_lang::shared::*;
 use structopt::*;

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use move_lang::command_line::{self as cli};
 use move_lang::shared::*;
 use structopt::*;

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #[macro_use]
 pub mod shared;
 

--- a/language/move-prover/bytecode-to-boogie/src/lib.rs
+++ b/language/move-prover/bytecode-to-boogie/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Translates bytecode to Boogie.
 
 pub mod bytecode_function_generator;

--- a/language/move-prover/bytecode-to-boogie/src/main.rs
+++ b/language/move-prover/bytecode-to-boogie/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use bytecode_source_map::source_map::SourceMap;
 use bytecode_to_boogie::translator::BoogieTranslator;
 use bytecode_verifier::VerifiedModule;

--- a/language/move-prover/stackless-bytecode-generator/src/lib.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod stdlib;
 pub mod transaction_scripts;
 

--- a/language/tools/cost-synthesis/src/lib.rs
+++ b/language/tools/cost-synthesis/src/lib.rs
@@ -3,10 +3,10 @@
 
 #![forbid(unsafe_code)]
 
-pub mod module_generator;
 mod bytecode_specifications;
 mod common;
 pub mod global_state;
+pub mod module_generator;
 pub mod natives;
 pub mod stack_generator;
 pub mod vm_runner;

--- a/language/tools/cost-synthesis/src/lib.rs
+++ b/language/tools/cost-synthesis/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-#[macro_use]
 pub mod module_generator;
 mod bytecode_specifications;
 mod common;

--- a/language/tools/cost-synthesis/src/lib.rs
+++ b/language/tools/cost-synthesis/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[macro_use]
+#![forbid(unsafe_code)]
 
+#[macro_use]
 pub mod module_generator;
 mod bytecode_specifications;
 mod common;

--- a/language/tools/cost-synthesis/src/main.rs
+++ b/language/tools/cost-synthesis/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This performs instruction cost synthesis for the various bytecode instructions that we have. We
 //! separate instructions into three sets:
 //! * Global-memory independent instructions;

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod abstract_state;
 pub mod borrow_graph;
 pub mod bytecode_generator;

--- a/language/tools/test-generation/src/main.rs
+++ b/language/tools/test-generation/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use structopt::StructOpt;
 use test_generation::{config::Args, run_generation};
 

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -1,5 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
 use ir_to_bytecode::{compiler::compile_program, parser::ast};
 use lazy_static::lazy_static;
 use libra_config::config::{VMConfig, VMPublishingOption};

--- a/language/vm/serializer_tests/src/lib.rs
+++ b/language/vm/serializer_tests/src/lib.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 // Empty src/lib.rs to get rusty-tags working.

--- a/language/vm/src/access.rs
+++ b/language/vm/src/access.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Defines accessors for compiled modules.
 
 use crate::{

--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     errors::{append_err_info, bounds_error, bytecode_offset_err, verification_error},
     file_format::{

--- a/language/vm/src/deserializer.rs
+++ b/language/vm/src/deserializer.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{errors::*, file_format::*, file_format_common::*, vm_string::VMString};
 use byteorder::{LittleEndian, ReadBytesExt};
 use libra_types::{

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::IndexKind;
 use libra_types::{
     account_address::AccountAddress,

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Binary format for transactions and modules.
 //!
 //! This module provides a simple Rust abstraction over the binary format. That is the format of

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Constants for the binary format.
 //!
 //! Definition for the constants of the binary format, used by the serializer and the deserializer.

--- a/language/vm/src/foreign_contracts.rs
+++ b/language/vm/src/foreign_contracts.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This file contains models of the vm crate's dependencies for use with MIRAI.
 
 pub mod types {

--- a/language/vm/src/gas_schedule.rs
+++ b/language/vm/src/gas_schedule.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module lays out the basic abstract costing schedule for bytecode instructions.
 //!
 //! It is important to note that the cost schedule defined in this file does not track hashing

--- a/language/vm/src/internals.rs
+++ b/language/vm/src/internals.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Types meant for use by other parts of this crate, and by other crates that are designed to
 //! work with the internals of these data structures.
 

--- a/language/vm/src/printers.rs
+++ b/language/vm/src/printers.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{file_format::*, vm_string::VMStr};
 use failure::*;
 use hex;

--- a/language/vm/src/proptest_types.rs
+++ b/language/vm/src/proptest_types.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Utilities for property-based testing.
 
 use crate::{

--- a/language/vm/src/resolver.rs
+++ b/language/vm/src/resolver.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module implements a resolver for importing a SignatureToken defined in one module into
 //! another. This functionaliy is used in verify_module_dependencies and verify_script_dependencies.
 use crate::{

--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Serialization of transactions and modules.
 //!
 //! This module exposes two entry points for serialization of `CompiledScript` and

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
 use libra_crypto::ed25519::{compat, Ed25519PublicKey};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};

--- a/language/vm/src/views.rs
+++ b/language/vm/src/views.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! An alternate representation of the file format built on top of the existing format.
 //!
 //! Some general notes:

--- a/language/vm/vm-genesis/src/lib.rs
+++ b/language/vm/vm-genesis/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::prelude::*;
 use lazy_static::lazy_static;
 use libra_crypto::{ed25519::*, traits::ValidKey};

--- a/language/vm/vm-genesis/src/main.rs
+++ b/language/vm/vm-genesis/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use libra_config::{config::PersistableConfig, trusted_peers::ConfigHelpers};
 use libra_prost_ext::MessageExt;
 use std::{fs::File, io::prelude::*};

--- a/language/vm/vm-runtime/src/lib.rs
+++ b/language/vm/vm-runtime/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! # The VM runtime
 //!
 //! ## Transaction flow

--- a/language/vm/vm-runtime/vm-cache-map/src/cache_map.rs
+++ b/language/vm/vm-runtime/vm-cache-map/src/cache_map.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::Arena;
 use chashmap::CHashMap;
 use std::{borrow::Borrow, hash::Hash};

--- a/language/vm/vm-runtime/vm-runtime-types/src/lib.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Types and data used by the VM runtime
 
 #[macro_use]

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -14,7 +14,6 @@ grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 parity-multiaddr = "0.5.0"
 rayon = "1.2.0"
-signal-hook = "0.1.10"
 structopt = "0.3.2"
 tokio = "=0.2.0-alpha.6"
 

--- a/libra-node/src/lib.rs
+++ b/libra-node/src/lib.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod main_node;

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -1,8 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use executable_helpers::helpers::setup_executable;
-use signal_hook;
 use std::{
     path::PathBuf,
     sync::{
@@ -26,24 +27,6 @@ struct Args {
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-fn register_signals(term: Arc<AtomicBool>) {
-    for signal in &[
-        signal_hook::SIGTERM,
-        signal_hook::SIGINT,
-        signal_hook::SIGHUP,
-    ] {
-        let term_clone = Arc::clone(&term);
-        let thread = std::thread::current();
-        unsafe {
-            signal_hook::register(*signal, move || {
-                term_clone.store(true, Ordering::Release);
-                thread.unpark();
-            })
-            .expect("failed to register signal handler");
-        }
-    }
-}
-
 fn main() {
     let args = Args::from_args();
 
@@ -53,7 +36,6 @@ fn main() {
     let _node_handle = libra_node::main_node::setup_environment(&mut config);
 
     let term = Arc::new(AtomicBool::new(false));
-    register_signals(Arc::clone(&term));
 
     while !term.load(Ordering::Acquire) {
         std::thread::park();

--- a/libra-swarm/src/lib.rs
+++ b/libra-swarm/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod client;
 pub mod swarm;
 pub mod utils;

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use libra_config::config::{NodeConfig, RoleType};
 use libra_swarm::{client, swarm::LibraSwarm};
 use libra_tools::tempdir::TempPath;

--- a/mempool/mempool-shared-proto/src/lib.rs
+++ b/mempool/mempool-shared-proto/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Proto crate for shared mempool
 
 pub mod proto;

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #![deny(missing_docs)]
 //! Mempool is used to hold transactions that have been submitted but not yet agreed upon and
 //! executed.

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-
 #![deny(missing_docs)]
+
 //! Mempool is used to hold transactions that have been submitted but not yet agreed upon and
 //! executed.
 //!
@@ -53,6 +53,7 @@
 //! checked periodically in the background, while the client-specified expiration is checked on
 //! every Consensus commit request. We use a separate system TTL to ensure that a transaction won't
 //! remain stuck in Mempool forever, even if Consensus doesn't make progress
+
 pub mod proto;
 pub use runtime::MempoolRuntime;
 

--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use futures::{
     future::Future,
     io::{AsyncRead, AsyncWrite},

--- a/network/socket-bench-server/src/main.rs
+++ b/network/socket-bench-server/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Standalone server for socket_muxer_bench
 //! ========================================
 //!

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -1,5 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
 //! Used to perform catching up between nodes for committed states.
 //! Used for node restarts, network partitions, full node syncs
 #![recursion_limit = "1024"]

--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module provides algorithms for accessing and updating a Merkle Accumulator structure
 //! persisted in a key-value store. Note that this doesn't write to the storage directly, rather,
 //! it reads from it via the `HashReader` trait and yields writes via an in memory `HashMap`.

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module implements [`JellyfishMerkleTree`] backed by storage module. The tree itself doesn't
 //! persist anything, but realizes the logic of R/W only. The write path will produce all the
 //! intermediate results in a batch for storage layer to commit and the read path will return

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This crate provides [`LibraDB`] which represents physical storage of the core Libra data
 //! structures.
 //!

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This library implements a schematized DB on top of [RocksDB](https://rocksdb.org/). It makes
 //! sure all data passed in and out are structured according to predefined schemas and prevents
 //! access to raw keys and values. This library also enforces a set of Libra specific DB options,

--- a/storage/state-view/src/lib.rs
+++ b/storage/state-view/src/lib.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This crate defines [`trait StateView`](StateView).
+
+#![forbid(unsafe_code)]
 
 use failure::prelude::*;
 use libra_types::access_path::AccessPath;

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This crate implements a client library for storage that wraps the protobuf storage client. The
 //! main motivation is to hide storage implementation details. For example, if we later want to
 //! expand state store to multiple machines and enable sharding, we only need to tweak the client

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This crate provides Protocol Buffers definitions for the services provided by the
 //! [`storage_service`](../storage_service/index.html) crate.
 //!

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This crate implements the storage [GRPC](http://grpc.io) service.
 //!
 //! The user of storage service is supposed to use it via client lib provided in

--- a/storage/storage-service/src/main.rs
+++ b/storage/storage-service/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use debug_interface::{node_debug_service::NodeDebugService, proto::create_node_debug_interface};
 use executable_helpers::helpers::setup_executable;
 use failure::prelude::*;

--- a/testsuite/cluster-test/src/aws.rs
+++ b/testsuite/cluster-test/src/aws.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use rusoto_core::Region;
 use rusoto_ec2::Ec2Client;
 use rusoto_ecr::EcrClient;

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{aws::Aws, instance::Instance};
 use failure::{self, prelude::*};
 use libra_config::config::AdmissionControlConfig;

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{aws::Aws, cluster::Cluster};
 use failure::prelude::{bail, format_err};
 use rusoto_core::RusotoError;

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 mod network_delay;
 mod packet_loss;
 mod reboot;

--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::effects::Effect;
 /// NetworkDelay introduces network delay from a given instance to a provided list of instances
 /// If no instances are provided, network delay is introduced on all outgoing packets

--- a/testsuite/cluster-test/src/effects/packet_loss.rs
+++ b/testsuite/cluster-test/src/effects/packet_loss.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 /// PacketLoss introduces a given percentage of PacketLoss for a given instance
 use crate::{effects::Action, instance::Instance};
 use failure;

--- a/testsuite/cluster-test/src/effects/reboot.rs
+++ b/testsuite/cluster-test/src/effects/reboot.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{effects::Action, instance::Instance};
 use failure;
 use slog_scope::info;

--- a/testsuite/cluster-test/src/effects/remove_network_effects.rs
+++ b/testsuite/cluster-test/src/effects/remove_network_effects.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 /// RemoveNetworkEffect deletes all network effects introduced on an instance
 use crate::{effects::Action, instance::Instance};
 use failure;

--- a/testsuite/cluster-test/src/effects/stop_container.rs
+++ b/testsuite/cluster-test/src/effects/stop_container.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{effects::Effect, instance::Instance};
 use failure;
 use std::fmt;

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 mod multi_region_network_simulation;
 mod packet_loss_random_validators;
 mod reboot_random_validator;

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 /// This module provides an experiment which simulates a multi-region environment.
 /// It undoes the simulation in the cluster after the given duration
 use crate::effects::Effect;

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 /// This module provides an experiment which introduces packet loss for
 /// a given number of instances in the cluster. It undoes the packet loss
 /// in the cluster after the given duration

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     cluster::Cluster,
     effects::{Action, Reboot},

--- a/testsuite/cluster-test/src/github.rs
+++ b/testsuite/cluster-test/src/github.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::{self, prelude::format_err};
 use reqwest::Url;
 use serde::Deserialize;

--- a/testsuite/cluster-test/src/health/commit_check.rs
+++ b/testsuite/cluster-test/src/health/commit_check.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::health::{Event, HealthCheck, HealthCheckContext, ValidatorEvent};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     cluster::Cluster,
     health::{Commit, Event, LogTail, ValidatorEvent},

--- a/testsuite/cluster-test/src/health/liveness_check.rs
+++ b/testsuite/cluster-test/src/health/liveness_check.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     cluster::Cluster,
     health::{Event, HealthCheck, HealthCheckContext, ValidatorEvent},

--- a/testsuite/cluster-test/src/health/log_tail.rs
+++ b/testsuite/cluster-test/src/health/log_tail.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{health::ValidatorEvent, util::unix_timestamp_now};
 use slog_scope::*;
 use std::{

--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 mod commit_check;
 mod debug_interface_log_tail;
 mod liveness_check;

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::{self, prelude::*};
 use std::{
     ffi::OsStr,

--- a/testsuite/cluster-test/src/prometheus.rs
+++ b/testsuite/cluster-test/src/prometheus.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::{
     self,
     prelude::{bail, format_err},

--- a/testsuite/cluster-test/src/slack.rs
+++ b/testsuite/cluster-test/src/slack.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use failure::{
     self,
     prelude::{bail, format_err},

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     cluster::Cluster,
     experiments::{Experiment, RebootRandomValidators},

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{cluster::Cluster, instance::Instance};
 use admission_control_proto::proto::admission_control::{
     AdmissionControlClient, SubmitTransactionRequest,

--- a/testsuite/tests/libratest/main.rs
+++ b/testsuite/tests/libratest/main.rs
@@ -1,4 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 mod smoke_test;

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! Suppose we have the following data structure in a smart contract:
 //!
 //! struct B {

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use bech32::{Bech32, FromBase32, ToBase32};
 use bytes::Bytes;
 use failure::prelude::*;

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,

--- a/types/src/account_state_blob/account_state_blob_test.rs
+++ b/types/src/account_state_blob/account_state_blob_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use super::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::collection::vec;

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #[cfg(any(test, feature = "fuzzing"))]
 use crate::account_config::{account_resource_path, AccountResource};
 use crate::{

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{transaction::Version, validator_set::ValidatorSet};
 use libra_crypto::hash::HashValue;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::account_address::AccountAddress;
 use crate::byte_array::ByteArray;
 use failure::prelude::*;

--- a/types/src/byte_array.rs
+++ b/types/src/byte_array.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use hex;
 use serde::{Deserialize, Serialize};
 

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     account_config::AccountEvent, event::EventKey, language_storage::TypeTag,
     ledger_info::LedgerInfo, proof::EventProof, transaction::Version,

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module defines a data structure made to contain a cryptographic
 //! signature, in the sense of an implementation of
 //! libra_crypto::traits::Signature. The container is an opaque NewType that

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::account_address::AccountAddress;
 use failure::prelude::*;
 use hex;

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::block_info::{BlockInfo, Round};
 use crate::{
     account_address::AccountAddress,

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use super::InMemoryAccumulator;
 use crate::proof::{
     definition::LeafCount,

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module implements an in-memory Merkle Accumulator that is similar to what we use in
 //! storage. This accumulator will only store a small portion of the tree -- for any subtree that
 //! is full, we store only the root. Also we only store the frozen nodes, therefore this structure

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module has definition of various proofs.
 
 #[cfg(test)]

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod accumulator;
 pub mod definition;
 pub mod position;

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! This module provides an abstraction for positioning a node in a binary tree,
 //! A `Position` uniquely identifies the location of a node
 //!

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::proof::position::*;
 
 /// Position is marked with in-order-traversal sequence.

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! All proofs generated in this module are not valid proofs. They are only for the purpose of
 //! testing conversion between Rust and Protobuf.
 

--- a/types/src/proof/unit_tests/proof_proto_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::proof::{
     AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
     TestAccumulatorProof, TestAccumulatorRangeProof, TransactionListProof, TransactionProof,

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::block_info::BlockInfo;
 use crate::{
     account_address::AccountAddress,

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1,5 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
 use crate::block_info::{BlockInfo, Round};
 use crate::event::EVENT_KEY_LENGTH;
 use crate::transaction::{ChangeSet, Transaction};

--- a/types/src/proto/mod.rs
+++ b/types/src/proto/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #![allow(bare_trait_objects)]
 
 #[allow(clippy::large_enum_variant)]

--- a/types/src/test_helpers/mod.rs
+++ b/types/src/test_helpers/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod transaction_test_helpers;
 
 pub fn assert_canonical_encode_decode<T>(t: T)

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     account_address::AccountAddress,
     transaction::{Module, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction},

--- a/types/src/transaction/change_set.rs
+++ b/types/src/transaction/change_set.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{contract_event::ContractEvent, write_set::WriteSet};
 use serde::{Deserialize, Serialize};
 

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     account_address::AccountAddress,
     proto::types::SignedTransaction as ProtoSignedTransaction,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::transaction::transaction_argument::TransactionArgument;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //use crate::errors::*;
 use crate::{account_address::AccountAddress, byte_array::ByteArray};
 use failure::prelude::*;

--- a/types/src/unit_tests/access_path_test.rs
+++ b/types/src/unit_tests/access_path_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/types/src/unit_tests/address_test.rs
+++ b/types/src/unit_tests/address_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
 use bech32::Bech32;
 use hex::FromHex;

--- a/types/src/unit_tests/block_metadata_test.rs
+++ b/types/src/unit_tests/block_metadata_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::block_metadata::BlockMetadata;
 use crate::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/canonical_serialization_examples.rs
+++ b/types/src/unit_tests/canonical_serialization_examples.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! These tests verify the behavior of LCS against some known test vectors with various types.
 
 use crate::transaction::ChangeSet;

--- a/types/src/unit_tests/code_debug_fmt_test.rs
+++ b/types/src/unit_tests/code_debug_fmt_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::transaction::Script;
 use std::fmt;
 

--- a/types/src/unit_tests/contract_event_proto_conversion_test.rs
+++ b/types/src/unit_tests/contract_event_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::contract_event::{ContractEvent, EventWithProof};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
+++ b/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     get_with_proof::{
         RequestItem, ResponseItem, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,

--- a/types/src/unit_tests/identifier_test.rs
+++ b/types/src/unit_tests/identifier_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS};
 use crate::test_helpers::assert_canonical_encode_decode;
 use lazy_static::lazy_static;

--- a/types/src/unit_tests/language_storage_test.rs
+++ b/types/src/unit_tests/language_storage_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::language_storage::ModuleId;
 use crate::test_helpers::assert_canonical_encode_decode;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;

--- a/types/src/unit_tests/ledger_info_proto_conversion_test.rs
+++ b/types/src/unit_tests/ledger_info_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{crypto_proxies::LedgerInfoWithSignatures, ledger_info::LedgerInfo};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/mod.rs
+++ b/types/src/unit_tests/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 mod access_path_test;
 mod address_test;
 mod block_metadata_test;

--- a/types/src/unit_tests/transaction_proto_conversion_test.rs
+++ b/types/src/unit_tests/transaction_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::transaction::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::test_helpers::assert_canonical_encode_decode;
 use crate::{
     account_address::AccountAddress,

--- a/types/src/unit_tests/validator_change_proto_conversion_test.rs
+++ b/types/src/unit_tests/validator_change_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::validator_change::ValidatorChangeEventWithProof;
 use libra_crypto::ed25519::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;

--- a/types/src/unit_tests/validator_set_test.rs
+++ b/types/src/unit_tests/validator_set_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::test_helpers::assert_canonical_encode_decode;
 use crate::validator_set::ValidatorSet;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;

--- a/types/src/unit_tests/vm_error_proto_conversion_test.rs
+++ b/types/src/unit_tests/vm_error_proto_conversion_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::vm_error::{StatusCode, VMStatus};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use std::convert::TryFrom;

--- a/types/src/unit_tests/write_set_test.rs
+++ b/types/src/unit_tests/write_set_test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::test_helpers::assert_canonical_encode_decode;
 use crate::write_set::WriteSet;
 use proptest::prelude::*;

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::crypto_proxies::ValidatorVerifier;
 use crate::ledger_info::LedgerInfoWithSignatures;
 use failure::*;

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::account_address::AccountAddress;
 use failure::Result;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::{
     access_path::{AccessPath, Accesses},
     account_config,

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
 use failure::Error;
 use libra_crypto::{test_utils::TEST_SEED, HashValue, *};

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use crate::account_address::AccountAddress;
 use crate::validator_set::ValidatorSet;
 use failure::prelude::*;

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #![allow(clippy::unit_arg)]
 
 use failure::prelude::*;

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 //! For each transaction the VM executes, the VM will output a `WriteSet` that contains each access
 //! path it updates. For each access path, the VM can either give its new value or delete it.
 

--- a/vm-validator/src/lib.rs
+++ b/vm-validator/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod mocks;
 pub mod vm_validator;

--- a/x/src/main.rs
+++ b/x/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 use structopt::StructOpt;
 
 mod bench;


### PR DESCRIPTION
One instance of unsafe code was deleted from libra-swarm, crates which use no
unsafe code have top level `#![forbid(unsafe_code)]`, and crates which use
unsafe code now forbid unsafe code in all other files.
