### PR TITLE
[config] disable metric dumps by default

### DIFF
--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -25,9 +25,9 @@ pub fn load_config_from_path(config: Option<&Path>) -> NodeConfig {
 }
 
 pub fn setup_metrics(peer_id: PeerId, node_config: &NodeConfig) {
-    if let Some(metrics_dir) = node_config.metrics.dir() {
+    if node_config.metrics.enabled {
         libra_metrics::dump_all_metrics_to_file_periodically(
-            &metrics_dir,
+            &node_config.metrics.dir(),
             &format!("{}.metrics", peer_id),
             node_config.metrics.collection_interval_ms,
         );

--- a/config/src/config/metrics_config.rs
+++ b/config/src/config/metrics_config.rs
@@ -7,8 +7,9 @@ use std::path::PathBuf;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MetricsConfig {
-    pub dir: PathBuf,
     pub collection_interval_ms: u64,
+    pub dir: PathBuf,
+    pub enabled: bool,
     #[serde(skip)]
     data_dir: PathBuf,
 }
@@ -16,21 +17,20 @@ pub struct MetricsConfig {
 impl Default for MetricsConfig {
     fn default() -> MetricsConfig {
         MetricsConfig {
-            dir: PathBuf::from("metrics"),
             collection_interval_ms: 1000,
             data_dir: PathBuf::from("/opt/libra/data"),
+            enabled: false,
+            dir: PathBuf::from("metrics"),
         }
     }
 }
 
 impl MetricsConfig {
-    pub fn dir(&self) -> Option<PathBuf> {
-        if self.dir.as_os_str().is_empty() {
-            None
-        } else if self.dir.is_relative() {
-            Some(self.data_dir.join(&self.dir))
+    pub fn dir(&self) -> PathBuf {
+        if self.dir.is_relative() {
+            self.data_dir.join(&self.dir)
         } else {
-            Some(self.dir.clone())
+            self.dir.clone()
         }
     }
 

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -39,8 +39,9 @@ is_async = true
 chan_size = 256
 
 [metrics]
-dir = "metrics"
 collection_interval_ms = 1000
+dir = "metrics"
+enabled = false
 
 [mempool]
 broadcast_transactions = true

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -3,8 +3,9 @@ data_dir = "/opt/libra/data"
 role = "validator"
 
 [metrics]
-dir = "metrics"
 collection_interval_ms = 1000
+dir = "metrics"
+enabled = false
 
 [execution]
 address = "localhost"


### PR DESCRIPTION
Improved the config so that it has an explicit enable field so that we
can have a default directory that does not impact whether or not it is
enabled.