### PR TITLE
[network] Change protocol format to align with layering

### DIFF
--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -18,7 +18,7 @@
 //! 3. The actual structure of the wire messages is left for higher layers to specify. The
 //!    DirectSend protocol is only concerned with shipping around opaque blobs. Current libra
 //!    DirectSend clients (consensus, mempool) mostly send protobuf enums around over a single
-//!    DirectSend protocol, e.g., `/libra/consensus/direct_send/0.1.0`.
+//!    DirectSend protocol, e.g., `/libra/direct_send/0.1.0/consensus/0.1.0`.
 //!
 //! ## Wire Protocol (dialer):
 //!
@@ -26,7 +26,7 @@
 //!
 //! 1. Requests a new outbound substream from the muxer.
 //! 2. Negotiates the substream using [`protocol-select`] to the protocol they
-//!    wish to speak, e.g., `/libra/mempool/direct_send/0.1.0`.
+//!    wish to speak, e.g., `/libra/direct_send/0.1.0/mempool/0.1.0`.
 //! 3. Sends the serialized message on the newly negotiated substream.
 //! 4. Drops the substream.
 //!

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -32,7 +32,7 @@ const MAX_SMALL_MSG_BYTES: usize = 32;
 const MAX_MEDIUM_MSG_BYTES: usize = 280;
 
 const MOCK_PEER_ID: PeerId = PeerId::new([0u8; ADDRESS_LENGTH]);
-const MOCK_PROTOCOL_ID: &[u8] = b"/libra/consensus/rpc/1.2.3";
+const MOCK_PROTOCOL_ID: &[u8] = b"/libra/rpc/1.2.3/consensus/1.2.3";
 const INBOUND_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[test]

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -21,7 +21,7 @@
 //!    higher layers to specify. The rpc protocol is only concerned with shipping
 //!    around opaque blobs. Current libra rpc clients (consensus, mempool) mostly
 //!    send protobuf enums around over a single rpc protocol,
-//!    e.g., `/libra/consensus/rpc/0.1.0`.
+//!    e.g., `/libra/rpc/0.1.0/consensus/0.1.0`.
 //!
 //! ## Wire Protocol (dialer):
 //!
@@ -29,7 +29,7 @@
 //!
 //! 1. Requests a new outbound substream from the muxer.
 //! 2. Negotiates the substream using [`protocol-select`] to the rpc method they
-//!    wish to call, e.g., `/libra/mempool/rpc/0.1.0`.
+//!    wish to call, e.g., `/libra/rpc/0.1.0/mempool/0.10`.
 //! 3. Sends the serialized request arguments on the newly negotiated substream.
 //! 4. Half-closes their output side.
 //! 5. Awaits the serialized response message from remote.
@@ -97,7 +97,7 @@ pub mod fuzzing;
 /// A wrapper struct for an inbound rpc request and its associated context.
 #[derive(Debug)]
 pub struct InboundRpcRequest {
-    /// Rpc method identifier, e.g., `/libra/consensus/rpc/0.1.0`. This is used
+    /// Rpc method identifier, e.g., `/libra/rpc/0.1.0/consensus/0.1.0`. This is used
     /// to dispatch the request to the corresponding client handler.
     pub protocol: ProtocolId,
     /// The serialized request data received from the sender.
@@ -122,7 +122,7 @@ pub struct InboundRpcRequest {
 /// A wrapper struct for an outbound rpc request and its associated context.
 #[derive(Debug)]
 pub struct OutboundRpcRequest {
-    /// Rpc method identifier, e.g., `/libra/consensus/rpc/0.1.0`. This is the
+    /// Rpc method identifier, e.g., `/libra/rpc/0.1.0/consensus/0.1.0`. This is the
     /// protocol we will negotiate our outbound substream to.
     pub protocol: ProtocolId,
     /// The serialized request data to be sent to the receiver.

--- a/network/src/validator_network/admission_control.rs
+++ b/network/src/validator_network/admission_control.rs
@@ -18,7 +18,7 @@ use libra_types::PeerId;
 use std::time::Duration;
 
 /// Protocol id for admission control RPC calls
-pub const ADMISSION_CONTROL_RPC_PROTOCOL: &[u8] = b"/libra/admission_control/rpc/0.1.0";
+pub const ADMISSION_CONTROL_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/admission_control/0.1.0";
 
 /// The interface from Network to Admission Control layer.
 ///

--- a/network/src/validator_network/consensus.rs
+++ b/network/src/validator_network/consensus.rs
@@ -16,9 +16,9 @@ use libra_types::{validator_public_keys::ValidatorPublicKeys, PeerId};
 use std::time::Duration;
 
 /// Protocol id for consensus RPC calls
-pub const CONSENSUS_RPC_PROTOCOL: &[u8] = b"/libra/consensus/rpc/0.1.0";
+pub const CONSENSUS_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/consensus/0.1.0";
 /// Protocol id for consensus direct-send calls
-pub const CONSENSUS_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/consensus/direct-send/0.1.0";
+pub const CONSENSUS_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/direct-send/0.1.0/consensus/0.1.0";
 
 /// The interface from Network to Consensus layer.
 ///

--- a/network/src/validator_network/discovery.rs
+++ b/network/src/validator_network/discovery.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use libra_types::PeerId;
 
-pub const DISCOVERY_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/discovery/0.1.0";
+pub const DISCOVERY_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/direct-send/0.1.0/discovery/0.1.0";
 
 /// The interface from Network to Discovery module.
 ///

--- a/network/src/validator_network/health_checker.rs
+++ b/network/src/validator_network/health_checker.rs
@@ -16,7 +16,7 @@ use libra_types::PeerId;
 use std::time::Duration;
 
 /// Protocol id for HealthChecker RPC calls
-pub const HEALTH_CHECKER_RPC_PROTOCOL: &[u8] = b"/libra/health-checker/rpc/0.1.0";
+pub const HEALTH_CHECKER_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/health-checker/0.1.0";
 
 /// The interface from Network to HealthChecker layer.
 ///

--- a/network/src/validator_network/mempool.rs
+++ b/network/src/validator_network/mempool.rs
@@ -14,7 +14,7 @@ use channel;
 use libra_types::PeerId;
 
 /// Protocol id for mempool direct-send calls
-pub const MEMPOOL_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/mempool/direct-send/0.1.0";
+pub const MEMPOOL_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/direct-send/0.1.0/mempool/0.1.0";
 
 /// The interface from Network to Mempool layer.
 ///

--- a/network/src/validator_network/state_synchronizer.rs
+++ b/network/src/validator_network/state_synchronizer.rs
@@ -15,7 +15,7 @@ use libra_types::PeerId;
 
 /// Protocol id for state-synchronizer direct-send calls
 pub const STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL: &[u8] =
-    b"/libra/state-synchronizer/direct-send/0.1.0";
+    b"/libra/direct-send/0.1.0/state-synchronizer/0.1.0";
 
 /// The interface from Network to StateSynchronizer layer.
 ///


### PR DESCRIPTION
## Motivation

We want to be able to version network protocols (RPC and direct send) separately from application layer protocols such as consensus, mempool, etc.