### PR TITLE
[configs] Add better failure handling and testing

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -114,7 +114,7 @@ impl ClientProxy {
         mnemonic_file: Option<String>,
     ) -> Result<Self> {
         let validator_verifier = Arc::new(
-            ConsensusPeersConfig::load_config(validator_set_file).get_validator_verifier(),
+            ConsensusPeersConfig::load_config(validator_set_file)?.get_validator_verifier(),
         );
         ensure!(
             !validator_verifier.is_empty(),

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -139,7 +139,7 @@ impl SwarmConfigBuilder {
         }
 
         let template = if let Some(template_path) = &&self.template_path {
-            NodeConfig::load_config(template_path)
+            NodeConfig::load_config(template_path)?
         } else {
             NodeConfig::default()
         };

--- a/config/data/configs/overrides/persistent_data.node.config.override.toml
+++ b/config/data/configs/overrides/persistent_data.node.config.override.toml
@@ -1,2 +1,0 @@
-[base]
-data_dir = '/tmp/libra/test_persistent'

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -110,10 +110,10 @@ impl ConsensusConfig {
 
     pub fn load(&mut self) -> Result<()> {
         if !self.consensus_keypair_file.as_os_str().is_empty() {
-            self.consensus_keypair = ConsensusKeyPair::load_config(self.consensus_keypair_file());
+            self.consensus_keypair = ConsensusKeyPair::load_config(self.consensus_keypair_file())?;
         }
         if !self.consensus_peers_file.as_os_str().is_empty() {
-            self.consensus_peers = ConsensusPeersConfig::load_config(self.consensus_peers_file());
+            self.consensus_peers = ConsensusPeersConfig::load_config(self.consensus_peers_file())?;
         }
         Ok(())
     }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -107,13 +107,13 @@ impl NetworkConfig {
 
     pub fn load(&mut self, network_role: RoleType) -> Result<()> {
         if !self.network_peers_file.as_os_str().is_empty() {
-            self.network_peers = NetworkPeersConfig::load_config(self.network_peers_file());
+            self.network_peers = NetworkPeersConfig::load_config(self.network_peers_file())?;
         }
         if !self.network_keypairs_file.as_os_str().is_empty() {
-            self.network_keypairs = NetworkKeyPairs::load_config(self.network_keypairs_file());
+            self.network_keypairs = NetworkKeyPairs::load_config(self.network_keypairs_file())?;
         }
         if !self.seed_peers_file.as_os_str().is_empty() {
-            self.seed_peers = SeedPeersConfig::load_config(self.seed_peers_file());
+            self.seed_peers = SeedPeersConfig::load_config(self.seed_peers_file())?;
         }
         if self.advertised_address.to_string().is_empty() {
             self.advertised_address =

--- a/consensus/safety-rules/src/persistent_storage.rs
+++ b/consensus/safety-rules/src/persistent_storage.rs
@@ -98,7 +98,8 @@ pub struct OnDiskStorage {
 
 impl OnDiskStorage {
     pub fn new_storage(file_path: PathBuf) -> Box<dyn PersistentStorage> {
-        let internal_data = InMemoryStorage::load_config(file_path.clone());
+        let internal_data =
+            InMemoryStorage::load_config(file_path.clone()).expect("Unable to parse config");
         Box::new(Self {
             file_path,
             internal_data,

--- a/terraform/validator-sets/dev/fn/node.config.toml
+++ b/terraform/validator-sets/dev/fn/node.config.toml
@@ -13,7 +13,7 @@ upstream_peers = ["${upstream_peer}"]
 [consensus]
 consensus_keypair_file = ""
 
-[debug-interface]
+[debug_interface]
 address = "0.0.0.0"
 
 [storage]


### PR DESCRIPTION
- Return Result from load_config so we can properly propagate reasonable error messages, which is quite useful when 
- Realized that rust doesn't evaluate iter/map unless you collect, so updated the test appropriately
- Realized the test is failing due to incompatible configs due to stronger type safety and fixed them by use rust string replacement