### PR TITLE
[Storage] Storage adapter for backup and restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,16 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "async-trait"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +175,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backup-restore"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1665,6 +1689,11 @@ dependencies = [
 [[package]]
 name = "hex"
 version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hex"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -5432,6 +5461,7 @@ dependencies = [
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
+"checksum async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "afe2eef13bc0f5a77e7c2fec6d863fa59eea6901e4949830b67f0c348d720100"
@@ -5559,6 +5589,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "mempool/mempool-shared-proto",
     "state-synchronizer",
     "storage/accumulator",
+    "storage/backup-restore",
     "storage/libradb",
     "storage/jellyfish-merkle",
     "storage/schemadb",

--- a/storage/backup-restore/Cargo.toml
+++ b/storage/backup-restore/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "backup-restore"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1.19"
+futures = "0.3.1"
+hex = "0.4.0"
+rand = "0.7"
+
+[dev-dependencies]
+itertools = "0.8"
+proptest = "0.9.4"
+tempfile = "3.1.0"

--- a/storage/backup-restore/src/adapter/local_storage/local_storage_test.rs
+++ b/storage/backup-restore/src/adapter/local_storage/local_storage_test.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use futures::executor::{block_on, block_on_stream};
+use proptest::{collection::vec, prelude::*};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_local_storage(contents in vec(vec(any::<u8>(), 1..1000), 1..10)) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let adapter = LocalStorage::new(tmpdir.path().to_path_buf());
+
+        let file_handles: Vec<_> = contents.iter().map(|content| {
+            let iter = content.chunks(10).map(|c| c.to_vec());
+            let stream = futures::stream::iter(iter);
+            block_on(adapter.write_new_file(stream)).unwrap()
+        }).collect();
+
+        for (handle, expected_content) in itertools::zip_eq(file_handles, contents) {
+            let mut actual_content = vec![];
+            for res in block_on_stream(adapter.read_file_content(&handle)) {
+                let bytes = res.unwrap();
+                actual_content.extend_from_slice(&bytes);
+            }
+            prop_assert_eq!(actual_content, expected_content);
+        }
+    }
+}

--- a/storage/backup-restore/src/adapter/local_storage/mod.rs
+++ b/storage/backup-restore/src/adapter/local_storage/mod.rs
@@ -1,0 +1,122 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod local_storage_test;
+
+use super::Adapter;
+use crate::FileHandle;
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::{stream::BoxStream, StreamExt};
+use rand::RngCore;
+use std::{
+    io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+};
+
+const FILENAME_LEN: usize = 16;
+
+/// A storage backend that stores everything in a local directory.
+pub struct LocalStorage {
+    /// The path where everything is stored.
+    dir: PathBuf,
+}
+
+impl LocalStorage {
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+}
+
+#[async_trait]
+impl Adapter for LocalStorage {
+    async fn write_new_file(
+        &self,
+        mut content: impl StreamExt<Item = Vec<u8>> + Send + Unpin + 'async_trait,
+    ) -> Result<FileHandle> {
+        let (mut file, handle) = create_random_file(&self.dir)?;
+        while let Some(bytes) = content.next().await {
+            file.write_all(&bytes)?;
+        }
+        file.sync_data()?;
+        Ok(handle)
+    }
+
+    fn read_file_content(&self, file_handle: &FileHandle) -> BoxStream<Result<Vec<u8>>> {
+        let file = match std::fs::File::open(&file_handle) {
+            Ok(f) => f,
+            Err(e) => return futures::stream::once(async { Err(e.into()) }).boxed(),
+        };
+
+        futures::stream::iter(FileIterator::new(file)).boxed()
+    }
+}
+
+/// Creates a file with random name in the given directory. Returns the reference to the open file
+/// as well as the handle (name) of the file.
+fn create_random_file(dir: &Path) -> Result<(std::fs::File, FileHandle)> {
+    loop {
+        let filename = create_random_filename(dir)
+            .into_os_string()
+            .into_string()
+            .expect("Filename should contain valid unicode.");
+
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&filename)
+        {
+            Ok(file) => return Ok((file, filename)),
+            Err(err) => {
+                if let std::io::ErrorKind::AlreadyExists = err.kind() {
+                    // This is very unlikely.
+                    continue;
+                } else {
+                    return Err(err.into());
+                }
+            }
+        }
+    }
+}
+
+/// Generates a random filename under given directory.
+fn create_random_filename(dir: &Path) -> PathBuf {
+    let mut filename = [0; FILENAME_LEN];
+    rand::thread_rng().fill_bytes(&mut filename);
+    dir.join(hex::encode(filename))
+}
+
+/// An iterator that reads one chunk from a file at a time and yields the bytes.
+struct FileIterator {
+    /// The reference to the open file.
+    file: BufReader<std::fs::File>,
+}
+
+impl FileIterator {
+    fn new(file: std::fs::File) -> Self {
+        Self {
+            file: BufReader::new(file),
+        }
+    }
+}
+
+impl Iterator for FileIterator {
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.file.fill_buf() {
+            Ok(buf) => {
+                let len = buf.len();
+                if len == 0 {
+                    None
+                } else {
+                    let ret = Some(Ok(buf.to_vec()));
+                    self.file.consume(len);
+                    ret
+                }
+            }
+            Err(e) => Some(Err(e.into())),
+        }
+    }
+}

--- a/storage/backup-restore/src/adapter/mod.rs
+++ b/storage/backup-restore/src/adapter/mod.rs
@@ -1,0 +1,24 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod local_storage;
+
+use crate::FileHandle;
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::{stream::BoxStream, StreamExt};
+
+/// `Adapter` defines the interfaces of the storage backend we use for backup and restore.
+#[async_trait]
+pub trait Adapter {
+    /// Writes the content of the file to the storage backend and returns a handle to the file once
+    /// finished.
+    async fn write_new_file(
+        &self,
+        content: impl StreamExt<Item = Vec<u8>> + Send + Unpin + 'async_trait,
+    ) -> Result<FileHandle>;
+
+    /// Returns the content of the file in a stream.
+    #[allow(clippy::ptr_arg)]
+    fn read_file_content(&self, file_handle: &FileHandle) -> BoxStream<Result<Vec<u8>>>;
+}

--- a/storage/backup-restore/src/lib.rs
+++ b/storage/backup-restore/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(dead_code)]
+mod adapter;
+
+type FileHandle = String;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This change 1) defines the `Adapter` interface for any storage backend used for backup and restore 2) implements a simple backend that uses a local directory.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.