### PR TITLE
[VMValidator] Stop using update_to_latest_ledger to retrieve account state

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -619,6 +619,20 @@ impl LibraDB {
             .get_account_state_with_proof_by_version(address, version)
     }
 
+    /// Given an account address, returns the latest account state. `None` if the account does not
+    /// exist.
+    pub fn get_latest_account_state(
+        &self,
+        address: AccountAddress,
+    ) -> Result<Option<AccountStateBlob>> {
+        let ledger_info_with_sigs = self.ledger_store.get_latest_ledger_info()?;
+        let version = ledger_info_with_sigs.ledger_info().version();
+        let (blob, _proof) = self
+            .state_store
+            .get_account_state_with_proof_by_version(address, version)?;
+        Ok(blob)
+    }
+
     /// Gets information needed from storage during the startup of the executor or state
     /// synchronizer module.
     ///

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -84,6 +84,69 @@ impl Into<(Version, HashValue)> for GetLatestStateRootResponse {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct GetLatestAccountStateRequest {
+    pub address: AccountAddress,
+}
+
+impl GetLatestAccountStateRequest {
+    pub fn new(address: AccountAddress) -> Self {
+        Self { address }
+    }
+}
+
+impl TryFrom<crate::proto::storage::GetLatestAccountStateRequest> for GetLatestAccountStateRequest {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::storage::GetLatestAccountStateRequest) -> Result<Self> {
+        let address = AccountAddress::try_from(&proto.address[..])?;
+        Ok(Self::new(address))
+    }
+}
+
+impl From<GetLatestAccountStateRequest> for crate::proto::storage::GetLatestAccountStateRequest {
+    fn from(request: GetLatestAccountStateRequest) -> Self {
+        Self {
+            address: request.address.into(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct GetLatestAccountStateResponse {
+    pub account_state_blob: Option<AccountStateBlob>,
+}
+
+impl GetLatestAccountStateResponse {
+    pub fn new(account_state_blob: Option<AccountStateBlob>) -> Self {
+        Self { account_state_blob }
+    }
+}
+
+impl TryFrom<crate::proto::storage::GetLatestAccountStateResponse>
+    for GetLatestAccountStateResponse
+{
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::storage::GetLatestAccountStateResponse) -> Result<Self> {
+        let account_state_blob = proto
+            .account_state_blob
+            .map(TryFrom::try_from)
+            .transpose()?;
+        Ok(Self::new(account_state_blob))
+    }
+}
+
+impl From<GetLatestAccountStateResponse> for crate::proto::storage::GetLatestAccountStateResponse {
+    fn from(response: GetLatestAccountStateResponse) -> Self {
+        Self {
+            account_state_blob: response.account_state_blob.map(Into::into),
+        }
+    }
+}
+
 /// Helper to construct and parse [`proto::storage::GetAccountStateWithProofByVersionRequest`]
 #[derive(PartialEq, Eq, Clone)]
 pub struct GetAccountStateWithProofByVersionRequest {

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -42,6 +42,9 @@ service Storage {
     rpc GetLatestStateRoot(GetLatestStateRootRequest)
     returns (GetLatestStateRootResponse);
 
+    rpc GetLatestAccountState(GetLatestAccountStateRequest)
+    returns (GetLatestAccountStateResponse);
+
     rpc GetAccountStateWithProofByVersion(
     GetAccountStateWithProofByVersionRequest)
     returns (GetAccountStateWithProofByVersionResponse);
@@ -95,6 +98,14 @@ message GetLatestStateRootRequest {}
 message GetLatestStateRootResponse {
     uint64 version = 1;
     bytes state_root_hash = 2;
+}
+
+message GetLatestAccountStateRequest {
+    bytes address = 1;
+}
+
+message GetLatestAccountStateResponse {
+    types.AccountStateBlob account_state_blob = 1;
 }
 
 message GetAccountStateWithProofByVersionRequest {

--- a/storage/storage-proto/src/tests.rs
+++ b/storage/storage-proto/src/tests.rs
@@ -13,6 +13,16 @@ proptest! {
     }
 
     #[test]
+    fn test_get_latest_account_state_request(req in any::<GetLatestAccountStateRequest>()) {
+        assert_protobuf_encode_decode::<crate::proto::storage::GetLatestAccountStateRequest, GetLatestAccountStateRequest>(&req);
+    }
+
+    #[test]
+    fn test_get_latest_account_state_response(resp in any::<GetLatestAccountStateResponse>()) {
+        assert_protobuf_encode_decode::<crate::proto::storage::GetLatestAccountStateResponse, GetLatestAccountStateResponse>(&resp);
+    }
+
+    #[test]
     fn test_save_transactions_request(req in any::<SaveTransactionsRequest>()) {
         assert_protobuf_encode_decode::<crate::proto::storage::SaveTransactionsRequest, SaveTransactionsRequest>(&req);
     }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -94,6 +94,13 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
+    fn get_latest_account_state_async(
+        &self,
+        _address: AccountAddress,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<AccountStateBlob>>> + Send>> {
+        unimplemented!()
+    }
+
     fn get_account_state_with_proof_by_version_async(
         &self,
         _address: AccountAddress,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The new API will be faster.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

CI.

## Related PRs

None.
