### PR TITLE
[move] Added dependcy checks and ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ dependencies = [
  "datatest-stable 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "text-diff 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -12,6 +12,7 @@ hex = "0.3.2"
 regex = "1.1.6"
 structopt = "0.3.3"
 text-diff = "0.4.0"
+petgraph = "0.4.13"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 
 move-vm = { path = "../vm", package = "vm" }

--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -30,7 +30,10 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    pub is_source_module: bool,
+    /// `None` if it is a library dependency
+    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
+    /// depedency graph
+    pub is_source_module: Option<usize>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     shared::*,
 };
-use std::{collections::VecDeque, fmt};
+use std::{collections::BTreeMap, collections::VecDeque, fmt};
 
 //**************************************************************************************************
 // Program
@@ -18,7 +18,7 @@ use std::{collections::VecDeque, fmt};
 #[derive(Debug)]
 pub struct Program {
     pub modules: UniqueMap<ModuleIdent, ModuleDefinition>,
-    pub main: Option<(Address, FunctionName, Function)>,
+    pub main: Option<(Vec<ModuleIdent>, Address, FunctionName, Function)>,
 }
 
 //**************************************************************************************************
@@ -27,6 +27,8 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
+    pub uses: BTreeMap<ModuleIdent, Loc>,
+    pub unused_aliases: Vec<ModuleIdent>,
     pub is_source_module: bool,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -30,7 +30,10 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    pub is_source_module: bool,
+    /// `None` if it is a library dependency
+    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
+    /// depedency graph
+    pub is_source_module: Option<usize>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -11,7 +11,7 @@ use crate::{
     shared::*,
 };
 use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     fmt,
 };
 
@@ -31,7 +31,11 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    pub is_source_module: bool,
+    pub uses: BTreeMap<ModuleIdent, Loc>,
+    /// `None` if it is a library dependency
+    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
+    /// depedency graph. `order` is initialized at `0` and set in the uses pass
+    pub is_source_module: Option<usize>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }

--- a/language/move-lang/src/naming/mod.rs
+++ b/language/move-lang/src/naming/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod ast;
 pub mod translate;
+mod uses;

--- a/language/move-lang/src/naming/uses.rs
+++ b/language/move-lang/src/naming/uses.rs
@@ -1,0 +1,379 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::shared::unique_map::UniqueMap;
+use crate::{errors::*, naming::ast as N, parser::ast::ModuleIdent, shared::*};
+use petgraph::algo::astar as petgraph_astar;
+use petgraph::algo::toposort as petgraph_toposort;
+use petgraph::algo::Cycle;
+use petgraph::graphmap::DiGraphMap;
+use std::collections::BTreeMap;
+
+//**************************************************************************************************
+// Entry
+//**************************************************************************************************
+
+pub fn verify(errors: &mut Errors, modules: &mut UniqueMap<ModuleIdent, N::ModuleDefinition>) {
+    let imm_modules = &modules;
+    let context = &mut Context::new(errors, imm_modules);
+    module_defs(context, modules);
+    match build_ordering(context) {
+        Err(cycle_node) => {
+            let cycle_ident = cycle_node.node_id().clone();
+            report_cycle(context, cycle_ident)
+        }
+        Ok(ordered_ids) => {
+            let ordering = ordered_ids
+                .into_iter()
+                .filter(|m| imm_modules.get(m).unwrap().is_source_module.is_some())
+                .cloned()
+                .enumerate()
+                .collect::<Vec<_>>();
+            for (order, mident) in ordering {
+                modules.get_mut(&mident).unwrap().is_source_module = Some(order)
+            }
+        }
+    }
+}
+
+struct Context<'a> {
+    errors: &'a mut Errors,
+    modules: &'a UniqueMap<ModuleIdent, N::ModuleDefinition>,
+    neighbors: BTreeMap<ModuleIdent, BTreeMap<ModuleIdent, Loc>>,
+    current_module: Option<ModuleIdent>,
+}
+
+impl<'a> Context<'a> {
+    fn new(
+        errors: &'a mut Errors,
+        modules: &'a UniqueMap<ModuleIdent, N::ModuleDefinition>,
+    ) -> Self {
+        Context {
+            errors,
+            modules,
+            neighbors: BTreeMap::new(),
+            current_module: None,
+        }
+    }
+
+    fn add_usage(&mut self, uses: &ModuleIdent, loc: Loc) {
+        if self.current_module.as_ref().unwrap() == uses || !self.modules.contains_key(uses) {
+            return;
+        }
+
+        let m = self
+            .neighbors
+            .entry(self.current_module.clone().unwrap())
+            .or_insert_with(BTreeMap::new);
+        if m.contains_key(uses) {
+            return;
+        }
+
+        m.insert(uses.clone(), loc);
+    }
+
+    fn dependency_graph(&self) -> DiGraphMap<&ModuleIdent, ()> {
+        let edges = self
+            .neighbors
+            .iter()
+            .flat_map(|(parent, children)| children.iter().map(move |(child, _)| (parent, child)));
+        DiGraphMap::from_edges(edges)
+    }
+}
+
+fn build_ordering<'a>(
+    context: &'a Context,
+) -> Result<Vec<&'a ModuleIdent>, Cycle<&'a ModuleIdent>> {
+    petgraph_toposort(&context.dependency_graph(), None)
+}
+
+fn report_cycle(context: &mut Context, cycle_ident: ModuleIdent) {
+    let cycle = shortest_cycle(&context.dependency_graph(), &cycle_ident);
+
+    // For printing uses, sort the cycle by location (earliest first)
+    let cycle_strings = cycle
+        .iter()
+        .map(|m| format!("'{}'", m))
+        .collect::<Vec<_>>()
+        .join(" uses ");
+
+    let (used_loc, user, used) = best_cycle_loc(context, cycle);
+
+    let use_msg = format!("Invalid use of module '{}' in module '{}'.", used, user);
+    let cycle_msg = format!(
+        "Using this module creates a dependency cycle: {}",
+        cycle_strings
+    );
+    context
+        .errors
+        .push(vec![(used_loc, use_msg), (used_loc, cycle_msg)])
+}
+
+fn shortest_cycle<'a>(
+    dependency_graph: &DiGraphMap<&'a ModuleIdent, ()>,
+    start: &'a ModuleIdent,
+) -> Vec<&'a ModuleIdent> {
+    let shortest_path = dependency_graph
+        .neighbors(start)
+        .fold(None, |shortest_path, neighbor| {
+            let path_opt = petgraph_astar(
+                dependency_graph,
+                neighbor,
+                |finish| finish == start,
+                |_e| 1,
+                |_| 0,
+            );
+            match (shortest_path, path_opt) {
+                (p, None) | (None, p) => p,
+                (Some((acc_len, acc_path)), Some((cur_len, cur_path))) => {
+                    Some(if cur_len < acc_len {
+                        (cur_len, cur_path)
+                    } else {
+                        (acc_len, acc_path)
+                    })
+                }
+            }
+        });
+    let (_, mut path) = shortest_path.unwrap();
+    path.insert(0, start);
+    path
+}
+
+fn best_cycle_loc<'a>(
+    context: &'a Context,
+    cycle: Vec<&'a ModuleIdent>,
+) -> (Loc, &'a ModuleIdent, &'a ModuleIdent) {
+    let len = cycle.len();
+    assert!(len >= 3);
+    let first = cycle[0];
+    let user = cycle[len - 2];
+    let used = cycle[len - 1];
+    assert!(first == used);
+    let used_loc = context.neighbors.get(user).unwrap().get(used).unwrap();
+    (*used_loc, user, used)
+}
+
+//**************************************************************************************************
+// Modules
+//**************************************************************************************************
+
+fn module_defs(context: &mut Context, modules: &UniqueMap<ModuleIdent, N::ModuleDefinition>) {
+    modules
+        .iter()
+        .for_each(|(mident, mdef)| module(context, mident, mdef))
+}
+
+fn module(context: &mut Context, mident: ModuleIdent, mdef: &N::ModuleDefinition) {
+    context.current_module = Some(mident);
+    mdef.uses
+        .iter()
+        .for_each(|(mident, loc)| context.add_usage(mident, *loc));
+    mdef.structs
+        .iter()
+        .for_each(|(_, sdef)| struct_def(context, sdef));
+    mdef.functions
+        .iter()
+        .for_each(|(_, fdef)| function(context, fdef));
+}
+
+fn struct_def(context: &mut Context, sdef: &N::StructDefinition) {
+    if let N::StructFields::Defined(fields) = &sdef.fields {
+        fields
+            .iter()
+            .for_each(|(_, (_, bt))| base_type(context, bt));
+    }
+}
+
+fn function(context: &mut Context, fdef: &N::Function) {
+    function_signature(context, &fdef.signature);
+    base_types(context, &fdef.acquires);
+    if let N::FunctionBody_::Defined(seq) = &fdef.body.value {
+        sequence(context, seq)
+    }
+}
+
+fn function_signature(context: &mut Context, sig: &N::FunctionSignature) {
+    single_types(context, sig.parameters.iter().map(|(_, st)| st));
+    type_(context, &sig.return_type)
+}
+
+//**************************************************************************************************
+// Types
+//**************************************************************************************************
+
+fn type_name(context: &mut Context, sp!(loc, tn_): &N::TypeName) {
+    use N::TypeName_ as TN;
+    if let TN::ModuleType(m, _) = tn_ {
+        context.add_usage(m, *loc)
+    }
+}
+
+fn base_types_opt(context: &mut Context, bs_opt: &Option<Vec<N::BaseType>>) {
+    bs_opt.iter().for_each(|bs| base_types(context, bs))
+}
+
+fn base_types<'a>(context: &mut Context, bs: impl IntoIterator<Item = &'a N::BaseType>) {
+    bs.into_iter().for_each(|bt| base_type(context, bt))
+}
+
+fn base_type(context: &mut Context, sp!(_, bt_): &N::BaseType) {
+    use N::BaseType_ as BT;
+    if let BT::Apply(_, tn, bs) = bt_ {
+        type_name(context, tn);
+        base_types(context, bs);
+    }
+}
+
+fn single_types<'a>(context: &mut Context, ss: impl IntoIterator<Item = &'a N::SingleType>) {
+    ss.into_iter().for_each(|st| single_type(context, st))
+}
+
+fn single_type(context: &mut Context, sp!(_, st_): &N::SingleType) {
+    use N::SingleType_ as ST;
+    match st_ {
+        ST::Base(bt) | ST::Ref(_, bt) => base_type(context, bt),
+    }
+}
+
+fn type_opt(context: &mut Context, t_opt: &Option<N::Type>) {
+    t_opt.iter().for_each(|t| type_(context, t))
+}
+
+fn type_(context: &mut Context, sp!(_, t_): &N::Type) {
+    use N::Type_ as T;
+    match t_ {
+        T::Unit => (),
+        T::Single(s) => single_type(context, s),
+        T::Multiple(ss) => single_types(context, ss),
+    }
+}
+
+//**************************************************************************************************
+// Expressions
+//**************************************************************************************************
+
+fn sequence(context: &mut Context, sequence: &N::Sequence) {
+    use N::SequenceItem_ as SI;
+    for sp!(_, item_) in sequence {
+        match item_ {
+            SI::Seq(e) => exp(context, e),
+            SI::Declare(bl, ty_opt) => {
+                binds(context, &bl.value);
+                type_opt(context, ty_opt);
+            }
+            SI::Bind(bl, e) => {
+                binds(context, &bl.value);
+                exp(context, e)
+            }
+        }
+    }
+}
+
+fn binds<'a>(context: &mut Context, bl: impl IntoIterator<Item = &'a N::Bind>) {
+    bl.into_iter().for_each(|b| bind(context, b))
+}
+
+fn bind(context: &mut Context, sp!(loc, b_): &N::Bind) {
+    use N::Bind_ as B;
+    if let B::Unpack(m, _, bs_opt, f) = b_ {
+        context.add_usage(m, *loc);
+        base_types_opt(context, bs_opt);
+        binds(context, f.iter().map(|(_, (_, b))| b));
+    }
+}
+
+fn assigns<'a>(context: &mut Context, al: impl IntoIterator<Item = &'a N::Assign>) {
+    al.into_iter().for_each(|a| assign(context, a))
+}
+
+fn assign(context: &mut Context, sp!(loc, a_): &N::Assign) {
+    use N::Assign_ as A;
+    if let A::Unpack(m, _, bs_opt, f) = a_ {
+        context.add_usage(m, *loc);
+        base_types_opt(context, bs_opt);
+        assigns(context, f.iter().map(|(_, (_, b))| b));
+    }
+}
+
+fn exp(context: &mut Context, sp!(loc, e_): &N::Exp) {
+    use N::Exp_ as E;
+    match e_ {
+        E::Unit
+        | E::UnresolvedError
+        | E::Break
+        | E::Continue
+        | E::Value(_)
+        | E::Move(_)
+        | E::Copy(_)
+        | E::Use(_) => (),
+
+        E::ModuleCall(m, _, bs_opt, er) => {
+            context.add_usage(m, *loc);
+            base_types_opt(context, bs_opt);
+            exp(context, er);
+        }
+
+        E::Builtin(bf, er) => {
+            builtin_function(context, bf);
+            exp(context, er);
+        }
+
+        E::IfElse(ec, et, ef) => {
+            exp(context, ec);
+            exp(context, et);
+            exp(context, ef)
+        }
+
+        E::BinopExp(e1, _, e2) | E::Mutate(e1, e2) | E::While(e1, e2) => {
+            exp(context, e1);
+            exp(context, e2)
+        }
+        E::Block(seq) => sequence(context, seq),
+        E::Assign(al, e) => {
+            assigns(context, &al.value);
+            exp(context, e)
+        }
+        E::FieldMutate(edotted, e) => {
+            exp_dotted(context, edotted);
+            exp(context, e);
+        }
+
+        E::Loop(e) | E::Return(e) | E::Abort(e) | E::Dereference(e) | E::UnaryExp(_, e) => {
+            exp(context, e)
+        }
+
+        E::Pack(m, _, bs_opt, fes) => {
+            context.add_usage(m, *loc);
+            base_types_opt(context, bs_opt);
+            fes.iter().for_each(|(_, (_, e))| exp(context, e))
+        }
+
+        E::ExpList(es) => es.iter().for_each(|e| exp(context, e)),
+
+        E::DerefBorrow(edotted) | E::Borrow(_, edotted) => exp_dotted(context, edotted),
+
+        E::Annotate(e, ty) => {
+            exp(context, e);
+            type_(context, ty)
+        }
+    }
+}
+
+fn exp_dotted(context: &mut Context, sp!(_, ed_): &N::ExpDotted) {
+    use N::ExpDotted_ as D;
+    match ed_ {
+        D::Exp(e) => exp(context, e),
+        D::Dot(edotted, _) => exp_dotted(context, edotted),
+    }
+}
+
+fn builtin_function(context: &mut Context, sp!(_, bf_): &N::BuiltinFunction) {
+    use N::BuiltinFunction_ as B;
+    match bf_ {
+        B::MoveToSender(bt_opt)
+        | B::MoveFrom(bt_opt)
+        | B::BorrowGlobal(_, bt_opt)
+        | B::Exists(bt_opt)
+        | B::Freeze(bt_opt) => bt_opt.iter().for_each(|bt| base_type(context, bt)),
+    }
+}

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -720,7 +720,7 @@ fn parse_return_abort_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Par
 // binary operators, this returns a value of zero so that they will be
 // below the minimum value and will mark the end of the binary expression
 // for the code in parse_binop_exp.
-fn get_precedence(token: &Tok) -> u32 {
+fn get_precedence(token: Tok) -> u32 {
     match token {
         // Reserved minimum precedence value is 1
         Tok::PipePipe => 2,
@@ -765,7 +765,7 @@ fn parse_binop_exp<'input>(
     min_prec: u32,
 ) -> Result<Exp, ParseError> {
     let mut result = lhs;
-    let mut next_tok_prec = get_precedence(&tokens.peek());
+    let mut next_tok_prec = get_precedence(tokens.peek());
 
     while next_tok_prec >= min_prec {
         // Parse the operator.
@@ -779,10 +779,10 @@ fn parse_binop_exp<'input>(
         // If the next token is another binary operator with a higher
         // precedence, then recursively parse that expression as the RHS.
         let this_prec = next_tok_prec;
-        next_tok_prec = get_precedence(&tokens.peek());
+        next_tok_prec = get_precedence(tokens.peek());
         if this_prec < next_tok_prec {
             rhs = parse_binop_exp(tokens, rhs, this_prec + 1)?;
-            next_tok_prec = get_precedence(&tokens.peek());
+            next_tok_prec = get_precedence(tokens.peek());
         }
 
         let op = match op_token {
@@ -1333,10 +1333,7 @@ fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<FileDefinition, Pars
 /// Parse the `input` string as a file of Move source code and return the
 /// result as either a FileDefinition value or a ParseError. The `file` name
 /// is used to identify source locations in error messages.
-pub fn parse_file_string<'input>(
-    file: &'static str,
-    input: &'input str,
-) -> Result<FileDefinition, ParseError> {
+pub fn parse_file_string(file: &'static str, input: &str) -> Result<FileDefinition, ParseError> {
     let mut tokens = Lexer::new(input, file);
     tokens.advance()?;
     parse_file(&mut tokens)

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 pub mod fake_natives;
+pub mod remembering_unique_map;
 pub mod unique_map;
 
 //**************************************************************************************************

--- a/language/move-lang/src/shared/remembering_unique_map.rs
+++ b/language/move-lang/src/shared/remembering_unique_map.rs
@@ -1,0 +1,231 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::unique_map::UniqueMap;
+use super::*;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::iter::IntoIterator;
+
+//**************************************************************************************************
+// UniqueMap
+//**************************************************************************************************
+
+/// wrapper around `UniqueMap` that remembers which values were asked for in `get`
+#[derive(Clone)]
+pub struct RememberingUniqueMap<K: TName + Ord, V> {
+    map: UniqueMap<K, V>,
+    gotten_keys: BTreeSet<K>,
+}
+
+#[allow(clippy::new_without_default)]
+impl<K: TName, V> RememberingUniqueMap<K, V> {
+    pub fn new() -> Self {
+        RememberingUniqueMap {
+            map: UniqueMap::new(),
+            gotten_keys: BTreeSet::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn add(&mut self, key: K, value: V) -> Result<(), K::Loc> {
+        self.map.add(key, value)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        self.gotten_keys.insert(key.clone());
+        self.map.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.gotten_keys.insert(key.clone());
+        self.map.get_mut(key)
+    }
+
+    pub fn get_loc(&mut self, key: &K) -> Option<&K::Loc> {
+        self.gotten_keys.insert(key.clone());
+        self.map.get_loc(key)
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.gotten_keys.remove(key);
+        self.map.remove(key)
+    }
+
+    pub fn map<V2, F>(self, f: F) -> RememberingUniqueMap<K, V2>
+    where
+        F: FnMut(K, V) -> V2,
+    {
+        RememberingUniqueMap {
+            map: self.map.map(f),
+            gotten_keys: self.gotten_keys,
+        }
+    }
+
+    pub fn ref_map<V2, F>(&self, f: F) -> RememberingUniqueMap<K, V2>
+    where
+        F: FnMut(K, &V) -> V2,
+    {
+        RememberingUniqueMap {
+            map: self.map.ref_map(f),
+            gotten_keys: self.gotten_keys.clone(),
+        }
+    }
+
+    pub fn union_with<F>(&self, other: &Self, f: F) -> Self
+    where
+        V: Clone,
+        F: FnMut(&K, &V, &V) -> V,
+    {
+        RememberingUniqueMap {
+            map: self.map.union_with(&other.map, f),
+            gotten_keys: self
+                .gotten_keys
+                .union(&other.gotten_keys)
+                .cloned()
+                .collect(),
+        }
+    }
+
+    pub fn iter(&self) -> Iter<K, V> {
+        self.into_iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+        self.into_iter()
+    }
+
+    pub fn maybe_from_opt_iter(
+        iter: impl Iterator<Item = Option<(K, V)>>,
+    ) -> Option<Result<RememberingUniqueMap<K, V>, (K::Key, K::Loc, K::Loc)>> {
+        let map_res = UniqueMap::maybe_from_opt_iter(iter)?;
+        Some(match map_res {
+            Ok(map) => Ok(RememberingUniqueMap {
+                map,
+                gotten_keys: BTreeSet::new(),
+            }),
+            Err(e) => Err(e),
+        })
+    }
+
+    pub fn maybe_from_iter(
+        iter: impl Iterator<Item = (K, V)>,
+    ) -> Result<RememberingUniqueMap<K, V>, (K::Key, K::Loc, K::Loc)> {
+        let map = UniqueMap::maybe_from_iter(iter)?;
+        Ok(RememberingUniqueMap {
+            map,
+            gotten_keys: BTreeSet::new(),
+        })
+    }
+
+    pub fn remember(self) -> BTreeSet<K> {
+        self.gotten_keys
+    }
+}
+
+impl<K: TName, V: PartialEq> PartialEq for RememberingUniqueMap<K, V> {
+    fn eq(&self, other: &RememberingUniqueMap<K, V>) -> bool {
+        self.map == other.map && self.gotten_keys == other.gotten_keys
+    }
+}
+impl<K: TName, V: Eq> Eq for RememberingUniqueMap<K, V> {}
+
+//**************************************************************************************************
+// Debug
+//**************************************************************************************************
+
+impl<K: TName + fmt::Debug, V: fmt::Debug> fmt::Debug for RememberingUniqueMap<K, V>
+where
+    K::Key: fmt::Debug,
+    K::Loc: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RememberingUniqueMap {{ map: {:#?}, gotten_keys: {:#?} }}",
+            self.map, self.gotten_keys
+        )
+    }
+}
+
+//**************************************************************************************************
+// IntoIter
+//**************************************************************************************************
+
+pub struct IntoIter<K: TName, V>(unique_map::IntoIter<K, V>);
+
+impl<K: TName, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<K: TName, V> IntoIterator for RememberingUniqueMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.map.into_iter())
+    }
+}
+
+//**************************************************************************************************
+// Iter
+//**************************************************************************************************
+
+pub struct Iter<'a, K: TName, V>(unique_map::Iter<'a, K, V>);
+
+impl<'a, K: TName, V> Iterator for Iter<'a, K, V> {
+    type Item = (K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, K: TName, V> IntoIterator for &'a RememberingUniqueMap<K, V> {
+    type Item = (K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let m = &self.map;
+        Iter(m.into_iter())
+    }
+}
+
+//**************************************************************************************************
+// IterMut
+//**************************************************************************************************
+
+pub struct IterMut<'a, K: TName, V>(unique_map::IterMut<'a, K, V>);
+
+impl<'a, K: TName, V> Iterator for IterMut<'a, K, V> {
+    type Item = (K, &'a mut V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, K: TName, V> IntoIterator for &'a mut RememberingUniqueMap<K, V> {
+    type Item = (K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let m = &mut self.map;
+        IterMut(m.into_iter())
+    }
+}

--- a/language/move-lang/src/shared/unique_map.rs
+++ b/language/move-lang/src/shared/unique_map.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use std::fmt::Debug;
 use std::{collections::BTreeMap, iter::IntoIterator};
 
 //**************************************************************************************************
@@ -151,6 +152,7 @@ impl<K: TName, V: PartialEq> PartialEq for UniqueMap<K, V> {
             && other.iter().all(|(k, _)| self.contains_key(&k))
     }
 }
+impl<K: TName, V: Eq> Eq for UniqueMap<K, V> {}
 
 //**************************************************************************************************
 // IntoIter

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -194,10 +194,12 @@ pub fn program(prog: G::Program) -> std::result::Result<Vec<CompiledUnit>, Error
         })
         .collect();
 
-    let source_modules = prog
+    let mut source_modules = prog
         .modules
         .into_iter()
-        .filter(|(_, mdef)| mdef.is_source_module);
+        .filter(|(_, mdef)| mdef.is_source_module.is_some())
+        .collect::<Vec<_>>();
+    source_modules.sort_by_key(|(_, mdef)| mdef.is_source_module.unwrap());
     for (m, mdef) in source_modules {
         match module(m, mdef, &sdecls, &fdecls) {
             Ok((n, cm)) => units.push(CompiledUnit::Module(n, cm)),

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -32,7 +32,10 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    pub is_source_module: bool,
+    /// `None` if it is a library dependency
+    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
+    /// depedency graph
+    pub is_source_module: Option<usize>,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -49,6 +49,7 @@ fn module(
         is_source_module,
         mut structs,
         functions: n_functions,
+        ..
     } = mdef;
     structs
         .iter_mut()

--- a/language/move-lang/tests/move_check/dependencies/cycle_2.exp
+++ b/language/move-lang/tests/move_check/dependencies/cycle_2.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/dependencies/cycle_2.move:5:9 ───
+   │
+ 5 │         0x1::B::foo()
+   │         ^^^^^^^^^^^^^ Invalid use of module '0x1::B' in module '0x1::A'.
+   ·
+ 5 │         0x1::B::foo()
+   │         ------------- Using this module creates a dependency cycle: '0x1::B' uses '0x1::A' uses '0x1::B'
+   │
+

--- a/language/move-lang/tests/move_check/dependencies/cycle_2.move
+++ b/language/move-lang/tests/move_check/dependencies/cycle_2.move
@@ -1,0 +1,13 @@
+address 0x1:
+
+module A {
+    public foo() {
+        0x1::B::foo()
+    }
+}
+
+module B {
+    public foo() {
+        0x1::A::foo()
+    }
+}

--- a/language/move-lang/tests/move_check/dependencies/cycle_3.exp
+++ b/language/move-lang/tests/move_check/dependencies/cycle_3.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/dependencies/cycle_3.move:93:12 ───
+    │
+ 93 │     foo(): 0x3::C::S {
+    │            ^^^^^^^^^ Invalid use of module '0x3::C' in module '0x3::B'.
+    ·
+ 93 │     foo(): 0x3::C::S {
+    │            --------- Using this module creates a dependency cycle: '0x3::C' uses '0x3::A' uses '0x3::B' uses '0x3::C'
+    │
+

--- a/language/move-lang/tests/move_check/dependencies/cycle_3.move
+++ b/language/move-lang/tests/move_check/dependencies/cycle_3.move
@@ -1,0 +1,107 @@
+address 0x1:
+
+module A {
+    use 0x1::B;
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo(): B::S {
+        0x1::B::s()
+    }
+}
+
+module B {
+    use 0x1::C;
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo(): C::S {
+        0x1::C::s()
+    }
+}
+
+module C {
+    use 0x1::A;
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo(): A::S {
+        0x1::A::s()
+    }
+}
+
+address 0x2:
+
+module A {
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo() {
+        0x2::B::s();
+    }
+}
+
+module C {
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo() {
+        0x2::A::s();
+    }
+}
+
+module B {
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo() {
+        0x2::C::s();
+    }
+}
+
+
+
+address 0x3:
+
+module C {
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo(): 0x3::A::S {
+        0x3::A::s()
+    }
+}
+
+module B {
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo(): 0x3::C::S {
+        0x3::C::s()
+    }
+}
+
+module A {
+
+    struct S{}
+
+    public s(): S { S{} }
+
+    foo(): 0x3::B::S {
+        0x3::B::s()
+    }
+}

--- a/language/move-lang/tests/move_check/dependencies/intersecting_cycles.exp
+++ b/language/move-lang/tests/move_check/dependencies/intersecting_cycles.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/dependencies/intersecting_cycles.move:10:10 ───
+    │
+ 10 │     c(): 0x1::C::S { abort 0 }
+    │          ^^^^^^^^^ Invalid use of module '0x1::C' in module '0x1::B'.
+    ·
+ 10 │     c(): 0x1::C::S { abort 0 }
+    │          --------- Using this module creates a dependency cycle: '0x1::C' uses '0x1::A' uses '0x1::B' uses '0x1::C'
+    │
+

--- a/language/move-lang/tests/move_check/dependencies/intersecting_cycles.move
+++ b/language/move-lang/tests/move_check/dependencies/intersecting_cycles.move
@@ -1,0 +1,29 @@
+address 0x1:
+
+module A {
+    struct S {}
+    b(): 0x1::B::S { abort 0 }
+}
+
+module B {
+    struct S {}
+    c(): 0x1::C::S { abort 0 }
+
+    d(): 0x1::D::S { abort 0 }
+}
+
+module C {
+    struct S {}
+    A(): 0x1::A::S { abort 0 }
+}
+
+
+module D {
+    struct S {}
+    e(): 0x1::E::S { abort 0 }
+}
+
+module E {
+    struct S {}
+    b(): 0x1::B::S { abort 0 }
+}

--- a/language/move-lang/tests/move_check/dependencies/multiple_cycles.exp
+++ b/language/move-lang/tests/move_check/dependencies/multiple_cycles.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/dependencies/multiple_cycles.move:25:10 ───
+    │
+ 25 │     f(): 0x1::F::S { abort 0 }
+    │          ^^^^^^^^^ Invalid use of module '0x1::F' in module '0x1::D'.
+    ·
+ 25 │     f(): 0x1::F::S { abort 0 }
+    │          --------- Using this module creates a dependency cycle: '0x1::F' uses '0x1::D' uses '0x1::F'
+    │
+

--- a/language/move-lang/tests/move_check/dependencies/multiple_cycles.move
+++ b/language/move-lang/tests/move_check/dependencies/multiple_cycles.move
@@ -1,0 +1,36 @@
+address 0x1:
+
+module A {
+    struct S {}
+    b(): 0x1::B::S { abort 0 }
+}
+
+module B {
+    struct S {}
+    a(): 0x1::A::S { abort 0 }
+    c(): 0x1::C::S { abort 0 }
+}
+
+module C {
+    struct S {}
+    b(): 0x1::B::S { abort 0 }
+}
+
+
+module D {
+    struct S {}
+    b(): 0x1::B::S { abort 0 }
+
+    e(): 0x1::E::S { abort 0 }
+    f(): 0x1::F::S { abort 0 }
+}
+
+module E {
+    struct S {}
+    f(): 0x1::F::S { abort 0 }
+}
+
+module F {
+    struct S {}
+    d(): 0x1::D::S { abort 0 }
+}

--- a/language/move-lang/tests/move_check/expansion/duplicate_alias.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_alias.exp
@@ -9,3 +9,11 @@ error:
    │                   - Previously defined here
    │
 
+error: 
+
+   ┌── tests/move_check/expansion/duplicate_alias.move:8:19 ───
+   │
+ 8 │     use 0x1::Y as Z;
+   │                   ^ Unused 'use' of alias 'Z'. Consider removing it
+   │
+

--- a/language/move-lang/tests/move_check/naming/generics_shadowing.move
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing.move
@@ -1,8 +1,6 @@
 address 0x1:
 
 module M {
-    use 0x1::X;
-
     resource struct S {}
 
     foo<S: copyable>(s: S): S {

--- a/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
@@ -1,50 +1,50 @@
 error: 
 
-   ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:16 ───
+   ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:16 ───
    │
- 9 │         (s1: Self::S);
+ 7 │         (s1: Self::S);
    │              ^^^^^^^ Invalid type annotation
    ·
- 8 │     foo<S>(s1: S, s2: S): S {
+ 6 │     foo<S>(s1: S, s2: S): S {
    │                - The type: 'S'
    ·
- 9 │         (s1: Self::S);
+ 7 │         (s1: Self::S);
    │              ------- Is not compatible with: '0x1::M::S'
    │
 
 error: 
 
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:9 ───
-    │
- 10 │         let s: S = S {};
-    │                    ^ Invalid construction. Expected a struct name
-    ·
- 8 │     foo<S>(s1: S, s2: S): S {
-    │         - But 'S' was declared as a type parameter here
-    │
+   ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:9 ───
+   │
+ 8 │         let s: S = S {};
+   │                    ^ Invalid construction. Expected a struct name
+   ·
+ 6 │     foo<S>(s1: S, s2: S): S {
+   │         - But 'S' was declared as a type parameter here
+   │
 
 error: 
 
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:16 ───
+    ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:16 ───
     │
- 11 │         bar(s1);
+ 9 │         bar(s1);
     │         ^^^^^^^ Invalid call of '0x1::M::bar'. Invalid argument for parameter 's'
     ·
- 8 │     foo<S>(s1: S, s2: S): S {
+ 6 │     foo<S>(s1: S, s2: S): S {
     │                - The type: 'S'
     ·
- 15 │     bar(s: S) {}
+ 13 │     bar(s: S) {}
     │            - Is not compatible with: '0x1::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:9 ───
+    ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:9 ───
     │
- 12 │         S {}
+ 10 │         S {}
     │         ^ Invalid construction. Expected a struct name
     ·
- 8 │     foo<S>(s1: S, s2: S): S {
+ 6 │     foo<S>(s1: S, s2: S): S {
     │         - But 'S' was declared as a type parameter here
     │
 

--- a/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.move
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.move
@@ -1,8 +1,6 @@
 address 0x1:
 
 module M {
-    use 0x1::X;
-
     struct S {}
 
     foo<S>(s1: S, s2: S): S {

--- a/language/move-lang/tests/move_check/parser/use_with_main.exp
+++ b/language/move-lang/tests/move_check/parser/use_with_main.exp
@@ -1,0 +1,48 @@
+error: 
+
+   ┌── tests/move_check/parser/use_with_main.move:2:5 ───
+   │
+ 2 │ use 0x0::Module;
+   │     ^^^^^^^^^^^ Invalid 'use'. Unbound module: '0x0::Module'
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_with_main.move:2:10 ───
+   │
+ 2 │ use 0x0::Module;
+   │          ^^^^^^ Unused 'use' of alias 'Module'. Consider removing it
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_with_main.move:3:5 ───
+   │
+ 3 │ use 0XaBcD::Module as M;
+   │     ^^^^^^^^^^^^^^ Invalid 'use'. Unbound module: '0xabcd::Module'
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_with_main.move:3:23 ───
+   │
+ 3 │ use 0XaBcD::Module as M;
+   │                       ^ Unused 'use' of alias 'M'. Consider removing it
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_with_main.move:4:5 ───
+   │
+ 4 │ use 0x0000::Z;
+   │     ^^^^^^^^^ Invalid 'use'. Unbound module: '0x0::Z'
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_with_main.move:4:13 ───
+   │
+ 4 │ use 0x0000::Z;
+   │             ^ Unused 'use' of alias 'Z'. Consider removing it
+   │
+


### PR DESCRIPTION
##  Motivation

- Added a check for cyclic dependencies
  - Due to limitations in the graph library, we only output a single cycle, even if multiple exist
- Used the dependency check to toposort the outputted binaries
 - We can handle multiple modules per-file/compilation unit. As such, they need to be outputted in a format that allows one to submit them on chain relatively easily. This sorting makes that process easier
- Added tests

## Test Plan

- wrote em; ran em
- cargo check; cargo test
