### PR TITLE
Make prover golden tests opt-in via env variable.

### DIFF
--- a/language/move-prover/bytecode-to-boogie/Cargo.toml
+++ b/language/move-prover/bytecode-to-boogie/Cargo.toml
@@ -26,4 +26,3 @@ prettydiff = "0.3.1"
 [features]
 default = []
 fuzzing = ["libra-types/fuzzing"]
-golden = []

--- a/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
@@ -50,9 +50,9 @@ pub fn generate_boogie(file_name: &str, target_modules: &[&str]) -> String {
     file_names.push(file_name);
     let (modules, source_maps) = compile_files(file_names.to_vec());
 
-    if cfg!(feature = "golden") {
-        // Verify or update golden file. This will run its own translate focused to the target test,
-        // so no need to pass in generated content.
+    if option_env!("VERIFY_BPL_GOLDEN").unwrap_or("0") == "1" {
+        // Verify or update golden files. This will run its own translate focused to the target
+        // test, so no need to pass in generated content.
         verify_or_update_golden(&modules, &source_maps, file_name, target_modules);
     }
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/README.md
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/README.md
@@ -1,18 +1,32 @@
 This directory contains a set of so-called golden files containing compilation results
-of the boogie translator. Those files are used for optional regression testing of the translator,
+of the boogie translator. Those files are used for regression testing of the translator,
 as well as for documenting the translation scheme.
 
-The tests are not run by default but are behind a feature flag. This is because upstream changes in the VM, mvir, or
-standard libraries may result in breaking them.
+The tests are *not* run by default but are guarded behind an environment variable. This is to
+avoid integration test failures for unrelated upstream changes in the VM, mvir, or standard
+libraries. For changes to the move prover, please run those tests manually and include the
+result in your PR.
+
+When running or updating the tests, keep in mind that upstream changes may have made the
+golden files out-of-date independent of your changes.
 
 To run those tests, use:
 
 ```shell script
-cargo test --test translator_test --features golden
+VERIFY_BPL_GOLDEN=1 cargo test --test translator_tests
 ```
 
 To update the golden files, use:
 
 ```shell script
-REGENERATE_GOLDENFILES=1 cargo test --test translator_test --features golden
+VERIFY_BPL_GOLDEN=1 REGENERATE_GOLDENFILES=1 cargo test --test translator_tests
 ```
+
+By careful with cargo caching of test results. Cargo doesn't know about the semantics of environment
+variables, and may not actually rerun tests for the different settings above. You may have to use
+
+```shell script
+touch tests/driver/mod.rs
+```
+
+... to enforce rerunning.


### PR DESCRIPTION
## Motivation

The new golden tests for the move prover where not intended to be run in Ci. This was
realized by using a cargo feature, but it appears that all features are tested for in Ci.

This PR makes those tests opt-in via an environment variable.

## Test Plan

Existing tests; manually testing the new opt-in feature.

## Related PRs

NA