### PR TITLE
[types] eliminate get_account_resource_or_default

### DIFF
--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -12,7 +12,7 @@ use libra_types::crypto_proxies::EpochInfo;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::get_account_resource_or_default,
+    account_config::AccountResource,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::{ContractEvent, EventWithProof},
     get_with_proof::{
@@ -156,7 +156,10 @@ impl GRPCClient {
 
     /// Get the latest account sequence number for the account specified.
     pub fn get_sequence_number(&mut self, address: AccountAddress) -> Result<u64> {
-        Ok(get_account_resource_or_default(&self.get_account_blob(address)?.0)?.sequence_number())
+        Ok(match self.get_account_blob(address)?.0 {
+            Some(blob) => AccountResource::try_from(&blob)?.sequence_number(),
+            None => 0,
+        })
     }
 
     /// Get the latest account state blob from validator.

--- a/client/src/query_commands.rs
+++ b/client/src/query_commands.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{client_proxy::ClientProxy, commands::*};
-use libra_types::account_config::get_account_resource_or_default;
 use transaction_builder::get_transaction_name;
 
 /// Major command for query operations.
@@ -93,20 +92,17 @@ impl Command for QueryCommandGetLatestAccountState {
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
         println!(">> Getting latest account state");
         match client.get_latest_account_state(&params) {
-            Ok((acc, version)) => match get_account_resource_or_default(&acc) {
-                Ok(_) => println!(
-                    "Latest account state is: \n \
-                     Account: {:#?}\n \
-                     State: {:#?}\n \
-                     Blockchain Version: {}\n",
-                    client
-                        .get_account_address_from_parameter(params[1])
-                        .expect("Unable to parse account parameter"),
-                    acc,
-                    version,
-                ),
-                Err(e) => report_error("Error converting account blob to account resource", e),
-            },
+            Ok((acc, version)) => println!(
+                "Latest account state is: \n \
+                 Account: {:#?}\n \
+                 State: {:#?}\n \
+                 Blockchain Version: {}\n",
+                client
+                    .get_account_address_from_parameter(params[1])
+                    .expect("Unable to parse account parameter"),
+                acc,
+                version,
+            ),
             Err(e) => report_error("Error getting latest account state", e),
         }
     }

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -14,7 +14,7 @@ use libra_types::crypto_proxies::EpochInfo;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::{association_address, get_account_resource_or_default},
+    account_config::{association_address, AccountResource},
     account_state_blob::AccountStateWithProof,
     block_info::BlockInfo,
     block_metadata::BlockMetadata,
@@ -25,7 +25,7 @@ use libra_types::{
     transaction::{Script, Transaction, TransactionListWithProof, TransactionWithProof},
 };
 use rand::SeedableRng;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::start_storage_service;
 use transaction_builder::{
@@ -709,7 +709,11 @@ fn verify_account_balance<F>(account_state_with_proof: &AccountStateWithProof, f
 where
     F: Fn(u64) -> bool,
 {
-    let balance = get_account_resource_or_default(&account_state_with_proof.blob)?.balance();
+    let balance = if let Some(blob) = &account_state_with_proof.blob {
+        AccountResource::try_from(blob)?.balance()
+    } else {
+        0
+    };
     ensure!(
         f(balance),
         "balance {} doesn't satisfy the condition passed in",
@@ -765,8 +769,11 @@ fn verify_uncommitted_txn_status(
         "proof_of_current_sequence_number should be provided when transaction is not committed."
     )
     })?;
-    let seq_num_in_account =
-        get_account_resource_or_default(&proof_of_current_sequence_number.blob)?.sequence_number();
+    let seq_num_in_account = if let Some(blob) = &proof_of_current_sequence_number.blob {
+        AccountResource::try_from(blob)?.sequence_number()
+    } else {
+        0
+    };
 
     ensure!(
         expected_seq_num == seq_num_in_account,

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "fuzzing"))]
-use crate::account_config::{account_resource_path, AccountResource};
+use crate::account_config::account_resource_path;
 use crate::{
-    account_address::AccountAddress, account_config::get_account_resource_or_default,
-    ledger_info::LedgerInfo, proof::AccountStateProof, transaction::Version,
+    account_address::AccountAddress, account_config::AccountResource, ledger_info::LedgerInfo,
+    proof::AccountStateProof, transaction::Version,
 };
 use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::{
@@ -31,7 +31,7 @@ pub struct AccountStateBlob {
 
 impl fmt::Debug for AccountStateBlob {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let decoded = get_account_resource_or_default(&Some(self.clone()))
+        let decoded = AccountResource::try_from(self)
             .map(|resource| format!("{:#?}", resource))
             .unwrap_or_else(|_| String::from("[fail]"));
 

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -102,12 +102,6 @@ impl Clone for EventKey {
     }
 }
 
-impl Default for EventKey {
-    fn default() -> Self {
-        Self([0; EVENT_KEY_LENGTH])
-    }
-}
-
 impl fmt::Debug for EventKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "EventKey({:?})", self.as_bytes())
@@ -174,7 +168,7 @@ impl TryFrom<&[u8]> for EventKey {
 }
 
 /// A Rust representation of an Event Handle Resource.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EventHandle {
     /// Number of events in the event stream.
     count: u64,


### PR DESCRIPTION
This function returns dummy data in situations where an error should be returned. Failing instead will make debugging easier.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Cleaning up the Rust representation of Move values.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests pass, should be pure refactoring.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
