### PR TITLE
[consensus][reconfig] notify epoch change upon sync

### DIFF
--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -247,6 +247,16 @@ impl NetworkSender {
         };
         self.broadcast(msg).await
     }
+
+    pub async fn notify_epoch_change(&mut self, proof: ValidatorChangeEventWithProof) {
+        let msg = ConsensusMsg {
+            message: Some(ConsensusMsg_oneof::EpochChange(proof.into())),
+        };
+        let self_msg = Event::Message((self.author, msg.clone()));
+        if let Err(e) = self.self_sender.send(Ok(self_msg)).await {
+            warn!("Failed to notify to self an epoch change {:?}", e);
+        }
+    }
 }
 
 pub struct NetworkTask<T> {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Normally a node aggregates the end-epoch QC and broadcasts the proof
to everyone else.

While there's edge cases that nodes might receive a SyncInfo that has
end-epoch QC and needs to start new epoch too, e.g. sending a older
SyncInfo to the node that's committing the reconfiguration block and
reply a SyncInfo with end-epoch QC.

This change addresses the problem and make sure nodes can switch epoch
after sync to the reconfig block.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
