### PR TITLE
[consensus][easy] rename highest_ledger_info to highest_commit_cert

### DIFF
--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -53,7 +53,7 @@ impl<T: Payload> From<ProposalUncheckedSignatures<T>> for ProposalMsg<T> {
 
 impl<T: Payload> ProposalUncheckedSignatures<T> {
     /// Validates the signatures of the proposal. This includes the leader's signature over the
-    /// block and the QC, the timeout certificate signatures and the highest_ledger_info signatures.
+    /// block and the QC, the timeout certificate signatures.
     pub fn validate_signatures(self, validator: &ValidatorVerifier) -> Result<ProposalMsg<T>> {
         // verify block leader's signature and QC
         self.0

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -217,13 +217,13 @@ impl<T: Payload> BlockStore<T> {
             error!("fail to delete block: {:?}", e);
         }
         *self.inner.write().unwrap() = tree;
-        // If we fail to commit B_i via state computer and crash, after restart our highest ledger info
+        // If we fail to commit B_i via state computer and crash, after restart our highest commit cert
         // will not match the latest commit B_j(j<i) of state computer.
         // This introduces an inconsistent state if we send out SyncInfo and others try to sync to
         // B_i and figure out we only have B_j.
-        // Here we commit up to the highest_ledger_info to maintain highest_ledger_info == state_computer.committed_trees.
-        if self.highest_ledger_info().commit_info().round() > self.root().round() {
-            let finality_proof = self.highest_ledger_info().ledger_info().clone();
+        // Here we commit up to the highest_commit_cert to maintain highest_commit_cert == state_computer.committed_trees.
+        if self.highest_commit_cert().commit_info().round() > self.root().round() {
+            let finality_proof = self.highest_commit_cert().ledger_info().clone();
             if let Err(e) = self.commit(finality_proof).await {
                 warn!("{:?}", e);
             }
@@ -441,8 +441,8 @@ impl<T: Payload> BlockReader for BlockStore<T> {
         self.inner.read().unwrap().highest_quorum_cert()
     }
 
-    fn highest_ledger_info(&self) -> Arc<QuorumCert> {
-        self.inner.read().unwrap().highest_ledger_info()
+    fn highest_commit_cert(&self) -> Arc<QuorumCert> {
+        self.inner.read().unwrap().highest_commit_cert()
     }
 
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>> {

--- a/consensus/src/chained_bft/block_storage/block_tree.rs
+++ b/consensus/src/chained_bft/block_storage/block_tree.rs
@@ -80,8 +80,8 @@ pub struct BlockTree<T> {
     highest_quorum_cert: Arc<QuorumCert>,
     /// The highest timeout certificate (if any).
     highest_timeout_cert: Option<Arc<TimeoutCertificate>>,
-    /// The quorum certificate that carries a highest ledger info
-    highest_ledger_info: Arc<QuorumCert>,
+    /// The quorum certificate that has highest commit info.
+    highest_commit_cert: Arc<QuorumCert>,
     /// Manages pending votes to be aggregated.
     pending_votes: PendingVotes,
     /// Map of block id to its completed quorum certificate (2f + 1 votes)
@@ -129,7 +129,7 @@ where
             highest_certified_block_id: root_id,
             highest_quorum_cert: Arc::clone(&root_quorum_cert),
             highest_timeout_cert,
-            highest_ledger_info: Arc::new(root_ledger_info),
+            highest_commit_cert: Arc::new(root_ledger_info),
             pending_votes: PendingVotes::new(),
             id_to_quorum_cert,
             pruned_block_ids,
@@ -190,8 +190,8 @@ where
         self.highest_timeout_cert.replace(tc);
     }
 
-    pub(super) fn highest_ledger_info(&self) -> Arc<QuorumCert> {
-        Arc::clone(&self.highest_ledger_info)
+    pub(super) fn highest_commit_cert(&self) -> Arc<QuorumCert> {
+        Arc::clone(&self.highest_commit_cert)
     }
 
     pub(super) fn get_quorum_cert_for_block(
@@ -257,8 +257,8 @@ where
             .entry(block_id)
             .or_insert_with(|| Arc::clone(&qc));
 
-        if self.highest_ledger_info.commit_info().round() < qc.commit_info().round() {
-            self.highest_ledger_info = qc;
+        if self.highest_commit_cert.commit_info().round() < qc.commit_info().round() {
+            self.highest_commit_cert = qc;
         }
 
         Ok(())

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -63,7 +63,7 @@ pub trait BlockReader: Send + Sync {
     fn highest_quorum_cert(&self) -> Arc<QuorumCert>;
 
     /// Return the quorum certificate that carries ledger info with the highest round
-    fn highest_ledger_info(&self) -> Arc<QuorumCert>;
+    fn highest_commit_cert(&self) -> Arc<QuorumCert>;
 
     /// Return the highest timeout certificate if available.
     fn highest_timeout_cert(&self) -> Option<Arc<TimeoutCertificate>>;

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -70,14 +70,14 @@ impl<T: Payload> BlockStore<T> {
     }
 
     /// Fetches dependencies for given sync_info.quorum_cert
-    /// If gap is large, performs state sync using process_highest_ledger_info
+    /// If gap is large, performs state sync using process_highest_commit_cert
     /// Inserts sync_info.quorum_cert into block store as the last step
     pub async fn sync_to(
         &self,
         sync_info: &SyncInfo,
         mut retriever: BlockRetriever,
     ) -> failure::Result<()> {
-        self.process_highest_ledger_info(sync_info.highest_ledger_info().clone(), &mut retriever)
+        self.process_highest_commit_cert(sync_info.highest_commit_cert().clone(), &mut retriever)
             .await?;
 
         match self.need_fetch_for_quorum_cert(sync_info.highest_quorum_cert()) {
@@ -123,37 +123,37 @@ impl<T: Payload> BlockStore<T> {
         self.insert_single_quorum_cert(qc)
     }
 
-    /// Check the highest ledger info sent by peer to see if we're behind and start a fast
+    /// Check the highest commit cert sent by peer to see if we're behind and start a fast
     /// forward sync if the committed block doesn't exist in our tree.
     /// It works as follows:
-    /// 1. request the committed 3-chain from the peer, if C2 is the highest_ledger_info
+    /// 1. request the committed 3-chain from the peer, if C2 is the highest_commit_cert
     /// we request for B0 <- C0 <- B1 <- C1 <- B2 (<- C2)
     /// 2. We persist the 3-chain to storage before start sync to ensure we could restart if we
     /// crash in the middle of the sync.
     /// 3. We prune the old tree and replace with a new tree built with the 3-chain.
-    async fn process_highest_ledger_info(
+    async fn process_highest_commit_cert(
         &self,
-        highest_ledger_info: QuorumCert,
+        highest_commit_cert: QuorumCert,
         retriever: &mut BlockRetriever,
     ) -> failure::Result<()> {
-        if !self.need_sync_for_quorum_cert(&highest_ledger_info) {
+        if !self.need_sync_for_quorum_cert(&highest_commit_cert) {
             return Ok(());
         }
         debug!(
             "Start state sync with peer: {}, to block: {} from {}",
             retriever.preferred_peer.short_str(),
-            highest_ledger_info.commit_info(),
+            highest_commit_cert.commit_info(),
             self.root()
         );
         let mut blocks = retriever
-            .retrieve_block_for_qc(&highest_ledger_info, 3)
+            .retrieve_block_for_qc(&highest_commit_cert, 3)
             .await?;
         assert_eq!(
             blocks.last().expect("should have 3-chain").id(),
-            highest_ledger_info.commit_info().id(),
+            highest_commit_cert.commit_info().id(),
         );
         let mut quorum_certs = vec![];
-        quorum_certs.push(highest_ledger_info.clone());
+        quorum_certs.push(highest_commit_cert.clone());
         quorum_certs.push(blocks[0].quorum_cert().clone());
         quorum_certs.push(blocks[1].quorum_cert().clone());
         // If a node restarts in the middle of state synchronization, it is going to try to catch up
@@ -162,12 +162,12 @@ impl<T: Payload> BlockStore<T> {
             .save_tree(blocks.clone(), quorum_certs.clone())?;
         let pre_sync_instance = Instant::now();
         self.state_computer
-            .sync_to_or_bail(highest_ledger_info.ledger_info().clone());
+            .sync_to_or_bail(highest_commit_cert.ledger_info().clone());
         counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());
         let root = (
             blocks.pop().expect("should have 3-chain"),
             quorum_certs.last().expect("should have 3-chain").clone(),
-            highest_ledger_info.clone(),
+            highest_commit_cert.clone(),
         );
         debug!("{}Sync to{} {}", Fg(Blue), Fg(Reset), root.0);
         // ensure it's [b1, b2]

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -192,7 +192,7 @@ impl<T: Payload> EventProcessor<T> {
 
     /// The function is responsible for processing the incoming proposals and the Quorum
     /// Certificate.
-    /// 1. sync up to the SyncInfo including committing to the committed state the HLI carries
+    /// 1. sync up to the SyncInfo including committing to the committed state the HCC carries
     /// and fetch all the blocks from the committed state to the HQC
     /// 2. forwarding the proposals to the ProposerElection queue,
     /// which is going to eventually trigger one winning proposal per round
@@ -299,7 +299,7 @@ impl<T: Payload> EventProcessor<T> {
         if current_hqc_round >= sync_info.hqc_round()
             && current_htc_round >= sync_info.htc_round()
             && self.block_store.root().round()
-                >= sync_info.highest_ledger_info().commit_info().round()
+                >= sync_info.highest_commit_cert().commit_info().round()
         {
             return Ok(());
         }
@@ -616,7 +616,7 @@ impl<T: Payload> EventProcessor<T> {
             .map(|tc| tc.as_ref().clone());
         SyncInfo::new(
             hqc,
-            self.block_store.highest_ledger_info().as_ref().clone(),
+            self.block_store.highest_commit_cert().as_ref().clone(),
             htc,
         )
     }
@@ -750,12 +750,12 @@ impl<T: Payload> EventProcessor<T> {
         preferred_peer: Author,
     ) -> failure::Result<()> {
         let deadline = self.pacemaker.current_round_deadline();
-        // Process local highest ledger info should be no-op, this will sync us to the QC
+        // Process local highest commit cert should be no-op, this will sync us to the QC
         self.block_store
             .sync_to(
                 &SyncInfo::new(
                     qc.as_ref().clone(),
-                    self.block_store.highest_ledger_info().as_ref().clone(),
+                    self.block_store.highest_commit_cert().as_ref().clone(),
                     None,
                 ),
                 self.create_block_retriever(deadline, preferred_peer),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
There's some confusion around the name because highest_ledger_info
is not a LedgerInfo but a QuorumCert.

Hopefully this could help reduce the confusion, highest_commit_cert
is a QuorumCert that carries a valid LedgerInfo which signals a
commit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
