### PR TITLE
[Storage] Move up get_epoch_change_ledger_infos changes to storage client

### DIFF
--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::SynchronizerState;
-use anyhow::{format_err, Result};
+use anyhow::{ensure, format_err, Result};
 use executor::{ExecutedTrees, Executor};
 use futures::{Future, FutureExt};
 use grpcio::EnvBuilder;
@@ -133,9 +133,11 @@ impl ExecutorProxyTrait for ExecutorProxy {
         start_epoch: u64,
         end_epoch: u64,
     ) -> Result<ValidatorChangeEventWithProof> {
-        let ledger_info_per_epoch = self
+        let (ledger_info_per_epoch, more) = self
             .storage_read_client
             .get_epoch_change_ledger_infos(start_epoch, end_epoch)?;
+        // TODO(zekun000): change this to query storage for more epoch changes.
+        ensure!(!more, "Exceeded max response length.");
         Ok(ValidatorChangeEventWithProof::new(ledger_info_per_epoch))
     }
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -214,7 +214,7 @@ impl StorageRead for StorageReadServiceClient {
         &self,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<(Vec<LedgerInfoWithSignatures>, bool)>> + Send>> {
         let proto_req = GetEpochChangeLedgerInfosRequest::new(start_epoch, end_epoch);
         convert_grpc_response(
             self.client()
@@ -436,7 +436,7 @@ pub trait StorageRead: Send + Sync {
         &self,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Result<Vec<LedgerInfoWithSignatures>> {
+    ) -> Result<(Vec<LedgerInfoWithSignatures>, bool)> {
         block_on(self.get_epoch_change_ledger_infos_async(start_epoch, end_epoch))
     }
 
@@ -448,7 +448,7 @@ pub trait StorageRead: Send + Sync {
         &self,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<(Vec<LedgerInfoWithSignatures>, bool)>> + Send>>;
 
     /// See [`LibraDB::backup_account_state`].
     ///

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -37,7 +37,7 @@ use libra_types::{
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
 #[cfg(any(test, feature = "fuzzing"))]
-use proptest::prelude::*;
+use proptest::{collection::vec, prelude::*};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
@@ -148,7 +148,8 @@ impl From<GetLatestAccountStateResponse> for crate::proto::storage::GetLatestAcc
 }
 
 /// Helper to construct and parse [`proto::storage::GetAccountStateWithProofByVersionRequest`]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetAccountStateWithProofByVersionRequest {
     /// The access path to query with.
     pub address: AccountAddress,
@@ -191,7 +192,8 @@ impl From<GetAccountStateWithProofByVersionRequest>
 }
 
 /// Helper to construct and parse [`proto::storage::GetAccountStateWithProofByVersionResponse`]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetAccountStateWithProofByVersionResponse {
     /// The account state blob requested.
     pub account_state_blob: Option<AccountStateBlob>,
@@ -670,7 +672,6 @@ impl From<GetEpochChangeLedgerInfosRequest>
 
 /// Helper to construct and parse [`proto::storage::GetEpochChangeLedgerInfosResponse`]
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetEpochChangeLedgerInfosResponse {
     pub ledger_infos_with_sigs: Vec<LedgerInfoWithSignatures>,
     pub more: bool,
@@ -724,8 +725,21 @@ impl Into<(Vec<LedgerInfoWithSignatures>, bool)> for GetEpochChangeLedgerInfosRe
     }
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
+impl Arbitrary for GetEpochChangeLedgerInfosResponse {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (vec(any::<LedgerInfoWithSignatures>(), 0..10), any::<bool>())
+            .prop_map(|(ledger_infos_with_sigs, more)| Self::new(ledger_infos_with_sigs, more))
+            .boxed()
+    }
+}
+
 /// Helper to construct and parse [`proto::storage::BackupAccountStateRequest`]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct BackupAccountStateRequest {
     /// The version of state to backup.
     pub version: Version,
@@ -757,7 +771,8 @@ impl From<BackupAccountStateRequest> for crate::proto::storage::BackupAccountSta
 }
 
 /// Helper to construct and parse [`proto::storage::BackupAccountStateResponse`]
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct BackupAccountStateResponse {
     /// The hashed account address
     pub account_key: HashValue,

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -673,13 +673,15 @@ impl From<GetEpochChangeLedgerInfosRequest>
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct GetEpochChangeLedgerInfosResponse {
     pub ledger_infos_with_sigs: Vec<LedgerInfoWithSignatures>,
+    pub more: bool,
 }
 
 impl GetEpochChangeLedgerInfosResponse {
     /// Constructor.
-    pub fn new(latest_ledger_infos: Vec<LedgerInfoWithSignatures>) -> Self {
+    pub fn new(ledger_infos_with_sigs: Vec<LedgerInfoWithSignatures>, more: bool) -> Self {
         Self {
-            ledger_infos_with_sigs: latest_ledger_infos,
+            ledger_infos_with_sigs,
+            more,
         }
     }
 }
@@ -696,6 +698,7 @@ impl TryFrom<crate::proto::storage::GetEpochChangeLedgerInfosResponse>
                 .into_iter()
                 .map(TryFrom::try_from)
                 .collect::<Result<Vec<_>>>()?,
+            more: proto.more,
         })
     }
 }
@@ -710,13 +713,14 @@ impl From<GetEpochChangeLedgerInfosResponse>
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            more: response.more,
         }
     }
 }
 
-impl Into<Vec<LedgerInfoWithSignatures>> for GetEpochChangeLedgerInfosResponse {
-    fn into(self) -> Vec<LedgerInfoWithSignatures> {
-        self.ledger_infos_with_sigs
+impl Into<(Vec<LedgerInfoWithSignatures>, bool)> for GetEpochChangeLedgerInfosResponse {
+    fn into(self) -> (Vec<LedgerInfoWithSignatures>, bool) {
+        (self.ledger_infos_with_sigs, self.more)
     }
 }
 

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -167,8 +167,11 @@ message GetEpochChangeLedgerInfosRequest {
 }
 
 message GetEpochChangeLedgerInfosResponse {
-    /// Vector of latest ledger infos per epoch (not sorted)
+    // Vector of latest ledger infos per epoch (not sorted)
     repeated types.LedgerInfoWithSignatures latest_ledger_infos = 1;
+    // Whether the above field has everything. true means the response is
+    // incomplete -- only first N are returned and there are more.
+    bool more = 2;
 }
 
 message BackupAccountStateRequest {

--- a/storage/storage-proto/src/tests.rs
+++ b/storage/storage-proto/src/tests.rs
@@ -4,46 +4,56 @@
 use super::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(10))]
+macro_rules! test_conversion {
+    ($test_name: ident, $rust_type: ident $(,)?) => {
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(10))]
 
-    #[test]
-    fn test_get_latest_state_root_response(resp in any::<GetLatestStateRootResponse>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::GetLatestStateRootResponse, GetLatestStateRootResponse>(&resp);
-    }
-
-    #[test]
-    fn test_get_latest_account_state_request(req in any::<GetLatestAccountStateRequest>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::GetLatestAccountStateRequest, GetLatestAccountStateRequest>(&req);
-    }
-
-    #[test]
-    fn test_get_latest_account_state_response(resp in any::<GetLatestAccountStateResponse>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::GetLatestAccountStateResponse, GetLatestAccountStateResponse>(&resp);
-    }
-
-    #[test]
-    fn test_save_transactions_request(req in any::<SaveTransactionsRequest>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::SaveTransactionsRequest, SaveTransactionsRequest>(&req);
-    }
-
-    #[test]
-    fn test_get_transactions_request(req in any::<GetTransactionsRequest>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::GetTransactionsRequest, GetTransactionsRequest>(&req);
-    }
-
-    #[test]
-    fn test_get_transactions_response(resp in any::<GetTransactionsResponse>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::GetTransactionsResponse, GetTransactionsResponse>(&resp);
-    }
-
-    #[test]
-    fn test_startup_info(startup_info in any::<StartupInfo>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::StartupInfo, StartupInfo>(&startup_info);
-    }
-
-    #[test]
-    fn test_get_startup_info_response(res in any::<GetStartupInfoResponse>()) {
-        assert_protobuf_encode_decode::<crate::proto::storage::GetStartupInfoResponse, GetStartupInfoResponse>(&res);
-    }
+            #[test]
+            fn $test_name(object in any::<$rust_type>()) {
+                type ProtoType = crate::proto::storage::$rust_type;
+                assert_protobuf_encode_decode::<ProtoType, $rust_type>(&object);
+            }
+        }
+    };
 }
+
+test_conversion!(
+    test_get_latest_state_root_response,
+    GetLatestStateRootResponse,
+);
+test_conversion!(
+    test_get_latest_account_state_request,
+    GetLatestAccountStateRequest,
+);
+test_conversion!(
+    test_get_latest_account_state_response,
+    GetLatestAccountStateResponse,
+);
+test_conversion!(
+    test_get_account_state_with_proof_by_version_request,
+    GetAccountStateWithProofByVersionRequest,
+);
+test_conversion!(
+    test_get_account_state_with_proof_by_version_response,
+    GetAccountStateWithProofByVersionResponse,
+);
+test_conversion!(test_save_transactions_request, SaveTransactionsRequest);
+test_conversion!(test_get_transactions_request, GetTransactionsRequest);
+test_conversion!(test_get_transactions_response, GetTransactionsResponse);
+test_conversion!(test_tree_state, TreeState);
+test_conversion!(test_startup_info, StartupInfo);
+test_conversion!(test_get_startup_info_response, GetStartupInfoResponse);
+test_conversion!(
+    test_get_epoch_change_ledger_infos_request,
+    GetEpochChangeLedgerInfosRequest,
+);
+test_conversion!(
+    test_get_epoch_change_ledger_infos_response,
+    GetEpochChangeLedgerInfosResponse,
+);
+test_conversion!(test_backup_account_state_request, BackupAccountStateRequest);
+test_conversion!(
+    test_backup_account_state_response,
+    BackupAccountStateResponse,
+);

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -246,10 +246,10 @@ impl StorageService {
         req: GetEpochChangeLedgerInfosRequest,
     ) -> Result<GetEpochChangeLedgerInfosResponse> {
         let rust_req = storage_proto::GetEpochChangeLedgerInfosRequest::try_from(req)?;
-        let ledger_infos = self
+        let (ledger_infos, more) = self
             .db
             .get_epoch_change_ledger_infos(rust_req.start_epoch, rust_req.end_epoch)?;
-        let rust_resp = storage_proto::GetEpochChangeLedgerInfosResponse::new(ledger_infos);
+        let rust_resp = storage_proto::GetEpochChangeLedgerInfosResponse::new(ledger_infos, more);
         Ok(rust_resp.into())
     }
 }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -120,7 +120,7 @@ impl StorageRead for MockStorageReadClient {
         &self,
         _start_epoch: u64,
         _end_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<LedgerInfoWithSignatures>>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<(Vec<LedgerInfoWithSignatures>, bool)>> + Send>> {
         unimplemented!()
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In a previous commit we changed `get_epoch_change_ledger_infos` in `ledger_store` to return a flag indicating whether the response is complete. Now continue the work and move up the change to
storage client.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

CI.

## Related PRs

None.
