### PR TITLE
[disassembler] Fix disassembly of direct instantiations of structs

### DIFF
--- a/language/compiler/bytecode-source-map/src/disassembler.rs
+++ b/language/compiler/bytecode-source-map/src/disassembler.rs
@@ -250,16 +250,24 @@ impl<Location: Clone + Eq + Default> Disassembler<Location> {
             SignatureToken::String => "string".to_string(),
             SignatureToken::ByteArray => "bytearray".to_string(),
             SignatureToken::Address => "address".to_string(),
-            SignatureToken::Struct(struct_handle_idx, _) => self
-                .source_mapper
-                .bytecode
-                .identifier_at(
-                    self.source_mapper
-                        .bytecode
-                        .struct_handle_at(struct_handle_idx)
-                        .name,
-                )
-                .to_string(),
+            SignatureToken::Struct(struct_handle_idx, instantiation) => {
+                let instantiation = instantiation
+                    .into_iter()
+                    .map(|tok| self.disassemble_sig_tok(tok, type_param_context))
+                    .collect::<Result<Vec<_>>>()?;
+                let formatted_instantiation = Self::format_type_params(&instantiation);
+                let name = self
+                    .source_mapper
+                    .bytecode
+                    .identifier_at(
+                        self.source_mapper
+                            .bytecode
+                            .struct_handle_at(struct_handle_idx)
+                            .name,
+                    )
+                    .to_string();
+                format!("{}{}", name, formatted_instantiation)
+            }
             SignatureToken::Reference(sig_tok) => format!(
                 "&{}",
                 self.disassemble_sig_tok(*sig_tok, type_param_context)?


### PR DESCRIPTION
Previously, we didn't print the instantiation for structs with generics.
This fixes this issue.

For example, this code: 
```rust
module M {
    struct S<T> {
        x: T,
    }
    struct A {
        a: Self.S<u64>,
    }
    bar<T>() {
      return;
    }
    foo() {
        Self.bar<u64>();
        return;
    }
}
```

## Previously:
```
module 00000000.M {
struct S<Ty0: All> {
        x: Ty0
}
struct A {
        a: S
}

bar<Ty0: All>() {
B0:
        0: Ret
}
foo() {
B0:
        0: Call[0](bar<u64>())
        1: Ret
}
}
```

## Now
```
module 00000000.M {
struct S<Ty0: All> {
        x: Ty0
}
struct A {
        a: S<u64>
}

bar<Ty0: All>() {
B0:
        0: Ret
}
foo() {
B0:
        0: Call[0](bar<u64>())
        1: Ret
}
}
```