### PR TITLE
[language] remove string from the ir parser and compiler

### DIFF
--- a/language/compiler/ir-to-bytecode/src/context.rs
+++ b/language/compiler/ir-to-bytecode/src/context.rs
@@ -23,7 +23,6 @@ use vm::{
         ModuleHandleIndex, SignatureToken, StructDefinitionIndex, StructHandle, StructHandleIndex,
         TableIndex, TypeSignature, TypeSignatureIndex,
     },
-    vm_string::VMString,
 };
 
 type TypeFormalMap = HashMap<TypeVar, TableIndex>;
@@ -151,8 +150,6 @@ pub struct MaterializedPools {
     pub locals_signatures: Vec<LocalsSignature>,
     /// Identifier pool
     pub identifiers: Vec<Identifier>,
-    /// User string pool
-    pub user_strings: Vec<VMString>,
     /// Byte array pool
     pub byte_array_pool: Vec<ByteArray>,
     /// Address pool
@@ -277,8 +274,6 @@ impl<'a> Context<'a> {
             type_signatures: Self::materialize_map(self.type_signatures),
             locals_signatures: Self::materialize_map(self.locals_signatures),
             identifiers: Self::materialize_map(self.identifiers),
-            // TODO: implement support for user strings (string literals)
-            user_strings: vec![],
             byte_array_pool: Self::materialize_map(self.byte_array_pool),
             address_pool: Self::materialize_map(self.address_pool),
         };
@@ -584,9 +579,9 @@ impl<'a> Context<'a> {
         orig: SignatureToken,
     ) -> Result<SignatureToken> {
         Ok(match orig {
+            SignatureToken::String => panic!("strings will be removed"),
             x @ SignatureToken::Bool
             | x @ SignatureToken::U64
-            | x @ SignatureToken::String
             | x @ SignatureToken::ByteArray
             | x @ SignatureToken::Address
             | x @ SignatureToken::TypeParameter(_) => x,

--- a/language/compiler/ir-to-bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/ast.rs
@@ -172,8 +172,6 @@ pub enum Type {
     Bool,
     /// `bytearray`
     ByteArray,
-    /// `string`, currently unused
-    String,
     /// A module defined struct
     Struct(QualifiedStructIdent, Vec<Type>),
     /// A reference type, the bool flag indicates whether the reference is mutable
@@ -453,8 +451,6 @@ pub enum CopyableVal {
     Bool(bool),
     /// `b"<bytes>"`
     ByteArray(ByteArray),
-    /// Not yet supported in the parser
-    String(String),
 }
 
 /// The type of a value and its location
@@ -1328,7 +1324,6 @@ impl fmt::Display for Type {
             Type::Bool => write!(f, "bool"),
             Type::Address => write!(f, "address"),
             Type::ByteArray => write!(f, "bytearray"),
-            Type::String => write!(f, "string"),
             Type::Struct(ident, tys) => write!(f, "{}{}", ident, format_type_actuals(tys)),
             Type::Reference(is_mutable, t) => {
                 write!(f, "&{}{}", if *is_mutable { "mut " } else { "" }, t)
@@ -1499,7 +1494,6 @@ impl fmt::Display for CopyableVal {
             CopyableVal::Bool(v) => write!(f, "{}", v),
             CopyableVal::ByteArray(v) => write!(f, "{}", v),
             CopyableVal::Address(v) => write!(f, "0x{}", hex::encode(&v)),
-            CopyableVal::String(v) => write!(f, "{}", v),
         }
     }
 }


### PR DESCRIPTION
## Summary
This removes the String constructs in the IR parser and compiler, as we've decided to not have a string type any time soon.

## Test Plan
cargo test