### PR TITLE
[cluster-test] Fix waiting for container in ct

### DIFF
--- a/testsuite/cluster-test/ct
+++ b/testsuite/cluster-test/ct
@@ -5,7 +5,7 @@ set -e
 
 DOCKER_IMAGE="cluster-test:latest"
 WAIT_TO="45m"
-CONTAINER="cluster-test-$RANDOM"
+export CONTAINER="cluster-test-$RANDOM"
 WORKPLACE="cluster-test"
 
 while (( "$#" )); do


### PR DESCRIPTION
It was not exporting `$CONTAINER` var before and wait always failed
