### PR TITLE
[consensus] serialization layer for safety rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,6 +3962,7 @@ dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "consensus-types 0.1.0",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -8,12 +8,14 @@ use std::path::PathBuf;
 #[serde(default, deny_unknown_fields)]
 pub struct SafetyRulesConfig {
     pub backend: SafetyRulesBackend,
+    pub service: SafetyRulesService,
 }
 
 impl Default for SafetyRulesConfig {
     fn default() -> Self {
         Self {
             backend: SafetyRulesBackend::InMemoryStorage,
+            service: SafetyRulesService::Local,
         }
     }
 }
@@ -67,4 +69,12 @@ impl OnDiskStorageConfig {
     pub fn set_data_dir(&mut self, data_dir: PathBuf) {
         self.data_dir = data_dir;
     }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum SafetyRulesService {
+    Local,
+    Remote,
 }

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 consensus-types = { path = "../consensus-types", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/consensus/safety-rules/src/consensus_state.rs
+++ b/consensus/safety-rules/src/consensus_state.rs
@@ -8,7 +8,7 @@ use std::fmt::{Display, Formatter};
 /// Public representation of the internal state of SafetyRules for monitoring / debugging purposes.
 /// This does not include sensitive data like private keys.
 /// @TODO add hash of ledger info (waypoint)
-#[derive(Serialize, Default, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConsensusState {
     epoch: u64,
     last_voted_round: Round,

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -3,9 +3,10 @@
 
 use anyhow;
 use consensus_types::common::Round;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
 /// Different reasons for proposal rejection
 pub enum Error {
     #[error("Internal error: {:?}", error)]
@@ -32,6 +33,9 @@ pub enum Error {
         last_voted_round: Round,
         proposal_round: Round,
     },
+
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
 }
 
 impl From<anyhow::Error> for Error {
@@ -39,5 +43,11 @@ impl From<anyhow::Error> for Error {
         Self::InternalError {
             error: format!("{}", error),
         }
+    }
+}
+
+impl From<lcs::Error> for Error {
+    fn from(error: lcs::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
     }
 }

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -25,5 +25,4 @@ pub use crate::{
 pub mod test_utils;
 
 #[cfg(test)]
-#[path = "safety_rules_test.rs"]
-mod safety_rules_test;
+mod tests;

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -7,6 +7,7 @@ mod consensus_state;
 mod error;
 mod local_client;
 mod persistent_storage;
+mod remote;
 mod safety_rules;
 mod safety_rules_manager;
 mod t_safety_rules;

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -23,7 +23,7 @@ impl<T: Payload> LocalClient<T> {
 }
 
 impl<T: Payload> TSafetyRules<T> for LocalClient<T> {
-    fn consensus_state(&self) -> ConsensusState {
+    fn consensus_state(&self) -> Result<ConsensusState, Error> {
         self.internal.read().unwrap().consensus_state()
     }
 

--- a/consensus/safety-rules/src/remote.rs
+++ b/consensus/safety-rules/src/remote.rs
@@ -1,0 +1,105 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ConsensusState, Error, SafetyRules, TSafetyRules};
+use consensus_types::{
+    block::Block, block_data::BlockData, common::Payload, quorum_cert::QuorumCert,
+    timeout::Timeout, vote::Vote, vote_proposal::VoteProposal,
+};
+use libra_types::crypto_proxies::Signature;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, RwLock};
+
+#[derive(Deserialize, Serialize)]
+pub enum SafetyRulesInput<T> {
+    ConsensusState,
+    Update(Box<QuorumCert>),
+    StartNewEpoch(Box<QuorumCert>),
+    #[serde(bound = "T: Payload")]
+    ConstructAndSignVote(Box<VoteProposal<T>>),
+    #[serde(bound = "T: Payload")]
+    SignProposal(Box<BlockData<T>>),
+    SignTimeout(Box<Timeout>),
+}
+
+pub struct RemoteService<T> {
+    internal: SafetyRules<T>,
+}
+
+impl<T: Payload> RemoteService<T> {
+    pub fn new(internal: SafetyRules<T>) -> Self {
+        Self { internal }
+    }
+
+    pub fn handle_message(&mut self, input_message: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let input = lcs::from_bytes(&input_message)?;
+
+        let output = match input {
+            SafetyRulesInput::ConsensusState => lcs::to_bytes(&self.internal.consensus_state()),
+            SafetyRulesInput::Update(qc) => lcs::to_bytes(&self.internal.update(&qc)),
+            SafetyRulesInput::StartNewEpoch(qc) => {
+                lcs::to_bytes(&self.internal.start_new_epoch(&qc))
+            }
+            SafetyRulesInput::ConstructAndSignVote(vote_proposal) => {
+                lcs::to_bytes(&self.internal.construct_and_sign_vote(&vote_proposal))
+            }
+            SafetyRulesInput::SignProposal(block_data) => {
+                lcs::to_bytes(&self.internal.sign_proposal(*block_data))
+            }
+            SafetyRulesInput::SignTimeout(timeout) => {
+                lcs::to_bytes(&self.internal.sign_timeout(&timeout))
+            }
+        };
+
+        Ok(output?)
+    }
+}
+
+pub struct RemoteClient<T> {
+    service: Arc<RwLock<RemoteService<T>>>,
+}
+
+impl<T: Payload> RemoteClient<T> {
+    pub fn new(service: Arc<RwLock<RemoteService<T>>>) -> Self {
+        Self { service }
+    }
+
+    pub fn request(&self, input: SafetyRulesInput<T>) -> Result<Vec<u8>, Error> {
+        let input_message = lcs::to_bytes(&input)?;
+        self.service.write().unwrap().handle_message(input_message)
+    }
+}
+
+impl<T: Payload> TSafetyRules<T> for RemoteClient<T> {
+    fn consensus_state(&self) -> Result<ConsensusState, Error> {
+        let response = self.request(SafetyRulesInput::ConsensusState)?;
+        lcs::from_bytes(&response)?
+    }
+
+    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        let response = self.request(SafetyRulesInput::Update(Box::new(qc.clone())))?;
+        lcs::from_bytes(&response)?
+    }
+
+    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        let response = self.request(SafetyRulesInput::StartNewEpoch(Box::new(qc.clone())))?;
+        lcs::from_bytes(&response)?
+    }
+
+    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
+        let response = self.request(SafetyRulesInput::ConstructAndSignVote(Box::new(
+            vote_proposal.clone(),
+        )))?;
+        lcs::from_bytes(&response)?
+    }
+
+    fn sign_proposal(&self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
+        let response = self.request(SafetyRulesInput::SignProposal(Box::new(block_data)))?;
+        lcs::from_bytes(&response)?
+    }
+
+    fn sign_timeout(&self, timeout: &Timeout) -> Result<Signature, Error> {
+        let response = self.request(SafetyRulesInput::SignTimeout(Box::new(timeout.clone())))?;
+        lcs::from_bytes(&response)?
+    }
+}

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -76,12 +76,12 @@ impl<T: Payload> SafetyRules<T> {
 }
 
 impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
-    fn consensus_state(&self) -> ConsensusState {
-        ConsensusState::new(
+    fn consensus_state(&self) -> Result<ConsensusState, Error> {
+        Ok(ConsensusState::new(
             self.persistent_storage.epoch(),
             self.persistent_storage.last_voted_round(),
             self.persistent_storage.preferred_round(),
-        )
+        ))
     }
 
     /// @TODO verify signatures of the QC, also the special genesis QC

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -12,7 +12,7 @@ use libra_types::crypto_proxies::Signature;
 pub trait TSafetyRules<T> {
     /// Provides the internal state of SafetyRules for monitoring / debugging purposes. This does
     /// not include sensitive data like private keys.
-    fn consensus_state(&self) -> ConsensusState;
+    fn consensus_state(&self) -> Result<ConsensusState, Error>;
 
     /// Learn about a new quorum certificate. In normal state, this updates the preferred round,
     /// if the parent is greater than our current preferred round.

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tests::suite, InMemoryStorage, SafetyRules, TSafetyRules};
+use crate::{tests::suite, InMemoryStorage, SafetyRulesManager, TSafetyRules};
 use consensus_types::common::{Payload, Round};
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::Arc;
@@ -12,10 +12,9 @@ fn test() {
 }
 
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
-    let signer = Arc::new(ValidatorSigner::from_int(0));
-    let safety_rules = Box::new(SafetyRules::<T>::new(
-        InMemoryStorage::default_storage(),
-        signer.clone(),
-    ));
-    (safety_rules, signer)
+    let signer = ValidatorSigner::from_int(0);
+    let safety_rules_manager =
+        SafetyRulesManager::new_local(Box::new(InMemoryStorage::default()), signer.clone());
+    let safety_rules = safety_rules_manager.client();
+    (safety_rules, Arc::new(signer.clone()))
 }

--- a/consensus/safety-rules/src/tests/mod.rs
+++ b/consensus/safety-rules/src/tests/mod.rs
@@ -1,4 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod local;
+mod remote;
 mod safety_rules;
+mod suite;

--- a/consensus/safety-rules/src/tests/mod.rs
+++ b/consensus/safety-rules/src/tests/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod safety_rules;

--- a/consensus/safety-rules/src/tests/remote.rs
+++ b/consensus/safety-rules/src/tests/remote.rs
@@ -1,0 +1,20 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{tests::suite, InMemoryStorage, SafetyRulesManager, TSafetyRules};
+use consensus_types::common::{Payload, Round};
+use libra_types::crypto_proxies::ValidatorSigner;
+use std::sync::Arc;
+
+#[test]
+fn test() {
+    suite::run_test_suite(safety_rules::<Round>, safety_rules::<Vec<u8>>);
+}
+
+fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
+    let signer = ValidatorSigner::from_int(0);
+    let safety_rules_manager =
+        SafetyRulesManager::new_remote(Box::new(InMemoryStorage::default()), signer.clone());
+    let safety_rules = safety_rules_manager.client();
+    (safety_rules, Arc::new(signer.clone()))
+}

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -39,7 +39,7 @@ fn test_initial_state() {
         InMemoryStorage::default_storage(),
         Arc::new(ValidatorSigner::from_int(0)),
     );
-    let state = safety_rules.consensus_state();
+    let state = safety_rules.consensus_state().unwrap();
     assert_eq!(state.last_voted_round(), block.round());
     assert_eq!(state.preferred_round(), block.round());
 }
@@ -74,43 +74,43 @@ fn test_preferred_block_rule() {
 
     safety_rules.update(a1.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         genesis_block.round()
     );
 
     safety_rules.update(b1.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         genesis_block.round()
     );
 
     safety_rules.update(a2.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         genesis_block.round()
     );
 
     safety_rules.update(b2.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         genesis_block.round()
     );
 
     safety_rules.update(a3.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         b1.block().round()
     );
 
     safety_rules.update(b3.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         b1.block().round()
     );
 
     safety_rules.update(a4.block().quorum_cert()).unwrap();
     assert_eq!(
-        safety_rules.consensus_state().preferred_round(),
+        safety_rules.consensus_state().unwrap().preferred_round(),
         a2.block().round()
     );
 }

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -1,0 +1,365 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{test_utils, Error, TSafetyRules};
+use consensus_types::{
+    block::block_test_utils, block::Block, common::Round, quorum_cert::QuorumCert,
+    timeout::Timeout, vote_proposal::VoteProposal,
+};
+use libra_crypto::hash::{CryptoHash, HashValue};
+use libra_types::crypto_proxies::ValidatorSigner;
+use rand::Rng;
+use std::sync::Arc;
+
+type Proof = test_utils::Proof;
+
+fn make_proposal_with_qc_and_proof(
+    round: Round,
+    proof: Proof,
+    qc: QuorumCert,
+    signer: &ValidatorSigner,
+) -> VoteProposal<Round> {
+    test_utils::make_proposal_with_qc_and_proof(round, round, proof, qc, signer)
+}
+
+fn make_proposal_with_parent(
+    round: Round,
+    parent: &VoteProposal<Round>,
+    committed: Option<&VoteProposal<Round>>,
+    signer: &ValidatorSigner,
+) -> VoteProposal<Round> {
+    test_utils::make_proposal_with_parent(round, round, parent, committed, signer)
+}
+
+type RoundCallback = fn() -> (Box<dyn TSafetyRules<Round>>, Arc<ValidatorSigner>);
+type ByteArrayCallback = fn() -> (Box<dyn TSafetyRules<Vec<u8>>>, Arc<ValidatorSigner>);
+
+pub fn run_test_suite(round_func: RoundCallback, byte_func: ByteArrayCallback) {
+    test_initial_state(round_func);
+    test_preferred_block_rule(round_func);
+    test_voting_potential_commit_id(round_func);
+    test_voting(round_func);
+    test_commit_rule_consecutive_rounds(round_func);
+    test_bad_execution_output(round_func);
+    test_end_to_end(byte_func);
+}
+
+fn test_initial_state(func: RoundCallback) {
+    // Start from scratch, verify the state
+    let (safety_rules, _) = func();
+    let block = Block::<Round>::make_genesis_block();
+    let state = safety_rules.consensus_state().unwrap();
+    assert_eq!(state.last_voted_round(), block.round());
+    assert_eq!(state.preferred_round(), block.round());
+}
+
+fn test_preferred_block_rule(func: RoundCallback) {
+    // Preferred block is the highest 2-chain head.
+    //
+    // build a tree of the following form:
+    //             _____    _____
+    //            /     \  /     \
+    // genesis---a1  b1  b2  a2  b3  a3---a4
+    //         \_____/ \_____/ \_____/
+    //
+    // PB should change from genesis to b1 and then a2.
+    let (mut safety_rules, signer) = func();
+
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &signer);
+    let b2 = make_proposal_with_parent(round + 3, &a1, None, &signer);
+    let a2 = make_proposal_with_parent(round + 4, &b1, None, &signer);
+    let b3 = make_proposal_with_parent(round + 5, &b2, None, &signer);
+    let a3 = make_proposal_with_parent(round + 6, &a2, None, &signer);
+    let a4 = make_proposal_with_parent(round + 7, &a3, None, &signer);
+
+    safety_rules.update(a1.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        genesis_block.round()
+    );
+
+    safety_rules.update(b1.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        genesis_block.round()
+    );
+
+    safety_rules.update(a2.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        genesis_block.round()
+    );
+
+    safety_rules.update(b2.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        genesis_block.round()
+    );
+
+    safety_rules.update(a3.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        b1.block().round()
+    );
+
+    safety_rules.update(b3.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        b1.block().round()
+    );
+
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.consensus_state().unwrap().preferred_round(),
+        a2.block().round()
+    );
+}
+
+fn test_voting_potential_commit_id(func: RoundCallback) {
+    // Test the potential ledger info that we're going to use in case of voting
+    // build a tree of the following form:
+    //            _____
+    //           /     \
+    // genesis--a1  b1  a2--a3--a4--a5
+    //        \_____/
+    //
+    // All the votes before a4 cannot produce any potential commits.
+    // A potential commit for proposal a4 is a2, a potential commit for proposal a5 is a3.
+    let (mut safety_rules, signer) = func();
+
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &signer);
+    let a2 = make_proposal_with_parent(round + 3, &a1, None, &signer);
+    let a3 = make_proposal_with_parent(round + 4, &a2, None, &signer);
+    let a4 = make_proposal_with_parent(round + 5, &a3, Some(&a2), &signer);
+    let a5 = make_proposal_with_parent(round + 6, &a4, Some(&a3), &signer);
+
+    for b in &[&a1, &b1, &a2, &a3] {
+        safety_rules.update(b.block().quorum_cert()).unwrap();
+        let vote = safety_rules.construct_and_sign_vote(b).unwrap();
+        assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+    }
+
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules
+            .construct_and_sign_vote(&a4)
+            .unwrap()
+            .ledger_info()
+            .consensus_block_id(),
+        a2.block().id(),
+    );
+
+    safety_rules.update(a5.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules
+            .construct_and_sign_vote(&a5)
+            .unwrap()
+            .ledger_info()
+            .consensus_block_id(),
+        a3.block().id(),
+    );
+}
+
+fn test_voting(func: RoundCallback) {
+    // build a tree of the following form:
+    //             _____    __________
+    //            /     \  /          \
+    // genesis---a1  b1  b2  a2---a3  b3  a4  b4
+    //         \_____/ \_____/     \______/   /
+    //                    \__________________/
+    //
+    //
+    // We'll introduce the votes in the following order:
+    // a1 (ok), potential_commit is None
+    // b1 (ok), potential commit is None
+    // a2 (ok), potential_commit is None
+    // b2 (old proposal)
+    // a3 (ok), potential commit is None
+    // b3 (ok), potential commit is None
+    // a4 (ok), potential commit is None
+    // a4 (old proposal)
+    // b4 (round lower then round of pb. PB: a2, parent(b4)=b2)
+    let (mut safety_rules, signer) = func();
+
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &signer);
+    let b2 = make_proposal_with_parent(round + 3, &a1, None, &signer);
+    let a2 = make_proposal_with_parent(round + 4, &b1, None, &signer);
+    let a3 = make_proposal_with_parent(round + 5, &a2, None, &signer);
+    let b3 = make_proposal_with_parent(round + 6, &b2, None, &signer);
+    let a4 = make_proposal_with_parent(round + 7, &a3, None, &signer);
+    let b4 = make_proposal_with_parent(round + 8, &b2, None, &signer);
+
+    safety_rules.update(a1.block().quorum_cert()).unwrap();
+    let mut vote = safety_rules.construct_and_sign_vote(&a1).unwrap();
+    assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+
+    safety_rules.update(b1.block().quorum_cert()).unwrap();
+    vote = safety_rules.construct_and_sign_vote(&b1).unwrap();
+    assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+
+    safety_rules.update(a2.block().quorum_cert()).unwrap();
+    vote = safety_rules.construct_and_sign_vote(&a2).unwrap();
+    assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+
+    safety_rules.update(b2.block().quorum_cert()).unwrap();
+
+    assert_eq!(
+        safety_rules.construct_and_sign_vote(&b2),
+        Err(Error::OldProposal {
+            last_voted_round: 4,
+            proposal_round: 3,
+        })
+    );
+
+    safety_rules.update(a3.block().quorum_cert()).unwrap();
+    vote = safety_rules.construct_and_sign_vote(&a3).unwrap();
+    assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+
+    safety_rules.update(b3.block().quorum_cert()).unwrap();
+    vote = safety_rules.construct_and_sign_vote(&b3).unwrap();
+    assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+
+    safety_rules.update(a4.block().quorum_cert()).unwrap();
+    vote = safety_rules.construct_and_sign_vote(&a4).unwrap();
+    assert_eq!(vote.ledger_info().consensus_block_id(), HashValue::zero());
+
+    assert_eq!(
+        safety_rules.construct_and_sign_vote(&a4),
+        Err(Error::OldProposal {
+            last_voted_round: 7,
+            proposal_round: 7,
+        })
+    );
+
+    safety_rules.update(b4.block().quorum_cert()).unwrap();
+    assert_eq!(
+        safety_rules.construct_and_sign_vote(&b4),
+        Err(Error::ProposalRoundLowerThenPreferredBlock { preferred_round: 4 })
+    );
+}
+
+fn test_commit_rule_consecutive_rounds(func: RoundCallback) {
+    // build a tree of the following form:
+    //             ___________
+    //            /           \
+    // genesis---a1  b1---b2   a2---a3---a4
+    //         \_____/
+    //
+    // a1 cannot be committed after a3 gathers QC because a1 and a2 are not consecutive
+    // a2 can be committed after a4 gathers QC
+    let (mut safety_rules, signer) = func();
+
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &signer);
+    let b1 = test_utils::make_proposal_with_qc(round + 2, genesis_qc.clone(), &signer);
+    let b2 = make_proposal_with_parent(round + 3, &b1, None, &signer);
+    let a2 = make_proposal_with_parent(round + 4, &a1, None, &signer);
+    let a3 = make_proposal_with_parent(round + 5, &a2, None, &signer);
+    let a4 = make_proposal_with_parent(round + 6, &a3, Some(&a2), &signer);
+
+    safety_rules.construct_and_sign_vote(&a1).unwrap();
+    safety_rules.construct_and_sign_vote(&b1).unwrap();
+    safety_rules.construct_and_sign_vote(&b2).unwrap();
+    safety_rules.construct_and_sign_vote(&a2).unwrap();
+    safety_rules.construct_and_sign_vote(&a3).unwrap();
+    safety_rules.construct_and_sign_vote(&a4).unwrap();
+}
+
+fn test_bad_execution_output(func: RoundCallback) {
+    // build a tree of the following form:
+    //                 _____
+    //                /     \
+    // genesis---a1--a2--a3  evil_a3
+    //
+    // evil_a3 attempts to append to a1 but fails append only check
+    // a3 works as it properly extends a2
+    let (mut safety_rules, signer) = func();
+
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &signer);
+    let a2 = make_proposal_with_parent(round + 2, &a1, None, &signer);
+    let a3 = make_proposal_with_parent(round + 3, &a2, None, &signer);
+
+    let a1_output = a1
+        .accumulator_extension_proof()
+        .verify(
+            a1.block()
+                .quorum_cert()
+                .certified_block()
+                .executed_state_id(),
+        )
+        .unwrap();
+
+    let evil_proof = Proof::new(
+        a1_output.frozen_subtree_roots().clone(),
+        a1_output.num_leaves(),
+        vec![Timeout::new(0, *a3.block().payload().unwrap()).hash()],
+    );
+
+    let evil_a3 = make_proposal_with_qc_and_proof(
+        round,
+        evil_proof,
+        a3.block().quorum_cert().clone(),
+        &signer,
+    );
+
+    let evil_a3_block = safety_rules.construct_and_sign_vote(&evil_a3);
+    assert!(evil_a3_block.is_err());
+
+    let a3_block = safety_rules.construct_and_sign_vote(&a3);
+    assert!(a3_block.is_ok());
+}
+
+fn test_end_to_end(func: ByteArrayCallback) {
+    let (mut safety_rules, signer) = func();
+
+    let genesis_block = Block::<Round>::make_genesis_block();
+    let genesis_qc = block_test_utils::certificate_for_genesis();
+    let round = genesis_block.round();
+
+    let mut rng = rand::thread_rng();
+    let data: Vec<u8> = (0..2048).map(|_| rng.gen::<u8>()).collect();
+
+    let p0 = test_utils::make_proposal_with_qc(round + 1, genesis_qc.clone(), &signer);
+    let p1 = test_utils::make_proposal_with_parent(data.clone(), round + 2, &p0, None, &signer);
+    let p2 = test_utils::make_proposal_with_parent(data.clone(), round + 3, &p1, None, &signer);
+    let p3 = test_utils::make_proposal_with_parent(data, round + 4, &p2, Some(&p0), &signer);
+
+    let state = safety_rules.consensus_state().unwrap();
+    assert_eq!(state.last_voted_round(), genesis_block.round());
+    assert_eq!(state.preferred_round(), genesis_block.round());
+
+    safety_rules.update(p0.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&p0).unwrap();
+    safety_rules.update(p1.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&p1).unwrap();
+    safety_rules.update(p2.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&p2).unwrap();
+    safety_rules.update(p3.block().quorum_cert()).unwrap();
+    safety_rules.construct_and_sign_vote(&p3).unwrap();
+
+    let state = safety_rules.consensus_state().unwrap();
+    assert_eq!(state.last_voted_round(), round + 4);
+    assert_eq!(state.preferred_round(), round + 2);
+}

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -367,7 +367,7 @@ fn process_successful_proposal_test() {
             proposal_id
         );
         assert_eq!(
-            node.event_processor.safety_rules.consensus_state(),
+            node.event_processor.safety_rules.consensus_state().unwrap(),
             ConsensusState::new(1, 1, 0),
         );
     });

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -98,10 +98,8 @@ impl NodeSetup {
             let (initial_data, storage) =
                 MockStorage::<TestPayload>::start_for_testing((&validators).into());
 
-            let safety_rules_manager = SafetyRulesManager::new_direct(
-                Box::new(InMemoryStorage::default()),
-                signer.clone(),
-            );
+            let safety_rules_manager =
+                SafetyRulesManager::new_local(Box::new(InMemoryStorage::default()), signer.clone());
 
             nodes.push(Self::new(
                 playground,


### PR DESCRIPTION
This PR shows how we can integrate a remote service for safety rules.
Refactored tests to validate local, remote, and original safety rules
Made the entire interface for TSafetyRules network safe (return errors)
There's some ugliness as a result of the refactor such as unwraps though they shouldn't affect production. At the same time, I can see an argument for cleaning that up before landing this PR. So we can assume this is a RFC unless folks feel generally good about it.