### PR TITLE
[language][move] Follow up changes for some parser tests

### DIFF
--- a/language/move-lang/tests/move_check/parser/address_misspelled.exp
+++ b/language/move-lang/tests/move_check/parser/address_misspelled.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/parser/address_misspelled.move:1:1 ───
+   │
+ 1 │ addrexx 0x1:
+   │ ^ Invalid address directive. Expected 'address' got 'addrexx'
+   │
+

--- a/language/move-lang/tests/move_check/parser/address_misspelled.move
+++ b/language/move-lang/tests/move_check/parser/address_misspelled.move
@@ -1,4 +1,1 @@
-// FIXME: The lalrpop parser does not support a custom error message with a location
-// and the Move compiler's normal error handling requires a source location, so this
-// currently leads to a panic and a test failure.
-// addrexx 0x1:
+addrexx 0x1:

--- a/language/move-lang/tests/move_check/parser/address_too_long.exp
+++ b/language/move-lang/tests/move_check/parser/address_too_long.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/parser/address_too_long.move:2:9 ───
+   │
+ 2 │ address 0x112233445566778899101122334455667788992011223344556677889930112233:
+   │         ^ The address [17, 34, 51, 68, 85, 102, 119, 136, 153, 16, 17, 34, 51, 68, 85, 102, 119, 136, 153, 32, 17, 34, 51, 68, 85, 102, 119, 136, 153, 48, 17, 34, 51] is of invalid length. Addresses are at most 32-bytes long
+   │
+

--- a/language/move-lang/tests/move_check/parser/address_too_long.move
+++ b/language/move-lang/tests/move_check/parser/address_too_long.move
@@ -1,5 +1,2 @@
 // Addresses are at most 32 bytes long.
-// FIXME: The lalrpop parser does not support a custom error message with a location
-// and the Move compiler's normal error handling requires a source location, so this
-// currently leads to a panic and a test failure.
-// address 0x112233445566778899101122334455667788992011223344556677889930112233:
+address 0x112233445566778899101122334455667788992011223344556677889930112233:

--- a/language/move-lang/tests/move_check/parser/expr_abort_braces.move
+++ b/language/move-lang/tests/move_check/parser/expr_abort_braces.move
@@ -1,6 +1,7 @@
 module M {
     f(v: u64) {
-        // Braces are not required for a control expression inside "abort"
+        // Braces or parenthesis are not required for a control expression
+        // inside an "abort" expression.
         abort if (v == 0) 10 else v
     }
 }

--- a/language/move-lang/tests/move_check/parser/expr_if_braces.move
+++ b/language/move-lang/tests/move_check/parser/expr_if_braces.move
@@ -1,6 +1,9 @@
 module M {
     f(cond: bool) {
-        // Braces are not required for a control expression inside "if"
+        // Braces or parenthesis are not required for a control expression
+        // inside an "if" expression.
+        if (cond) { if (cond) () };
+        if (cond) ( if (cond) () );
         if (cond) if (cond) ()
     }
 }

--- a/language/move-lang/tests/move_check/parser/expr_loop_braces.move
+++ b/language/move-lang/tests/move_check/parser/expr_loop_braces.move
@@ -1,6 +1,9 @@
 module M {
     f(v: u64) {
-        // Braces are not required for a control expression inside "loop"
+        // Braces or parenthesis are not required for a control expression
+        // inside a "loop" expression.
+        loop { if (v < 10) break };
+        loop ( if (v < 10) break );
         loop if (v < 10) break
     }
 }

--- a/language/move-lang/tests/move_check/parser/expr_return_braces.move
+++ b/language/move-lang/tests/move_check/parser/expr_return_braces.move
@@ -1,6 +1,7 @@
 module M {
     f(v: u64): u64 {
-        // Braces are not required for a control expression inside "return"
+        // Braces or parenthesis are not required for a control expression
+        // inside a "return" expression.
         return if (v > 10) 10 else v
     }
 }

--- a/language/move-lang/tests/move_check/parser/expr_while_braces.move
+++ b/language/move-lang/tests/move_check/parser/expr_while_braces.move
@@ -1,6 +1,9 @@
 module M {
     f(v: u64) {
-        // Braces are not required for a control expression inside "while"
+        // Braces or parenthesis are not required for a control expression
+        // inside a "while" expression.
+        while (v < 10) { v = v + 1 };
+        while (v < 10) ( v = v + 1 );
         while (v < 10) v = v + 1
     }
 }

--- a/language/move-lang/tests/move_check/parser/function_return_type.move
+++ b/language/move-lang/tests/move_check/parser/function_return_type.move
@@ -4,8 +4,7 @@ module M {
 
     // Test a single type return value.
     f2(): u64 { 1 }
-    // FIXME: Current lalrpop grammar does not allow parens with a single return type.
-    // f3(): (u64) { 1 }
+    f3(): (u64) { 1 }
     f4(p: &u64): &u64 { p }
 
     // Test multiple return values.

--- a/language/move-lang/tests/move_check/parser/let_binding.move
+++ b/language/move-lang/tests/move_check/parser/let_binding.move
@@ -8,16 +8,12 @@ module M {
     f() {
         let () = ();
         let (): () = ();
-        // FIXME: The grammar currently treats "()" as a single token, but it is
-        // not clear if that has any advantage compared to separate tokens that
-        // allow whitespace in between them.
-        // let ( ) = ( );
-        // let ( ): ( ) = ( );
+        // Test with whitespace between parenthesis.
+        let ( ) = ( );
+        let ( ): ( ) = ( );
         let v1 = 1;
         let v2: u64 = 2;
-        // FIXME: The grammar does not currently accept a single variable inside
-        // parens, but for consistency, maybe that ought to be allowed.
-        // let (v3) = 3;
+        let (v3) = 3; // for consistency, check a single variable inside parens
         let (x1, x2) = (1, 2);
         let (x3, x4): (u64, u64) = (3, 4);
     }


### PR DESCRIPTION
The parser tests in https://github.com/libra/libra/pull/1903 included some disabled checks that were not supported by the old lalrpop parser. Now that we have switched to the new parser, we can enable those tests. Also, in response to the previous review feedback, this clarifies that either braces or parenthesis are sufficient to allow using control expressions nested in various contexts.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the modified tests and confirmed that they pass.