### PR TITLE
[network][metrics] Add libra_network_discovery_notes metric

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -109,6 +109,13 @@ impl RoleType {
     pub fn is_validator(&self) -> bool {
         *self == RoleType::Validator
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RoleType::Validator => "validator",
+            RoleType::FullNode => "full_node",
+        }
+    }
 }
 
 impl std::str::FromStr for RoleType {
@@ -125,10 +132,7 @@ impl std::str::FromStr for RoleType {
 
 impl fmt::Display for RoleType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            RoleType::Validator => write!(f, "validator"),
-            RoleType::FullNode => write!(f, "full_node"),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -15,6 +15,15 @@ lazy_static::lazy_static! {
         &["role_type", "state"]
     ).unwrap();
 
+    pub static ref LIBRA_NETWORK_DISCOVERY_NOTES: IntGaugeVec = register_int_gauge_vec!(
+        // metric name
+        "libra_network_discovery_notes",
+        // metric description
+        "Libra network discovery notes",
+        // metric labels (dimensions)
+        &["role_type"]
+    ).unwrap();
+
     pub static ref LIBRA_NETWORK_RPC_MESSAGES: IntCounterVec = register_int_counter_vec!(
         "libra_network_rpc_messages",
         "Libra network rpc messages counter",

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -291,7 +291,7 @@ where
                 }
                 // update libra_network_peer counter
                 counters::LIBRA_NETWORK_PEERS
-                    .with_label_values(&[&role.to_string(), "connected"])
+                    .with_label_values(&[role.as_str(), "connected"])
                     .dec();
                 // Send LostPeer notifications to subscribers
                 for ch in &mut self.peer_event_handlers {
@@ -467,7 +467,7 @@ where
         if send_new_peer_notification {
             // update libra_network_peer counter
             counters::LIBRA_NETWORK_PEERS
-                .with_label_values(&[&role.to_string(), "connected"])
+                .with_label_values(&[role.as_str(), "connected"])
                 .inc();
 
             for ch in &mut self.peer_event_handlers {

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -8,6 +8,7 @@ use crate::protocols::direct_send::Message;
 use crate::validator_network::DISCOVERY_DIRECT_SEND_PROTOCOL;
 use crate::ProtocolId;
 use core::str::FromStr;
+use libra_config::config::RoleType;
 use libra_crypto::{test_utils::TEST_SEED, *};
 use prost::Message as _;
 use rand::{rngs::StdRng, SeedableRng};
@@ -81,9 +82,11 @@ fn setup_discovery(
     let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(1);
     let (network_notifs_tx, network_notifs_rx) = channel::new_test(0);
     let (ticker_tx, ticker_rx) = channel::new_test(0);
+    let role = RoleType::Validator;
     let discovery = {
         Discovery::new(
             peer_id,
+            role,
             addrs,
             signer,
             vec![(seed_peer_id, seed_peer_info)].into_iter().collect(),

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -530,6 +530,7 @@ impl NetworkBuilder {
                 vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
             );
             let peer_id = self.peer_id;
+            let role = self.role;
             let addrs = vec![self
                 .advertised_address
                 .clone()
@@ -541,6 +542,7 @@ impl NetworkBuilder {
             let f = async move {
                 let discovery = Discovery::new(
                     peer_id,
+                    role,
                     addrs,
                     signer,
                     seed_peers,


### PR DESCRIPTION
+ This metric records the number of verified discovery notes we
have for _other_ peers (not including our own note). We exclude
counting our own note to be consistent with the "connected_peers"
metric.

+ Motiviation: following a discussion in the chat, viewing the number
of discovery notes (i.e., peers that we can dial) vs the number of
actual connected peers would be a useful metric for debugging
connectivity issues.

+ Add `fn RoleType::as_str(&self) -> &'static str` to avoid unecessary
allocation + copy when recording connected peers and discovery notes
metrics.
