### PR TITLE
[consensus] moving txn manager trait into correct file

### DIFF
--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_replication::{StateComputer, TxnManager};
+use crate::state_replication::StateComputer;
+use crate::txn_manager::TxnManager;
 use crate::{
     chained_bft::{
         chained_bft_smr::{ChainedBftSMR, ChainedBftSMRConfig},

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -11,7 +11,8 @@ use crate::{
         persistent_storage::{PersistentStorage, RecoveryData},
     },
     counters,
-    state_replication::{StateComputer, StateMachineReplication, TxnManager},
+    state_replication::{StateComputer, StateMachineReplication},
+    txn_manager::TxnManager,
     util::time_service::ClockTimeService,
 };
 use channel;

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -12,7 +12,8 @@ use crate::chained_bft::liveness::rotating_proposer_election::{choose_leader, Ro
 use crate::chained_bft::network::NetworkSender;
 use crate::chained_bft::persistent_storage::{PersistentStorage, RecoveryData};
 use crate::counters;
-use crate::state_replication::{StateComputer, TxnManager};
+use crate::state_replication::StateComputer;
+use crate::txn_manager::TxnManager;
 use crate::util::time_service::{ClockTimeService, TimeService};
 use consensus_types::common::{Payload, Round};
 use consensus_types::epoch_retrieval::EpochRetrievalRequest;

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -13,7 +13,7 @@ use crate::{
         persistent_storage::PersistentStorage,
     },
     counters,
-    state_replication::TxnManager,
+    txn_manager::TxnManager,
     util::time_service::{
         duration_since_epoch, wait_if_possible, TimeService, WaitingError, WaitingSuccess,
     },

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -4,7 +4,7 @@
 use crate::{
     chained_bft::block_storage::BlockReader,
     counters,
-    state_replication::TxnManager,
+    txn_manager::TxnManager,
     util::time_service::{wait_if_possible, TimeService, WaitingError, WaitingSuccess},
 };
 use consensus_types::{

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_replication::TxnManager;
+use crate::txn_manager::TxnManager;
 use executor::StateComputeResult;
 use failure::Result;
 use futures::{channel::mpsc, future, Future, FutureExt, SinkExt};

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -1,37 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::txn_manager::TxnManager;
 use consensus_types::block::Block;
 use consensus_types::executed_block::ExecutedBlock;
-use executor::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
+use executor::{ExecutedTrees, ProcessedVMOutput};
 use failure::Result;
 use futures::Future;
 use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeEventWithProof};
 use std::{pin::Pin, sync::Arc};
-
-/// Retrieves and updates the status of transactions on demand (e.g., via talking with Mempool)
-pub trait TxnManager: Send + Sync {
-    type Payload;
-
-    /// Brings new transactions to be applied.
-    /// The `exclude_txns` list includes the transactions that are already pending in the
-    /// branch of blocks consensus is trying to extend.
-    fn pull_txns(
-        &self,
-        max_size: u64,
-        exclude_txns: Vec<&Self::Payload>,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Payload>> + Send>>;
-
-    /// Notifies TxnManager about the payload of the committed block including the state compute
-    /// result, which includes the specifics of what transactions succeeded and failed.
-    fn commit_txns<'a>(
-        &'a self,
-        txns: &Self::Payload,
-        compute_result: &StateComputeResult,
-        // Monotonic timestamp_usecs of committed blocks is used to GC expired transactions.
-        timestamp_usecs: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
-}
 
 /// While Consensus is managing proposed blocks, `StateComputer` is managing the results of the
 /// (speculative) execution of their payload.


### PR DESCRIPTION
The TxnManager trait was living in state_replication.rs whereas it makes more sense for it to live in txn_manager.rs
