### PR TITLE
[language][move] Remove the ParseError type

### DIFF
--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -4,6 +4,7 @@
 use codespan::{ByteIndex, Span};
 use std::str::FromStr;
 
+use crate::errors::*;
 use crate::parser::ast::*;
 use crate::parser::lexer::*;
 use crate::shared::*;
@@ -13,23 +14,30 @@ use crate::shared::*;
 // Note that this allows an optional trailing comma.
 
 //**************************************************************************************************
-// ParseError
+// Error Handling
 //**************************************************************************************************
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ParseError {
-    InvalidToken {
-        location: usize,
-    },
-    UnrecognizedToken {
-        location: usize,
-        actual: String,
-        expected: Vec<String>,
-    },
-    User {
-        location: usize,
-        error: String,
-    },
+fn unexpected_token_error(
+    file: &'static str,
+    start_loc: usize,
+    actual: &str,
+    expected: Vec<String>,
+) -> Error {
+    let fmt_expected =
+        |expected: Vec<String>| -> String { format!("Expected: {}", expected.join(", ")) };
+    let end_loc = start_loc + actual.len();
+    let span = Span::new(ByteIndex(start_loc as u32), ByteIndex(end_loc as u32));
+    let loc = Loc::new(file, span);
+    vec![
+        (loc, format!("Unexpected token: '{}'", actual)),
+        (loc, fmt_expected(expected)),
+    ]
+}
+
+fn user_error(file: &'static str, start_loc: usize, error: String) -> Error {
+    let span = Span::new(ByteIndex(start_loc as u32), ByteIndex(start_loc as u32));
+    let loc = Loc::new(file, span);
+    vec![(loc, error)]
 }
 
 //**************************************************************************************************
@@ -37,7 +45,7 @@ pub enum ParseError {
 //**************************************************************************************************
 
 macro_rules! token_match {
-    ($x:expr, $loc:expr, $actual:expr,
+    ($x:expr, $file:expr, $loc:expr, $actual:expr,
      { $($c:ident::$p:ident => $e_p:expr),* }) => {{
         $(use $c::$p;)*
         match $x {
@@ -45,11 +53,7 @@ macro_rules! token_match {
             _ => {{
                 let mut v = vec![];
                 $(v.push(format!("'{}'", $p.to_string()));)*
-                return Err(ParseError::UnrecognizedToken {
-                    location: $loc,
-                    actual: $actual,
-                    expected: v,
-                });
+                return Err(unexpected_token_error($file, $loc, $actual, v));
             }}
         }
     }}
@@ -69,14 +73,15 @@ fn spanned<T>(file: &'static str, start: usize, end: usize, value: T) -> Spanned
     }
 }
 
-fn consume_token<'input>(tokens: &mut Lexer<'input>, tok: Tok) -> Result<(), ParseError> {
+fn consume_token<'input>(tokens: &mut Lexer<'input>, tok: Tok) -> Result<(), Error> {
     let peeked = tokens.peek();
     if tok != peeked {
-        return Err(ParseError::UnrecognizedToken {
-            location: tokens.start_loc(),
-            actual: tokens.content().to_string(),
-            expected: vec![format!("'{}'", tok.to_string())],
-        });
+        return Err(unexpected_token_error(
+            tokens.file_name(),
+            tokens.start_loc(),
+            tokens.content(),
+            vec![format!("'{}'", tok.to_string())],
+        ));
     }
     tokens.advance()?;
     Ok(())
@@ -87,7 +92,7 @@ fn consume_token<'input>(tokens: &mut Lexer<'input>, tok: Tok) -> Result<(), Par
 fn consume_optional_token_with_loc<'input>(
     tokens: &mut Lexer<'input>,
     tok: Tok,
-) -> Result<Option<Loc>, ParseError> {
+) -> Result<Option<Loc>, Error> {
     if tokens.peek() == tok {
         let start_loc = tokens.start_loc();
         tokens.advance()?;
@@ -104,14 +109,15 @@ fn consume_optional_token_with_loc<'input>(
 
 // Parse a name:
 //      Name = <NameValue>
-fn parse_name<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<String>, ParseError> {
+fn parse_name<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<String>, Error> {
     let start_loc = tokens.start_loc();
     if tokens.peek() != Tok::NameValue {
-        return Err(ParseError::UnrecognizedToken {
-            location: start_loc,
-            actual: tokens.content().to_string(),
-            expected: vec!["a name value".to_string()],
-        });
+        return Err(unexpected_token_error(
+            tokens.file_name(),
+            start_loc,
+            tokens.content(),
+            vec!["a name value".to_string()],
+        ));
     }
     let name = tokens.content().to_string();
     tokens.advance()?;
@@ -121,9 +127,7 @@ fn parse_name<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<String>, Par
 
 // Parse a name that is followed by type arguments:
 //      NameBeginArgs = <NameBeginArgsValue>
-fn parse_name_begin_args<'input>(
-    tokens: &mut Lexer<'input>,
-) -> Result<Spanned<String>, ParseError> {
+fn parse_name_begin_args<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<String>, Error> {
     assert!(tokens.peek() == Tok::NameBeginArgsValue);
     let start_loc = tokens.start_loc();
     let s = tokens.content();
@@ -139,57 +143,57 @@ fn parse_name_begin_args<'input>(
 // indicate whether there are type arguments to parse.
 fn parse_name_maybe_args<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Spanned<String>, bool), ParseError> {
+) -> Result<(Spanned<String>, bool), Error> {
     match tokens.peek() {
         Tok::NameValue => Ok((parse_name(tokens)?, false)),
         Tok::NameBeginArgsValue => Ok((parse_name_begin_args(tokens)?, true)),
-        _ => Err(ParseError::UnrecognizedToken {
-            location: tokens.start_loc(),
-            actual: tokens.content().to_string(),
-            expected: vec!["a name value".to_string()],
-        }),
+        _ => Err(unexpected_token_error(
+            tokens.file_name(),
+            tokens.start_loc(),
+            tokens.content(),
+            vec!["a name value".to_string()],
+        )),
     }
 }
 
 // Parse an account address:
 //      Address = <AddressValue>
-fn parse_address<'input>(tokens: &mut Lexer<'input>) -> Result<Address, ParseError> {
+fn parse_address<'input>(tokens: &mut Lexer<'input>) -> Result<Address, Error> {
     if tokens.peek() != Tok::AddressValue {
-        return Err(ParseError::UnrecognizedToken {
-            location: tokens.start_loc(),
-            actual: tokens.content().to_string(),
-            expected: vec!["an account address value".to_string()],
-        });
+        return Err(unexpected_token_error(
+            tokens.file_name(),
+            tokens.start_loc(),
+            tokens.content(),
+            vec!["an account address value".to_string()],
+        ));
     }
-    let addr = Address::parse_str(&tokens.content()).map_err(|msg| ParseError::User {
-        location: tokens.start_loc(),
-        error: msg,
-    });
+    let addr = Address::parse_str(&tokens.content())
+        .map_err(|msg| user_error(tokens.file_name(), tokens.start_loc(), msg));
     tokens.advance()?;
     addr
 }
 
 // Parse a variable name:
 //      Var = <Name>
-fn parse_var<'input>(tokens: &mut Lexer<'input>) -> Result<Var, ParseError> {
+fn parse_var<'input>(tokens: &mut Lexer<'input>) -> Result<Var, Error> {
     Ok(Var(parse_name(tokens)?))
 }
 
 // Parse a field name:
 //      Field = <Name>
-fn parse_field<'input>(tokens: &mut Lexer<'input>) -> Result<Field, ParseError> {
+fn parse_field<'input>(tokens: &mut Lexer<'input>) -> Result<Field, Error> {
     Ok(Field(parse_name(tokens)?))
 }
 
 // Parse a module name:
 //      ModuleName = <Name>
-fn parse_module_name<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleName, ParseError> {
+fn parse_module_name<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleName, Error> {
     Ok(ModuleName(parse_name(tokens)?))
 }
 
 // Parse a module identifier:
 //      ModuleIdent = <Address> "::" <ModuleName>
-fn parse_module_ident<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleIdent, ParseError> {
+fn parse_module_ident<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleIdent, Error> {
     let start_loc = tokens.start_loc();
     let address = parse_address(tokens)?;
     consume_token(tokens, Tok::ColonColon)?;
@@ -217,11 +221,9 @@ fn parse_module_ident<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleIdent,
 // The name may have arguments, as marked by a "<" after the name.
 // The return value is a tuple containing the ModuleAccess and a flag to
 // indicate whether there are type arguments to parse.
-fn parse_module_access<'input>(
-    tokens: &mut Lexer<'input>,
-) -> Result<(ModuleAccess, bool), ParseError> {
+fn parse_module_access<'input>(tokens: &mut Lexer<'input>) -> Result<(ModuleAccess, bool), Error> {
     let start_loc = tokens.start_loc();
-    let (acc, has_args) = token_match!(tokens.peek(), start_loc, tokens.content().to_string(), {
+    let (acc, has_args) = token_match!(tokens.peek(), tokens.file_name(), start_loc, tokens.content(), {
         Tok::NameValue => {
             // Check if this is a ModuleName followed by "::".
             let m = parse_name(tokens)?;
@@ -259,7 +261,7 @@ fn parse_module_access<'input>(
 
 // Parse a field name optionally followed by a colon and an expression argument:
 //      ExpField = <Field> <":" <Exp>>?
-fn parse_exp_field<'input>(tokens: &mut Lexer<'input>) -> Result<(Field, Exp), ParseError> {
+fn parse_exp_field<'input>(tokens: &mut Lexer<'input>) -> Result<(Field, Exp), Error> {
     let f = parse_field(tokens)?;
     let arg = if tokens.peek() == Tok::Colon {
         tokens.advance()?; // consume the colon
@@ -275,7 +277,7 @@ fn parse_exp_field<'input>(tokens: &mut Lexer<'input>) -> Result<(Field, Exp), P
 //
 // If the binding is not specified, the default is to use a variable
 // with the same name as the field.
-fn parse_bind_field<'input>(tokens: &mut Lexer<'input>) -> Result<(Field, Bind), ParseError> {
+fn parse_bind_field<'input>(tokens: &mut Lexer<'input>) -> Result<(Field, Bind), Error> {
     let f = parse_field(tokens)?;
     let arg = if tokens.peek() == Tok::Colon {
         tokens.advance()?; // consume the colon
@@ -292,7 +294,7 @@ fn parse_bind_field<'input>(tokens: &mut Lexer<'input>) -> Result<(Field, Bind),
 //          <Var>
 //          | <ModuleAccess> "{" Comma<BindField> "}"
 //          | <ModuleAccessBeginArgs> <TypeArgs> "{" Comma<BindField> "}"
-fn parse_bind<'input>(tokens: &mut Lexer<'input>) -> Result<Bind, ParseError> {
+fn parse_bind<'input>(tokens: &mut Lexer<'input>) -> Result<Bind, Error> {
     let start_loc = tokens.start_loc();
     if tokens.peek() == Tok::NameValue {
         let next_tok = tokens.lookahead()?;
@@ -331,7 +333,7 @@ fn parse_bind<'input>(tokens: &mut Lexer<'input>) -> Result<Bind, ParseError> {
 //
 // The list is enclosed in parenthesis, except that the parenthesis are
 // optional if there is a single Bind.
-fn parse_bind_list<'input>(tokens: &mut Lexer<'input>) -> Result<BindList, ParseError> {
+fn parse_bind_list<'input>(tokens: &mut Lexer<'input>) -> Result<BindList, Error> {
     let start_loc = tokens.start_loc();
     let mut b: Vec<Bind> = vec![];
     if tokens.peek() != Tok::LParen {
@@ -363,9 +365,9 @@ fn parse_bind_list<'input>(tokens: &mut Lexer<'input>) -> Result<BindList, Parse
 //          | "true"
 //          | "false"
 //          | <U64>
-fn parse_value<'input>(tokens: &mut Lexer<'input>) -> Result<Value, ParseError> {
+fn parse_value<'input>(tokens: &mut Lexer<'input>) -> Result<Value, Error> {
     let start_loc = tokens.start_loc();
-    let val = token_match!(tokens.peek(), start_loc, tokens.content().to_string(), {
+    let val = token_match!(tokens.peek(), tokens.file_name(), start_loc, tokens.content(), {
         Tok::AddressValue => {
             let addr = parse_address(tokens)?;
             Value_::Address(addr)
@@ -396,7 +398,7 @@ fn parse_value<'input>(tokens: &mut Lexer<'input>) -> Result<Value, ParseError> 
 //      SequenceItem =
 //          <Exp>
 //          | "let" <BindList> (":" <Type>)? ("=" <Exp>)?
-fn parse_sequence_item<'input>(tokens: &mut Lexer<'input>) -> Result<SequenceItem, ParseError> {
+fn parse_sequence_item<'input>(tokens: &mut Lexer<'input>) -> Result<SequenceItem, Error> {
     let start_loc = tokens.start_loc();
     let item = if tokens.peek() != Tok::Let {
         let e = parse_exp(tokens)?;
@@ -427,7 +429,7 @@ fn parse_sequence_item<'input>(tokens: &mut Lexer<'input>) -> Result<SequenceIte
 //
 // Note that this does not include the opening brace of a block but it
 // does consume the closing right brace.
-fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, ParseError> {
+fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error> {
     let mut seq: Vec<SequenceItem> = vec![];
     let mut eopt = None;
     while tokens.peek() != Tok::RBrace {
@@ -474,9 +476,9 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, ParseE
 //          | <ModuleAccessBeginArgs> <TypeArgs> "(" Comma<Exp> ")"
 //          | "::" <Name> "(" Comma<Exp> ")"
 //          | "::" <NameBeginArgs> <TypeArgs> "(" Comma<Exp> ")"
-fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError> {
+fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
-    let term = token_match!(tokens.peek(), start_loc, tokens.content().to_string(), {
+    let term = token_match!(tokens.peek(), tokens.file_name(), start_loc, tokens.content(), {
         Tok::Move => {
             tokens.advance()?;
             Exp_::Move(parse_var(tokens)?)
@@ -581,14 +583,14 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError> {
 
 // Parse the subset of expression terms for pack and call operations.
 // This is a helper function for parse_term.
-fn parse_pack_or_call<'input>(tokens: &mut Lexer<'input>) -> Result<Exp_, ParseError> {
+fn parse_pack_or_call<'input>(tokens: &mut Lexer<'input>) -> Result<Exp_, Error> {
     let (n, has_args) = parse_module_access(tokens)?;
     let tys = if has_args {
         Some(parse_type_args(tokens)?)
     } else {
         None
     };
-    token_match!(tokens.peek(), tokens.start_loc(), tokens.content().to_string(), {
+    token_match!(tokens.peek(), tokens.file_name(), tokens.start_loc(), tokens.content(), {
 
         // <ModuleAccess> "{" Comma<ExpField> "}"
         // <ModuleAccessBeginArgs> <TypeArgs> "{" Comma<ExpField> "}"
@@ -616,7 +618,7 @@ fn parse_pack_or_call<'input>(tokens: &mut Lexer<'input>) -> Result<Exp_, ParseE
 }
 
 // Parse the arguments to a call: "(" Comma<Exp> ")"
-fn parse_call_args<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<Vec<Exp>>, ParseError> {
+fn parse_call_args<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<Vec<Exp>>, Error> {
     let start_loc = tokens.start_loc();
     consume_token(tokens, Tok::LParen)?;
     let mut args = vec![];
@@ -641,7 +643,7 @@ fn parse_call_args<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<Vec<Exp
 //          | "return" <Exp>
 //          | "abort" <Exp>
 //          | <BinOpExp>
-fn parse_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError> {
+fn parse_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
     let exp = match tokens.peek() {
         Tok::If => {
@@ -745,7 +747,7 @@ fn parse_binop_exp<'input>(
     tokens: &mut Lexer<'input>,
     lhs: Exp,
     min_prec: u32,
-) -> Result<Exp, ParseError> {
+) -> Result<Exp, Error> {
     let mut result = lhs;
     let mut next_tok_prec = get_precedence(tokens.peek());
 
@@ -805,7 +807,7 @@ fn parse_binop_exp<'input>(
 //          | "&" <UnaryExp>
 //          | "*" <UnaryExp>
 //          | <DotChain>
-fn parse_unary_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError> {
+fn parse_unary_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
     let exp = match tokens.peek() {
         Tok::Exclaim => {
@@ -849,7 +851,7 @@ fn parse_unary_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError
 //      DotChain =
 //          <DotChain> "." <Name>
 //          | <Term>
-fn parse_dot_chain<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError> {
+fn parse_dot_chain<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
     let mut lhs = parse_term(tokens)?;
 
@@ -871,7 +873,7 @@ fn parse_dot_chain<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError
 //      BaseType =
 //          <ModuleAccess>
 //          | <ModuleAccessBeginArgs> <TypeArgs>
-fn parse_base_type<'input>(tokens: &mut Lexer<'input>) -> Result<SingleType, ParseError> {
+fn parse_base_type<'input>(tokens: &mut Lexer<'input>) -> Result<SingleType, Error> {
     let start_loc = tokens.start_loc();
     let (tn, has_args) = parse_module_access(tokens)?;
     let tys = if has_args {
@@ -888,7 +890,7 @@ fn parse_base_type<'input>(tokens: &mut Lexer<'input>) -> Result<SingleType, Par
 //      TypeArgs = ((<BaseType> ",")* <BaseType>)? ">"
 //
 // This is used for the type arguments following NameBeginArgs.
-fn parse_type_args<'input>(tokens: &mut Lexer<'input>) -> Result<Vec<SingleType>, ParseError> {
+fn parse_type_args<'input>(tokens: &mut Lexer<'input>) -> Result<Vec<SingleType>, Error> {
     let mut tys: Vec<SingleType> = vec![];
     if tokens.peek() != Tok::Greater {
         loop {
@@ -908,7 +910,7 @@ fn parse_type_args<'input>(tokens: &mut Lexer<'input>) -> Result<Vec<SingleType>
 //          <BaseType>
 //          | "&" <BaseType>
 //          | "&mut" <BaseType>
-fn parse_single_type<'input>(tokens: &mut Lexer<'input>) -> Result<SingleType, ParseError> {
+fn parse_single_type<'input>(tokens: &mut Lexer<'input>) -> Result<SingleType, Error> {
     let start_loc = tokens.start_loc();
     let (b, mutable) = match tokens.peek() {
         Tok::Amp => {
@@ -933,7 +935,7 @@ fn parse_single_type<'input>(tokens: &mut Lexer<'input>) -> Result<SingleType, P
 //          "(" ")"
 //          | <SingleType>
 //          | "(" (<SingleType> ",")* <SingleType> ")"
-fn parse_type<'input>(tokens: &mut Lexer<'input>) -> Result<Type, ParseError> {
+fn parse_type<'input>(tokens: &mut Lexer<'input>) -> Result<Type, Error> {
     let start_loc = tokens.start_loc();
     let mut ts: Vec<SingleType> = vec![];
     if tokens.peek() != Tok::LParen {
@@ -966,13 +968,13 @@ fn parse_type<'input>(tokens: &mut Lexer<'input>) -> Result<Type, ParseError> {
 //      Constraint =
 //          ":" "copyable"
 //          | ":" "resource"
-fn parse_type_parameter<'input>(tokens: &mut Lexer<'input>) -> Result<(Name, Kind), ParseError> {
+fn parse_type_parameter<'input>(tokens: &mut Lexer<'input>) -> Result<(Name, Kind), Error> {
     let n = parse_name(tokens)?;
 
     let kind = if tokens.peek() == Tok::Colon {
         tokens.advance()?;
         let start_loc = tokens.start_loc();
-        let k = token_match!(tokens.peek(), start_loc, tokens.content().to_string(), {
+        let k = token_match!(tokens.peek(), tokens.file_name(), start_loc, tokens.content(), {
             Tok::Copyable => Kind_::Affine,
             Tok::Resource => Kind_::Resource
         });
@@ -1015,16 +1017,17 @@ fn parse_type_parameter<'input>(tokens: &mut Lexer<'input>) -> Result<(Name, Kin
 fn parse_function_decl<'input>(
     tokens: &mut Lexer<'input>,
     allow_native: bool,
-) -> Result<Function, ParseError> {
+) -> Result<Function, Error> {
     // Record the source location of the "native" keyword (if there is one).
     let native_opt = if allow_native {
         consume_optional_token_with_loc(tokens, Tok::Native)?
     } else {
         if tokens.peek() == Tok::Native {
-            return Err(ParseError::User {
-                location: tokens.start_loc(),
-                error: "Native functions can only be declared inside a module".to_string(),
-            });
+            return Err(user_error(
+                tokens.file_name(),
+                tokens.start_loc(),
+                "Native functions can only be declared inside a module".to_string(),
+            ));
         }
         None
     };
@@ -1131,9 +1134,7 @@ fn parse_function_decl<'input>(
 //          <Name>
 //          | <NameBeginArgs> Comma<TypeParameter> ">"
 //      FieldAnnot = <Field> ":" <SingleType>
-fn parse_struct_definition<'input>(
-    tokens: &mut Lexer<'input>,
-) -> Result<StructDefinition, ParseError> {
+fn parse_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<StructDefinition, Error> {
     // Record the source location of the "native" keyword (if there is one).
     let native_opt = consume_optional_token_with_loc(tokens, Tok::Native)?;
 
@@ -1196,7 +1197,7 @@ fn parse_struct_definition<'input>(
 //      UseDecl = "use" <ModuleIdent> ("as" <ModuleName>)? ";"
 fn parse_use_decl<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(ModuleIdent, Option<ModuleName>), ParseError> {
+) -> Result<(ModuleIdent, Option<ModuleName>), Error> {
     consume_token(tokens, Tok::Use)?;
     let ident = parse_module_ident(tokens)?;
     let alias = if tokens.peek() == Tok::As {
@@ -1209,7 +1210,7 @@ fn parse_use_decl<'input>(
     Ok((ident, alias))
 }
 
-fn is_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<bool, ParseError> {
+fn is_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<bool, Error> {
     let mut t = tokens.peek();
     if t == Tok::Native {
         t = tokens.lookahead()?;
@@ -1224,7 +1225,7 @@ fn is_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<bool, Pars
 //              <StructDefinition>*
 //              <FunctionDecl>*
 //          "}"
-fn parse_module<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleDefinition, ParseError> {
+fn parse_module<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleDefinition, Error> {
     consume_token(tokens, Tok::Module)?;
     let name = parse_module_name(tokens)?;
     consume_token(tokens, Tok::LBrace)?;
@@ -1263,7 +1264,7 @@ fn parse_module<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleDefinition, 
 //          | <UseDecl>* <MoveFunctionDecl>
 //
 // Note that "address" is not a token.
-fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<FileDefinition, ParseError> {
+fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<FileDefinition, Error> {
     let f = if tokens.peek() == Tok::EOF
         || tokens.peek() == Tok::Module
         || (tokens.peek() == Tok::NameValue && tokens.lookahead()? == Tok::AddressValue)
@@ -1279,10 +1280,11 @@ fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<FileDefinition, Pars
                         "Invalid address directive. Expected 'address' got '{}'",
                         addr_name.value
                     );
-                    return Err(ParseError::User {
-                        location: addr_name.loc.span().start().to_usize(),
-                        error: msg,
-                    });
+                    return Err(user_error(
+                        tokens.file_name(),
+                        addr_name.loc.span().start().to_usize(),
+                        msg,
+                    ));
                 }
                 let start_loc = tokens.start_loc();
                 let addr = parse_address(tokens)?;
@@ -1301,11 +1303,12 @@ fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<FileDefinition, Pars
         }
         let function = parse_function_decl(tokens, /* allow_native */ false)?;
         if tokens.peek() != Tok::EOF {
-            return Err(ParseError::UnrecognizedToken {
-                location: tokens.start_loc(),
-                actual: tokens.content().to_string(),
-                expected: vec![],
-            });
+            return Err(unexpected_token_error(
+                tokens.file_name(),
+                tokens.start_loc(),
+                tokens.content(),
+                vec![],
+            ));
         }
         FileDefinition::Main(Main { uses, function })
     };
@@ -1313,9 +1316,9 @@ fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<FileDefinition, Pars
 }
 
 /// Parse the `input` string as a file of Move source code and return the
-/// result as either a FileDefinition value or a ParseError. The `file` name
+/// result as either a FileDefinition value or an Error. The `file` name
 /// is used to identify source locations in error messages.
-pub fn parse_file_string(file: &'static str, input: &str) -> Result<FileDefinition, ParseError> {
+pub fn parse_file_string(file: &'static str, input: &str) -> Result<FileDefinition, Error> {
     let mut tokens = Lexer::new(input, file);
     tokens.advance()?;
     parse_file(&mut tokens)


### PR DESCRIPTION
The ParseError enum was left over from the lalrpop transition. Change the parser to emit errors directly in the same way as the rest of the compiler.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This does not change any of the errors, so no test changes are needed.