### PR TITLE
[consensus] adding a security log when a retrieved block does not verify

### DIFF
--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -45,6 +45,9 @@ pub enum SecurityEvent {
     /// HealthChecker received an invalid message
     InvalidHealthCheckerMsg,
 
+    /// A received block is invalid
+    InvalidRetrievedBlock,
+
     /// A block being committed or executed is invalid
     InvalidBlock,
 


### PR DESCRIPTION
when using `request_block()` to obtain a block, we should log failure to verify it as there is no reason why an honest peer would send us badly formed blocks.


