### PR TITLE
[config] Explicitly specify config names

### DIFF
--- a/terraform/validator-sets/dev/val/node.config.toml
+++ b/terraform/validator-sets/dev/val/node.config.toml
@@ -1,9 +1,16 @@
 [base]
 role = "validator"
 
+[consensus]
+consensus_keypair_file = "consensus_keypair.config.toml"
+consensus_peers_file = "consensus_peers.config.toml"
+
 [validator_network]
 advertised_address = "/ip4/${self_ip}/tcp/6180"
 peer_id = "${peer_id}"
+network_keypairs_file = "network_keypairs.config.toml"
+network_peers_file = "network_peers.config.toml"
+seed_peers_file = "seed_peers.config.toml"
 
 [[full_node_networks]]
 listen_address = "/ip4/0.0.0.0/tcp/6181"


### PR DESCRIPTION
Historically this code made assumptions about the names of configs,
though the path to forming those names didn't have a transparent path:
- validator-set.sh calls libra-config that spits out one set of files
- validator-set.sh renames some of those files
- terraform renames those files again
- libra-node expects those files in a deterministic fashion

So even complete end-to-end tests within the libra codebase would have
failed to spot this naming issues. Rather than rely on defaults that can
change, this commit explicitly specifies these.

In addition, an earlier commit will now fail tests if the paths are
changed.