### PR TITLE
[monitoring]Rework storage counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,7 @@ dependencies = [
  "libra-types 0.1.0",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2"
 proptest = { version = "0.9.2", optional = true }
 proptest-derive = { version = "0.1.2", optional = true }
 prost = "0.5.0"
+prometheus = { version = "0.7.0", default-features = false }
 rand = "0.6.5"
 rusty-fork = "0.2.1"
 strum = "0.15.0"

--- a/storage/libradb/src/ledger_counters/mod.rs
+++ b/storage/libradb/src/ledger_counters/mod.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::OP_COUNTER;
+use lazy_static::lazy_static;
 use num_derive::ToPrimitive;
 use num_traits::ToPrimitive;
+use prometheus::IntGaugeVec;
 #[cfg(test)]
 use proptest::{collection::hash_map, prelude::*};
 #[cfg(test)]
@@ -12,6 +14,18 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use strum::IntoEnumIterator;
 use strum_macros::{AsRefStr, EnumIter};
+
+// register Prometheus counters
+lazy_static! {
+    pub static ref LIBRA_STORAGE_LEDGER: IntGaugeVec = register_int_gauge_vec!(
+        // metric name
+        "libra_storage_ledger",
+        // metric description
+        "Libra storage ledger counters",
+        // metric labels (dimensions)
+        &["type"]
+    ).unwrap();
+}
 
 /// Types of ledger counters.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ToPrimitive, EnumIter, AsRefStr)]
@@ -122,6 +136,9 @@ impl LedgerCounters {
     pub fn bump_op_counters(&self) {
         for counter in LedgerCounter::iter() {
             OP_COUNTER.set(counter.as_ref(), self.get(counter));
+            LIBRA_STORAGE_LEDGER
+                .with_label_values(&[counter.as_ref()])
+                .set(self.get(counter) as i64);
         }
     }
 

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -9,6 +9,8 @@
 //! It relays read/write operations on the physical storage via [`schemadb`] to the underlying
 //! Key-Value storage system, and implements libra data structures on top of it.
 
+#[macro_use]
+extern crate prometheus;
 // Used in other crates for testing.
 pub mod mock_genesis;
 // Used in this and other crates for testing.
@@ -65,6 +67,7 @@ use libra_types::{
         Version,
     },
 };
+use prometheus::{IntCounter, IntGauge, IntGaugeVec};
 use schemadb::{ColumnFamilyOptions, ColumnFamilyOptionsMap, DB, DEFAULT_CF_NAME};
 use std::{convert::TryInto, iter::Iterator, path::Path, sync::Arc, time::Instant};
 use storage_proto::StartupInfo;
@@ -72,6 +75,27 @@ use storage_proto::TreeState;
 
 lazy_static! {
     static ref OP_COUNTER: OpMetrics = OpMetrics::new_and_registered("storage");
+}
+
+lazy_static! {
+    pub static ref LIBRA_STORAGE_CF_SIZE_BYTES: IntGaugeVec = register_int_gauge_vec!(
+        // metric name
+        "libra_storage_cf_size_bytes",
+        // metric description
+        "Libra storage Column Family size in bytes",
+        // metric labels (dimensions)
+        &["cf_name"]
+    ).unwrap();
+
+    pub static ref LIBRA_STORAGE_COMMITTED_TXNS: IntCounter = register_int_counter!(
+        "libra_storage_committed_txns",
+        "Libra storage committed transactions"
+    ).unwrap();
+
+    pub static ref LIBRA_STORAGE_LATEST_TXN_VERSION: IntGauge = register_int_gauge!(
+        "libra_storage_latest_transaction_version",
+        "Libra storage latest transaction version"
+    ).unwrap();
 }
 
 const MAX_LIMIT: u64 = 1000;
@@ -375,7 +399,9 @@ impl LibraDB {
         if num_txns > 0 {
             let last_version = first_version + num_txns - 1;
             OP_COUNTER.inc_by("committed_txns", num_txns as usize);
+            LIBRA_STORAGE_COMMITTED_TXNS.inc_by(num_txns as i64);
             OP_COUNTER.set("latest_transaction_version", last_version as usize);
+            LIBRA_STORAGE_LATEST_TXN_VERSION.set(last_version as i64);
             counters
                 .expect("Counters should be bumped with transactions being saved.")
                 .bump_op_counters();
@@ -730,6 +756,9 @@ impl LibraDB {
             Ok(cf_sizes) => {
                 for (cf_name, size) in cf_sizes {
                     OP_COUNTER.set(&format!("cf_size_bytes_{}", cf_name), size as usize);
+                    LIBRA_STORAGE_CF_SIZE_BYTES
+                        .with_label_values(&[&cf_name])
+                        .set(size as i64);
                 }
             }
             Err(err) => warn!(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Recreate storage counters following the Prometheus best practice. Will cleanup old counters after landing this PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Start a local network and compare old vs new counters.
Old counters:
```
# HELP storage Counters for storage
# TYPE storage counter
storage{op="committed_txns"} 447
# HELP storage_gauge Gauges for storage
# TYPE storage_gauge gauge
storage_gauge{op="cf_size_bytes_default"} 0
storage_gauge{op="cf_size_bytes_epoch_by_version"} 0
storage_gauge{op="cf_size_bytes_event"} 0
storage_gauge{op="cf_size_bytes_event_accumulator"} 0
storage_gauge{op="cf_size_bytes_event_by_key"} 0
storage_gauge{op="cf_size_bytes_jellyfish_merkle_node"} 0
storage_gauge{op="cf_size_bytes_ledger_counters"} 0
storage_gauge{op="cf_size_bytes_stale_node_index"} 0
storage_gauge{op="cf_size_bytes_transaction"} 0
storage_gauge{op="cf_size_bytes_transaction_accumulator"} 0
storage_gauge{op="cf_size_bytes_transaction_by_account"} 0
storage_gauge{op="cf_size_bytes_transaction_info"} 0
storage_gauge{op="events_created"} 3
storage_gauge{op="latest_transaction_version"} 446
storage_gauge{op="new_state_leaves"} 898
storage_gauge{op="new_state_nodes"} 1346
storage_gauge{op="stale_state_leaves"} 892
storage_gauge{op="stale_state_nodes"} 1338
```
New counters:
```
# HELP libra_storage_cf_size_bytes Libra storage Column Family size in bytes
# TYPE libra_storage_cf_size_bytes gauge
libra_storage_cf_size_bytes{cf_name="default"} 0
libra_storage_cf_size_bytes{cf_name="epoch_by_version"} 0
libra_storage_cf_size_bytes{cf_name="event"} 0
libra_storage_cf_size_bytes{cf_name="event_accumulator"} 0
libra_storage_cf_size_bytes{cf_name="event_by_key"} 0
libra_storage_cf_size_bytes{cf_name="jellyfish_merkle_node"} 0
libra_storage_cf_size_bytes{cf_name="ledger_counters"} 0
libra_storage_cf_size_bytes{cf_name="stale_node_index"} 0
libra_storage_cf_size_bytes{cf_name="transaction"} 0
libra_storage_cf_size_bytes{cf_name="transaction_accumulator"} 0
libra_storage_cf_size_bytes{cf_name="transaction_by_account"} 0
libra_storage_cf_size_bytes{cf_name="transaction_info"} 0
# HELP libra_storage_committed_txns Libra storage committed transactions
# TYPE libra_storage_committed_txns counter
libra_storage_committed_txns 447
# HELP libra_storage_latest_transaction_version Libra storage latest transaction version
# TYPE libra_storage_latest_transaction_version gauge
libra_storage_latest_transaction_version 446
# HELP libra_storage_ledger Libra storage ledger counters
# TYPE libra_storage_ledger gauge
libra_storage_ledger{type="events_created"} 3
libra_storage_ledger{type="new_state_leaves"} 898
libra_storage_ledger{type="new_state_nodes"} 1346
libra_storage_ledger{type="stale_state_leaves"} 892
libra_storage_ledger{type="stale_state_nodes"} 1338
```
