### PR TITLE
[language][move] Minor reformatting of parser error messages

### DIFF
--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -163,9 +163,8 @@ fn check_errors(errors: Errors) -> Result<(), Errors> {
 //**************************************************************************************************
 
 fn parsing_error(fname: &'static str, e: ParseError) -> Error {
-    let fmt_expected = |expected: Vec<String>| -> String {
-        format!("Expected: {}", expected.join(", "))
-    };
+    let fmt_expected =
+        |expected: Vec<String>| -> String { format!("Expected: {}", expected.join(", ")) };
     match e {
         ParseError::InvalidToken { location: l } => {
             let span = Span::new(ByteIndex(l as u32), ByteIndex(l as u32));

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -164,9 +164,7 @@ fn check_errors(errors: Errors) -> Result<(), Errors> {
 
 fn parsing_error(fname: &'static str, e: ParseError) -> Error {
     let fmt_expected = |expected: Vec<String>| -> String {
-        // FIXME: Remove extra space after "Expected:" that was inserted to match the
-        // old parser and minimize test changes during the transition.
-        format!("Expected:  {}", expected.join(", "))
+        format!("Expected: {}", expected.join(", "))
     };
     match e {
         ParseError::InvalidToken { location: l } => {
@@ -183,7 +181,7 @@ fn parsing_error(fname: &'static str, e: ParseError) -> Error {
             let span = Span::new(ByteIndex(l as u32), ByteIndex(end_loc as u32));
             let loc = Loc::new(fname, span);
             vec![
-                (loc, format!("Unrecognized Token: {}", actual)),
+                (loc, format!("Unexpected token: '{}'", actual)),
                 (loc, fmt_expected(expected)),
             ]
         }

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -44,7 +44,7 @@ macro_rules! token_match {
             $($p => {{ $e_p }},)*
             _ => {{
                 let mut v = vec![];
-                $(v.push(format!("\"{}\"", $p.to_string()));)*
+                $(v.push(format!("'{}'", $p.to_string()));)*
                 return Err(ParseError::UnrecognizedToken {
                     location: $loc,
                     actual: $actual,
@@ -75,7 +75,7 @@ fn consume_token<'input>(tokens: &mut Lexer<'input>, tok: Tok) -> Result<(), Par
         return Err(ParseError::UnrecognizedToken {
             location: tokens.start_loc(),
             actual: tokens.content().to_string(),
-            expected: vec![format!("\"{}\"", tok.to_string())],
+            expected: vec![format!("'{}'", tok.to_string())],
         });
     }
     tokens.advance()?;

--- a/language/move-lang/tests/move_check/expansion/global_access_pack.exp
+++ b/language/move-lang/tests/move_check/expansion/global_access_pack.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/global_access_pack.move:3:13 ───
    │
  3 │         ::S { }
-   │             ^ Unrecognized Token: {
+   │             ^ Unexpected token: '{'
    ·
  3 │         ::S { }
-   │             - Expected:  "("
+   │             - Expected: '('
    │
 

--- a/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_not_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_not_name.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/invalid_unpack_assign_lhs_not_name.move:4:11 ───
    │
  4 │         0 { f } = 0;
-   │           ^ Unrecognized Token: {
+   │           ^ Unexpected token: '{'
    ·
  4 │         0 { f } = 0;
-   │           - Expected:  ";"
+   │           - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.move:3:11 ───
    │
  3 │         0 {} = 0;
-   │           ^ Unrecognized Token: {
+   │           ^ Unexpected token: '{'
    ·
  3 │         0 {} = 0;
-   │           - Expected:  ";"
+   │           - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/mdot_with_non_address_exp.exp
+++ b/language/move-lang/tests/move_check/expansion/mdot_with_non_address_exp.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/mdot_with_non_address_exp.move:9:11 ───
    │
  9 │         01::X::bar()
-   │           ^^ Unrecognized Token: ::
+   │           ^^ Unexpected token: '::'
    ·
  9 │         01::X::bar()
-   │           -- Expected:  ";"
+   │           -- Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_block_expr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/pack_no_fields_block_expr.move:4:21 ───
    │
  4 │         let s = S { let x = 0; x };
-   │                     ^^^ Unrecognized Token: let
+   │                     ^^^ Unexpected token: 'let'
    ·
  4 │         let s = S { let x = 0; x };
-   │                     --- Expected:  a name value
+   │                     --- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/pack_no_fields_single_block_expr.move:4:21 ───
    │
  4 │         let s = S { false };
-   │                     ^^^^^ Unrecognized Token: false
+   │                     ^^^^^ Unexpected token: 'false'
    ·
  4 │         let s = S { false };
-   │                     ----- Expected:  a name value
+   │                     ----- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/pack_no_fields_single_block_other_expr.move:6:19 ───
    │
  6 │         let s = S 0;
-   │                   ^ Unrecognized Token: 0
+   │                   ^ Unexpected token: '0'
    ·
  6 │         let s = S 0;
-   │                   - Expected:  ";"
+   │                   - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_fields.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_fields.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/standalone_fields.move:3:11 ───
    │
  3 │         {f: 1, g: 0};
-   │           ^ Unrecognized Token: :
+   │           ^ Unexpected token: ':'
    ·
  3 │         {f: 1, g: 0};
-   │           - Expected:  ";"
+   │           - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/standalone_mname_with_type_args.move:3:27 ───
    │
  3 │         let _ = 0 + M<u64>;
-   │                           ^ Unrecognized Token: ;
+   │                           ^ Unexpected token: ';'
    ·
  3 │         let _ = 0 + M<u64>;
-   │                           - Expected:  "{", "("
+   │                           - Expected: '{', '('
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/standalone_name_with_type_args.move:3:23 ───
    │
  3 │         let _ = n<u64>;
-   │                       ^ Unrecognized Token: ;
+   │                       ^ Unexpected token: ';'
    ·
  3 │         let _ = n<u64>;
-   │                       - Expected:  "{", "("
+   │                       - Expected: '{', '('
    │
 

--- a/language/move-lang/tests/move_check/expansion/type_arguments_on_field_access.exp
+++ b/language/move-lang/tests/move_check/expansion/type_arguments_on_field_access.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/type_arguments_on_field_access.move:6:11 ───
    │
  6 │         x.f<u64>;
-   │           ^^ Unrecognized Token: f<
+   │           ^^ Unexpected token: 'f<'
    ·
  6 │         x.f<u64>;
-   │           -- Expected:  a name value
+   │           -- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_block_expr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/unpack_assign_block_expr.move:4:13 ───
    │
  4 │         S { let f = 0; } = S { f: 0 };
-   │             ^^^ Unrecognized Token: let
+   │             ^^^ Unexpected token: 'let'
    ·
  4 │         S { let f = 0; } = S { f: 0 };
-   │             --- Expected:  a name value
+   │             --- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_block_single_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_block_single_expr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/unpack_assign_block_single_expr.move:4:13 ───
    │
  4 │         S { 0 } = S { f: 0 };
-   │             ^ Unrecognized Token: 0
+   │             ^ Unexpected token: '0'
    ·
  4 │         S { 0 } = S { f: 0 };
-   │             - Expected:  a name value
+   │             - Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_other_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_other_expr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/unpack_assign_other_expr.move:9:11 ───
    │
  9 │         S f = S { f: 0 };
-   │           ^ Unrecognized Token: f
+   │           ^ Unexpected token: 'f'
    ·
  9 │         S f = S { f: 0 };
-   │           - Expected:  ";"
+   │           - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/weird_apply_assign.exp
+++ b/language/move-lang/tests/move_check/expansion/weird_apply_assign.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/expansion/weird_apply_assign.move:7:11 ───
    │
  7 │         S f = S { f: 0 };
-   │           ^ Unrecognized Token: f
+   │           ^ Unexpected token: 'f'
    ·
  7 │         S f = S { f: 0 };
-   │           - Expected:  ";"
+   │           - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/naming/standalone_module_ident.exp
+++ b/language/move-lang/tests/move_check/naming/standalone_module_ident.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/naming/standalone_module_ident.move:9:23 ───
    │
  9 │         let x = 0x1::X;
-   │                       ^ Unrecognized Token: ;
+   │                       ^ Unexpected token: ';'
    ·
  9 │         let x = 0x1::X;
-   │                       - Expected:  "::"
+   │                       - Expected: '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/address_not_hex.exp
+++ b/language/move-lang/tests/move_check/parser/address_not_hex.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/address_not_hex.move:1:9 ───
    │
  1 │ address 1:
-   │         ^ Unrecognized Token: 1
+   │         ^ Unexpected token: '1'
    ·
  1 │ address 1:
-   │         - Expected:  "("
+   │         - Expected: '('
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_abort_braces.exp
+++ b/language/move-lang/tests/move_check/parser/expr_abort_braces.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_abort_braces.move:4:15 ───
    │
  4 │         abort if (v == 0) 10 else v
-   │               ^^ Unrecognized Token: if
+   │               ^^ Unexpected token: 'if'
    ·
  4 │         abort if (v == 0) 10 else v
-   │               -- Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │               -- Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_abort_missing_value.exp
+++ b/language/move-lang/tests/move_check/parser/expr_abort_missing_value.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_abort_missing_value.move:5:5 ───
    │
  5 │     }
-   │     ^ Unrecognized Token: }
+   │     ^ Unexpected token: '}'
    ·
  5 │     }
-   │     - Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │     - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_if_braces.exp
+++ b/language/move-lang/tests/move_check/parser/expr_if_braces.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_if_braces.move:4:19 ───
    │
  4 │         if (cond) if (cond) ()
-   │                   ^^ Unrecognized Token: if
+   │                   ^^ Unexpected token: 'if'
    ·
  4 │         if (cond) if (cond) ()
-   │                   -- Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │                   -- Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_if_missing_parens.exp
+++ b/language/move-lang/tests/move_check/parser/expr_if_missing_parens.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_if_missing_parens.move:4:12 ───
    │
  4 │         if v < 3 ()
-   │            ^ Unrecognized Token: v
+   │            ^ Unexpected token: 'v'
    ·
  4 │         if v < 3 ()
-   │            - Expected:  "("
+   │            - Expected: '('
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_loop_braces.exp
+++ b/language/move-lang/tests/move_check/parser/expr_loop_braces.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_loop_braces.move:4:14 ───
    │
  4 │         loop if (v < 10) break
-   │              ^^ Unrecognized Token: if
+   │              ^^ Unexpected token: 'if'
    ·
  4 │         loop if (v < 10) break
-   │              -- Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │              -- Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_return_braces.exp
+++ b/language/move-lang/tests/move_check/parser/expr_return_braces.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_return_braces.move:4:16 ───
    │
  4 │         return if (v > 10) 10 else v
-   │                ^^ Unrecognized Token: if
+   │                ^^ Unexpected token: 'if'
    ·
  4 │         return if (v > 10) 10 else v
-   │                -- Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │                -- Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_return_missing_value.exp
+++ b/language/move-lang/tests/move_check/parser/expr_return_missing_value.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_return_missing_value.move:5:5 ───
    │
  5 │     }
-   │     ^ Unrecognized Token: }
+   │     ^ Unexpected token: '}'
    ·
  5 │     }
-   │     - Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │     - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_while_braces.exp
+++ b/language/move-lang/tests/move_check/parser/expr_while_braces.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_while_braces.move:4:26 ───
    │
  4 │         while (v < 10) v = v + 1
-   │                          ^ Unrecognized Token: =
+   │                          ^ Unexpected token: '='
    ·
  4 │         while (v < 10) v = v + 1
-   │                          - Expected:  ";"
+   │                          - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_while_missing_parens.exp
+++ b/language/move-lang/tests/move_check/parser/expr_while_missing_parens.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/expr_while_missing_parens.move:4:15 ───
    │
  4 │         while v < 3 { v = v + 1 }
-   │               ^ Unrecognized Token: v
+   │               ^ Unexpected token: 'v'
    ·
  4 │         while v < 3 { v = v + 1 }
-   │               - Expected:  "("
+   │               - Expected: '('
    │
 

--- a/language/move-lang/tests/move_check/parser/extra_text_after_main.exp
+++ b/language/move-lang/tests/move_check/parser/extra_text_after_main.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/extra_text_after_main.move:5:1 ───
    │
  5 │ foo() {
-   │ ^^^ Unrecognized Token: foo
+   │ ^^^ Unexpected token: 'foo'
    ·
  5 │ foo() {
-   │ --- Expected:  
+   │ --- Expected: 
    │
 

--- a/language/move-lang/tests/move_check/parser/function_acquires_missing_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_acquires_missing_comma.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_acquires_missing_comma.move:5:21 ───
    │
  5 │     f() acquires X1 X2 {
-   │                     ^^ Unrecognized Token: X2
+   │                     ^^ Unexpected token: 'X2'
    ·
  5 │     f() acquires X1 X2 {
-   │                     -- Expected:  "{"
+   │                     -- Expected: '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_acquires_trailing_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_acquires_trailing_comma.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_acquires_trailing_comma.move:4:21 ───
    │
  4 │     f() acquires X, {
-   │                     ^ Unrecognized Token: {
+   │                     ^ Unexpected token: '{'
    ·
  4 │     f() acquires X, {
-   │                     - Expected:  "[Name]", "[Name<Types>]", "[Address]"
+   │                     - Expected: '[Name]', '[Name<Types>]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_incomplete.exp
+++ b/language/move-lang/tests/move_check/parser/function_incomplete.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_incomplete.move:3:1 ───
    │
  3 │ 
-   │ ^ Unrecognized Token: 
+   │ ^ Unexpected token: ''
    ·
  3 │ 
-   │ - Expected:  "move", "copy", "break", "continue", "[Name]", "[Name<Types>]", "[Address]", "true", "false", "[U64]", "(", "{", "::"
+   │ - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_native_with_body.exp
+++ b/language/move-lang/tests/move_check/parser/function_native_with_body.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_native_with_body.move:3:17 ───
    │
  3 │     native fn() {}
-   │                 ^ Unrecognized Token: {
+   │                 ^ Unexpected token: '{'
    ·
  3 │     native fn() {}
-   │                 - Expected:  ";"
+   │                 - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_params_missing.exp
+++ b/language/move-lang/tests/move_check/parser/function_params_missing.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_params_missing.move:3:8 ───
    │
  3 │     fn { }
-   │        ^ Unrecognized Token: {
+   │        ^ Unexpected token: '{'
    ·
  3 │     fn { }
-   │        - Expected:  "("
+   │        - Expected: '('
    │
 

--- a/language/move-lang/tests/move_check/parser/function_public_native.exp
+++ b/language/move-lang/tests/move_check/parser/function_public_native.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_public_native.move:3:12 ───
    │
  3 │     public native f();
-   │            ^^^^^^ Unrecognized Token: native
+   │            ^^^^^^ Unexpected token: 'native'
    ·
  3 │     public native f();
-   │            ------ Expected:  a name value
+   │            ------ Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/function_return_trailing_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_return_trailing_comma.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_return_trailing_comma.move:3:20 ───
    │
  3 │     f(): (u64, u64,) { (1, 2) }
-   │                    ^ Unrecognized Token: )
+   │                    ^ Unexpected token: ')'
    ·
  3 │     f(): (u64, u64,) { (1, 2) }
-   │                    - Expected:  "[Name]", "[Name<Types>]", "[Address]"
+   │                    - Expected: '[Name]', '[Name<Types>]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_return_type_missing.exp
+++ b/language/move-lang/tests/move_check/parser/function_return_type_missing.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_return_type_missing.move:3:10 ───
    │
  3 │     f(): { }
-   │          ^ Unrecognized Token: {
+   │          ^ Unexpected token: '{'
    ·
  3 │     f(): { }
-   │          - Expected:  "[Name]", "[Name<Types>]", "[Address]"
+   │          - Expected: '[Name]', '[Name<Types>]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_type_extra_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_type_extra_comma.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_type_extra_comma.move:2:8 ───
    │
  2 │     fn<,T>() { }
-   │        ^ Unrecognized Token: ,
+   │        ^ Unexpected token: ','
    ·
  2 │     fn<,T>() { }
-   │        - Expected:  a name value
+   │        - Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/function_type_missing_angle.exp
+++ b/language/move-lang/tests/move_check/parser/function_type_missing_angle.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_type_missing_angle.move:3:15 ───
    │
  3 │     fn<T1, T2 () { }
-   │               ^ Unrecognized Token: (
+   │               ^ Unexpected token: '('
    ·
  3 │     fn<T1, T2 () { }
-   │               - Expected:  ","
+   │               - Expected: ','
    │
 

--- a/language/move-lang/tests/move_check/parser/function_without_body.exp
+++ b/language/move-lang/tests/move_check/parser/function_without_body.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/function_without_body.move:3:9 ───
    │
  3 │     fn();
-   │         ^ Unrecognized Token: ;
+   │         ^ Unexpected token: ';'
    ·
  3 │     fn();
-   │         - Expected:  "{"
+   │         - Expected: '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_complex_expression.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_complex_expression.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_complex_expression.move:3:29 ───
    │
  3 │         (if (true) 5 else 0)();
-   │                             ^ Unrecognized Token: (
+   │                             ^ Unexpected token: '('
    ·
  3 │         (if (true) 5 else 0)();
-   │                             - Expected:  ";"
+   │                             - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_parens_around_name.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_parens_around_name.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_parens_around_name.move:3:14 ───
    │
  3 │         (foo)()
-   │              ^ Unrecognized Token: (
+   │              ^ Unexpected token: '('
    ·
  3 │         (foo)()
-   │              - Expected:  ";"
+   │              - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_return.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_return.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_return.move:3:20 ───
    │
  3 │         (return ())(0, 1);
-   │                    ^ Unrecognized Token: (
+   │                    ^ Unexpected token: '('
    ·
  3 │         (return ())(0, 1);
-   │                    - Expected:  ";"
+   │                    - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_value.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_value.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_value.move:3:10 ───
    │
  3 │         5();
-   │          ^ Unrecognized Token: (
+   │          ^ Unexpected token: '('
    ·
  3 │         5();
-   │          - Expected:  ";"
+   │          - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_pack_mname_non_addr.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_pack_mname_non_addr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/invalid_pack_mname_non_addr.move:4:14 ───
    │
  4 │         false::M::S { }
-   │              ^^ Unrecognized Token: ::
+   │              ^^ Unexpected token: '::'
    ·
  4 │         false::M::S { }
-   │              -- Expected:  ";"
+   │              -- Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.move:4:14 ───
    │
  4 │         false::M { f } = 0;
-   │              ^^ Unrecognized Token: ::
+   │              ^^ Unexpected token: '::'
    ·
  4 │         false::M { f } = 0;
-   │              -- Expected:  ";"
+   │              -- Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
@@ -3,9 +3,9 @@ error:
     ┌── tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.move:11:14 ───
     │
  11 │         X::S 0 = 0;
-    │              ^ Unrecognized Token: 0
+    │              ^ Unexpected token: '0'
     ·
  11 │         X::S 0 = 0;
-    │              - Expected:  "{", "("
+    │              - Expected: '{', '('
     │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_fields.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_fields.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/let_binding_missing_fields.move:6:26 ───
    │
  6 │         let Generic<u64> = g;
-   │                          ^ Unrecognized Token: =
+   │                          ^ Unexpected token: '='
    ·
  6 │         let Generic<u64> = g;
-   │                          - Expected:  "{"
+   │                          - Expected: '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/let_binding_missing_paren.move:3:21 ───
    │
  3 │         let (x1, x2 = (1, 2);
-   │                     ^ Unrecognized Token: =
+   │                     ^ Unexpected token: '='
    ·
  3 │         let (x1, x2 = (1, 2);
-   │                     - Expected:  ","
+   │                     - Expected: ','
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/let_binding_missing_type.move:3:17 ───
    │
  3 │         let x : = 0;
-   │                 ^ Unrecognized Token: =
+   │                 ^ Unexpected token: '='
    ·
  3 │         let x : = 0;
-   │                 - Expected:  "[Name]", "[Name<Types>]", "[Address]"
+   │                 - Expected: '[Name]', '[Name<Types>]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_trailing_comma.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_trailing_comma.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/let_binding_trailing_comma.move:3:21 ───
    │
  3 │         let (x1, x2,) = (1, 2);
-   │                     ^ Unrecognized Token: )
+   │                     ^ Unexpected token: ')'
    ·
  3 │         let (x1, x2,) = (1, 2);
-   │                     - Expected:  "[Name]", "[Name<Types>]", "[Address]"
+   │                     - Expected: '[Name]', '[Name<Types>]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/parser/module_missing_lbrace.exp
+++ b/language/move-lang/tests/move_check/parser/module_missing_lbrace.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/module_missing_lbrace.move:2:5 ───
    │
  2 │     f() {}
-   │     ^ Unrecognized Token: f
+   │     ^ Unexpected token: 'f'
    ·
  2 │     f() {}
-   │     - Expected:  "{"
+   │     - Expected: '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/module_missing_rbrace.exp
+++ b/language/move-lang/tests/move_check/parser/module_missing_rbrace.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/module_missing_rbrace.move:4:1 ───
    │
  4 │ 
-   │ ^ Unrecognized Token: 
+   │ ^ Unexpected token: ''
    ·
  4 │ 
-   │ - Expected:  a name value
+   │ - Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/module_struct_after_func.exp
+++ b/language/move-lang/tests/move_check/parser/module_struct_after_func.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/module_struct_after_func.move:4:5 ───
    │
  4 │     struct S {}
-   │     ^^^^^^ Unrecognized Token: struct
+   │     ^^^^^^ Unexpected token: 'struct'
    ·
  4 │     struct S {}
-   │     ------ Expected:  a name value
+   │     ------ Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/module_use_after_func.exp
+++ b/language/move-lang/tests/move_check/parser/module_use_after_func.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/module_use_after_func.move:4:5 ───
    │
  4 │     use 0x1::X;
-   │     ^^^ Unrecognized Token: use
+   │     ^^^ Unexpected token: 'use'
    ·
  4 │     use 0x1::X;
-   │     --- Expected:  a name value
+   │     --- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/module_use_after_struct.exp
+++ b/language/move-lang/tests/move_check/parser/module_use_after_struct.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/module_use_after_struct.move:4:5 ───
    │
  4 │     use 0x1::X;
-   │     ^^^ Unrecognized Token: use
+   │     ^^^ Unexpected token: 'use'
    ·
  4 │     use 0x1::X;
-   │     --- Expected:  a name value
+   │     --- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_field_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/struct_field_missing_type.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_field_missing_type.move:2:18 ───
    │
  2 │     struct S { f }
-   │                  ^ Unrecognized Token: }
+   │                  ^ Unexpected token: '}'
    ·
  2 │     struct S { f }
-   │                  - Expected:  ":"
+   │                  - Expected: ':'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
+++ b/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_missing_lbrace.move:3:5 ───
    │
  3 │     f() {}
-   │     ^ Unrecognized Token: f
+   │     ^ Unexpected token: 'f'
    ·
  3 │     f() {}
-   │     - Expected:  ","
+   │     - Expected: ','
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_native_missing_semicolon.exp
+++ b/language/move-lang/tests/move_check/parser/struct_native_missing_semicolon.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_native_missing_semicolon.move:3:1 ───
    │
  3 │ }
-   │ ^ Unrecognized Token: }
+   │ ^ Unexpected token: '}'
    ·
  3 │ }
-   │ - Expected:  ";"
+   │ - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_native_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_native_resource.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_native_resource.move:3:14 ───
    │
  3 │     resource native struct S;
-   │              ^^^^^^ Unrecognized Token: native
+   │              ^^^^^^ Unexpected token: 'native'
    ·
  3 │     resource native struct S;
-   │              ------ Expected:  "struct"
+   │              ------ Expected: 'struct'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_native_with_fields.exp
+++ b/language/move-lang/tests/move_check/parser/struct_native_with_fields.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_native_with_fields.move:3:21 ───
    │
  3 │     native struct S { f: u64 }
-   │                     ^ Unrecognized Token: {
+   │                     ^ Unexpected token: '{'
    ·
  3 │     native struct S { f: u64 }
-   │                     - Expected:  ";"
+   │                     - Expected: ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_resource.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_resource.move:3:12 ───
    │
  3 │     struct resource S { }
-   │            ^^^^^^^^ Unrecognized Token: resource
+   │            ^^^^^^^^ Unexpected token: 'resource'
    ·
  3 │     struct resource S { }
-   │            -------- Expected:  a name value
+   │            -------- Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_copyable.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_copyable.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_type_copyable.move:3:17 ───
    │
  3 │     struct S<T: copy> { }
-   │                 ^^^^ Unrecognized Token: copy
+   │                 ^^^^ Unexpected token: 'copy'
    ·
  3 │     struct S<T: copy> { }
-   │                 ---- Expected:  "copyable", "resource"
+   │                 ---- Expected: 'copyable', 'resource'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_extra_comma.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_extra_comma.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_type_extra_comma.move:2:14 ───
    │
  2 │     struct S<,T> { }
-   │              ^ Unrecognized Token: ,
+   │              ^ Unexpected token: ','
    ·
  2 │     struct S<,T> { }
-   │              - Expected:  a name value
+   │              - Expected: a name value
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_missing_angle.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_missing_angle.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_type_missing_angle.move:3:21 ───
    │
  3 │     struct S<T1, T2 { }
-   │                     ^ Unrecognized Token: {
+   │                     ^ Unexpected token: '{'
    ·
  3 │     struct S<T1, T2 { }
-   │                     - Expected:  ","
+   │                     - Expected: ','
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_resource.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_type_resource.move:3:17 ───
    │
  3 │     struct S<T: res> { }
-   │                 ^^^ Unrecognized Token: res
+   │                 ^^^ Unexpected token: 'res'
    ·
  3 │     struct S<T: res> { }
-   │                 --- Expected:  "copyable", "resource"
+   │                 --- Expected: 'copyable', 'resource'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_without_fields.exp
+++ b/language/move-lang/tests/move_check/parser/struct_without_fields.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/struct_without_fields.move:3:13 ───
    │
  3 │     struct S;
-   │             ^ Unrecognized Token: ;
+   │             ^ Unexpected token: ';'
    ·
  3 │     struct S;
-   │             - Expected:  "{"
+   │             - Expected: '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/use_with_address.exp
+++ b/language/move-lang/tests/move_check/parser/use_with_address.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/use_with_address.move:3:9 ───
    │
  3 │ address 0x1:
-   │         ^^^ Unrecognized Token: 0x1
+   │         ^^^ Unexpected token: '0x1'
    ·
  3 │ address 0x1:
-   │         --- Expected:  "("
+   │         --- Expected: '('
    │
 

--- a/language/move-lang/tests/move_check/parser/use_with_module.exp
+++ b/language/move-lang/tests/move_check/parser/use_with_module.exp
@@ -3,9 +3,9 @@ error:
    ┌── tests/move_check/parser/use_with_module.move:3:1 ───
    │
  3 │ module M {
-   │ ^^^^^^ Unrecognized Token: module
+   │ ^^^^^^ Unexpected token: 'module'
    ·
  3 │ module M {
-   │ ------ Expected:  a name value
+   │ ------ Expected: a name value
    │
 


### PR DESCRIPTION
When converting from lalrpop, I tried to minimize the difference in the parser error messages, but now that we have switched to the new parser, I would like to make a few changes:

- Remove extra blank space after "Expected:" and before the list of expected tokens.

- Report UnrecognizedToken errors as "Unexpected token". These tokens are recognized perfectly well -- these problems occur when the tokens are not expected in a particular context. The message should reflect that.

- Use single quotes for tokens. The old parser used no quotes at all for UnrecognizedToken errors, and it used double quotes for the list of expected tokens. Other parts of the move-lang compiler use single quotes, and we should be consistent.

Note that I am still hoping to quickly make more substantive improvements in error messages, so these quick cleanups are just the first step.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests updated and confirmed that they pass.