### PR TITLE
[cluster-test] Use 'Name' tag instead of 'PeerId'

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -92,9 +92,8 @@ impl Cluster {
                         InstanceRole::Prometheus => {
                             prometheus_ip = Some(ip);
                         }
-                        InstanceRole::Peer(peer_id) => {
-                            let short_hash = peer_id[..8].into();
-                            instances.push(Instance::new(short_hash, ip, ac_port));
+                        InstanceRole::Peer(peer_name) => {
+                            instances.push(Instance::new(peer_name, ip, ac_port));
                         }
                         _ => {}
                     }
@@ -142,7 +141,7 @@ impl Cluster {
     pub fn get_instance(&self, name: &str) -> Option<&Instance> {
         self.instances
             .iter()
-            .find(|instance| instance.short_hash() == name)
+            .find(|instance| instance.peer_name() == name)
     }
 
     /// Splits this cluster into two
@@ -189,10 +188,10 @@ fn parse_tags(tags: Vec<Tag>) -> InstanceRole {
     let mut map: HashMap<_, _> = tags.into_iter().map(|tag| (tag.key, tag.value)).collect();
     let role = map.remove(&Some("Role".to_string()));
     if role == Some(Some("validator".to_string())) {
-        let peer_id = map.remove(&Some("PeerId".to_string()));
-        let peer_id = peer_id.expect("Validator instance without PeerId");
-        let peer_id = peer_id.expect("PeerId tag without value");
-        return InstanceRole::Peer(peer_id);
+        let peer_name = map.remove(&Some("Name".to_string()));
+        let peer_name = peer_name.expect("Validator instance without Name");
+        let peer_name = peer_name.expect("'Name' tag without value");
+        return InstanceRole::Peer(peer_name);
     } else if role == Some(Some("monitoring".to_string())) {
         return InstanceRole::Prometheus;
     }

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -70,7 +70,7 @@ impl DeploymentManager {
             request.service = format!(
                 "{w}/{w}-validator-{hash}",
                 w = self.aws.workspace(),
-                hash = instance.short_hash()
+                hash = instance.peer_name()
             );
 
             self.aws

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -48,7 +48,7 @@ impl ExperimentParam for RecoveryTimeParams {
 impl Experiment for RecoveryTime {
     fn affected_validators(&self) -> HashSet<String> {
         let mut result = HashSet::new();
-        result.insert(self.instance.short_hash().clone());
+        result.insert(self.instance.peer_name().clone());
         result
     }
 

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -48,7 +48,7 @@ impl DebugPortLogThread {
                 started_sender: Some(started_sender),
             };
             thread::Builder::new()
-                .name(format!("log-tail-{}", instance.short_hash()))
+                .name(format!("log-tail-{}", instance.peer_name()))
                 .spawn(move || debug_port_log_thread.run())
                 .expect("Failed to spawn log tail thread");
         }
@@ -107,7 +107,7 @@ impl DebugPortLogThread {
             return None;
         };
         Some(ValidatorEvent {
-            validator: self.instance.short_hash().clone(),
+            validator: self.instance.peer_name().clone(),
             timestamp: Duration::from_millis(event.timestamp as u64),
             received_timestamp: unix_timestamp_now(),
             event: e,

--- a/testsuite/cluster-test/src/health/liveness_check.rs
+++ b/testsuite/cluster-test/src/health/liveness_check.rs
@@ -25,7 +25,7 @@ impl LivenessHealthCheck {
     pub fn new(cluster: &Cluster) -> Self {
         let mut last_committed = HashMap::new();
         for instance in cluster.instances() {
-            last_committed.insert(instance.short_hash().clone(), LastCommitInfo::default());
+            last_committed.insert(instance.peer_name().clone(), LastCommitInfo::default());
         }
         Self { last_committed }
     }

--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -112,7 +112,7 @@ impl HealthCheckRunner {
     ) -> Result<Vec<String>> {
         let mut node_health = HashMap::new();
         for instance in self.cluster.instances() {
-            node_health.insert(instance.short_hash().clone(), true);
+            node_health.insert(instance.peer_name().clone(), true);
         }
         let mut messages = vec![];
 

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -11,15 +11,15 @@ use tokio;
 
 #[derive(Clone)]
 pub struct Instance {
-    short_hash: String,
+    peer_name: String,
     ip: String,
     ac_port: u32,
 }
 
 impl Instance {
-    pub fn new(short_hash: String, ip: String, ac_port: u32) -> Instance {
+    pub fn new(peer_name: String, ip: String, ac_port: u32) -> Instance {
         Instance {
-            short_hash,
+            peer_name,
             ip,
             ac_port,
         }
@@ -98,8 +98,8 @@ impl Instance {
             .unwrap_or(false)
     }
 
-    pub fn short_hash(&self) -> &String {
-        &self.short_hash
+    pub fn peer_name(&self) -> &String {
+        &self.peer_name
     }
 
     pub fn ip(&self) -> &String {
@@ -113,14 +113,14 @@ impl Instance {
 
 impl fmt::Display for Instance {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}({})", self.short_hash, self.ip)
+        write!(f, "{}({})", self.peer_name, self.ip)
     }
 }
 
 pub fn instancelist_to_set(instances: &[Instance]) -> HashSet<String> {
     let mut r = HashSet::new();
     for instance in instances {
-        r.insert(instance.short_hash().clone());
+        r.insert(instance.peer_name().clone());
     }
     r
 }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -327,7 +327,7 @@ impl ClusterUtil {
 
     pub fn discovery(&self) {
         for instance in self.cluster.instances() {
-            println!("{} {}", instance.short_hash(), instance.ip());
+            println!("{} {}", instance.peer_name(), instance.ip());
         }
     }
 
@@ -686,7 +686,7 @@ impl ClusterTestRunner {
             }
             let stop_validator = rng.gen_range(0, instances.len());
             let stop_validator = instances.remove(stop_validator);
-            stopped_instance_ids.push(stop_validator.short_hash().clone());
+            stopped_instance_ids.push(stop_validator.peer_name().clone());
             let stop_effect = StopContainer::new(stop_validator);
             info!(
                 "Stopped {} validators: {}",
@@ -728,7 +728,7 @@ impl ClusterTestRunner {
     fn wait_until_all_healthy(&mut self) -> Result<()> {
         let wait_deadline = Instant::now() + Duration::from_secs(20 * 60);
         for instance in self.cluster.instances() {
-            self.health_check_runner.invalidate(instance.short_hash());
+            self.health_check_runner.invalidate(instance.peer_name());
         }
         loop {
             let now = Instant::now();

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -120,7 +120,7 @@ impl TxEmitter {
             let accounts = (&mut all_accounts).take(req.accounts_per_client).collect();
             let all_addresses = all_addresses.clone();
             let stop = stop.clone();
-            let peer_id = instance.short_hash().clone();
+            let peer_id = instance.peer_name().clone();
             let params = req.thread_params.clone();
             let thread = SubmissionThread {
                 accounts,


### PR DESCRIPTION
## Summary

PeerId is no longer a tag on the AWS instance, so using the "Name" tag to identify an instance. Since we no longer have the PeerId, we dont have the short_hash either, so rename it to peer_name

## Test

Tested on my cluster which was brought up by dynamic config