### PR TITLE
storage: use async-trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,6 +4354,7 @@ name = "storage-client"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4387,6 +4388,7 @@ name = "storage-service"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug-interface 0.1.0",
  "executable-helpers 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 futures = { version = "0.3.0", features = ["compat"] }
 futures_01 = { version = "0.1.28", package = "futures" }
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 tokio = { version = "0.2", features = ["full"] }
 tonic = { git = "https://github.com/hyperium/tonic.git" }
 futures = { version = "0.3.0", features = ["compat"] }


### PR DESCRIPTION
Convert the StorageRead and StorageWrite traits to use async-trait, this
makes the method signatures much easier to deal with and simplifies the
implementation of each trait.