### PR TITLE
[cluster-test] Auto-discover workplace

### DIFF
--- a/testsuite/cluster-test/ct
+++ b/testsuite/cluster-test/ct
@@ -6,7 +6,6 @@ set -e
 DOCKER_IMAGE="cluster-test:latest"
 WAIT_TO="45m"
 export CONTAINER="cluster-test-$RANDOM"
-WORKPLACE="cluster-test"
 
 while (( "$#" )); do
   case "$1" in
@@ -24,10 +23,6 @@ while (( "$#" )); do
       ;;
     -T|--wait-timeout)
       WAIT_TO=$2
-      shift 2
-      ;;
-    -w|--workplace)
-      WORKPLACE=$2
       shift 2
       ;;
     --) # end argument parsing
@@ -49,6 +44,6 @@ docker rm $CONTAINER 2>/dev/null >/dev/null || :
 trap "echo Terminating on signal; docker rm -f $CONTAINER >/dev/null" SIGINT SIGTERM
 
 # This could in theory fail due to concurrency, but it seem unlikely
-docker run -v /libra_rsa:/libra_rsa --name $CONTAINER --rm $DOCKER_IMAGE --workplace $WORKPLACE $* &
+docker run -v /libra_rsa:/libra_rsa --name $CONTAINER --rm $DOCKER_IMAGE $* &
 
 wait

--- a/testsuite/cluster-test/src/aws.rs
+++ b/testsuite/cluster-test/src/aws.rs
@@ -13,7 +13,7 @@ use std::{thread, time::Duration};
 
 #[derive(Clone)]
 pub struct Aws {
-    workplace: String,
+    workspace: String,
     ec2: Ec2Client,
     ecr: EcrClient,
     ecs: EcsClient,
@@ -22,9 +22,9 @@ pub struct Aws {
 impl Aws {
     pub fn new() -> Self {
         let ec2 = Ec2Client::new(Region::UsWest2);
-        let workplace = discover_workplace(&ec2);
+        let workspace = discover_workspace(&ec2);
         Self {
-            workplace,
+            workspace,
             ec2,
             ecr: EcrClient::new(Region::UsWest2),
             ecs: EcsClient::new(Region::UsWest2),
@@ -43,8 +43,8 @@ impl Aws {
         &self.ecs
     }
 
-    pub fn workplace(&self) -> &String {
-        &self.workplace
+    pub fn workspace(&self) -> &String {
+        &self.workspace
     }
 
     pub fn region(&self) -> &str {
@@ -52,7 +52,7 @@ impl Aws {
     }
 }
 
-fn discover_workplace(ec2: &Ec2Client) -> String {
+fn discover_workspace(ec2: &Ec2Client) -> String {
     let instance_id = current_instance_id();
     let mut attempt = 0;
     loop {
@@ -70,10 +70,10 @@ fn discover_workplace(ec2: &Ec2Client) -> String {
             Err(e) => {
                 attempt += 1;
                 if attempt > 10 {
-                    panic!("Failed to discover workplace");
+                    panic!("Failed to discover workspace");
                 }
                 error!(
-                    "Transient failure when discovering workplace(attempt {}): {}",
+                    "Transient failure when discovering workspace(attempt {}): {}",
                     attempt, e
                 );
                 thread::sleep(Duration::from_secs(1));
@@ -82,23 +82,23 @@ fn discover_workplace(ec2: &Ec2Client) -> String {
         };
         let reservation = result
             .reservations
-            .expect("discover_workplace: no reservations")
+            .expect("discover_workspace: no reservations")
             .remove(0)
             .instances
-            .expect("discover_workplace: no instances")
+            .expect("discover_workspace: no instances")
             .remove(0);
-        let tags = reservation.tags.expect("discover_workplace: no tags");
+        let tags = reservation.tags.expect("discover_workspace: no tags");
         for tag in tags.iter() {
             if tag.key == Some("Workspace".to_string()) {
                 return tag
                     .value
                     .as_ref()
-                    .expect("discover_workplace: no tag value")
+                    .expect("discover_workspace: no tag value")
                     .to_string();
             }
         }
         panic!(
-            "discover_workplace: no workplace tag. Instance id: {}, tags: {:?}",
+            "discover_workspace: no workspace tag. Instance id: {}, tags: {:?}",
             instance_id, tags
         );
     }

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -48,7 +48,7 @@ impl Cluster {
             let filters = vec![
                 Filter {
                     name: Some("tag:Workspace".into()),
-                    values: Some(vec![aws.workplace().clone()]),
+                    values: Some(vec![aws.workspace().clone()]),
                 },
                 Filter {
                     name: Some("instance-state-name".into()),
@@ -110,7 +110,7 @@ impl Cluster {
             "No instances were discovered for cluster"
         );
         let prometheus_ip =
-            prometheus_ip.ok_or_else(|| format_err!("Prometheus was not found in workplace"))?;
+            prometheus_ip.ok_or_else(|| format_err!("Prometheus was not found in workspace"))?;
         Ok(Self {
             instances,
             prometheus_ip: Some(prometheus_ip),

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -32,15 +32,15 @@ const MASTER_PREFIX: &str = "master_";
 
 impl DeploymentManager {
     pub fn new(aws: Aws, cluster: Cluster) -> Self {
-        let running_tag = env::var("TAG").unwrap_or_else(|_| aws.workplace().to_string());
+        let running_tag = env::var("TAG").unwrap_or_else(|_| aws.workspace().to_string());
         if running_tag == SOURCE_TAG
             || running_tag == TESTED_TAG
             || running_tag.starts_with(UPSTREAM_PREFIX)
             || running_tag.starts_with(MASTER_PREFIX)
         {
             panic!(
-                "Cluster test can not deploy if workplace is configured to use {} tag.\
-                 Use custom tag for your workplace to use --deploy",
+                "Cluster test can not deploy if workspace is configured to use {} tag.\
+                 Use custom tag for your workspace to use --deploy",
                 running_tag
             );
         }
@@ -82,11 +82,11 @@ impl DeploymentManager {
     pub fn update_all_services(&self) -> Result<()> {
         for instance in self.cluster.instances() {
             let mut request = UpdateServiceRequest::default();
-            request.cluster = Some(self.aws.workplace().clone());
+            request.cluster = Some(self.aws.workspace().clone());
             request.force_new_deployment = Some(true);
             request.service = format!(
                 "{w}/{w}-validator-{hash}",
-                w = self.aws.workplace(),
+                w = self.aws.workspace(),
                 hash = instance.short_hash()
             );
 

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -50,8 +50,6 @@ const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(5);
 #[derive(StructOpt, Debug)]
 #[structopt(group = ArgGroup::with_name("action").required(true))]
 struct Args {
-    #[structopt(short = "w", long, conflicts_with = "swarm")]
-    workplace: Option<String>,
     #[structopt(short = "p", long, use_delimiter = true)]
     peers: Vec<String>,
 
@@ -297,12 +295,7 @@ impl BasicSwarmUtil {
 
 impl ClusterUtil {
     pub fn setup(args: &Args) -> Self {
-        let aws = Aws::new(
-            args.workplace
-                .as_ref()
-                .expect("--workplace not set")
-                .clone(),
-        );
+        let aws = Aws::new();
         let cluster = Cluster::discover(&aws, &args.mint_file).expect("Failed to discover cluster");
         let cluster = if args.peers.is_empty() {
             cluster

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -307,7 +307,11 @@ impl ClusterUtil {
                 .prometheus_ip()
                 .expect("Failed to discover prometheus ip in aws"),
         );
-        info!("Discovered {} peers", cluster.instances().len());
+        info!(
+            "Discovered {} peers in {} workspace",
+            cluster.instances().len(),
+            aws.workspace()
+        );
         Self {
             cluster,
             aws,


### PR DESCRIPTION
Currently we have to specify `--workplace` parameter to cluster test
This makes writing utilities such as `ct` complicated because they have to hardcode workplace name

This diff removes `--workplace` parameter and make cluster test to auto-discover workplace using instance metadata

Fixes #1289


Plz use delegate + so I can merge it manually