### PR TITLE
[config] Add error handling on save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "safety-rules"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "consensus-types 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -1109,7 +1109,8 @@ mod tests {
         let consensus_peers_path = consensus_peer_file.path();
         consensus_config
             .consensus_peers
-            .save_config(consensus_peers_path);
+            .save_config(consensus_peers_path)
+            .expect("Unable to save consensus_peers.config");
         let val_set_file = consensus_peers_path.to_str().unwrap().to_string();
 
         // We don't need to specify host/port since the client won't be used to connect, only to

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,196 @@
+# Libra Configuration
+
+The Libra Configuration describes the operational details for a Libra Node
+(Validator / Full node) and provides the Libra Clients information on how to
+connect to the BlockChain and derive trust.
+
+A Validator performs the BFT protocol and hosts the source of truth for the
+blockchain.
+
+A Fullnode offers replication services for a Validator and often the entry
+point for clients to limit client queries that may impact the performance of
+the blockchain.
+
+Clients are any service interested in learning about the state of the
+blockchain or performing transactions.
+
+## Organization
+
+Libra Configuration is broken up into many utilities:
+- src/config hosts the core configuration file structure
+- src/generation assists in building sets of configurations for a validator /
+  full node set
+- src/keys specifies means for storing and accessing keys from within
+  configurations
+- config-builder extends src/generation with a command-line utility and
+  support for generating genesis
+- dynamic-config-builder is the next generation of config-builder that
+  supports deterministic generation of run-time usable configurations for
+bootstrapping (test) networks
+- generate-keypair generates Ed25519 key pairs in LCS format
+
+The separation of the config-builder into its own crate was dicated by the
+need for config-builder to be able to generate genesis. Genesis requires the
+VM as a dependency, which is not a dependency for loading or using the
+configuration from many of the services.
+
+## Building a Test Network
+
+dynamic-config-builder builds a single nodes configuration within a network
+or swarm of nodes. This can be used to create a LIbra TestNet or to add a
+FullNetwork to an existing Network. In addition, it enables generation of a
+mint / faucet client capable of performing mint transactions / creating
+accounts.
+
+## Generating a new TestNet
+
+The only pre-requirements for generating a TestNet configuration is having a
+list of IP Addresses and ports to host libra, a pre-agreed upon shared
+secret, and a fixed ordering for each node in the network. Fullnode networks
+can either be added to existing configs or generate completely new configs.
+
+Each peer, I, can then generate their own configurations by:
+
+    validator-config-builder \
+        -a $PUBLIC_MULTIADDR_FOR_NODE_I \
+        -b $PUBLIC_MULTIADDR_FOR_NODE_0 \
+        -d /opt/libra/data \
+        -i $I \
+        -l $ANY_MULTIADDR_FOR_NODE_I \
+        -n $TOTAL_NUMBER_OF_NODES \
+        -o /opt/libra/etc \
+        -s $SHARED_SECRET
+
+As an example, this is the 2nd node (offset 1) in a set of 4:
+
+    validator-config-builder \
+        -a "/ip4/1.1.1.2/tcp/7000" \
+        -b "/ip4/1.1.1.1/tcp/7000" \
+        -d /opt/libra/etc \
+        -i 1 \
+        -l "/ip4/0.0.0.0/tcp/7000" \
+        -n 4 \
+        -o /opt/libra/etc \
+        -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627
+
+To create a mint service's consensus peer config and key that connects to
+this service:
+
+    faucet-config-builder \
+        -n 4 \
+        -o /opt/libra/etc \
+        -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627
+
+Adding a full node network is similar to instantiating a validator config. The
+difference is that if a config already exists at that path, the assumption is
+to append the full node network, if the network isn't already defined.
+Secondly, full nodes support public or permissioned networks. The former
+requires no further configuration, whereas the latter needs a full node
+specific seed, total number of full nodes, and index into the configuration
+set. The total number includes the upstream peer which is indexed into the
+first position (0).
+
+    full-node-config-builder \
+        -a $PUBLIC_MULTIADDR_FOR_NODE_I \
+        -b $PUBLIC_MULTIADDR_FOR_NODE_0 \
+        -d /opt/libra/data \
+        -l $ANY_MULTIADDR_FOR_NODE_I \
+        -n $TOTAL_NUMBER_OF_NODES \
+        -o /opt/libra/etc \
+        -s $SHARED_SECRET \
+        [ -i $I -f $TOTAL_NUMBER_OF_FULL_NODES -c $FULL_NODE_SHARED_SECRET | -p ]
+
+As an example a of adding 4 membered permissioned network connecting to the
+node above:
+
+    full-node-config-builder \
+        -a "/ip4/1.1.1.2/tcp/7100" \
+        -b "/ip4/1.1.1.2/tcp/7100" \
+        -d /opt/libra/fn/data \
+        -l "/ip4/0.0.0.0/tcp/7100" \
+        -n 4 \
+        -o /opt/libra/fn/etc \
+        -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627 \
+        -i 0 \
+        -f 4 \
+        -c 28292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f4041424344454547
+
+Similarly a public network could be added via:
+
+    full-node-config-builder \
+        -a "/ip4/1.1.1.2/tcp/7100" \
+        -b "/ip4/1.1.1.2/tcp/7100" \
+        -d /opt/libra/fn/data \
+        -l "/ip4/0.0.0.0/tcp/7100" \
+        -n 4 \
+        -o /opt/libra/fn/etc \
+        -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627 \
+        -p
+
+## Internals
+
+There are several configurations contained within Libra Configuration.
+
+### Libra Node Configuration
+The Libra Configuration contains several modules:
+
+- AdmissionControlConfig - Where a Libra Node host their AC
+- BaseConfig - Specifies the Nodes role and base directories
+- ConsensusConfig - The behaviors of Consensus including the SafetyRules TCB
+- DebugInterface - A special gRPC service for identifying internals of the
+  system
+- ExecutionConfig - The gRPC service endpoint and path to the genesis file
+  that defines the Move standard library and the initial Validator set.
+- LoggerConfig - Configures the Libra logging service
+- MempoolConfig - Parameters for configuring uncommitted transaction storage
+- MetricsConfig - Local storage for metrics
+- NetworkConfig - LibraNet configuration file that specifies peers with keys,
+  seed addresses to connect to upstream peers, the local peers network keys,
+and other network configuration parameters
+- NodeConfig - Host all configuration files for a Libra Node
+- SafetyRulesConfig - Specifies the persistentcy strategy for Libra Safety
+  Rules
+- StateSyncConfig - Specifies parameters around state sycnhronization and the
+  set of peers to that provide the data
+- StorageConfig - Where the LibraDB is stored and its gRPC service endpoints
+- VMConfig - Specifies the allowed publishing options and scripts that can be
+  executed
+
+### Client Configuration
+
+- ConsensusPeersConfig - The clients source of truth for the set of Libra
+  nodes (Validators and Full nodes derive this from genesis / blockchain).
+
+### Shared Configuration
+
+- TestConfig - Used during tests to hold account keys and temporary paths for
+  the configurations that will automatically be cleaned up after the test.
+
+## Testing
+Configuration tests serve many purposes:
+
+- Identifying when defaults have changed
+- Ensuring that parsing / storing works consistently
+- That default filename assumptions are maintained
+
+Several of the defaults in the configurations, in particular paths and
+addresses, have dependecies outside the Libra code base. These tests serve as
+a reminder that there may be rammifications from breaking these that impact
+production deployments.
+
+## TODO
+
+- Add ability to turn off services that are optional (debug interface, AC
+  gRPC)
+- Eliminate BaseConfig, the data directory should be explicitly defined for
+  each path, configs that are relative should be using the path of the
+NodeConfig handed over during load / save. The Role can go directly into the
+root of NodeConfig
+- Eliminate ConsensusPeersConfig from ConsensusConfig and make it top level.
+- Is the execution gRPC interface being deprecated? Cleanup configs.
+- LoggerConfig should allow specifying the severity.
+- Eliminate generate-keypair
+- Move data to src/config/test\_data
+- Build distinct binaries in dynamic-config-builder for validator, full node,
+  and faucet nodes then delete config-builder
+- Generating public networks is broken

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -195,7 +195,7 @@ impl SwarmConfigBuilder {
                 self.is_permissioned,
                 true,
             )?;
-            upstream_peer.save(&PathBuf::from("node.config.toml"));
+            upstream_peer.save(&PathBuf::from("node.config.toml"))?;
         }
 
         ensure!(
@@ -216,7 +216,7 @@ impl SwarmConfigBuilder {
             config.set_data_dir(node_dir.clone())?;
             config_files.push(node_dir.join("node.config.toml"));
             config.execution.genesis = genesis.clone();
-            config.save(&PathBuf::from("node.config.toml"));
+            config.save(&PathBuf::from("node.config.toml"))?;
         }
 
         Ok(SwarmConfig { config_files })

--- a/config/dynamic-config-builder/src/main.rs
+++ b/config/dynamic-config-builder/src/main.rs
@@ -103,17 +103,23 @@ fn main() {
             .expect("Unable to write to key file");
 
         let consensus_peers_path = args.output_dir.join("consensus_peers.config.toml");
-        consensus_peers.save_config(consensus_peers_path);
+        consensus_peers
+            .save_config(consensus_peers_path)
+            .expect("Unable to save consensus_peers.config");
     } else {
         let mut node_config = config_builder.build().expect("ConfigBuilder failed");
         node_config
             .set_data_dir(args.output_dir.clone())
             .expect("Unable to set directory");
         let config_file = args.output_dir.join("node.config.toml");
-        node_config.save(&config_file);
+        node_config
+            .save(&config_file)
+            .expect("Unable to save configs");
         node_config
             .set_data_dir(args.data_dir)
             .expect("Unable to set directory");
-        node_config.save_config(&config_file);
+        node_config
+            .save_config(&config_file)
+            .expect("Unable to save node.config");
     }
 }

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -132,21 +132,22 @@ impl ConsensusConfig {
         Ok(())
     }
 
-    pub fn save(&mut self) {
+    pub fn save(&mut self) -> Result<()> {
         if self.consensus_keypair != ConsensusKeyPair::default() {
             if self.consensus_keypair_file.as_os_str().is_empty() {
                 self.consensus_keypair_file = PathBuf::from(CONSENSUS_KEYPAIR_DEFAULT);
             }
 
             self.consensus_keypair
-                .save_config(self.consensus_keypair_file());
+                .save_config(self.consensus_keypair_file())?;
         }
 
         if self.consensus_peers_file.as_os_str().is_empty() {
             self.consensus_peers_file = PathBuf::from(CONSENSUS_PEERS_DEFAULT);
         }
         self.consensus_peers
-            .save_config(self.consensus_peers_file());
+            .save_config(self.consensus_peers_file())?;
+        Ok(())
     }
 
     pub fn consensus_keypair_file(&self) -> PathBuf {
@@ -252,15 +253,14 @@ mod test {
         assert_eq!(config.consensus_peers_file, PathBuf::new());
 
         // Assert default loading doesn't affect paths and default remain in place
-        let result = config.load();
-        assert!(result.is_ok());
+        config.load().unwrap();
         assert_eq!(config.consensus_keypair, keypair);
         assert_eq!(config.consensus_keypair_file, PathBuf::new());
         assert_eq!(config.consensus_peers, peers);
         assert_eq!(config.consensus_peers_file, PathBuf::new());
 
         // Assert saving updates peers but not key pairs due to default behavior
-        config.save();
+        config.save().unwrap();
         assert_eq!(config.consensus_keypair, keypair);
         assert_eq!(config.consensus_keypair_file, PathBuf::new());
         assert_eq!(config.consensus_peers, peers);
@@ -284,7 +284,7 @@ mod test {
         assert_eq!(config.consensus_peers_file, PathBuf::new());
 
         // Assert saving updates paths
-        config.save();
+        config.save().unwrap();
         assert_eq!(config.consensus_keypair, keypair);
         assert_eq!(
             config.consensus_keypair_file,
@@ -303,8 +303,7 @@ mod test {
         assert_eq!(new_config.consensus_keypair_file, PathBuf::new());
         assert_eq!(new_config.consensus_peers_file, PathBuf::new());
         // Loading populates things correctly
-        let result = new_config.load();
-        assert!(result.is_ok());
+        new_config.load().unwrap();
         assert_eq!(new_config.consensus_keypair, keypair);
         assert_eq!(
             new_config.consensus_keypair_file,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -66,16 +66,15 @@ impl ExecutionConfig {
         Ok(())
     }
 
-    pub fn save(&mut self) {
+    pub fn save(&mut self) -> Result<()> {
         if let Some(genesis) = &self.genesis {
             if self.genesis_file_location.as_os_str().is_empty() {
                 self.genesis_file_location = PathBuf::from(GENESIS_DEFAULT);
             }
-            let mut file =
-                File::create(self.genesis_file_location()).expect("Unable to create genesis.blob");
-            file.write_all(&lcs::to_bytes(&genesis).expect("Unable to serialize genesis"))
-                .expect("Unable to write genesis");
+            let mut file = File::create(self.genesis_file_location())?;
+            file.write_all(&lcs::to_bytes(&genesis)?)?;
         }
+        Ok(())
     }
 
     pub fn genesis_file_location(&self) -> PathBuf {
@@ -108,7 +107,7 @@ mod test {
         let fake_genesis = Transaction::WriteSet(WriteSetMut::new(vec![]).freeze().unwrap());
         let (mut config, _path) = generate_config();
         config.genesis = Some(fake_genesis.clone());
-        config.save();
+        config.save().expect("Unable to save");
         // Verifies some without path
         assert_eq!(config.genesis_file_location, PathBuf::from(GENESIS_DEFAULT));
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -176,27 +176,28 @@ impl NetworkConfig {
         format!("{}.{}", self.peer_id.to_string(), config_path)
     }
 
-    pub fn save(&mut self) {
+    pub fn save(&mut self) -> Result<()> {
         if self.is_permissioned {
             if self.network_keypairs_file.as_os_str().is_empty() {
                 let file_name = self.default_path(NETWORK_KEYPAIRS_DEFAULT);
                 self.network_keypairs_file = PathBuf::from(file_name);
             }
             self.network_keypairs
-                .save_config(self.network_keypairs_file());
+                .save_config(self.network_keypairs_file())?;
         }
 
         if self.network_peers_file.as_os_str().is_empty() {
             let file_name = self.default_path(NETWORK_PEERS_DEFAULT);
             self.network_peers_file = PathBuf::from(file_name);
         }
-        self.network_peers.save_config(self.network_peers_file());
+        self.network_peers.save_config(self.network_peers_file())?;
 
         if self.seed_peers_file.as_os_str().is_empty() {
             let file_name = self.default_path(SEED_PEERS_DEFAULT);
             self.seed_peers_file = PathBuf::from(file_name);
         }
-        self.seed_peers.save_config(self.seed_peers_file());
+        self.seed_peers.save_config(self.seed_peers_file())?;
+        Ok(())
     }
 
     pub fn random(&mut self, rng: &mut StdRng) {
@@ -329,8 +330,7 @@ mod test {
         assert_eq!(config.seed_peers_file, PathBuf::new());
 
         // Assert default loading doesn't affect paths and defaults remain in place
-        let result = config.load(RoleType::Validator);
-        assert!(result.is_ok());
+        config.load(RoleType::Validator).unwrap();
         assert_eq!(config.network_peers, peers);
         assert_eq!(config.network_peers_file, PathBuf::new());
         assert_eq!(config.network_keypairs, NetworkKeyPairs::default());
@@ -339,7 +339,7 @@ mod test {
         assert_eq!(config.seed_peers, SeedPeersConfig::default());
 
         // Assert saving updates paths
-        config.save();
+        config.save().unwrap();
         assert_eq!(config.network_peers, peers);
         assert_eq!(
             config.network_keypairs_file,
@@ -375,7 +375,7 @@ mod test {
         assert_eq!(config.seed_peers_file, PathBuf::new());
 
         // Assert saving updates paths
-        config.save();
+        config.save().unwrap();
         assert_eq!(config.network_keypairs, keypairs);
         assert_eq!(
             config.network_keypairs_file,

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 consensus-types = { path = "../consensus-types", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -173,43 +173,43 @@ fn test_preferred_block_rule() {
     let a3 = make_proposal_with_parent(round + 6, &a2, None, &validator_signer);
     let a4 = make_proposal_with_parent(round + 7, &a3, None, &validator_signer);
 
-    safety_rules.update(a1.block().quorum_cert());
+    safety_rules.update(a1.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         genesis_block.round()
     );
 
-    safety_rules.update(b1.block().quorum_cert());
+    safety_rules.update(b1.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         genesis_block.round()
     );
 
-    safety_rules.update(a2.block().quorum_cert());
+    safety_rules.update(a2.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         genesis_block.round()
     );
 
-    safety_rules.update(b2.block().quorum_cert());
+    safety_rules.update(b2.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         genesis_block.round()
     );
 
-    safety_rules.update(a3.block().quorum_cert());
+    safety_rules.update(a3.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         b1.block().round()
     );
 
-    safety_rules.update(b3.block().quorum_cert());
+    safety_rules.update(b3.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         b1.block().round()
     );
 
-    safety_rules.update(a4.block().quorum_cert());
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.consensus_state().preferred_round(),
         a2.block().round()
@@ -245,12 +245,12 @@ fn test_voting_potential_commit_id() {
     let a5 = make_proposal_with_parent(round + 6, &a4, Some(&a3), &validator_signer);
 
     for b in &[&a1, &b1, &a2, &a3] {
-        safety_rules.update(b.block().quorum_cert());
+        safety_rules.update(b.block().quorum_cert()).unwrap();
         let vote = safety_rules.construct_and_sign_vote(b).unwrap();
         assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
     }
 
-    safety_rules.update(a4.block().quorum_cert());
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules
             .construct_and_sign_vote(&a4)
@@ -260,7 +260,7 @@ fn test_voting_potential_commit_id() {
         a2.block().id(),
     );
 
-    safety_rules.update(a5.block().quorum_cert());
+    safety_rules.update(a5.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules
             .construct_and_sign_vote(&a5)
@@ -310,19 +310,19 @@ fn test_voting() {
     let a4 = make_proposal_with_parent(round + 7, &a3, None, &validator_signer);
     let b4 = make_proposal_with_parent(round + 8, &b2, None, &validator_signer);
 
-    safety_rules.update(a1.block().quorum_cert());
+    safety_rules.update(a1.block().quorum_cert()).unwrap();
     let mut vote = safety_rules.construct_and_sign_vote(&a1).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(b1.block().quorum_cert());
+    safety_rules.update(b1.block().quorum_cert()).unwrap();
     vote = safety_rules.construct_and_sign_vote(&b1).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(a2.block().quorum_cert());
+    safety_rules.update(a2.block().quorum_cert()).unwrap();
     vote = safety_rules.construct_and_sign_vote(&a2).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(b2.block().quorum_cert());
+    safety_rules.update(b2.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b2),
         Err(Error::OldProposal {
@@ -331,19 +331,19 @@ fn test_voting() {
         })
     );
 
-    safety_rules.update(a3.block().quorum_cert());
+    safety_rules.update(a3.block().quorum_cert()).unwrap();
     vote = safety_rules.construct_and_sign_vote(&a3).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(b3.block().quorum_cert());
+    safety_rules.update(b3.block().quorum_cert()).unwrap();
     vote = safety_rules.construct_and_sign_vote(&b3).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(a4.block().quorum_cert());
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
     vote = safety_rules.construct_and_sign_vote(&a4).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(a4.block().quorum_cert());
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.construct_and_sign_vote(&a4),
         Err(Error::OldProposal {
@@ -351,7 +351,7 @@ fn test_voting() {
             proposal_round: 7,
         })
     );
-    safety_rules.update(b4.block().quorum_cert());
+    safety_rules.update(b4.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b4),
         Err(Error::ProposalRoundLowerThenPreferredBlock { preferred_round: 4 })

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -173,7 +173,8 @@ impl SMRNode {
         for smr_id in 0..num_nodes {
             let (initial_data, storage) = MockStorage::start_for_testing(validator_set.clone());
             let safety_rules_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
-            OnDiskStorage::default_storage(safety_rules_path.clone());
+            OnDiskStorage::default_storage(safety_rules_path.clone())
+                .expect("Unable to allocate SafetyRules storage");
             nodes.push(Self::start(
                 playground,
                 signers.remove(0),

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -202,8 +202,10 @@ impl<T: Payload> EpochManager<T> {
             SafetyRulesBackend::OnDiskStorage(config) => {
                 if config.default {
                     OnDiskStorage::default_storage(config.path().clone())
+                        .expect("Unable to allocate SafetyRules storage")
                 } else {
                     OnDiskStorage::new_storage(config.path().clone())
+                        .expect("Unable to instantiate SafetyRules storage")
                 }
             }
         };
@@ -216,7 +218,9 @@ impl<T: Payload> EpochManager<T> {
             self.config.max_pruned_blocks_in_mem,
         )));
 
-        safety_rules.start_new_epoch(block_store.highest_quorum_cert().as_ref());
+        safety_rules
+            .start_new_epoch(block_store.highest_quorum_cert().as_ref())
+            .expect("Unable to transition SafetyRules to the new epoch");
 
         // txn manager is required both by proposal generator (to pull the proposers)
         // and by event processor (to update their status).

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -440,7 +440,7 @@ impl<T: Payload> EventProcessor<T> {
         qc: &QuorumCert,
         tc: Option<&TimeoutCertificate>,
     ) -> anyhow::Result<()> {
-        self.safety_rules.update(qc);
+        self.safety_rules.update(qc)?;
         let consensus_state = self.safety_rules.consensus_state();
         counters::PREFERRED_BLOCK_ROUND.set(consensus_state.preferred_round() as i64);
 

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -99,7 +99,8 @@ impl NodeSetup {
                 MockStorage::<TestPayload>::start_for_testing((&validators).into());
 
             let safety_rules_file = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
-            OnDiskStorage::default_storage(safety_rules_file.clone());
+            OnDiskStorage::default_storage(safety_rules_file.clone())
+                .expect("Unable to allocate SafetyRules storage");
 
             nodes.push(Self::new(
                 playground,
@@ -172,7 +173,8 @@ impl NodeSetup {
         );
 
         let safety_rules = SafetyRules::new(
-            OnDiskStorage::new_storage(safety_rules_file.clone()),
+            OnDiskStorage::new_storage(safety_rules_file.clone())
+                .expect("Unable to allocate SafetyRules storage"),
             Arc::new(signer.clone()),
         );
 

--- a/language/vm/vm-genesis/src/main.rs
+++ b/language/vm/vm-genesis/src/main.rs
@@ -35,7 +35,9 @@ fn main() {
         GENESIS_LOCATION, CONFIG_LOCATION
     );
     let config = default_config();
-    config.save_config(CONFIG_LOCATION);
+    config
+        .save_config(CONFIG_LOCATION)
+        .expect("Unable to save genesis config");
 
     let mut file = File::create(GENESIS_LOCATION).unwrap();
     file.write_all(&generate_genesis_blob()).unwrap();


### PR DESCRIPTION
Save historically used expect but that meant that if an application
faile to persist its data, it would crash even if it was a recoverable
event, i.e., persisting data wasn't critical to operations.

Now this returns back a Result.

This affected safety rules substantially and so the API now supports an
"InternalError" rather than crashing upon these events. While it is
up for debate if SafetyRules should crash or just signal further
upstream that this is a blocking error that should retry again later is
delegated to the future.