### PR TITLE
[config] make debug interface bind to 0.0.0.0 by default

### DIFF
--- a/config/src/config/debug_interface_config.rs
+++ b/config/src/config/debug_interface_config.rs
@@ -22,7 +22,7 @@ impl Default for DebugInterfaceConfig {
             storage_node_debug_port: 6194,
             metrics_server_port: 9101,
             public_metrics_server_port: 9102,
-            address: "localhost".to_string(),
+            address: "0.0.0.0".to_string(),
         }
     }
 }

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -27,7 +27,7 @@ admission_control_node_debug_port = 6191
 storage_node_debug_port = 6194
 metrics_server_port = 9101
 public_metrics_server_port = 9102
-address = "localhost"
+address = "0.0.0.0"
 
 [execution]
 address = "localhost"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -27,7 +27,7 @@ admission_control_node_debug_port = 6191
 storage_node_debug_port = 6194
 metrics_server_port = 9101
 public_metrics_server_port = 9102
-address = "localhost"
+address = "0.0.0.0"
 
 [storage]
 address = "localhost"


### PR DESCRIPTION
Every config we generated had these as default but our default was not
this. This fixes this asymmetry.