### PR TITLE
[Storage] Add backup and restore command line tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,11 +200,19 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-types 0.1.0",
+ "libradb 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-client 0.1.0",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/storage/backup-restore/Cargo.toml
+++ b/storage/backup-restore/Cargo.toml
@@ -11,11 +11,20 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.19"
+byteorder = "1.3.2"
 futures = "0.3.1"
+grpcio = { version = "=0.5.0-alpha.4", default-features = false }
 hex = "0.4.0"
+itertools = "0.8"
 rand = "0.7"
+structopt = "0.3"
+
+lcs = { path = "../../common/lcs", package = "libra-canonical-serialization", version = "0.1.0" }
+libradb = { path = "../libradb", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+storage-client = { path = "../storage-client", version = "0.1.0" }
 
 [dev-dependencies]
-itertools = "0.8"
 proptest = "0.9.4"
 tempfile = "3.1.0"

--- a/storage/backup-restore/src/adapter/local_storage/local_storage_test.rs
+++ b/storage/backup-restore/src/adapter/local_storage/local_storage_test.rs
@@ -21,7 +21,7 @@ proptest! {
 
         for (handle, expected_content) in itertools::zip_eq(file_handles, contents) {
             let mut actual_content = vec![];
-            for res in block_on_stream(adapter.read_file_content(&handle)) {
+            for res in block_on_stream(LocalStorage::read_file_content(&handle)) {
                 let bytes = res.unwrap();
                 actual_content.extend_from_slice(&bytes);
             }

--- a/storage/backup-restore/src/adapter/mod.rs
+++ b/storage/backup-restore/src/adapter/mod.rs
@@ -15,10 +15,10 @@ pub trait Adapter {
     /// finished.
     async fn write_new_file(
         &self,
-        content: impl StreamExt<Item = Vec<u8>> + Send + Unpin + 'async_trait,
+        content: impl StreamExt<Item = Vec<u8>> + Send + 'async_trait,
     ) -> Result<FileHandle>;
 
     /// Returns the content of the file in a stream.
     #[allow(clippy::ptr_arg)]
-    fn read_file_content(&self, file_handle: &FileHandle) -> BoxStream<Result<Vec<u8>>>;
+    fn read_file_content(file_handle: &FileHandle) -> BoxStream<Result<Vec<u8>>>;
 }

--- a/storage/backup-restore/src/bin/backup.rs
+++ b/storage/backup-restore/src/bin/backup.rs
@@ -1,0 +1,50 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use backup_restore::{adapter::local_storage::LocalStorage, backup_account_state};
+use futures::executor::block_on;
+use grpcio::EnvBuilder;
+use std::{path::PathBuf, sync::Arc};
+use storage_client::{StorageRead, StorageReadServiceClient};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// Default 4M.
+    #[structopt(long, default_value = "4194304")]
+    state_chunk_size: usize,
+
+    /// Where the backup is stored.
+    #[structopt(long, parse(from_os_str))]
+    local_dir: PathBuf,
+
+    /// The port of the storage service.
+    #[structopt(long)]
+    node_port: u16,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+
+    let env = Arc::new(EnvBuilder::new().build());
+    let client = StorageReadServiceClient::new(env, "localhost", opt.node_port);
+
+    let (version, state_root_hash) = block_on(client.get_latest_state_root_async())
+        .expect("Failed to get latest version and state root hash.");
+    println!("Latest version: {}", version);
+    println!("State root hash: {:x}", state_root_hash);
+
+    let adapter = LocalStorage::new(opt.local_dir);
+    let file_handles = futures::executor::block_on(backup_account_state(
+        &client,
+        version,
+        &adapter,
+        opt.state_chunk_size,
+    ))
+    .expect("Failed to backup account state.");
+
+    for (account_state_file, proof_file) in file_handles {
+        println!("{}", account_state_file);
+        println!("{}", proof_file);
+    }
+}

--- a/storage/backup-restore/src/bin/restore.rs
+++ b/storage/backup-restore/src/bin/restore.rs
@@ -1,0 +1,108 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use backup_restore::{
+    adapter::{local_storage::LocalStorage, Adapter},
+    FileHandle,
+};
+use byteorder::{LittleEndian, ReadBytesExt};
+use futures::executor::block_on_stream;
+use itertools::Itertools;
+use libra_crypto::HashValue;
+use libra_types::{account_state_blob::AccountStateBlob, proof::SparseMerkleRangeProof};
+use libradb::LibraDB;
+use std::{
+    io::{BufRead, Read},
+    path::PathBuf,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(long, parse(from_os_str))]
+    db_dir: PathBuf,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+
+    let libradb = LibraDB::new(&opt.db_dir);
+
+    let stdin = std::io::stdin();
+    let mut iter = stdin.lock().lines();
+
+    println!("Input version:");
+    let version = iter
+        .next()
+        .expect("Must provide version.")
+        .expect("Failed to read from stdin.")
+        .parse::<u64>()
+        .expect("Version must be valid u64.");
+    println!("Version: {}", version);
+
+    println!("Input state root hash:");
+    let root_hash_hex = iter
+        .next()
+        .expect("Must provide state root hash.")
+        .expect("Failed to read from stdin.");
+    let root_hash = HashValue::from_slice(
+        &hex::decode(&root_hash_hex).expect("State root hash must be valid hex."),
+    )
+    .expect("Invalid root hash.");
+    println!("State root hash: {:x}", root_hash);
+
+    let chunk_and_proofs = iter.tuples().map(|(file1, file2)| {
+        let account_state_file = file1.expect("Failed to read from stdin.");
+        let accounts = read_account_state_chunk(account_state_file)
+            .expect("Failed to read account state file.");
+
+        let proof_file = file2.expect("Failed to read from stdin");
+        let proof = read_proof(proof_file).expect("Failed to read proof file.");
+
+        (accounts, proof)
+    });
+
+    libradb
+        .restore_account_state(chunk_and_proofs, version, root_hash)
+        .expect("Failed to restore account state.");
+
+    println!("Finished restoring account state.");
+}
+
+fn read_account_state_chunk(file: FileHandle) -> Result<Vec<(HashValue, AccountStateBlob)>> {
+    let content = read_file(file)?;
+
+    let mut chunk = vec![];
+    let mut reader = std::io::Cursor::new(content);
+    loop {
+        let mut buf = [0u8; HashValue::LENGTH];
+        if reader.read_exact(&mut buf).is_err() {
+            break;
+        }
+        let key = HashValue::new(buf);
+
+        let len = reader.read_u32::<LittleEndian>()?;
+        let mut buf = vec![0u8; len as usize];
+        reader.read_exact(&mut buf)?;
+        let blob = AccountStateBlob::from(buf);
+
+        chunk.push((key, blob));
+    }
+
+    Ok(chunk)
+}
+
+fn read_proof(file: FileHandle) -> Result<SparseMerkleRangeProof> {
+    let content = read_file(file)?;
+    let proof = lcs::from_bytes(&content)?;
+    Ok(proof)
+}
+
+fn read_file(file: FileHandle) -> Result<Vec<u8>> {
+    let mut content = vec![];
+    for bytes_res in block_on_stream(LocalStorage::read_file_content(&file)) {
+        content.extend(bytes_res?);
+    }
+    Ok(content)
+}

--- a/storage/backup-restore/src/lib.rs
+++ b/storage/backup-restore/src/lib.rs
@@ -1,7 +1,85 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[allow(dead_code)]
-mod adapter;
+pub mod adapter;
 
-type FileHandle = String;
+use crate::adapter::Adapter;
+use anyhow::Result;
+use futures::{stream, StreamExt};
+use libra_crypto::HashValue;
+use libra_types::transaction::Version;
+use storage_client::{StorageRead, StorageReadServiceClient};
+
+pub type FileHandle = String;
+
+pub async fn backup_account_state(
+    client: &StorageReadServiceClient,
+    version: Version,
+    adapter: &impl Adapter,
+    max_chunk_size: usize,
+) -> Result<Vec<(FileHandle, FileHandle)>> {
+    let mut chunk = vec![];
+    let mut ret = vec![];
+
+    let mut account_stream = client.backup_account_state(version)?;
+    let mut prev_key = None;
+    while let Some(resp) = account_stream.next().await.transpose()? {
+        let key = resp.account_key;
+        let blob = resp.account_state_blob;
+        println!("Backing up key: {:x}", key);
+
+        let mut bytes = key.to_vec();
+        let blob: Vec<u8> = blob.into();
+        assert!(blob.len() <= std::u32::MAX as usize);
+        let blob_len = blob.len() as u32;
+        bytes.extend_from_slice(&blob_len.to_le_bytes());
+        bytes.extend(blob);
+        assert!(bytes.len() <= max_chunk_size);
+
+        if chunk.len() + bytes.len() > max_chunk_size {
+            assert!(chunk.len() <= max_chunk_size);
+            let account_state_file = adapter
+                .write_new_file(stream::once(async move { chunk }))
+                .await?;
+
+            let prev_key = prev_key.expect("max_chunk_size should be larger than account size.");
+            println!(
+                "Reached max_chunk_size. Asking proof for key: {:?}",
+                prev_key,
+            );
+            let proof_file = get_proof_and_write(client, adapter, prev_key, version).await?;
+            ret.push((account_state_file, proof_file));
+            chunk = vec![];
+        }
+
+        chunk.extend(bytes);
+        prev_key = Some(key);
+    }
+
+    assert!(!chunk.is_empty());
+    assert!(chunk.len() <= max_chunk_size);
+    let account_state_file = adapter
+        .write_new_file(stream::once(async move { chunk }))
+        .await?;
+
+    let prev_key = prev_key.expect("Should have at least one account.");
+    println!("Asking proof for last key: {:x}", prev_key);
+    let proof_file = get_proof_and_write(client, adapter, prev_key, version).await?;
+    ret.push((account_state_file, proof_file));
+
+    Ok(ret)
+}
+
+async fn get_proof_and_write(
+    client: &StorageReadServiceClient,
+    adapter: &impl Adapter,
+    key: HashValue,
+    version: Version,
+) -> Result<FileHandle> {
+    let proof = client.get_account_state_range_proof(key, version).await?;
+    let proof_bytes: Vec<u8> = lcs::to_bytes(&proof)?;
+    let file = adapter
+        .write_new_file(stream::once(async move { proof_bytes }))
+        .await?;
+    Ok(file)
+}

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -189,7 +189,7 @@ impl StorageRead for StorageReadServiceClient {
         Ok(resp)
     }
 
-    async fn backup_account_state_async(
+    fn backup_account_state(
         &self,
         version: Version,
     ) -> Result<BoxStream<'_, Result<BackupAccountStateResponse, Error>>> {
@@ -333,11 +333,9 @@ pub trait StorageRead: Send + Sync {
 
     /// See [`LibraDB::backup_account_state`].
     ///
-    /// Due to the streaming nature of this API, only an async version is provided.
-    ///
     /// [`LibraDB::backup_account_state`]:
     /// ../libradb/struct.LibraDB.html#method.backup_account_state
-    async fn backup_account_state_async(
+    fn backup_account_state(
         &self,
         version: u64,
     ) -> Result<BoxStream<'_, Result<BackupAccountStateResponse, Error>>>;

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -110,7 +110,7 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
-    async fn backup_account_state_async(
+    fn backup_account_state(
         &self,
         _version: u64,
     ) -> Result<BoxStream<'_, Result<BackupAccountStateResponse, Error>>> {

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -117,13 +117,12 @@ proptest! {
         }
 
         // Check state backup for all account states.
-        let stream = rt.block_on(read_client.backup_account_state_async(version - 1));
-        let backup_responses = rt.block_on(stream.unwrap().collect::<Vec<_>>());
+        let stream = read_client.backup_account_state(version - 1).unwrap();
+        let backup_responses = rt.block_on(stream.collect::<Vec<_>>());
         for ((hash, blob), response) in zip_eq(all_accounts, backup_responses) {
             let resp = response.unwrap();
             prop_assert_eq!(&hash, &resp.account_key);
             prop_assert_eq!(&blob, &resp.account_state_blob);
         }
-
     }
 }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -630,7 +630,7 @@ pub type TestAccumulatorRangeProof = AccumulatorRangeProof<TestOnlyHasher>;
 ///
 /// if the proof wants show that `[a, b, c, d, e]` exists in the tree, it would need the siblings
 /// `X` and `h` on the right.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SparseMerkleRangeProof {
     /// The vector of siblings on the right of the path from root to last leaf. The ones near the
     /// bottom are at the beginning of the vector. In the above example, it's `[X, h]`.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This implements a few basic things. The backup tool will ask the server for the latest version, then using the version to initiate the backup_account_state request. Then it splits the stream into small chunks according to some chunk size and creates a file for each chunk. The restore tool will take the files as input, then construct an iterator of account chunks and proofs and use them to restore libradb.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

Run a few nodes locally:

```
cargo run -p libra-swarm -- -n 4
```

Find the port of the storage service of the first node in the log. Let's say 56004.

```
rm -rf /Users/wqfish/backup/*
cd storage/backup-restore && cargo run --bin backup -- --node-port 56004 --local-dir /Users/wqfish/backup
```

Output looks like this:

```
    Finished dev [unoptimized + debuginfo] target(s) in 0.56s
     Running `/Users/wqfish/github/libra/target/debug/backup --node-port 56004 --local-dir /Users/wqfish/backup`
Latest version: 2023
State root hash: 3676a2d667aa22c451f6c2ee0f32ae4af2d2ca372ab040f73459ef6e2aacfdf0
Backing up key: 08918f254d7d9d26ad8d80dfa9634d54e5d76d8cc8ba3df074afbdd4e90508ec
Backing up key: 1814e73b23a275b504e14a3819d90301e5e85c948332ecf3aa93c6ef85456a24
Backing up key: 4e6c7a62a1c9a19f6f22281155df54f8d0befaee862aacf899156b091c4abef7
Backing up key: 56b25e48235b31aca639c7ffefb579a5cfb71692af078f098bb90982f2aa6c2c
Backing up key: 7d8384bbc4c99f261d3618bed1b44ae17efd7caf6158074a7d1059351e85bd16
Backing up key: af72c7660400b757f666cfda1891f2b976dafcd990a9f22c9ebd9291b72c7ee0
Backing up key: c5a56dd1eade475e9198759944231a744e710bc2bcd7dc553b07a45e3ba0656e
Backing up key: d12938776ae5e41d87bea13d73d2819026ec0e545d9592f8ffbf7aebfa3d1be0
Backing up key: e36160bcaa86c55b976a28a8ee4d93ac66f8da99b68a4f515517ceea8646e018
Asking proof for last key: e36160bcaa86c55b976a28a8ee4d93ac66f8da99b68a4f515517ceea8646e018
/Users/wqfish/backup/9ce3bb61845539b041efc5fd4aa137e3
/Users/wqfish/backup/fbb35172db6996fda8752edfd15d4fe5
```

Then make the following `input` file and run the following command to restore:
```
2023
3676a2d667aa22c451f6c2ee0f32ae4af2d2ca372ab040f73459ef6e2aacfdf0
/Users/wqfish/backup/9ce3bb61845539b041efc5fd4aa137e3
/Users/wqfish/backup/fbb35172db6996fda8752edfd15d4fe5
```

```
rm -rf /Users/wqfish/db2/libradb
cat input | cargo run --bin restore -- --db-dir /Users/wqfish/db2
```

## Related PRs

None.