### PR TITLE
[vm] Create entry point for MoveVM

### DIFF
--- a/language/vm/vm-genesis/src/genesis_gas_schedule.rs
+++ b/language/vm/vm-genesis/src/genesis_gas_schedule.rs
@@ -13,7 +13,7 @@ use vm::{
     gas_schedule::{CostTable, GasCost, GAS_SCHEDULE_NAME, MAXIMUM_NUMBER_OF_GAS_UNITS},
 };
 use vm_runtime::{
-    data_cache::RemoteCache, chain_state::TransactionExecutionContext,
+    chain_state::TransactionExecutionContext, data_cache::RemoteCache,
     gas_meter::GAS_SCHEDULE_MODULE, runtime::VMRuntime,
 };
 use vm_runtime_types::value::Value;

--- a/language/vm/vm-genesis/src/genesis_gas_schedule.rs
+++ b/language/vm/vm-genesis/src/genesis_gas_schedule.rs
@@ -13,7 +13,7 @@ use vm::{
     gas_schedule::{CostTable, GasCost, GAS_SCHEDULE_NAME, MAXIMUM_NUMBER_OF_GAS_UNITS},
 };
 use vm_runtime::{
-    data_cache::RemoteCache, execution_context::TransactionExecutionContext,
+    data_cache::RemoteCache, chain_state::TransactionExecutionContext,
     gas_meter::GAS_SCHEDULE_MODULE, runtime::VMRuntime,
 };
 use vm_runtime_types::value::Value;

--- a/language/vm/vm-runtime/src/chain_state.rs
+++ b/language/vm/vm-runtime/src/chain_state.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::data_cache::{RemoteCache, TransactionDataCache};
 use libra_types::{
     access_path::AccessPath,

--- a/language/vm/vm-runtime/src/chain_state.rs
+++ b/language/vm/vm-runtime/src/chain_state.rs
@@ -1,0 +1,106 @@
+use crate::data_cache::{RemoteCache, TransactionDataCache};
+use libra_types::{
+    access_path::AccessPath,
+    contract_event::ContractEvent,
+    language_storage::ModuleId,
+    vm_error::{StatusCode, VMStatus},
+    write_set::WriteSet,
+};
+use vm::{
+    errors::VMResult,
+    gas_schedule::{GasAlgebra, GasCarrier, GasUnits},
+};
+use vm_runtime_types::{loaded_data::struct_def::StructDef, value::GlobalRef};
+
+pub trait ChainState {
+    fn deduct_gas(&mut self, amount: GasUnits<GasCarrier>) -> VMResult<()>;
+    fn remaining_gas(&self) -> GasUnits<GasCarrier>;
+
+    fn load_data(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<&mut GlobalRef>;
+    fn publish_resource(&mut self, ap: &AccessPath, root: GlobalRef) -> VMResult<()>;
+
+    fn exists_module(&self, key: &ModuleId) -> bool;
+    fn emit_event(&mut self, event: ContractEvent);
+}
+
+/// A TransactionExecutionContext holds the mutable data that needs to be persisted from one
+/// section of the transaction flow to another. Because of this, this is the _only_ data that can
+/// both be mutated, and persist between interpretation instances.
+pub struct TransactionExecutionContext<'txn> {
+    /// Gas metering to track cost of execution.
+    gas_left: GasUnits<GasCarrier>,
+    /// List of events "fired" during the course of an execution.
+    event_data: Vec<ContractEvent>,
+    /// Data store
+    data_view: TransactionDataCache<'txn>,
+}
+
+/// The transaction
+impl<'txn> TransactionExecutionContext<'txn> {
+    pub fn new(gas_left: GasUnits<GasCarrier>, data_cache: &'txn dyn RemoteCache) -> Self {
+        Self {
+            gas_left,
+            event_data: Vec::new(),
+            data_view: TransactionDataCache::new(data_cache),
+        }
+    }
+
+    /// Clear all the writes local to this execution.
+    pub fn clear(&mut self) {
+        self.data_view.clear();
+        self.event_data.clear();
+    }
+
+    /// Return the list of events emitted during execution.
+    pub fn events(&self) -> &[ContractEvent] {
+        &self.event_data
+    }
+
+    /// Return the gas remaining
+    pub fn gas_left(&self) -> GasUnits<GasCarrier> {
+        self.gas_left
+    }
+
+    /// Generate a `WriteSet` as a result of an execution.
+    pub fn make_write_set(
+        &mut self,
+        to_be_published_modules: Vec<(ModuleId, Vec<u8>)>,
+    ) -> VMResult<WriteSet> {
+        self.data_view.make_write_set(to_be_published_modules)
+    }
+}
+
+impl<'txn> ChainState for TransactionExecutionContext<'txn> {
+    fn deduct_gas(&mut self, amount: GasUnits<GasCarrier>) -> VMResult<()> {
+        if self
+            .gas_left
+            .app(&amount, |curr_gas, gas_amt| curr_gas >= gas_amt)
+        {
+            self.gas_left = self.gas_left.sub(amount);
+            Ok(())
+        } else {
+            // Zero out the internal gas state
+            self.gas_left = GasUnits::new(0);
+            Err(VMStatus::new(StatusCode::OUT_OF_GAS))
+        }
+    }
+
+    fn publish_resource(&mut self, ap: &AccessPath, root: GlobalRef) -> VMResult<()> {
+        self.data_view.publish_resource(ap, root)
+    }
+
+    fn remaining_gas(&self) -> GasUnits<GasCarrier> {
+        self.gas_left
+    }
+
+    fn load_data(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<&mut GlobalRef> {
+        self.data_view.load_data(ap, def)
+    }
+    fn exists_module(&self, key: &ModuleId) -> bool {
+        self.data_view.exists_module(key)
+    }
+
+    fn emit_event(&mut self, event: ContractEvent) {
+        self.event_data.push(event)
+    }
+}

--- a/language/vm/vm-runtime/src/execution_context.rs
+++ b/language/vm/vm-runtime/src/execution_context.rs
@@ -1,13 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::data_cache::{RemoteCache, TransactionDataCache};
+use crate::chain_state::ChainState;
+use libra_logger::prelude::*;
 use libra_types::{
     access_path::AccessPath,
     contract_event::ContractEvent,
     language_storage::ModuleId,
-    vm_error::{StatusCode, VMStatus},
-    write_set::WriteSet,
+    vm_error::{sub_status, StatusCode},
 };
 use vm::{
     errors::*,
@@ -17,53 +17,6 @@ use vm_runtime_types::{
     loaded_data::struct_def::StructDef,
     value::{GlobalRef, Struct, Value},
 };
-
-/// A TransactionExecutionContext holds the mutable data that needs to be persisted from one
-/// section of the transaction flow to another. Because of this, this is the _only_ data that can
-/// both be mutated, and persist between interpretation instances.
-pub struct TransactionExecutionContext<'txn> {
-    /// Gas metering to track cost of execution.
-    gas_left: GasUnits<GasCarrier>,
-    /// List of events "fired" during the course of an execution.
-    event_data: Vec<ContractEvent>,
-    /// Data store
-    data_view: TransactionDataCache<'txn>,
-}
-
-/// The transaction
-impl<'txn> TransactionExecutionContext<'txn> {
-    pub fn new(gas_left: GasUnits<GasCarrier>, data_cache: &'txn dyn RemoteCache) -> Self {
-        Self {
-            gas_left,
-            event_data: Vec::new(),
-            data_view: TransactionDataCache::new(data_cache),
-        }
-    }
-
-    /// Clear all the writes local to this execution.
-    pub fn clear(&mut self) {
-        self.data_view.clear();
-        self.event_data.clear();
-    }
-
-    /// Return the list of events emitted during execution.
-    pub fn events(&self) -> &[ContractEvent] {
-        &self.event_data
-    }
-
-    /// Return the gas remaining
-    pub fn gas_left(&self) -> GasUnits<GasCarrier> {
-        self.gas_left
-    }
-
-    /// Generate a `WriteSet` as a result of an execution.
-    pub fn make_write_set(
-        &mut self,
-        to_be_published_modules: Vec<(ModuleId, Vec<u8>)>,
-    ) -> VMResult<WriteSet> {
-        self.data_view.make_write_set(to_be_published_modules)
-    }
-}
 
 /// The InterpreterContext context trait speficies the mutations that are allowed to the
 /// TransactionExecutionContext within the interpreter.
@@ -94,18 +47,51 @@ pub trait InterpreterContext {
     fn exists_module(&self, m: &ModuleId) -> bool;
 }
 
-impl<'txn> InterpreterContext for TransactionExecutionContext<'txn> {
+impl<T: ChainState> InterpreterContext for T {
     fn move_resource_to(
         &mut self,
         ap: &AccessPath,
         def: StructDef,
         resource: Struct,
     ) -> VMResult<()> {
-        self.data_view.move_resource_to(&ap, def, resource)
+        // a resource can be written to an AccessPath if the data does not exists or
+        // it was deleted (MoveFrom)
+        let can_write = match self.load_data(ap, def) {
+            Ok(data) => data.is_deleted(),
+            Err(e) => match e.major_status {
+                StatusCode::MISSING_DATA => true,
+                _ => return Err(e),
+            },
+        };
+        if can_write {
+            let new_root = GlobalRef::move_to(ap.clone(), resource);
+            self.publish_resource(ap, new_root)
+        } else {
+            warn!("[VM] Cannot write over existing resource {}", ap);
+            Err(vm_error(
+                Location::new(),
+                StatusCode::CANNOT_WRITE_EXISTING_RESOURCE,
+            ))
+        }
     }
 
     fn move_resource_from(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<Value> {
-        self.data_view.move_resource_from(&ap, def)
+        let root_ref = match self.load_data(ap, def) {
+            Ok(gref) => gref,
+            Err(e) => {
+                warn!("[VM] (MoveFrom) Error reading data for {}: {:?}", ap, e);
+                return Err(e);
+            }
+        };
+        // is_loadable() checks ref count and whether the data was deleted
+        if root_ref.is_loadable() {
+            Ok(root_ref.move_from()?)
+        } else {
+            Err(
+                vm_error(Location::new(), StatusCode::DYNAMIC_REFERENCE_ERROR)
+                    .with_sub_status(sub_status::DRE_GLOBAL_ALREADY_BORROWED),
+            )
+        }
     }
 
     fn resource_exists(
@@ -113,36 +99,51 @@ impl<'txn> InterpreterContext for TransactionExecutionContext<'txn> {
         ap: &AccessPath,
         def: StructDef,
     ) -> VMResult<(bool, AbstractMemorySize<GasCarrier>)> {
-        self.data_view.resource_exists(&ap, def)
+        Ok(match self.load_data(ap, def) {
+            Ok(gref) => {
+                if gref.is_deleted() {
+                    (false, AbstractMemorySize::new(0))
+                } else {
+                    (true, gref.size())
+                }
+            }
+            Err(_) => (false, AbstractMemorySize::new(0)),
+        })
     }
 
     fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<GlobalRef> {
-        self.data_view.borrow_global(&ap, def)
-    }
-
-    fn push_event(&mut self, event: ContractEvent) {
-        self.event_data.push(event)
-    }
-
-    fn remaining_gas(&self) -> GasUnits<GasCarrier> {
-        self.gas_left()
-    }
-
-    fn deduct_gas(&mut self, amount: GasUnits<GasCarrier>) -> VMResult<()> {
-        if self
-            .gas_left
-            .app(&amount, |curr_gas, gas_amt| curr_gas >= gas_amt)
-        {
-            self.gas_left = self.gas_left.sub(amount);
-            Ok(())
+        let root_ref = match self.load_data(ap, def) {
+            Ok(gref) => gref,
+            Err(e) => {
+                error!("[VM] (BorrowGlobal) Error reading data for {}: {:?}", ap, e);
+                return Err(e);
+            }
+        };
+        // is_loadable() checks ref count and whether the data was deleted
+        if root_ref.is_loadable() {
+            // shallow_ref increment ref count
+            Ok(root_ref.clone())
         } else {
-            // Zero out the internal gas state
-            self.gas_left = GasUnits::new(0);
-            Err(VMStatus::new(StatusCode::OUT_OF_GAS))
+            Err(
+                vm_error(Location::new(), StatusCode::DYNAMIC_REFERENCE_ERROR)
+                    .with_sub_status(sub_status::DRE_GLOBAL_ALREADY_BORROWED),
+            )
         }
     }
 
+    fn push_event(&mut self, event: ContractEvent) {
+        self.emit_event(event)
+    }
+
+    fn remaining_gas(&self) -> GasUnits<GasCarrier> {
+        self.remaining_gas()
+    }
+
+    fn deduct_gas(&mut self, amount: GasUnits<GasCarrier>) -> VMResult<()> {
+        self.deduct_gas(amount)
+    }
+
     fn exists_module(&self, m: &ModuleId) -> bool {
-        self.data_view.exists_module(m)
+        self.exists_module(m)
     }
 }

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "instruction_synthesis"))]
-use crate::data_cache::RemoteCache;
-#[cfg(any(test, feature = "instruction_synthesis"))]
 use crate::chain_state::TransactionExecutionContext;
+#[cfg(any(test, feature = "instruction_synthesis"))]
+use crate::data_cache::RemoteCache;
 use crate::{
     code_cache::module_cache::ModuleCache,
     counters::*,

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -4,7 +4,7 @@
 #[cfg(any(test, feature = "instruction_synthesis"))]
 use crate::data_cache::RemoteCache;
 #[cfg(any(test, feature = "instruction_synthesis"))]
-use crate::execution_context::TransactionExecutionContext;
+use crate::chain_state::TransactionExecutionContext;
 use crate::{
     code_cache::module_cache::ModuleCache,
     counters::*,

--- a/language/vm/vm-runtime/src/lib.rs
+++ b/language/vm/vm-runtime/src/lib.rs
@@ -115,9 +115,11 @@ mod counters;
 pub mod foreign_contracts;
 
 mod block_processor;
+mod chain_state;
 #[macro_use]
 pub mod gas_meter;
 mod libra_vm;
+mod move_vm;
 mod process_txn;
 mod system_txn;
 #[cfg(test)]

--- a/language/vm/vm-runtime/src/lib.rs
+++ b/language/vm/vm-runtime/src/lib.rs
@@ -115,7 +115,6 @@ mod counters;
 pub mod foreign_contracts;
 
 mod block_processor;
-mod chain_state;
 #[macro_use]
 pub mod gas_meter;
 mod libra_vm;
@@ -125,6 +124,7 @@ mod system_txn;
 #[cfg(test)]
 mod unit_tests;
 
+pub mod chain_state;
 pub mod code_cache;
 pub mod data_cache;
 pub mod execution_context;

--- a/language/vm/vm-runtime/src/libra_vm.rs
+++ b/language/vm/vm-runtime/src/libra_vm.rs
@@ -47,6 +47,8 @@ impl VMVerifier for LibraVM {
     ) -> Option<VMStatus> {
         // TODO: This should be implemented as an async function.
         record_stats! {time_hist | TXN_VALIDATION_TIME_TAKEN | {
+            // XXX: This is different from invoking bytecode verifier. Will clean the code up after
+            // refactor.
             self.move_vm
                 .execute_runtime(move |runtime| verify_transaction(runtime, transaction, state_view))
             }
@@ -66,8 +68,6 @@ impl VMExecutor for LibraVM {
         config: &VMConfig,
         state_view: &dyn StateView,
     ) -> VMResult<Vec<TransactionOutput>> {
-        // XXX This means that scripts and modules are NOT tested against the whitelist! This
-        // needs to be fixed.
         let vm = MoveVM::new(config);
 
         let mut result = vec![];

--- a/language/vm/vm-runtime/src/libra_vm.rs
+++ b/language/vm/vm-runtime/src/libra_vm.rs
@@ -205,6 +205,6 @@ fn vm_thread_safe() {
 
     assert_send::<LibraVM>();
     assert_sync::<LibraVM>();
-    assert_send::<MoveVMImpl>();
-    assert_sync::<MoveVMImpl>();
+    assert_send::<MoveVM>();
+    assert_sync::<MoveVM>();
 }

--- a/language/vm/vm-runtime/src/libra_vm.rs
+++ b/language/vm/vm-runtime/src/libra_vm.rs
@@ -5,7 +5,7 @@ use crate::{
     block_processor::execute_user_transaction_block,
     counters::*,
     data_cache::BlockDataCache,
-    loaded_data::loaded_module::LoadedModule,
+    move_vm::MoveVM,
     process_txn::validate::{ValidatedTransaction, ValidationMode},
     runtime::VMRuntime,
     system_txn::block_metadata_processor::process_block_metadata,
@@ -22,35 +22,16 @@ use libra_types::{
 };
 use std::sync::Arc;
 use vm::{errors::VMResult, gas_schedule::CostTable, transaction_metadata::TransactionMetadata};
-use vm_cache_map::Arena;
-
-// MoveVMImpl is the type that will evolve to MoveVM.
-// Right now, VMRuntime flows around but we may want to develop the API around MoveVM
-pub use move_vm_definition::MoveVMImpl;
-
-rental! {
-    mod move_vm_definition {
-        use super::*;
-
-        #[rental]
-        pub struct MoveVMImpl {
-            alloc: Box<Arena<LoadedModule>>,
-            runtime: VMRuntime<'alloc>,
-        }
-    }
-}
 
 /// A wrapper to make VMRuntime standalone and thread safe.
 #[derive(Clone)]
 pub struct LibraVM {
-    move_vm: Arc<MoveVMImpl>,
+    move_vm: Arc<MoveVM>,
 }
 
 impl LibraVM {
     pub fn new(config: &VMConfig) -> Self {
-        let inner = MoveVMImpl::new(Box::new(Arena::new()), |arena| {
-            VMRuntime::new(&*arena, config)
-        });
+        let inner = MoveVM::new(config);
         Self {
             move_vm: Arc::new(inner),
         }
@@ -67,7 +48,7 @@ impl VMVerifier for LibraVM {
         // TODO: This should be implemented as an async function.
         record_stats! {time_hist | TXN_VALIDATION_TIME_TAKEN | {
             self.move_vm
-                .rent(move |runtime| verify_transaction(runtime, transaction, state_view))
+                .execute_runtime(move |runtime| verify_transaction(runtime, transaction, state_view))
             }
         }
     }
@@ -85,11 +66,9 @@ impl VMExecutor for LibraVM {
         config: &VMConfig,
         state_view: &dyn StateView,
     ) -> VMResult<Vec<TransactionOutput>> {
-        let vm = MoveVMImpl::new(Box::new(Arena::new()), |arena| {
-            // XXX This means that scripts and modules are NOT tested against the whitelist! This
-            // needs to be fixed.
-            VMRuntime::new(&*arena, config)
-        });
+        // XXX This means that scripts and modules are NOT tested against the whitelist! This
+        // needs to be fixed.
+        let vm = MoveVM::new(config);
 
         let mut result = vec![];
         let blocks = chunk_block_transactions(transactions);
@@ -97,13 +76,13 @@ impl VMExecutor for LibraVM {
         for block in blocks {
             match block {
                 TransactionBlock::UserTransaction(txns) => {
-                    let outs = vm.rent(|runtime| {
+                    let outs = vm.execute_runtime(|runtime| {
                         execute_user_transaction_block(txns, runtime, &mut data_cache, state_view)
                     });
                     result.append(&mut outs?);
                 }
                 TransactionBlock::BlockPrologue(block_metadata) => {
-                    result.push(vm.rent(|runtime| {
+                    result.push(vm.execute_runtime(|runtime| {
                         process_block_metadata(block_metadata, runtime, state_view, &mut data_cache)
                     }))
                 }

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     chain_state::ChainState, loaded_data::loaded_module::LoadedModule, runtime::VMRuntime,
 };

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -30,8 +30,8 @@ impl MoveVM {
         }))
     }
 
-    // API for temporal backward compatibility. Will get rid of it later with the following three
-    // api.
+    // API for temporal backward compatibility.
+    // TODO: Get rid of it later with the following three api after LibraVM refactor.
     pub fn execute_runtime<F, T>(&self, f: F) -> T
     where
         F: FnOnce(&VMRuntime) -> T,

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -1,0 +1,99 @@
+use crate::{
+    chain_state::ChainState, loaded_data::loaded_module::LoadedModule, runtime::VMRuntime,
+};
+use libra_config::config::VMConfig;
+use libra_state_view::StateView;
+use libra_types::{identifier::IdentStr, language_storage::ModuleId};
+use move_vm_definition::MoveVMImpl;
+use vm::{errors::VMResult, gas_schedule::CostTable, transaction_metadata::TransactionMetadata};
+use vm_cache_map::Arena;
+use vm_runtime_types::value::Value;
+
+rental! {
+    mod move_vm_definition {
+        use super::*;
+
+        #[rental]
+        pub struct MoveVMImpl {
+            alloc: Box<Arena<LoadedModule>>,
+            runtime: VMRuntime<'alloc>,
+        }
+    }
+}
+
+pub struct MoveVM(MoveVMImpl);
+
+impl MoveVM {
+    pub fn new(config: &VMConfig) -> Self {
+        MoveVM(MoveVMImpl::new(Box::new(Arena::new()), |arena| {
+            VMRuntime::new(&*arena, config)
+        }))
+    }
+
+    // API for temporal backward compatibility. Will get rid of it later with the following three
+    // api.
+    pub fn execute_runtime<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&VMRuntime) -> T,
+    {
+        self.0.rent(|runtime| f(runtime))
+    }
+
+    #[allow(unused)]
+    pub fn execute_function<S: ChainState>(
+        &self,
+        module: &ModuleId,
+        function_name: &IdentStr,
+        gas_schedule: &CostTable,
+        state_view: &dyn StateView,
+        chain_state: &mut S,
+        txn_data: &TransactionMetadata,
+        args: Vec<Value>,
+    ) -> VMResult<()> {
+        self.0.rent(|runtime| {
+            runtime.execute_function(
+                state_view,
+                chain_state,
+                txn_data,
+                gas_schedule,
+                module,
+                function_name,
+                args,
+            )
+        })
+    }
+
+    #[allow(unused)]
+    pub fn execute_script<S: ChainState>(
+        &self,
+        script: Vec<u8>,
+        gas_schedule: &CostTable,
+        state_view: &dyn StateView,
+        chain_state: &mut S,
+        txn_data: &TransactionMetadata,
+        args: Vec<Value>,
+    ) -> VMResult<()> {
+        self.0.rent(|runtime| {
+            runtime.execute_script(
+                state_view,
+                chain_state,
+                txn_data,
+                gas_schedule,
+                script,
+                args,
+            )
+        })
+    }
+
+    #[allow(unused)]
+    pub fn publish_module<S: ChainState>(
+        &self,
+        module: Vec<u8>,
+        chain_state: &mut S,
+        txn_data: &TransactionMetadata,
+    ) -> VMResult<()> {
+        self.0
+            .rent(|runtime| runtime.publish_module(&module, chain_state, txn_data))
+            .map(|_| ())
+    }
+}

--- a/language/vm/vm-runtime/src/runtime.rs
+++ b/language/vm/vm-runtime/src/runtime.rs
@@ -77,10 +77,8 @@ impl<'alloc> VMRuntime<'alloc> {
     pub(crate) fn publish_module(
         &self,
         module: &[u8],
-        _state_view: &dyn StateView,
         context: &mut dyn InterpreterContext,
         txn_data: &TransactionMetadata,
-        _gas_schedule: &CostTable,
     ) -> VMResult<ModuleId> {
         let compiled_module = match CompiledModule::deserialize(module) {
             Ok(module) => module,

--- a/language/vm/vm-runtime/src/txn_executor.rs
+++ b/language/vm/vm-runtime/src/txn_executor.rs
@@ -3,9 +3,9 @@
 //! Processor for a single transaction.
 
 use crate::{
+    chain_state::TransactionExecutionContext,
     counters::*,
     data_cache::{BlockDataCache, RemoteCache},
-    execution_context::TransactionExecutionContext,
     runtime::VMRuntime,
 };
 use bytecode_verifier::VerifiedModule;
@@ -195,15 +195,9 @@ impl<'txn> TransactionExecutor<'txn> {
         &mut self,
         module: &[u8],
         runtime: &VMRuntime,
-        state_view: &dyn StateView,
+        _state_view: &dyn StateView,
     ) -> VMResult<ModuleId> {
-        runtime.publish_module(
-            module,
-            state_view,
-            &mut self.interpreter_context,
-            &self.txn_data,
-            self.gas_schedule,
-        )
+        runtime.publish_module(module, &mut self.interpreter_context, &self.txn_data)
     }
 
     /// Execute a function with the sender set to `sender`, restoring the original sender afterward.

--- a/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
@@ -8,7 +8,7 @@ use crate::{
         module_cache::{BlockModuleCache, ModuleCache, VMModuleCache},
     },
     data_cache::BlockDataCache,
-    execution_context::TransactionExecutionContext,
+    chain_state::TransactionExecutionContext,
     loaded_data::{
         function::{FunctionRef, FunctionReference},
         loaded_module::LoadedModule,

--- a/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
+++ b/language/vm/vm-runtime/src/unit_tests/module_cache_tests.rs
@@ -3,12 +3,12 @@
 
 use super::*;
 use crate::{
+    chain_state::TransactionExecutionContext,
     code_cache::{
         module_adapter::FakeFetcher,
         module_cache::{BlockModuleCache, ModuleCache, VMModuleCache},
     },
     data_cache::BlockDataCache,
-    chain_state::TransactionExecutionContext,
     loaded_data::{
         function::{FunctionRef, FunctionReference},
         loaded_module::LoadedModule,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is the follow up cleanup for #1946. The goal here is to have a clear separation between Move, the language runtime and the Libra transaction logic. This PR will create an entry point for wrapping the logic for the Move language runtime.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

cargo test
## Related PRs

#1946 
