### PR TITLE
[vm] VerTxn's lifetime should be txn.

### DIFF
--- a/language/vm/vm-runtime/src/process_txn/verify.rs
+++ b/language/vm/vm-runtime/src/process_txn/verify.rs
@@ -124,7 +124,7 @@ where
     fn verify_script(
         script: &Script,
         script_cache: &'txn ScriptCache<'alloc>,
-    ) -> Result<FunctionRef<'alloc>, VMStatus> {
+    ) -> Result<FunctionRef<'txn>, VMStatus> {
         // Ensure the script can correctly be resolved into main.
         let main = script_cache.cache_script(&script.code())?;
 
@@ -166,15 +166,15 @@ where
     P: ModuleCache<'alloc>,
 {
     pub(super) txn_executor: TransactionExecutor<'alloc, 'txn, P>,
-    pub(super) verified_txn: VerTxn<'alloc>,
+    pub(super) verified_txn: VerTxn<'txn>,
 }
 
 /// A verified transaction is a transaction executing code that has gone through the verifier.
 ///
 /// It can be a program, a script or a module. A transaction script gets executed by the VM.
 /// A module script publishes the module provided.
-pub enum VerTxn<'alloc> {
-    Script(FunctionRef<'alloc>),
+pub enum VerTxn<'txn> {
+    Script(FunctionRef<'txn>),
     Module(Box<VerifiedModule>),
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

VerTxn's lifetime is `alloc` currently, it should be `txn`, because it only lives in the txn process period.

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

No new code, the unit test is enough.
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
