### PR TITLE
[State sync] Integration tests for waypoint synchronization

### DIFF
--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -11,7 +11,8 @@ use config_builder;
 use executor::ExecutedTrees;
 use futures::{executor::block_on, future::FutureExt, Future};
 use libra_config::config::RoleType;
-use libra_crypto::x25519::X25519StaticPublicKey;
+use libra_config::waypoint::Waypoint;
+use libra_crypto::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED, x25519, HashValue};
 use libra_logger::set_simple_logger;
 use libra_types::block_info::BlockInfo;
@@ -112,61 +113,92 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         Ok(self.storage.read().unwrap().get_epoch_changes(start_epoch))
     }
 
-    fn get_ledger_info(&self, version: u64) -> Option<LedgerInfoWithSignatures> {
+    fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
         self.storage.read().unwrap().get_ledger_info(version)
     }
 }
 
 struct SynchronizerEnv {
-    _runtime: Runtime,
-    _synchronizers: Vec<StateSynchronizer>,
+    runtime: Runtime,
+    synchronizers: Vec<StateSynchronizer>,
     clients: Vec<Arc<StateSyncClient>>,
     storage_proxies: Vec<Arc<RwLock<MockStorage>>>, // to directly modify peers storage
-    network_signing_public_keys: Vec<Ed25519PublicKey>,
-    network_identity_public_keys: Vec<X25519StaticPublicKey>,
+    signers: Vec<ValidatorSigner>,
+    network_signers: Vec<Ed25519PrivateKey>,
+    public_keys: Vec<ValidatorPublicKeys>,
+    peer_ids: Vec<PeerId>,
+    peer_addresses: Vec<Multiaddr>,
 }
 
 impl SynchronizerEnv {
     // Returns the initial peers with their signatures
-    fn initial_setup() -> (
+    fn initial_setup(
+        count: usize,
+    ) -> (
         Vec<ValidatorSigner>,
         Vec<Ed25519PrivateKey>,
         Vec<ValidatorPublicKeys>,
     ) {
-        let (signers, _verifier) = random_validator_verifier(2, None, true);
+        let (signers, _verifier) = random_validator_verifier(count, None, true);
 
         // Setup signing public keys.
         let mut rng = StdRng::from_seed(TEST_SEED);
-        let (a_signing_private_key, a_signing_public_key) = compat::generate_keypair(&mut rng);
-        let (b_signing_private_key, b_signing_public_key) = compat::generate_keypair(&mut rng);
+        let signing_keys = (0..count)
+            .map(|_| compat::generate_keypair(&mut rng))
+            .collect::<Vec<(Ed25519PrivateKey, Ed25519PublicKey)>>();
         // Setup identity public keys.
-        let (_a_identity_private_key, a_identity_public_key) =
-            x25519::compat::generate_keypair(&mut rng);
-        let (_b_identity_private_key, b_identity_public_key) =
-            x25519::compat::generate_keypair(&mut rng);
+        let identity_keys = (0..count)
+            .map(|_| x25519::compat::generate_keypair(&mut rng))
+            .collect::<Vec<(X25519StaticPrivateKey, X25519StaticPublicKey)>>();
 
-        // The voting power of peer 1 is enough to generate an LI that passes validation.
-        let validators_keys = vec![
-            ValidatorPublicKeys::new(
-                signers[0].author(),
-                signers[0].public_key(),
-                1,
-                a_signing_public_key.clone(),
-                a_identity_public_key.clone(),
-            ),
-            ValidatorPublicKeys::new(
-                signers[1].author(),
-                signers[1].public_key(),
-                3,
-                b_signing_public_key.clone(),
-                b_identity_public_key.clone(),
-            ),
-        ];
+        let mut validators_keys = vec![];
+        // The voting power of peer 0 is enough to generate an LI that passes validation.
+        for (idx, signer) in signers.iter().enumerate() {
+            let voting_power = if idx == 0 { 1000 } else { 1 };
+            let validator_public_keys = ValidatorPublicKeys::new(
+                signer.author(),
+                signer.public_key(),
+                voting_power,
+                signing_keys[idx].1.clone(),
+                identity_keys[idx].1.clone(),
+            );
+            validators_keys.push(validator_public_keys);
+        }
         (
             signers,
-            vec![a_signing_private_key, b_signing_private_key],
+            signing_keys
+                .iter()
+                .map(|(private_key, _)| private_key.clone())
+                .collect::<Vec<Ed25519PrivateKey>>(),
             validators_keys,
         )
+    }
+
+    // Moves peer 0 to the next epoch. Note that other peers are not going to be able to discover
+    // their new signers: they're going to learn about the new epoch public key through state
+    // synchronization, but private keys are discovered separately.
+    pub fn move_to_next_epoch(&self) {
+        let num_peers = self.public_keys.len();
+        let (signers, _verifier) = random_validator_verifier(num_peers, None, true);
+        let new_keys = self
+            .public_keys
+            .iter()
+            .enumerate()
+            .map(|(idx, validator_keys)| {
+                ValidatorPublicKeys::new(
+                    signers[idx].author(),
+                    signers[idx].public_key(),
+                    validator_keys.consensus_voting_power(),
+                    validator_keys.network_signing_public_key().clone(),
+                    validator_keys.network_identity_public_key().clone(),
+                )
+            })
+            .collect::<Vec<ValidatorPublicKeys>>();
+        let validator_set = ValidatorSet::new(new_keys);
+        self.storage_proxies[0]
+            .write()
+            .unwrap()
+            .move_to_next_epoch(signers[0].clone(), validator_set);
     }
 
     fn genesis_li(validators: &[ValidatorPublicKeys]) -> LedgerInfoWithSignatures {
@@ -187,27 +219,34 @@ impl SynchronizerEnv {
         )
     }
 
-    fn new(handler: MockRpcHandler, role: RoleType) -> Self {
+    fn new(num_peers: usize) -> Self {
         set_simple_logger("state-sync");
         let runtime = Runtime::new().unwrap();
-        let (signers, network_signers, public_keys) = Self::initial_setup();
-        let peers = signers.iter().map(|s| s.author()).collect::<Vec<PeerId>>();
-        let network_signing_public_keys = public_keys
-            .iter()
-            .map(|pk| pk.network_signing_public_key().clone())
-            .collect::<Vec<Ed25519PublicKey>>();
-        let network_identity_public_keys = public_keys
-            .iter()
-            .map(|pk| pk.network_identity_public_key().clone())
-            .collect::<Vec<X25519StaticPublicKey>>();
+        let (signers, network_signers, public_keys) = Self::initial_setup(num_peers);
+        let peer_ids = signers.iter().map(|s| s.author()).collect::<Vec<PeerId>>();
 
-        // setup network
-        let addr: Multiaddr = "/memory/0".parse().unwrap();
-        let protocols = vec![ProtocolId::from_static(
-            STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
-        )];
+        Self {
+            runtime,
+            synchronizers: vec![],
+            clients: vec![],
+            storage_proxies: vec![],
+            signers,
+            network_signers,
+            public_keys,
+            peer_ids,
+            peer_addresses: vec![],
+        }
+    }
 
-        let trusted_peers: HashMap<_, _> = public_keys
+    fn start_next_synchronizer(
+        &mut self,
+        handler: MockRpcHandler,
+        role: RoleType,
+        waypoint: Option<Waypoint>,
+    ) {
+        let new_peer_idx = self.synchronizers.len();
+        let trusted_peers: HashMap<_, _> = self
+            .public_keys
             .iter()
             .map(|public_keys| {
                 (
@@ -220,42 +259,40 @@ impl SynchronizerEnv {
             })
             .collect();
 
-        let (listener_addr, mut network_provider) = NetworkBuilder::new(
-            runtime.handle().clone(),
-            peers[1],
+        // setup network
+        let addr: Multiaddr = "/memory/0".parse().unwrap();
+        let protocols = vec![ProtocolId::from_static(
+            STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
+        )];
+
+        let mut seed_peers = HashMap::new();
+        if new_peer_idx > 0 {
+            seed_peers.insert(
+                self.peer_ids[new_peer_idx - 1],
+                vec![self.peer_addresses[new_peer_idx - 1].clone()],
+            );
+        }
+        let (peer_addr, mut network_provider) = NetworkBuilder::new(
+            self.runtime.handle().clone(),
+            self.peer_ids[new_peer_idx],
             addr.clone(),
             RoleType::Validator,
         )
         .signing_keys((
-            network_signers[1].clone(),
-            public_keys[1].network_signing_public_key().clone(),
+            self.network_signers[new_peer_idx].clone(),
+            self.public_keys[new_peer_idx]
+                .network_signing_public_key()
+                .clone(),
         ))
         .trusted_peers(trusted_peers.clone())
+        .seed_peers(seed_peers)
         .transport(TransportType::Memory)
         .direct_send_protocols(protocols.clone())
         .build();
-        let (sender_b, events_b) = network_provider.add_state_synchronizer(protocols.clone());
-        runtime.handle().spawn(network_provider.start());
 
-        let (_dialer_addr, mut network_provider) = NetworkBuilder::new(
-            runtime.handle().clone(),
-            peers[0],
-            addr.clone(),
-            RoleType::Validator,
-        )
-        .transport(TransportType::Memory)
-        .signing_keys((
-            network_signers[0].clone(),
-            public_keys[0].network_signing_public_key().clone(),
-        ))
-        .trusted_peers(trusted_peers.clone())
-        .seed_peers([(peers[1], vec![listener_addr])].iter().cloned().collect())
-        .direct_send_protocols(protocols.clone())
-        .build();
-        let (sender_a, events_a) = network_provider.add_state_synchronizer(protocols);
-        runtime.handle().spawn(network_provider.start());
+        let (sender, events) = network_provider.add_state_synchronizer(protocols.clone());
+        self.runtime.handle().spawn(network_provider.start());
 
-        // create synchronizers
         let mut config = config_builder::test_config().0;
         if !role.is_validator() {
             let mut network = config.validator_network.unwrap();
@@ -264,49 +301,32 @@ impl SynchronizerEnv {
             config.validator_network = None;
         }
         config.base.role = role;
-        config
-            .state_sync
-            .upstream_peers
-            .upstream_peers
-            .push(peers[1]);
-
-        let genesis_li = Self::genesis_li(&public_keys);
-        let storage_proxies = vec![
-            Arc::new(RwLock::new(MockStorage::new(
-                genesis_li.clone(),
-                signers[0].clone(),
-            ))),
-            Arc::new(RwLock::new(MockStorage::new(
-                genesis_li.clone(),
-                signers[1].clone(),
-            ))),
-        ];
-        let synchronizers: Vec<StateSynchronizer> = vec![
-            StateSynchronizer::bootstrap_with_executor_proxy(
-                vec![(sender_a, events_a)],
-                role,
-                None,
-                &config.state_sync,
-                MockExecutorProxy::new(Self::default_handler(), storage_proxies[0].clone()),
-            ),
-            StateSynchronizer::bootstrap_with_executor_proxy(
-                vec![(sender_b, events_b)],
-                role,
-                None,
-                &config.state_sync,
-                MockExecutorProxy::new(handler, storage_proxies[1].clone()),
-            ),
-        ];
-        let clients = synchronizers.iter().map(|s| s.create_client()).collect();
-
-        Self {
-            clients,
-            _synchronizers: synchronizers,
-            _runtime: runtime,
-            storage_proxies,
-            network_signing_public_keys,
-            network_identity_public_keys,
+        if new_peer_idx > 0 {
+            // set the upstream peer in the config
+            config
+                .state_sync
+                .upstream_peers
+                .upstream_peers
+                .push(self.peer_ids[new_peer_idx - 1]);
         }
+
+        let genesis_li = Self::genesis_li(&self.public_keys);
+        let storage_proxy = Arc::new(RwLock::new(MockStorage::new(
+            genesis_li,
+            self.signers[new_peer_idx].clone(),
+        )));
+        let synchronizer = StateSynchronizer::bootstrap_with_executor_proxy(
+            vec![(sender, events)],
+            role,
+            waypoint,
+            &config.state_sync,
+            MockExecutorProxy::new(handler, storage_proxy.clone()),
+        );
+        let client = synchronizer.create_client();
+        self.synchronizers.push(synchronizer);
+        self.clients.push(client);
+        self.storage_proxies.push(storage_proxy);
+        self.peer_addresses.push(peer_addr);
     }
 
     fn default_handler() -> MockRpcHandler {
@@ -333,6 +353,14 @@ impl SynchronizerEnv {
             .highest_local_li()
     }
 
+    // Find LedgerInfo for a given version.
+    fn get_ledger_info(&self, peer_id: usize, version: u64) -> Result<LedgerInfoWithSignatures> {
+        self.storage_proxies[peer_id]
+            .read()
+            .unwrap()
+            .get_ledger_info(version)
+    }
+
     fn wait_for_version(&self, peer_id: usize, target_version: u64) -> bool {
         let max_retries = 30;
         for _ in 0..max_retries {
@@ -345,55 +373,41 @@ impl SynchronizerEnv {
         false
     }
 
-    // Moves peer 1 to the next epoch. Note that peer 0 is not going to be able to discover its new
-    // signer: it'll learn about the new epoch public keys through state synchronization, but the
-    // private keys are supposed to be discovered separately.
-    pub fn move_to_next_epoch(&self) {
-        let (signers, _verifier) = random_validator_verifier(2, None, true);
-        let new_keys = vec![
-            ValidatorPublicKeys::new(
-                signers[0].author(),
-                signers[0].public_key(),
-                1,
-                self.network_signing_public_keys[0].clone(),
-                self.network_identity_public_keys[0].clone(),
-            ),
-            ValidatorPublicKeys::new(
-                signers[1].author(),
-                signers[1].public_key(),
-                3,
-                self.network_signing_public_keys[1].clone(),
-                self.network_identity_public_keys[1].clone(),
-            ),
-        ];
-        let validator_set = ValidatorSet::new(new_keys);
-        self.storage_proxies[1]
-            .write()
-            .unwrap()
-            .move_to_next_epoch(signers[1].clone(), validator_set);
+    fn wait_until_initialized(&self, peer_id: usize) -> Result<()> {
+        block_on(self.synchronizers[peer_id].wait_until_initialized())
     }
 }
 
 #[test]
 fn test_basic_catch_up() {
-    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::Validator);
+    let mut env = SynchronizerEnv::new(2);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
 
     // test small sequential syncs
     for version in 1..5 {
-        env.commit(1, version);
-        let target_li = env.latest_li(1);
-        env.sync_to(0, target_li);
-        assert_eq!(env.latest_li(0).ledger_info().version(), version);
+        env.commit(0, version);
+        let target_li = env.latest_li(0);
+        env.sync_to(1, target_li);
+        assert_eq!(env.latest_li(1).ledger_info().version(), version);
     }
     // test batch sync for multiple transactions
-    env.commit(1, 20);
-    env.sync_to(0, env.latest_li(1));
-    assert_eq!(env.latest_li(0).ledger_info().version(), 20);
+    env.commit(0, 20);
+    env.sync_to(1, env.latest_li(0));
+    assert_eq!(env.latest_li(1).ledger_info().version(), 20);
 
     // test batch sync for multiple chunks
-    env.commit(1, 2000);
-    env.sync_to(0, env.latest_li(1));
-    assert_eq!(env.latest_li(0).ledger_info().version(), 2000);
+    env.commit(0, 2000);
+    env.sync_to(1, env.latest_li(0));
+    assert_eq!(env.latest_li(1).ledger_info().version(), 2000);
 }
 
 #[test]
@@ -409,59 +423,129 @@ fn test_flaky_peer_sync() {
             Ok(resp)
         }
     });
-    let env = SynchronizerEnv::new(handler, RoleType::Validator);
-    env.commit(1, 20);
-    env.sync_to(0, env.latest_li(1));
-    assert_eq!(env.latest_li(0).ledger_info().version(), 20);
+    let mut env = SynchronizerEnv::new(2);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
+    env.start_next_synchronizer(handler, RoleType::Validator, None);
+    env.commit(0, 20);
+    env.sync_to(1, env.latest_li(0));
+    assert_eq!(env.latest_li(1).ledger_info().version(), 20);
 }
 
 #[test]
 fn test_full_node() {
-    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::FullNode);
-    env.commit(1, 10);
+    let mut env = SynchronizerEnv::new(2);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
+    env.start_next_synchronizer(SynchronizerEnv::default_handler(), RoleType::FullNode, None);
+    env.commit(0, 10);
     // first sync should be fulfilled immediately after peer discovery
-    assert!(env.wait_for_version(0, 10));
-    env.commit(1, 20);
+    assert!(env.wait_for_version(1, 10));
+    env.commit(0, 20);
     // second sync will be done via long polling cause first node should send new request
     // after receiving first chunk immediately
-    assert!(env.wait_for_version(0, 20));
+    assert!(env.wait_for_version(1, 20));
 }
 
 #[test]
 fn catch_up_through_epochs_validators() {
-    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::Validator);
+    let mut env = SynchronizerEnv::new(2);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
 
     // catch up to the next epoch starting from the middle of the current one
-    env.commit(1, 20);
-    env.sync_to(0, env.latest_li(1));
-    env.commit(1, 40);
+    env.commit(0, 20);
+    env.sync_to(1, env.latest_li(0));
+    env.commit(0, 40);
     env.move_to_next_epoch();
-    env.commit(1, 100);
-    env.sync_to(0, env.latest_li(1));
-    assert_eq!(env.latest_li(0).ledger_info().version(), 100);
-    assert_eq!(env.latest_li(0).ledger_info().epoch(), 2);
+    env.commit(0, 100);
+    env.sync_to(1, env.latest_li(0));
+    assert_eq!(env.latest_li(1).ledger_info().version(), 100);
+    assert_eq!(env.latest_li(1).ledger_info().epoch(), 2);
 
     // catch up through multiple epochs
     for epoch in 2..10 {
-        env.commit(1, epoch * 100);
+        env.commit(0, epoch * 100);
         env.move_to_next_epoch();
     }
-    env.commit(1, 950); // At this point peer 1 is at epoch 10 and version 950
-    env.sync_to(0, env.latest_li(1));
-    assert_eq!(env.latest_li(0).ledger_info().version(), 950);
-    assert_eq!(env.latest_li(0).ledger_info().epoch(), 10);
+    env.commit(0, 950); // At this point peer 0 is at epoch 10 and version 950
+    env.sync_to(1, env.latest_li(0));
+    assert_eq!(env.latest_li(1).ledger_info().version(), 950);
+    assert_eq!(env.latest_li(1).ledger_info().epoch(), 10);
 }
 
 #[test]
 fn catch_up_through_epochs_full_node() {
-    let env = SynchronizerEnv::new(SynchronizerEnv::default_handler(), RoleType::FullNode);
+    let mut env = SynchronizerEnv::new(3);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
     // catch up through multiple epochs
     for epoch in 1..10 {
-        env.commit(1, epoch * 100);
+        env.commit(0, epoch * 100);
         env.move_to_next_epoch();
     }
-    env.commit(1, 950); // At this point peer 1 is at epoch 10 and version 950
+    env.commit(0, 950); // At this point peer 0 is at epoch 10 and version 950
 
-    assert!(env.wait_for_version(0, 950));
-    assert_eq!(env.latest_li(0).ledger_info().epoch(), 10);
+    env.start_next_synchronizer(SynchronizerEnv::default_handler(), RoleType::FullNode, None);
+    assert!(env.wait_for_version(1, 950));
+    assert_eq!(env.latest_li(1).ledger_info().epoch(), 10);
+
+    // Peer 2 has peer 1 as its upstream, should catch up from it.
+    env.start_next_synchronizer(SynchronizerEnv::default_handler(), RoleType::FullNode, None);
+    assert!(env.wait_for_version(2, 950));
+    assert_eq!(env.latest_li(2).ledger_info().epoch(), 10);
+}
+
+#[test]
+fn catch_up_with_waypoints() {
+    let mut env = SynchronizerEnv::new(3);
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::Validator,
+        None,
+    );
+    for epoch in 1..10 {
+        env.commit(0, epoch * 100);
+        env.move_to_next_epoch();
+    }
+    env.commit(0, 950); // At this point peer 0 is at epoch 10 and version 950
+
+    // Create a waypoint based on LedgerInfo of peer 0 at version 700 (epoch 7)
+    let waypoint_li = env.get_ledger_info(0, 700).unwrap();
+    let waypoint = Waypoint::new(waypoint_li.ledger_info()).unwrap();
+
+    env.start_next_synchronizer(
+        SynchronizerEnv::default_handler(),
+        RoleType::FullNode,
+        Some(waypoint),
+    );
+    env.wait_until_initialized(1).unwrap();
+    assert!(env.latest_li(1).ledger_info().version() >= 700);
+    assert!(env.latest_li(1).ledger_info().epoch() >= 7);
+
+    // Once caught up with the waypoint peer 1 continues with the regular state sync
+    assert!(env.wait_for_version(1, 950));
+    assert_eq!(env.latest_li(1).ledger_info().epoch(), 10);
+
+    // Peer 2 has peer 1 as its upstream, should catch up from it.
+    env.start_next_synchronizer(SynchronizerEnv::default_handler(), RoleType::FullNode, None);
+    assert!(env.wait_for_version(2, 950));
+    assert_eq!(env.latest_li(2).ledger_info().epoch(), 10);
 }


### PR DESCRIPTION
Summary:
Some refactoring of the integration tests to allow for:
* chains of peers, in which a peer serves as an upstream to the next one.
* not starting all the peers at once

As a result, we can now run tests that verify chains of state sync.
We can also build a test, in which peer 0 runs to epoch 10, a waypoint is taken based on its LedgerInfo of epoch 7, peer 1 starts with this waypoint and finishes its initialization, peer 2 sync ups to peer 1.

Testing: all these tests

Issues: ref #1384
