### PR TITLE
[faucet] Move faucet to use dynamic-config-builder

### DIFF
--- a/docker/mint/docker-run.sh
+++ b/docker/mint/docker-run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+export RUST_BACKTRACE=full
+/opt/libra/bin/dynamic-config-builder -d /opt/libra/etc -o /opt/libra/etc --faucet-client -a "/ip4/0.0.0.0/tcp/1" \
+-b "/ip4/0.0.0.0/tcp/1" -l "/ip4/0.0.0.0/tcp/1" -n $CFG_NUM_VALIDATORS -s $CFG_SEED
+
+cd /opt/libra/bin && \
+exec gunicorn --bind 0.0.0.0:8000 --access-logfile - --error-logfile - --log-level $LOG_LEVEL server


### PR DESCRIPTION

## Motivation
This moves faucet docker image to use dynamic configs

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

terraform deploy to personal workspace
