### PR TITLE
errors: migrate to using thiserror and anyhow for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "libra-types 0.1.0",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,7 @@ name = "network"
 version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
+ "anyhow 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2717,6 +2718,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket-bench-server 0.1.0",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "storage-client 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-genesis 0.1.0",
  "vm-runtime 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,6 +1854,7 @@ dependencies = [
  "libra-failure-ext 0.1.0",
  "libra-types 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "storage-proto 0.1.0",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-tools 0.1.0",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)",
@@ -4635,6 +4636,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-id"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5908,6 +5927,8 @@ dependencies = [
 "checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum text-diff 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "309238dd66f8bf11a20d015b727b926f294a13fcb8d56770bb984e7a22c43897"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95be1032c63011f20b01c5edb64930e2b51512782b43b458b1e3449613d70f87"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.17"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2118,7 +2118,7 @@ dependencies = [
 name = "libra-failure-ext"
 version = "0.1.0"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-failure-macros 0.1.0",
 ]
 
@@ -2691,7 +2691,7 @@ name = "network"
 version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
- "anyhow 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5503,7 +5503,7 @@ dependencies = [
 name = "x"
 version = "0.1.0"
 dependencies = [
- "anyhow 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5566,7 +5566,7 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
-"checksum anyhow 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "70a45816cea85cf69e3b34c7c99a13ca1654ee222029636a8674958043a2fac1"
+"checksum anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b412394828b7ca486b362f300b762d8e43dafd6f0d727b63f1cd2ade207c6cef"
 "checksum arc-swap 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "854ede29f7a0ce90519fb2439d030320c6201119b87dab0ee96044603e1130b9"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2068,6 +2068,7 @@ dependencies = [
  "parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ dependencies = [
  "libra-types 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/common/failure-ext/Cargo.toml
+++ b/common/failure-ext/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-failure = "0.1.3"
+anyhow = "1.0"
 
 libra-failure-macros = { path = "failure-macros", version = "0.1.0" }

--- a/common/failure-ext/src/lib.rs
+++ b/common/failure-ext/src/lib.rs
@@ -13,21 +13,16 @@
 //! // Most of the types and macros you'll need can be found in the prelude.
 //! use failure::prelude::*;
 
-pub use failure::{
-    _core, bail, ensure, err_msg, format_err, AsFail, Backtrace, Causes, Compat, Context, Error,
-    Fail, ResultExt, SyncFailure,
-};
+pub use anyhow::{anyhow, bail, ensure, format_err, Chain, Context, Error, Result};
 
 // Custom error handling macros are placed in the failure-macros crate. Due to
 // the way intra-crate macro exports currently work, macros can't be exported
 // from anywhere but the top level when they are defined in the same crate.
 pub use libra_failure_macros::{bail_err, unrecoverable};
 
-pub type Result<T> = ::std::result::Result<T, Error>;
-
 /// Prelude module containing most commonly used types/macros this crate exports.
 pub mod prelude {
     pub use crate::Result;
-    pub use failure::{bail, ensure, err_msg, format_err, Error, Fail, ResultExt};
+    pub use anyhow::{anyhow, bail, ensure, format_err, Context, Error};
     pub use libra_failure_macros::{bail_err, unrecoverable};
 }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -16,6 +16,7 @@ mirai-annotations = "1.4.0"
 parity-multiaddr = { version = "0.5.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.99", features = ["rc"], default-features = false }
+thiserror = "1.0"
 toml = { version = "0.5.3", default-features = false }
 
 failure = { path = "../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -12,6 +12,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use thiserror::Error;
 use toml;
 
 mod admission_control_config;
@@ -145,14 +146,9 @@ impl fmt::Display for RoleType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("Invalid node role: {0}")]
 pub struct ParseRoleError(String);
-
-impl fmt::Display for ParseRoleError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "Invalid node role: {}", &self.0)
-    }
-}
 
 impl NodeConfig {
     /// This clones the underlying data except for the keypair so that this config can be used as a

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -6,7 +6,7 @@ use crate::{
     keys::{self, KeyPair},
     utils,
 };
-use failure::{self, ensure, Result};
+use failure::{self, anyhow, ensure, Result};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
@@ -117,11 +117,10 @@ impl NetworkConfig {
         }
         if self.advertised_address.to_string().is_empty() {
             self.advertised_address =
-                utils::get_local_ip().ok_or_else(|| ::failure::err_msg("No local IP"))?;
+                utils::get_local_ip().ok_or_else(|| anyhow!("No local IP"))?;
         }
         if self.listen_address.to_string().is_empty() {
-            self.listen_address =
-                utils::get_local_ip().ok_or_else(|| ::failure::err_msg("No local IP"))?;
+            self.listen_address = utils::get_local_ip().ok_or_else(|| anyhow!("No local IP"))?;
         }
         // If PeerId is not set, it is derived from NetworkIdentityKey.
         if self.peer_id == PeerId::default() {

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -26,6 +26,7 @@ rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 serde_json = "1.0"
 siphasher = { version = "0.3.0", default-features = false }
+thiserror = "1.0"
 termion = { version = "1.5.3", default-features = false }
 tokio = { version = "0.2", features = ["full"] }
 prometheus = { version = "0.7.0", default-features = false }

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -92,7 +92,7 @@ impl<T: Payload> ProposalMsg<T> {
         );
         self.proposal
             .verify_well_formed()
-            .with_context(|e| format!("Fail to verify ProposalMsg's block: {:}", e))?;
+            .context("Fail to verify ProposalMsg's block")?;
         ensure!(
             self.proposal.round() > 0,
             "Proposal for {} has an incorrect round of 0",

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -120,7 +120,7 @@ impl QuorumCert {
         }
         self.ledger_info()
             .verify(validator)
-            .with_context(|e| format!("Fail to verify QuorumCert: {:?}", e))?;
+            .context("Fail to verify QuorumCert")?;
         Ok(())
     }
 }

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{common::Round, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate};
-use failure::{ensure, ResultExt};
+use failure::{ensure, Context};
 use libra_types::block_info::BlockInfo;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use network;
@@ -110,7 +110,7 @@ impl SyncInfo {
                 }
                 Ok(())
             })
-            .with_context(|e| format!("Fail to verify SyncInfo: {:?}", e))?;
+            .context("Fail to verify SyncInfo")?;
         Ok(())
     }
 

--- a/consensus/consensus-types/src/timeout_certificate.rs
+++ b/consensus/consensus-types/src/timeout_certificate.rs
@@ -46,7 +46,7 @@ impl TimeoutCertificate {
         for (author, signature) in self.signatures() {
             signature
                 .verify(validator, *author, timeout_hash)
-                .with_context(|e| format!("Fail to verify TimeoutCertificate: {:?}", e))?;
+                .context("Fail to verify TimeoutCertificate")?;
         }
         Ok(())
     }

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{common::Author, timeout::Timeout, vote_data::VoteData};
-use failure::{ensure, ResultExt};
+use failure::{ensure, Context};
 use libra_crypto::hash::CryptoHash;
 use libra_types::{
     crypto_proxies::{Signature, ValidatorSigner, ValidatorVerifier},
@@ -127,11 +127,11 @@ impl Vote {
         );
         self.signature()
             .verify(validator, self.author(), self.ledger_info.hash())
-            .with_context(|e| format!("Fail to verify Vote: {:?}", e))?;
+            .context("Fail to verify Vote")?;
         if let Some(timeout_signature) = &self.timeout_signature {
             timeout_signature
                 .verify(validator, self.author(), self.timeout().hash())
-                .with_context(|e| format!("Fail to verify Vote: {:?}", e))?;
+                .context("Fail to verify Vote")?;
         }
         Ok(())
     }

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -13,6 +13,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 failure = { path = "../../common/failure-ext", version = "0.1.0", package = "libra-failure-ext" }
 serde = { version = "1.0.99", default-features = false }
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -12,7 +12,6 @@ use consensus_types::{
     vote_data::VoteData,
     vote_proposal::VoteProposal,
 };
-use failure::Fail;
 use libra_crypto::hash::HashValue;
 use libra_types::{
     block_info::BlockInfo,
@@ -22,28 +21,27 @@ use libra_types::{
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
+use thiserror::Error;
 
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 /// Different reasons for proposal rejection
 pub enum Error {
-    #[fail(
-        display = "Unable to verify that the new tree extneds the parent: {:?}",
-        error
-    )]
+    #[error("Unable to verify that the new tree extneds the parent: {:?}", error)]
     InvalidAccumulatorExtension { error: String },
 
     /// This proposal's round is less than round of preferred block.
     /// Returns the id of the preferred block.
-    #[fail(
-        display = "Proposal's round is lower than round of preferred block at round {:?}",
+    #[error(
+        "Proposal's round is lower than round of preferred block at round {:?}",
         preferred_round
     )]
     ProposalRoundLowerThenPreferredBlock { preferred_round: Round },
 
     /// This proposal is too old - return last_voted_round
-    #[fail(
-        display = "Proposal at round {:?} is not newer than the last vote round {:?}",
-        proposal_round, last_voted_round
+    #[error(
+        "Proposal at round {:?} is not newer than the last vote round {:?}",
+        proposal_round,
+        last_voted_round
     )]
     OldProposal {
         last_voted_round: Round,

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -13,7 +13,7 @@ use consensus_types::{
     common::{Author, Payload, Round},
     quorum_cert::QuorumCert,
 };
-use failure::ResultExt;
+use failure::Context;
 use libra_logger::prelude::*;
 use std::{
     sync::{Arc, Mutex},
@@ -199,7 +199,7 @@ impl<T: Payload> ProposalGenerator<T> {
             self.txn_manager
                 .pull_txns(self.max_block_size, exclude_payload)
                 .await
-                .with_context(|e| format!("Fail to retrieve txn: {}", e))?
+                .context("Fail to retrieve txn")?
         };
 
         Ok(BlockData::new_proposal(

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -8,7 +8,7 @@ use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
-use failure::{Result, ResultExt};
+use failure::{Context, Result};
 use libra_config::config::NodeConfig;
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
@@ -70,11 +70,11 @@ impl<T: Payload> RecoveryData<T> {
         validators: Arc<ValidatorVerifier>,
     ) -> Result<Self> {
         let root =
-            Self::find_root(&mut blocks, &mut quorum_certs, storage_ledger).with_context(|e| {
+            Self::find_root(&mut blocks, &mut quorum_certs, storage_ledger).with_context(|| {
                 // for better readability
                 quorum_certs.sort_by_key(|qc| qc.certified_block().round());
                 format!(
-                    "Blocks in db: {}\nQuorum Certs in db: {}\nerror: {}",
+                    "Blocks in db: {}\nQuorum Certs in db: {}\n",
                     blocks
                         .iter()
                         .map(|b| format!("\n\t{}", b))
@@ -85,7 +85,6 @@ impl<T: Payload> RecoveryData<T> {
                         .map(|qc| format!("\n\t{}", qc))
                         .collect::<Vec<String>>()
                         .concat(),
-                    e,
                 )
             })?;
 

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -8,6 +8,7 @@ use std::{
     pin::Pin,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use thiserror::Error;
 use tokio::{runtime::Handle, time::delay_for};
 
 /// Time service is an abstraction for operations that depend on time
@@ -135,13 +136,12 @@ pub enum WaitingSuccess {
 }
 
 /// Error states for wait_if_possible
-#[derive(Debug, PartialEq, Eq, Fail)]
+#[derive(Debug, PartialEq, Eq, Error)]
+#[error("{:?}", self)]
 pub enum WaitingError {
     /// The waiting period exceeds the maximum allowed duration, returning immediately
-    #[fail(display = "MaxWaitExceeded")]
     MaxWaitExceeded,
     /// Waiting to ensure the current time exceeds min_duration_since_epoch failed
-    #[fail(display = "WaitFailed")]
     WaitFailed {
         current_duration_since_epoch: Duration,
         wait_duration: Duration,

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.96", features = ["derive"] }
 sha2 = "0.8.0"
 sha3 = "0.8.2"
 static_assertions = { version = "1.0.0", optional = true }
+thiserror = "1.0"
 threshold_crypto = "0.3"
 tiny-keccak = "1.5.0"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false }

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -320,7 +320,7 @@ impl Signature for Ed25519Signature {
         public_key
             .0
             .verify(message, &self.0)
-            .map_err(std::convert::Into::into)
+            .map_err(|e| anyhow!("{}", e))
             .and(Ok(()))
     }
 
@@ -347,7 +347,8 @@ impl Signature for Ed25519Signature {
         // messages as the number of signatures. In our case, we just populate the same
         // message to meet dalek's api requirements.
         let messages = vec![message_ref; dalek_signatures.len()];
-        ed25519_dalek::verify_batch(&messages[..], &dalek_signatures[..], &dalek_public_keys[..])?;
+        ed25519_dalek::verify_batch(&messages[..], &dalek_signatures[..], &dalek_public_keys[..])
+            .map_err(|e| anyhow!("{}", e))?;
         Ok(())
     }
 }

--- a/crypto/crypto/src/hkdf.rs
+++ b/crypto/crypto/src/hkdf.rs
@@ -82,6 +82,7 @@ use digest::{
 use generic_array::typenum::Unsigned;
 use hmac::{Hmac, Mac};
 use std::marker::PhantomData;
+use thiserror::Error;
 
 /// Structure representing the HKDF, capable of HKDF-Extract and HKDF-Expand operations, as defined
 /// in RFC 5869.
@@ -172,24 +173,24 @@ where
 /// b) hash functions outputting less than 32 bits are not supported (i.e., SHA1 is not supported).
 /// c) small PRK value in HKDF-Expand according to RFC 5869.
 /// d) any other underlying HMAC error.
-#[derive(Clone, Debug, PartialEq, Eq, failure::prelude::Fail)]
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
 pub enum HkdfError {
     /// HKDF expand output exceeds the maximum allowed or is zero.
-    #[fail(
-        display = "HKDF expand error - requested output size exceeds the maximum allowed or is zero"
-    )]
+    #[error("HKDF expand error - requested output size exceeds the maximum allowed or is zero")]
     InvalidOutputLengthError,
     /// Hash function is not supported because its output is less than 32 bits.
-    #[fail(display = "HKDF error - the hash function is not supported because \
-                      its output is less than 32 bits")]
+    #[error(
+        "HKDF error - the hash function is not supported because \
+         its output is less than 32 bits"
+    )]
     NotSupportedHashFunctionError,
     /// PRK on HKDF-Expand should not be less than the underlying hash output bits.
-    #[fail(
-        display = "HKDF expand error - the pseudorandom key input ('prk' in RFC 5869) \
-                   is less than the underlying hash output bits"
+    #[error(
+        "HKDF expand error - the pseudorandom key input ('prk' in RFC 5869) \
+         is less than the underlying hash output bits"
     )]
     WrongPseudorandomKeyError,
     /// HMAC key related error; unlikely to happen because every key size is accepted in HMAC.
-    #[fail(display = "HMAC key error")]
+    #[error("HMAC key error")]
     MACKeyError,
 }

--- a/crypto/crypto/src/slip0010.rs
+++ b/crypto/crypto/src/slip0010.rs
@@ -14,6 +14,7 @@ use byteorder::{BigEndian, ByteOrder};
 use ed25519_dalek::{PublicKey, SecretKey};
 use hmac::{Hmac, Mac};
 use sha2::Sha512;
+use thiserror::Error;
 
 /// Extended private key that includes additional child_path and chain-code.
 pub struct ExtendedPrivKey {
@@ -180,15 +181,15 @@ impl Slip0010 {
 /// a) invalid key-path.
 /// b) secret_key generation errors.
 /// c) hmac related errors.
-#[derive(Clone, Debug, PartialEq, Eq, failure::prelude::Fail)]
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
 pub enum Slip0010Error {
     /// Invalid key path.
-    #[fail(display = "SLIP-0010 invalid key path")]
+    #[error("SLIP-0010 invalid key path")]
     KeyPathError,
     /// Any error related to key derivation.
-    #[fail(display = "SLIP-0010 - cannot generate key")]
+    #[error("SLIP-0010 - cannot generate key")]
     SecretKeyError,
     /// HMAC key related error; unlikely to happen because every key size is accepted in HMAC.
-    #[fail(display = "SLIP-0010 - HMAC key error")]
+    #[error("SLIP-0010 - HMAC key error")]
     MACKeyError,
 }

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -10,6 +10,7 @@ use crate::HashValue;
 use core::convert::{From, TryFrom};
 use failure::prelude::*;
 use std::{fmt::Debug, hash::Hash};
+use thiserror::Error;
 
 /// An error type for key and signature validation issues, see [`ValidKey`][ValidKey].
 ///
@@ -18,25 +19,20 @@ use std::{fmt::Debug, hash::Hash};
 /// (often, due to mangled material or curve equation failure for ECC) and
 /// validation errors (material recognizable but unacceptable for use,
 /// e.g. unsafe).
-#[derive(Clone, Debug, PartialEq, Eq, failure::prelude::Fail)]
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[error("{:?}", self)]
 pub enum CryptoMaterialError {
     /// Key or signature material does not deserialize correctly.
-    #[fail(display = "DeserializationError")]
     DeserializationError,
     /// Key or signature material deserializes, but is otherwise not valid.
-    #[fail(display = "ValidationError")]
     ValidationError,
     /// Key or signature material does not have the expected size.
-    #[fail(display = "WrongLengthError")]
     WrongLengthError,
     /// Part of the signature or key is not canonical resulting to malleability issues.
-    #[fail(display = "CanonicalRepresentationError")]
     CanonicalRepresentationError,
     /// A curve point (i.e., a public key) lies on a small group.
-    #[fail(display = "SmallSubgroupError")]
     SmallSubgroupError,
     /// A curve point (i.e., a public key) does not satisfy the curve equation.
-    #[fail(display = "PointNotOnCurveError")]
     PointNotOnCurveError,
 }
 

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -18,6 +18,7 @@ bytecode-source-map = { path = "../bytecode-source-map", version = "0.1.0" }
 log = "0.4.7"
 codespan = "0.2.1"
 codespan-reporting = "0.2.1"
+thiserror = "1.0"
 
 [features]
 default = []

--- a/language/compiler/ir-to-bytecode/src/errors.rs
+++ b/language/compiler/ir-to-bytecode/src/errors.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use failure::Fail;
 use libra_types::vm_error::VMStatus;
+use thiserror::Error;
 
-#[derive(Clone, Debug, Eq, Fail, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Error, Ord, PartialEq, PartialOrd)]
 pub enum InternalCompilerError {
-    #[fail(display = "Post-compile bounds check errors: {:?}", _0)]
+    #[error("Post-compile bounds check errors: {0:?}")]
     BoundsCheckErrors(Vec<VMStatus>),
 }

--- a/language/functional_tests/Cargo.toml
+++ b/language/functional_tests/Cargo.toml
@@ -22,6 +22,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 filecheck = "0.4.0"
 lazy_static = "1.3.0"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
+thiserror = "1.0"
 
 [dev-dependencies]
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }

--- a/language/functional_tests/src/checker.rs
+++ b/language/functional_tests/src/checker.rs
@@ -57,10 +57,13 @@ impl FromStr for Directive {
 /// Check the output using filecheck checker.
 pub fn run_filecheck(output: &str, checks: &str) -> Result<bool> {
     let mut builder = filecheck::CheckerBuilder::new();
-    builder.text(checks)?;
+    builder.text(checks).map_err(|e| anyhow!("{:?}", e))?;
     let checker = builder.finish();
     // filecheck allows one to pass in a variable map, however we're not using it
-    if !checker.check(output, filecheck::NO_VARIABLES)? {
+    if !checker
+        .check(output, filecheck::NO_VARIABLES)
+        .map_err(|e| anyhow!("{:?}", e))?
+    {
         return Err(ErrorKind::CheckerFailure.into());
     }
     Ok(!checker.is_empty())

--- a/language/functional_tests/src/errors.rs
+++ b/language/functional_tests/src/errors.rs
@@ -1,26 +1,22 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use failure::Fail;
+pub use failure::{Error, Result};
 use libra_types::{transaction::TransactionOutput, vm_error::VMStatus};
-
-pub use failure::Error;
+use thiserror::Error;
 
 /// Defines all errors in this crate.
-#[derive(Clone, Debug, Fail)]
+#[derive(Clone, Debug, Error)]
 pub enum ErrorKind {
-    #[fail(display = "an error occurred when executing the transaction")]
+    #[error("an error occurred when executing the transaction")]
     VMExecutionFailure(TransactionOutput),
-    #[fail(display = "the transaction was discarded")]
+    #[error("the transaction was discarded")]
     DiscardedTransaction(TransactionOutput),
-    #[fail(display = "the checker has failed to match the directives against the output")]
+    #[error("the checker has failed to match the directives against the output")]
     CheckerFailure,
-    #[fail(display = "verification error {:?}", _0)]
+    #[error("verification error {0:?}")]
     VerificationFailure(Vec<VMStatus>),
-    #[fail(display = "other error: {}", _0)]
+    #[error("other error: {0}")]
     #[allow(dead_code)]
     Other(String),
 }
-
-/// The common result type used in this crate.
-pub type Result<T> = std::result::Result<T, Error>;

--- a/language/functional_tests/src/errors.rs
+++ b/language/functional_tests/src/errors.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub use failure::{Error, Result};
+pub use failure::{anyhow, Error, Result};
 use libra_types::{transaction::TransactionOutput, vm_error::VMStatus};
 use thiserror::Error;
 

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -14,6 +14,7 @@ client_lib = { package = "client", path = "../client", version = "0.1.0" }
 ctrlc = { version = "3.1.3", default-features = false }
 lazy_static = { version = "1.3.0", default-features = false }
 structopt = "0.3.2"
+thiserror = "1.0"
 
 libra-config = { path = "../config", version = "0.1.0", features = ["fuzzing"] }
 config-builder = { path = "../config/config-builder", version = "0.1.0" }

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -18,6 +18,7 @@ use std::{
     process::{Child, Command},
     str::FromStr,
 };
+use thiserror::Error;
 
 const LIBRA_NODE_BIN: &str = "libra-node";
 
@@ -203,25 +204,19 @@ pub struct LibraSwarm {
     pub config: SwarmConfig,
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum SwarmLaunchFailure {
     /// Timeout while waiting for nodes to start
-    #[fail(display = "Node launch check timeout")]
+    #[error("Node launch check timeout")]
     LaunchTimeout,
     /// Node return status indicates a crash
-    #[fail(display = "Node crash")]
+    #[error("Node crash")]
     NodeCrash,
     /// Timeout while waiting for the nodes to report that they're all interconnected
-    #[fail(display = "Node connectivity check timeout")]
+    #[error("Node connectivity check timeout")]
     ConnectivityTimeout,
-    #[fail(display = "IO Error")]
-    IoError(#[cause] io::Error),
-}
-
-impl From<io::Error> for SwarmLaunchFailure {
-    fn from(err: io::Error) -> Self {
-        SwarmLaunchFailure::IoError(err)
-    }
+    #[error("IO Error")]
+    IoError(#[from] io::Error),
 }
 
 impl LibraSwarm {

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,6 +20,8 @@ pin-project = "0.4.2"
 prost = "0.5.0"
 prometheus = { version = "0.7.0", default-features = false }
 rand = "0.6.5"
+thiserror = "1.0"
+anyhow = "1.0"
 tokio = { version = "0.2", features = ["full"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 tokio-retry = "0.2.0"

--- a/network/src/error.rs
+++ b/network/src/error.rs
@@ -2,182 +2,145 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::peer_manager::PeerManagerError;
-use failure::{Backtrace, Context, Fail};
 use futures::channel::{mpsc, oneshot};
 use libra_types::validator_verifier::VerifyError;
-use std::{
-    fmt::{self, Display},
-    io,
-};
+use std::io;
+use thiserror::Error;
 
 /// Errors propagated from the network module.
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("{inner}")]
 pub struct NetworkError {
-    inner: Context<NetworkErrorKind>,
+    inner: anyhow::Error,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Error)]
 pub enum NetworkErrorKind {
-    #[fail(display = "IO error")]
+    #[error("IO error")]
     IoError,
 
-    #[fail(display = "Error parsing protobuf message")]
+    #[error("Error parsing protobuf message")]
     ProtobufParseError,
 
-    #[fail(display = "Invalid signature error")]
+    #[error("Invalid signature error")]
     SignatureError,
 
-    #[fail(display = "Failed to parse multiaddrs")]
+    #[error("Failed to parse multiaddrs")]
     MultiaddrError,
 
-    #[fail(display = "Error sending on mpsc channel")]
+    #[error("Error sending on mpsc channel")]
     MpscSendError,
 
-    #[fail(display = "Oneshot channel unexpectedly dropped")]
+    #[error("Oneshot channel unexpectedly dropped")]
     OneshotCanceled,
 
-    #[fail(display = "Error setting timeout")]
+    #[error("Error setting timeout")]
     TimerError,
 
-    #[fail(display = "Operation timed out")]
+    #[error("Operation timed out")]
     TimedOut,
 
-    #[fail(display = "Unknown tokio::time Error variant")]
+    #[error("Unknown tokio::time Error variant")]
     UnknownTimerError,
 
-    #[fail(display = "PeerManager error")]
+    #[error("PeerManager error")]
     PeerManagerError,
 
-    #[fail(display = "Parsing error")]
+    #[error("Parsing error")]
     ParsingError,
 
-    #[fail(display = "Peer not connected")]
+    #[error("Peer not connected")]
     NotConnected,
-}
-
-impl Fail for NetworkError {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-impl Display for NetworkError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.inner)
-    }
-}
-
-impl NetworkError {
-    pub fn kind(&self) -> NetworkErrorKind {
-        *self.inner.get_context()
-    }
 }
 
 impl From<NetworkErrorKind> for NetworkError {
     fn from(kind: NetworkErrorKind) -> NetworkError {
         NetworkError {
-            inner: Context::new(kind),
+            inner: anyhow::Error::new(kind),
         }
     }
 }
 
-impl From<Context<NetworkErrorKind>> for NetworkError {
-    fn from(inner: Context<NetworkErrorKind>) -> NetworkError {
+impl From<anyhow::Error> for NetworkError {
+    fn from(inner: anyhow::Error) -> NetworkError {
         NetworkError { inner }
     }
 }
 
 impl From<io::Error> for NetworkError {
     fn from(err: io::Error) -> NetworkError {
-        err.context(NetworkErrorKind::IoError).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::IoError)
+            .into()
     }
 }
 
 impl From<VerifyError> for NetworkError {
     fn from(err: VerifyError) -> NetworkError {
-        err.context(NetworkErrorKind::SignatureError).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::SignatureError)
+            .into()
     }
 }
 
 impl From<prost::EncodeError> for NetworkError {
     fn from(err: prost::EncodeError) -> NetworkError {
-        err.context(NetworkErrorKind::ProtobufParseError).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::ProtobufParseError)
+            .into()
     }
 }
 
 impl From<prost::DecodeError> for NetworkError {
     fn from(err: prost::DecodeError) -> NetworkError {
-        err.context(NetworkErrorKind::ProtobufParseError).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::ProtobufParseError)
+            .into()
     }
 }
 
 impl From<parity_multiaddr::Error> for NetworkError {
     fn from(err: parity_multiaddr::Error) -> NetworkError {
-        err.context(NetworkErrorKind::MultiaddrError).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::MultiaddrError)
+            .into()
     }
 }
 
 impl From<mpsc::SendError> for NetworkError {
     fn from(err: mpsc::SendError) -> NetworkError {
-        err.context(NetworkErrorKind::MpscSendError).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::MpscSendError)
+            .into()
     }
 }
 
 impl From<oneshot::Canceled> for NetworkError {
     fn from(err: oneshot::Canceled) -> NetworkError {
-        err.context(NetworkErrorKind::OneshotCanceled).into()
+        anyhow::Error::new(err)
+            .context(NetworkErrorKind::OneshotCanceled)
+            .into()
     }
 }
 
 impl From<PeerManagerError> for NetworkError {
     fn from(err: PeerManagerError) -> NetworkError {
         match err {
-            PeerManagerError::IoError(_) => err.context(NetworkErrorKind::IoError).into(),
-            PeerManagerError::NotConnected(_) => err.context(NetworkErrorKind::NotConnected).into(),
-            err => err.context(NetworkErrorKind::PeerManagerError).into(),
+            PeerManagerError::IoError(_) => anyhow::Error::new(err)
+                .context(NetworkErrorKind::IoError)
+                .into(),
+            PeerManagerError::NotConnected(_) => anyhow::Error::new(err)
+                .context(NetworkErrorKind::NotConnected)
+                .into(),
+            err => anyhow::Error::new(err)
+                .context(NetworkErrorKind::PeerManagerError)
+                .into(),
         }
     }
 }
 
 impl From<tokio::time::Elapsed> for NetworkError {
     fn from(_err: tokio::time::Elapsed) -> NetworkError {
-        Context::new(NetworkErrorKind::TimedOut).into()
-    }
-}
-
-#[cfg(test)]
-mod test {
-
-    use super::*;
-    use failure::AsFail;
-
-    // This test demos a causal error chain that can be created using the `context` method of `Fail`
-    // types.
-    #[test]
-    fn causal_chain() {
-        let base_error = ::failure::err_msg("First error");
-        let first_level_error = base_error.context(NetworkErrorKind::TimedOut);
-        let second_level_error = first_level_error.context(NetworkErrorKind::PeerManagerError);
-        let network_error: NetworkError = second_level_error.into();
-        // When called without RUST_BACKTRACE=1, the debug mode should print the following:
-        // NetworkError { inner: ErrorMessage { msg: "First error" }
-        // Operation timed out
-        // PeerManager error }
-        eprintln!("{:?}", network_error);
-        // The display mode output is just the outermost error:
-        // PeerManager error
-        eprintln!("{}", network_error);
-        // Alternatively, we can iterate over the individual failures in the causal chain to get
-        // the following output:
-        // Error: PeerManager error
-        // Error: Operation timed out
-        // Error: First error
-        for e in network_error.as_fail().iter_chain() {
-            eprintln!("Error: {}", e);
-        }
+        NetworkErrorKind::TimedOut.into()
     }
 }

--- a/network/src/peer_manager/error.rs
+++ b/network/src/peer_manager/error.rs
@@ -3,41 +3,35 @@
 
 //! Errors that originate from the PeerManager module
 
-use failure::Fail;
 use futures::channel::oneshot;
 use libra_types::PeerId;
 use parity_multiaddr::Multiaddr;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum PeerManagerError {
-    #[fail(display = "IO error: {}", _0)]
-    IoError(#[fail(cause)] ::std::io::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] ::std::io::Error),
 
-    #[fail(display = "Transport error: {}", _0)]
-    TransportError(#[fail(cause)] ::failure::Error),
+    #[error("Transport error: {0}")]
+    TransportError(::failure::Error),
 
-    #[fail(display = "Shutting down Peer")]
+    #[error("Shutting down Peer")]
     ShuttingDownPeer,
 
-    #[fail(display = "Not connected with Peer {}", _0)]
+    #[error("Not connected with Peer {0}")]
     NotConnected(PeerId),
 
-    #[fail(display = "Already connected at {}", _0)]
+    #[error("Already connected at {0}")]
     AlreadyConnected(Multiaddr),
 
-    #[fail(display = "Sending end of oneshot dropped")]
+    #[error("Sending end of oneshot dropped")]
     OneshotSenderDropped,
 }
 
 impl PeerManagerError {
     pub fn from_transport_error<E: Into<::failure::Error>>(error: E) -> Self {
         PeerManagerError::TransportError(error.into())
-    }
-}
-
-impl From<::std::io::Error> for PeerManagerError {
-    fn from(error: ::std::io::Error) -> Self {
-        PeerManagerError::IoError(error)
     }
 }
 

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -38,8 +38,8 @@ use crate::{
     validator_network::{DiscoveryNetworkEvents, DiscoveryNetworkSender, Event},
     NetworkPublicKeys,
 };
+use anyhow::anyhow;
 use channel;
-use failure::{format_err, Fail};
 use futures::{
     future::{Future, FutureExt},
     sink::SinkExt,
@@ -460,12 +460,12 @@ fn verify_note(
     // validate PeerId
 
     let peer_id = PeerId::try_from(note.peer_id.clone())
-        .map_err(|err| err.context(NetworkErrorKind::ParsingError))?;
+        .map_err(|err| anyhow!(err).context(NetworkErrorKind::ParsingError))?;
 
     // validate PeerInfo
 
     let signed_peer_info = note.signed_peer_info.as_ref().ok_or_else(|| {
-        format_err!("Discovery Note missing signed_peer_info field")
+        anyhow!("Discovery Note missing signed_peer_info field")
             .context(NetworkErrorKind::ParsingError)
     })?;
     let peer_info_bytes = &signed_peer_info.peer_info;
@@ -535,7 +535,7 @@ fn verify_signature(
     )
     .expect("Quorum size should be valid.");
     let signature = Ed25519Signature::try_from(signature)
-        .map_err(|err| err.context(NetworkErrorKind::SignatureError))?;
+        .map_err(|err| anyhow!(err).context(NetworkErrorKind::SignatureError))?;
     verifier.verify_signature(signer, get_hash(msg), &signature)?;
     Ok(())
 }

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -19,6 +19,7 @@ num-traits = "0.2"
 proptest = { version = "0.9.2", optional = true }
 proptest-derive = { version = "0.1.2", optional = true }
 serde = { version = "1.0.89", features = ["derive"] }
+thiserror = "1.0"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -16,7 +16,7 @@ mod node_type_test;
 use crate::nibble_path::NibblePath;
 use bincode::{deserialize, serialize};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
-use failure::{Fail, Result, *};
+use failure::{Result, *};
 use libra_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
@@ -40,6 +40,7 @@ use std::{
     io::{prelude::*, Cursor, Read, SeekFrom, Write},
     mem::size_of,
 };
+use thiserror::Error;
 
 /// The unique key of each node.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -646,24 +647,25 @@ impl Node {
 
 /// Error thrown when a [`Node`] fails to be deserialized out of a byte sequence stored in physical
 /// storage, via [`Node::decode`].
-#[derive(Debug, Fail, Eq, PartialEq)]
+#[derive(Debug, Error, Eq, PartialEq)]
 pub enum NodeDecodeError {
     /// Input is empty.
-    #[fail(display = "Missing tag due to empty input")]
+    #[error("Missing tag due to empty input")]
     EmptyInput,
 
     /// The first byte of the input is not a known tag representing one of the variants.
-    #[fail(display = "lead tag byte is unknown: {}", unknown_tag)]
+    #[error("lead tag byte is unknown: {}", unknown_tag)]
     UnknownTag { unknown_tag: u8 },
 
     /// No children found in internal node
-    #[fail(display = "No children found in internal node")]
+    #[error("No children found in internal node")]
     NoChildren,
 
     /// Extra leaf bits set
-    #[fail(
-        display = "Non-existent leaf bits set, existing: {}, leaves: {}",
-        existing, leaves
+    #[error(
+        "Non-existent leaf bits set, existing: {}, leaves: {}",
+        existing,
+        leaves
     )]
     ExtraLeaves { existing: u16, leaves: u16 },
 }

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -24,6 +24,7 @@ rusty-fork = "0.2.1"
 strum = "0.15.0"
 strum_macros = "0.15.0"
 serde = "1.0.96"
+thiserror = "1.0"
 
 accumulator = { path = "../accumulator", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/storage/libradb/src/errors.rs
+++ b/storage/libradb/src/errors.rs
@@ -3,18 +3,15 @@
 
 //! This module defines error types used by [`LibraDB`](crate::LibraDB).
 
-use failure::Fail;
+use thiserror::Error;
 
 /// This enum defines errors commonly used among [`LibraDB`](crate::LibraDB) APIs.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum LibraDbError {
     /// A requested item is not found.
-    #[fail(display = "{} not found.", _0)]
+    #[error("{0} not found.")]
     NotFound(String),
     /// Requested too many items.
-    #[fail(
-        display = "Too many items requested: at least {} requested, max is {}",
-        _0, _1
-    )]
+    #[error("Too many items requested: at least {0} requested, max is {1}")]
     TooManyRequested(u64, u64),
 }

--- a/storage/libradb/src/pruner/mod.rs
+++ b/storage/libradb/src/pruner/mod.rs
@@ -11,25 +11,23 @@ use crate::{
     OP_COUNTER,
 };
 use failure::prelude::*;
+use jellyfish_merkle::StaleNodeIndex;
 use libra_logger::prelude::*;
 use libra_types::transaction::Version;
 use schemadb::{ReadOptions, SchemaBatch, SchemaIterator, DB};
+#[cfg(test)]
+use std::thread::sleep;
+use std::{
+    iter::Peekable,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
 use std::{
     sync::{
         mpsc::{channel, Receiver, Sender},
         Arc, Mutex,
     },
     thread::JoinHandle,
-};
-
-use failure::_core::sync::atomic::Ordering;
-use jellyfish_merkle::StaleNodeIndex;
-#[cfg(test)]
-use std::thread::sleep;
-use std::{
-    iter::Peekable,
-    sync::atomic::AtomicU64,
-    time::{Duration, Instant},
 };
 
 /// The `Pruner` is meant to be part of a `LibraDB` instance and runs in the background to prune old

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -1,21 +1,22 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, fmt::Display};
-
-use failure::_core::fmt::{Error, Formatter};
-use failure::_core::time::Duration;
-
-use crate::cluster::Cluster;
-use crate::effects::{Effect, StopContainer};
-use crate::experiments::Context;
-use crate::experiments::Experiment;
-use crate::instance::Instance;
-use crate::{instance, stats};
+use crate::{
+    cluster::Cluster,
+    effects::{Effect, StopContainer},
+    experiments::Context,
+    experiments::Experiment,
+    instance,
+    instance::Instance,
+    stats,
+    util::unix_timestamp_now,
+};
 use futures::future::{join_all, BoxFuture, FutureExt};
-
-use crate::util::unix_timestamp_now;
-
+use std::{
+    collections::HashSet,
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -1,20 +1,19 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Display;
-
-use failure::_core::fmt::{Error, Formatter};
-use failure::_core::time::Duration;
-
-use crate::cluster::Cluster;
-use crate::effects::{three_region_simulation_effects, Effect};
-use crate::experiments::Context;
-use crate::experiments::Experiment;
-use crate::stats;
-
-use crate::util::unix_timestamp_now;
-use futures::future::join_all;
-use futures::future::{BoxFuture, FutureExt};
+use crate::{
+    cluster::Cluster,
+    effects::{three_region_simulation_effects, Effect},
+    experiments::Context,
+    experiments::Experiment,
+    stats,
+    util::unix_timestamp_now,
+};
+use futures::future::{join_all, BoxFuture, FutureExt};
+use std::{
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
 
 pub struct PerformanceBenchmarkThreeRegionSimulation {
     cluster: Cluster,

--- a/testsuite/libra-fuzzer/src/commands.rs
+++ b/testsuite/libra-fuzzer/src/commands.rs
@@ -45,13 +45,13 @@ pub fn make_corpus(
         let name = hex::encode(hash.as_slice());
         let path = corpus_dir.join(name);
         let mut f = fs::File::create(&path)
-            .with_context(|_| format!("Failed to create file: {:?}", path))?;
+            .with_context(|| format!("Failed to create file: {:?}", path))?;
         if debug {
             println!("Writing {} bytes to file: {:?}", result.len(), path);
         }
 
         f.write_all(&result)
-            .with_context(|_| format!("Failed to write to file: {:?}", path))?;
+            .with_context(|| format!("Failed to write to file: {:?}", path))?;
         idx += 1;
     }
     Ok(idx)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -25,6 +25,7 @@ prost = "0.5.0"
 radix_trie = { version = "0.1.4", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }
+thiserror = "1.0"
 tiny-keccak = { version = "1.5.0", default-features = false }
 
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -3,11 +3,11 @@
 
 #![forbid(unsafe_code)]
 
-//use crate::errors::*;
 use crate::{account_address::AccountAddress, byte_array::ByteArray};
 use failure::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
+use thiserror::Error;
 
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionArgument {
@@ -32,9 +32,9 @@ impl fmt::Debug for TransactionArgument {
     }
 }
 
-#[derive(Clone, Debug, Fail)]
+#[derive(Clone, Debug, Error)]
 pub enum ErrorKind {
-    #[fail(display = "ParseError: {}", _0)]
+    #[error("ParseError: {0}")]
     ParseError(String),
 }
 

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -11,30 +11,33 @@ use libra_crypto::*;
 use mirai_annotations::*;
 use std::collections::BTreeMap;
 use std::fmt;
+use thiserror::Error;
 
 /// Errors possible during signature verification.
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum VerifyError {
-    #[fail(display = "Author is unknown")]
+    #[error("Author is unknown")]
     /// The author for this signature is unknown by this validator.
     UnknownAuthor,
-    #[fail(
-        display = "The voting power ({}) is less than quorum voting power ({})",
-        voting_power, quorum_voting_power
+    #[error(
+        "The voting power ({}) is less than quorum voting power ({})",
+        voting_power,
+        quorum_voting_power
     )]
     TooLittleVotingPower {
         voting_power: u64,
         quorum_voting_power: u64,
     },
-    #[fail(
-        display = "The number of signatures ({}) is greater than total number of authors ({})",
-        num_of_signatures, num_of_authors
+    #[error(
+        "The number of signatures ({}) is greater than total number of authors ({})",
+        num_of_signatures,
+        num_of_authors
     )]
     TooManySignatures {
         num_of_signatures: usize,
         num_of_authors: usize,
     },
-    #[fail(display = "Signature is invalid")]
+    #[error("Signature is invalid")]
     /// The signature does not match the hash.
     InvalidSignature,
 }


### PR DESCRIPTION
Migrate from using failure to anyhow for general purpose error handling.
One of the biggest issues with the failure crate is that it isn't
compatible with the stdlib Error trait which makes it a little difficult
to inter-operate with error types which are not failure::Fail types
whereas the anyhow crate provides a general purpose error type which
implements the stdlib Error trait.

For right now the types inside of our failure-ext crate have just been switched out with the ones in anyhow. A future PR will go through the effort of individually converting each crate to not rely on the failure-ext crate and instead rely directly on anyhow.