### PR TITLE
Client support for waypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4630,6 +4630,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-swarm 0.1.0",
  "libra-tools 0.1.0",
+ "libra-types 0.1.0",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -6,6 +6,7 @@
 use chrono::prelude::{SecondsFormat, Utc};
 use client::{client_proxy::ClientProxy, commands::*};
 use libra_logger::set_default_global_logger;
+use libra_types::waypoint::Waypoint;
 use rustyline::{config::CompletionType, error::ReadlineError, Config, Editor};
 use std::num::NonZeroU16;
 use structopt::StructOpt;
@@ -42,6 +43,9 @@ struct Args {
     /// If set, client will sync with validator during wallet recovery.
     #[structopt(short = "r", long = "sync")]
     pub sync: bool,
+    /// If set, a client uses the waypoint parameter for its initial LedgerInfo verification.
+    #[structopt(name = "waypoint", short, long)]
+    pub waypoint: Option<Waypoint>,
     /// Verbose output.
     #[structopt(short = "v", long = "verbose")]
     pub verbose: bool,
@@ -63,6 +67,7 @@ fn main() -> std::io::Result<()> {
         args.sync,
         args.faucet_server,
         args.mnemonic_file,
+        args.waypoint,
     )
     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, &format!("{}", e)[..]))?;
 

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -39,7 +39,7 @@ pub use safety_rules_config::*;
 mod test_config;
 pub use test_config::*;
 mod vm_config;
-use crate::waypoint::Waypoint;
+use libra_types::waypoint::Waypoint;
 pub use vm_config::*;
 
 /// Config pulls in configuration information from the config file.

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -7,4 +7,3 @@ pub mod config;
 pub mod generator;
 pub mod keys;
 pub mod utils;
-pub mod waypoint;

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -19,6 +19,7 @@ use libra_types::account_address::AccountAddress;
 use libra_types::crypto_proxies::{EpochInfo, ValidatorChangeProof};
 use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorVerifier};
 use libra_types::proto::types::ValidatorChangeProof as ValidatorChangeProofProto;
+use libra_types::validator_change::VerifierType;
 use network::{
     proto::{
         ConsensusMsg, ConsensusMsg_oneof, Proposal, RequestBlock, RequestEpoch,
@@ -496,8 +497,9 @@ impl<T: Payload> NetworkTask<T> {
         let msg_epoch = proof.epoch()?;
         match msg_epoch.cmp(&self.epoch()) {
             Ordering::Equal => {
-                let rlock = self.epoch_info.read().unwrap();
-                let target_ledger_info = proof.verify(rlock.epoch, &rlock.verifier)?;
+                let verifier =
+                    VerifierType::TrustedVerifier(self.epoch_info.read().unwrap().clone());
+                let target_ledger_info = proof.verify(&verifier)?;
                 debug!(
                     "Received epoch change to {}",
                     target_ledger_info.ledger_info().epoch() + 1

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -11,6 +11,7 @@ use libra_crypto::{
     ed25519::*, hash::GENESIS_BLOCK_ID, test_utils::TEST_SEED, HashValue, PrivateKey,
 };
 use libra_types::crypto_proxies::EpochInfo;
+use libra_types::validator_change::VerifierType;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -410,10 +411,10 @@ fn test_execution_with_storage() {
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
-        &mut EpochInfo {
+        &VerifierType::TrustedVerifier(EpochInfo {
             epoch: 0,
             verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
-        },
+        }),
         0,
         &request_items,
         &response_items,
@@ -620,10 +621,10 @@ fn test_execution_with_storage() {
         .update_to_latest_ledger(/* client_known_version = */ 0, request_items.clone())
         .unwrap();
     verify_update_to_latest_ledger_response(
-        &mut EpochInfo {
+        &&VerifierType::TrustedVerifier(EpochInfo {
             epoch: 0,
             verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
-        },
+        }),
         0,
         &request_items,
         &response_items,

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -162,6 +162,7 @@ impl InProcessTestClient {
                 false,
                 /* faucet server */ None,
                 Some(mnemonic_file_path.to_string()),
+                None,
             )
             .unwrap(),
             alias_to_cmd,

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -17,12 +17,12 @@ use futures::{
 };
 use libra_config::config::RoleType;
 use libra_config::config::StateSyncConfig;
-use libra_config::waypoint::Waypoint;
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::ValidatorChangeProof;
 use libra_types::transaction::Version;
 use libra_types::{
     crypto_proxies::LedgerInfoWithSignatures, transaction::TransactionListWithProof,
+    waypoint::Waypoint,
 };
 use network::{
     proto::{StateSynchronizerMsg, StateSynchronizerMsg_oneof},

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -15,9 +15,9 @@ use futures::{
     SinkExt,
 };
 use libra_config::config::{NodeConfig, RoleType, StateSyncConfig};
-use libra_config::waypoint::Waypoint;
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use libra_types::crypto_proxies::ValidatorChangeProof;
+use libra_types::waypoint::Waypoint;
 use network::validator_network::{StateSynchronizerEvents, StateSynchronizerSender};
 use std::sync::Arc;
 use tokio::runtime::{Builder, Runtime};

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -11,19 +11,19 @@ use config_builder;
 use executor::ExecutedTrees;
 use futures::executor::block_on;
 use libra_config::config::RoleType;
-use libra_config::waypoint::Waypoint;
 use libra_crypto::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED, x25519, HashValue};
 use libra_logger::set_simple_logger;
-use libra_types::block_info::BlockInfo;
-use libra_types::crypto_proxies::ValidatorPublicKeys;
-use libra_types::crypto_proxies::ValidatorSet;
-use libra_types::crypto_proxies::{
-    random_validator_verifier, ValidatorChangeProof, ValidatorSigner,
-};
 use libra_types::{
-    crypto_proxies::LedgerInfoWithSignatures, ledger_info::LedgerInfo, proof::TransactionListProof,
+    block_info::BlockInfo,
+    crypto_proxies::{
+        random_validator_verifier, LedgerInfoWithSignatures, ValidatorChangeProof,
+        ValidatorPublicKeys, ValidatorSet, ValidatorSigner,
+    },
+    ledger_info::LedgerInfo,
+    proof::TransactionListProof,
     transaction::TransactionListWithProof,
+    waypoint::Waypoint,
 };
 use network::{
     validator_network::{

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -26,5 +26,6 @@ lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-se
 libra-swarm = { path = "../libra-swarm", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
 libra-tools = { path = "../common/tools", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -6,11 +6,14 @@ use cli::{
     TransactionArgument, TransactionPayload,
 };
 use libra_config::config::{NodeConfig, RoleType};
-use libra_crypto::{ed25519::*, test_utils::KeyPair, SigningKey};
+use libra_crypto::{ed25519::*, test_utils::KeyPair, HashValue, SigningKey};
 use libra_logger::prelude::*;
 use libra_swarm::swarm::LibraNode;
 use libra_swarm::{swarm::LibraSwarm, utils};
 use libra_tools::tempdir::TempPath;
+use libra_types::block_info::BlockInfo;
+use libra_types::ledger_info::LedgerInfo;
+use libra_types::waypoint::Waypoint;
 use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
 use std::fs::{self, File};
@@ -98,7 +101,7 @@ impl TestEnvironment {
         panic!("Max out {} attempts to launch test swarm", num_attempts);
     }
 
-    fn get_ac_client(&self, port: u16) -> ClientProxy {
+    fn get_ac_client(&self, port: u16, waypoint: Option<Waypoint>) -> ClientProxy {
         let mnemonic_file_path = self
             .mnemonic_file
             .path()
@@ -116,20 +119,29 @@ impl TestEnvironment {
             false,
             /* faucet server */ None,
             Some(mnemonic_file_path),
+            waypoint,
         )
         .unwrap()
     }
 
-    fn get_validator_ac_client(&self, node_index: usize) -> ClientProxy {
+    fn get_validator_ac_client(
+        &self,
+        node_index: usize,
+        waypoint: Option<Waypoint>,
+    ) -> ClientProxy {
         let port = self.validator_swarm.get_ac_port(node_index);
-        self.get_ac_client(port)
+        self.get_ac_client(port, waypoint)
     }
 
-    fn get_full_node_ac_client(&self, node_index: usize) -> ClientProxy {
+    fn get_full_node_ac_client(
+        &self,
+        node_index: usize,
+        waypoint: Option<Waypoint>,
+    ) -> ClientProxy {
         match &self.full_node_swarm {
             Some(swarm) => {
                 let port = swarm.get_ac_port(node_index);
-                self.get_ac_client(port)
+                self.get_ac_client(port, waypoint)
             }
             None => {
                 panic!("Full Node swarm is not initialized");
@@ -148,7 +160,7 @@ fn setup_swarm_and_client_proxy(
 ) -> (TestEnvironment, ClientProxy) {
     let mut env = TestEnvironment::new(num_nodes);
     env.launch_swarm(RoleType::Validator);
-    let ac_client = env.get_validator_ac_client(client_port_index);
+    let ac_client = env.get_validator_ac_client(client_port_index, None);
     (env, ac_client)
 }
 
@@ -386,7 +398,7 @@ fn test_startup_sync_state() {
         .is_ok());
     // create the client for the restarted node
     let accounts = client_proxy_1.copy_all_accounts();
-    let mut client_proxy_0 = env.get_validator_ac_client(0);
+    let mut client_proxy_0 = env.get_validator_ac_client(0, None);
     let sender_address = accounts[0].address;
     client_proxy_0.set_accounts(accounts);
     client_proxy_0.wait_for_transaction(sender_address, 1);
@@ -462,7 +474,7 @@ fn test_basic_state_synchronization() {
     assert!(env.validator_swarm.wait_for_all_nodes_to_catchup());
 
     // Connect to the newly recovered node and verify its state
-    let mut client_proxy2 = env.get_validator_ac_client(node_to_restart);
+    let mut client_proxy2 = env.get_validator_ac_client(node_to_restart, None);
     client_proxy2.set_accounts(client_proxy.copy_all_accounts());
     assert_eq!(
         Decimal::from_f64(85.0),
@@ -577,12 +589,12 @@ fn test_full_node_basic_flow() {
     env.launch_swarm(RoleType::FullNode);
 
     // execute smoke script
-    test_smoke_script(env.get_validator_ac_client(0));
+    test_smoke_script(env.get_validator_ac_client(0, None));
 
     // read state from full node client
-    let mut validator_ac_client = env.get_validator_ac_client(1);
-    let mut full_node_client = env.get_full_node_ac_client(1);
-    let mut full_node_client_2 = env.get_full_node_ac_client(0);
+    let mut validator_ac_client = env.get_validator_ac_client(1, None);
+    let mut full_node_client = env.get_full_node_ac_client(1, None);
+    let mut full_node_client_2 = env.get_full_node_ac_client(0, None);
     for idx in 0..3 {
         validator_ac_client.create_next_account(false).unwrap();
         full_node_client.create_next_account(false).unwrap();
@@ -697,7 +709,7 @@ fn test_full_node_basic_flow() {
 fn test_e2e_reconfiguration() {
     let (mut env, mut client_proxy_1) = setup_swarm_and_client_proxy(3, 1);
     // the client connected to the removed validator
-    let mut client_proxy_0 = env.get_validator_ac_client(0);
+    let mut client_proxy_0 = env.get_validator_ac_client(0, None);
     client_proxy_1.create_next_account(false).unwrap();
     client_proxy_0.set_accounts(client_proxy_1.copy_all_accounts());
     client_proxy_1
@@ -745,4 +757,71 @@ fn test_e2e_reconfiguration() {
         Decimal::from_f64(20.0),
         Decimal::from_str(&client_proxy_0.get_balance(&["b", "0"]).unwrap()).ok()
     );
+}
+
+#[test]
+fn test_client_waypoints() {
+    let (mut env, mut client_proxy) = setup_swarm_and_client_proxy(3, 1);
+    // Make sure some txns are committed
+    client_proxy.create_next_account(false).unwrap();
+    client_proxy
+        .mint_coins(&["mintb", "0", "10"], true)
+        .unwrap();
+
+    // Create the waypoint for the initial epoch
+    let genesis_li = client_proxy
+        .latest_epoch_change_li()
+        .expect("Failed to retrieve genesis LedgerInfo");
+    assert_eq!(genesis_li.ledger_info().epoch(), 0);
+    let genesis_waypoint = Waypoint::new(genesis_li.ledger_info())
+        .expect("Failed to generate waypoint from genesis LI");
+
+    // Start another client with the genesis waypoint and make sure it successfully connects
+    let mut client_with_waypoint = env.get_validator_ac_client(0, Some(genesis_waypoint.clone()));
+    client_with_waypoint.test_validator_connection().unwrap();
+    assert_eq!(
+        client_with_waypoint.latest_epoch_change_li().unwrap(),
+        genesis_li
+    );
+
+    // Start next epoch
+    let peer_id = env
+        .get_validator(0)
+        .unwrap()
+        .validator_peer_id()
+        .unwrap()
+        .to_string();
+    client_proxy
+        .remove_validator(&["remove_validator", &peer_id], true)
+        .unwrap();
+    client_proxy
+        .mint_coins(&["mintb", "0", "10"], true)
+        .unwrap();
+    assert_eq!(
+        Decimal::from_f64(20.0),
+        Decimal::from_str(&client_proxy.get_balance(&["b", "0"]).unwrap()).ok()
+    );
+    let epoch_1_li = client_proxy
+        .latest_epoch_change_li()
+        .expect("Failed to retrieve end of epoch 1 LedgerInfo");
+
+    assert_eq!(epoch_1_li.ledger_info().epoch(), 1);
+    let epoch_1_waypoint = Waypoint::new(epoch_1_li.ledger_info())
+        .expect("Failed to generate waypoint from end of epoch 1");
+
+    // Start a client with the waypoint for end of epoch 1 and make sure it successfully connects
+    client_with_waypoint = env.get_validator_ac_client(1, Some(epoch_1_waypoint.clone()));
+    client_with_waypoint.test_validator_connection().unwrap();
+    assert_eq!(
+        client_with_waypoint.latest_epoch_change_li().unwrap(),
+        epoch_1_li
+    );
+
+    // Verify that a client with the wrong waypoint is not going to be able to connect to the chain.
+    let bad_li = LedgerInfo::new(BlockInfo::genesis(), HashValue::zero());
+    let bad_waypoint = Waypoint::new(&bad_li).unwrap();
+    let mut client_with_bad_waypoint = env.get_validator_ac_client(1, Some(bad_waypoint));
+    assert!(client_with_bad_waypoint
+        .test_validator_connection()
+        .is_err());
 }

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -105,6 +105,15 @@ pub struct EpochInfo {
     pub verifier: Arc<ValidatorVerifier>,
 }
 
+impl EpochInfo {
+    pub fn empty() -> Self {
+        Self {
+            epoch: 0,
+            verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
+        }
+    }
+}
+
 impl fmt::Display for EpochInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -32,6 +32,7 @@ pub mod validator_set;
 pub mod validator_signer;
 pub mod validator_verifier;
 pub mod vm_error;
+pub mod waypoint;
 pub mod write_set;
 
 pub use account_address::AccountAddress as PeerId;

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -1,12 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{crypto_proxies::ValidatorSet, ledger_info::LedgerInfo, transaction::Version};
 use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
 use libra_crypto_derive::CryptoHasher;
-use libra_types::crypto_proxies::ValidatorSet;
-use libra_types::ledger_info::LedgerInfo;
-use libra_types::transaction::Version;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -125,10 +123,10 @@ impl CryptoHash for Ledger2WaypointConverter {
 #[cfg(test)]
 mod test {
     use super::Waypoint;
+    use crate::block_info::BlockInfo;
+    use crate::crypto_proxies::ValidatorSet;
+    use crate::ledger_info::LedgerInfo;
     use libra_crypto::HashValue;
-    use libra_types::block_info::BlockInfo;
-    use libra_types::crypto_proxies::ValidatorSet;
-    use libra_types::ledger_info::LedgerInfo;
     use std::str::FromStr;
 
     #[test]


### PR DESCRIPTION
Summary: support for client verification using the predefined waypoint.
The waypoint can be passed as a cli parameter.
The clients can also return the latest epoch change LedgerInfo, which can be used for generating the waypoint.

Testing: added a smoke test that verifies waypoint generation / consumption by the clients.

Issues: ref #1384