### PR TITLE
[consensus] add safety rules as a separate module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3960,9 +3960,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "consensus-types 0.1.0",
+ "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/consensus-types/src/accumulator_extension_proof.rs
+++ b/consensus/consensus-types/src/accumulator_extension_proof.rs
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 /// returns the new tree to acquire a new root and version. Note: this is used internally by
 /// VoteProposal hence why it exists within consensus-types andd not libra-types.
 /// @TODO This should contain AccumulatorConsistencyProof once that is code complete
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct AccumulatorExtensionProof<H> {
     /// Represents the roots of all the full subtrees from left to right in the original accumulator.
     frozen_subtree_roots: Vec<HashValue>,

--- a/consensus/consensus-types/src/vote_proposal.rs
+++ b/consensus/consensus-types/src/vote_proposal.rs
@@ -13,7 +13,7 @@ use std::{
 
 /// This structure contains all the information needed by safety rules to
 /// evaluate a proposal / block for correctness / safety and to produce a Vote.
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct VoteProposal<T> {
     /// Contains the data necessary to construct the parent's execution output state
     /// and the childs in a verifiable way

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -16,8 +16,15 @@ serde = { version = "1.0.99", default-features = false }
 thiserror = "1.0"
 
 [dev-dependencies]
+criterion = "0.3"
+rand = { version = "0.6.5", default-features = false }
 tempfile = "3.1.0"
+
+[[bench]]
+name = "safety_rules"
+harness = false
 
 [features]
 default = []
 fuzzing = ["consensus-types/fuzzing"]
+testing = []

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use consensus_types::{block::block_test_utils, block::Block};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use libra_types::crypto_proxies::ValidatorSigner;
+use rand::Rng;
+use safety_rules::{
+    test_utils, {InMemoryStorage, SafetyRules, TSafetyRules},
+};
+use std::sync::Arc;
+
+/// Execute an in order series of blocks (0 <- 1 <- 2 <- 3 and commit 0 and continue to rotate
+/// left, appending new blocks on the right, committing the left most block
+fn lsr(n: u64) {
+    let validator_signer = ValidatorSigner::from_int(0);
+    let mut safety_rules = SafetyRules::new(
+        InMemoryStorage::default_storage(),
+        Arc::new(validator_signer.clone()),
+    );
+
+    let mut rng = rand::thread_rng();
+    let data: Vec<u8> = (0..2048).map(|_| rng.gen::<u8>()).collect();
+
+    let genesis_block = Block::<Vec<u8>>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let mut round = genesis_block.round();
+
+    round += 1;
+    let mut b0 = test_utils::make_proposal_with_qc(round, genesis_qc.clone(), &validator_signer);
+    safety_rules.update(b0.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&b0).unwrap();
+
+    round += 1;
+    let mut b1 =
+        test_utils::make_proposal_with_parent(data.clone(), round, &b0, None, &validator_signer);
+    safety_rules.update(b1.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&b1).unwrap();
+
+    round += 1;
+    let mut b2 =
+        test_utils::make_proposal_with_parent(data.clone(), round, &b1, None, &validator_signer);
+    safety_rules.update(b2.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&b2).unwrap();
+
+    for _i in 0..n {
+        round += 1;
+        let b3 = test_utils::make_proposal_with_parent(
+            data.clone(),
+            round,
+            &b2,
+            Some(&b0),
+            &validator_signer,
+        );
+
+        safety_rules.update(b3.block().quorum_cert()).unwrap();
+        safety_rules.construct_and_sign_vote(&b3).unwrap();
+
+        b0 = b1;
+        b1 = b2;
+        b2 = b3;
+    }
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("lsr 10", |b| b.iter(|| lsr(black_box(10))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/consensus/safety-rules/src/consensus_state.rs
+++ b/consensus/safety-rules/src/consensus_state.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use consensus_types::common::Round;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+/// Public representation of the internal state of SafetyRules for monitoring / debugging purposes.
+/// This does not include sensitive data like private keys.
+/// @TODO add hash of ledger info (waypoint)
+#[derive(Serialize, Default, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct ConsensusState {
+    epoch: u64,
+    last_voted_round: Round,
+    // A "preferred block" is the two-chain head with the highest block round. The expectation is
+    // that a new proposal's parent is higher or equal to the preferred_round.
+    preferred_round: Round,
+}
+
+impl Display for ConsensusState {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "ConsensusState: [\n\
+             \tepoch = {},
+             \tlast_voted_round = {},\n\
+             \tpreferred_round = {}\n\
+             ]",
+            self.epoch, self.last_voted_round, self.preferred_round
+        )
+    }
+}
+
+impl ConsensusState {
+    pub fn new(epoch: u64, last_voted_round: Round, preferred_round: Round) -> Self {
+        Self {
+            epoch,
+            last_voted_round,
+            preferred_round,
+        }
+    }
+
+    /// Returns the current epoch
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Returns the last round that was voted on
+    pub fn last_voted_round(&self) -> Round {
+        self.last_voted_round
+    }
+
+    /// Returns the preferred block round
+    pub fn preferred_round(&self) -> Round {
+        self.preferred_round
+    }
+}

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow;
+use consensus_types::common::Round;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+/// Different reasons for proposal rejection
+pub enum Error {
+    #[error("Internal error: {:?}", error)]
+    InternalError { error: String },
+
+    #[error("Unable to verify that the new tree extneds the parent: {:?}", error)]
+    InvalidAccumulatorExtension { error: String },
+
+    /// This proposal's round is less than round of preferred block.
+    /// Returns the id of the preferred block.
+    #[error(
+        "Proposal's round is lower than round of preferred block at round {:?}",
+        preferred_round
+    )]
+    ProposalRoundLowerThenPreferredBlock { preferred_round: Round },
+
+    /// This proposal is too old - return last_voted_round
+    #[error(
+        "Proposal at round {:?} is not newer than the last vote round {:?}",
+        proposal_round,
+        last_voted_round
+    )]
+    OldProposal {
+        last_voted_round: Round,
+        proposal_round: Round,
+    },
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        Self::InternalError {
+            error: format!("{}", error),
+        }
+    }
+}

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -15,6 +15,10 @@ pub use crate::{
     safety_rules::SafetyRules,
 };
 
+#[cfg(any(test, feature = "testing"))]
+#[path = "test_utils.rs"]
+pub mod test_utils;
+
 #[cfg(test)]
 #[path = "safety_rules_test.rs"]
 mod safety_rules_test;

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -3,12 +3,16 @@
 
 #![forbid(unsafe_code)]
 
+mod consensus_state;
+mod error;
 mod persistent_storage;
 mod safety_rules;
 
 pub use crate::{
+    consensus_state::ConsensusState,
+    error::Error,
     persistent_storage::{InMemoryStorage, OnDiskStorage},
-    safety_rules::{ConsensusState, Error, SafetyRules},
+    safety_rules::SafetyRules,
 };
 
 #[cfg(test)]

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -5,8 +5,10 @@
 
 mod consensus_state;
 mod error;
+mod local_client;
 mod persistent_storage;
 mod safety_rules;
+mod safety_rules_manager;
 mod t_safety_rules;
 
 pub use crate::{
@@ -14,6 +16,7 @@ pub use crate::{
     error::Error,
     persistent_storage::{InMemoryStorage, OnDiskStorage},
     safety_rules::SafetyRules,
+    safety_rules_manager::{SafetyRulesManager, SafetyRulesManagerConfig},
     t_safety_rules::TSafetyRules,
 };
 

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -7,12 +7,14 @@ mod consensus_state;
 mod error;
 mod persistent_storage;
 mod safety_rules;
+mod t_safety_rules;
 
 pub use crate::{
     consensus_state::ConsensusState,
     error::Error,
     persistent_storage::{InMemoryStorage, OnDiskStorage},
     safety_rules::SafetyRules,
+    t_safety_rules::TSafetyRules,
 };
 
 #[cfg(any(test, feature = "testing"))]

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -1,0 +1,52 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ConsensusState, Error, SafetyRules, TSafetyRules};
+use consensus_types::{
+    block::Block, block_data::BlockData, common::Payload, quorum_cert::QuorumCert,
+    timeout::Timeout, vote::Vote, vote_proposal::VoteProposal,
+};
+use libra_types::crypto_proxies::Signature;
+use std::sync::{Arc, RwLock};
+
+/// A local interface into SafetyRules. Constructed in such a way that the container / caller
+/// cannot distinguish this API from an actual client/server process without being exposed to
+/// the actual container instead the caller can access a Box<dyn TSafetyRules>.
+pub struct LocalClient<T> {
+    internal: Arc<RwLock<SafetyRules<T>>>,
+}
+
+impl<T: Payload> LocalClient<T> {
+    pub fn new(internal: Arc<RwLock<SafetyRules<T>>>) -> Self {
+        Self { internal }
+    }
+}
+
+impl<T: Payload> TSafetyRules<T> for LocalClient<T> {
+    fn consensus_state(&self) -> ConsensusState {
+        self.internal.read().unwrap().consensus_state()
+    }
+
+    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        self.internal.write().unwrap().update(qc)
+    }
+
+    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        self.internal.write().unwrap().start_new_epoch(qc)
+    }
+
+    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
+        self.internal
+            .write()
+            .unwrap()
+            .construct_and_sign_vote(vote_proposal)
+    }
+
+    fn sign_proposal(&self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
+        self.internal.write().unwrap().sign_proposal(block_data)
+    }
+
+    fn sign_timeout(&self, timeout: &Timeout) -> Result<Signature, Error> {
+        self.internal.write().unwrap().sign_timeout(timeout)
+    }
+}

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{consensus_state::ConsensusState, error::Error, persistent_storage::PersistentStorage};
+use crate::{
+    consensus_state::ConsensusState, error::Error, persistent_storage::PersistentStorage,
+    t_safety_rules::TSafetyRules,
+};
 use consensus_types::{
     block::Block, block_data::BlockData, common::Payload, quorum_cert::QuorumCert,
     timeout::Timeout, vote::Vote, vote_data::VoteData, vote_proposal::VoteProposal,
@@ -12,7 +15,7 @@ use libra_types::{
     crypto_proxies::{Signature, ValidatorSigner},
     ledger_info::LedgerInfo,
 };
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 /// SafetyRules is responsible for the safety of the consensus:
 /// 1) voting rules
@@ -23,12 +26,13 @@ use std::sync::Arc;
 /// @TODO bootstrap with a hash of a ledger info (waypoint) that includes a validator set
 /// @TODO update storage with hash of ledger info (waypoint) during epoch changes (includes a new validator
 /// set)
-pub struct SafetyRules {
+pub struct SafetyRules<T> {
     persistent_storage: Box<dyn PersistentStorage>,
     validator_signer: Arc<ValidatorSigner>,
+    marker: PhantomData<T>,
 }
 
-impl SafetyRules {
+impl<T: Payload> SafetyRules<T> {
     /// Constructs a new instance of SafetyRules with the given persistent storage and the
     /// consensus private keys
     /// @TODO replace this with an API that takes in a SafetyRulesConfig
@@ -40,42 +44,8 @@ impl SafetyRules {
         Self {
             persistent_storage,
             validator_signer,
+            marker: PhantomData,
         }
-    }
-
-    pub fn signer(&self) -> &ValidatorSigner {
-        &self.validator_signer
-    }
-
-    /// Learn about a new quorum certificate. In normal state, this updates the preferred round,
-    /// if the parent is greater than our current preferred round.
-    /// @TODO verify signatures of the QC, also the special genesis QC
-    /// @TODO improving signaling by stating reaction to passed in QC:
-    ///     QC has older preferred round,
-    ///     signatures are incorrect,
-    ///     epoch is unexpected
-    ///     updating to new preferred round
-    /// @TODO update epoch with validator set
-    /// @TODO if public key does not match private key in validator set, access persistent storage
-    /// to identify new key
-    pub fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        if qc.parent_block().round() > self.persistent_storage.preferred_round() {
-            self.persistent_storage
-                .set_preferred_round(qc.parent_block().round())?;
-        }
-        Ok(())
-    }
-
-    /// Notify the safety rules about the new epoch start.
-    pub fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        if qc.commit_info().epoch() > self.persistent_storage.epoch() {
-            self.persistent_storage
-                .set_epoch(qc.commit_info().epoch())?;
-            self.persistent_storage.set_last_voted_round(0)?;
-            self.persistent_storage.set_preferred_round(0)?;
-        }
-        self.update(qc)?;
-        Ok(())
     }
 
     /// Produces a LedgerInfo that either commits a block based upon the 3-chain commit rule
@@ -84,7 +54,7 @@ impl SafetyRules {
     /// 1) B0 <- B1 <- B2 <--
     /// 2) round(B0) + 1 = round(B1), and
     /// 3) round(B1) + 1 = round(B2).
-    pub fn construct_ledger_info<T: Payload>(&self, proposed_block: &Block<T>) -> LedgerInfo {
+    pub fn construct_ledger_info(&self, proposed_block: &Block<T>) -> LedgerInfo {
         let block2 = proposed_block.round();
         let block1 = proposed_block.quorum_cert().certified_block().round();
         let block0 = proposed_block.quorum_cert().parent_block().round();
@@ -100,9 +70,13 @@ impl SafetyRules {
         }
     }
 
-    /// Provides the internal state of SafetyRules for monitoring / debugging purposes. This does
-    /// not include sensitive data like private keys.
-    pub fn consensus_state(&self) -> ConsensusState {
+    pub fn signer(&self) -> &ValidatorSigner {
+        &self.validator_signer
+    }
+}
+
+impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
+    fn consensus_state(&self) -> ConsensusState {
         ConsensusState::new(
             self.persistent_storage.epoch(),
             self.persistent_storage.last_voted_round(),
@@ -110,14 +84,38 @@ impl SafetyRules {
         )
     }
 
-    /// Attempts to vote for a given proposal following the voting rules.
+    /// @TODO verify signatures of the QC, also the special genesis QC
+    /// @TODO improving signaling by stating reaction to passed in QC:
+    ///     QC has older preferred round,
+    ///     signatures are incorrect,
+    ///     epoch is unexpected
+    ///     updating to new preferred round
+    /// @TODO update epoch with validator set
+    /// @TODO if public key does not match private key in validator set, access persistent storage
+    /// to identify new key
+    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        if qc.parent_block().round() > self.persistent_storage.preferred_round() {
+            self.persistent_storage
+                .set_preferred_round(qc.parent_block().round())?;
+        }
+        Ok(())
+    }
+
+    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        if qc.commit_info().epoch() > self.persistent_storage.epoch() {
+            self.persistent_storage
+                .set_epoch(qc.commit_info().epoch())?;
+            self.persistent_storage.set_last_voted_round(0)?;
+            self.persistent_storage.set_preferred_round(0)?;
+        }
+        self.update(qc)?;
+        Ok(())
+    }
+
     /// @TODO verify signature on vote proposal
     /// @TODO verify QC correctness
     /// @TODO verify epoch on vote proposal
-    pub fn construct_and_sign_vote<T: Payload>(
-        &mut self,
-        vote_proposal: &VoteProposal<T>,
-    ) -> Result<Vote, Error> {
+    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
         let proposed_block = vote_proposal.block();
 
         if proposed_block.round() <= self.persistent_storage.last_voted_round() {
@@ -166,23 +164,19 @@ impl SafetyRules {
         ))
     }
 
-    /// As the holder of the private key, SafetyRules also signs proposals or blocks.
-    /// A Block is a signed BlockData along with some additional metadata.
     /// @TODO only sign blocks that are later than last_voted_round and match the current epoch
     /// @TODO verify QC correctness
     /// @TODO verify QC matches preferred round
-    pub fn sign_proposal<T: Payload>(&self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
+    fn sign_proposal(&self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
         Ok(Block::new_proposal_from_block_data(
             block_data,
             &self.validator_signer,
         ))
     }
 
-    /// As the holder of the private key, SafetyRules also signs what is effectively a
-    /// timeout message. This returns the signature for that timeout message.
     /// @TODO only sign a timeout if it matches last_voted_round or last_voted_round + 1
     /// @TODO update last_voted_round
-    pub fn sign_timeout(&self, timeout: &Timeout) -> Result<Signature, Error> {
+    fn sign_timeout(&self, timeout: &Timeout) -> Result<Signature, Error> {
         Ok(timeout.sign(&self.validator_signer))
     }
 }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -1,20 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    consensus_state::ConsensusState,
-    error::Error,
-    persistent_storage::PersistentStorage,
-};
+use crate::{consensus_state::ConsensusState, error::Error, persistent_storage::PersistentStorage};
 use consensus_types::{
-    block::Block,
-    block_data::BlockData,
-    common::Payload,
-    quorum_cert::QuorumCert,
-    timeout::Timeout,
-    vote::Vote,
-    vote_data::VoteData,
-    vote_proposal::VoteProposal,
+    block::Block, block_data::BlockData, common::Payload, quorum_cert::QuorumCert,
+    timeout::Timeout, vote::Vote, vote_data::VoteData, vote_proposal::VoteProposal,
 };
 use libra_crypto::hash::HashValue;
 use libra_types::{
@@ -116,7 +106,7 @@ impl SafetyRules {
         ConsensusState::new(
             self.persistent_storage.epoch(),
             self.persistent_storage.last_voted_round(),
-             self.persistent_storage.preferred_round(),
+            self.persistent_storage.preferred_round(),
         )
     }
 

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -69,6 +69,13 @@ impl<T: Payload> SafetyRulesManager<T> {
             .validator_signer
             .take()
             .expect("validator_signer missing");
+        Self::new_direct(storage, validator_signer)
+    }
+
+    pub fn new_direct(
+        storage: Box<dyn PersistentStorage>,
+        validator_signer: ValidatorSigner,
+    ) -> Self {
         let safety_rules = SafetyRules::new(storage, Arc::new(validator_signer));
 
         Self {

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -1,0 +1,86 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    local_client::LocalClient, persistent_storage::PersistentStorage, InMemoryStorage,
+    OnDiskStorage, SafetyRules, TSafetyRules,
+};
+use consensus_types::common::Payload;
+use libra_config::config::{NodeConfig, SafetyRulesBackend, SafetyRulesConfig};
+use libra_types::crypto_proxies::ValidatorSigner;
+use std::sync::{Arc, RwLock};
+
+pub struct SafetyRulesManagerConfig {
+    storage: Option<Box<dyn PersistentStorage>>,
+    validator_signer: Option<ValidatorSigner>,
+}
+
+impl SafetyRulesManagerConfig {
+    pub fn new(config: &mut NodeConfig) -> Self {
+        let private_key = config
+            .consensus
+            .consensus_keypair
+            .take_private()
+            .expect("Failed to take Consensus private key, key absent or already read");
+
+        let author = config
+            .validator_network
+            .as_ref()
+            .expect("Missing validator network")
+            .peer_id;
+
+        let validator_signer = ValidatorSigner::new(author, private_key);
+        Self::new_with_signer(validator_signer, &config.consensus.safety_rules)
+    }
+
+    pub fn new_with_signer(validator_signer: ValidatorSigner, config: &SafetyRulesConfig) -> Self {
+        let storage = match &config.backend {
+            SafetyRulesBackend::InMemoryStorage => InMemoryStorage::default_storage(),
+            SafetyRulesBackend::OnDiskStorage(config) => {
+                if config.default {
+                    OnDiskStorage::default_storage(config.path().clone())
+                        .expect("Unable to allocate SafetyRules storage")
+                } else {
+                    OnDiskStorage::new_storage(config.path().clone())
+                        .expect("Unable to instantiate SafetyRules storage")
+                }
+            }
+        };
+
+        Self {
+            storage: Some(storage),
+            validator_signer: Some(validator_signer),
+        }
+    }
+}
+
+enum SafetyRulesWrapper<T> {
+    Local(Arc<RwLock<SafetyRules<T>>>),
+}
+
+pub struct SafetyRulesManager<T> {
+    internal_safety_rules: SafetyRulesWrapper<T>,
+}
+
+impl<T: Payload> SafetyRulesManager<T> {
+    pub fn new(mut config: SafetyRulesManagerConfig) -> Self {
+        let storage = config.storage.take().expect("validator_signer missing");
+        let validator_signer = config
+            .validator_signer
+            .take()
+            .expect("validator_signer missing");
+        let safety_rules = SafetyRules::new(storage, Arc::new(validator_signer));
+
+        Self {
+            internal_safety_rules: SafetyRulesWrapper::Local(Arc::new(RwLock::new(safety_rules))),
+        }
+    }
+
+    pub fn client(&self) -> Box<dyn TSafetyRules<T> + Send + Sync> {
+        match &self.internal_safety_rules {
+            SafetyRulesWrapper::Local(safety_rules) => {
+                Box::new(LocalClient::new(safety_rules.clone()))
+            }
+        }
+    }
+}

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -1,30 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Error, InMemoryStorage, SafetyRules};
+use crate::{test_utils, Error, InMemoryStorage, SafetyRules};
 use consensus_types::{
-    accumulator_extension_proof::AccumulatorExtensionProof,
-    block::block_test_utils::certificate_for_genesis, block::Block, common::Round,
-    quorum_cert::QuorumCert, timeout::Timeout, vote::Vote, vote_data::VoteData,
-    vote_proposal::VoteProposal,
+    block::block_test_utils, block::Block, common::Round, quorum_cert::QuorumCert,
+    timeout::Timeout, vote_proposal::VoteProposal,
 };
-use libra_crypto::hash::{CryptoHash, HashValue, TransactionAccumulatorHasher};
-use libra_types::{
-    block_info::BlockInfo,
-    crypto_proxies::ValidatorSigner,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-};
+use libra_crypto::hash::{CryptoHash, HashValue};
+use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::Arc;
-use std::{
-    collections::BTreeMap,
-    time::{SystemTime, UNIX_EPOCH},
-};
 
-type Proof = AccumulatorExtensionProof<TransactionAccumulatorHasher>;
-
-fn empty_proof() -> Proof {
-    Proof::new(vec![], 0, vec![])
-}
+type Proof = test_utils::Proof;
 
 fn make_proposal_with_qc_and_proof(
     round: Round,
@@ -32,28 +18,7 @@ fn make_proposal_with_qc_and_proof(
     qc: QuorumCert,
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal<Round> {
-    VoteProposal::<Round>::new(
-        proof,
-        Block::<Round>::new_proposal(
-            round,
-            round,
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            qc,
-            validator_signer,
-        ),
-        None,
-    )
-}
-
-fn make_proposal_with_qc(
-    round: Round,
-    qc: QuorumCert,
-    validator_signer: &ValidatorSigner,
-) -> VoteProposal<Round> {
-    make_proposal_with_qc_and_proof(round, empty_proof(), qc, validator_signer)
+    test_utils::make_proposal_with_qc_and_proof(round, round, proof, qc, validator_signer)
 }
 
 fn make_proposal_with_parent(
@@ -62,73 +27,7 @@ fn make_proposal_with_parent(
     committed: Option<&VoteProposal<Round>>,
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal<Round> {
-    let parent_output = parent
-        .accumulator_extension_proof()
-        .verify(
-            parent
-                .block()
-                .quorum_cert()
-                .certified_block()
-                .executed_state_id(),
-        )
-        .unwrap();
-
-    let proof = Proof::new(
-        parent_output.frozen_subtree_roots().clone(),
-        parent_output.num_leaves(),
-        vec![Timeout::new(0, round).hash()],
-    );
-
-    let vote_data = VoteData::new(
-        parent
-            .block()
-            .gen_block_info(parent_output.root_hash(), parent_output.version(), None),
-        parent.block().quorum_cert().certified_block().clone(),
-    );
-
-    let ledger_info = match committed {
-        Some(committed) => {
-            let tree = committed
-                .accumulator_extension_proof()
-                .verify(
-                    committed
-                        .block()
-                        .quorum_cert()
-                        .certified_block()
-                        .executed_state_id(),
-                )
-                .unwrap();
-            let commit_block_info = BlockInfo::new(
-                committed.block().epoch(),
-                committed.block().round(),
-                committed.block().id(),
-                tree.root_hash(),
-                tree.version(),
-                committed.block().timestamp_usecs(),
-                None,
-            );
-            LedgerInfo::new(commit_block_info, vote_data.hash())
-        }
-        None => LedgerInfo::new(BlockInfo::empty(), vote_data.hash()),
-    };
-
-    let vote = Vote::new(
-        vote_data.clone(),
-        validator_signer.author(),
-        ledger_info,
-        validator_signer,
-    );
-
-    let mut ledger_info_with_signatures =
-        LedgerInfoWithSignatures::new(vote.ledger_info().clone(), BTreeMap::new());
-
-    vote.signature()
-        .clone()
-        .add_to_li(vote.author(), &mut ledger_info_with_signatures);
-
-    let qc = QuorumCert::new(vote_data, ledger_info_with_signatures);
-
-    make_proposal_with_qc_and_proof(round, proof, qc, validator_signer)
+    test_utils::make_proposal_with_parent(round, round, parent, committed, validator_signer)
 }
 
 #[test]
@@ -162,11 +61,11 @@ fn test_preferred_block_rule() {
     //
     // PB should change from genesis to b1 and then a2.
     let genesis_block = Block::<Round>::make_genesis_block();
-    let genesis_qc = certificate_for_genesis();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
     let round = genesis_block.round();
 
-    let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
-    let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
     let b2 = make_proposal_with_parent(round + 3, &a1, None, &validator_signer);
     let a2 = make_proposal_with_parent(round + 4, &b1, None, &validator_signer);
     let b3 = make_proposal_with_parent(round + 5, &b2, None, &validator_signer);
@@ -234,11 +133,11 @@ fn test_voting_potential_commit_id() {
     // All the votes before a4 cannot produce any potential commits.
     // A potential commit for proposal a4 is a2, a potential commit for proposal a5 is a3.
     let genesis_block = Block::<Round>::make_genesis_block();
-    let genesis_qc = certificate_for_genesis();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
     let round = genesis_block.round();
 
-    let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
-    let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
     let a2 = make_proposal_with_parent(round + 3, &a1, None, &validator_signer);
     let a3 = make_proposal_with_parent(round + 4, &a2, None, &validator_signer);
     let a4 = make_proposal_with_parent(round + 5, &a3, Some(&a2), &validator_signer);
@@ -298,11 +197,11 @@ fn test_voting() {
     // a4 (old proposal)
     // b4 (round lower then round of pb. PB: a2, parent(b4)=b2)
     let genesis_block = Block::<Round>::make_genesis_block();
-    let genesis_qc = certificate_for_genesis();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
     let round = genesis_block.round();
 
-    let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
-    let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
     let b2 = make_proposal_with_parent(round + 3, &a1, None, &validator_signer);
     let a2 = make_proposal_with_parent(round + 4, &b1, None, &validator_signer);
     let a3 = make_proposal_with_parent(round + 5, &a2, None, &validator_signer);
@@ -323,6 +222,7 @@ fn test_voting() {
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
     safety_rules.update(b2.block().quorum_cert()).unwrap();
+
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b2),
         Err(Error::OldProposal {
@@ -343,7 +243,6 @@ fn test_voting() {
     vote = safety_rules.construct_and_sign_vote(&a4).unwrap();
     assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
 
-    safety_rules.update(a4.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.construct_and_sign_vote(&a4),
         Err(Error::OldProposal {
@@ -351,6 +250,7 @@ fn test_voting() {
             proposal_round: 7,
         })
     );
+
     safety_rules.update(b4.block().quorum_cert()).unwrap();
     assert_eq!(
         safety_rules.construct_and_sign_vote(&b4),
@@ -375,11 +275,11 @@ fn test_commit_rule_consecutive_rounds() {
     // a1 cannot be committed after a3 gathers QC because a1 and a2 are not consecutive
     // a2 can be committed after a4 gathers QC
     let genesis_block = Block::<Round>::make_genesis_block();
-    let genesis_qc = certificate_for_genesis();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
     let round = genesis_block.round();
 
-    let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
-    let b1 = make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &validator_signer);
     let b2 = make_proposal_with_parent(round + 3, &b1, None, &validator_signer);
     let a2 = make_proposal_with_parent(round + 4, &a1, None, &validator_signer);
     let a3 = make_proposal_with_parent(round + 5, &a2, None, &validator_signer);
@@ -437,10 +337,10 @@ fn test_bad_execution_output() {
     // evil_a3 attempts to append to a1 but fails append only check
     // a3 works as it properly extends a2
     let genesis_block = Block::<Round>::make_genesis_block();
-    let genesis_qc = certificate_for_genesis();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
     let round = genesis_block.round();
 
-    let a1 = make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &validator_signer);
     let a2 = make_proposal_with_parent(round + 2, &a1, None, &validator_signer);
     let a3 = make_proposal_with_parent(round + 3, &a2, None, &validator_signer);
 

--- a/consensus/safety-rules/src/safety_rules_test.rs
+++ b/consensus/safety-rules/src/safety_rules_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{test_utils, Error, InMemoryStorage, SafetyRules};
+use crate::{test_utils, Error, InMemoryStorage, SafetyRules, TSafetyRules};
 use consensus_types::{
     block::block_test_utils, block::Block, common::Round, quorum_cert::QuorumCert,
     timeout::Timeout, vote_proposal::VoteProposal,
@@ -35,7 +35,7 @@ fn test_initial_state() {
     // Start from scratch, verify the state
     let block = Block::<Round>::make_genesis_block();
 
-    let safety_rules = SafetyRules::new(
+    let safety_rules = SafetyRules::<Round>::new(
         InMemoryStorage::default_storage(),
         Arc::new(ValidatorSigner::from_int(0)),
     );
@@ -48,7 +48,7 @@ fn test_initial_state() {
 fn test_preferred_block_rule() {
     // Preferred block is the highest 2-chain head.
     let validator_signer = ValidatorSigner::from_int(0);
-    let mut safety_rules = SafetyRules::new(
+    let mut safety_rules = SafetyRules::<Round>::new(
         InMemoryStorage::default_storage(),
         Arc::new(validator_signer.clone()),
     );
@@ -119,7 +119,7 @@ fn test_preferred_block_rule() {
 /// Test the potential ledger info that we're going to use in case of voting
 fn test_voting_potential_commit_id() {
     let validator_signer = ValidatorSigner::from_int(0);
-    let mut safety_rules = SafetyRules::new(
+    let mut safety_rules = SafetyRules::<Round>::new(
         InMemoryStorage::default_storage(),
         Arc::new(validator_signer.clone()),
     );
@@ -173,7 +173,7 @@ fn test_voting_potential_commit_id() {
 #[test]
 fn test_voting() {
     let validator_signer = ValidatorSigner::from_int(0);
-    let mut safety_rules = SafetyRules::new(
+    let mut safety_rules = SafetyRules::<Round>::new(
         InMemoryStorage::default_storage(),
         Arc::new(validator_signer.clone()),
     );
@@ -261,7 +261,7 @@ fn test_voting() {
 #[test]
 fn test_commit_rule_consecutive_rounds() {
     let validator_signer = ValidatorSigner::from_int(0);
-    let safety_rules = SafetyRules::new(
+    let safety_rules = SafetyRules::<Round>::new(
         InMemoryStorage::default_storage(),
         Arc::new(validator_signer.clone()),
     );
@@ -327,7 +327,7 @@ fn test_commit_rule_consecutive_rounds() {
 fn test_bad_execution_output() {
     let validator_signer = Arc::new(ValidatorSigner::from_int(0));
     let mut safety_rules =
-        SafetyRules::new(InMemoryStorage::default_storage(), validator_signer.clone());
+        SafetyRules::<Round>::new(InMemoryStorage::default_storage(), validator_signer.clone());
 
     // build a tree of the following form:
     //                 _____

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -1,0 +1,34 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ConsensusState, Error};
+use consensus_types::{
+    block::Block, block_data::BlockData, quorum_cert::QuorumCert, timeout::Timeout, vote::Vote,
+    vote_proposal::VoteProposal,
+};
+use libra_types::crypto_proxies::Signature;
+
+/// Interface for SafetyRules
+pub trait TSafetyRules<T> {
+    /// Provides the internal state of SafetyRules for monitoring / debugging purposes. This does
+    /// not include sensitive data like private keys.
+    fn consensus_state(&self) -> ConsensusState;
+
+    /// Learn about a new quorum certificate. In normal state, this updates the preferred round,
+    /// if the parent is greater than our current preferred round.
+    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error>;
+
+    /// Notify the safety rules about the new epoch start.
+    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error>;
+
+    /// Attempts to vote for a given proposal following the voting rules.
+    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error>;
+
+    /// As the holder of the private key, SafetyRules also signs proposals or blocks.
+    /// A Block is a signed BlockData along with some additional metadata.
+    fn sign_proposal(&self, block_data: BlockData<T>) -> Result<Block<T>, Error>;
+
+    /// As the holder of the private key, SafetyRules also signs what is effectively a
+    /// timeout message. This returns the signature for that timeout message.
+    fn sign_timeout(&self, timeout: &Timeout) -> Result<Signature, Error>;
+}

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -1,0 +1,136 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use consensus_types::{
+    accumulator_extension_proof::AccumulatorExtensionProof,
+    block::Block,
+    common::{Payload, Round},
+    quorum_cert::QuorumCert,
+    timeout::Timeout,
+    vote::Vote,
+    vote_data::VoteData,
+    vote_proposal::VoteProposal,
+};
+use libra_crypto::hash::{CryptoHash, TransactionAccumulatorHasher};
+use libra_types::{
+    block_info::BlockInfo,
+    crypto_proxies::ValidatorSigner,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+};
+use std::{
+    collections::BTreeMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub type Proof = AccumulatorExtensionProof<TransactionAccumulatorHasher>;
+
+pub fn empty_proof() -> Proof {
+    Proof::new(vec![], 0, vec![])
+}
+
+pub fn make_proposal_with_qc_and_proof<P: Payload>(
+    payload: P,
+    round: Round,
+    proof: Proof,
+    qc: QuorumCert,
+    validator_signer: &ValidatorSigner,
+) -> VoteProposal<P> {
+    VoteProposal::<P>::new(
+        proof,
+        Block::<P>::new_proposal(
+            payload,
+            round,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            qc,
+            validator_signer,
+        ),
+        None,
+    )
+}
+
+pub fn make_proposal_with_qc<P: Payload>(
+    round: Round,
+    qc: QuorumCert,
+    validator_signer: &ValidatorSigner,
+) -> VoteProposal<P> {
+    make_proposal_with_qc_and_proof(P::default(), round, empty_proof(), qc, validator_signer)
+}
+
+pub fn make_proposal_with_parent<P: Payload>(
+    payload: P,
+    round: Round,
+    parent: &VoteProposal<P>,
+    committed: Option<&VoteProposal<P>>,
+    validator_signer: &ValidatorSigner,
+) -> VoteProposal<P> {
+    let parent_output = parent
+        .accumulator_extension_proof()
+        .verify(
+            parent
+                .block()
+                .quorum_cert()
+                .certified_block()
+                .executed_state_id(),
+        )
+        .unwrap();
+
+    let proof = Proof::new(
+        parent_output.frozen_subtree_roots().clone(),
+        parent_output.num_leaves(),
+        vec![Timeout::new(0, round).hash()],
+    );
+
+    let vote_data = VoteData::new(
+        parent
+            .block()
+            .gen_block_info(parent_output.root_hash(), parent_output.version(), None),
+        parent.block().quorum_cert().certified_block().clone(),
+    );
+
+    let ledger_info = match committed {
+        Some(committed) => {
+            let tree = committed
+                .accumulator_extension_proof()
+                .verify(
+                    committed
+                        .block()
+                        .quorum_cert()
+                        .certified_block()
+                        .executed_state_id(),
+                )
+                .unwrap();
+            let commit_block_info = BlockInfo::new(
+                committed.block().epoch(),
+                committed.block().round(),
+                committed.block().id(),
+                tree.root_hash(),
+                tree.version(),
+                committed.block().timestamp_usecs(),
+                None,
+            );
+            LedgerInfo::new(commit_block_info, vote_data.hash())
+        }
+        None => LedgerInfo::new(BlockInfo::empty(), vote_data.hash()),
+    };
+
+    let vote = Vote::new(
+        vote_data.clone(),
+        validator_signer.author(),
+        ledger_info,
+        validator_signer,
+    );
+
+    let mut ledger_info_with_signatures =
+        LedgerInfoWithSignatures::new(vote.ledger_info().clone(), BTreeMap::new());
+
+    vote.signature()
+        .clone()
+        .add_to_li(vote.author(), &mut ledger_info_with_signatures);
+
+    let qc = QuorumCert::new(vote_data, ledger_info_with_signatures);
+
+    make_proposal_with_qc_and_proof(payload, round, proof, qc, validator_signer)
+}

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -13,13 +13,13 @@ use crate::{
     txn_manager::MempoolProxy,
 };
 use anyhow::Result;
-use consensus_types::common::Author;
 use executor::Executor;
 use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_mempool::proto::mempool_client::MempoolClientWrapper;
-use libra_types::{crypto_proxies::ValidatorSigner, transaction::SignedTransaction};
+use libra_types::transaction::SignedTransaction;
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};
+use safety_rules::SafetyRulesManagerConfig;
 use state_synchronizer::StateSyncClient;
 use std::sync::Arc;
 use tokio::runtime;
@@ -27,10 +27,9 @@ use vm_runtime::LibraVM;
 
 ///  The state necessary to begin state machine replication including ValidatorSet, networking etc.
 pub struct InitialSetup {
-    pub author: Author,
-    pub signer: ValidatorSigner,
     pub network_sender: ConsensusNetworkSender,
     pub network_events: ConsensusNetworkEvents,
+    pub safety_rules_manager_config: Option<SafetyRulesManagerConfig>,
 }
 
 /// Supports the implementation of ConsensusProvider using LibraBFT.
@@ -56,8 +55,8 @@ impl ChainedBftProvider {
             .expect("Failed to create Tokio runtime!");
 
         let initial_setup = Self::initialize_setup(network_sender, network_events, node_config);
-        debug!("[Consensus] My peer: {:?}", initial_setup.author);
-        let config = ChainedBftSMRConfig::from_node_config(&node_config.consensus);
+        let config = ChainedBftSMRConfig::from_node_config(&node_config);
+        debug!("[Consensus] My peer: {:?}", config.author);
         let storage = Arc::new(StorageWriteProxy::new(node_config));
         let initial_data = storage.start();
 
@@ -81,18 +80,10 @@ impl ChainedBftProvider {
         network_events: ConsensusNetworkEvents,
         node_config: &mut NodeConfig,
     ) -> InitialSetup {
-        let author = node_config.validator_network.as_ref().unwrap().peer_id;
-        let private_key = node_config
-            .consensus
-            .consensus_keypair
-            .take_private()
-            .expect("Failed to take Consensus private key, key absent or already read");
-        let signer = ValidatorSigner::new(author, private_key);
         InitialSetup {
-            author,
-            signer,
             network_sender,
             network_events,
+            safety_rules_manager_config: Some(SafetyRulesManagerConfig::new(node_config)),
         }
     }
 }

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -26,7 +26,7 @@ use libra_types::crypto_proxies::{
 use network::proto::ConsensusMsg;
 use network::proto::ConsensusMsg_oneof;
 use network::validator_network::{ConsensusNetworkSender, Event};
-use safety_rules::{InMemoryStorage, OnDiskStorage, SafetyRules};
+use safety_rules::{InMemoryStorage, OnDiskStorage, SafetyRules, TSafetyRules};
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::sync::{Arc, RwLock};
@@ -255,7 +255,7 @@ where
         ));
 
         safety_rules
-            .start_new_epoch(block_store.highest_quorum_cert().as_ref())
+            .start_new_epoch(&block_store.highest_quorum_cert())
             .expect("Unable to transition SafetyRules to the new epoch");
 
         // txn manager is required both by proposal generator (to pull the proposers)

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -47,7 +47,7 @@ use crate::chained_bft::network::IncomingBlockRetrievalRequest;
 use consensus_types::block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus};
 #[cfg(test)]
 use safety_rules::ConsensusState;
-use safety_rules::{SafetyRules, TSafetyRules};
+use safety_rules::TSafetyRules;
 use std::convert::TryInto;
 use std::time::Instant;
 use std::{sync::Arc, time::Duration};
@@ -71,7 +71,7 @@ pub struct EventProcessor<TM, T> {
     pacemaker: Pacemaker,
     proposer_election: Box<dyn ProposerElection<T> + Send + Sync>,
     proposal_generator: ProposalGenerator<TM, T>,
-    safety_rules: SafetyRules,
+    safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
     txn_manager: TM,
     network: NetworkSender,
     storage: Arc<dyn PersistentStorage<T>>,
@@ -92,7 +92,7 @@ where
         pacemaker: Pacemaker,
         proposer_election: Box<dyn ProposerElection<T> + Send + Sync>,
         proposal_generator: ProposalGenerator<TM, T>,
-        safety_rules: SafetyRules,
+        safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
         txn_manager: TM,
         network: NetworkSender,
         storage: Arc<dyn PersistentStorage<T>>,

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -47,7 +47,7 @@ use crate::chained_bft::network::IncomingBlockRetrievalRequest;
 use consensus_types::block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus};
 #[cfg(test)]
 use safety_rules::ConsensusState;
-use safety_rules::SafetyRules;
+use safety_rules::{SafetyRules, TSafetyRules};
 use std::convert::TryInto;
 use std::time::Instant;
 use std::{sync::Arc, time::Duration};

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -136,7 +136,7 @@ fn create_node_for_fuzzing() -> EventProcessor<MockTransactionManager, TestPaylo
         pacemaker,
         proposer_election,
         proposal_generator,
-        safety_rules,
+        Box::new(safety_rules),
         MockTransactionManager::new().0,
         network,
         storage.clone(),

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -56,7 +56,7 @@ use network::{
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
 };
 use prost::Message as _;
-use safety_rules::{ConsensusState, OnDiskStorage, SafetyRules, TSafetyRules};
+use safety_rules::{ConsensusState, OnDiskStorage, SafetyRules};
 use std::sync::RwLock;
 use std::{collections::HashMap, convert::TryFrom, path::PathBuf, sync::Arc, time::Duration};
 use tempfile::NamedTempFile;
@@ -191,7 +191,7 @@ impl NodeSetup {
             pacemaker,
             proposer_election,
             proposal_generator,
-            safety_rules,
+            Box::new(safety_rules),
             MockTransactionManager::new().0,
             network,
             storage.clone(),

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -56,7 +56,7 @@ use network::{
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
 };
 use prost::Message as _;
-use safety_rules::{ConsensusState, OnDiskStorage, SafetyRules};
+use safety_rules::{ConsensusState, OnDiskStorage, SafetyRules, TSafetyRules};
 use std::sync::RwLock;
 use std::{collections::HashMap, convert::TryFrom, path::PathBuf, sync::Arc, time::Duration};
 use tempfile::NamedTempFile;


### PR DESCRIPTION
This PR effectively separates safety rules into its own universe. It is the last precursor before adding in the network interface between consensus and safety rules.
- Enable safety rules to persist across epochs (means we can leverage in memory safety rules for testing)
- Construct an abstraction around safety rules that works for both client/server and in memory
- Add a benchmark to evaluate design decisions