### PR TITLE
add Clone trait bound to TransactionValidation to remove explicit Clone in SharedMempool

### DIFF
--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -55,6 +55,7 @@ pub enum SharedMempoolNotification {
 }
 
 /// Struct that owns all dependencies required by shared mempool routines
+#[derive(Clone)]
 struct SharedMempool<V>
 where
     V: TransactionValidation + 'static,
@@ -66,25 +67,6 @@ where
     validator: Arc<V>,
     peer_info: Arc<Mutex<PeerInfo>>,
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
-}
-
-// TODO(gzh): Cannot derive `Clone`.
-// Issue: https://github.com/rust-lang/rust/issues/26925
-impl<V> Clone for SharedMempool<V>
-where
-    V: TransactionValidation + 'static,
-{
-    fn clone(&self) -> Self {
-        Self {
-            mempool: Arc::clone(&self.mempool),
-            network_sender: self.network_sender.clone(),
-            config: self.config.clone(),
-            storage_read_client: Arc::clone(&self.storage_read_client),
-            validator: Arc::clone(&self.validator),
-            peer_info: self.peer_info.clone(),
-            subscribers: self.subscribers.clone(),
-        }
-    }
 }
 
 fn notify_subscribers(

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -20,7 +20,7 @@ use vm_runtime::{LibraVM, VMVerifier};
 #[path = "unit_tests/vm_validator_test.rs"]
 mod vm_validator_test;
 
-pub trait TransactionValidation: Send + Sync {
+pub trait TransactionValidation: Send + Sync + Clone {
     type ValidationInstance: VMVerifier;
     /// Validate a txn from client
     fn validate_transaction(


### PR DESCRIPTION
## Summary

Adding Clone trait bound to `TransactionValidation` to remove explicit `Clone` derivation for `SharedMempool`

## Test Plan

Existing tests pass
