### PR TITLE
[storage] make epoch proof consistent with get_epoch

### DIFF
--- a/consensus/consensus-types/src/epoch_retrieval.rs
+++ b/consensus/consensus-types/src/epoch_retrieval.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 #[derive(Serialize, Deserialize)]
 pub struct EpochRetrievalRequest {
     pub start_epoch: u64,
-    pub target_epoch: u64,
+    pub end_epoch: u64,
 }
 
 impl TryFrom<network::proto::RequestEpoch> for EpochRetrievalRequest {

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -317,7 +317,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
             last_vote,
             blocks,
             quorum_certs,
-            startup_info.ledger_info.ledger_info(),
+            startup_info.latest_ledger_info.ledger_info(),
             root_executed_trees,
             highest_timeout_certificate,
             startup_info

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -87,6 +87,7 @@ impl StateComputer for MockStateComputer {
     fn get_epoch_proof(
         &self,
         _start_epoch: u64,
+        _end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeEventWithProof>> + Send>> {
         future::err(format_err!(
             "epoch proof not supported in mock state computer"
@@ -131,6 +132,7 @@ impl StateComputer for EmptyStateComputer {
     fn get_epoch_proof(
         &self,
         _start_epoch: u64,
+        _end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeEventWithProof>> + Send>> {
         future::err(format_err!(
             "epoch proof not supported in empty state computer"

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -147,7 +147,10 @@ impl StateComputer for ExecutionProxy {
     fn get_epoch_proof(
         &self,
         start_epoch: u64,
+        end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeEventWithProof>> + Send>> {
-        self.synchronizer.get_epoch_proof(start_epoch).boxed()
+        self.synchronizer
+            .get_epoch_proof(start_epoch, end_epoch)
+            .boxed()
     }
 }

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -83,6 +83,7 @@ pub trait StateComputer: Send + Sync {
     fn get_epoch_proof(
         &self,
         start_epoch: u64,
+        end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeEventWithProof>> + Send>>;
 }
 

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -88,7 +88,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
                 .expect("No ValidatorSet found for the start of the epoch")
                 .into();
             Ok(SynchronizerState::new(
-                storage_info.ledger_info,
+                storage_info.latest_ledger_info,
                 synced_trees,
                 current_verifier,
             ))

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -38,7 +38,12 @@ pub trait ExecutorProxyTrait: Sync + Send {
         target_version: u64,
     ) -> Pin<Box<dyn Future<Output = Result<TransactionListWithProof>> + Send>>;
 
-    fn get_epoch_proof(&self, start_epoch: u64) -> Result<ValidatorChangeEventWithProof>;
+    /// Get the epoch change ledger info for [start_epoch, end_epoch) so that we can move to end_epoch.
+    fn get_epoch_proof(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<ValidatorChangeEventWithProof>;
 }
 
 pub(crate) struct ExecutorProxy {
@@ -120,10 +125,14 @@ impl ExecutorProxyTrait for ExecutorProxy {
             .boxed()
     }
 
-    fn get_epoch_proof(&self, start_epoch: u64) -> Result<ValidatorChangeEventWithProof> {
+    fn get_epoch_proof(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<ValidatorChangeEventWithProof> {
         let ledger_info_per_epoch = self
             .storage_read_client
-            .get_epoch_change_ledger_infos(start_epoch)?;
+            .get_epoch_change_ledger_infos(start_epoch, end_epoch)?;
         Ok(ValidatorChangeEventWithProof::new(ledger_info_per_epoch))
     }
 }

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -127,11 +127,13 @@ impl StateSyncClient {
     pub fn get_epoch_proof(
         &self,
         start_epoch: u64,
+        end_epoch: u64,
     ) -> impl Future<Output = Result<ValidatorChangeEventWithProof>> {
         let mut sender = self.coordinator_sender.clone();
         let (cb_sender, cb_receiver) = oneshot::channel();
         let request = EpochRetrievalRequest {
             start_epoch,
+            end_epoch,
             callback: cb_sender,
         };
         async move {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -102,7 +102,11 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         async move { response }.boxed()
     }
 
-    fn get_epoch_proof(&self, start_epoch: u64) -> Result<ValidatorChangeEventWithProof> {
+    fn get_epoch_proof(
+        &self,
+        start_epoch: u64,
+        _end_epoch: u64,
+    ) -> Result<ValidatorChangeEventWithProof> {
         Ok(self.storage.read().unwrap().get_epoch_changes(start_epoch))
     }
 }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -623,6 +623,8 @@ impl LibraDB {
         };
         let li_version = ledger_info_with_sigs.ledger_info().version();
         assert!(latest_tree_state.version >= li_version);
+        // To get the current validator set, if the latest_ledger_info is at epoch boundary, we
+        // move to the next epoch
         let mut target_epoch = ledger_info_with_sigs.ledger_info().epoch();
         if ledger_info_with_sigs
             .ledger_info()
@@ -645,7 +647,7 @@ impl LibraDB {
                 .ledger_store
                 .get_ledger_frozen_subtree_hashes(committed_version)?;
             StartupInfo {
-                ledger_info: ledger_info_with_sigs,
+                latest_ledger_info: ledger_info_with_sigs,
                 ledger_info_with_validators,
                 committed_tree_state: TreeState::new(
                     committed_version,
@@ -657,7 +659,7 @@ impl LibraDB {
         } else {
             // The version of the latest ledger info matches other data. So the storage is not in sync mode.
             StartupInfo {
-                ledger_info: ledger_info_with_sigs,
+                latest_ledger_info: ledger_info_with_sigs,
                 ledger_info_with_validators,
                 committed_tree_state: latest_tree_state,
                 synced_tree_state: None,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -17,13 +17,15 @@ use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::collections::HashMap;
 
 fn verify_epochs(db: &LibraDB, ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> Result<()> {
+    let (_, latest_li, mut proof, _) = db.update_to_latest_ledger(0, Vec::new())?;
     let epoch_change_lis: Vec<_> = ledger_infos_with_sigs
         .iter()
-        .filter(|info| info.ledger_info().next_validator_set().is_some())
+        .filter(|info| {
+            info.ledger_info().next_validator_set().is_some()
+                && info.ledger_info().epoch() < latest_li.ledger_info().epoch()
+        })
         .cloned()
         .collect();
-
-    let (_, _, mut proof, _) = db.update_to_latest_ledger(0, Vec::new())?;
 
     // The very first validator change in the returned proof is the
     // validator change of genesis (LedgerInfo with epoch 0).

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -185,8 +185,9 @@ impl StorageRead for StorageReadServiceClient {
     fn get_epoch_change_ledger_infos_async(
         &self,
         start_epoch: u64,
+        end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {
-        let proto_req = GetEpochChangeLedgerInfosRequest::new(start_epoch);
+        let proto_req = GetEpochChangeLedgerInfosRequest::new(start_epoch, end_epoch);
         convert_grpc_response(
             self.client()
                 .get_epoch_change_ledger_infos_async(&proto_req.into()),
@@ -370,8 +371,9 @@ pub trait StorageRead: Send + Sync {
     fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
+        end_epoch: u64,
     ) -> Result<Vec<LedgerInfoWithSignatures>> {
-        block_on(self.get_epoch_change_ledger_infos_async(start_epoch))
+        block_on(self.get_epoch_change_ledger_infos_async(start_epoch, end_epoch))
     }
 
     /// See [`LibraDB::get_epoch_change_ledger_infos`].
@@ -381,6 +383,7 @@ pub trait StorageRead: Send + Sync {
     fn get_epoch_change_ledger_infos_async(
         &self,
         start_epoch: u64,
+        end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>>;
 
     /// See [`LibraDB::backup_account_state`].

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -442,12 +442,16 @@ impl From<GetStartupInfoResponse> for crate::proto::storage::GetStartupInfoRespo
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetEpochChangeLedgerInfosRequest {
     pub start_epoch: u64,
+    pub end_epoch: u64,
 }
 
 impl GetEpochChangeLedgerInfosRequest {
     /// Constructor.
-    pub fn new(start_epoch: u64) -> Self {
-        Self { start_epoch }
+    pub fn new(start_epoch: u64, end_epoch: u64) -> Self {
+        Self {
+            start_epoch,
+            end_epoch,
+        }
     }
 }
 
@@ -459,6 +463,7 @@ impl TryFrom<crate::proto::storage::GetEpochChangeLedgerInfosRequest>
     fn try_from(proto: crate::proto::storage::GetEpochChangeLedgerInfosRequest) -> Result<Self> {
         Ok(Self {
             start_epoch: proto.start_epoch,
+            end_epoch: proto.end_epoch,
         })
     }
 }
@@ -469,6 +474,7 @@ impl From<GetEpochChangeLedgerInfosRequest>
     fn from(request: GetEpochChangeLedgerInfosRequest) -> Self {
         Self {
             start_epoch: request.start_epoch,
+            end_epoch: request.end_epoch,
         }
     }
 }

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -360,7 +360,7 @@ impl From<TreeState> for crate::proto::storage::TreeState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StartupInfo {
-    pub ledger_info: LedgerInfoWithSignatures,
+    pub latest_ledger_info: LedgerInfoWithSignatures,
     pub ledger_info_with_validators: LedgerInfoWithSignatures,
     pub committed_tree_state: TreeState,
     pub synced_tree_state: Option<TreeState>,
@@ -388,7 +388,7 @@ impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
             .transpose()?;
 
         Ok(Self {
-            ledger_info,
+            latest_ledger_info: ledger_info,
             ledger_info_with_validators,
             committed_tree_state,
             synced_tree_state,
@@ -398,7 +398,7 @@ impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
 
 impl From<StartupInfo> for crate::proto::storage::StartupInfo {
     fn from(info: StartupInfo) -> Self {
-        let ledger_info = Some(info.ledger_info.into());
+        let ledger_info = Some(info.latest_ledger_info.into());
         let ledger_info_with_validators = Some(info.ledger_info_with_validators.into());
         let committed_tree_state = Some(info.committed_tree_state.into());
         let synced_tree_state = info.synced_tree_state.map(Into::into);

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -138,6 +138,8 @@ message StartupInfo {
 message GetEpochChangeLedgerInfosRequest {
     /// The last epoch number with available information to the client.
     uint64 start_epoch = 1;
+    /// The target epoch number that client wants to sync to.
+    uint64 end_epoch = 2;
 }
 
 message GetEpochChangeLedgerInfosResponse {

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -227,7 +227,7 @@ impl StorageService {
         let rust_req = storage_proto::GetEpochChangeLedgerInfosRequest::try_from(req)?;
         let ledger_infos = self
             .db
-            .get_epoch_change_ledger_infos(rust_req.start_epoch)?;
+            .get_epoch_change_ledger_infos(rust_req.start_epoch, rust_req.end_epoch)?;
         let rust_resp = storage_proto::GetEpochChangeLedgerInfosResponse::new(ledger_infos);
         Ok(rust_resp.into())
     }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -106,6 +106,7 @@ impl StorageRead for MockStorageReadClient {
     fn get_epoch_change_ledger_infos_async(
         &self,
         _start_epoch: u64,
+        _end_epoch: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {
         unimplemented!()
     }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -699,7 +699,7 @@ fn test_full_node_basic_flow() {
 
 #[test]
 fn test_e2e_reconfiguration() {
-    let (mut env, mut client_proxy_1) = setup_swarm_and_client_proxy(5, 1);
+    let (mut env, mut client_proxy_1) = setup_swarm_and_client_proxy(3, 1);
     // the client connected to the removed validator
     let mut client_proxy_0 = env.get_validator_ac_client(0);
     client_proxy_1.create_next_account(false).unwrap();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

With #1948, we change the version -> epoch mapping. This PR reflects the change in get_epoch_proof too.
We return the proof from `start_epoch` to the epoch corresponding the `ledger_version`(get_epoch(ledger_version).

If start_epoch = 5, get_epoch(ledger_version) =8, the proof contains vec![5->6, 6->7, 7->8]

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Modified tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
