### PR TITLE
[move-prover] parsing unary and binary ops

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ast::{BinOp, CopyableVal, Field, StructName, UnaryOp};
+use crate::ast::{BinOp, CopyableVal, Field, StructName};
 use libra_types::account_address::AccountAddress;
 
 /// AST for the Move Prover specification language. Just postconditions for now
@@ -30,7 +30,6 @@ pub enum StorageLocation {
     Address(AccountAddress),
     /// The return value of the current procedure
     Ret,
-    // TODO: & and * operators
     // TODO: useful constants like U64_MAX
     // TODO: add generics to GlobalResource
 }
@@ -47,13 +46,16 @@ pub enum SpecExp {
         type_: StructName,
         address: StorageLocation,
     },
-    /// Unary operators also suported by Move
-    Unop(Box<SpecExp>, UnaryOp),
+    /// Dereference of a storage location (written *s)
+    Dereference(StorageLocation),
+    /// Reference to a storage location (written &s)
+    Reference(StorageLocation),
+    /// Negation of a boolean expression (written !e),
+    Not(Box<SpecExp>),
     /// Binary operators also suported by Move
     Binop(Box<SpecExp>, BinOp, Box<SpecExp>),
-    /// Implication, which is not supported by Move
-    Implies(Box<SpecExp>, Box<SpecExp>), // TODO: add generics to GlobalExists
-                                         // TODO: iff
+    // TODO: add generics to GlobalExists
+    // TODO: binary operators not supported by Move like implies and iff
 }
 
 /// A specification directive to be verified

--- a/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
+++ b/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
@@ -1,4 +1,4 @@
-// Tests for parsing of postconditions
+// Tests for parsing specifications
 
 // Test parsing the conditions themselves relative to return values, acquires clauses
 //! no-run: runtime
@@ -175,6 +175,50 @@ module TestEnsuresAccessPath {
   ensures global<T>(t/a)
   {
       return move(t);
+  }
+
+}
+
+//! new-transaction
+//! no-run: runtime
+module TestBinaryOps {
+  resource T { b: bool }
+  resource Pair { x: u64, y: u64}
+
+  public ret_eq_seven(): u64
+  ensures return == 7
+  {
+      return 7;
+  }
+
+  public ret_neq_seven(): u64
+  ensures return != 7
+  {
+      return 5;
+  }
+
+  public ret_add(x: u64): u64
+  ensures return == x + 1
+  {
+      return move(x) + 1;
+  }
+
+  public ret_sub(x: u64): u64
+  ensures return - 1 == x
+  {
+      return move(x) + 1;
+  }
+
+  public ret_unop(x: bool): bool
+  ensures return == !x
+  {
+      return !move(x);
+  }
+
+  public ret_access_path_exp(p: &Self.Pair): u64
+  ensures return == p/x + p/y
+  {
+      return *&copy(p).x + *&move(p).y;
   }
 
 }


### PR DESCRIPTION
Finishing up the initial parser for the Move IR specification language.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Working toward integrating the Move prover prototype with the IR language.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New E2E tests.
