### PR TITLE
[Storage] Change get_startup_info to not use get_epoch_change_ledger_infos

### DIFF
--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -312,10 +312,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
             .get_startup_info()
             .expect("unable to read ledger info from storage")
             .expect("startup info is None");
-        let validator_set = startup_info
-            .get_validator_set()
-            .expect("should have ValidatorSet when start new epoch")
-            .clone();
+        let validator_set = startup_info.get_validator_set().clone();
         let root_executed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
         let mut initial_data = RecoveryData::new(
             last_vote,

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -312,6 +312,10 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
             .get_startup_info()
             .expect("unable to read ledger info from storage")
             .expect("startup info is None");
+        let validator_set = startup_info
+            .get_validator_set()
+            .expect("should have ValidatorSet when start new epoch")
+            .clone();
         let root_executed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
         let mut initial_data = RecoveryData::new(
             last_vote,
@@ -320,12 +324,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
             startup_info.latest_ledger_info.ledger_info(),
             root_executed_trees,
             highest_timeout_certificate,
-            startup_info
-                .ledger_info_with_validators
-                .ledger_info()
-                .next_validator_set()
-                .expect("should have ValidatorSet when start new epoch")
-                .clone(),
+            validator_set,
         )
         .expect("Cannot construct recovery data");
 

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -76,17 +76,18 @@ impl ExecutorProxyTrait for ExecutorProxy {
                 .get_startup_info_async()
                 .await?
                 .ok_or_else(|| format_err!("[state sync] Failed to access storage info"))?;
+
+            let current_verifier = storage_info
+                .get_validator_set()
+                .expect("No ValidatorSet found for the start of the epoch.")
+                .into();
+
             let synced_trees = if let Some(synced_tree_state) = storage_info.synced_tree_state {
                 ExecutedTrees::from(synced_tree_state)
             } else {
                 ExecutedTrees::from(storage_info.committed_tree_state)
             };
-            let current_verifier = storage_info
-                .ledger_info_with_validators
-                .ledger_info()
-                .next_validator_set()
-                .expect("No ValidatorSet found for the start of the epoch")
-                .into();
+
             Ok(SynchronizerState::new(
                 storage_info.latest_ledger_info,
                 synced_trees,

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -77,10 +77,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
                 .await?
                 .ok_or_else(|| format_err!("[state sync] Failed to access storage info"))?;
 
-            let current_verifier = storage_info
-                .get_validator_set()
-                .expect("No ValidatorSet found for the start of the epoch.")
-                .into();
+            let current_verifier = storage_info.get_validator_set().into();
 
             let synced_trees = if let Some(synced_tree_state) = storage_info.synced_tree_state {
                 ExecutedTrees::from(synced_tree_state)

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -385,10 +385,13 @@ impl StartupInfo {
         }
     }
 
-    pub fn get_validator_set(&self) -> Option<&ValidatorSet> {
+    pub fn get_validator_set(&self) -> &ValidatorSet {
         match self.latest_ledger_info.ledger_info().next_validator_set() {
-            Some(x) => Some(x),
-            None => self.latest_validator_set.as_ref(),
+            Some(x) => x,
+            None => self
+                .latest_validator_set
+                .as_ref()
+                .expect("Validator set must exist."),
         }
     }
 }

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -27,15 +27,17 @@
 
 pub mod proto;
 
-use anyhow::{format_err, Error, Result};
+use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::HashValue;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
-    crypto_proxies::LedgerInfoWithSignatures,
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorSet},
     proof::SparseMerkleProof,
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
@@ -358,38 +360,117 @@ impl From<TreeState> for crate::proto::storage::TreeState {
 
 /// Helper to construct and parse [`proto::storage::StartupInfo`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StartupInfo {
+    /// The latest ledger info.
     pub latest_ledger_info: LedgerInfoWithSignatures,
-    pub ledger_info_with_validators: LedgerInfoWithSignatures,
+    /// If the above ledger info doesn't carry a validator set, the latest validator set. Otherwise
+    /// `None`.
+    pub latest_validator_set: Option<ValidatorSet>,
     pub committed_tree_state: TreeState,
     pub synced_tree_state: Option<TreeState>,
+}
+
+impl StartupInfo {
+    pub fn new(
+        latest_ledger_info: LedgerInfoWithSignatures,
+        latest_validator_set: Option<ValidatorSet>,
+        committed_tree_state: TreeState,
+        synced_tree_state: Option<TreeState>,
+    ) -> Self {
+        Self {
+            latest_ledger_info,
+            latest_validator_set,
+            committed_tree_state,
+            synced_tree_state,
+        }
+    }
+
+    pub fn get_validator_set(&self) -> Option<&ValidatorSet> {
+        match self.latest_ledger_info.ledger_info().next_validator_set() {
+            Some(x) => Some(x),
+            None => self.latest_validator_set.as_ref(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn arb_startup_info() -> impl Strategy<Value = StartupInfo> {
+    any::<LedgerInfoWithSignatures>()
+        .prop_flat_map(|latest_ledger_info| {
+            let latest_validator_set_strategy = if latest_ledger_info
+                .ledger_info()
+                .next_validator_set()
+                .is_some()
+            {
+                Just(None).boxed()
+            } else {
+                any::<ValidatorSet>().prop_map(Some).boxed()
+            };
+
+            (
+                Just(latest_ledger_info),
+                latest_validator_set_strategy,
+                any::<TreeState>(),
+                any::<Option<TreeState>>(),
+            )
+        })
+        .prop_map(
+            |(
+                latest_ledger_info,
+                latest_validator_set,
+                committed_tree_state,
+                synced_tree_state,
+            )| {
+                StartupInfo::new(
+                    latest_ledger_info,
+                    latest_validator_set,
+                    committed_tree_state,
+                    synced_tree_state,
+                )
+            },
+        )
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for StartupInfo {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        arb_startup_info().boxed()
+    }
 }
 
 impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
     type Error = Error;
 
     fn try_from(proto: crate::proto::storage::StartupInfo) -> Result<Self> {
-        let ledger_info = proto
-            .ledger_info
-            .ok_or_else(|| format_err!("Missing ledger_info"))?
+        let latest_ledger_info: LedgerInfoWithSignatures = proto
+            .latest_ledger_info
+            .ok_or_else(|| format_err!("Missing latest_ledger_info"))?
             .try_into()?;
-        let ledger_info_with_validators = proto
-            .ledger_info_with_validators
-            .ok_or_else(|| format_err!("Missing ledger_info"))?
-            .try_into()?;
+        let latest_validator_set = proto
+            .latest_validator_set
+            .map(TryInto::try_into)
+            .transpose()?;
         let committed_tree_state = proto
             .committed_tree_state
             .ok_or_else(|| format_err!("Missing committed_tree_state"))?
             .try_into()?;
-        let synced_tree_state = proto
-            .synced_tree_state
-            .map(TreeState::try_from)
-            .transpose()?;
+        let synced_tree_state = proto.synced_tree_state.map(TryInto::try_into).transpose()?;
+
+        ensure!(
+            latest_ledger_info
+                .ledger_info()
+                .next_validator_set()
+                .is_some()
+                != latest_validator_set.is_some(),
+            "Only one validator set should exist.",
+        );
 
         Ok(Self {
-            latest_ledger_info: ledger_info,
-            ledger_info_with_validators,
+            latest_ledger_info,
+            latest_validator_set,
             committed_tree_state,
             synced_tree_state,
         })
@@ -398,14 +479,14 @@ impl TryFrom<crate::proto::storage::StartupInfo> for StartupInfo {
 
 impl From<StartupInfo> for crate::proto::storage::StartupInfo {
     fn from(info: StartupInfo) -> Self {
-        let ledger_info = Some(info.latest_ledger_info.into());
-        let ledger_info_with_validators = Some(info.ledger_info_with_validators.into());
+        let latest_ledger_info = Some(info.latest_ledger_info.into());
+        let latest_validator_set = info.latest_validator_set.map(Into::into);
         let committed_tree_state = Some(info.committed_tree_state.into());
         let synced_tree_state = info.synced_tree_state.map(Into::into);
 
         Self {
-            ledger_info,
-            ledger_info_with_validators,
+            latest_ledger_info,
+            latest_validator_set,
             committed_tree_state,
             synced_tree_state,
         }

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -5,11 +5,12 @@ syntax = "proto3";
 
 package storage;
 
+import "account_state_blob.proto";
 import "get_with_proof.proto";
 import "ledger_info.proto";
-import "transaction.proto";
-import "account_state_blob.proto";
 import "proof.proto";
+import "transaction.proto";
+import "validator_set.proto";
 
 // -----------------------------------------------------------------------------
 // ---------------- Service definition for storage
@@ -122,10 +123,12 @@ message StartupInfo {
     // The latest committed LedgerInfo. Note that at start up storage can have more
     // transactions than the latest committed LedgerInfo indicates due to an incomplete
     // start up sync.
-    types.LedgerInfoWithSignatures ledger_info = 1;
+    types.LedgerInfoWithSignatures latest_ledger_info = 1;
 
-    // The latest LedgerInfo that carries a ValidatorSet
-    types.LedgerInfoWithSignatures ledger_info_with_validators = 2;
+    // If the above LedgerInfo doesn't carry a validator set (which is normally
+    // the case unless the above is on an epoch boundary), the latest validator
+    // set.
+    types.ValidatorSet latest_validator_set = 2;
 
     // The latest committed tree state matching the ledger info above.
     TreeState committed_tree_state = 3;

--- a/storage/storage-proto/src/tests.rs
+++ b/storage/storage-proto/src/tests.rs
@@ -3,7 +3,6 @@
 
 use super::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
-use proptest::prelude::*;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -961,7 +961,9 @@ impl BlockInfoGen {
     pub fn materialize(self, universe: &mut AccountInfoUniverse, block_size: usize) -> BlockInfo {
         assert!(block_size > 0, "No empty blocks are allowed.");
 
-        let (epoch, next_validator_set) = if self.new_epoch {
+        let current_epoch = universe.get_epoch();
+        // The first LedgerInfo should always carry a validator set.
+        let (epoch, next_validator_set) = if current_epoch == 0 || self.new_epoch {
             (
                 universe.get_and_bump_epoch(),
                 Some(ValidatorSet::new(Vec::new())),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The current implementation of `get_startup_info` seems a bit complex. It also doesn't have much test coverage. This change moves some functionality into ledger_store and add some unit test.

Also, since I'm planning to change the behavior of `get_epoch_change_ledger_infos`, reducing the usage of this method will be helpful.

Also change the structure of `StartupInfo` a bit -- having two LedgerInfo objects inside it is pretty confusing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Not sure.

## Test Plan

CI.

## Related PRs

None.