### PR TITLE
[crypto] adding benches for hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ dependencies = [
  "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)",

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -43,6 +43,7 @@ byteorder = "1.3.2"
 proptest = "0.9.1"
 proptest-derive = "0.1.0"
 ripemd160 = "0.8.0"
+criterion = "0.3"
 
 [features]
 default = ["std", "u64_backend"]
@@ -52,3 +53,7 @@ fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
 std = ["curve25519-dalek/std", "ed25519-dalek/std", "x25519-dalek/std"]
 u64_backend = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
 fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]
+
+[[bench]]
+name = "hash"
+harness = false

--- a/crypto/crypto/benches/hash.rs
+++ b/crypto/crypto/benches/hash.rs
@@ -1,0 +1,41 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+extern crate criterion;
+
+use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue, SparseMerkleInternalHasher};
+
+struct HashBencher(&'static [u8]);
+
+impl HashBencher {
+    fn bench_hash(input: &'static [u8]) -> HashValue {
+        let bench = Self(input);
+        bench.hash()
+    }
+}
+
+impl CryptoHash for HashBencher {
+    type Hasher = SparseMerkleInternalHasher;
+    fn hash(&self) -> HashValue {
+        let mut state = Self::Hasher::default();
+        state.write(self.0);
+        state.finish()
+    }
+}
+
+fn bench_hasher(c: &mut criterion::Criterion) {
+    let expected_digest =
+        HashValue::from_hex("a2a3adfaed90739641d57dc3d0f8e6231b0d038748dad0feaec765c9aa9676a6")
+            .unwrap();
+
+    c.bench_function("hashing", |b| {
+        b.iter(|| {
+            let digest = HashBencher::bench_hash(criterion::black_box(b"someinput"));
+            assert_eq!(digest, expected_digest);
+        })
+    });
+}
+
+criterion_group!(benches, bench_hasher);
+criterion_main!(benches);


### PR DESCRIPTION
Hashing being a bottleneck, it would be nice to have some bench numbers to compare with different implementations or even different hash functions.

You can run this one with:

```
cargo bench -p libra-crypto
```