### PR TITLE
Test generation of struct-related bytecodes and bytecode sequences.

### DIFF
--- a/language/tools/test-generation/src/abstract_state.rs
+++ b/language/tools/test-generation/src/abstract_state.rs
@@ -81,6 +81,10 @@ impl AbstractValue {
         );
         AbstractValue { token, kind }
     }
+
+    pub fn new_value(token: SignatureToken, kind: Kind) -> AbstractValue {
+        AbstractValue { token, kind }
+    }
 }
 
 /// An AbstractState represents an abstract view of the execution of the

--- a/language/tools/test-generation/src/control_flow_graph.rs
+++ b/language/tools/test-generation/src/control_flow_graph.rs
@@ -4,7 +4,7 @@
 use crate::abstract_state::{AbstractValue, BorrowState};
 use rand::{rngs::StdRng, Rng};
 use std::collections::{HashMap, VecDeque};
-use vm::file_format::{Bytecode, FunctionSignature, SignatureToken};
+use vm::file_format::{Bytecode, FunctionSignature, Kind, SignatureToken};
 
 /// This type holds basic block identifiers
 type BlockIDSize = u16;
@@ -238,6 +238,7 @@ impl CFG {
             !cfg.basic_blocks.is_empty(),
             "Cannot add locals to empty cfg"
         );
+        debug!("add locals: {:#?}", locals);
         for block_id in 0..cfg.basic_blocks.len() {
             let cfg_copy = cfg.clone();
             let basic_block = cfg
@@ -256,7 +257,10 @@ impl CFG {
                         };
                         (
                             i,
-                            (AbstractValue::new_primitive(token.clone()), borrow_state),
+                            (
+                                AbstractValue::new_value(token.clone(), Kind::Unrestricted),
+                                borrow_state,
+                            ),
                         )
                     })
                     .collect();

--- a/language/tools/test-generation/src/transitions.rs
+++ b/language/tools/test-generation/src/transitions.rs
@@ -176,7 +176,7 @@ pub fn stack_satisfies_struct_signature(
         .flatten()
         .map(|field| field.type_signature().token());
     let mut satisfied = true;
-    for (i, token_view) in field_token_views.enumerate() {
+    for (i, token_view) in field_token_views.rev().enumerate() {
         let abstract_value = AbstractValue {
             token: token_view.as_inner().clone(),
             kind: token_view.kind(&[]),
@@ -198,8 +198,7 @@ pub fn stack_struct_popn(
     let mut state = state.clone();
     let struct_def = state_copy.module.struct_def_at(struct_index);
     let struct_def_view = StructDefinitionView::new(&state_copy.module, struct_def);
-    let number_of_pops = struct_def_view.fields().iter().len();
-    for _ in 0..number_of_pops {
+    for _ in struct_def_view.fields().unwrap() {
         state = stack_pop(&state)?;
     }
     Ok(state)

--- a/language/tools/utils/src/inhabitation/inhabit.rs
+++ b/language/tools/utils/src/inhabitation/inhabit.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use vm::file_format::{
+    AddressPoolIndex, ByteArrayPoolIndex, Bytecode, CompiledModuleMut, LocalsSignatureIndex,
+    SignatureToken, StructDefinitionIndex, StructFieldInformation, TableIndex, UserStringIndex,
+};
+
+/// Generate a sequence of instructions whose overall effect is to push a single value of type token
+/// on the stack, specifically without consuming any values that existed on the stack prior to the
+/// execution of the instruction sequence.
+pub fn inhabit_with_bytecode_seq(
+    module: &CompiledModuleMut,
+    token: &SignatureToken,
+) -> Vec<Bytecode> {
+    match token {
+        SignatureToken::String => vec![Bytecode::LdStr(UserStringIndex::new(0))],
+        SignatureToken::Address => vec![Bytecode::LdAddr(AddressPoolIndex::new(0))],
+        SignatureToken::U64 => vec![Bytecode::LdConst(0)],
+        SignatureToken::Bool => vec![Bytecode::LdFalse],
+        SignatureToken::ByteArray => vec![Bytecode::LdByteArray(ByteArrayPoolIndex::new(0))],
+        SignatureToken::Struct(handle_idx, _fixme) => {
+            let empty_ty_param_index = module
+                .locals_signatures
+                .iter()
+                .position(|sig| sig.is_empty())
+                .expect("locals signatures must have an empty locals signature");
+            let struct_def_idx = module
+                .struct_defs
+                .iter()
+                .position(|struct_def| struct_def.struct_handle == *handle_idx)
+                .expect("struct def should exist for every struct handle in the test generator");
+            let struct_def = &module.struct_defs[struct_def_idx];
+            let (num_fields, index) = match struct_def.field_information {
+                StructFieldInformation::Native => panic!("Can't inhabit native structs"),
+                StructFieldInformation::Declared {
+                    field_count,
+                    fields,
+                } => (field_count as usize, fields.0 as usize),
+            };
+            let fields = &module.field_defs[index..(index + num_fields)];
+            let mut bytecodes: Vec<Bytecode> = fields
+                .iter()
+                .flat_map(|field| {
+                    inhabit_with_bytecode_seq(
+                        &module,
+                        &module.type_signatures[field.signature.0 as usize].0,
+                    )
+                })
+                .collect();
+            bytecodes.push(Bytecode::Pack(
+                StructDefinitionIndex(struct_def_idx as TableIndex),
+                LocalsSignatureIndex(empty_ty_param_index as TableIndex),
+            ));
+            bytecodes
+        }
+        _ => unimplemented!("Unsupported return type: {:#?}", token),
+    }
+}

--- a/language/tools/utils/src/inhabitation/mod.rs
+++ b/language/tools/utils/src/inhabitation/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod inhabitation;
-pub mod module_generation;
+mod inhabit;
+
+pub use inhabit::inhabit_with_bytecode_seq;


### PR DESCRIPTION
Allow generation of structs  (so `Pack` and `Unpack` instructions) in test generation. Only look at the top commit on this PR. 

Needed to fix an off-by-1 error in the stack usage accounting for `Pack` that was leading to unbalanced stack usage errors. 