### PR TITLE
[cluster-test] Use /data/libra/common/ to delete db

### DIFF
--- a/testsuite/cluster-test/src/effects/delete_libra_data.rs
+++ b/testsuite/cluster-test/src/effects/delete_libra_data.rs
@@ -24,7 +24,7 @@ impl Action for DeleteLibraData {
         async move {
             info!("DeleteLibraData {}", self.instance);
             self.instance
-                .run_cmd(vec!["sudo rm -rf /data/libra/*db"])
+                .run_cmd(vec!["sudo rm -rf /data/libra/common"])
                 .await
         }
             .boxed()

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -770,7 +770,7 @@ impl ClusterTestRunner {
 
     async fn wipe_instance(log_file: &str, suffix: &str, instance: &Instance) {
         instance
-            .run_cmd_tee_err(vec!["sudo", "rm", "-rf", "/data/libra/*db"])
+            .run_cmd_tee_err(vec!["sudo", "rm", "-rf", "/data/libra/common"])
             .await
             .map_err(|e| info!("Failed to wipe {}: {:?}", instance, e))
             .ok();


### PR DESCRIPTION
## Summary

@davidiw 's PR https://github.com/libra/libra/pull/1995 added `common/` directory for libradb. Hence we need to update cluster-test code to wipe this directory when deleting libradb

## Test Plan

Tested on my cluster