### PR TITLE
[cluster-test] Refactor perf benchmarks in cluster-test into Experiments

### DIFF
--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -9,15 +9,16 @@ mod reboot;
 mod remove_network_effects;
 mod stop_container;
 
+use crate::thread_pool_executor::ThreadPoolExecutor;
 use failure;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;
 pub use reboot::Reboot;
 pub use remove_network_effects::RemoveNetworkEffects;
+use slog_scope::info;
 use std::fmt::Display;
 pub use stop_container::StopContainer;
-
 pub trait Action: Display + Send {
     fn apply(&self) -> failure::Result<()>;
     fn is_complete(&self) -> bool;
@@ -26,4 +27,32 @@ pub trait Action: Display + Send {
 pub trait Effect: Display + Send {
     fn activate(&self) -> failure::Result<()>;
     fn deactivate(&self) -> failure::Result<()>;
+}
+
+pub fn activate_all<T: Effect>(thread_pool_executor: ThreadPoolExecutor, effects: &mut [T]) {
+    let jobs = effects
+        .iter_mut()
+        .map(|effect| {
+            move || {
+                if let Err(e) = effect.activate() {
+                    info!("Failed to activate {}: {:?}", effect, e);
+                }
+            }
+        })
+        .collect();
+    thread_pool_executor.execute_jobs(jobs);
+}
+
+pub fn deactivate_all<T: Effect>(thread_pool_executor: ThreadPoolExecutor, effects: &mut [T]) {
+    let jobs = effects
+        .iter_mut()
+        .map(|effect| {
+            move || {
+                if let Err(e) = effect.deactivate() {
+                    info!("Failed to deactivate {}: {:?}", effect, e);
+                }
+            }
+        })
+        .collect();
+    thread_pool_executor.execute_jobs(jobs);
 }

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,20 +3,51 @@
 
 #![forbid(unsafe_code)]
 
-mod multi_region_network_simulation;
-mod packet_loss_random_validators;
-mod reboot_random_validator;
+use std::time::Duration;
+use std::{collections::HashSet, fmt::Display};
 
 pub use multi_region_network_simulation::{MultiRegionSimulation, MultiRegionSimulationParams};
 pub use packet_loss_random_validators::{
     PacketLossRandomValidators, PacketLossRandomValidatorsParams,
 };
+pub use performance_benchmark_nodes_down::PerformanceBenchmarkNodesDown;
+pub use performance_benchmark_three_region_simulation::PerformanceBenchmarkThreeRegionSimulation;
 pub use reboot_random_validator::RebootRandomValidators;
-use std::time::Duration;
-use std::{collections::HashSet, fmt::Display};
+
+use crate::prometheus::Prometheus;
+use crate::thread_pool_executor::ThreadPoolExecutor;
+use crate::tx_emitter::TxEmitter;
+
+mod multi_region_network_simulation;
+mod packet_loss_random_validators;
+mod performance_benchmark_nodes_down;
+mod performance_benchmark_three_region_simulation;
+mod reboot_random_validator;
 
 pub trait Experiment: Display + Send {
-    fn affected_validators(&self) -> HashSet<String>;
-    fn run(&self) -> failure::Result<()>;
+    fn affected_validators(&self) -> HashSet<String> {
+        HashSet::new()
+    }
+    fn run(&mut self, context: &mut Context) -> failure::Result<Option<String>>;
     fn deadline(&self) -> Duration;
+}
+
+pub struct Context {
+    tx_emitter: TxEmitter,
+    prometheus: Prometheus,
+    thread_pool_executor: ThreadPoolExecutor,
+}
+
+impl Context {
+    pub fn new(
+        tx_emitter: TxEmitter,
+        prometheus: Prometheus,
+        thread_pool_executor: ThreadPoolExecutor,
+    ) -> Self {
+        Context {
+            tx_emitter,
+            prometheus,
+            thread_pool_executor,
+        }
+    }
 }

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -2,19 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
+use std::{fmt, thread, time::Duration};
+
+use slog_scope::{info, warn};
+use structopt::StructOpt;
+
+use failure;
 
 /// This module provides an experiment which simulates a multi-region environment.
 /// It undoes the simulation in the cluster after the given duration
 use crate::effects::Effect;
 use crate::effects::NetworkDelay;
+use crate::experiments::Context;
 use crate::prometheus::Prometheus;
 use crate::tx_emitter::{EmitJobRequest, EmitThreadParams, TxEmitter};
 use crate::util::unix_timestamp_now;
 use crate::{cluster::Cluster, experiments::Experiment, thread_pool_executor::ThreadPoolExecutor};
-use failure;
-use slog_scope::{info, warn};
-use std::{collections::HashSet, fmt, thread, time::Duration};
-use structopt::StructOpt;
 
 #[derive(Default, Debug)]
 struct Metrics {
@@ -198,15 +201,7 @@ fn print_results(metrics: Vec<Metrics>) {
 }
 
 impl Experiment for MultiRegionSimulation {
-    fn affected_validators(&self) -> HashSet<String> {
-        let mut r = HashSet::new();
-        for instance in self.cluster.clone().into_instances() {
-            r.insert(instance.short_hash().clone());
-        }
-        r
-    }
-
-    fn run(&self) -> failure::Result<()> {
+    fn run(&mut self, _context: &mut Context) -> failure::Result<Option<String>> {
         let mut emitter = TxEmitter::new(&self.cluster);
         let mut results = vec![];
         for split in &self.params.splits {
@@ -237,7 +232,7 @@ impl Experiment for MultiRegionSimulation {
             }
         }
         print_results(results);
-        Ok(())
+        Ok(None)
     }
 
     fn deadline(&self) -> Duration {

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -3,6 +3,13 @@
 
 #![forbid(unsafe_code)]
 
+use std::{fmt, thread, time::Duration};
+
+use structopt::StructOpt;
+
+use failure;
+
+use crate::experiments::Context;
 /// This module provides an experiment which introduces packet loss for
 /// a given number of instances in the cluster. It undoes the packet loss
 /// in the cluster after the given duration
@@ -12,9 +19,6 @@ use crate::{
     experiments::Experiment,
     instance::Instance,
 };
-use failure;
-use std::{collections::HashSet, fmt, thread, time::Duration};
-use structopt::StructOpt;
 
 pub struct PacketLossRandomValidators {
     instances: Vec<Instance>,
@@ -61,15 +65,7 @@ impl PacketLossRandomValidators {
 }
 
 impl Experiment for PacketLossRandomValidators {
-    fn affected_validators(&self) -> HashSet<String> {
-        let mut r = HashSet::new();
-        for instance in self.instances.iter() {
-            r.insert(instance.short_hash().clone());
-        }
-        r
-    }
-
-    fn run(&self) -> failure::Result<()> {
+    fn run(&mut self, _context: &mut Context) -> failure::Result<Option<String>> {
         let mut instances = vec![];
         for instance in self.instances.iter() {
             let packet_loss = PacketLoss::new(instance.clone(), self.percent);
@@ -81,7 +77,7 @@ impl Experiment for PacketLossRandomValidators {
             let remove_network_effects = RemoveNetworkEffects::new(instance.clone());
             remove_network_effects.apply()?;
         }
-        Ok(())
+        Ok(None)
     }
 
     fn deadline(&self) -> Duration {

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -1,0 +1,75 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, fmt::Display};
+
+use failure::_core::fmt::{Error, Formatter};
+use failure::_core::time::Duration;
+
+use crate::cluster::Cluster;
+use crate::effects::StopContainer;
+use crate::experiments::Context;
+use crate::experiments::Experiment;
+use crate::instance::Instance;
+use crate::{effects, instance, stats};
+
+use crate::util::unix_timestamp_now;
+
+pub struct PerformanceBenchmarkNodesDown {
+    down_instances: Vec<Instance>,
+    up_instances: Vec<Instance>,
+    num_nodes_down: usize,
+}
+
+impl PerformanceBenchmarkNodesDown {
+    pub fn new(cluster: Cluster, num_nodes_down: usize) -> Self {
+        let (down_instances, up_instances) = cluster.split_n_random(num_nodes_down);
+        Self {
+            down_instances: down_instances.into_instances(),
+            up_instances: up_instances.into_instances(),
+            num_nodes_down,
+        }
+    }
+}
+
+impl Experiment for PerformanceBenchmarkNodesDown {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&self.down_instances)
+    }
+
+    fn run(&mut self, context: &mut Context) -> failure::Result<Option<String>> {
+        let mut stop_effects: Vec<_> = self
+            .down_instances
+            .clone()
+            .into_iter()
+            .map(StopContainer::new)
+            .collect();
+        effects::activate_all(context.thread_pool_executor.clone(), &mut stop_effects);
+        let window = Duration::from_secs(180);
+        context
+            .tx_emitter
+            .emit_txn_for(window + Duration::from_secs(60), self.up_instances.clone())?;
+        let end = unix_timestamp_now();
+        let start = end - window;
+        let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
+        effects::deactivate_all(context.thread_pool_executor.clone(), &mut stop_effects);
+        Ok(Some(format!(
+            "{} : {:.0} TPS, {:.1} ms latency",
+            self, avg_tps, avg_latency
+        )))
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(480)
+    }
+}
+
+impl Display for PerformanceBenchmarkNodesDown {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        if self.num_nodes_down == 0 {
+            write!(f, "all up")
+        } else {
+            write!(f, "{}% down", self.num_nodes_down)
+        }
+    }
+}

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Display;
+
+use failure::_core::fmt::{Error, Formatter};
+use failure::_core::time::Duration;
+
+use crate::cluster::Cluster;
+use crate::effects::three_region_simulation_effects;
+use crate::experiments::Context;
+use crate::experiments::Experiment;
+use crate::{effects, stats};
+
+use crate::util::unix_timestamp_now;
+
+pub struct PerformanceBenchmarkThreeRegionSimulation {
+    cluster: Cluster,
+}
+
+impl PerformanceBenchmarkThreeRegionSimulation {
+    pub fn new(cluster: Cluster) -> Self {
+        Self { cluster }
+    }
+}
+
+impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
+    fn run(&mut self, context: &mut Context) -> failure::Result<Option<String>> {
+        let (us, euro) = self.cluster.split_n_random(80);
+        let (us_west, us_east) = us.split_n_random(40);
+        let mut network_effects = three_region_simulation_effects(
+            (
+                us_west.instances().clone(),
+                us_east.instances().clone(),
+                euro.instances().clone(),
+            ),
+            (
+                Duration::from_millis(60), // us_east<->eu one way delay
+                Duration::from_millis(95), // us_west<->eu one way delay
+                Duration::from_millis(40), // us_west<->us_east one way delay
+            ),
+        );
+        effects::activate_all(context.thread_pool_executor.clone(), &mut network_effects);
+        let window = Duration::from_secs(180);
+        context.tx_emitter.emit_txn_for(
+            window + Duration::from_secs(60),
+            self.cluster.instances().clone(),
+        )?;
+        let end = unix_timestamp_now();
+        let start = end - window;
+        let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
+        effects::deactivate_all(context.thread_pool_executor.clone(), &mut network_effects);
+        Ok(Some(format!(
+            "{} : {:.0} TPS, {:.1} ms latency",
+            self, avg_tps, avg_latency
+        )))
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(420)
+    }
+}
+
+impl Display for PerformanceBenchmarkThreeRegionSimulation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "3 Region Simulation")
+    }
+}

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use failure::{self, prelude::*};
+use std::collections::HashSet;
 use std::{
     ffi::OsStr,
     fmt,
@@ -88,4 +89,12 @@ impl fmt::Display for Instance {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}({})", self.short_hash, self.ip)
     }
+}
+
+pub fn instancelist_to_set(instances: &[Instance]) -> HashSet<String> {
+    let mut r = HashSet::new();
+    for instance in instances {
+        r.insert(instance.short_hash().clone());
+    }
+    r
 }

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -11,6 +11,7 @@ pub mod health;
 pub mod instance;
 pub mod prometheus;
 pub mod slack;
+pub mod stats;
 pub mod suite;
 pub mod thread_pool_executor;
 pub mod tx_emitter;

--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::prometheus::Prometheus;
+use failure::{self, prelude::format_err};
+use std::time::Duration;
+
+pub fn avg_tps(prometheus: &Prometheus, start: Duration, end: Duration) -> failure::Result<f64> {
+    prometheus
+        .query_range_avg(
+            "irate(libra_consensus_last_committed_version[1m])".to_string(),
+            &start,
+            &end,
+            10, /* step */
+        )
+        .map_err(|e| format_err!("No tps data: {}", e))
+}
+
+pub fn avg_latency(
+    prometheus: &Prometheus,
+    start: Duration,
+    end: Duration,
+) -> failure::Result<f64> {
+    prometheus.query_range_avg(
+        "irate(mempool_duration_sum{op='e2e.latency'}[1m])/irate(mempool_duration_count{op='e2e.latency'}[1m])"
+            .to_string(),
+        &start,
+        &end,
+        10 /* step */,
+    ).map(|x| x * 1000.).map_err(|e| format_err!("No latency data: {}", e))
+}
+
+pub fn txn_stats(
+    prometheus: &Prometheus,
+    start: Duration,
+    end: Duration,
+) -> failure::Result<(f64, f64)> {
+    Ok((
+        avg_tps(prometheus, start, end)?,
+        avg_latency(prometheus, start, end)?,
+    ))
+}

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
+use std::cmp::min;
+
+use crate::experiments::{
+    PerformanceBenchmarkNodesDown, PerformanceBenchmarkThreeRegionSimulation,
+};
 
 use crate::{
     cluster::Cluster,
     experiments::{Experiment, RebootRandomValidators},
 };
-use std::cmp::min;
 
 pub struct ExperimentSuite {
     pub experiments: Vec<Box<dyn Experiment>>,
@@ -22,6 +26,33 @@ impl ExperimentSuite {
             let b: Box<dyn Experiment> = Box::new(RebootRandomValidators::new(count, cluster));
             experiments.push(b);
         }
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            0,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            10,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
+            cluster.clone(),
+        )));
+        Self { experiments }
+    }
+
+    pub fn new_perf_suite(cluster: &Cluster) -> Self {
+        let mut experiments: Vec<Box<dyn Experiment>> = vec![];
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            0,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
+            cluster.clone(),
+            10,
+        )));
+        experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
+            cluster.clone(),
+        )));
         Self { experiments }
     }
 }

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -53,6 +53,7 @@ use std::thread::JoinHandle;
 
 const MAX_TXN_BATCH_SIZE: usize = 100; // Max transactions per account in mempool
 
+#[derive(Clone)]
 pub struct TxEmitter {
     accounts: Vec<AccountData>,
     mint_file: String,
@@ -188,6 +189,21 @@ impl TxEmitter {
         let env_builder = Arc::new(EnvBuilder::new().name_prefix("ac-grpc-").build());
         let ch = ChannelBuilder::new(env_builder).connect(&address);
         AdmissionControlClient::new(ch)
+    }
+
+    pub fn emit_txn_for(
+        &mut self,
+        duration: Duration,
+        instances: Vec<Instance>,
+    ) -> failure::Result<()> {
+        let job = self.start_job(EmitJobRequest {
+            instances,
+            accounts_per_client: 10,
+            thread_params: EmitThreadParams::default(),
+        })?;
+        thread::sleep(duration);
+        self.stop_job(job);
+        Ok(())
     }
 }
 
@@ -456,6 +472,7 @@ fn load_faucet_account(
     })
 }
 
+#[derive(Clone)]
 struct AccountData {
     pub address: AccountAddress,
     pub key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,


### PR DESCRIPTION
Re-opening PR #1812 since it did not get merged for some reason and I accidentally deleted that branch.

## Summary

* At a high level: As we add more and more test cases to cluster-test, it becomes hard to squeeze all of them in main.rs. At a high level, this moves individual tests into individual `Experiment`s and moves a few more functions away from main into other libraries
* We construct `ExperimentSuite`s with the list of `Experiment`s required and then run those `ExperimentSuite`

Details:
* Update experiment run to return an Option<String> which is the result of an experiment
  * Some experiments will have results like perf results, some experiments will not like reboot random validators
* Convert perf benchmarks into three separate experiments: PerformanceBenchmark, PerformanceBenchmarkNodesDown, PerformanceBenchmarkThreeRegionSimulation
  * This reduces the amount of code that we have to maintain in main.rs makes creating new experiment suites easier
* Update `new_pre_release` which adds the performance experiments as well
* Create a stats module which contains the queries for various stats like tps, latency, etc. Move code from main.rs to this module
* Move activate_all, deactivate_all logic into effects module
* Move emit_txn_for into tx_emitter module

## Test Plan

Ran on my dev cluster