### PR TITLE
[cluster-test] Add experiment to test recovery_time

### DIFF
--- a/testsuite/cluster-test/src/effects/delete_libra_data.rs
+++ b/testsuite/cluster-test/src/effects/delete_libra_data.rs
@@ -1,0 +1,38 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{effects::Action, instance::Instance};
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt};
+use slog_scope::info;
+use std::fmt;
+
+pub struct DeleteLibraData {
+    instance: Instance,
+}
+
+impl DeleteLibraData {
+    pub fn new(instance: Instance) -> Self {
+        Self { instance }
+    }
+}
+
+impl Action for DeleteLibraData {
+    fn apply(&self) -> BoxFuture<Result<()>> {
+        async move {
+            info!("DeleteLibraData {}", self.instance);
+            self.instance
+                .run_cmd(vec!["sudo rm -rf /data/libra/*db"])
+                .await
+        }
+            .boxed()
+    }
+}
+
+impl fmt::Display for DeleteLibraData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DeleteLibraData {}", self.instance)
+    }
+}

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod delete_libra_data;
 mod network_delay;
 mod packet_loss;
 mod reboot;
@@ -10,6 +11,7 @@ mod remove_network_effects;
 mod stop_container;
 
 use anyhow::Result;
+pub use delete_libra_data::DeleteLibraData;
 use futures::future::BoxFuture;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -8,6 +8,7 @@ mod packet_loss_random_validators;
 mod performance_benchmark_nodes_down;
 mod performance_benchmark_three_region_simulation;
 mod reboot_random_validator;
+mod recovery_time;
 
 use std::time::Duration;
 use std::{collections::HashSet, fmt::Display};
@@ -23,6 +24,7 @@ pub use performance_benchmark_three_region_simulation::PerformanceBenchmarkThree
 pub use reboot_random_validator::{RebootRandomValidators, RebootRandomValidatorsParams};
 
 use crate::cluster::Cluster;
+use crate::experiments::recovery_time::{RecoveryTime, RecoveryTimeParams};
 use crate::prometheus::Prometheus;
 use crate::tx_emitter::TxEmitter;
 use futures::future::BoxFuture;
@@ -88,6 +90,14 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
         "reboot_random_validators" => Box::new(RebootRandomValidators::new(
             RebootRandomValidatorsParams::from_clap(
                 &RebootRandomValidatorsParams::clap()
+                    .global_setting(AppSettings::NoBinaryName)
+                    .get_matches_from(args),
+            ),
+            cluster,
+        )),
+        "recovery_time" => Box::new(RecoveryTime::new(
+            RecoveryTimeParams::from_clap(
+                &RecoveryTimeParams::clap()
                     .global_setting(AppSettings::NoBinaryName)
                     .get_matches_from(args),
             ),

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -1,0 +1,107 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::{collections::HashSet, fmt, time::Duration};
+
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt};
+use rand::Rng;
+use structopt::StructOpt;
+use tokio::time;
+
+use crate::cluster::Cluster;
+use crate::effects::{DeleteLibraData, Effect, StopContainer};
+use crate::experiments::Context;
+use crate::instance::Instance;
+use crate::tx_emitter::{EmitJobRequest, EmitThreadParams};
+use crate::{effects::Action, experiments::Experiment};
+use slog_scope::info;
+use std::time::Instant;
+
+#[derive(StructOpt, Debug)]
+pub struct RecoveryTimeParams {
+    #[structopt(
+        long,
+        default_value = "100",
+        help = "Number of accounts to mint before starting the experiment"
+    )]
+    pub num_accounts_to_mint: u64,
+}
+
+pub struct RecoveryTime {
+    params: RecoveryTimeParams,
+    instance: Instance,
+}
+
+impl RecoveryTime {
+    pub fn new(params: RecoveryTimeParams, cluster: &Cluster) -> Self {
+        let rnd_index = rand::thread_rng().gen_range(0, cluster.instances().len());
+        let instance = cluster.instances()[rnd_index].clone();
+        Self { params, instance }
+    }
+}
+
+impl Experiment for RecoveryTime {
+    fn affected_validators(&self) -> HashSet<String> {
+        let mut result = HashSet::new();
+        result.insert(self.instance.short_hash().clone());
+        result
+    }
+
+    fn run<'a>(&'a mut self, context: &'a mut Context) -> BoxFuture<'a, Result<Option<String>>> {
+        async move {
+            let stop_effect = StopContainer::new(self.instance.clone());
+            let delete_action = DeleteLibraData::new(self.instance.clone());
+            context.tx_emitter.mint_accounts(
+                &EmitJobRequest {
+                    instances: context.cluster.instances().to_vec(),
+                    accounts_per_client: 100,
+                    thread_params: EmitThreadParams::default(),
+                },
+                self.params.num_accounts_to_mint as usize,
+            )?;
+            info!("Stopping {}", self.instance);
+            stop_effect.activate().await?;
+            info!("Deleted db for {}", self.instance);
+            delete_action.apply().await?;
+            info!("Starting instance {}", self.instance);
+            stop_effect.deactivate().await?;
+            info!("Waiting for instance to be up: {}", self.instance);
+            while !self.instance.is_up() {
+                time::delay_for(Duration::from_secs(1)).await;
+            }
+            let start_instant = Instant::now();
+            info!(
+                "Instance {} is up. Waiting for it to start committing.",
+                self.instance
+            );
+            while self
+                .instance
+                .counter("libra_consensus_last_committed_round")
+                .is_err()
+            {
+                time::delay_for(Duration::from_secs(1)).await;
+            }
+            let time_to_recover = start_instant.elapsed();
+            let result = format!(
+                "Recovery rate : {:.1} txn/sec",
+                self.params.num_accounts_to_mint as f64 / time_to_recover.as_secs() as f64
+            );
+            info!("{}", result);
+            Ok(Some(result))
+        }
+            .boxed()
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(20 * 60)
+    }
+}
+
+impl fmt::Display for RecoveryTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RecoveryTime")
+    }
+}

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -139,7 +139,7 @@ impl TxEmitter {
         Ok(EmitJob { workers, stop })
     }
 
-    fn mint_accounts(&mut self, req: &EmitJobRequest, num_accounts: usize) -> Result<()> {
+    pub fn mint_accounts(&mut self, req: &EmitJobRequest, num_accounts: usize) -> Result<()> {
         if self.accounts.len() >= num_accounts {
             info!("Not minting accounts");
             return Ok(()); // Early return to skip printing 'Minting ...' logs


### PR DESCRIPTION
## Summary

This experiment tests the time it takes for a validator to recover after N accounts have been minted (~N transactions in the system) and the validator has its databases wiped

This relies on prometheus to measure the time between a validator startup and the time it starts committing transactions.

I avoided using `HealthCheckRunner` for this experiment because it seems very complicated to setup because of its dependency on `LogTail`

## Test Plan

Ran on my cluster

```
cluster-test-runner ec2-user:~$ ct --run-experiment recovery_time -- --num-accounts-to-mint 10000
Dec 05 00:52:15.109 INFO Discovered 100 peers in kush4 workspace
Dec 05 00:52:15.409 INFO Log tail thread started in 300 ms
Dec 05 00:52:15.410 INFO Will use kush tag for deployment
Dec 05 00:52:16.055 INFO Starting experiment RecoveryTime
Dec 05 00:52:16.866 INFO Completed minting seed accounts
Dec 05 00:52:35.821 INFO Mint is done
Dec 05 00:52:35.821 INFO Stopping 91fa58e1(10.0.1.129)
Dec 05 00:52:47.440 INFO Deleted directories for 91fa58e1(10.0.1.129)
Dec 05 00:52:47.440 INFO DeleteLibraData 91fa58e1(10.0.1.129)
Dec 05 00:53:07.816 INFO Starting instance 91fa58e1(10.0.1.129)
Dec 05 00:53:08.424 INFO Waiting for instance to be up: 91fa58e1(10.0.1.129)
Dec 05 00:53:13.443 INFO Instance 91fa58e1(10.0.1.129) is up. Waiting for it to start committing.
Dec 05 00:55:28.896 INFO Instance started committing after : 135 seconds
Dec 05 00:55:31.742 INFO Experiment finished, waiting until all affected validators recover
Dec 05 00:55:36.753 INFO Experiment completed
```