### PR TITLE
Add flag to ValidatorChangeEventWithProof to indicate whether it is complete

### DIFF
--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -174,9 +174,10 @@ impl<T: Payload> BlockStore<T> {
         if highest_commit_cert.ends_epoch() {
             retriever
                 .network
-                .notify_epoch_change(ValidatorChangeProof::new(vec![highest_commit_cert
-                    .ledger_info()
-                    .clone()]))
+                .notify_epoch_change(ValidatorChangeProof::new(
+                    vec![highest_commit_cert.ledger_info().clone()],
+                    /* more = */ false,
+                ))
                 .await;
         }
         Ok(())

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -815,7 +815,10 @@ where
         }
         if finality_proof.ledger_info().next_validator_set().is_some() {
             self.network
-                .broadcast_epoch_change(ValidatorChangeProof::new(vec![finality_proof]))
+                .broadcast_epoch_change(ValidatorChangeProof::new(
+                    vec![finality_proof],
+                    /* more = */ false,
+                ))
                 .await
         }
     }

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -125,12 +125,15 @@ impl ExecutorProxyTrait for ExecutorProxy {
     }
 
     fn get_epoch_proof(&self, start_epoch: u64, end_epoch: u64) -> Result<ValidatorChangeProof> {
-        let (ledger_info_per_epoch, more) = self
+        let validator_change_proof = self
             .storage_read_client
             .get_epoch_change_ledger_infos(start_epoch, end_epoch)?;
-        // TODO(zekun000): change this to query storage for more epoch changes.
-        ensure!(!more, "Exceeded max response length.");
-        Ok(ValidatorChangeProof::new(ledger_info_per_epoch))
+        // TODO(zekun000): change this (or caller of this) to query storage for more epoch changes.
+        ensure!(
+            !validator_change_proof.more,
+            "Exceeded max response length."
+        );
+        Ok(validator_change_proof)
     }
 
     fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -100,7 +100,7 @@ impl MockStorage {
         for epoch_num in known_epoch..self.epoch_num() {
             epoch_change_lis.push(self.ledger_infos.get(&epoch_num).unwrap().clone());
         }
-        ValidatorChangeProof::new(epoch_change_lis)
+        ValidatorChangeProof::new(epoch_change_lis, /* more = */ false)
     }
 
     pub fn get_chunk(

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -37,10 +37,9 @@ use storage_proto::{
     proto::storage::{GetLatestStateRootRequest, GetStartupInfoRequest, StorageClient},
     BackupAccountStateRequest, BackupAccountStateResponse,
     GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
-    GetEpochChangeLedgerInfosRequest, GetEpochChangeLedgerInfosResponse,
-    GetLatestAccountStateRequest, GetLatestAccountStateResponse, GetLatestStateRootResponse,
-    GetStartupInfoResponse, GetTransactionsRequest, GetTransactionsResponse,
-    SaveTransactionsRequest, StartupInfo,
+    GetEpochChangeLedgerInfosRequest, GetLatestAccountStateRequest, GetLatestAccountStateResponse,
+    GetLatestStateRootResponse, GetStartupInfoResponse, GetTransactionsRequest,
+    GetTransactionsResponse, SaveTransactionsRequest, StartupInfo,
 };
 
 pub use crate::state_view::VerifiedStateView;
@@ -214,14 +213,14 @@ impl StorageRead for StorageReadServiceClient {
         &self,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<(Vec<LedgerInfoWithSignatures>, bool)>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeProof>> + Send>> {
         let proto_req = GetEpochChangeLedgerInfosRequest::new(start_epoch, end_epoch);
         convert_grpc_response(
             self.client()
                 .get_epoch_change_ledger_infos_async(&proto_req.into()),
         )
         .map(|resp| {
-            let resp = GetEpochChangeLedgerInfosResponse::try_from(resp?)?;
+            let resp = ValidatorChangeProof::try_from(resp?)?;
             Ok(resp.into())
         })
         .boxed()
@@ -436,7 +435,7 @@ pub trait StorageRead: Send + Sync {
         &self,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Result<(Vec<LedgerInfoWithSignatures>, bool)> {
+    ) -> Result<ValidatorChangeProof> {
         block_on(self.get_epoch_change_ledger_infos_async(start_epoch, end_epoch))
     }
 
@@ -448,7 +447,7 @@ pub trait StorageRead: Send + Sync {
         &self,
         start_epoch: u64,
         end_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<(Vec<LedgerInfoWithSignatures>, bool)>> + Send>>;
+    ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeProof>> + Send>>;
 
     /// See [`LibraDB::backup_account_state`].
     ///

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -219,10 +219,7 @@ impl StorageRead for StorageReadServiceClient {
             self.client()
                 .get_epoch_change_ledger_infos_async(&proto_req.into()),
         )
-        .map(|resp| {
-            let resp = ValidatorChangeProof::try_from(resp?)?;
-            Ok(resp.into())
-        })
+        .map(|resp| ValidatorChangeProof::try_from(resp?))
         .boxed()
     }
 

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -37,7 +37,7 @@ use libra_types::{
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
 #[cfg(any(test, feature = "fuzzing"))]
-use proptest::{collection::vec, prelude::*};
+use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use std::convert::{TryFrom, TryInto};
@@ -667,73 +667,6 @@ impl From<GetEpochChangeLedgerInfosRequest>
             start_epoch: request.start_epoch,
             end_epoch: request.end_epoch,
         }
-    }
-}
-
-/// Helper to construct and parse [`proto::storage::GetEpochChangeLedgerInfosResponse`]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GetEpochChangeLedgerInfosResponse {
-    pub ledger_infos_with_sigs: Vec<LedgerInfoWithSignatures>,
-    pub more: bool,
-}
-
-impl GetEpochChangeLedgerInfosResponse {
-    /// Constructor.
-    pub fn new(ledger_infos_with_sigs: Vec<LedgerInfoWithSignatures>, more: bool) -> Self {
-        Self {
-            ledger_infos_with_sigs,
-            more,
-        }
-    }
-}
-
-impl TryFrom<crate::proto::storage::GetEpochChangeLedgerInfosResponse>
-    for GetEpochChangeLedgerInfosResponse
-{
-    type Error = Error;
-
-    fn try_from(proto: crate::proto::storage::GetEpochChangeLedgerInfosResponse) -> Result<Self> {
-        Ok(Self {
-            ledger_infos_with_sigs: proto
-                .latest_ledger_infos
-                .into_iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<Vec<_>>>()?,
-            more: proto.more,
-        })
-    }
-}
-
-impl From<GetEpochChangeLedgerInfosResponse>
-    for crate::proto::storage::GetEpochChangeLedgerInfosResponse
-{
-    fn from(response: GetEpochChangeLedgerInfosResponse) -> Self {
-        Self {
-            latest_ledger_infos: response
-                .ledger_infos_with_sigs
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-            more: response.more,
-        }
-    }
-}
-
-impl Into<(Vec<LedgerInfoWithSignatures>, bool)> for GetEpochChangeLedgerInfosResponse {
-    fn into(self) -> (Vec<LedgerInfoWithSignatures>, bool) {
-        (self.ledger_infos_with_sigs, self.more)
-    }
-}
-
-#[cfg(any(test, feature = "fuzzing"))]
-impl Arbitrary for GetEpochChangeLedgerInfosResponse {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (vec(any::<LedgerInfoWithSignatures>(), 0..10), any::<bool>())
-            .prop_map(|(ledger_infos_with_sigs, more)| Self::new(ledger_infos_with_sigs, more))
-            .boxed()
     }
 }
 

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -10,6 +10,7 @@ import "get_with_proof.proto";
 import "ledger_info.proto";
 import "proof.proto";
 import "transaction.proto";
+import "validator_change.proto";
 import "validator_set.proto";
 
 // -----------------------------------------------------------------------------
@@ -55,7 +56,7 @@ service Storage {
 
     // Returns latest ledger infos per epoch.
     rpc GetEpochChangeLedgerInfos(GetEpochChangeLedgerInfosRequest)
-    returns (GetEpochChangeLedgerInfosResponse);
+    returns (types.ValidatorChangeProof);
 
     // Returns a stream of account states.
     rpc BackupAccountState(BackupAccountStateRequest)
@@ -164,14 +165,6 @@ message GetEpochChangeLedgerInfosRequest {
     uint64 start_epoch = 1;
     /// The target epoch number that client wants to sync to.
     uint64 end_epoch = 2;
-}
-
-message GetEpochChangeLedgerInfosResponse {
-    // Vector of latest ledger infos per epoch (not sorted)
-    repeated types.LedgerInfoWithSignatures latest_ledger_infos = 1;
-    // Whether the above field has everything. true means the response is
-    // incomplete -- only first N are returned and there are more.
-    bool more = 2;
 }
 
 message BackupAccountStateRequest {

--- a/storage/storage-proto/src/tests.rs
+++ b/storage/storage-proto/src/tests.rs
@@ -48,10 +48,6 @@ test_conversion!(
     test_get_epoch_change_ledger_infos_request,
     GetEpochChangeLedgerInfosRequest,
 );
-test_conversion!(
-    test_get_epoch_change_ledger_infos_response,
-    GetEpochChangeLedgerInfosResponse,
-);
 test_conversion!(test_backup_account_state_request, BackupAccountStateRequest);
 test_conversion!(
     test_backup_account_state_response,

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -120,7 +120,7 @@ impl StorageRead for MockStorageReadClient {
         &self,
         _start_epoch: u64,
         _end_epoch: u64,
-    ) -> Pin<Box<dyn Future<Output = Result<(Vec<LedgerInfoWithSignatures>, bool)>> + Send>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ValidatorChangeProof>> + Send>> {
         unimplemented!()
     }
 

--- a/types/src/proto/validator_change.proto
+++ b/types/src/proto/validator_change.proto
@@ -5,19 +5,14 @@ syntax = "proto3";
 
 package types;
 
-import "events.proto";
 import "ledger_info.proto";
 
-// This is used to prove validator changes.  When a validator is changing, it
-// triggers an event on /validator_change_account/events/sent.  To tell the
-// client about validator changes, we query
-// /validator_change_account/events/sent to get all versions that contain
-// validator changes after the version that we are trying to update from. For
-// each of these versions, the old validator set would have signed the ledger
-// info at that version.  The client needs this as well as the event results +
-// proof.  The client can then verify that these events were under the current
-// tree and that the changes were signed by the old validators (and that the
-// events correctly show which validators are the new validators).
+// This is used to prove validator changes.
 message ValidatorChangeProof {
+  // A list of LedgerInfos with contiguous increasing epoch numbers.
   repeated LedgerInfoWithSignatures ledger_info_with_sigs = 1;
+
+  // A flag (when true) that indicates the above list is incomplete and only
+  // contains the first N epoch changes.
+  bool more = 2;
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Changed the server to not return any response items in `update_to_latest_ledger` request if the response does not have all necessary `LedgerInfo`s for the client to update to latest one.

Also realized that now `GetEpochChangeLedgerInfosResponse` is identical to `ValidatorChangeEventWithProof`, so remove the struct entirely.

This change finishes the required server side changes for https://github.com/libra/libra/issues/1923

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

@zekun000 will read it.

## Test Plan

CI.

## Related PRs

None.