### PR TITLE
Update cargo test instruction in READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ git clone https://github.com/libra/libra.git
 cd libra
 ./scripts/dev_setup.sh
 cargo build
-cargo test
+cargo xtest
 ```
 
 ## Our Development Process

--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -289,7 +289,7 @@ conditions to perform this conditional compilation:
   as the conditional test-only code.
 - the "fuzzing" custom feature, which is used to enable fuzzing and testing
 related code in downstream crates. Note that this must be passed explicitly to
-`cargo test` and `cargo bench`. Never use this in `[dependencies]` or
+`cargo xtest` and `cargo x bench`. Never use this in `[dependencies]` or
 `[dev-dependencies]` unless the crate is only for testing, otherwise Cargo's
 feature unification may pollute production code with the extra testing/fuzzing code.
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Now that we use `cargo x`, the old instructions no longer work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

N/A

## Related PRs

None.
