### PR TITLE
[consensus] tolerate sync failure

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -31,6 +31,7 @@ use num_traits::{
 use reqwest;
 use rust_decimal::Decimal;
 use serde_json;
+use std::sync::Arc;
 use std::{
     collections::{BTreeMap, HashMap},
     convert::TryFrom,
@@ -116,7 +117,7 @@ impl ClientProxy {
             ac_port,
             EpochInfo {
                 epoch: 0,
-                verifier: ValidatorVerifier::new(BTreeMap::new()),
+                verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
             },
         )?;
 

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -163,7 +163,8 @@ impl<T: Payload> BlockStore<T> {
             .save_tree(blocks.clone(), quorum_certs.clone())?;
         let pre_sync_instance = Instant::now();
         self.state_computer
-            .sync_to_or_bail(highest_commit_cert.ledger_info().clone());
+            .sync_to(highest_commit_cert.ledger_info().clone())
+            .await?;
         counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());
         let (root, root_executed_trees, blocks, quorum_certs) = self.storage.start().take();
         debug!("{}Sync to{} {}", Fg(Blue), Fg(Reset), root.0);

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -69,16 +69,6 @@ pub trait StateComputer: Send + Sync {
         target: LedgerInfoWithSignatures,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 
-    fn sync_to_or_bail(&self, commit: LedgerInfoWithSignatures) {
-        let status = futures::executor::block_on(self.sync_to(commit));
-        // TODO: this is going to change after https://github.com/libra/libra/issues/1590
-        status.expect(
-            "state synchronizer failure, this validator will be killed as it can not \
-             recover from this error.  After the validator is restarted, synchronization will \
-             be retried. failure:",
-        )
-    }
-
     /// Generate the epoch change proof from start_epoch to the latest epoch.
     fn get_epoch_proof(
         &self,

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -412,7 +412,7 @@ fn test_execution_with_storage() {
     verify_update_to_latest_ledger_response(
         &mut EpochInfo {
             epoch: 0,
-            verifier: ValidatorVerifier::new(BTreeMap::new()),
+            verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
         },
         0,
         &request_items,
@@ -622,7 +622,7 @@ fn test_execution_with_storage() {
     verify_update_to_latest_ledger_response(
         &mut EpochInfo {
             epoch: 0,
-            verifier: ValidatorVerifier::new(BTreeMap::new()),
+            verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
         },
         0,
         &request_items,

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -241,23 +241,29 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         self.sync_state_with_local_storage().await?;
         let highest_local_li = self.local_state.highest_local_li.ledger_info();
         let target_version = request.target.ledger_info().version();
-        counters::TARGET_VERSION.set(target_version as i64);
-        debug!(
-            "[state sync] sync requested. Known LI: {}, requested_version: {}",
-            highest_local_li, target_version
-        );
-
-        if target_version <= highest_local_li.version() {
-            warn!(
-                "[state sync] Sync request for version {} <= known version {}",
-                target_version,
-                highest_local_li.version()
-            );
+        if target_version == highest_local_li.version() {
             return request
                 .callback
                 .send(Ok(()))
                 .map_err(|_| format_err!("Callback error"));
         }
+
+        if target_version < highest_local_li.version() {
+            request
+                .callback
+                .send(Err(format_err!("Sync request to old version")))
+                .map_err(|_| format_err!("Callback error"))?;
+            bail!(
+                "[state sync] Sync request for version {} < known version {}",
+                target_version,
+                highest_local_li.version()
+            );
+        }
+        counters::TARGET_VERSION.set(target_version as i64);
+        debug!(
+            "[state sync] sync requested. Known LI: {}, requested_version: {}",
+            highest_local_li, target_version
+        );
 
         self.peer_manager
             .set_peers(request.target.signatures().keys().copied().collect());

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -13,6 +13,7 @@ extern crate prometheus;
 use executor::ExecutedTrees;
 use libra_types::crypto_proxies::{EpochInfo, ValidatorVerifier};
 use libra_types::{account_address::AccountAddress, crypto_proxies::LedgerInfoWithSignatures};
+use std::sync::Arc;
 pub use synchronizer::{StateSyncClient, StateSynchronizer};
 
 mod chunk_request;
@@ -51,11 +52,11 @@ impl SynchronizerState {
         let trusted_epoch = match highest_local_li.ledger_info().next_validator_set() {
             Some(validator_set) => EpochInfo {
                 epoch: current_epoch + 1,
-                verifier: validator_set.into(),
+                verifier: Arc::new(validator_set.into()),
             },
             None => EpochInfo {
                 epoch: current_epoch,
-                verifier: current_verifier,
+                verifier: Arc::new(current_verifier),
             },
         };
         SynchronizerState {

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -95,13 +95,14 @@ pub type ValidatorSigner = RawValidatorSigner<Ed25519PrivateKey>;
 pub type ValidatorPublicKeys = RawValidatorPublicKeys<Ed25519PublicKey>;
 pub type ValidatorSet = RawValidatorSet<Ed25519PublicKey>;
 pub use crate::validator_change::ValidatorChangeEventWithProof;
+use std::sync::Arc;
 
 #[derive(Clone)]
 /// EpochInfo represents a trusted validator set to validate messages from the specific epoch,
 /// it could be updated with ValidatorChangeEventWithProof.
 pub struct EpochInfo {
     pub epoch: u64,
-    pub verifier: ValidatorVerifier,
+    pub verifier: Arc<ValidatorVerifier>,
 }
 
 impl fmt::Display for EpochInfo {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We use to panic upon state sync failure because of the design. With the
new design of idempotent commit, we're able to tolerate the sync
failure now.

We also unified network.epoch_info with epoch_manager in order to tolerate the failure.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
