### PR TITLE
[language][move] Improve parser error messages for comma-separated lists

### DIFF
--- a/language/move-lang/tests/move_check/parser/function_type_extra_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_type_extra_comma.exp
@@ -3,9 +3,6 @@ error:
    ┌── tests/move_check/parser/function_type_extra_comma.move:2:8 ───
    │
  2 │     fn<,T>() { }
-   │        ^ Unexpected token: ','
-   ·
- 2 │     fn<,T>() { }
-   │        - Expected: a name value
+   │        ^ Expected a type parameter
    │
 

--- a/language/move-lang/tests/move_check/parser/function_type_missing_angle.exp
+++ b/language/move-lang/tests/move_check/parser/function_type_missing_angle.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/parser/function_type_missing_angle.move:3:15 ───
+   ┌── tests/move_check/parser/function_type_missing_angle.move:3:7 ───
    │
  3 │     fn<T1, T2 () { }
-   │               ^ Unexpected token: '('
+   │               ^ Expected '>'
    ·
  3 │     fn<T1, T2 () { }
-   │               - Expected: ','
+   │       - To match this '<'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/parser/let_binding_missing_paren.move:3:21 ───
+   ┌── tests/move_check/parser/let_binding_missing_paren.move:3:13 ───
    │
  3 │         let (x1, x2 = (1, 2);
-   │                     ^ Unexpected token: '='
+   │                     ^ Expected ')'
    ·
  3 │         let (x1, x2 = (1, 2);
-   │                     - Expected: ','
+   │             - To match this '('
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
+++ b/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/parser/struct_missing_lbrace.move:3:5 ───
+   ┌── tests/move_check/parser/struct_missing_lbrace.move:2:14 ───
    │
  3 │     f() {}
-   │     ^ Unexpected token: 'f'
+   │     ^ Expected '}'
    ·
- 3 │     f() {}
-   │     - Expected: ','
+ 2 │     struct S { f: u64
+   │              - To match this '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_extra_comma.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_extra_comma.exp
@@ -3,9 +3,6 @@ error:
    ┌── tests/move_check/parser/struct_type_extra_comma.move:2:14 ───
    │
  2 │     struct S<,T> { }
-   │              ^ Unexpected token: ','
-   ·
- 2 │     struct S<,T> { }
-   │              - Expected: a name value
+   │              ^ Expected a type parameter
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_missing_angle.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_missing_angle.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/parser/struct_type_missing_angle.move:3:21 ───
+   ┌── tests/move_check/parser/struct_type_missing_angle.move:3:13 ───
    │
  3 │     struct S<T1, T2 { }
-   │                     ^ Unexpected token: '{'
+   │                     ^ Expected '>'
    ·
  3 │     struct S<T1, T2 { }
-   │                     - Expected: ','
+   │             - To match this '<'
    │
 


### PR DESCRIPTION
Replace some "unexpected token" errors with messages that are specific to comma-separated lists. This changes the parse_comma_list function to also consume the starting and ending tokens, so that it can report better messages about them. For type arguments, where the starting "<" character is attached to the type name token, this requires identifying the source location for that "<" character and also a separate parse_comma_list_after_start entry point. To simplify the code a bit, this also adds a new match_token function that combines the operation of checking for a token and then advancing past it.

## Motivation

See above

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated parser tests to check for the new messages