### PR TITLE
[config] Eliminate dependency on terraform configs

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -449,7 +449,6 @@ mod test {
 
     #[test]
     fn verify_all_configs() {
-        // First test well defined configs
         let _ = vec![
             // This contains all the default fields written to disk, it verifies that the default
             // is consistent and can be loaded without failure
@@ -466,29 +465,6 @@ mod test {
         .iter()
         .map(|path| {
             NodeConfig::load(PathBuf::from(path)).unwrap_or_else(|_| panic!("Error in {}", path))
-        })
-        .collect::<Vec<_>>();
-
-        // Now test configs that require some additional manipulation
-        let _ = vec![
-            "../terraform/validator-sets/100/fn/node.config.toml",
-            "../terraform/validator-sets/100/val/node.config.toml",
-            "../terraform/validator-sets/dev/fn/node.config.toml",
-            "../terraform/validator-sets/dev/val/node.config.toml",
-        ]
-        .iter()
-        .map(|path| {
-            let mut file =
-                File::open(&path).unwrap_or_else(|_| panic!("Unable to open file: {}", path));
-            let mut contents = String::new();
-            file.read_to_string(&mut contents)
-                .unwrap_or_else(|_| panic!("Unable to read file: {}", path));
-            let new_contents = contents
-                .replace("${peer_id}", &PeerId::default().to_string())
-                .replace("${fullnode_id}", &PeerId::default().to_string())
-                .replace("${upstream_peer}", &PeerId::default().to_string())
-                .replace("${self_ip}", "0.0.0.0");
-            NodeConfig::parse(&new_contents).unwrap_or_else(|_| panic!("Error in {}", path));
         })
         .collect::<Vec<_>>();
     }

--- a/language/e2e-tests/src/data_store.rs
+++ b/language/e2e-tests/src/data_store.rs
@@ -16,7 +16,6 @@ use libra_types::{
 use std::{collections::HashMap, fs::File, io::prelude::*, path::PathBuf};
 use vm::{errors::*, CompiledModule};
 use vm_runtime::data_cache::RemoteCache;
-use walkdir::WalkDir;
 
 lazy_static! {
     /// The write set encoded in the genesis transaction.
@@ -26,23 +25,6 @@ lazy_static! {
         path.push("vm/vm-genesis/genesis/genesis.blob");
 
         load_genesis(path)
-    };
-
-    pub static ref TESTNET_GENESIS: Vec<WriteSet> = {
-        let mut base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        base_path.pop();
-        base_path.pop();
-        base_path.push("terraform/validator-sets/");
-
-        let files = WalkDir::new(base_path)
-            .into_iter()
-            .filter_map(|f| f.ok())
-            .filter(|f| f.path().ends_with("genesis.blob"))
-            .map(|f| load_genesis(f.path().to_path_buf()))
-            .collect::<Vec<_>>();
-
-        assert!(!files.is_empty());
-        files
     };
 }
 

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     account::{Account, AccountData},
-    data_store::{FakeDataStore, GENESIS_WRITE_SET, TESTNET_GENESIS},
+    data_store::{FakeDataStore, GENESIS_WRITE_SET},
 };
 use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_state_view::StateView;
@@ -37,8 +37,7 @@ pub fn test_all_genesis_impl<T, F>(test_fn: F) -> Result<(), T>
 where
     F: Fn(FakeExecutor) -> Result<(), T>,
 {
-    let mut genesis: Vec<&WriteSet> = TESTNET_GENESIS.iter().collect();
-    genesis.push(&GENESIS_WRITE_SET);
+    let genesis: Vec<&WriteSet> = vec![&GENESIS_WRITE_SET];
     genesis
         .iter()
         .map(|ws| test_fn(FakeExecutor::from_genesis(ws, None)))


### PR DESCRIPTION
These files depend on Terraform validator sets ... those are being
destroyed! So these need to be removed as well.