### PR TITLE
[terraform] Allow port 9101 to cluster-test-host

### DIFF
--- a/terraform/cluster-test.tf
+++ b/terraform/cluster-test.tf
@@ -114,6 +114,15 @@ resource "aws_security_group_rule" "cluster-test-debug-port-validator" {
   source_security_group_id = aws_security_group.cluster-test-host.id
 }
 
+resource "aws_security_group_rule" "cluster-test-metrics-port-validator" {
+  security_group_id        = aws_security_group.validator.id
+  type                     = "ingress"
+  from_port                = 9101
+  to_port                  = 9101
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.cluster-test-host.id
+}
+
 resource "aws_security_group_rule" "cluster-test-egress" {
   security_group_id = aws_security_group.cluster-test-host.id
   type              = "egress"


### PR DESCRIPTION
## Summary

Port 9101 serves counters at `/counters`. This endpoint can be used for getting metrics directly from the validator instead of prometheus. prometheus metrics can be as stale as 15 seconds. This endpoint gives us realtime metrics.