### PR TITLE
Internal storage API for retrieving items without epoch change proofs

### DIFF
--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -32,6 +32,10 @@ service Storage {
     types.UpdateToLatestLedgerRequest)
     returns (types.UpdateToLatestLedgerResponse);
 
+    // Retrieving items without any proofs from storage.
+    // Can be used for non-critical / preliminary requests that with to remain lightweight.
+    rpc RetrieveItems(types.RetrieveItemsRequest) returns (types.RetrieveItemsResponse);
+
     // When we receive a request from a peer validator asking a list of
     // transactions for state synchronization, this API can be used to serve the
     // request. Note that the peer should specify a ledger version and all proofs

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -76,6 +76,14 @@ impl StorageRead for MockStorageReadClient {
         futures::future::ok(ret).boxed()
     }
 
+    fn retrieve_items_async(
+        &self,
+        _request_items: Vec<RequestItem>,
+    ) -> Pin<Box<dyn Future<Output = Result<(Vec<ResponseItem>, LedgerInfoWithSignatures)>> + Send>>
+    {
+        unimplemented!()
+    }
+
     fn get_transactions_async(
         &self,
         _start_version: Version,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -349,6 +349,7 @@ fn query_sequence_numbers(
     let mut result = vec![];
     for addresses_batch in addresses.chunks(MAX_TXN_BATCH_SIZE) {
         let mut update_request = UpdateToLatestLedgerRequest::default();
+        update_request.client_known_version = 1;
         for address in addresses_batch {
             let mut request_item = RequestItem::default();
             let mut account_state_request = GetAccountStateRequest::default();

--- a/types/src/proto/get_with_proof.proto
+++ b/types/src/proto/get_with_proof.proto
@@ -190,6 +190,20 @@ message ResponseItem {
 }
 
 // -----------------------------------------------------------------------------
+// ---------------- Retrieving items without any proofs from storage
+// ---------------- Can be used for non-critical / preliminary requests
+// ---------------- that wish to remain lightweight.
+// -----------------------------------------------------------------------------
+message RetrieveItemsRequest {
+    repeated RequestItem requested_items = 1;
+}
+
+message RetrieveItemsResponse {
+    repeated ResponseItem response_items = 1;
+    LedgerInfoWithSignatures ledger_info_with_sigs = 2;
+}
+
+// -----------------------------------------------------------------------------
 // ---------------- Get account state (balance, sequence number, etc.)
 // -----------------------------------------------------------------------------
 

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -67,11 +67,8 @@ impl TransactionValidation for VMValidator {
         let address = AccountAddress::new([0xff; ADDRESS_LENGTH]);
         let item = RequestItem::GetAccountState { address };
 
-        match self
-            .storage_read_client
-            .update_to_latest_ledger(/* client_known_version = */ 0, vec![item])
-        {
-            Ok((mut items, ledger_info_with_sigs, _, _)) => {
+        match self.storage_read_client.retrieve_items(vec![item]) {
+            Ok((mut items, ledger_info_with_sigs)) => {
                 if items.len() != 1 {
                     return Box::new(err(format_err!(
                         "Unexpected number of items ({}).",
@@ -109,8 +106,8 @@ pub async fn get_account_state(
     address: AccountAddress,
 ) -> Result<(u64, u64)> {
     let req_item = RequestItem::GetAccountState { address };
-    let (response_items, _, _, _) = storage_read_client
-        .update_to_latest_ledger_async(0 /* client_known_version */, vec![req_item])
+    let (response_items, _) = storage_read_client
+        .retrieve_items_async(vec![req_item])
         .await?;
     let account_state = match &response_items[0] {
         ResponseItem::GetAccountState {


### PR DESCRIPTION
Summary:
New transactions in Mempool used to go through a series of vm_validator checks, and each such check used to call update_latest_ledger_info.
The update_latest_ledger_info might work hard to retrieve the epoch change proofs in case the client version in the request is not properly set.
In our case case client version was always set to 0.
The irony is that vm validator does not really use any of these proofs: it's not very critical. In the case the local storage
is corrupt the bad transaction might infiltrate the consensus but would still fail later during the execution.

We now have two options: either mempool managing a state with the known state and sending the right client version, or having a lightweight API
for retrieving the items without the epoch proofs. I added an internal storage API for retrieving the items without the epoch change proofs.

Testing: existing test coverage

Issues: ref #1996 