### PR TITLE
[move] Added inverse traversal CFG

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -229,6 +229,14 @@ impl Command_ {
         }
     }
 
+    pub fn is_exit(&self) -> bool {
+        use Command_::*;
+        match self {
+            Assign(_, _) | Mutate(_, _) | IgnoreAndPop { .. } | Jump(_) | JumpIf { .. } => false,
+            Abort(_) | Return(_) => true,
+        }
+    }
+
     pub fn successors(&self) -> BTreeSet<Label> {
         use Command_::*;
 

--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -71,7 +71,7 @@ pub fn verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
-    cfg: &super::cfg::BlockCFG,
+    cfg: &mut super::cfg::BlockCFG,
 ) {
     let mut initial_state = BorrowState::initial(locals);
     initial_state.bind_arguments(&signature.parameters);

--- a/language/move-lang/src/cfgir/cfg.rs
+++ b/language/move-lang/src/cfgir/cfg.rs
@@ -9,6 +9,19 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 // CFG
 //**************************************************************************************************
 
+pub trait CFG {
+    fn successors(&self, label: Label) -> &BTreeSet<Label>;
+
+    fn predecessors(&self, label: Label) -> &BTreeSet<Label>;
+    fn commands<'a>(&'a self, label: Label) -> Box<dyn Iterator<Item = &'a Command> + 'a>;
+    fn num_blocks(&self) -> usize;
+    fn start_block(&self) -> Label;
+}
+
+//**************************************************************************************************
+// BlockCFG
+//**************************************************************************************************
+
 const DEAD_CODE_ERR: &str = "Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.";
 
 #[derive(Debug)]
@@ -20,11 +33,11 @@ pub struct BlockCFG<'a> {
 }
 
 impl<'a> BlockCFG<'a> {
-    pub fn new(start: Label, blocks: &'a mut Blocks) -> (BlockCFG<'a>, Errors) {
+    pub fn new(start: Label, blocks: &'a mut Blocks) -> (BlockCFG, Errors) {
         let mut seen = BTreeSet::new();
         let mut work_list = VecDeque::new();
-        seen.insert(start.clone());
-        work_list.push_back(start.clone());
+        seen.insert(start);
+        work_list.push_back(start);
 
         // build successor map from reachable code
         let mut successor_map = BTreeMap::new();
@@ -33,22 +46,23 @@ impl<'a> BlockCFG<'a> {
             let successors = last_cmd.value.successors();
             for successor in &successors {
                 if !seen.contains(successor) {
-                    seen.insert(successor.clone());
-                    work_list.push_back(successor.clone());
+                    seen.insert(*successor);
+                    work_list.push_back(*successor)
                 }
             }
-            let old = successor_map.insert(label.clone(), successors);
+            let old = successor_map.insert(label, successors);
             assert!(old.is_none());
         }
 
         // build inverse map
-        let mut predecessor_map = BTreeMap::new();
+        let mut predecessor_map = successor_map
+            .keys()
+            .cloned()
+            .map(|lbl| (lbl, BTreeSet::new()))
+            .collect::<BTreeMap<_, _>>();
         for (parent, children) in &successor_map {
             for child in children {
-                predecessor_map
-                    .entry(child.clone())
-                    .or_insert_with(BTreeSet::new)
-                    .insert(parent.clone());
+                predecessor_map.get_mut(child).unwrap().insert(*parent);
             }
         }
 
@@ -70,31 +84,131 @@ impl<'a> BlockCFG<'a> {
         (cfg, errors)
     }
 
-    pub fn successors(&self, label: &Label) -> &BTreeSet<Label> {
-        self.successor_map.get(label).unwrap()
+    pub fn block(&self, label: Label) -> &BasicBlock {
+        self.blocks.get(&label).unwrap()
     }
 
-    pub fn predecessors(&self, label: &Label) -> &BTreeSet<Label> {
-        self.predecessor_map.get(label).unwrap()
+    pub fn block_mut(&mut self, label: Label) -> &mut BasicBlock {
+        self.blocks.get_mut(&label).unwrap()
+    }
+}
+
+impl<'a> CFG for BlockCFG<'a> {
+    fn successors(&self, label: Label) -> &BTreeSet<Label> {
+        self.successor_map.get(&label).unwrap()
     }
 
-    pub fn block(&self, label: &Label) -> &BasicBlock {
-        self.blocks.get(label).unwrap()
+    fn predecessors(&self, label: Label) -> &BTreeSet<Label> {
+        self.predecessor_map.get(&label).unwrap()
     }
 
-    pub fn block_mut(&mut self, label: &Label) -> &mut BasicBlock {
-        self.blocks.get_mut(label).unwrap()
+    fn commands<'s>(&'s self, label: Label) -> Box<dyn Iterator<Item = &'s Command> + 's> {
+        Box::new(self.block(label).iter())
     }
 
-    pub fn blocks_iter_mut(&mut self) -> impl Iterator<Item = (&Label, &mut BasicBlock)> {
-        self.blocks.iter_mut()
-    }
-
-    pub fn num_blocks(&self) -> usize {
+    fn num_blocks(&self) -> usize {
         self.blocks.len()
     }
 
-    pub fn start_block(&self) -> Label {
+    fn start_block(&self) -> Label {
+        self.start
+    }
+}
+
+//**************************************************************************************************
+// Reverse Traversal Block CFG
+//**************************************************************************************************
+
+#[derive(Debug)]
+pub struct ReverseBlockCFG<'a> {
+    start: Label,
+    blocks: &'a mut Blocks,
+    successor_map: &'a mut BTreeMap<Label, BTreeSet<Label>>,
+    predecessor_map: &'a mut BTreeMap<Label, BTreeSet<Label>>,
+}
+
+impl<'a> ReverseBlockCFG<'a> {
+    pub fn new(forward_cfg: &'a mut BlockCFG, infinite_loop_starts: BTreeSet<Label>) -> Self {
+        let blocks: &'a mut Blocks = &mut forward_cfg.blocks;
+        let forward_successors = &mut forward_cfg.successor_map;
+        let forward_predecessor = &mut forward_cfg.predecessor_map;
+        let end_blocks = {
+            let mut end_blocks = BTreeSet::new();
+            for (lbl, successors) in forward_successors.iter() {
+                let loop_start_successors = successors
+                    .iter()
+                    .filter(|l| infinite_loop_starts.contains(l));
+                for loop_start_successor in loop_start_successors {
+                    if lbl >= loop_start_successor {
+                        end_blocks.insert(*lbl);
+                    }
+                }
+            }
+            for (lbl, block) in blocks.iter() {
+                let last_cmd = block.back().unwrap();
+                if last_cmd.value.is_exit() {
+                    end_blocks.insert(*lbl);
+                }
+            }
+            end_blocks
+        };
+
+        let terminal = Label(blocks.keys().map(|lbl| lbl.0).max().unwrap_or(0) + 1);
+        assert!(!blocks.contains_key(&terminal), "{:#?}", blocks);
+        blocks.insert(terminal, BasicBlock::new());
+        for terminal_predecessor in &end_blocks {
+            forward_successors
+                .entry(*terminal_predecessor)
+                .or_insert_with(BTreeSet::new)
+                .insert(terminal);
+        }
+        forward_predecessor.insert(terminal, end_blocks);
+
+        Self {
+            start: terminal,
+            blocks,
+            successor_map: forward_predecessor,
+            predecessor_map: forward_successors,
+        }
+    }
+
+    pub fn block(&self, label: Label) -> &BasicBlock {
+        self.blocks.get(&label).unwrap()
+    }
+}
+
+impl<'a> Drop for ReverseBlockCFG<'a> {
+    fn drop(&mut self) {
+        let empty_block = self.blocks.remove(&self.start);
+        assert!(empty_block.unwrap().is_empty());
+        let start_successors = self.successor_map.remove(&self.start).unwrap();
+        for start_successor in start_successors {
+            self.predecessor_map
+                .get_mut(&start_successor)
+                .unwrap()
+                .remove(&self.start);
+        }
+    }
+}
+
+impl<'a> CFG for ReverseBlockCFG<'a> {
+    fn successors(&self, label: Label) -> &BTreeSet<Label> {
+        self.successor_map.get(&label).unwrap()
+    }
+
+    fn predecessors(&self, label: Label) -> &BTreeSet<Label> {
+        self.predecessor_map.get(&label).unwrap()
+    }
+
+    fn commands<'s>(&'s self, label: Label) -> Box<dyn Iterator<Item = &'s Command> + 's> {
+        Box::new(self.block(label).iter().rev())
+    }
+
+    fn num_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
+    fn start_block(&self) -> Label {
         self.start
     }
 }

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -81,7 +81,7 @@ pub fn verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
-    cfg: &super::cfg::BlockCFG,
+    cfg: &mut super::cfg::BlockCFG,
 ) {
     let initial_state = LocalStates::initial(&signature.parameters, locals);
     let mut locals_safety = LocalsSafety::new(locals);

--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -12,6 +12,7 @@ use crate::shared::unique_map::UniqueMap;
 use crate::{errors::Errors, parser::ast::Var};
 use ast::*;
 use cfg::*;
+use std::collections::BTreeSet;
 
 /// This is a placeholder for "optimization passes" that "fix" operations so the behave as expected
 /// The two major passes here are:
@@ -22,15 +23,17 @@ use cfg::*;
 pub fn refine(
     _signature: &FunctionSignature,
     _locals: &UniqueMap<Var, SingleType>,
-    _cfg: &mut BlockCFG,
+    cfg: &mut BlockCFG,
+    infinite_loop_starts: BTreeSet<Label>,
 ) {
+    ReverseBlockCFG::new(cfg, infinite_loop_starts);
 }
 
 pub fn verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
-    cfg: &BlockCFG,
+    cfg: &mut BlockCFG,
 ) {
     locals::verify(errors, signature, locals, cfg);
     borrows::verify(errors, signature, locals, cfg)

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -132,6 +132,8 @@ pub enum Statement_ {
     },
     Loop {
         block: Block,
+        has_break: bool,
+        has_return_abort: bool,
     },
 }
 pub type Statement = Spanned<Statement_>;


### PR DESCRIPTION
## Motivation

- Added a CFG that traverses blocks and commands in inverse order
  - There is a fake terminal node added as the root/start for the reverse traversal 
  - The predecessors of the fake node are any node without a normal successor 
  - Additionally, any infinite loop without a break/return/abort will be a predecessor of this fake terminal node
- Will be used later for liveness analysis

## Test Plan

- no new tests yet
- assertions are tested on construction
- New tests will be added after usage