### PR TITLE
Audit all first party unsafe code

### DIFF
--- a/language/vm/src/vm_string.rs
+++ b/language/vm/src/vm_string.rs
@@ -107,8 +107,12 @@ pub struct VMStr(str);
 impl VMStr {
     pub fn new<'a>(s: impl AsRef<str> + 'a) -> &'a VMStr {
         let s = s.as_ref();
-        // VMStr and str have the same layout, so this is safe to do.
-        // This follows the pattern in Rust core https://doc.rust-lang.org/src/std/path.rs.html.
+        // UNSAFE CODE: This code requires auditing before modifications may land.
+        // JUSTIFICATION: The input and output references have the same
+        // lifetime and VMStr and str have the same layout, so this is safe to
+        // do. See
+        // https://rust-lang.github.io/unsafe-code-guidelines/layout/structs-and-tuples.html#single-field-structs
+        // AUDITOR: metajack
         unsafe { &*(s as *const str as *const VMStr) }
     }
 

--- a/types/src/identifier.rs
+++ b/types/src/identifier.rs
@@ -206,8 +206,11 @@ impl fmt::Display for IdentStr {
 // This function is private -- it is used by code within this module once it has verified
 // identifier invariants.
 fn str_to_ident_str(s: &str) -> &IdentStr {
-    // IdentStr and str have the same layout, so this is safe to do.
-    // This follows the pattern in Rust core https://doc.rust-lang.org/src/std/path.rs.html.
+    // UNSAFE CODE: This code requires auditing before modifications may land.
+    // JUSTIFICATION: The input and output references have the same lifetime
+    // and IdentStr and str have the same layout, so this is safe to do. See
+    // https://rust-lang.github.io/unsafe-code-guidelines/layout/structs-and-tuples.html#single-field-structs
+    // AUDITOR: metajack
     unsafe { &*(s as *const str as *const IdentStr) }
 }
 


### PR DESCRIPTION
I have audited all four cases of unsafe code in the Libra Core codebase. This puts standard comment markers by unsafe code, documenting why it is safe and who audited the work.

Two instances are benign type casts. One instance is carrying forward a lifetime transmutation used by an underlying library. The last is a work around for the lack of async process APIs in Rust, which we can remove soon (see #1850).