### PR TITLE
[security][draft] getting rid of a recoverable panic

### DIFF
--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -5,6 +5,7 @@ use consensus_types::{
     executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
 };
 use libra_crypto::HashValue;
+use libra_types::validator_verifier::VerifyError;
 use std::sync::Arc;
 
 mod block_store;
@@ -30,6 +31,8 @@ pub enum VoteReceptionResult {
     NewQuorumCertificate(Arc<QuorumCert>),
     /// The vote completes a new TimeoutCertificate
     NewTimeoutCertificate(Arc<TimeoutCertificate>),
+    /// There might be some issues adding a vote
+    ErrorAddingVote(VerifyError),
 }
 
 pub trait BlockReader: Send + Sync {

--- a/consensus/src/chained_bft/block_storage/pending_votes.rs
+++ b/consensus/src/chained_bft/block_storage/pending_votes.rs
@@ -105,7 +105,10 @@ impl PendingVotes {
             Err(VerifyError::TooLittleVotingPower { voting_power, .. }) => {
                 VoteReceptionResult::VoteAdded(voting_power)
             }
-            _ => panic!("Unexpected verification error, vote = {}", vote),
+            Err(error) => {
+                error!("MUST_FIX: vote received could not be added: {}", error);
+                VoteReceptionResult::ErrorAddingVote(error)
+            }
         }
     }
 


### PR DESCRIPTION
This should not panic as we can recover from this error: do nothing.

Sure, it might indicate some deeper problem, but we do not need to take down our validator because of this. This way we can continue to vote in subsequent round until the issue is fixed.

**draft:** I just need to understand how to properly log the error.