### PR TITLE
[Storage] Expose the LedgerInfo by version API

### DIFF
--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -139,7 +139,16 @@ impl ExecutorProxyTrait for ExecutorProxy {
         Ok(ValidatorChangeEventWithProof::new(ledger_info_per_epoch))
     }
 
-    fn get_ledger_info(&self, _version: u64) -> Option<LedgerInfoWithSignatures> {
-        panic!("Not implemented");
+    fn get_ledger_info(&self, version: u64) -> Option<LedgerInfoWithSignatures> {
+        match self.storage_read_client.get_ledger_info_by_version(version) {
+            Ok(li) => {
+                if li.ledger_info().version() == version {
+                    Some(li)
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        }
     }
 }

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -720,6 +720,63 @@ impl Into<Vec<LedgerInfoWithSignatures>> for GetEpochChangeLedgerInfosResponse {
     }
 }
 
+/// Helper to construct and parse [`proto::storage::GetLedgerInfoByVersionRequest`]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct GetLedgerInfoByVersionRequest {
+    pub version: Version,
+}
+
+impl TryFrom<crate::proto::storage::GetLedgerInfoByVersionRequest>
+    for GetLedgerInfoByVersionRequest
+{
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::storage::GetLedgerInfoByVersionRequest) -> Result<Self> {
+        Ok(Self {
+            version: proto.version,
+        })
+    }
+}
+
+impl From<GetLedgerInfoByVersionRequest> for crate::proto::storage::GetLedgerInfoByVersionRequest {
+    fn from(request: GetLedgerInfoByVersionRequest) -> Self {
+        Self {
+            version: request.version,
+        }
+    }
+}
+
+/// Helper to construct and parse [`proto::storage::GetLedgerInfoByVersionResponse`]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct GetLedgerInfoByVersionResponse {
+    pub ledger_info: LedgerInfoWithSignatures,
+}
+
+impl TryFrom<crate::proto::storage::GetLedgerInfoByVersionResponse>
+    for GetLedgerInfoByVersionResponse
+{
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::storage::GetLedgerInfoByVersionResponse) -> Result<Self> {
+        let ledger_info: LedgerInfoWithSignatures = proto
+            .ledger_info
+            .ok_or_else(|| format_err!("Missing ledger_info"))?
+            .try_into()?;
+        Ok(Self { ledger_info })
+    }
+}
+
+impl From<GetLedgerInfoByVersionResponse>
+    for crate::proto::storage::GetLedgerInfoByVersionResponse
+{
+    fn from(response: GetLedgerInfoByVersionResponse) -> Self {
+        let ledger_info = Some(response.ledger_info.into());
+        Self { ledger_info }
+    }
+}
+
 /// Helper to construct and parse [`proto::storage::BackupAccountStateRequest`]
 #[derive(PartialEq, Eq, Clone)]
 pub struct BackupAccountStateRequest {

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -57,6 +57,10 @@ service Storage {
     rpc GetEpochChangeLedgerInfos(GetEpochChangeLedgerInfosRequest)
     returns (GetEpochChangeLedgerInfosResponse);
 
+    // Returns the lowest ledger info that includes the given version.
+    rpc GetLedgerInfoByVersion(GetLedgerInfoByVersionRequest)
+    returns (GetLedgerInfoByVersionResponse);
+
     // Returns a stream of account states.
     rpc BackupAccountState(BackupAccountStateRequest)
     returns (stream BackupAccountStateResponse);
@@ -169,6 +173,16 @@ message GetEpochChangeLedgerInfosRequest {
 message GetEpochChangeLedgerInfosResponse {
     /// Vector of latest ledger infos per epoch (not sorted)
     repeated types.LedgerInfoWithSignatures latest_ledger_infos = 1;
+}
+
+message GetLedgerInfoByVersionRequest {
+    /// The returned LedgerInfo is a minimal LedgerInfo that is equal or higher than the given version.
+    uint64 version = 1;
+}
+
+message GetLedgerInfoByVersionResponse {
+    /// The LedgerInfoWithSignatures corresponding to the given version.
+    types.LedgerInfoWithSignatures ledger_info = 1;
 }
 
 message BackupAccountStateRequest {

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -124,6 +124,13 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
+    fn get_ledger_info_by_version_async(
+        &self,
+        _version: Version,
+    ) -> Pin<Box<dyn Future<Output = Result<LedgerInfoWithSignatures>> + Send>> {
+        unimplemented!()
+    }
+
     fn backup_account_state_async(
         &self,
         _version: u64,


### PR DESCRIPTION
Summary:
We need an API for finding the LedgerInfo corresponding to the given version.
The storage API is going to return the lowest LedgerInfo that is covering the given version. Specifically for the waypoint at the epoch boundary the returned LedgerInfo would match the waypoint version.

Testing: current test coverage

Issues: ref #1384
