### PR TITLE
[network] Resolve 2 inbound connections from same peer by dropping older connection

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -375,8 +375,9 @@ where
         new_origin: ConnectionOrigin,
     ) -> bool {
         match (existing_origin, new_origin) {
-            // The remote dialed us twice for some reason, drop the new incoming connection
-            (ConnectionOrigin::Inbound, ConnectionOrigin::Inbound) => false,
+            // If the remote dials while an existing connection is open, the older connection is
+            // dropped.
+            (ConnectionOrigin::Inbound, ConnectionOrigin::Inbound) => true,
             (ConnectionOrigin::Inbound, ConnectionOrigin::Outbound) => remote_peer_id < own_peer_id,
             (ConnectionOrigin::Outbound, ConnectionOrigin::Inbound) => own_peer_id < remote_peer_id,
             // We should never dial the same peer twice, but if we do drop the new connection

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -430,13 +430,13 @@ fn peer_manager_simultaneous_dial_two_inbound() {
             )
             .await;
 
-        // outbound2 should have been dropped since it was the second inbound connection
+        // outbound1 should have been dropped since it was the older inbound connection
         check_correct_connection_is_live(
-            outbound1,
             outbound2,
+            outbound1,
             ids[0],
             role,
-            false,
+            true,
             &mut peer_manager.peer_notifs_rx,
         )
         .await;


### PR DESCRIPTION
## Motivation

A remote peer might be dialing despite a pre-existing connection for
a genuine reason. For example, while the older instance of the node is
generating core dump, a newer instance might start dialing (pointed out [here](https://github.com/libra/libra/issues/1670#issuecomment-552119623)).

Caveat: We need to rate-limit the number of inbound connections a peer
can create with any node. This can be done at the load-balancer layer,
or in ConnectionHandler itself.

## Test Plan
Had to "fix" existing unit test to allow new behavior.