### PR TITLE
Improve proptests to reflect that no empty blocks are allowed

### DIFF
--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -10,7 +10,7 @@ use proptest::{collection::vec, prelude::*};
 fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<LedgerInfoWithSignatures>> {
     (
         any_with::<AccountInfoUniverse>(3),
-        vec((any::<LedgerInfoWithSignaturesGen>(), 0..10usize), 1..100),
+        vec((any::<LedgerInfoWithSignaturesGen>(), 1..10usize), 1..100),
     )
         .prop_map(|(mut universe, gens)| {
             gens.into_iter()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Now that we do not have empty blocks and implementation of many components are based on this assumption, we stop generating empty blocks in tests.

Also change the `BlockInfoGen` generation so we create less epoch changes to make the tests closer to real world scenario.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Maybe.

## Test Plan

CI.

## Related PRs

None.