### PR TITLE
[consensus] replace rmp serde with lcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,6 @@ dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safety-rules 0.1.0",
  "schemadb 0.1.0",
@@ -801,7 +800,6 @@ dependencies = [
  "network 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3660,25 +3658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rmp 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59"
@@ -5763,8 +5742,6 @@ dependencies = [
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
-"checksum rmp 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f594cb7ff8f1c5a7907f6be91f15795c8301e0d5718eb007fb5832723dd716e"
-"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 "checksum rocksdb 0.3.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)" = "<none>"
 "checksum rusoto_core 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "351e97aedcc659bd03168ff7fd3dbb270b6ee812c0c51c7953d2ef6f0a119aa9"
 "checksum rusoto_credential 0.41.1 (registry+https://github.com/rust-lang/crates.io-index)" = "22a9b3b73099876f50d3de8e0974de71934ddca4d48d11268456b47c4d2fff87"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -22,7 +22,6 @@ num-traits = { version = "0.2.8", default-features = false }
 parity-multiaddr = { version = "0.5.0", default-features = false }
 prost = "0.5.0"
 rand = { version = "0.6.5", default-features = false }
-rmp-serde = { version = "0.13.7", default-features = false }
 rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 serde_json = "1.0"

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -13,7 +13,6 @@ lazy_static = { version = "1.3.0", default-features = false }
 mirai-annotations = { version = "1.5.0", default-features = false }
 proptest = { version = "0.9.4", optional = true }
 rand = { version = "0.6.5", default-features = false }
-rmp-serde = { version = "0.13.7", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -16,7 +16,6 @@ use libra_types::crypto_proxies::ValidatorPublicKeys;
 use libra_types::crypto_proxies::ValidatorSet;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use libra_types::ledger_info::LedgerInfo;
-use rmp_serde::{from_slice, to_vec_named};
 use std::{collections::HashSet, sync::Arc};
 use storage_client::StorageRead;
 
@@ -264,7 +263,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
     }
 
     fn save_state(&self, vote: &Vote) -> Result<()> {
-        self.db.save_state(to_vec_named(vote)?)
+        self.db.save_state(lcs::to_bytes(vote)?)
     }
 
     fn start(&self) -> RecoveryData<T> {
@@ -275,11 +274,11 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
             .expect("unable to recover consensus data");
 
         let last_vote = raw_data.0.map(|vote_data| {
-            from_slice(&vote_data[..]).expect("unable to deserialize last vote msg")
+            lcs::from_bytes(&vote_data[..]).expect("unable to deserialize last vote msg")
         });
 
         let highest_timeout_certificate = raw_data.1.map(|ts| {
-            from_slice(&ts[..]).expect("unable to deserialize highest timeout certificate")
+            lcs::from_bytes(&ts[..]).expect("unable to deserialize highest timeout certificate")
         });
         let blocks = raw_data.2;
         let quorum_certs: Vec<_> = raw_data.3;
@@ -342,6 +341,6 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
 
     fn save_highest_timeout_cert(&self, highest_timeout_cert: TimeoutCertificate) -> Result<()> {
         self.db
-            .save_highest_timeout_certificate(to_vec_named(&highest_timeout_cert)?)
+            .save_highest_timeout_certificate(lcs::to_bytes(&highest_timeout_cert)?)
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

rmp serde starts to fail when the vote carries next_validator_set, I didn't dig into why but it's better to be consistent with lcs too.

to reproduce:
```
let bytes = to_vec_named(vote)?; // the vote has next_validator_set
let vote = from_slice(&bytes[..]).expect("???");
```
it'd panic with `LengthMismatch(4)`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests, we'll have it covered with e2e reconfiguration tests too.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
