### PR TITLE
[VMValidator] Use new API to get latest state root and version

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -591,6 +591,12 @@ impl LibraDB {
 
     // =========================== Libra Core Internal APIs ========================================
 
+    /// Gets the latest state root hash together with its version.
+    pub fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+        let (version, txn_info) = self.ledger_store.get_latest_transaction_info()?;
+        Ok((version, txn_info.state_root_hash()))
+    }
+
     /// Gets an account state by account address, out of the ledger state indicated by the state
     /// Merkle tree root hash.
     ///

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -42,6 +42,48 @@ use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct GetLatestStateRootResponse {
+    pub version: Version,
+    pub state_root_hash: HashValue,
+}
+
+impl GetLatestStateRootResponse {
+    pub fn new(version: Version, state_root_hash: HashValue) -> Self {
+        Self {
+            version,
+            state_root_hash,
+        }
+    }
+}
+
+impl TryFrom<crate::proto::storage::GetLatestStateRootResponse> for GetLatestStateRootResponse {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::storage::GetLatestStateRootResponse) -> Result<Self> {
+        let version = proto.version;
+        let state_root_hash = HashValue::from_slice(&proto.state_root_hash)?;
+
+        Ok(Self::new(version, state_root_hash))
+    }
+}
+
+impl From<GetLatestStateRootResponse> for crate::proto::storage::GetLatestStateRootResponse {
+    fn from(response: GetLatestStateRootResponse) -> Self {
+        Self {
+            version: response.version,
+            state_root_hash: response.state_root_hash.to_vec(),
+        }
+    }
+}
+
+impl Into<(Version, HashValue)> for GetLatestStateRootResponse {
+    fn into(self) -> (Version, HashValue) {
+        (self.version, self.state_root_hash)
+    }
+}
+
 /// Helper to construct and parse [`proto::storage::GetAccountStateWithProofByVersionRequest`]
 #[derive(PartialEq, Eq, Clone)]
 pub struct GetAccountStateWithProofByVersionRequest {

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -39,6 +39,9 @@ service Storage {
     // in the response will be relative to this given ledger version.
     rpc GetTransactions(GetTransactionsRequest) returns (GetTransactionsResponse);
 
+    rpc GetLatestStateRoot(GetLatestStateRootRequest)
+    returns (GetLatestStateRootResponse);
+
     rpc GetAccountStateWithProofByVersion(
     GetAccountStateWithProofByVersionRequest)
     returns (GetAccountStateWithProofByVersionResponse);
@@ -85,6 +88,13 @@ message GetTransactionsRequest {
 
 message GetTransactionsResponse {
     types.TransactionListWithProof txn_list_with_proof = 1;
+}
+
+message GetLatestStateRootRequest {}
+
+message GetLatestStateRootResponse {
+    uint64 version = 1;
+    bytes state_root_hash = 2;
 }
 
 message GetAccountStateWithProofByVersionRequest {

--- a/storage/storage-proto/src/tests.rs
+++ b/storage/storage-proto/src/tests.rs
@@ -8,6 +8,11 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
     #[test]
+    fn test_get_latest_state_root_response(resp in any::<GetLatestStateRootResponse>()) {
+        assert_protobuf_encode_decode::<crate::proto::storage::GetLatestStateRootResponse, GetLatestStateRootResponse>(&resp);
+    }
+
+    #[test]
     fn test_save_transactions_request(req in any::<SaveTransactionsRequest>()) {
         assert_protobuf_encode_decode::<crate::proto::storage::SaveTransactionsRequest, SaveTransactionsRequest>(&req);
     }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -88,6 +88,12 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
+    fn get_latest_state_root_async(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<(Version, HashValue)>> + Send>> {
+        unimplemented!()
+    }
+
     fn get_account_state_with_proof_by_version_async(
         &self,
         _address: AccountAddress,

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, format_err, Error, Result};
+use anyhow::{bail, Error, Result};
 use futures::future::{err, ok, Future};
 use libra_config::config::NodeConfig;
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     account_config::get_account_resource_or_default,
     get_with_proof::{RequestItem, ResponseItem},
     transaction::SignedTransaction,
@@ -51,51 +51,16 @@ impl TransactionValidation for VMValidator {
         &self,
         txn: SignedTransaction,
     ) -> Box<dyn Future<Item = Option<VMStatus>, Error = Error> + Send> {
-        // TODO: For transaction validation, there are two options to go:
-        // 1. Trust storage: there is no need to get root hash from storage here. We will
-        // create another struct similar to `VerifiedStateView` that implements `StateView`
-        // but does not do verification.
-        // 2. Don't trust storage. This requires more work:
-        // 1) AC must have validator set information
-        // 2) Get state_root from transaction info which can be verified with signatures of
-        // validator set.
-        // 3) Create VerifiedStateView with verified state
-        // root.
-
-        // Just ask something from storage. It doesn't matter what it is -- we just need the
-        // transaction info object in account state proof which contains the state root hash.
-        let address = AccountAddress::new([0xff; ADDRESS_LENGTH]);
-        let item = RequestItem::GetAccountState { address };
-
-        match self
-            .storage_read_client
-            .update_to_latest_ledger(/* client_known_version = */ 0, vec![item])
-        {
-            Ok((mut items, ledger_info_with_sigs, _, _)) => {
-                if items.len() != 1 {
-                    return Box::new(err(format_err!(
-                        "Unexpected number of items ({}).",
-                        items.len()
-                    )));
-                }
-
-                match items.remove(0) {
-                    ResponseItem::GetAccountState {
-                        account_state_with_proof,
-                    } => {
-                        let transaction_info = account_state_with_proof.proof.transaction_info();
-                        let state_root = transaction_info.state_root_hash();
-                        let smt = SparseMerkleTree::new(state_root);
-                        let state_view = VerifiedStateView::new(
-                            Arc::clone(&self.storage_read_client),
-                            Some(ledger_info_with_sigs.ledger_info().version()),
-                            state_root,
-                            &smt,
-                        );
-                        Box::new(ok(self.vm.validate_transaction(txn, &state_view)))
-                    }
-                    _ => panic!("Unexpected item in response."),
-                }
+        match self.storage_read_client.get_latest_state_root() {
+            Ok((version, state_root)) => {
+                let smt = SparseMerkleTree::new(state_root);
+                let state_view = VerifiedStateView::new(
+                    Arc::clone(&self.storage_read_client),
+                    Some(version),
+                    state_root,
+                    &smt,
+                );
+                Box::new(ok(self.vm.validate_transaction(txn, &state_view)))
             }
             Err(e) => Box::new(err(e)),
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The [current way](https://github.com/libra/libra/blob/a4ea6a1d81b2bc77d762a553c2e55700a1e305c4/vm-validator/src/vm_validator.rs#L54) to find the latest state root and version is a bit hacky. This change adds a proper API and use the new API to get them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

CI.

## Related PRs

None.