### PR TITLE
[cluster-test] Rework experiment creation

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -20,14 +20,17 @@ pub use packet_loss_random_validators::{
 pub use performance_benchmark_nodes_down::{
     PerformanceBenchmarkNodesDown, PerformanceBenchmarkNodesDownParams,
 };
-pub use performance_benchmark_three_region_simulation::PerformanceBenchmarkThreeRegionSimulation;
+pub use performance_benchmark_three_region_simulation::{
+    PerformanceBenchmarkThreeRegionSimulation, PerformanceBenchmarkThreeRegionSimulationParams,
+};
 pub use reboot_random_validator::{RebootRandomValidators, RebootRandomValidatorsParams};
 
 use crate::cluster::Cluster;
-use crate::experiments::recovery_time::{RecoveryTime, RecoveryTimeParams};
+use crate::experiments::recovery_time::RecoveryTimeParams;
 use crate::prometheus::Prometheus;
 use crate::tx_emitter::TxEmitter;
 use futures::future::BoxFuture;
+use std::collections::HashMap;
 use structopt::{clap::AppSettings, StructOpt};
 
 pub trait Experiment: Display + Send {
@@ -39,6 +42,11 @@ pub trait Experiment: Display + Send {
         context: &'a mut Context,
     ) -> BoxFuture<'a, anyhow::Result<Option<String>>>;
     fn deadline(&self) -> Duration;
+}
+
+pub trait ExperimentParam {
+    type E: Experiment;
+    fn build(self, cluster: &Cluster) -> Self::E;
 }
 
 pub struct Context {
@@ -57,52 +65,50 @@ impl Context {
     }
 }
 
+fn from_args<P: ExperimentParam>(args: &[String], cluster: &Cluster) -> Box<dyn Experiment>
+where
+    P: StructOpt + 'static,
+{
+    let params = P::from_clap(
+        &P::clap()
+            .global_setting(AppSettings::NoBinaryName)
+            .get_matches_from(args),
+    );
+    Box::new(params.build(cluster))
+}
+
 /// Given an experiment name and its flags, it constructs an instance of that experiment
 /// and returns it as a `Box<dyn Experiment>`
 pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn Experiment> {
-    match name {
-        "multi_region_simulation" => Box::new(MultiRegionSimulation::new(
-            MultiRegionSimulationParams::from_clap(
-                &MultiRegionSimulationParams::clap()
-                    .global_setting(AppSettings::NoBinaryName)
-                    .get_matches_from(args),
-            ),
-        )),
-        "packet_loss_random_validators" => Box::new(PacketLossRandomValidators::new(
-            PacketLossRandomValidatorsParams::from_clap(
-                &PacketLossRandomValidatorsParams::clap()
-                    .global_setting(AppSettings::NoBinaryName)
-                    .get_matches_from(args),
-            ),
-            cluster,
-        )),
-        "performance_benchmark_nodes_down" => Box::new(PerformanceBenchmarkNodesDown::new(
-            PerformanceBenchmarkNodesDownParams::from_clap(
-                &PerformanceBenchmarkNodesDownParams::clap()
-                    .global_setting(AppSettings::NoBinaryName)
-                    .get_matches_from(args),
-            ),
-            cluster,
-        )),
-        "performance_benchmark_three_region_simulation" => {
-            Box::new(PerformanceBenchmarkThreeRegionSimulation::new(cluster))
-        }
-        "reboot_random_validators" => Box::new(RebootRandomValidators::new(
-            RebootRandomValidatorsParams::from_clap(
-                &RebootRandomValidatorsParams::clap()
-                    .global_setting(AppSettings::NoBinaryName)
-                    .get_matches_from(args),
-            ),
-            cluster,
-        )),
-        "recovery_time" => Box::new(RecoveryTime::new(
-            RecoveryTimeParams::from_clap(
-                &RecoveryTimeParams::clap()
-                    .global_setting(AppSettings::NoBinaryName)
-                    .get_matches_from(args),
-            ),
-            cluster,
-        )),
-        name => panic!("Invalid experiment name: {}", name),
+    fn f<P: ExperimentParam + StructOpt + 'static>(
+    ) -> Box<dyn Fn(&[String], &Cluster) -> Box<dyn Experiment>> {
+        Box::new(from_args::<P>)
     }
+
+    let mut known_experiments = HashMap::new();
+
+    known_experiments.insert("recovery_time", f::<RecoveryTimeParams>());
+    known_experiments.insert(
+        "multi_region_simulation",
+        f::<MultiRegionSimulationParams>(),
+    );
+    known_experiments.insert(
+        "packet_loss_random_validators",
+        f::<PacketLossRandomValidatorsParams>(),
+    );
+    known_experiments.insert(
+        "performance_benchmark_nodes_down",
+        f::<PerformanceBenchmarkNodesDownParams>(),
+    );
+    known_experiments.insert(
+        "performance_benchmark_three_region_simulation",
+        f::<PerformanceBenchmarkThreeRegionSimulationParams>(),
+    );
+    known_experiments.insert(
+        "reboot_random_validators",
+        f::<RebootRandomValidatorsParams>(),
+    );
+
+    let builder = known_experiments.get(name).expect("Experiment not found");
+    builder(args, cluster)
 }

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -14,8 +14,9 @@ use tokio::time;
 /// It undoes the simulation in the cluster after the given duration
 use crate::effects::Effect;
 use crate::effects::NetworkDelay;
-use crate::experiments::Context;
+use crate::experiments::{Context, ExperimentParam};
 
+use crate::cluster::Cluster;
 use crate::experiments::Experiment;
 use crate::tx_emitter::{EmitJobRequest, EmitThreadParams, TxEmitter};
 use crate::util::unix_timestamp_now;
@@ -57,11 +58,14 @@ pub struct MultiRegionSimulationParams {
     duration_secs: u64,
 }
 
-impl MultiRegionSimulation {
-    pub fn new(params: MultiRegionSimulationParams) -> Self {
-        Self { params }
+impl ExperimentParam for MultiRegionSimulationParams {
+    type E = MultiRegionSimulation;
+    fn build(self, _cluster: &Cluster) -> Self::E {
+        Self::E { params: self }
     }
+}
 
+impl MultiRegionSimulation {
     async fn single_run(
         &self,
         count: usize,

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -22,6 +22,7 @@ pub struct PacketLossRandomValidators {
     percent: f32,
     duration: Duration,
 }
+use crate::experiments::ExperimentParam;
 use tokio::time;
 
 #[derive(StructOpt, Debug)]
@@ -46,18 +47,19 @@ pub struct PacketLossRandomValidatorsParams {
     duration_secs: u64,
 }
 
-impl PacketLossRandomValidators {
-    pub fn new(params: PacketLossRandomValidatorsParams, cluster: &Cluster) -> Self {
+impl ExperimentParam for PacketLossRandomValidatorsParams {
+    type E = PacketLossRandomValidators;
+    fn build(self, cluster: &Cluster) -> Self::E {
         let total_instances = cluster.instances().len();
         let packet_loss_num_instances: usize = std::cmp::min(
-            ((params.percent_instances / 100.0) * total_instances as f32).ceil() as usize,
+            ((self.percent_instances / 100.0) * total_instances as f32).ceil() as usize,
             total_instances,
         );
         let (test_cluster, _) = cluster.split_n_random(packet_loss_num_instances);
-        Self {
+        Self::E {
             instances: test_cluster.into_instances(),
-            percent: params.packet_loss_percent,
-            duration: Duration::from_secs(params.duration_secs),
+            percent: self.packet_loss_percent,
+            duration: Duration::from_secs(self.duration_secs),
         }
     }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::experiments::ExperimentParam;
 use crate::{
     cluster::Cluster,
     effects::{Effect, StopContainer},
@@ -35,13 +36,14 @@ pub struct PerformanceBenchmarkNodesDown {
     num_nodes_down: usize,
 }
 
-impl PerformanceBenchmarkNodesDown {
-    pub fn new(params: PerformanceBenchmarkNodesDownParams, cluster: &Cluster) -> Self {
-        let (down_instances, up_instances) = cluster.split_n_random(params.num_nodes_down);
-        Self {
+impl ExperimentParam for PerformanceBenchmarkNodesDownParams {
+    type E = PerformanceBenchmarkNodesDown;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let (down_instances, up_instances) = cluster.split_n_random(self.num_nodes_down);
+        Self::E {
             down_instances: down_instances.into_instances(),
             up_instances: up_instances.into_instances(),
-            num_nodes_down: params.num_nodes_down,
+            num_nodes_down: self.num_nodes_down,
         }
     }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::experiments::ExperimentParam;
 use crate::{
     cluster::Cluster,
     effects::{three_region_simulation_effects, Effect},
@@ -14,14 +15,19 @@ use std::{
     fmt::{Display, Error, Formatter},
     time::Duration,
 };
+use structopt::StructOpt;
 
 pub struct PerformanceBenchmarkThreeRegionSimulation {
     cluster: Cluster,
 }
 
-impl PerformanceBenchmarkThreeRegionSimulation {
-    pub fn new(cluster: &Cluster) -> Self {
-        Self {
+#[derive(StructOpt, Debug)]
+pub struct PerformanceBenchmarkThreeRegionSimulationParams {}
+
+impl ExperimentParam for PerformanceBenchmarkThreeRegionSimulationParams {
+    type E = PerformanceBenchmarkThreeRegionSimulation;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        Self::E {
             cluster: cluster.clone(),
         }
     }

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 use anyhow::{bail, Result};
 
-use crate::experiments::Context;
+use crate::experiments::{Context, ExperimentParam};
 use crate::{
     cluster::Cluster,
     effects::{Action, Reboot},
@@ -31,24 +31,24 @@ pub struct RebootRandomValidators {
     instances: Vec<Instance>,
 }
 
-impl RebootRandomValidators {
-    pub fn new(params: RebootRandomValidatorsParams, cluster: &Cluster) -> Self {
-        if params.count > cluster.instances().len() {
+impl ExperimentParam for RebootRandomValidatorsParams {
+    type E = RebootRandomValidators;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        if self.count > cluster.instances().len() {
             panic!(
                 "Can not reboot {} validators in cluster with {} instances",
-                params.count,
+                self.count,
                 cluster.instances().len()
             );
         }
-        let mut instances = Vec::with_capacity(params.count);
+        let mut instances = Vec::with_capacity(self.count);
         let mut all_instances = cluster.instances().clone();
         let mut rnd = rand::thread_rng();
-        for _i in 0..params.count {
+        for _i in 0..self.count {
             let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));
             instances.push(instance);
         }
-
-        Self { instances }
+        Self::E { instances }
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -7,13 +7,12 @@ use std::{collections::HashSet, fmt, time::Duration};
 
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt};
-use rand::Rng;
 use structopt::StructOpt;
 use tokio::time;
 
 use crate::cluster::Cluster;
 use crate::effects::{DeleteLibraData, Effect, StopContainer};
-use crate::experiments::Context;
+use crate::experiments::{Context, ExperimentParam};
 use crate::instance::Instance;
 use crate::tx_emitter::{EmitJobRequest, EmitThreadParams};
 use crate::{effects::Action, experiments::Experiment};
@@ -35,11 +34,14 @@ pub struct RecoveryTime {
     instance: Instance,
 }
 
-impl RecoveryTime {
-    pub fn new(params: RecoveryTimeParams, cluster: &Cluster) -> Self {
-        let rnd_index = rand::thread_rng().gen_range(0, cluster.instances().len());
-        let instance = cluster.instances()[rnd_index].clone();
-        Self { params, instance }
+impl ExperimentParam for RecoveryTimeParams {
+    type E = RecoveryTime;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let instance = cluster.random_instance().clone();
+        Self::E {
+            params: self,
+            instance,
+        }
     }
 }
 

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -4,12 +4,12 @@
 #![forbid(unsafe_code)]
 use std::cmp::min;
 
+use crate::experiments::ExperimentParam;
 use crate::{
     cluster::Cluster,
     experiments::{
-        Experiment, PerformanceBenchmarkNodesDown, PerformanceBenchmarkNodesDownParams,
-        PerformanceBenchmarkThreeRegionSimulation, RebootRandomValidators,
-        RebootRandomValidatorsParams,
+        Experiment, PerformanceBenchmarkNodesDownParams,
+        PerformanceBenchmarkThreeRegionSimulationParams, RebootRandomValidatorsParams,
     },
 };
 
@@ -23,39 +23,33 @@ impl ExperimentSuite {
         let count = min(3, cluster.instances().len() / 3);
         // Reboot different sets of 3 validators *100 times
         for _ in 0..20 {
-            let b: Box<dyn Experiment> = Box::new(RebootRandomValidators::new(
-                RebootRandomValidatorsParams { count },
-                cluster,
-            ));
+            let b: Box<dyn Experiment> =
+                Box::new(RebootRandomValidatorsParams { count }.build(cluster));
             experiments.push(b);
         }
-        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 },
-            cluster,
-        )));
-        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 },
-            cluster,
-        )));
-        experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
-            cluster,
-        )));
+        experiments.push(Box::new(
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 }.build(cluster),
+        ));
+        experiments.push(Box::new(
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 }.build(cluster),
+        ));
+        experiments.push(Box::new(
+            PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
+        ));
         Self { experiments }
     }
 
     pub fn new_perf_suite(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
-        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 },
-            cluster,
-        )));
-        experiments.push(Box::new(PerformanceBenchmarkNodesDown::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 },
-            cluster,
-        )));
-        experiments.push(Box::new(PerformanceBenchmarkThreeRegionSimulation::new(
-            cluster,
-        )));
+        experiments.push(Box::new(
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 }.build(cluster),
+        ));
+        experiments.push(Box::new(
+            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 }.build(cluster),
+        ));
+        experiments.push(Box::new(
+            PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
+        ));
         Self { experiments }
     }
 }


### PR DESCRIPTION
Main goal of this diff is to unify experiments creation further and make sure 'registration' of experiment in experiments crate is as short as possible

With this diff, after defining Experiment and ExperimentParam, you only need to add one line to `experiments/mod.rs` to register experiment:

```
    known_experiments.insert("experiment_name", f::<ExperimentParams>());

```
