### PR TITLE
[Storage] Last version of an epoch to be mapped to the same epoch

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -535,12 +535,7 @@ impl LibraDB {
 
         // TODO: cache last epoch change version to avoid a DB access in most cases.
         let client_epoch = self.ledger_store.get_epoch(client_known_version)?;
-        let current_epoch = if ledger_info.next_validator_set().is_some() {
-            ledger_info.epoch() + 1
-        } else {
-            ledger_info.epoch()
-        };
-        let validator_change_proof = if client_epoch < current_epoch {
+        let validator_change_proof = if client_epoch < ledger_info.epoch() {
             self.ledger_store
                 .get_epoch_change_ledger_infos(client_epoch, ledger_info.version())?
         } else {

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -23,8 +23,12 @@ fn verify_epochs(db: &LibraDB, ledger_infos_with_sigs: &[LedgerInfoWithSignature
         .cloned()
         .collect();
 
-    let (_, _, proof, _) = db.update_to_latest_ledger(0, Vec::new())?;
+    let (_, _, mut proof, _) = db.update_to_latest_ledger(0, Vec::new())?;
 
+    // The very first validator change in the returned proof is the
+    // validator change of genesis (LedgerInfo with epoch 0).
+    let first_epoch_change_li = proof.ledger_info_with_sigs.remove(0);
+    assert_eq!(first_epoch_change_li.ledger_info().epoch(), 0);
     assert_eq!(epoch_change_lis, proof.ledger_info_with_sigs);
 
     Ok(())

--- a/storage/libradb/src/schema/epoch_by_version/mod.rs
+++ b/storage/libradb/src/schema/epoch_by_version/mod.rs
@@ -3,7 +3,8 @@
 
 //! This module defines physical storage schema for an index to help us find out which epoch a
 //! ledger version is in, by storing a version <-> epoch pair for each version where the epoch
-//! number bumps.
+//! number bumps: a pair (`version`, `epoch_num`) indicates that the last version of `epoch_num` is
+//! `version`.
 //!
 //! ```text
 //! |<--key-->|<---value-->|

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -93,7 +93,7 @@ prop_compose! {
         mut universe in any_with::<AccountInfoUniverse>(5).no_shrink(),
         batches in vec(
             (
-                vec(any::<TransactionToCommitGen>(), 0..=2),
+                vec(any::<TransactionToCommitGen>(), 1..=2),
                 any::<LedgerInfoWithSignaturesGen>(),
             ),
             1..10,


### PR DESCRIPTION
Summary:
The last version of an epoch used to be mapped to the next epoch because of the "empty block" concerns
(in case the very first ledger info in the next epoch is an empty block the same version would belong to both epochs).

However, we do not allow empty blocks anymore, so this concern is not valid now.
Being able to map the last version of an epoch to the same epoch is important for Waypoints and client processing in general:
* in case of waypoints a client should be able to retrieve the LedgerInfo the waypoint certifies
* specifically we want a client to be able to retrieve the initial validator set given the genesis waypoint

In this commit we change the indexing of versions to the epochs: the index keeps the last version of the epoch.
One consequence is that a client with version `0` is always receiving the initial validator set back when updating to the latest ledger info.

Testing: updated the existing tests.

Issues: ref #1384