### PR TITLE
[cluster-test] Mount datadir to /opt/libra/etc/libradb/db

### DIFF
--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -16,7 +16,7 @@
             {"containerPort": 6191, "hostPort": 6191}
         ],
         "mountPoints": [
-            {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
+            {"sourceVolume": "libra-data", "containerPath": "/opt/libra/etc/libradb/db"}
         ],
         "environment": [
             %{ if cfg_upstream_node_index != "" }

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -174,7 +174,7 @@ variable "log_to_file" {
 }
 
 locals {
-  validator_command = var.log_to_file ? jsonencode(["bash", "-c", "/docker-run-dynamic.sh >> /opt/libra/data/libra.log 2>&1"]) : ""
+  validator_command = var.log_to_file ? jsonencode(["bash", "-c", "/docker-run-dynamic.sh >> /opt/libra/etc/libradb/db/libra.log 2>&1"]) : ""
 }
 
 data "template_file" "ecs_task_definition" {


### PR DESCRIPTION
## Summary

Temporary fix to enable libra-node to write logs and rocksdb data to the `/data` directory on the host

The config currently hardcodes the storage directory to `/opt/libra/etc/libradb/db`, so here we mount `/data` from host into `/opt/libra/etc/libradb/db` on the container. We also change the location of the libra.log inside the container, but it stays on `/data` directory on the host

## Test Plan

`terraform apply`