### PR TITLE
[cluster-test] Remove flags for individual experiments

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,6 +3,12 @@
 
 #![forbid(unsafe_code)]
 
+mod multi_region_network_simulation;
+mod packet_loss_random_validators;
+mod performance_benchmark_nodes_down;
+mod performance_benchmark_three_region_simulation;
+mod reboot_random_validator;
+
 use std::time::Duration;
 use std::{collections::HashSet, fmt::Display};
 
@@ -10,19 +16,17 @@ pub use multi_region_network_simulation::{MultiRegionSimulation, MultiRegionSimu
 pub use packet_loss_random_validators::{
     PacketLossRandomValidators, PacketLossRandomValidatorsParams,
 };
-pub use performance_benchmark_nodes_down::PerformanceBenchmarkNodesDown;
+pub use performance_benchmark_nodes_down::{
+    PerformanceBenchmarkNodesDown, PerformanceBenchmarkNodesDownParams,
+};
 pub use performance_benchmark_three_region_simulation::PerformanceBenchmarkThreeRegionSimulation;
-pub use reboot_random_validator::RebootRandomValidators;
+pub use reboot_random_validator::{RebootRandomValidators, RebootRandomValidatorsParams};
 
+use crate::cluster::Cluster;
 use crate::prometheus::Prometheus;
 use crate::thread_pool_executor::ThreadPoolExecutor;
 use crate::tx_emitter::TxEmitter;
-
-mod multi_region_network_simulation;
-mod packet_loss_random_validators;
-mod performance_benchmark_nodes_down;
-mod performance_benchmark_three_region_simulation;
-mod reboot_random_validator;
+use structopt::{clap::AppSettings, StructOpt};
 
 pub trait Experiment: Display + Send {
     fn affected_validators(&self) -> HashSet<String> {
@@ -36,6 +40,7 @@ pub struct Context {
     tx_emitter: TxEmitter,
     prometheus: Prometheus,
     thread_pool_executor: ThreadPoolExecutor,
+    cluster: Cluster,
 }
 
 impl Context {
@@ -43,11 +48,55 @@ impl Context {
         tx_emitter: TxEmitter,
         prometheus: Prometheus,
         thread_pool_executor: ThreadPoolExecutor,
+        cluster: Cluster,
     ) -> Self {
         Context {
             tx_emitter,
             prometheus,
             thread_pool_executor,
+            cluster,
         }
+    }
+}
+
+/// Given an experiment name and its flags, it constructs an instance of that experiment
+/// and returns it as a `Box<dyn Experiment>`
+pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn Experiment> {
+    match name {
+        "multi_region_simulation" => Box::new(MultiRegionSimulation::new(
+            MultiRegionSimulationParams::from_clap(
+                &MultiRegionSimulationParams::clap()
+                    .global_setting(AppSettings::NoBinaryName)
+                    .get_matches_from(args),
+            ),
+        )),
+        "packet_loss_random_validators" => Box::new(PacketLossRandomValidators::new(
+            PacketLossRandomValidatorsParams::from_clap(
+                &PacketLossRandomValidatorsParams::clap()
+                    .global_setting(AppSettings::NoBinaryName)
+                    .get_matches_from(args),
+            ),
+            cluster,
+        )),
+        "performance_benchmark_nodes_down" => Box::new(PerformanceBenchmarkNodesDown::new(
+            PerformanceBenchmarkNodesDownParams::from_clap(
+                &PerformanceBenchmarkNodesDownParams::clap()
+                    .global_setting(AppSettings::NoBinaryName)
+                    .get_matches_from(args),
+            ),
+            cluster,
+        )),
+        "performance_benchmark_three_region_simulation" => {
+            Box::new(PerformanceBenchmarkThreeRegionSimulation::new(cluster))
+        }
+        "reboot_random_validators" => Box::new(RebootRandomValidators::new(
+            RebootRandomValidatorsParams::from_clap(
+                &RebootRandomValidatorsParams::clap()
+                    .global_setting(AppSettings::NoBinaryName)
+                    .get_matches_from(args),
+            ),
+            cluster,
+        )),
+        name => panic!("Invalid experiment name: {}", name),
     }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -15,6 +15,18 @@ use crate::{effects, instance, stats};
 
 use crate::util::unix_timestamp_now;
 
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct PerformanceBenchmarkNodesDownParams {
+    #[structopt(
+        long,
+        default_value = "10",
+        help = "Number of nodes which should be down"
+    )]
+    pub num_nodes_down: usize,
+}
+
 pub struct PerformanceBenchmarkNodesDown {
     down_instances: Vec<Instance>,
     up_instances: Vec<Instance>,
@@ -22,12 +34,12 @@ pub struct PerformanceBenchmarkNodesDown {
 }
 
 impl PerformanceBenchmarkNodesDown {
-    pub fn new(cluster: Cluster, num_nodes_down: usize) -> Self {
-        let (down_instances, up_instances) = cluster.split_n_random(num_nodes_down);
+    pub fn new(params: PerformanceBenchmarkNodesDownParams, cluster: &Cluster) -> Self {
+        let (down_instances, up_instances) = cluster.split_n_random(params.num_nodes_down);
         Self {
             down_instances: down_instances.into_instances(),
             up_instances: up_instances.into_instances(),
-            num_nodes_down,
+            num_nodes_down: params.num_nodes_down,
         }
     }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -19,8 +19,10 @@ pub struct PerformanceBenchmarkThreeRegionSimulation {
 }
 
 impl PerformanceBenchmarkThreeRegionSimulation {
-    pub fn new(cluster: Cluster) -> Self {
-        Self { cluster }
+    pub fn new(cluster: &Cluster) -> Self {
+        Self {
+            cluster: cluster.clone(),
+        }
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -18,23 +18,31 @@ use crate::{
     instance::Instance,
 };
 
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct RebootRandomValidatorsParams {
+    #[structopt(long, default_value = "10", help = "Number of nodes to reboot")]
+    pub count: usize,
+}
+
 pub struct RebootRandomValidators {
     instances: Vec<Instance>,
 }
 
 impl RebootRandomValidators {
-    pub fn new(count: usize, cluster: &Cluster) -> Self {
-        if count > cluster.instances().len() {
+    pub fn new(params: RebootRandomValidatorsParams, cluster: &Cluster) -> Self {
+        if params.count > cluster.instances().len() {
             panic!(
                 "Can not reboot {} validators in cluster with {} instances",
-                count,
+                params.count,
                 cluster.instances().len()
             );
         }
-        let mut instances = Vec::with_capacity(count);
+        let mut instances = Vec::with_capacity(params.count);
         let mut all_instances = cluster.instances().clone();
         let mut rnd = rand::thread_rng();
-        for _i in 0..count {
+        for _i in 0..params.count {
             let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));
             instances.push(instance);
         }

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -4,13 +4,13 @@
 #![forbid(unsafe_code)]
 use std::cmp::min;
 
-use crate::experiments::{
-    PerformanceBenchmarkNodesDown, PerformanceBenchmarkThreeRegionSimulation,
-};
-
 use crate::{
     cluster::Cluster,
-    experiments::{Experiment, RebootRandomValidators},
+    experiments::{
+        Experiment, PerformanceBenchmarkNodesDown, PerformanceBenchmarkNodesDownParams,
+        PerformanceBenchmarkThreeRegionSimulation, RebootRandomValidators,
+        RebootRandomValidatorsParams,
+    },
 };
 
 pub struct ExperimentSuite {
@@ -23,19 +23,22 @@ impl ExperimentSuite {
         let count = min(3, cluster.instances().len() / 3);
         // Reboot different sets of 3 validators *100 times
         for _ in 0..20 {
-            let b: Box<dyn Experiment> = Box::new(RebootRandomValidators::new(count, cluster));
+            let b: Box<dyn Experiment> = Box::new(RebootRandomValidators::new(
+                RebootRandomValidatorsParams { count },
+                cluster,
+            ));
             experiments.push(b);
         }
         experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            cluster.clone(),
-            0,
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 },
+            cluster,
         )));
         experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            cluster.clone(),
-            10,
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 },
+            cluster,
         )));
         experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
-            cluster.clone(),
+            cluster,
         )));
         Self { experiments }
     }
@@ -43,15 +46,15 @@ impl ExperimentSuite {
     pub fn new_perf_suite(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
         experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            cluster.clone(),
-            0,
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 },
+            cluster,
         )));
         experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            cluster.clone(),
-            10,
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 },
+            cluster,
         )));
         experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
-            cluster.clone(),
+            cluster,
         )));
         Self { experiments }
     }


### PR DESCRIPTION
## Summary

* Replace with a single flag `--run-experiment` to run a single experiment.
* Usage `--run-experiment <experiment_name> -- <flag1> <flag2>...`

## Test Plan

Ran on my cluster