### PR TITLE
[cluster-test] [ci] Remove run_suite_in_loop

### DIFF
--- a/testsuite/cluster-test/ct
+++ b/testsuite/cluster-test/ct
@@ -45,7 +45,7 @@ docker rm $CONTAINER 2>/dev/null >/dev/null || :
 
 trap "echo Terminating on signal; docker rm -f $CONTAINER >/dev/null" SIGINT SIGTERM
 
-VARS="-e SLACK_LOG_URL -e SLACK_CHANGELOG_URL"
+VARS="-e SLACK_CHANGELOG_URL"
 
 # This could in theory fail due to concurrency, but it seem unlikely
 docker run $VARS -v /libra_rsa:/libra_rsa --name $CONTAINER --rm $DOCKER_IMAGE $* &


### PR DESCRIPTION
Historically cluster test used to be independent tool, it was polling ECR for new `nightly` images and tagging them with `nightly_tested` after cluster test passed

We now have more comprehensive integration with Circle CI, that allows to run cluster test directly from CI
This is more preferred method as it provides more visibility and allows later to integrate cluster test into more complex scenarios, such as run pre-commit.

Since we are switching to Circle orchestrated runs, we no longer need polling loop inside cluster test.
This diff removes polling loop, and also re-purpose `--run` as a shorter version for `--run-experiment`

It also removes slack integration with `#cluster_test_log` channel - failure signal now moves to `#push` channel where all CI pipeline messages are collected

Please use `delegate+`, will merge after confirming that CI way works