### PR TITLE
bytes: move most crates to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "admission-control-proto 0.1.0",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
@@ -751,7 +751,7 @@ name = "consensus"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "consensus-types 0.1.0",
@@ -2070,7 +2070,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)",
@@ -2278,7 +2278,7 @@ dependencies = [
 name = "libra-prost-ext"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2323,6 +2323,7 @@ dependencies = [
  "bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2664,7 +2665,7 @@ dependencies = [
 name = "netcore"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memsocket 0.1.0",
@@ -4204,7 +4205,7 @@ dependencies = [
 name = "socket-bench-server"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
@@ -4257,7 +4258,7 @@ dependencies = [
 name = "state-synchronizer"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "config-builder 0.1.0",
  "executor 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2883,6 +2883,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "opaque-debug"
@@ -5743,6 +5748,7 @@ dependencies = [
 "checksum num_enum_derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47b3a6cd5b8ac2ca83258cbaf693f740aca5681818b4720497305fd642447eb0"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
 name = "memsocket"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.12"
+bytes = "0.5"
 prost = "0.5.0"
 futures = { version = "0.3.0", features = ["compat"] }
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["protobuf-codec"] }

--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -7,6 +7,7 @@ use channel;
 use futures::executor::block_on;
 use libra_config::config::{AdmissionControlConfig, RoleType};
 use libra_proptest_helpers::ValueGenerator;
+use libra_prost_ext::MessageExt;
 use libra_types::transaction::SignedTransaction;
 use network::validator_network::AdmissionControlNetworkSender;
 use proptest;
@@ -30,9 +31,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
     let mut req = SubmitTransactionRequest::default();
     req.transaction = Some(signed_txn.into());
 
-    let mut bytes = bytes::BytesMut::with_capacity(req.encoded_len());
-    req.encode(&mut bytes).unwrap();
-    bytes.to_vec()
+    req.to_vec().unwrap()
 }
 
 /// fuzzer takes a serialized SubmitTransactionRequest an process it with an admission control

--- a/common/prost-ext/Cargo.toml
+++ b/common/prost-ext/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "0.4.12"
+bytes = "0.5"
 prost = "0.5.0"

--- a/common/prost-ext/src/lib.rs
+++ b/common/prost-ext/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use prost::{EncodeError, Message};
 
 impl<T: ?Sized> MessageExt for T where T: Message {}
@@ -13,9 +13,9 @@ pub trait MessageExt: Message {
     where
         Self: Sized,
     {
-        let mut bytes = BytesMut::with_capacity(self.encoded_len());
+        let mut bytes = Vec::with_capacity(self.encoded_len());
         self.encode(&mut bytes)?;
-        Ok(bytes.freeze())
+        Ok(bytes.into())
     }
 
     fn to_vec(&self) -> Result<Vec<u8>, EncodeError>

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
-bytes = "0.4.12"
+bytes = "0.5"
 futures = "0.3.0"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -714,7 +714,7 @@ fn process_block_retrieval() {
             .await;
         match rx1.await {
             Ok(Ok(bytes)) => {
-                let msg = ConsensusMsg::decode(bytes).unwrap();
+                let msg = ConsensusMsg::decode(bytes.as_ref()).unwrap();
                 let response = match msg.message {
                     Some(ConsensusMsg_oneof::RespondBlock(proto)) => {
                         BlockRetrievalResponse::<TestPayload>::try_from(proto)
@@ -740,7 +740,7 @@ fn process_block_retrieval() {
             .await;
         match rx2.await {
             Ok(Ok(bytes)) => {
-                let msg = ConsensusMsg::decode(bytes).unwrap();
+                let msg = ConsensusMsg::decode(bytes.as_ref()).unwrap();
                 let response = match msg.message {
                     Some(ConsensusMsg_oneof::RespondBlock(proto)) => {
                         BlockRetrievalResponse::<TestPayload>::try_from(proto)
@@ -765,7 +765,7 @@ fn process_block_retrieval() {
             .await;
         match rx3.await {
             Ok(Ok(bytes)) => {
-                let msg = ConsensusMsg::decode(bytes).unwrap();
+                let msg = ConsensusMsg::decode(bytes.as_ref()).unwrap();
                 let response = match msg.message {
                     Some(ConsensusMsg_oneof::RespondBlock(proto)) => {
                         BlockRetrievalResponse::<TestPayload>::try_from(proto)

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3.2"
-bytes = "0.4.12"
+bytes = "0.5"
 curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false }
 digest = "0.8.1"
 ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", features = ["serde"], default-features = false }

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -347,7 +347,7 @@ impl fmt::Display for HashValue {
 
 impl From<HashValue> for Bytes {
     fn from(value: HashValue) -> Bytes {
-        value.hash.as_ref().into()
+        Bytes::copy_from_slice(value.hash.as_ref())
     }
 }
 

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 
 [dependencies]
 futures = "0.3.0"
-bytes = { version = "0.4.12", default-features = false }
+bytes = "0.5"
 once_cell = "1.2.0"

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 [dependencies]
 futures = "0.3.0"
 bytes = { version = "0.4.12", default-features = false }
-lazy_static = { version = "1.3.0", default-features = false }
+once_cell = "1.2.0"

--- a/network/memsocket/src/lib.rs
+++ b/network/memsocket/src/lib.rs
@@ -9,12 +9,11 @@ use futures::{
     stream::{FusedStream, Stream},
     task::{Context, Poll},
 };
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::{collections::HashMap, num::NonZeroU16, pin::Pin, sync::Mutex};
 
-lazy_static! {
-    static ref SWITCHBOARD: Mutex<SwitchBoard> = Mutex::new(SwitchBoard(HashMap::default(), 1));
-}
+static SWITCHBOARD: Lazy<Mutex<SwitchBoard>> =
+    Lazy::new(|| Mutex::new(SwitchBoard(HashMap::default(), 1)));
 
 struct SwitchBoard(HashMap<NonZeroU16, UnboundedSender<MemorySocket>>, u16);
 

--- a/network/memsocket/src/lib.rs
+++ b/network/memsocket/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use bytes::{Buf, Bytes, IntoBuf};
+use bytes::{buf::BufExt, Buf, Bytes};
 use futures::{
     channel::mpsc::{self, UnboundedReceiver, UnboundedSender},
     io::{AsyncRead, AsyncWrite, Error, ErrorKind, Result},
@@ -244,7 +244,7 @@ impl<'a> Stream for Incoming<'a> {
 pub struct MemorySocket {
     incoming: UnboundedReceiver<Bytes>,
     outgoing: UnboundedSender<Bytes>,
-    current_buffer: Option<<Bytes as IntoBuf>::Buf>,
+    current_buffer: Option<Bytes>,
     seen_eof: bool,
 }
 
@@ -365,7 +365,7 @@ impl AsyncRead for MemorySocket {
                                     return Poll::Pending;
                                 }
                             }
-                            Poll::Ready(Some(buf)) => Some(buf.into_buf()),
+                            Poll::Ready(Some(buf)) => Some(buf),
                             Poll::Ready(None) => return Poll::Ready(Ok(bytes_read)),
                         }
                     };
@@ -386,7 +386,7 @@ impl AsyncWrite for MemorySocket {
 
         match self.outgoing.poll_ready(context) {
             Poll::Ready(Ok(())) => {
-                if let Err(e) = self.outgoing.start_send(buf.into()) {
+                if let Err(e) = self.outgoing.start_send(Bytes::copy_from_slice(buf)) {
                     if e.is_disconnected() {
                         return Poll::Ready(Err(Error::new(ErrorKind::BrokenPipe, e)));
                     }

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = { version = "0.4.12", default-features = false }
+bytes = "0.5"
 futures = { version = "0.3.0", features = ["io-compat", "compat"] }
 futures_01 = { version = "0.1.28", package = "futures" }
 parity-multiaddr = { version = "0.5.0", default-features = false }

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = { version = "0.4.12", default-features = false }
+bytes = "0.5"
 futures = { version = "0.3.0", features = ["io-compat", "compat"] }
 futures_01 = { version = "0.1.28", package = "futures" }
 parity-multiaddr = "0.5.0"

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -28,4 +28,4 @@ mod transport;
 mod utils;
 
 /// Type for unique identifier associated with each network protocol
-pub type ProtocolId = bytes::Bytes;
+pub type ProtocolId = bytes05::Bytes;

--- a/network/src/protocols/direct_send/test.rs
+++ b/network/src/protocols/direct_send/test.rs
@@ -9,7 +9,7 @@ use crate::{
     protocols::direct_send::{DirectSend, DirectSendNotification, DirectSendRequest, Message},
     ProtocolId,
 };
-use bytes::Bytes;
+use bytes05::Bytes;
 use channel;
 use futures::{sink::SinkExt, stream::StreamExt};
 use libra_types::PeerId;
@@ -101,11 +101,11 @@ fn test_inbound_substream() {
         let mut dialer_substream =
             Framed::new(IoCompat::new(dialer_substream), LengthDelimitedCodec::new());
         dialer_substream
-            .send(bytes05::Bytes::from_static(MESSAGE_1))
+            .send(Bytes::from_static(MESSAGE_1))
             .await
             .unwrap();
         dialer_substream
-            .send(bytes05::Bytes::from_static(MESSAGE_2))
+            .send(Bytes::from_static(MESSAGE_2))
             .await
             .unwrap();
     };
@@ -149,7 +149,7 @@ fn test_inbound_substream_closed() {
         let mut dialer_substream =
             Framed::new(IoCompat::new(dialer_substream), LengthDelimitedCodec::new());
         dialer_substream
-            .send(bytes05::Bytes::from_static(MESSAGE_1))
+            .send(Bytes::from_static(MESSAGE_1))
             .await
             .unwrap();
         // close the substream on the dialer side

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -34,7 +34,7 @@ fn get_raw_message(msg: DiscoveryMsg) -> Message {
 
 fn parse_raw_message(msg: Message) -> Result<DiscoveryMsg, NetworkError> {
     assert_eq!(msg.protocol, DISCOVERY_DIRECT_SEND_PROTOCOL);
-    let msg = DiscoveryMsg::decode(msg.mdata)?;
+    let msg = DiscoveryMsg::decode(msg.mdata.as_ref())?;
     Ok(msg)
 }
 

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     utils::MessageExt,
     validator_network::{Event, HealthCheckerNetworkEvents, HealthCheckerNetworkSender},
 };
-use bytes::Bytes;
+use bytes05::Bytes;
 use futures::{
     channel::oneshot,
     stream::{FusedStream, FuturesUnordered, Stream, StreamExt},

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -69,7 +69,7 @@ async fn expect_ping(
         ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL)
     );
 
-    let req_msg = HealthCheckerMsg::decode(req_data).unwrap();
+    let req_msg = HealthCheckerMsg::decode(req_data.as_ref()).unwrap();
     match req_msg.message {
         Some(HealthCheckerMsg_oneof::Ping(ping_msg)) => (ping_msg, res_tx),
         _ => panic!("Unexpected HealthCheckerMsg: {:?}", req_msg),
@@ -125,7 +125,7 @@ async fn send_inbound_ping(
 
 async fn expect_pong(res_rx: oneshot::Receiver<Result<Bytes, RpcError>>) {
     let res_data = res_rx.await.unwrap().unwrap();
-    let res_msg = HealthCheckerMsg::decode(res_data).unwrap();
+    let res_msg = HealthCheckerMsg::decode(res_data.as_ref()).unwrap();
     match res_msg.message {
         Some(HealthCheckerMsg_oneof::Pong(_)) => {}
         _ => panic!("Unexpected HealthCheckerMsg: {:?}", res_msg),

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::MessageExt,
     ProtocolId,
 };
-use bytes::Bytes;
+use bytes05::Bytes;
 use futures::{
     channel::oneshot,
     ready,
@@ -135,11 +135,11 @@ impl<TMessage: Message + Default> Stream for NetworkEvents<TMessage> {
             NetworkNotification::NewPeer(peer_id) => Ok(Event::NewPeer(peer_id)),
             NetworkNotification::LostPeer(peer_id) => Ok(Event::LostPeer(peer_id)),
             NetworkNotification::RecvRpc(peer_id, rpc_req) => {
-                let req_msg = TMessage::decode(rpc_req.data)?;
+                let req_msg = TMessage::decode(rpc_req.data.as_ref())?;
                 Ok(Event::RpcRequest((peer_id, req_msg, rpc_req.res_tx)))
             }
             NetworkNotification::RecvMessage(peer_id, msg) => {
-                let msg = TMessage::decode(msg.mdata)?;
+                let msg = TMessage::decode(msg.mdata.as_ref())?;
                 Ok(Event::Message((peer_id, msg)))
             }
         }))
@@ -278,7 +278,7 @@ impl<TMessage: Message + Default> NetworkSender<TMessage> {
 
         // wait for response and deserialize
         let res_data = res_rx.await??;
-        let res_msg = TMessage::decode(res_data)?;
+        let res_msg = TMessage::decode(res_data.as_ref())?;
         Ok(res_msg)
     }
 

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -29,7 +29,7 @@ libra-types = { path = "../types", version = "0.1.0" }
 vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
-bytes = "0.4.12"
+bytes = "0.5"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -12,7 +12,8 @@ edition = "2018"
 [dependencies]
 bech32 = "0.6.0"
 byteorder = { version = "1.3.2", default-features = false }
-bytes = { version = "0.4.12", default-features = false }
+bytes = "0.4.12"
+bytes05 = { version = "0.5", package = "bytes" }
 chrono = { version = "0.4.7", default-features = false, features = ["clock"] }
 hex = { version = "0.3.2", default-features = false }
 itertools = { version = "0.8.0", default-features = false }

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use bech32::{Bech32, FromBase32, ToBase32};
-use bytes::Bytes;
+use bytes05::Bytes;
 use failure::prelude::*;
 use hex;
 use libra_crypto::{
@@ -170,7 +170,7 @@ impl TryFrom<Bytes> for AccountAddress {
 
 impl From<AccountAddress> for Bytes {
     fn from(addr: AccountAddress) -> Bytes {
-        addr.0.as_ref().into()
+        Bytes::copy_from_slice(addr.0.as_ref())
     }
 }
 


### PR DESCRIPTION
 Most crates are update to bytes 0.5, eliminating some potential
    performance regressions introduced in f102b9fd ([rust] move to futures
    0.3 and tokio 0.2, 2019-11-06).
    
    Some crates still need to have 0.4 because prost still requires the 0.4
    version imported globally as `::bytes`. Once prost does a release to
    update to bytes 0.5 we can finish moving the rest of the crates to 0.5.