### PR TITLE
Fix unsound unsafe cast in VMStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5096,6 +5096,7 @@ dependencies = [
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ref-cast 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ref-cast 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3528,6 +3529,24 @@ dependencies = [
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ref-cast-impl 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5732,6 +5751,8 @@ dependencies = [
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
+"checksum ref-cast 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "077f197a31bfe7e4169145f9eca08d32705c6c6126c139c26793acdf163ac3ef"
+"checksum ref-cast-impl 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c36eb52b69b87c9e3a07387f476c88fd0dba9a1713b38e56617ed66b45392c1f"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1.3.0"
 mirai-annotations = "1.4.0"
 proptest = { version = "0.9", optional = true }
 proptest-derive = { version = "0.1.1", optional = true }
+ref-cast = "1.0"
 serde = { version = "1", features = ["derive"] }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/vm/src/access.rs
+++ b/language/vm/src/access.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Defines accessors for compiled modules.
 
 use crate::{

--- a/language/vm/src/check_bounds.rs
+++ b/language/vm/src/check_bounds.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     errors::{append_err_info, bounds_error, bytecode_offset_err, verification_error},
     file_format::{

--- a/language/vm/src/deserializer.rs
+++ b/language/vm/src/deserializer.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{errors::*, file_format::*, file_format_common::*, vm_string::VMString};
 use byteorder::{LittleEndian, ReadBytesExt};
 use libra_types::{

--- a/language/vm/src/errors.rs
+++ b/language/vm/src/errors.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::IndexKind;
 use libra_types::{
     account_address::AccountAddress,

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Binary format for transactions and modules.
 //!
 //! This module provides a simple Rust abstraction over the binary format. That is the format of

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Constants for the binary format.
 //!
 //! Definition for the constants of the binary format, used by the serializer and the deserializer.

--- a/language/vm/src/foreign_contracts.rs
+++ b/language/vm/src/foreign_contracts.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This file contains models of the vm crate's dependencies for use with MIRAI.
 
 pub mod types {

--- a/language/vm/src/gas_schedule.rs
+++ b/language/vm/src/gas_schedule.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This module lays out the basic abstract costing schedule for bytecode instructions.
 //!
 //! It is important to note that the cost schedule defined in this file does not track hashing

--- a/language/vm/src/internals.rs
+++ b/language/vm/src/internals.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Types meant for use by other parts of this crate, and by other crates that are designed to
 //! work with the internals of these data structures.
 

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 #[macro_use]
 extern crate mirai_annotations;
 

--- a/language/vm/src/printers.rs
+++ b/language/vm/src/printers.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{file_format::*, vm_string::VMStr};
 use anyhow::{bail, format_err, Result};
 use hex;

--- a/language/vm/src/proptest_types.rs
+++ b/language/vm/src/proptest_types.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Utilities for property-based testing.
 
 use crate::{

--- a/language/vm/src/resolver.rs
+++ b/language/vm/src/resolver.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This module implements a resolver for importing a SignatureToken defined in one module into
 //! another. This functionaliy is used in verify_module_dependencies and verify_script_dependencies.
 use crate::{

--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Serialization of transactions and modules.
 //!
 //! This module exposes two entry points for serialization of `CompiledScript` and

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
 use libra_crypto::ed25519::{compat, Ed25519PublicKey};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};

--- a/language/vm/src/views.rs
+++ b/language/vm/src/views.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! An alternate representation of the file format built on top of the existing format.
 //!
 //! Some general notes:

--- a/language/vm/src/vm_string.rs
+++ b/language/vm/src/vm_string.rs
@@ -105,8 +105,7 @@ impl fmt::Display for VMString {
 pub struct VMStr(str);
 
 impl VMStr {
-    pub fn new<'a>(s: impl AsRef<str> + 'a) -> &'a VMStr {
-        let s = s.as_ref();
+    pub fn new(s: &str) -> &VMStr {
         // UNSAFE CODE: This code requires auditing before modifications may land.
         // JUSTIFICATION: The input and output references have the same
         // lifetime and VMStr and str have the same layout, so this is safe to

--- a/language/vm/src/vm_string.rs
+++ b/language/vm/src/vm_string.rs
@@ -10,6 +10,7 @@
 
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
+use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, fmt, ops::Deref, result, string::FromUtf8Error};
 
@@ -100,19 +101,13 @@ impl fmt::Display for VMString {
 /// A borrowed string in Move code.
 ///
 /// For more details, see the module level documentation.
-#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd, RefCast)]
 #[repr(transparent)]
 pub struct VMStr(str);
 
 impl VMStr {
     pub fn new(s: &str) -> &VMStr {
-        // UNSAFE CODE: This code requires auditing before modifications may land.
-        // JUSTIFICATION: The input and output references have the same
-        // lifetime and VMStr and str have the same layout, so this is safe to
-        // do. See
-        // https://rust-lang.github.io/unsafe-code-guidelines/layout/structs-and-tuples.html#single-field-structs
-        // AUDITOR: metajack
-        unsafe { &*(s as *const str as *const VMStr) }
+        VMStr::ref_cast(s)
     }
 
     /// Returns the length of `self` in bytes.

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -25,6 +25,7 @@ proptest-derive = { version = "0.1.2", default-features = false, optional = true
 prost = "0.5.0"
 radix_trie = { version = "0.1.4", default-features = false }
 rand = "0.6.5"
+ref-cast = "1.0"
 serde = { version = "1.0.99", default-features = false }
 thiserror = "1.0"
 tiny-keccak = { version = "1.5.0", default-features = false }

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! Suppose we have the following data structure in a smart contract:
 //!
 //! struct B {

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use anyhow::{ensure, Error, Result};
 use bech32::{Bech32, FromBase32, ToBase32};
 use bytes05::Bytes;

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,

--- a/types/src/account_state_blob/account_state_blob_test.rs
+++ b/types/src/account_state_blob/account_state_blob_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use super::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::collection::vec;

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 #[cfg(any(test, feature = "fuzzing"))]
 use crate::account_config::{account_resource_path, AccountResource};
 use crate::{

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{crypto_proxies::ValidatorSet, transaction::Version};
 use libra_crypto::hash::HashValue;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::account_address::AccountAddress;
 use crate::byte_array::ByteArray;
 use anyhow::Result;

--- a/types/src/byte_array.rs
+++ b/types/src/byte_array.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use hex;
 use serde::{Deserialize, Serialize};
 

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     account_config::AccountEvent, event::EventKey, language_storage::TypeTag,
     ledger_info::LedgerInfo, proof::EventProof, transaction::Version,

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This module defines a data structure made to contain a cryptographic
 //! signature, in the sense of an implementation of
 //! libra_crypto::traits::Signature. The container is an opaque NewType that

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
 use hex;

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::block_info::{BlockInfo, Round};
 use crate::{
     account_address::AccountAddress,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#![forbid(unsafe_code)]
+
 pub mod access_path;
 pub mod account_address;
 pub mod account_config;

--- a/types/src/proof/accumulator/accumulator_test.rs
+++ b/types/src/proof/accumulator/accumulator_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use super::InMemoryAccumulator;
 use crate::proof::{
     definition::LeafCount,

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This module implements an in-memory Merkle Accumulator that is similar to what we use in
 //! storage. This accumulator will only store a small portion of the tree -- for any subtree that
 //! is full, we store only the root. Also we only store the frozen nodes, therefore this structure

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This module has definition of various proofs.
 
 #[cfg(test)]

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 pub mod accumulator;
 pub mod definition;
 pub mod position;

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! This module provides an abstraction for positioning a node in a binary tree,
 //! A `Position` uniquely identifies the location of a node
 //!

--- a/types/src/proof/position/position_test.rs
+++ b/types/src/proof/position/position_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::proof::position::*;
 
 /// Position is marked with in-order-traversal sequence.

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! All proofs generated in this module are not valid proofs. They are only for the purpose of
 //! testing conversion between Rust and Protobuf.
 

--- a/types/src/proof/unit_tests/proof_proto_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::proof::{
     AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
     TestAccumulatorProof, TestAccumulatorRangeProof, TransactionListProof, TransactionProof,

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::block_info::BlockInfo;
 use crate::{
     account_address::AccountAddress,

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::block_info::{BlockInfo, Round};
 use crate::crypto_proxies::ValidatorSet;
 use crate::event::EVENT_KEY_LENGTH;

--- a/types/src/proto/mod.rs
+++ b/types/src/proto/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 #![allow(bare_trait_objects)]
 
 #[allow(clippy::large_enum_variant)]

--- a/types/src/test_helpers/mod.rs
+++ b/types/src/test_helpers/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 pub mod transaction_test_helpers;
 
 pub fn assert_canonical_encode_decode<T>(t: T)

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     account_address::AccountAddress,
     transaction::{Module, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction},

--- a/types/src/transaction/change_set.rs
+++ b/types/src/transaction/change_set.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{contract_event::ContractEvent, write_set::WriteSet};
 use serde::{Deserialize, Serialize};
 

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     account_address::AccountAddress,
     proto::types::SignedTransaction as ProtoSignedTransaction,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use serde::{Deserialize, Serialize};
 use std::fmt;
 

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::transaction::transaction_argument::TransactionArgument;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{account_address::AccountAddress, byte_array::ByteArray};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};

--- a/types/src/unit_tests/access_path_test.rs
+++ b/types/src/unit_tests/access_path_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},

--- a/types/src/unit_tests/address_test.rs
+++ b/types/src/unit_tests/address_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
 use bech32::Bech32;
 use hex::FromHex;

--- a/types/src/unit_tests/block_metadata_test.rs
+++ b/types/src/unit_tests/block_metadata_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::block_metadata::BlockMetadata;
 use crate::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/canonical_serialization_examples.rs
+++ b/types/src/unit_tests/canonical_serialization_examples.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! These tests verify the behavior of LCS against some known test vectors with various types.
 
 use crate::transaction::ChangeSet;

--- a/types/src/unit_tests/code_debug_fmt_test.rs
+++ b/types/src/unit_tests/code_debug_fmt_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::transaction::Script;
 use std::fmt;
 

--- a/types/src/unit_tests/contract_event_proto_conversion_test.rs
+++ b/types/src/unit_tests/contract_event_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::contract_event::{ContractEvent, EventWithProof};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
+++ b/types/src/unit_tests/get_with_proof_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     get_with_proof::{
         RequestItem, ResponseItem, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,

--- a/types/src/unit_tests/identifier_test.rs
+++ b/types/src/unit_tests/identifier_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::identifier::{IdentStr, Identifier, ALLOWED_IDENTIFIERS};
 use crate::test_helpers::assert_canonical_encode_decode;
 use lazy_static::lazy_static;

--- a/types/src/unit_tests/language_storage_test.rs
+++ b/types/src/unit_tests/language_storage_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::language_storage::ModuleId;
 use crate::test_helpers::assert_canonical_encode_decode;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;

--- a/types/src/unit_tests/ledger_info_proto_conversion_test.rs
+++ b/types/src/unit_tests/ledger_info_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{crypto_proxies::LedgerInfoWithSignatures, ledger_info::LedgerInfo};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/mod.rs
+++ b/types/src/unit_tests/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 mod access_path_test;
 mod address_test;
 mod block_metadata_test;

--- a/types/src/unit_tests/transaction_proto_conversion_test.rs
+++ b/types/src/unit_tests/transaction_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::transaction::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::test_helpers::assert_canonical_encode_decode;
 use crate::{
     account_address::AccountAddress,

--- a/types/src/unit_tests/validator_change_proto_conversion_test.rs
+++ b/types/src/unit_tests/validator_change_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::validator_change::ValidatorChangeEventWithProof;
 use libra_crypto::ed25519::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;

--- a/types/src/unit_tests/validator_set_test.rs
+++ b/types/src/unit_tests/validator_set_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::crypto_proxies::ValidatorSet;
 use crate::test_helpers::assert_canonical_encode_decode;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;

--- a/types/src/unit_tests/vm_error_proto_conversion_test.rs
+++ b/types/src/unit_tests/vm_error_proto_conversion_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::vm_error::{StatusCode, VMStatus};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use std::convert::TryFrom;

--- a/types/src/unit_tests/write_set_test.rs
+++ b/types/src/unit_tests/write_set_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::test_helpers::assert_canonical_encode_decode;
 use crate::write_set::WriteSet;
 use proptest::prelude::*;

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::crypto_proxies::ValidatorVerifier;
 use crate::ledger_info::LedgerInfoWithSignatures;
 use anyhow::{ensure, format_err, Error, Result};

--- a/types/src/validator_public_keys.rs
+++ b/types/src/validator_public_keys.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::account_address::AccountAddress;
 use anyhow::{Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{
     access_path::{AccessPath, Accesses},
     account_config,

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
 use anyhow::Error;
 use libra_crypto::{test_utils::TEST_SEED, HashValue, *};

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::account_address::AccountAddress;
 use crate::validator_set::ValidatorSet;
 use anyhow::{ensure, Result};

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
 #![allow(clippy::unit_arg)]
 
 use anyhow::{Error, Result};

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 //! For each transaction the VM executes, the VM will output a `WriteSet` that contains each access
 //! path it updates. For each access path, the VM can either give its new value or delete it.
 


### PR DESCRIPTION
The signature of VMStr::new is currently unsound.

```rust
// previous signature
pub fn new<'a>(s: impl AsRef<str> + 'a) -> &'a VMStr;
```

The following program demonstrates a heap Use After Free arising from the incorrect lifetime bound in this signature.

```rust
use vm::vm_string::VMStr;

fn main() {
    let s = "...........".to_owned();
    let v = VMStr::new(s);
    println!("{}", v);
}
```

This program instantiates VMStr::new with 'a = 'static. The type String satisfies impl AsRef\<str\>+'static so the borrow checker is fine with it. Note that String is 'static because it does not borrow any data so it lives as long as the owner wants, not restricted by any lifetime shorter than 'static.

Ownership of the owned string *s* is moved into VMStr::new and dropped at the end of new. The reference returned by VMStr::new then points to a freed part of the heap.

On my machine this minimal repro prints a variety of exciting content, such as:

```console
h`É
   KV
```

but could just as easily segfault or leak secrets in real usage.

Fortunately VMStr::new is only ever currently invoked with arguments of type &str and &Box\<str\>, for which the VMStr::new signature happens to do the right thing. For this reason I felt it was not necessary to disclose this privately as a vulnerability.

---

- The first commit fixes the signature of VMStr::new to enforce the lifetime bound assumed by the unsafe cast inside.
- The second and third commits delete the unsafe code from libra-types and vm in favor of https://github.com/dtolnay/ref-cast, whose safe API would have prevented this bug.
- The fourth and fifth commits enforce #!\[forbid(unsafe_code)\] more aggressively where possible.

## Test Plan

- `$ cargo check --manifest-path types/Cargo.toml`
- `$ cargo check --manifest-path language/vm/Cargo.toml`

## Related PRs

- https://github.com/libra/libra/pull/1851 -- this bug was unfortunately missed during a very recent audit. FYI @metajack @bmwill 