### PR TITLE
[consensus] moving some block checks from block store to block.verify

### DIFF
--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -410,7 +410,7 @@ fn test_empty_reconfiguration_suffix() {
         vec![42],
     );
     // Child of reconfiguration carries a payload will fail to insert
-    assert!(block_on(block_store.execute_and_insert_block(a4)).is_err());
+    assert!(a4.verify_well_formed().is_err());
     let a5 = inserter.create_block_with_qc(
         inserter.create_qc_for_block(a3.as_ref(), None),
         a3.as_ref().timestamp_usecs(),
@@ -430,5 +430,5 @@ fn test_empty_reconfiguration_suffix() {
         5,
         vec![42],
     );
-    assert!(block_on(block_store.execute_and_insert_block(a6)).is_err());
+    assert!(a6.verify_well_formed().is_err());
 }

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -374,7 +374,7 @@ fn test_network_api() {
     );
     let previous_qc = certificate_for_genesis();
     let proposal = ProposalMsg::new(
-        Block::new_proposal(0, 1, 0, previous_qc.clone(), &signers[0]),
+        Block::new_proposal(0, 1, 1, previous_qc.clone(), &signers[0]),
         SyncInfo::new(previous_qc.clone(), previous_qc.clone(), None),
     );
     block_on(async move {


### PR DESCRIPTION
Some of the checks (for example reconfiguration checks) are done in block store when they could be
happening in `block.verify_well_formed()`.

Since blocks are always going through this `verify_well_formed()` verification, reconfig issues should be caught early.