### PR TITLE
[language] Do not use "unreachable" for code that is actually reachable.

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context;
 use codespan::{ByteIndex, Span};
 use std::fmt;
 use std::str::FromStr;
@@ -114,13 +115,14 @@ fn parse_account_address<'input>(
             location: tokens.start_loc(),
         });
     }
-    let addr = AccountAddress::from_hex_literal(&tokens.content()).unwrap_or_else(|_| {
-        // The lexer guarantees this, but tracking it all the way to here is tedious.
-        unreachable!(
-            "The address {:?} is of invalid length. Addresses are at most 32-bytes long",
-            tokens.content()
-        )
-    });
+    let addr = AccountAddress::from_hex_literal(&tokens.content())
+        .with_context(|| {
+            format!(
+                "The address {:?} is of invalid length. Addresses are at most 32-bytes long",
+                tokens.content()
+            )
+        })
+        .unwrap();
     tokens.advance()?;
     Ok(addr)
 }


### PR DESCRIPTION
PR#1757 changed this from a panic to "unreachable", but it is not unreachable. The lexer does not check the length of account addresses, and AccountAddress::from_hex_literal will fail if the address is too long.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I manually tested a case where this fails and also ran the functional tests to make sure this does not break anything.
