### PR TITLE
[docker] Add libra_init image build

### DIFF
--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:buster AS toolchain
+
+# To use http/https proxy while building, use:
+# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
+
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
+    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
+    && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+FROM toolchain AS builder
+
+COPY . /libra
+
+RUN cargo build --release -p config-builder -p generate-keypair && cd target/release && rm -r build deps incremental
+RUN strip target/release/libra-config target/release/generate-keypair
+
+### Production Image ###
+FROM debian:buster AS prod
+
+RUN apt-get update && apt-get install gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/libra/bin
+COPY --from=builder /libra/target/release/libra-config /opt/libra/bin
+COPY --from=builder /libra/target/release/generate-keypair /opt/libra/bin
+
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.vcs-ref=$GIT_REV
+LABEL vcs-upstream=$GIT_UPSTREAM

--- a/docker/init/build.sh
+++ b/docker/init/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+PROXY=""
+if [ "$https_proxy" ]; then
+    PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+fi
+
+docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_init --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"


### PR DESCRIPTION
This will be used as an initContainer in k8s to setup configuration for
validators/fullnodes. It contains `libra-config` to generate fullnode
keys, and `envsubst` to interpolate configuration.

Test Plan: Built it