### PR TITLE
[network] Split InternalEvent enum in PeerManager

### DIFF
--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -111,8 +111,11 @@ lazy_static::lazy_static! {
     /// Counter of pending Peer Manager notifications to Connectivity Manager
     pub static ref PENDING_PEER_MANAGER_CONNECTIVITY_MANAGER_NOTIFICATIONS: IntGauge = OP_COUNTERS.gauge("pending_peer_manager_connectivity_manager_notifications");
 
-    /// Counter of pending internal events in Peer Manager
-    pub static ref PENDING_PEER_MANAGER_INTERNAL_EVENTS: IntGauge = OP_COUNTERS.gauge("pending_peer_manager_internal_events");
+    /// Counter of pending Peer events to PeerManager.
+    pub static ref PENDING_PEER_NOTIFICATIONS: IntGauge = OP_COUNTERS.gauge("pending_peer_notifications");
+
+    /// Counter of pending Connection Handler notifications to PeerManager.
+    pub static ref PENDING_CONNECTION_HANDLER_NOTIFICATIONS: IntGauge = OP_COUNTERS.gauge("pending_connection_handler_notifications");
 
     /// Counter of pending dial requests in Peer Manager
     pub static ref PENDING_PEER_MANAGER_DIAL_REQUESTS: IntGauge  = OP_COUNTERS.gauge("pending_peer_manager_dial_requests");


### PR DESCRIPTION

## Motivation
Previously, InternalEvents were generated by 2 different actors - Peer    and ConnectionHandler. This is contrary to other actors were events     generated by those actors are named `<X>Notification`, for example,    PeerManagerNotification, etc.

This is the first part among series of changes to split peer manager    into components allowing per-connection LibraNet stack (#1670)