### PR TITLE
[language][bytecode verifier] Relaxed rules for joining references

### DIFF
--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad5.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_global_bad5.mvir
@@ -2,12 +2,25 @@ module A {
     resource T{v: u64}
 
     public A5(b: bool) acquires T {
-        let t_ref: &mut Self.T;
+        let u: u64;
+        let t: Self.T;
+        let t1_ref: &mut Self.T;
+        let t2_ref: &mut Self.T;
+
+        t = T { v: 0 };
         if (move(b)) {
-            t_ref = borrow_global_mut<T>(get_txn_sender());
+            t1_ref = borrow_global_mut<T>(get_txn_sender());
+        } else {
+            t1_ref = &mut t;
         }
+
+        t2_ref = borrow_global_mut<T>(get_txn_sender());
+        _ = move(t1_ref);
+        _ = move(t2_ref);
+        T { v: u } = move(t);
+
         return;
     }
 }
 
-// check: JOIN_FAILURE
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/functional_tests/tests/testsuite/borrow_tests/borrow_if.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/borrow_if.mvir
@@ -12,4 +12,3 @@ main() {
 }
 
 // check: MOVELOC_UNAVAILABLE_ERROR
-// check: JOIN_FAILURE

--- a/language/functional_tests/tests/testsuite/borrow_tests/join_borrow_unavailable_valid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/join_borrow_unavailable_valid.mvir
@@ -7,7 +7,6 @@ module M {
 
         u = 0;
 
-        // INVALID
         if (move(cond)) {
             x = &u;
         } else {
@@ -17,5 +16,3 @@ module M {
         return;
     }
 }
-
-// check: JOIN_FAILURE

--- a/language/functional_tests/tests/testsuite/borrow_tests/ref_moved_one_branch.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/ref_moved_one_branch.mvir
@@ -1,0 +1,15 @@
+module A {
+    struct S {value: u64}
+
+    public t(changed: bool, s: &mut Self.S) {
+        if (move(changed)) {
+            Self.foo(&mut move(s).value);
+        }
+        return;
+    }
+
+    foo(x: &mut u64) {
+        *copy(x) = *copy(x) + 1;
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/commands/join_failure.mvir
+++ b/language/functional_tests/tests/testsuite/commands/join_failure.mvir
@@ -1,13 +1,18 @@
-main() {
-    let x: u64;
-    let y: &u64;
-
-    x = 7;
-    if (true) {
-        y = &x;
+module M {
+    resource R { f:bool }
+    t0() {
+        let r: Self.R;
+        let f: bool;
+        r = R{ f: false };
+        if (true) {
+            R{ f: f } = move(r);
+        } else {
+            R{ f: f } = move(r);
+            r = R{ f: false };
+        }
+        R{ f: f } = move(r);
+        return;
     }
-
-    return;
 }
 
 // check: JOIN_FAILURE


### PR DESCRIPTION
## Motivation

This PR makes two major modifications to the type and memory safety checker of the bytecode verifier.

- The first modification relaxes the rule that the same set of references are available in the two abstract states being joined.
  - Before this PR, this discrepancy resulted in a join error.
  - Now a minimal set of references in each abstract state are successively released so that both end up with the same set of references (in each side, release any reference not present in the other side) and thus could be joined by the old method.
  - This foundational change is modifies the definition of the weakening relation over abstract states.
    - We now allow `as1` to be weakened by `as2` if there is a set of references `R` such that `as1'`, the result of releasing the set of references `R` in `as1`, is weakened (using the old definition) by `as2`. To avoid a search over the order in which references in `R` should be released when checking weakening from `as1` to `as2`, we need the property that the final abstract state is the same regardless of the order in which references in R are released. **We believe this property to be true.**
    - Furthermore, for the abstract interpretation to successfully calculate a set of abstract states at fixpoint that locally satisfy the weakening rule for each edge in the CFG, we (at least) need the property that `release(r, join(as1, as2))` is weaker than `join(release(as1, r), release(as2, r))`. **We believe this property to be true as well.**
- The second modification relaxes the invariant on an abstract state requiring that any borrowed local is available.
  - After this PR, the invariant maintained is weaker and requires that any borrowed resource local is available. Thus, it is possible that a basic block is checked in a context when an unrestricted local is borrowed but unavailable.
  - As a result of this PR, the rule for joining local values is purely kind driven.
    - Joining local values at the same status is always allowed
    - Joining an unavailable/available resource/all value is an error
    - Joining an unavailable/available unrestricted value is always allowed

Thanks to @shazqadeer for writing up this in-depth summary!

## Test Plan

- Added a new test
- Updated old tests
