### PR TITLE
[AC SMP merge] add inbound RPC support for SMP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,8 +2178,10 @@ dependencies = [
 name = "libra-mempool"
 version = "0.1.0"
 dependencies = [
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2194,6 +2196,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2693,6 +2696,7 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2704,6 +2708,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-failure-ext 0.1.0",
  "libra-logger 0.1.0",
+ "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -21,6 +21,7 @@ use network::{
         CONSENSUS_DIRECT_SEND_PROTOCOL,
         CONSENSUS_RPC_PROTOCOL,
         MEMPOOL_DIRECT_SEND_PROTOCOL,
+        MEMPOOL_RPC_PROTOCOL,
         STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
     },
     NetworkPublicKeys, ProtocolId,
@@ -113,6 +114,7 @@ pub fn setup_network(
         .rpc_protocols(vec![
             ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL),
             ProtocolId::from_static(ADMISSION_CONTROL_RPC_PROTOCOL),
+            ProtocolId::from_static(MEMPOOL_RPC_PROTOCOL),
         ]);
     if config.is_permissioned {
         // If the node wants to run in permissioned mode, it should also have authentication and

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
+bytes05 = { version = "0.5", package = "bytes" }
 chrono = "0.4.7"
 futures = "0.1.28"
 futures-preview = { version = "0.3.0", package = "futures", features = ["compat"] }
@@ -35,11 +36,13 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
+libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"
 channel = { path = "../common/channel", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+assert_matches = "1.3.0"
 
 [build-dependencies]
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -39,6 +39,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }
 libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
+libra-mempool-shared-proto = { path = "../mempool/mempool-shared-proto", version = "0.1.0" }
 
 proptest = { version = "0.9.4", default-features = false, optional = true }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
@@ -46,6 +47,7 @@ libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0
 [dev-dependencies]
 criterion = "0.3.0"
 socket-bench-server = { path = "socket-bench-server", version = "0.1.0" }
+assert_matches = "1.3.0"
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/network/build.rs
+++ b/network/build.rs
@@ -15,6 +15,7 @@ fn main() {
         "../types/src/proto",
         "src/proto",
         "../admission_control/admission-control-proto/src/proto",
+        "../mempool/mempool-shared-proto/src/proto",
     ];
 
     prost_build::compile_protos(&proto_files, &includes).unwrap();

--- a/network/src/proto/mempool.proto
+++ b/network/src/proto/mempool.proto
@@ -5,7 +5,9 @@ syntax = "proto3";
 
 package mempool;
 
+import "mempool_status.proto";
 import "transaction.proto";
+import "vm_errors.proto";
 
 /* MempoolSyncMsg represents the messages exchanging between validators to keep
  * transactions in sync. The proto definition provides the spec on the wire so
@@ -13,6 +15,21 @@ import "transaction.proto";
  * Mempool service is responsible for sending and receiving MempoolSyncMsg
  * across validators. */
 message MempoolSyncMsg {
+  oneof message {
+    BroadcastTransactionsRequest broadcast_transactions_request = 1;
+    BroadcastTransactionsResponse broadcast_transactions_response = 2;
+  }
+}
+
+// ------------------------------------------------------------
+// ---------------- Submit transactions -----------------------
+// ------------------------------------------------------------
+// The request for transaction submission.
+message BroadcastTransactionsRequest {
   bytes peer_id = 1;
   repeated types.SignedTransaction transactions = 2;
+}
+
+message BroadcastTransactionsResponse {
+  uint64 backpressure_ms = 1;
 }

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -31,7 +31,10 @@ pub use self::{
     health_checker::{
         health_checker_msg::Message as HealthCheckerMsg_oneof, HealthCheckerMsg, Ping, Pong,
     },
-    mempool::MempoolSyncMsg,
+    mempool::{
+        mempool_sync_msg::Message as MempoolSyncMsg_oneof, BroadcastTransactionsRequest,
+        BroadcastTransactionsResponse, MempoolSyncMsg,
+    },
     network::{
         identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,
         PeerInfo, SignedFullNodePayload, SignedPeerInfo,

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -53,7 +53,9 @@ pub use health_checker::{
     HealthCheckerNetworkEvents, HealthCheckerNetworkSender, HEALTH_CHECKER_RPC_PROTOCOL,
 };
 use libra_types::PeerId;
-pub use mempool::{MempoolNetworkEvents, MempoolNetworkSender, MEMPOOL_DIRECT_SEND_PROTOCOL};
+pub use mempool::{
+    MempoolNetworkEvents, MempoolNetworkSender, MEMPOOL_DIRECT_SEND_PROTOCOL, MEMPOOL_RPC_PROTOCOL,
+};
 pub use state_synchronizer::{
     StateSynchronizerEvents, StateSynchronizerSender, STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
 };


### PR DESCRIPTION
## Summary
This is the first of many PR's to change the SMP-SMP networking protocol from direct send ('fire and forget') to RPC. 

This PR builds out the first basic workflow for SMP to (1) listen for and (2) handle inbound RPC requests from other nodes SMP. 

### (1) listening for inbound RPC requests:
Specific changes:
- changing `mempool.proto` to support RPC requests and response for SMP
- refactoring existing tests and existing networking code for SMP based on above proto changes
- adding inbound RPC entrypoint for batched transaction submissions to SMP

### (2) handling inbound RPC requests
Specific changes: 
- adding functionality in `shared_mempool.rs` to validate and add the transactions to local mempool 

Description: with these changes, SMP tries to vm-validate and add transactions to local mempool. For now, it returns a dummy response to the sender via RPC callback. 

## Test Plan

- For (1) listening for inbound RPC requests: Added unit test in `network/src/validator_network/mempool.rs` to test SMP receiving inbound RPC calls
- For (2) handling inbound RPC requests: Logic for actually handling the transactions in the inbound RPC calls will be tested in integration tests in later PRs, once the outbound RPC calls are implemented
- Refactored existing tests pass

