### PR TITLE
tokio: update to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-validator 0.1.0",
 ]
 
@@ -344,7 +344,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-semaphore 0.1.0",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -537,7 +537,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -665,7 +665,7 @@ dependencies = [
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
 ]
 
@@ -793,7 +793,7 @@ dependencies = [
  "storage-client 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-genesis 0.1.0",
  "vm-runtime 0.1.0",
  "vm-validator 0.1.0",
@@ -1502,7 +1502,7 @@ name = "futures-semaphore"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2198,7 +2198,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ttl_cache 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-validator 0.1.0",
 ]
@@ -2265,7 +2265,7 @@ dependencies = [
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-runtime 0.1.0",
 ]
 
@@ -2674,7 +2674,7 @@ dependencies = [
  "memsocket 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2709,7 +2709,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket-bench-server 0.1.0",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4211,7 +4211,7 @@ dependencies = [
  "netcore 0.1.0",
  "noise 0.1.0",
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4274,7 +4274,7 @@ dependencies = [
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
  "vm-runtime 0.1.0",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4988,7 +4988,7 @@ dependencies = [
  "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5918,7 +5918,7 @@ dependencies = [
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-"checksum tokio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5f74af90f3137ddcda0750d904390b289793c40fce7b6e94600b367533205d8"
+"checksum tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "beeef686ef92a222de07e089f455d9f8478bbba9651718f9e4b276babe829082"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -143,12 +143,11 @@ impl From<PeerManagerError> for NetworkError {
     }
 }
 
-//FIXME
-//impl From<time::timeout::Elapsed> for NetworkError {
-//    fn from(_err: time::timeout::Elapsed) -> NetworkError {
-//        Context::new(NetworkErrorKind::TimedOut).into()
-//    }
-//}
+impl From<tokio::time::Elapsed> for NetworkError {
+    fn from(_err: tokio::time::Elapsed) -> NetworkError {
+        Context::new(NetworkErrorKind::TimedOut).into()
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/network/src/protocols/rpc/error.rs
+++ b/network/src/protocols/rpc/error.rs
@@ -85,9 +85,8 @@ impl From<mpsc::SendError> for RpcError {
     }
 }
 
-// TODO add back once tokio exposes the Elapsed type
-//impl From<time::timeout::Elapsed> for RpcError {
-//    fn from(_err: time::timeout::Elapsed) -> RpcError {
-//        RpcError::TimedOut
-//    }
-//}
+impl From<tokio::time::Elapsed> for RpcError {
+    fn from(_err: tokio::time::Elapsed) -> RpcError {
+        RpcError::TimedOut
+    }
+}

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -302,7 +302,6 @@ async fn handle_outbound_rpc<TSubstream>(
                 timeout,
                 handle_outbound_rpc_inner(peer_mgr_tx, peer_id, protocol, req_data),
             )
-            .map_err(Into::<std::io::Error>::into)
             .map_err(Into::<RpcError>::into)
             .map(|r| r.and_then(|x| x))
             .boxed()
@@ -411,7 +410,6 @@ async fn handle_inbound_substream<TSubstream>(
                     substream.substream,
                 ),
             )
-            .map_err(Into::<std::io::Error>::into)
             .map_err(Into::<RpcError>::into)
             .map(|r| r.and_then(|x| x))
             .await;

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -410,8 +410,7 @@ fn outbound_rpc_timeout() {
         // Check error is timeout error
         let err = res.expect_err("Dialer's rpc request should fail");
         match err {
-            //FIXME when when tokio timout::Elapsed is exported again
-            RpcError::IoError(_) => {}
+            RpcError::TimedOut => {}
             err => panic!("Unexpected error: {:?}, expected TimedOut", err),
         };
     };


### PR DESCRIPTION
tokio 0.2.1 fixes a few things like properly exposing the `Elapsed` type
which is the error you recieve on a failed timeout.
