### PR TITLE
[cluster-test] Install awscli

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -17,8 +17,7 @@ fi
 
 mkdir -p /opt/libra
 
-# No longer needed
-# yum -y install awscli
+yum -y install awscli
 
 echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config
 systemctl try-restart ecs --no-block


### PR DESCRIPTION
One of previous commits removed installing awscli from cluster-test runner.
We need it actually, so putting it back

Since we have single ec2_user_data.sh for all instances, this will mean installing awscli on all hosts, which should not be big deal(it was there before)
