### PR TITLE
[WIP][RFC][AC SMP merge] add outbound rpc for SMP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
+ "parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ dependencies = [
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
  "parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2217,8 +2218,10 @@ name = "libra-mempool"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2229,6 +2232,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2731,6 +2735,7 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2741,6 +2746,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -9,12 +9,13 @@ use crate::{
 use anyhow::{anyhow, ensure, Result};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::TEST_SEED,
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
     Uniform, ValidKey,
 };
 use libra_types::PeerId;
 use parity_multiaddr::Multiaddr;
-use rand::rngs::StdRng;
+use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom, path::PathBuf, string::ToString};
 
@@ -81,6 +82,50 @@ impl Default for NetworkConfig {
 }
 
 impl NetworkConfig {
+    /// Creates a validator network of with `nodes_in_network_count` validator nodes
+    pub fn default_validator_network_with_peers(
+        nodes_in_network_count: u32,
+    ) -> HashMap<PeerId, Self> {
+        let mut peers_network_config: HashMap<PeerId, Self> = HashMap::new();
+        let mut peers_keypairs: HashMap<PeerId, NetworkKeyPairs> = HashMap::new();
+        let mut all_peers: Vec<PeerId> = Vec::new();
+
+        // create peers
+        let mut rng = StdRng::from_seed(TEST_SEED);
+        for _n in 0..nodes_in_network_count {
+            let signing_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+            let identity_key = X25519StaticPrivateKey::generate_for_testing(&mut rng);
+            let keypair = NetworkKeyPairs::load(signing_key, identity_key);
+            let peer_id = PeerId::try_from(keypair.identity_keys.public().to_bytes()).unwrap();
+            peers_keypairs.insert(peer_id.clone(), keypair);
+            all_peers.push(peer_id.clone());
+        }
+
+        for (peer_id, keypair) in peers_keypairs.into_iter() {
+            let other_peers: Vec<&PeerId> =
+                all_peers.iter().filter(|peer| peer != &&peer_id).collect();
+            let network_peers = Self::default_multiple_peers(&keypair, other_peers.clone());
+
+            let config = Self {
+                peer_id,
+                listen_address: "/ip4/0.0.0.0/tcp/6180".parse::<Multiaddr>().unwrap(),
+                advertised_address: "/ip4/127.0.0.1/tcp/6180".parse::<Multiaddr>().unwrap(),
+                discovery_interval_ms: 1000,
+                connectivity_check_interval_ms: 5000,
+                enable_encryption_and_authentication: true,
+                is_permissioned: true,
+                network_keypairs_file: PathBuf::new(),
+                network_keypairs: keypair,
+                network_peers_file: PathBuf::new(),
+                network_peers,
+                seed_peers_file: PathBuf::new(),
+                seed_peers: SeedPeersConfig::default(),
+            };
+            peers_network_config.insert(peer_id.clone(), config);
+        }
+        peers_network_config
+    }
+
     /// This clones the underlying data except for the keypair so that this config can be used as a
     /// template for another config.
     pub fn clone_for_template(&self) -> Self {
@@ -202,6 +247,24 @@ impl NetworkConfig {
                 signing_public_key: keypair.signing_keys.public().clone(),
             },
         );
+        peers
+    }
+
+    /// creates a default NetworkPeersConfig with all peers in `peer_ids`
+    fn default_multiple_peers(
+        keypair: &NetworkKeyPairs,
+        peer_ids: Vec<&PeerId>,
+    ) -> NetworkPeersConfig {
+        let mut peers = NetworkPeersConfig::default();
+        for peer_id in peer_ids.iter() {
+            peers.peers.insert(
+                **peer_id,
+                NetworkPeerInfo {
+                    identity_public_key: keypair.identity_keys.public().clone(),
+                    signing_public_key: keypair.signing_keys.public().clone(),
+                },
+            );
+        }
         peers
     }
 }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -25,6 +25,7 @@ use network::{
         CONSENSUS_DIRECT_SEND_PROTOCOL,
         CONSENSUS_RPC_PROTOCOL,
         MEMPOOL_DIRECT_SEND_PROTOCOL,
+        MEMPOOL_RPC_PROTOCOL,
         STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
     },
     ProtocolId,
@@ -123,6 +124,7 @@ pub fn setup_network(
         .rpc_protocols(vec![
             ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL),
             ProtocolId::from_static(ADMISSION_CONTROL_RPC_PROTOCOL),
+            ProtocolId::from_static(MEMPOOL_RPC_PROTOCOL),
         ]);
     if config.is_permissioned {
         // If the node wants to run in permissioned mode, it should also have authentication and
@@ -279,8 +281,10 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         // network provider -> consensus -> state synchronizer -> network provider. This deadlock
         // was observed in GitHub Issue #749. A long term fix might be make
         // consensus initialization async instead of blocking on state synchronizer.
-        let (mempool_network_sender, mempool_network_events) = network_provider
-            .add_mempool(vec![ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL)]);
+        let (mempool_network_sender, mempool_network_events) = network_provider.add_mempool(vec![
+            ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL),
+            ProtocolId::from_static(MEMPOOL_RPC_PROTOCOL),
+        ]);
         let (consensus_network_sender, consensus_network_events) =
             network_provider.add_consensus(vec![
                 ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL),

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -36,6 +36,7 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
+prometheus = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "0.2", features = ["full"] }
 tonic = { git = "https://github.com/hyperium/tonic.git" }
 ttl_cache = "0.4.2"
 
+channel = { path = "../common/channel", version = "0.1.0" }
 libra-mempool-shared-proto = { path = "mempool-shared-proto", version = "0.1.0" }
 bounded-executor = { path = "../common/bounded-executor", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
@@ -41,6 +42,7 @@ assert_matches = "1.3.0"
 rand = "0.6.5"
 channel = { path = "../common/channel", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+parity-multiaddr = { version = "0.6.0", default-features = false }
 
 [build-dependencies]
 tonic-build = { git = "https://github.com/hyperium/tonic.git" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -12,8 +12,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 bytes = "0.4.12"
+bytes05 = { version = "0.5", package = "bytes" }
 chrono = "0.4.7"
-futures = { version = "0.3.0", package = "futures", features = ["compat"] }
+futures = { version = "0.3.0", package = "futures", features = ["compat", "thread-pool"] }
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 lazy_static = "1.3.0"
 lru-cache = "0.1.1"
@@ -27,6 +28,7 @@ bounded-executor = { path = "../common/bounded-executor", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
 mirai-annotations = "1.5.0"
 network = { path = "../network", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
@@ -35,6 +37,7 @@ libra-types = { path = "../types", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 rand = "0.6.5"
 channel = { path = "../common/channel", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -1,28 +1,36 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    core_mempool::{unit_tests::common::TestTransaction, CoreMempool, TimelineState},
-    shared_mempool::{start_shared_mempool, SharedMempoolNotification, SyncEvent},
-};
+use crate::core_mempool::{unit_tests::common::TestTransaction, CoreMempool, TimelineState};
+use crate::shared_mempool::{start_shared_mempool, SharedMempoolNotification};
+use assert_matches;
 use channel;
 use futures::{
-    channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+    channel::{
+        mpsc::{unbounded, UnboundedReceiver},
+        oneshot,
+    },
     executor::block_on,
     SinkExt, StreamExt,
 };
-use libra_config::config::NodeConfig;
+use libra_config::config::{NetworkConfig, NodeConfig};
+use libra_prost_ext::MessageExt;
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
     interface::{NetworkNotification, NetworkRequest},
-    proto::MempoolSyncMsg,
+    proto::{BroadcastTransactionsResponse, MempoolSyncMsg, MempoolSyncMsg_oneof},
     validator_network::{MempoolNetworkEvents, MempoolNetworkSender},
 };
-use prost::Message;
+use network::{
+    protocols::rpc::InboundRpcRequest, validator_network::MEMPOOL_RPC_PROTOCOL, ProtocolId,
+};
+use prost::Message as _;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
     sync::{Arc, Mutex},
+    thread,
+    time::Duration,
 };
 use storage_service::mocks::mock_storage_client::MockStorageReadClient;
 use tokio::runtime::Runtime;
@@ -35,23 +43,31 @@ struct SharedMempoolNetwork {
     network_notifs_txs: HashMap<PeerId, channel::Sender<NetworkNotification>>,
     runtimes: HashMap<PeerId, Runtime>,
     subscribers: HashMap<PeerId, UnboundedReceiver<SharedMempoolNotification>>,
-    timers: HashMap<PeerId, UnboundedSender<SyncEvent>>,
 }
 
 impl SharedMempoolNetwork {
-    fn bootstrap_with_config(peers: Vec<PeerId>, mut config: NodeConfig) -> Self {
+    fn bootstrap_validator_network_smp(validator_nodes_count: u32) -> (Self, Vec<PeerId>) {
+        let mut config = NodeConfig::random();
         let mut smp = Self::default();
         config.mempool.shared_mempool_batch_size = 1;
 
-        for peer in peers {
+        // add all peers in this vector as validator peers
+        let validator_network_peers =
+            NetworkConfig::default_validator_network_with_peers(validator_nodes_count);
+
+        let mut peers: Vec<PeerId> = Vec::new();
+        for peer in validator_network_peers.keys() {
+            peers.push(peer.clone());
+        }
+        for (peer, validator_network_config) in validator_network_peers.into_iter() {
             let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
             let (network_reqs_tx, network_reqs_rx) = channel::new_test(8);
             let (network_notifs_tx, network_notifs_rx) = channel::new_test(8);
             let network_sender = MempoolNetworkSender::new(network_reqs_tx);
             let network_events = MempoolNetworkEvents::new(network_notifs_rx);
             let (sender, subscriber) = unbounded();
-            let (timer_sender, timer_receiver) = unbounded();
 
+            config.validator_network = Some(validator_network_config);
             let runtime = start_shared_mempool(
                 &config,
                 Arc::clone(&mempool),
@@ -60,21 +76,15 @@ impl SharedMempoolNetwork {
                 Arc::new(MockStorageReadClient),
                 Arc::new(MockVMValidator),
                 vec![sender],
-                Some(timer_receiver.map(|_| SyncEvent).boxed()),
             );
 
             smp.mempools.insert(peer, mempool);
             smp.network_reqs_rxs.insert(peer, network_reqs_rx);
             smp.network_notifs_txs.insert(peer, network_notifs_tx);
             smp.subscribers.insert(peer, subscriber);
-            smp.timers.insert(peer, timer_sender);
             smp.runtimes.insert(peer, runtime);
         }
-        smp
-    }
-
-    fn bootstrap(peers: Vec<PeerId>) -> Self {
-        Self::bootstrap_with_config(peers, NodeConfig::random())
+        (smp, peers)
     }
 
     fn add_txns(&mut self, peer_id: &PeerId, txns: Vec<TestTransaction>) {
@@ -98,39 +108,113 @@ impl SharedMempoolNetwork {
         }
     }
 
-    /// deliveres next message from given node to it's peer
-    fn deliver_message(&mut self, peer: &PeerId) -> (SignedTransaction, PeerId) {
-        // emulate timer tick
-        self.timers
-            .get(peer)
-            .unwrap()
-            .unbounded_send(SyncEvent)
-            .unwrap();
+    /// wait for a set of SharedMempoolNotification events in no particular order
+    fn wait_for_sync_events(
+        &mut self,
+        peer_id: &PeerId,
+        mut events: HashSet<SharedMempoolNotification>,
+    ) {
+        let subscriber = self.subscribers.get_mut(peer_id).unwrap();
+        loop {
+            let event = block_on(subscriber.next()).unwrap();
+            events.remove(&event);
+            if events.is_empty() {
+                break;
+            }
+        }
+    }
 
-        // await next message from node
+    fn wait_for_worker_update(&mut self, peer_id: &PeerId, expected_worker_peer: &PeerId) {
+        self.wait_for_worker_updates(peer_id, vec![*expected_worker_peer]);
+    }
+
+    /// wait for SharedMempoolNotification::SyncUpdate from worker processes for `expected_worker_peers`
+    /// in SMP of `peer_id`. There is no expected ordering of events received from `expected_worker_peers`
+    fn wait_for_worker_updates(&mut self, peer_id: &PeerId, expected_worker_peers: Vec<PeerId>) {
+        let expected_events = expected_worker_peers
+            .into_iter()
+            .map(|worker_peer| SharedMempoolNotification::SyncUpdate { worker_peer })
+            .collect();
+
+        self.wait_for_sync_events(peer_id, expected_events);
+    }
+
+    /// delivers next single message from given node to its peer
+    fn deliver_message(&mut self, peer: &PeerId) -> (Vec<SignedTransaction>, PeerId) {
+        thread::sleep(Duration::from_millis(50)); // TODO this is hardcoded from default config - change this!
+
+        let res_msg = BroadcastTransactionsResponse::default();
+        let res_msg_enum = MempoolSyncMsg {
+            message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsResponse(
+                res_msg.clone(),
+            )),
+        };
+        let res_data = res_msg_enum.to_bytes().unwrap();
+
+        // wait for requests sent
         let network_reqs_rx = self.network_reqs_rxs.get_mut(peer).unwrap();
         let network_req = block_on(network_reqs_rx.next()).unwrap();
 
         match network_req {
-            NetworkRequest::SendMessage(peer_id, msg) => {
-                let mut sync_msg = MempoolSyncMsg::decode(msg.mdata.as_ref()).unwrap();
-                let transaction =
-                    SignedTransaction::try_from(sync_msg.transactions.pop().unwrap()).unwrap();
-                // send it to peer
+            NetworkRequest::SendRpc(peer_id, msg) => {
+                // parse msg
+                let sync_msg = MempoolSyncMsg::decode(msg.data.as_ref()).unwrap();
+                let req = assert_matches::assert_matches!(
+                    sync_msg.message.clone(),
+                    Some(MempoolSyncMsg_oneof::BroadcastTransactionsRequest(req)) => req,
+                    "expected to receive BroadcastTransactionRequest"
+                );
+
+                // get transactions
+                let transactions: Vec<_> = req
+                    .transactions
+                    .clone()
+                    .into_iter()
+                    .filter_map(|txn| match SignedTransaction::try_from(txn.clone()) {
+                        Ok(t) => Some(t),
+                        Err(_e) => None,
+                    })
+                    .collect();
+                let protocol = ProtocolId::from_static(MEMPOOL_RPC_PROTOCOL);
+                let req_msg_enum = MempoolSyncMsg {
+                    message: sync_msg.message,
+                };
+                let data = req_msg_enum.to_bytes().unwrap();
+
+                // callback from receiving node to (this) sending node
+                let (res_tx, res_rx) = oneshot::channel();
+                let inbound_rpc_req = InboundRpcRequest {
+                    protocol,
+                    data,
+                    res_tx,
+                };
                 let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&peer_id).unwrap();
                 block_on(
-                    receiver_network_notif_tx.send(NetworkNotification::RecvMessage(*peer, msg)),
+                    receiver_network_notif_tx
+                        .send(NetworkNotification::RecvRpc(*peer, inbound_rpc_req)),
                 )
                 .unwrap();
+                block_on(res_rx).unwrap().ok();
+
+                // remote replies with some response message
+                block_on(async {
+                    msg.res_tx.send(Ok(res_data)).unwrap();
+                });
 
                 // await message delivery
                 self.wait_for_event(&peer_id, SharedMempoolNotification::NewTransactions);
 
-                // verify transaction was inserted into Mempool
+                // verify txns were inserted into mempool
                 let mempool = self.mempools.get(&peer_id).unwrap();
-                let block = mempool.lock().unwrap().get_block(100, HashSet::new());
-                assert!(block.iter().any(|t| t == &transaction));
-                (transaction, peer_id)
+
+                let mut mempool_lock = mempool
+                    .lock()
+                    .expect("[shared mempool test] failed to get mempool lock");
+                let block = mempool_lock.get_block(100, HashSet::new());
+                for transaction in transactions.iter() {
+                    assert!(block.contains(&transaction));
+                }
+                (transactions, peer_id)
             }
             _ => panic!("peer {:?} didn't broadcast transaction", peer),
         }
@@ -148,13 +232,14 @@ impl SharedMempoolNetwork {
     }
 }
 
+// TODO: add test for txns sent within same validator network
 #[test]
 fn test_basic_flow() {
-    let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(2);
+    let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
 
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b]);
     smp.add_txns(
-        &peer_a,
+        peer_a,
         vec![
             TestTransaction::new(1, 0, 1),
             TestTransaction::new(1, 1, 1),
@@ -163,133 +248,196 @@ fn test_basic_flow() {
     );
 
     // A discovers new peer B
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
 
     for seq in 0..3 {
         // A attempts to send message
-        let transaction = smp.deliver_message(&peer_a).0;
-        assert_eq!(transaction.sequence_number(), seq);
+        let (transactions, _) = smp.deliver_message(&peer_a);
+        assert_eq!(transactions.len(), 1); // TODO use test config batch size
+        let txn = assert_matches::assert_matches!(
+            transactions.get(0),
+            Some(txn) => txn,
+            "expect first SignedTransaction to exist",
+        );
+        assert_eq!(txn.sequence_number(), seq);
+        smp.wait_for_worker_update(peer_a, peer_b);
     }
 }
 
 #[test]
 fn test_metric_cache_ignore_shared_txns() {
-    let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
-
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b]);
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(2);
+    let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
     let txns = vec![
         TestTransaction::new(1, 0, 1),
         TestTransaction::new(1, 1, 1),
         TestTransaction::new(1, 2, 1),
     ];
+
     smp.add_txns(
         &peer_a,
         vec![txns[0].clone(), txns[1].clone(), txns[2].clone()],
     );
+
     // Check if txns's creation timestamp exist in peer_a's metrics_cache.
     assert_eq!(smp.exist_in_metrics_cache(&peer_a, &txns[0]), true);
     assert_eq!(smp.exist_in_metrics_cache(&peer_a, &txns[1]), true);
     assert_eq!(smp.exist_in_metrics_cache(&peer_a, &txns[2]), true);
 
     // Let peer_a discover new peer_b.
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
     for txn in txns.iter().take(3) {
         // Let peer_a share txns with peer_b
-        let (_transaction, rx_peer) = smp.deliver_message(&peer_a);
-        // Check if txns's creation timestamp exist in peer_b's metrics_cache.
+        let (_transactions, rx_peer) = smp.deliver_message(&peer_a);
         assert_eq!(smp.exist_in_metrics_cache(&rx_peer, txn), false);
     }
 }
 
 #[test]
 fn test_interruption_in_sync() {
-    let (peer_a, peer_b, peer_c) = (PeerId::random(), PeerId::random(), PeerId::random());
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b, peer_c]);
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(3);
+    let (peer_a, peer_b, peer_c) = (
+        peers.get(0).unwrap(),
+        peers.get(1).unwrap(),
+        peers.get(2).unwrap(),
+    );
+
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 0, 1)]);
 
     // A discovers 2 peers
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_c));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_c));
 
     // make sure it delivered first transaction to both nodes
     let mut peers = vec![
         smp.deliver_message(&peer_a).1,
         smp.deliver_message(&peer_a).1,
     ];
+    smp.wait_for_worker_updates(&peer_a, vec![*peer_b, *peer_c]);
     peers.sort();
-    let mut expected_peers = vec![peer_b, peer_c];
+    let mut expected_peers = vec![*peer_b, *peer_c];
     expected_peers.sort();
     assert_eq!(peers, expected_peers);
 
     // A loses connection to B
-    smp.send_event(&peer_a, NetworkNotification::LostPeer(peer_b));
+    smp.send_event(&peer_a, NetworkNotification::LostPeer(*peer_b));
 
-    // only C receives following transactions
+    let mut results = Vec::new();
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 1, 1)]);
-    let (txn, peer_id) = smp.deliver_message(&peer_a);
-    assert_eq!(peer_id, peer_c);
-    assert_eq!(txn.sequence_number(), 1);
+    results.push(smp.deliver_message(&peer_a));
 
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 2, 1)]);
-    let (txn, peer_id) = smp.deliver_message(&peer_a);
-    assert_eq!(peer_id, peer_c);
-    assert_eq!(txn.sequence_number(), 2);
+    results.push(smp.deliver_message(&peer_a));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
+    for _ in 0..2 {
+        results.push(smp.deliver_message(&peer_a));
+    }
 
-    // A reconnects to B
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
+    // check for the following possible ordering of transactions in message delivery:
+    // C1, C2, B1, B2
+    // C1, B2, C2, B2
+    // B1, C1, C2, B2
+    //
+    // there are multiple possible orderings because the worker process for peer B may not be paused
+    // immediately (the `PAUSE` message from master may reach worker for peer B between the time the worker
+    // checked the channel from master and the time it broadcasts transactions
 
-    // B should receive transaction 2
-    let (txn, peer_id) = smp.deliver_message(&peer_a);
-    assert_eq!(peer_id, peer_b);
-    assert_eq!(txn.sequence_number(), 1);
+    let expected_values = vec![
+        vec![(peer_c, 1), (peer_c, 2), (peer_b, 1), (peer_b, 2)],
+        vec![(peer_c, 1), (peer_b, 1), (peer_c, 2), (peer_b, 2)],
+        vec![(peer_b, 1), (peer_c, 1), (peer_b, 2), (peer_c, 2)],
+    ];
+    let mut matched = false;
+
+    for expected in &expected_values {
+        let mut actual_matches_expected = true;
+        for i in 0..4 {
+            let expected_event = expected[i];
+            let actual_event = &results[i];
+
+            actual_matches_expected = (actual_event.1 == *expected_event.0)
+                && (actual_event.0.get(0).unwrap().sequence_number() == expected_event.1);
+        }
+        if actual_matches_expected {
+            matched = true;
+            break;
+        }
+    }
+    assert!(matched);
 }
 
 #[test]
 fn test_ready_transactions() {
-    let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b]);
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(2);
+    let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
+
     smp.add_txns(
         &peer_a,
         vec![TestTransaction::new(1, 0, 1), TestTransaction::new(1, 2, 1)],
     );
     // first message delivery
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
     smp.deliver_message(&peer_a);
+    smp.wait_for_worker_update(peer_a, peer_b);
 
     // add txn1 to Mempool
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 1, 1)]);
     // txn1 unlocked txn2. Now all transactions can go through in correct order
-    let txn = &smp.deliver_message(&peer_a).0;
+    let txns = &smp.deliver_message(&peer_a).0;
+    smp.wait_for_worker_update(peer_a, peer_b);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sequence_number(), 1);
-    let txn = &smp.deliver_message(&peer_a).0;
+    let txns = &smp.deliver_message(&peer_a).0;
+    smp.wait_for_worker_update(peer_a, peer_b);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sequence_number(), 2);
 }
 
 #[test]
 fn test_broadcast_self_transactions() {
-    let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b]);
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(2);
+    let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
+
     smp.add_txns(&peer_a, vec![TestTransaction::new(0, 0, 1)]);
 
     // A and B discover each other
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
-    smp.send_event(&peer_b, NetworkNotification::NewPeer(peer_a));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
+    smp.send_event(&peer_b, NetworkNotification::NewPeer(*peer_a));
 
     // A sends txn to B
     smp.deliver_message(&peer_a);
+    smp.wait_for_worker_update(peer_a, peer_b);
 
     // add new txn to B
     smp.add_txns(&peer_b, vec![TestTransaction::new(1, 0, 1)]);
 
     // verify that A will receive only second transaction from B
-    let (txn, _) = smp.deliver_message(&peer_b);
+    let (txns, _) = smp.deliver_message(&peer_b);
+    smp.wait_for_worker_update(peer_b, peer_a);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sender(), TestTransaction::get_address(1));
 }
 
 #[test]
 fn test_broadcast_dependencies() {
-    let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b]);
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(2);
+    let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
+
     // Peer A has transactions with sequence numbers 0 and 2
     smp.add_txns(
         &peer_a,
@@ -299,33 +447,56 @@ fn test_broadcast_dependencies() {
     smp.add_txns(&peer_b, vec![TestTransaction::new(0, 1, 1)]);
 
     // A and B discover each other
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
-    smp.send_event(&peer_b, NetworkNotification::NewPeer(peer_a));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
+    smp.send_event(&peer_b, NetworkNotification::NewPeer(*peer_a));
 
     // B receives 0
     smp.deliver_message(&peer_a);
+    smp.wait_for_worker_update(peer_a, peer_b);
     // now B can broadcast 1
-    let txn = smp.deliver_message(&peer_b).0;
+    let txns = smp.deliver_message(&peer_b).0;
+    smp.wait_for_worker_update(peer_b, peer_a);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sequence_number(), 1);
+
     // now A can broadcast 2
-    let txn = smp.deliver_message(&peer_a).0;
+    let txns = smp.deliver_message(&peer_a).0;
+    smp.wait_for_worker_update(peer_a, peer_b);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sequence_number(), 2);
 }
 
 #[test]
 fn test_broadcast_updated_transaction() {
-    let (peer_a, peer_b) = (PeerId::random(), PeerId::random());
-    let mut smp = SharedMempoolNetwork::bootstrap(vec![peer_a, peer_b]);
+    let (mut smp, peers) = SharedMempoolNetwork::bootstrap_validator_network_smp(2);
+    let (peer_a, peer_b) = (peers.get(0).unwrap(), peers.get(1).unwrap());
 
     // Peer A has a transaction with sequence number 0 and gas price 1
     smp.add_txns(&peer_a, vec![TestTransaction::new(0, 0, 1)]);
 
     // A and B discover each other
-    smp.send_event(&peer_a, NetworkNotification::NewPeer(peer_b));
-    smp.send_event(&peer_b, NetworkNotification::NewPeer(peer_a));
+    smp.send_event(&peer_a, NetworkNotification::NewPeer(*peer_b));
+    smp.send_event(&peer_b, NetworkNotification::NewPeer(*peer_a));
 
     // B receives 0
-    let txn = smp.deliver_message(&peer_a).0;
+    let txns = smp.deliver_message(&peer_a).0;
+    smp.wait_for_worker_update(peer_a, peer_b);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sequence_number(), 0);
     assert_eq!(txn.gas_unit_price(), 1);
 
@@ -333,7 +504,14 @@ fn test_broadcast_updated_transaction() {
     smp.add_txns(&peer_a, vec![TestTransaction::new(0, 0, 5)]);
 
     // trigger send from A to B and check B has updated gas price for sequence 0
-    let txn = smp.deliver_message(&peer_a).0;
+    let txns = smp.deliver_message(&peer_a).0;
+    smp.wait_for_worker_update(peer_a, peer_b);
+    assert_eq!(txns.len(), 1);
+    let txn = assert_matches::assert_matches!(
+        txns.get(0),
+        Some(txn) => txn,
+        "expect first SignedTransaction to exist",
+    );
     assert_eq!(txn.sequence_number(), 0);
     assert_eq!(txn.gas_unit_price(), 5);
 }

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -1,0 +1,84 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use lazy_static;
+use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
+
+lazy_static::lazy_static! {
+    /// number of workers, by status
+    pub static ref WORKERS: IntGaugeVec = register_int_gauge_vec!(
+        // metric name
+        "libra_mempool_workers_total",
+        // metric description
+        "Number of worker processes handling txn broadcasts",
+        // metric_labels
+        &[
+            "status", // START, PAUSE, KILL
+            "worker_peer_id"
+        ]
+    ).unwrap();
+
+    /// number of new_peer / lost peer
+    pub static ref PEER_NOTIFICATION: IntCounterVec = register_int_counter_vec!(
+        "libra_mempool_peer_notifications_total",
+        "Number of peer notifications that shared mempool receives",
+        &["type", "notification_sender_peer_id"]
+    ).unwrap();
+
+    /// time between getting an RpcRequest and actually spawning it
+    pub static ref RPC_PROCESS_SPAWN_TIME: HistogramVec = register_histogram_vec!(
+        "libra_mempool_rpc_process_spawn_time_s",
+        "Histogram of time it takes for an process to be spawned",
+        &[
+            "from_peer"
+        ]
+    ).unwrap();
+
+    /// time needed to handle inbound RPC request
+    pub static ref TXN_SUBMISSION_PROCESSING_TIME: HistogramVec = register_histogram_vec!(
+        "libra_mempool_txn_submission_processing_time_s",
+        "Histogram of time it takes for shared mempool to process an incoming txn broadcast",
+        &[
+            "sender_peer_id",
+        ]
+    ).unwrap();
+
+    // outbound RPC call duration / timeouts
+
+    // callback duration
+    pub static ref OUTBOUND_TXN_BROADCAST_TIME: HistogramVec = register_histogram_vec!(
+        "libra_mempool_outbound_txn_broadcast_time_duration_s",
+        "Histogram of time it takes for ",
+        &[
+            "to_peer"
+        ]
+    ).unwrap();
+
+    // callback timeouts
+    pub static ref TIMEOUT: IntGaugeVec = register_int_gauge_vec!(
+        "libra_mempool_rpc_timeouts_total",
+        "Number of RPC timeouts",
+        &[
+            "other_peer", // peer id of rpc
+            "direction", // callback, outbound
+        ]
+    ).unwrap();
+
+    pub static ref SUBMIT_TXNS_MEMPOOL_TIME_BREAKDOWN: HistogramVec = register_histogram_vec!(
+        "libra_mempool_process_txns_time_breakdown_ms",
+        "Histogram of the time breakdown of submitting transactions to mempool",
+        &[
+            "sender_peer_id",
+            "activity", // convert_proto, vm_validation, mempool_lock, add_txn, callback
+        ]
+    ).unwrap();
+
+    pub static ref BROADCAST_TXNS_TIME_BREAKDOWN: HistogramVec = register_histogram_vec!(
+        "libra_mempool_broadcast_txns_time_breakdown_ms",
+        "Histogram of the time breakdown of broadcasting transactions to mempool",
+        &[
+            "sender_peer_id",
+            "activity", // mempool_lock, network_send, master_push
+        ]
+    ).unwrap();
+}

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+// Increase recursion limit to allow for use of select! macro.
+#![recursion_limit = "1024"]
 
 //! Mempool is used to hold transactions that have been submitted but not yet agreed upon and
 //! executed.

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -56,10 +56,14 @@
 //! every Consensus commit request. We use a separate system TTL to ensure that a transaction won't
 //! remain stuck in Mempool forever, even if Consensus doesn't make progress
 
+#[macro_use]
+extern crate prometheus;
+
 pub mod proto;
 pub use runtime::MempoolRuntime;
 
 mod core_mempool;
+mod counters;
 mod mempool_service;
 mod runtime;
 mod shared_mempool;

--- a/mempool/src/runtime.rs
+++ b/mempool/src/runtime.rs
@@ -60,7 +60,6 @@ impl MempoolRuntime {
             storage_client,
             vm_validator,
             vec![],
-            None,
         );
 
         let addr = format!(

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -1,25 +1,37 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    core_mempool::{CoreMempool, TimelineState},
-    OP_COUNTERS,
-};
+use anyhow::{format_err, Result};
 use bounded_executor::BoundedExecutor;
-use futures::{channel::mpsc::UnboundedSender, future::join_all, Stream, StreamExt};
+use bytes05::Bytes;
+
+use crate::core_mempool::{CoreMempool, TimelineState};
+use futures::{
+    channel::{
+        mpsc::{channel, Receiver, Sender, UnboundedSender},
+        oneshot,
+    },
+    executor::ThreadPool,
+    future::join_all,
+    sink::SinkExt,
+    StreamExt,
+};
 use libra_config::config::{MempoolConfig, NodeConfig};
 use libra_logger::prelude::*;
+use libra_prost_ext::MessageExt;
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
-    proto::MempoolSyncMsg,
-    validator_network::{Event, MempoolNetworkEvents, MempoolNetworkSender},
+    proto::{
+        BroadcastTransactionsRequest, BroadcastTransactionsResponse, MempoolSyncMsg,
+        MempoolSyncMsg_oneof,
+    },
+    validator_network::{Event, MempoolNetworkEvents, MempoolNetworkSender, RpcError},
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     convert::{TryFrom, TryInto},
-    ops::Deref,
-    pin::Pin,
     sync::{Arc, Mutex},
+    thread::sleep,
     time::Duration,
 };
 use storage_client::StorageRead;
@@ -29,28 +41,40 @@ use tokio::{
 };
 use vm_validator::vm_validator::{get_account_state, TransactionValidation};
 
+const WORKER_CHANNEL_BUFFER_SIZE: usize = 5;
+const WORKER_TO_MASTER_CHANNEL_BUFFER_SIZE: usize = 100;
+
 /// state of last sync with peer
-/// `timeline_id` is position in log of ready transactions
-/// `is_alive` - is connection healthy
-#[derive(Clone)]
+/// `timeline_id`: the timeline ID of the last transaction broadcast to and successfully processed this peer
+/// `is_alive`: is the worker process for this peer still alive
+/// `to_worker`: the sending end of the channel for sending activity status to the worker process for this peer
+#[derive(Clone, Debug)]
 struct PeerSyncState {
     timeline_id: u64,
     is_alive: bool,
+    to_worker: Sender<OutboundProcessState>,
+}
+
+#[derive(Clone)]
+struct PeerSyncUpdate {
+    peer_id: PeerId,
+    timeline_id: u64,
+}
+
+#[derive(Debug, PartialEq)]
+enum OutboundProcessState {
+    START,
+    PAUSE,
+    KILL,
 }
 
 type PeerInfo = HashMap<PeerId, PeerSyncState>;
 
-/// Outbound peer syncing event emitted by [`IntervalStream`].
-#[derive(Debug)]
-pub(crate) struct SyncEvent;
-
-type IntervalStream = Pin<Box<dyn Stream<Item = SyncEvent> + Send + 'static>>;
-
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SharedMempoolNotification {
-    Sync,
     PeerStateChange,
     NewTransactions,
+    SyncUpdate { worker_peer: PeerId },
 }
 
 /// Struct that owns all dependencies required by shared mempool routines
@@ -64,7 +88,7 @@ where
     config: MempoolConfig,
     storage_read_client: Arc<dyn StorageRead>,
     validator: Arc<V>,
-    peer_info: Arc<Mutex<PeerInfo>>,
+    validator_peers: HashSet<PeerId>, // read-only and doesn't change, so thread-safe
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
 }
 
@@ -77,110 +101,82 @@ fn notify_subscribers(
     }
 }
 
-fn default_timer(tick_ms: u64) -> IntervalStream {
-    interval(Duration::from_millis(tick_ms))
-        .map(|_| SyncEvent)
-        .boxed()
-}
-
-/// new peer discovery handler
-/// adds new entry to `peer_info`
-fn new_peer(peer_info: &Mutex<PeerInfo>, peer_id: PeerId) {
-    peer_info
-        .lock()
-        .expect("[shared mempool] failed to acquire peer_info lock")
-        .entry(peer_id)
-        .or_insert(PeerSyncState {
-            timeline_id: 0,
-            is_alive: true,
-        })
-        .is_alive = true;
-}
-
-/// lost peer handler. Marks connection as dead
-fn lost_peer(peer_info: &Mutex<PeerInfo>, peer_id: PeerId) {
-    if let Some(state) = peer_info
-        .lock()
-        .expect("[shared mempool] failed to acquire peer_info lock")
-        .get_mut(&peer_id)
-    {
-        state.is_alive = false;
-    }
-}
-
-/// sync routine
-/// used to periodically broadcast ready to go transactions to peers
-async fn sync_with_peers<'a>(
-    peer_info: &'a Mutex<PeerInfo>,
-    mempool: &'a Mutex<CoreMempool>,
-    network_sender: &'a mut MempoolNetworkSender,
-    batch_size: usize,
-) {
-    // Clone the underlying peer_info map and use this to sync and collect
-    // state updates. We do this instead of holding the lock for the whole
-    // function since that would hold the lock across await points which is bad.
-    let peer_info_copy = peer_info
-        .lock()
-        .expect("[shared mempool] failed to acquire peer_info lock")
-        .deref()
-        .clone();
-
-    let mut state_updates = vec![];
-
-    for (peer_id, peer_state) in peer_info_copy.into_iter() {
-        if peer_state.is_alive {
-            let timeline_id = peer_state.timeline_id;
-
-            let (transactions, new_timeline_id) = mempool
-                .lock()
-                .expect("[shared mempool] failed to acquire mempool lock")
-                .read_timeline(timeline_id, batch_size);
-
-            if !transactions.is_empty() {
-                OP_COUNTERS.inc_by("smp.sync_with_peers", transactions.len());
-                let mut msg = MempoolSyncMsg::default();
-                msg.peer_id = peer_id.into();
-                msg.transactions = transactions
-                    .into_iter()
-                    .map(|txn| txn.try_into().unwrap())
-                    .collect();
-
-                trace!(
-                    "MempoolNetworkSender.send_to peer {} msg {:?}",
-                    peer_id,
-                    msg
-                );
-                // Since this is a direct-send, this will only error if the network
-                // module has unexpectedly crashed or shutdown.
-                network_sender
-                    .send_to(peer_id, msg)
-                    .await
-                    .expect("[shared mempool] failed to direct-send mempool sync message");
-            }
-
-            state_updates.push((peer_id, new_timeline_id));
-        }
-    }
-
-    // Lock the shared peer_info and apply state updates.
-    let mut peer_info = peer_info
-        .lock()
-        .expect("[shared mempool] failed to acquire peer_info lock");
-    for (peer_id, new_timeline_id) in state_updates {
-        peer_info
-            .entry(peer_id)
-            .and_modify(|t| t.timeline_id = new_timeline_id);
-    }
-}
-
-/// used to validate incoming transactions and add them to local Mempool
-async fn process_incoming_transactions<V>(
+/// send callback here
+async fn process_rpc_submit_transactions_request<V>(
     smp: SharedMempool<V>,
     peer_id: PeerId,
-    transactions: Vec<SignedTransaction>,
+    request: BroadcastTransactionsRequest,
+    callback: oneshot::Sender<Result<Bytes, RpcError>>,
 ) where
     V: TransactionValidation,
 {
+    // the RPC response object that will be returned to sender via callback
+    let resp = match submit_transactions_to_mempool(smp.clone(), peer_id, request).await {
+        Ok(response) => response,
+        Err(e) => {
+            error!(
+                "[shared mempool] Error occurred in submitting transactions to local mempool: {:?}",
+                e
+            );
+            // TODO return error in response
+            let mut response = BroadcastTransactionsResponse::default();
+            response.backpressure_ms = 0; // TODO this is placeholder
+            response
+        }
+    };
+    let response_msg = MempoolSyncMsg {
+        message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsResponse(resp)),
+    };
+
+    // send response to callback
+    let response_data = response_msg.to_bytes().expect("failed to serialize proto");
+    if let Err(err) = callback
+        .send(Ok(response_data))
+        .map_err(|_| format_err!("[shared mempool] handling inbound RPC call timed out"))
+    {
+        error!(
+            "[shared mempool] failed to process batched transaction request, error: {:?}",
+            err
+        );
+    }
+    notify_subscribers(SharedMempoolNotification::NewTransactions, &smp.subscribers);
+}
+
+/// Tries to add transactions to local mempool
+/// returns RPC response that can be sent to callback
+/// peer_id is the PeerId of the node that sent the request
+async fn submit_transactions_to_mempool<V>(
+    smp: SharedMempool<V>,
+    peer_id: PeerId,
+    request: BroadcastTransactionsRequest,
+) -> Result<BroadcastTransactionsResponse>
+where
+    V: TransactionValidation,
+{
+    /////////////////////////////////////////////
+    // convert from proto to SignedTransaction //
+    /////////////////////////////////////////////
+    let transactions: Vec<_> = request
+        .transactions
+        .clone()
+        .into_iter()
+        .filter_map(|txn| match SignedTransaction::try_from(txn.clone()) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                // TODO make RPC response for this invalid transaction
+                // log error
+                security_log(SecurityEvent::InvalidTransactionMP)
+                    .error(&e)
+                    .data(&txn)
+                    .log();
+                None
+            }
+        })
+        .collect();
+
+    //////////////////////////////////
+    // validate transactions via VM //
+    //////////////////////////////////
     let account_states = join_all(
         transactions
             .iter()
@@ -188,15 +184,12 @@ async fn process_incoming_transactions<V>(
     )
     .await;
 
-    // eagerly filter out transactions that were already committed
     let transactions: Vec<_> = transactions
         .into_iter()
         .enumerate()
         .filter_map(|(idx, t)| {
             if let Ok((sequence_number, balance)) = account_states[idx] {
-                if t.sequence_number() >= sequence_number {
-                    return Some((t, sequence_number, balance));
-                }
+                return Some((t, sequence_number, balance));
             }
             None
         })
@@ -209,56 +202,50 @@ async fn process_incoming_transactions<V>(
     )
     .await;
 
-    {
-        let mut mempool = smp
-            .mempool
-            .lock()
-            .expect("[shared mempool] failed to acquire mempool lock");
+    ///////////////////////////////
+    // add txns to local mempool //
+    ///////////////////////////////
 
-        for (idx, (transaction, sequence_number, balance)) in transactions.into_iter().enumerate() {
-            if let Ok(None) = validations[idx] {
-                let gas_cost = transaction.max_gas_amount();
-                let insertion_result = mempool.add_txn(
-                    transaction,
-                    gas_cost,
-                    sequence_number,
-                    balance,
-                    TimelineState::NonQualified,
-                );
-                OP_COUNTERS.inc(&format!(
-                    "smp.transactions.status.{:?}.{:?}",
-                    insertion_result.code, peer_id
-                ));
-            } else {
-                OP_COUNTERS.inc(&format!(
-                    "smp.transactions.status.validation_failed.{:?}",
-                    peer_id
-                ));
-            }
+    // The [`TimelineState`] for adding txns to mempool should only be TimelineState::NonQualified,
+    // (i.e. this node should never try to broadcast it) if this MempoolSyncMsg came from one validator
+    // to another validator in the same validator network.
+    // TODO later get TimelineState from network analysis, to accommodate dynamic configs/network
+    let timeline_state = if smp.validator_peers.contains(&peer_id) {
+        TimelineState::NonQualified
+    } else {
+        TimelineState::NotReady
+    };
+
+    let mut mempool = smp
+        .mempool
+        .lock()
+        .expect("[shared mempool] failed to acquire mempool lock");
+
+    for (idx, (transaction, sequence_number, balance)) in transactions.into_iter().enumerate() {
+        if let Ok(None) = validations[idx] {
+            let gas_cost = transaction.max_gas_amount();
+            mempool.add_txn(
+                transaction,
+                gas_cost,
+                sequence_number,
+                balance,
+                // peer validator SMP network or from FN
+                timeline_state,
+            );
+        // TODO log/update counters for MempoolAddTransactionStatus
+        // TODO check for MempoolAddTransactionStatus::MempoolIsFull and calculate backpressure
+        } else {
+            // txn vm validation failed
+            // TODO log/update counters for failed vm validation VMStatus
         }
     }
-    notify_subscribers(SharedMempoolNotification::NewTransactions, &smp.subscribers);
-}
 
-/// This task handles [`SyncEvent`], which is periodically emitted for us to
-/// broadcast ready to go transactions to peers.
-async fn outbound_sync_task<V>(smp: SharedMempool<V>, mut interval: IntervalStream)
-where
-    V: TransactionValidation,
-{
-    let peer_info = smp.peer_info;
-    let mempool = smp.mempool;
-    let mut network_sender = smp.network_sender;
-    let batch_size = smp.config.shared_mempool_batch_size;
-    let subscribers = smp.subscribers;
-
-    while let Some(sync_event) = interval.next().await {
-        trace!("SyncEvent: {:?}", sync_event);
-        sync_with_peers(&peer_info, &mempool, &mut network_sender, batch_size).await;
-        notify_subscribers(SharedMempoolNotification::Sync, &subscribers);
-    }
-
-    crit!("SharedMempool outbound_sync_task terminated");
+    // return RPC response for this request
+    // TODO currently this is a dummy response - need to add real backpressure
+    // and potentially more info on individual txn failures
+    let mut response = BroadcastTransactionsResponse::default();
+    response.backpressure_ms = 0;
+    Ok(response)
 }
 
 /// This task handles inbound network events.
@@ -269,73 +256,145 @@ async fn inbound_network_task<V>(
 ) where
     V: TransactionValidation,
 {
-    let peer_info = smp.peer_info.clone();
+    let mut peer_info: PeerInfo = HashMap::new();
     let subscribers = smp.subscribers.clone();
 
     // Use a BoundedExecutor to restrict only `workers_available` concurrent
     // worker tasks that can process incoming transactions.
     let workers_available = smp.config.shared_mempool_max_concurrent_inbound_syncs;
-    let bounded_executor = BoundedExecutor::new(workers_available, executor);
+    let bounded_executor = BoundedExecutor::new(workers_available, executor.clone());
 
-    while let Some(event) = network_events.next().await {
-        trace!("SharedMempoolEvent::NetworkEvent::{:?}", event);
-        match event {
-            Ok(network_event) => match network_event {
-                Event::NewPeer(peer_id) => {
-                    OP_COUNTERS.inc("smp.event.new_peer");
-                    new_peer(&peer_info, peer_id);
-                    notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
-                }
-                Event::LostPeer(peer_id) => {
-                    OP_COUNTERS.inc("smp.event.lost_peer");
-                    lost_peer(&peer_info, peer_id);
-                    notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
-                }
-                Event::Message((peer_id, msg)) => {
-                    OP_COUNTERS.inc("smp.event.message");
-                    let transactions: Vec<_> = msg
-                        .transactions
-                        .clone()
-                        .into_iter()
-                        .filter_map(|txn| match SignedTransaction::try_from(txn) {
-                            Ok(t) => Some(t),
-                            Err(e) => {
-                                security_log(SecurityEvent::InvalidTransactionMP)
-                                    .error(&e)
-                                    .data(&msg)
-                                    .log();
-                                None
+    // Create a threadpool that manages concurrent worker processes
+    let worker_pool = ThreadPool::new().unwrap();
+    let (worker_sender, mut receiver) = channel(WORKER_TO_MASTER_CHANNEL_BUFFER_SIZE);
+    loop {
+        ::futures::select! {
+            // network events
+            maybe_network_event = network_events.next() => {
+                match maybe_network_event {
+                    None => {
+                        // TODO log termination of network events stream
+                        return;
+                    }
+                    Some(network_event) => match network_event {
+                        Ok(event) => match event {
+                            Event::NewPeer(peer_id) => {
+                                // TODO log event
+                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
+                                let mut timeline_id = 0;
+
+                                // start outbound rpc sync process for this new peer\
+                                // check if this brand new peer
+                                if let Some(mut peer_sync_state) = peer_info.get_mut(&peer_id) {
+                                    // try restarting paused worker
+                                    if peer_sync_state.to_worker.send(OutboundProcessState::START).await.is_err() {
+                                        // TODO log this
+
+                                        // restart worker process for this peer
+                                        timeline_id = peer_sync_state.timeline_id;
+                                    } else {
+                                        continue;
+                                    }
+                                }
+
+                                // start brand new worker
+                                let (master_sender, worker_receiver) = channel(WORKER_CHANNEL_BUFFER_SIZE);
+                                let smp_outbound = smp.clone();
+                                let mempool = smp_outbound.mempool.clone();
+                                let mut network_sender = smp_outbound.network_sender.clone();
+                                peer_info.insert(peer_id, PeerSyncState {
+                                    timeline_id,
+                                    is_alive: true,
+                                    to_worker: master_sender,
+                                });
+                                let worker_sender_clone = worker_sender.clone();
+
+                                // TODO log
+                                worker_pool.spawn_ok(async move {
+                                    worker(
+                                        worker_receiver,
+                                        worker_sender_clone,
+                                        peer_id,
+                                        &mempool,
+                                         &mut network_sender,
+                                        timeline_id,
+                                    )
+                                    .await;
+                                });
                             }
-                        })
-                        .collect();
-                    OP_COUNTERS.inc_by(
-                        &format!("smp.transactions.received.{:?}", peer_id),
-                        transactions.len(),
-                    );
-                    bounded_executor
-                        .spawn(process_incoming_transactions(
-                            smp.clone(),
-                            peer_id,
-                            transactions,
-                        ))
-                        .await;
-                }
-                _ => {
-                    security_log(SecurityEvent::InvalidNetworkEventMP)
-                        .error("UnexpectedNetworkEvent")
-                        .data(&network_event)
-                        .log();
-                    debug_assert!(false, "Unexpected network event");
+                            Event::LostPeer(peer_id) => {
+                                // TODO log event
+                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
+
+                                if let Some(peer_sync_state) = peer_info.get_mut(&peer_id) {
+                                    // check state
+                                    if peer_sync_state.is_alive {
+                                        if peer_sync_state.to_worker.send(OutboundProcessState::PAUSE).await.is_err() {
+                                            // TODO log this
+                                            // disconnected channels will just treat worker process as dead
+                                        }
+                                        peer_sync_state.is_alive = false;
+                                    } else {
+                                        error!(
+                                            "[shared mempool] received LostPeer event for peer {} which was already lost",
+                                            peer_id
+                                        );
+                                    }
+                                } else {
+                                    error!(
+                                        "[shared mempool] received LostPeer event for non-existent peer {}",
+                                        peer_id
+                                    );
+                                }
+
+                            }
+                            Event::RpcRequest((peer_id, msg, callback)) => {
+                                // handle rpc events for transactions
+                                if let Some(MempoolSyncMsg_oneof::BroadcastTransactionsRequest(request)) =
+                                    msg.message
+                                {
+                                    // get transactions from MempoolSyncMsg
+                                    bounded_executor
+                                        .spawn(process_rpc_submit_transactions_request(
+                                            smp.clone(),
+                                            peer_id,
+                                            request,
+                                            callback,
+                                        ))
+                                        .await;
+                                }
+                            }
+                            _ => {}
+
+                        }
+                        Err(e) => {
+                            security_log(SecurityEvent::InvalidNetworkEventMP)
+                                .error(&e)
+                                .log();
+                        }
+                    }
                 }
             },
-            Err(e) => {
-                security_log(SecurityEvent::InvalidNetworkEventMP)
-                    .error(&e)
-                    .log();
+            maybe_peer_sync_update = receiver.next() => {
+                match maybe_peer_sync_update {
+                    None => { }, // TODO log
+                    Some(peer_sync_update) => {
+                        notify_subscribers(SharedMempoolNotification::SyncUpdate {worker_peer: peer_sync_update.peer_id}, &subscribers);
+                        if let Some(sync_state) = peer_info.get_mut(&peer_sync_update.peer_id) {
+                            sync_state.timeline_id = peer_sync_update.timeline_id;
+                        } else {
+                            error!("[shared mempool] unexpectedly got peer sync update from a worker for unknown peer");
+                        }
+                    }
+                }
+            },
+            complete => {
+                // TODO log
+                break;
             }
         }
     }
-    crit!("SharedMempool inbound_network_task terminated");
+    crit!("[shared_mempool] finished listening to inbound event");
 }
 
 /// GC all expired transactions by SystemTTL
@@ -347,8 +406,113 @@ async fn gc_task(mempool: Arc<Mutex<CoreMempool>>, gc_interval_ms: u64) {
             .expect("[shared mempool] failed to acquire mempool lock")
             .gc_by_system_ttl();
     }
-
     crit!("SharedMempool gc_task terminated");
+}
+
+async fn worker<'a>(
+    mut from_master: Receiver<OutboundProcessState>,
+    mut to_master: Sender<PeerSyncUpdate>,
+    peer_id: PeerId,
+    mempool: &'a Arc<Mutex<CoreMempool>>,
+    network_sender: &'a mut MempoolNetworkSender,
+    timeline_id: u64,
+) {
+    let mut state: OutboundProcessState = OutboundProcessState::START;
+    let current_sleep_duration_ms = 50; // TODO this is hard coded, get from config instead
+    let timeout = Duration::from_secs(1); // TODO hardcoded, get from config instead
+    let batch_size = 1; // TODO hardcoded, get from config instead
+    let mut curr_timeline_id = timeline_id; // TODO check for valid timeline_id (e.g. no negative)
+
+    // channel for ::futures::select non-event loop below
+    let (sender, mut receiver) = channel(WORKER_CHANNEL_BUFFER_SIZE);
+    sender.clone().send(1).await.ok();
+
+    while state != OutboundProcessState::KILL {
+        ::futures::select! {
+            maybe_new_state = from_master.next() => {
+                match maybe_new_state {
+                    None => {
+                        // TODO log
+                        state = OutboundProcessState::KILL;
+                    }
+                    Some(new_state) => {
+                        state = new_state;
+                    }
+                }
+            },
+            // non-event channel
+            // this is needed to unblock from waiting for update from `from_master` when
+            // there is none
+            // Note: we cannot use the default arm, as this does not give enough time for the
+            // future in `from_master` to become ready
+            non_event = receiver.next() => {
+                if non_event.is_none() {
+                    unreachable!("[shared_mempool] non-event channel in worker process \
+                        unexpectedly closed");
+                } else {
+                    sender.clone().send(1).await.ok();
+                }
+            },
+            complete => {
+                // channel `from_master` terminated, so should close
+                // TODO log
+                state = OutboundProcessState::KILL;
+            }
+        }
+
+        if state == OutboundProcessState::START {
+            // broadcast transactions to peer
+            let (transactions, new_timeline_id) = mempool
+                .lock()
+                .expect("[shared mempool] failed to acquire mempool lock")
+                .read_timeline(curr_timeline_id, batch_size);
+
+            if !transactions.is_empty() {
+                let mut req = BroadcastTransactionsRequest::default();
+                req.peer_id = peer_id.into();
+                req.transactions = transactions
+                    .into_iter()
+                    .map(|txn| txn.try_into().unwrap())
+                    .collect();
+
+                let result = network_sender
+                    .broadcast_transactions(peer_id.clone(), req, timeout)
+                    .await;
+                match result {
+                    Ok(_res) => {
+                        // TODO update timeline_id/sleep from response
+                        // TODO log
+                        curr_timeline_id = new_timeline_id;
+                    }
+                    Err(_e) => {
+                        // TODO log and handle RPC error
+                    }
+                }
+
+                // send back timeline_id to master
+                if let Err(e) = to_master
+                    .send(PeerSyncUpdate {
+                        peer_id,
+                        timeline_id: curr_timeline_id,
+                    })
+                    .await
+                {
+                    // TODO log this
+                    // this will shut down channels to/from this worker thread, so master will know
+                    // this is dead and needs to start new worker for this peer
+                    if e.is_disconnected() {
+                        // TODO log
+                        return;
+                    }
+                } else {
+                    // TODO log
+                }
+            } else {
+                // TODO log
+            }
+            sleep(Duration::from_millis(current_sleep_duration_ms));
+        }
+    }
 }
 
 /// bootstrap of SharedMempool
@@ -364,7 +528,6 @@ pub(crate) fn start_shared_mempool<V>(
     storage_read_client: Arc<dyn StorageRead>,
     validator: Arc<V>,
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
-    timer: Option<IntervalStream>,
 ) -> Runtime
 where
     V: TransactionValidation + 'static,
@@ -377,7 +540,11 @@ where
         .expect("[shared mempool] failed to create runtime");
     let executor = runtime.handle();
 
-    let peer_info = Arc::new(Mutex::new(PeerInfo::new()));
+    let validator_peers = if let Some(v) = &config.validator_network {
+        v.network_peers.peers.iter().map(|(key, _)| *key).collect()
+    } else {
+        HashSet::new()
+    };
 
     let smp = SharedMempool {
         mempool: mempool.clone(),
@@ -385,18 +552,9 @@ where
         network_sender,
         storage_read_client,
         validator,
-        peer_info,
+        validator_peers,
         subscribers,
     };
-
-    let interval_ms = config.mempool.shared_mempool_tick_interval_ms;
-    let smp_outbound = smp.clone();
-    let f = async move {
-        let interval = timer.unwrap_or_else(|| default_timer(interval_ms));
-        outbound_sync_task(smp_outbound, interval).await
-    };
-
-    executor.spawn(f);
 
     executor.spawn(inbound_network_task(smp, executor.clone(), network_events));
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -38,6 +38,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }
 libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
+libra-mempool-shared-proto = { path = "../mempool/mempool-shared-proto", version = "0.1.0" }
 
 proptest = { version = "0.9.4", default-features = false, optional = true }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
@@ -45,6 +46,7 @@ libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0
 [dev-dependencies]
 criterion = "0.3.0"
 socket-bench-server = { path = "socket-bench-server", version = "0.1.0" }
+assert_matches = "1.3.0"
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/network/build.rs
+++ b/network/build.rs
@@ -15,6 +15,7 @@ fn main() {
         "../types/src/proto",
         "src/proto",
         "../admission_control/admission-control-proto/src/proto",
+        "../mempool/mempool-shared-proto/src/proto",
     ];
 
     prost_build::compile_protos(&proto_files, &includes).unwrap();

--- a/network/src/proto/mempool.proto
+++ b/network/src/proto/mempool.proto
@@ -28,6 +28,12 @@ message BroadcastTransactionsRequest {
   repeated types.SignedTransaction transactions = 2;
 }
 
+enum BroadcastTransactionsStatusCode {
+  Success = 0;
+  MempoolIsFull = 1;
+  SharedMempoolError = 2;
+}
+
 message BroadcastTransactionsResponse {
-  uint64 backpressure_ms = 1;
+  BroadcastTransactionsStatusCode code = 1;
 }

--- a/network/src/proto/mempool.proto
+++ b/network/src/proto/mempool.proto
@@ -13,6 +13,21 @@ import "transaction.proto";
  * Mempool service is responsible for sending and receiving MempoolSyncMsg
  * across validators. */
 message MempoolSyncMsg {
+  oneof message {
+    BroadcastTransactionsRequest broadcast_transactions_request = 1;
+    BroadcastTransactionsResponse broadcast_transactions_response = 2;
+  }
+}
+
+// ------------------------------------------------------------
+// ---------------- Submit transactions -----------------------
+// ------------------------------------------------------------
+// The request for transaction submission.
+message BroadcastTransactionsRequest {
   bytes peer_id = 1;
   repeated types.SignedTransaction transactions = 2;
+}
+
+message BroadcastTransactionsResponse {
+  uint64 backpressure_ms = 1;
 }

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     },
     mempool::{
         mempool_sync_msg::Message as MempoolSyncMsg_oneof, BroadcastTransactionsRequest,
-        BroadcastTransactionsResponse, MempoolSyncMsg,
+        BroadcastTransactionsResponse, BroadcastTransactionsStatusCode, MempoolSyncMsg,
     },
     network::{
         identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -31,7 +31,10 @@ pub use self::{
     health_checker::{
         health_checker_msg::Message as HealthCheckerMsg_oneof, HealthCheckerMsg, Ping, Pong,
     },
-    mempool::MempoolSyncMsg,
+    mempool::{
+        mempool_sync_msg::Message as MempoolSyncMsg_oneof, BroadcastTransactionsRequest,
+        BroadcastTransactionsResponse, MempoolSyncMsg,
+    },
     network::{
         identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,
         PeerInfo, SignedFullNodePayload, SignedPeerInfo,

--- a/network/src/validator_network/mempool.rs
+++ b/network/src/validator_network/mempool.rs
@@ -6,15 +6,21 @@
 use crate::{
     error::NetworkError,
     interface::NetworkRequest,
-    proto::MempoolSyncMsg,
+    proto::{
+        BroadcastTransactionsRequest, BroadcastTransactionsResponse, MempoolSyncMsg,
+        MempoolSyncMsg_oneof,
+    },
+    protocols::rpc::error::RpcError,
     validator_network::{NetworkEvents, NetworkSender},
     ProtocolId,
 };
 use channel;
 use libra_types::PeerId;
+use std::time::Duration;
 
 /// Protocol id for mempool direct-send calls
 pub const MEMPOOL_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/direct-send/0.1.0/mempool/0.1.0";
+pub const MEMPOOL_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/mempool/0.1.0";
 
 /// The interface from Network to Mempool layer.
 ///
@@ -45,6 +51,7 @@ impl MempoolNetworkSender {
         }
     }
 
+    /// for direct sends
     pub async fn send_to(
         &mut self,
         recipient: PeerId,
@@ -53,21 +60,62 @@ impl MempoolNetworkSender {
         let protocol = ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL);
         self.inner.send_to(recipient, protocol, message).await
     }
+
+    /// Send a `BroadcastTransactionsRequest` RPC request to remote peer `recipient`. Returns the
+    /// future `BroadcastTransactionsResponse` returned by the remote peer.
+    ///
+    /// The rpc request can be canceled at any point by dropping the returned
+    /// future.
+    pub async fn broadcast_transactions(
+        &mut self,
+        recipient: PeerId,
+        req_msg: BroadcastTransactionsRequest,
+        timeout: Duration,
+    ) -> Result<BroadcastTransactionsResponse, RpcError> {
+        let protocol = ProtocolId::from_static(MEMPOOL_RPC_PROTOCOL);
+        let req_msg_enum = MempoolSyncMsg {
+            message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsRequest(req_msg)),
+        };
+
+        let res_msg_enum = self
+            .inner
+            .unary_rpc(recipient, protocol, req_msg_enum, timeout)
+            .await?;
+        if let Some(MempoolSyncMsg_oneof::BroadcastTransactionsResponse(response)) =
+            res_msg_enum.message
+        {
+            Ok(response)
+        } else {
+            // TODO: context
+            Err(RpcError::InvalidRpcResponse)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        interface::NetworkNotification, protocols::direct_send::Message, utils::MessageExt,
+        interface::NetworkNotification,
+        proto::{BroadcastTransactionsRequest, MempoolSyncMsg_oneof},
+        protocols::{direct_send::Message, rpc::InboundRpcRequest},
+        utils::MessageExt,
         validator_network::Event,
     };
-    use futures::{executor::block_on, sink::SinkExt, stream::StreamExt};
+    use futures::{
+        channel::oneshot, executor::block_on, future::try_join, sink::SinkExt, stream::StreamExt,
+    };
+    use prost::Message as _;
 
-    fn new_test_sync_msg(peer_id: PeerId) -> MempoolSyncMsg {
-        let mut mempool_msg = MempoolSyncMsg::default();
-        mempool_msg.peer_id = peer_id.into();
-        mempool_msg
+    fn new_test_sync_req_msg(peer_id: PeerId) -> MempoolSyncMsg {
+        let mut submit_txns_req = BroadcastTransactionsRequest::default();
+        submit_txns_req.peer_id = peer_id.into();
+
+        MempoolSyncMsg {
+            message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsRequest(
+                submit_txns_req,
+            )),
+        }
     }
 
     // Direct send messages should get deserialized through the
@@ -78,7 +126,7 @@ mod tests {
         let mut stream = MempoolNetworkEvents::new(mempool_rx);
 
         let peer_id = PeerId::random();
-        let mempool_msg = new_test_sync_msg(peer_id);
+        let mempool_msg = new_test_sync_req_msg(peer_id);
         let network_msg = Message {
             protocol: ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL),
             mdata: mempool_msg.clone().to_bytes().unwrap(),
@@ -100,7 +148,7 @@ mod tests {
         let mut sender = MempoolNetworkSender::new(network_reqs_tx);
 
         let peer_id = PeerId::random();
-        let mempool_msg = new_test_sync_msg(peer_id);
+        let mempool_msg = new_test_sync_req_msg(peer_id);
         let expected_network_msg = Message {
             protocol: ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL),
             mdata: mempool_msg.clone().to_bytes().unwrap(),
@@ -118,5 +166,82 @@ mod tests {
             }
             event => panic!("Unexpected event: {:?}", event),
         }
+    }
+
+    #[test]
+    fn test_shared_mempool_inbound_rpc() {
+        let (mut smp_tx, smp_rx) = channel::new_test(8);
+        let mut stream = MempoolNetworkEvents::new(smp_rx);
+
+        // build rpc request
+        let req_msg = BroadcastTransactionsRequest::default();
+        let req_msg_enum = MempoolSyncMsg {
+            message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsRequest(req_msg)),
+        };
+        let req_data = req_msg_enum.clone().to_bytes().unwrap();
+        let (res_tx, _) = oneshot::channel();
+        let rpc_req = InboundRpcRequest {
+            protocol: ProtocolId::from_static(MEMPOOL_RPC_PROTOCOL),
+            data: req_data,
+            res_tx,
+        };
+
+        // mock receiving rpc request
+        let peer_id = PeerId::random();
+        let event = NetworkNotification::RecvRpc(peer_id, rpc_req);
+        block_on(smp_tx.send(event)).unwrap();
+
+        // request should be properly deserialized
+        let (res_tx, _) = oneshot::channel();
+        let expected_event = Event::RpcRequest((peer_id, req_msg_enum.clone(), res_tx));
+        let event = block_on(stream.next()).unwrap().unwrap();
+        assert_eq!(event, expected_event);
+    }
+
+    #[test]
+    fn test_shared_mempool_outbound_rpc() {
+        let (network_reqs_tx, mut network_reqs_rx) = channel::new_test(8);
+        let mut sender = MempoolNetworkSender::new(network_reqs_tx);
+
+        // make submit_transaction_request rpc request
+        let peer_id = PeerId::random();
+        let req_msg = BroadcastTransactionsRequest::default();
+        let f_res_msg =
+            sender.broadcast_transactions(peer_id, req_msg.clone(), Duration::from_secs(5));
+
+        // build rpc response
+        let res_msg = BroadcastTransactionsResponse::default();
+        let res_msg_enum = MempoolSyncMsg {
+            message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsResponse(
+                res_msg.clone(),
+            )),
+        };
+        let res_data = res_msg_enum.to_bytes().unwrap();
+
+        // the future response
+        let f_recv = async move {
+            match network_reqs_rx.next().await.unwrap() {
+                NetworkRequest::SendRpc(recv_peer_id, req) => {
+                    assert_eq!(recv_peer_id, peer_id);
+                    assert_eq!(req.protocol.as_ref(), MEMPOOL_RPC_PROTOCOL);
+
+                    // check request deserializes
+                    let mut req_msg_enum = MempoolSyncMsg::decode(req.data.as_ref()).unwrap();
+                    let recv_req_msg = req_msg_enum.message.take();
+                    assert_eq!(
+                        recv_req_msg,
+                        Some(MempoolSyncMsg_oneof::BroadcastTransactionsRequest(req_msg))
+                    );
+
+                    // remote replies with some response message
+                    req.res_tx.send(Ok(res_data)).unwrap();
+                    Ok(())
+                }
+                event => panic!("Unexpected event: {:?}", event),
+            }
+        };
+
+        let (recv_res_msg, _) = block_on(try_join(f_res_msg, f_recv)).unwrap();
+        assert_eq!(recv_res_msg, res_msg);
     }
 }

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -53,7 +53,9 @@ pub use health_checker::{
     HealthCheckerNetworkEvents, HealthCheckerNetworkSender, HEALTH_CHECKER_RPC_PROTOCOL,
 };
 use libra_types::PeerId;
-pub use mempool::{MempoolNetworkEvents, MempoolNetworkSender, MEMPOOL_DIRECT_SEND_PROTOCOL};
+pub use mempool::{
+    MempoolNetworkEvents, MempoolNetworkSender, MEMPOOL_DIRECT_SEND_PROTOCOL, MEMPOOL_RPC_PROTOCOL,
+};
 pub use state_synchronizer::{
     StateSynchronizerEvents, StateSynchronizerSender, STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
 };

--- a/network/src/validator_network/test.rs
+++ b/network/src/validator_network/test.rs
@@ -5,8 +5,9 @@
 use crate::{
     common::NetworkPublicKeys,
     proto::{
-        BroadcastTransactionsRequest, BroadcastTransactionsResponse, ConsensusMsg,
-        ConsensusMsg_oneof, MempoolSyncMsg, MempoolSyncMsg_oneof, RequestBlock, RespondBlock,
+        BroadcastTransactionsRequest, BroadcastTransactionsResponse,
+        BroadcastTransactionsStatusCode, ConsensusMsg, ConsensusMsg_oneof, MempoolSyncMsg,
+        MempoolSyncMsg_oneof, RequestBlock, RespondBlock,
     },
     utils::MessageExt,
     validator_network::{
@@ -211,7 +212,7 @@ fn test_mempool_sync() {
 
                 // send response back to callback
                 let mut resp = BroadcastTransactionsResponse::default();
-                resp.backpressure_ms = 0;
+                resp.set_code(BroadcastTransactionsStatusCode::Success);
                 let response_msg = MempoolSyncMsg {
                     message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsResponse(resp)),
                 };
@@ -367,7 +368,7 @@ fn test_permissionless_mempool_sync() {
 
                 // send response back to callback
                 let mut resp = BroadcastTransactionsResponse::default();
-                resp.backpressure_ms = 0;
+                resp.set_code(BroadcastTransactionsStatusCode::Success);
                 let response_msg = MempoolSyncMsg {
                     message: Some(MempoolSyncMsg_oneof::BroadcastTransactionsResponse(resp)),
                 };

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -621,6 +621,13 @@ fn test_full_node_basic_flow() {
     full_node_client.create_next_account(false).unwrap();
     full_node_client_2.create_next_account(false).unwrap();
 
+    let sequence = full_node_client
+        .get_sequence_number(&["sequence", sender_account, "true"])
+        .unwrap();
+    validator_ac_client.wait_for_transaction(
+        validator_ac_client.faucet_account.clone().unwrap().address,
+        sequence,
+    );
     let mint_result = full_node_client.mint_coins(&["mintb", "3", "10"], true);
     assert!(mint_result.is_ok());
     assert_eq!(


### PR DESCRIPTION
## Summary

This is second PR for the AC-SMP refactor/merge project - first PR in stack is https://github.com/libra/libra/pull/1870
- adding parallel processes that handle periodic broadcasting of batches of transactions via RPC

TODO: 
- potentially add more tests (especially for killing worker thread for disconnected peer)
- add logging/error-handling (esp. in RPC response proto structs)
- `shared_mempool` and some tests use hard-coded values. Replace them with actual values from config
- remove code that these changes deprecate

## Test Plan

Refactored `network/src/validator_network/test.rs` and `shared_mempool_test`, which pass


## Related PRs
First PR in stack: https://github.com/libra/libra/pull/1870

