### PR TITLE
[consensus][reconfig] ensure deterministic timestamp for genesis

### DIFF
--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -140,11 +140,8 @@ where
     pub fn new_nil(round: Round, quorum_cert: QuorumCert) -> Self {
         // We want all the NIL blocks to agree on the timestamps even though they're generated
         // independently by different validators, hence we're using the timestamp of a parent + 1.
-        // The reason for artificially adding 1 usec is to support execution state synchronization,
-        // which doesn't have any other way of determining the order of ledger infos rather than
-        // comparing their timestamps.
         assume!(quorum_cert.certified_block().timestamp_usecs() < u64::max_value()); // unlikely to be false in this universe
-        let timestamp_usecs = quorum_cert.certified_block().timestamp_usecs() + 1;
+        let timestamp_usecs = quorum_cert.certified_block().timestamp_usecs();
 
         Self {
             epoch: quorum_cert.certified_block().epoch(),

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -30,10 +30,7 @@ fn test_nil_block() {
         genesis_block.id()
     );
     assert_eq!(nil_block.round(), 1);
-    assert_eq!(
-        nil_block.timestamp_usecs(),
-        genesis_block.timestamp_usecs() + 1
-    );
+    assert_eq!(nil_block.timestamp_usecs(), genesis_block.timestamp_usecs());
     assert_eq!(nil_block.is_nil_block(), true);
     assert!(nil_block.author().is_none());
 

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -367,7 +367,6 @@ fn test_need_fetch_for_qc() {
         a3.round() + 1,
         HashValue::zero(),
         a3.round(),
-        None,
     );
     let too_old_qc = certificate_for_genesis();
     let can_insert_qc = placeholder_certificate_for_block(
@@ -376,7 +375,6 @@ fn test_need_fetch_for_qc() {
         a3.round(),
         a2.id(),
         a2.round(),
-        None,
     );
     let duplicate_qc = block_store.get_quorum_cert_for_block(a2.id()).unwrap();
     assert_eq!(
@@ -407,7 +405,7 @@ fn test_empty_reconfiguration_suffix() {
     let a3 = inserter.insert_reconfiguration_block(&a2, 3);
     let a4 = inserter.create_block_with_qc(
         inserter.create_qc_for_block(a3.as_ref(), None),
-        a3.as_ref(),
+        a3.as_ref().timestamp_usecs(),
         4,
         vec![42],
     );
@@ -415,7 +413,7 @@ fn test_empty_reconfiguration_suffix() {
     assert!(block_on(block_store.execute_and_insert_block(a4)).is_err());
     let a5 = inserter.create_block_with_qc(
         inserter.create_qc_for_block(a3.as_ref(), None),
-        a3.as_ref(),
+        a3.as_ref().timestamp_usecs(),
         4,
         vec![],
     );
@@ -425,6 +423,12 @@ fn test_empty_reconfiguration_suffix() {
     // Block continues another branch can carry payload
     inserter.insert_block(&a2, 4, None);
     block_store.prune_tree(a3.id());
-    // If reconfiguration is committed, the child block can carry payload
-    let _a6 = inserter.insert_block(&a3, 4, None);
+    // If reconfiguration is committed, the child block will fail to insert
+    let a6 = inserter.create_block_with_qc(
+        inserter.create_qc_for_block(a5.as_ref(), None),
+        a5.as_ref().timestamp_usecs(),
+        5,
+        vec![42],
+    );
+    assert!(block_on(block_store.execute_and_insert_block(a6)).is_err());
 }

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -9,9 +9,7 @@ use crate::{
     },
     util::mock_time_service::SimulatedTimeService,
 };
-use consensus_types::block::block_test_utils::{
-    certificate_for_genesis, placeholder_certificate_for_block,
-};
+use consensus_types::block::block_test_utils::{certificate_for_genesis, gen_test_certificate};
 use consensus_types::block::Block;
 use futures::executor::block_on;
 use libra_types::crypto_proxies::ValidatorSigner;
@@ -129,38 +127,38 @@ fn test_empty_proposal_after_reconfiguration() {
     assert!(!normal_proposal_1.payload().unwrap().is_empty());
     let a2 = inserter.insert_reconfiguration_block(&a1, 2);
     inserter.insert_qc_for_block(a2.as_ref(), None);
-    // if reconfiguration is committed, generate normal proposal
-    let li = placeholder_certificate_for_block(
-        vec![inserter.signer()],
-        a2.id(),
-        a2.round(),
-        a2.id(),
-        a2.round(),
-        Some(a2.id()),
-    );
-    block_on(block_store.commit(li.ledger_info().clone())).unwrap();
-    let normal_proposal_2 =
-        block_on(proposal_generator.generate_proposal(43, minute_from_now())).unwrap();
-    assert!(!normal_proposal_2.payload().unwrap().is_empty());
-    // insert another pending reconfiguration block
-    let a3 = inserter.insert_reconfiguration_block(&a2, 3);
-    inserter.insert_qc_for_block(&a3, None);
-
     // The direct child is empty
     let empty_proposal_1 =
-        block_on(proposal_generator.generate_proposal(44, minute_from_now())).unwrap();
+        block_on(proposal_generator.generate_proposal(43, minute_from_now())).unwrap();
     assert!(empty_proposal_1.payload().unwrap().is_empty());
     // insert one more block after reconfiguration
+    let a3 = inserter.create_block_with_qc(
+        inserter.create_qc_for_block(a2.as_ref(), None),
+        a2.as_ref().timestamp_usecs(),
+        3,
+        vec![],
+    );
+    let a3 = block_on(block_store.execute_and_insert_block(a3)).unwrap();
+    inserter.insert_qc_for_block(a3.as_ref(), None);
+    // Indirect child is empty too
+    let empty_proposal_2 =
+        block_on(proposal_generator.generate_proposal(44, minute_from_now())).unwrap();
+    assert!(empty_proposal_2.payload().unwrap().is_empty());
+    // if reconfiguration is committed, not allow to generate proposal
     let a4 = inserter.create_block_with_qc(
         inserter.create_qc_for_block(a3.as_ref(), None),
-        a3.as_ref(),
+        a2.as_ref().timestamp_usecs(),
         4,
         vec![],
     );
     let a4 = block_on(block_store.execute_and_insert_block(a4)).unwrap();
-    inserter.insert_qc_for_block(a4.as_ref(), None);
-    // Indirect child is empty too
-    let empty_proposal_2 =
-        block_on(proposal_generator.generate_proposal(45, minute_from_now())).unwrap();
-    assert!(empty_proposal_2.payload().unwrap().is_empty());
+    let li = gen_test_certificate(
+        vec![inserter.signer()],
+        a4.block_info(),
+        a3.block_info(),
+        Some(a2.block_info()),
+    );
+    block_store.insert_single_quorum_cert(li).unwrap();
+    let err_proposal = block_on(proposal_generator.generate_proposal(45, minute_from_now()));
+    assert!(err_proposal.is_err());
 }

--- a/executor/src/block_processor.rs
+++ b/executor/src/block_processor.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
     HashValue,
 };
 use libra_logger::prelude::*;
-use libra_types::block_info::BlockInfo;
+use libra_types::block_info::{BlockInfo, Round};
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -43,12 +43,15 @@ enum Mode {
     Syncing,
 }
 
+pub const GENESIS_EPOCH: u64 = 0;
+pub const GENESIS_ROUND: Round = 0;
+
 pub(crate) struct BlockProcessor<V> {
     /// Where the processor receives commands.
     command_receiver: mpsc::Receiver<Command>,
 
-    /// The timestamp of the last committed ledger info.
-    committed_timestamp_usecs: u64,
+    /// The epoch/round of the last committed ledger info.
+    committed_epoch_and_round: (u64, u64),
 
     /// The latest committed merkle trees.
     committed_trees: Arc<Mutex<ExecutedTrees>>,
@@ -83,14 +86,14 @@ where
         storage_write_client: Arc<dyn StorageWrite>,
         committed_trees: Arc<Mutex<ExecutedTrees>>,
         synced_trees: Option<ExecutedTrees>,
-        committed_timestamp_usecs: u64,
+        committed_epoch_and_round: (u64, u64),
         vm_config: VMConfig,
         genesis_txn: Transaction,
         resp_sender: oneshot::Sender<()>,
     ) -> Self {
         let mut processor = BlockProcessor {
             command_receiver,
-            committed_timestamp_usecs,
+            committed_epoch_and_round,
             committed_trees,
             synced_trees,
             blocks_to_execute: VecDeque::new(),
@@ -135,8 +138,8 @@ where
         let root_hash = output.accu_root();
         let ledger_info = LedgerInfo::new(
             BlockInfo::new(
-                0,
-                0,
+                GENESIS_EPOCH,
+                GENESIS_ROUND,
                 *PRE_GENESIS_BLOCK_ID,
                 root_hash,
                 0,
@@ -247,13 +250,14 @@ where
     /// Verifies the transactions based on the provided proofs and ledger info. If the transactions
     /// are valid, executes them and commits immediately if execution results match the proofs.
     fn execute_and_commit_chunk(&mut self, chunk: Chunk) -> Result<()> {
-        if chunk.ledger_info_with_sigs.ledger_info().timestamp_usecs()
-            <= self.committed_timestamp_usecs
-        {
+        let epoch_and_round = (
+            chunk.ledger_info_with_sigs.ledger_info().epoch(),
+            chunk.ledger_info_with_sigs.ledger_info().round(),
+        );
+        if epoch_and_round <= self.committed_epoch_and_round {
             warn!(
-                "Ledger info is too old: local timestamp: {}, timestamp in request: {}.",
-                self.committed_timestamp_usecs,
-                chunk.ledger_info_with_sigs.ledger_info().timestamp_usecs(),
+                "Ledger info is too old: local epoch/round: {:?}, epoch/round in request: {:?}.",
+                self.committed_epoch_and_round, epoch_and_round
             );
             return Ok(());
         }
@@ -364,7 +368,10 @@ where
         );
 
         if let Some(ledger_info_with_sigs) = ledger_info_to_commit {
-            self.committed_timestamp_usecs = ledger_info_with_sigs.ledger_info().timestamp_usecs();
+            self.committed_epoch_and_round = (
+                ledger_info_with_sigs.ledger_info().epoch(),
+                ledger_info_with_sigs.ledger_info().round(),
+            );
             assert!(self.sync_mode());
             *self.committed_trees.lock().unwrap() =
                 self.synced_trees.take().expect("synced trees must exist.");
@@ -544,7 +551,10 @@ where
 
         // Now that the blocks are persisted successfully, we can reply to consensus and update
         // in-memory state.
-        self.committed_timestamp_usecs = ledger_info_with_sigs.ledger_info().timestamp_usecs();
+        self.committed_epoch_and_round = (
+            ledger_info_with_sigs.ledger_info().epoch(),
+            ledger_info_with_sigs.ledger_info().round(),
+        );
         *self.committed_trees.lock().unwrap() = last_block.output.executed_trees().clone();
         for block in block_batch.blocks {
             for txn_data in block.output.transaction_data() {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We may have arbitrary long suffix blocks after reconfiguration and
many of them could commit the reconfiguration block and derive the
genesis.
Thus to guarantee the deterministic genesis, the timestamp of all of
those commit have to be the same.

This change we ensure all suffix blocks have the same timestamp as
the reconfiguration block. Also all nil blocks have the same timestamp as parent.

Changing the executor to use epoch/round to compare instead of
timestamps.
#897 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
