### PR TITLE
[types] get_ordered_account_addresses => get_ordered_account_addresses_iter

### DIFF
--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -94,7 +94,9 @@ impl<T: Payload> EpochManager<T> {
         epoch: u64,
         validators: &ValidatorVerifier,
     ) -> Box<dyn ProposerElection<T> + Send + Sync> {
-        let proposers = validators.get_ordered_account_addresses();
+        let proposers = validators
+            .get_ordered_account_addresses_iter()
+            .collect::<Vec<_>>();
         match self.config.proposer_type {
             ConsensusProposerType::MultipleOrderedProposers => {
                 Box::new(MultiProposer::new(epoch, proposers, 2))

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -154,11 +154,12 @@ impl NetworkSender {
             error!("Error broadcasting to self: {:?}", err);
         }
 
-        // Get the list of validators excluding our own account address.
+        // Get the list of validators excluding our own account address. Note the
+        // ordering is not important in this case.
         let self_author = self.author;
         let other_validators = self
             .validators
-            .get_account_addresses_iter()
+            .get_ordered_account_addresses_iter()
             .filter(|author| author != &self_author);
 
         // Broadcast message over direct-send to all other validators.


### PR DESCRIPTION
Since `BTreeMap` stores entries in key-sorted ordered (https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.keys), we can avoid an unnecessary sort and copy by just returning this iterator.