### PR TITLE
[cluster-test] Fix safety rules location

### DIFF
--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -49,7 +49,7 @@ impl Default for OnDiskStorageConfig {
     fn default() -> Self {
         Self {
             default: false,
-            path: PathBuf::from("safety_rules.toml"),
+            path: PathBuf::from("libradb/safety_rules.toml"),
             data_dir: PathBuf::from("/opt/libra/data"),
         }
     }


### PR DESCRIPTION
This diff hotfixes location of safety_rules moving it to directory where other dbs (like consensus db and state db) are located.

Previously we had structure like this
```
/opt/libra/data/
   safety_rules.toml
   libradb/
      db/
        libradb/
        consensusdb/
```
Now it looks like this:
```
/opt/libra/data/
   libradb/
      safety_rules.toml
      db/
        libradb/
        consensusdb/
```

We probably need to revisit directory names later again as it is quite confusing, but for now this diff is needed to finally unblock cluster test that was broken for 5 days now
