### PR TITLE
[cluster-test] Add full node support to perf testing

### DIFF
--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -63,7 +63,7 @@ impl DeploymentManager {
     }
 
     pub fn update_all_services(&self) -> Result<()> {
-        for instance in self.cluster.instances() {
+        for instance in &self.cluster.get_all_instances() {
             let mut request = UpdateServiceRequest::default();
             request.cluster = Some(self.aws.workspace().clone());
             request.force_new_deployment = Some(true);

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -72,8 +72,11 @@ impl MultiRegionSimulation {
         cross_region_delay: Duration,
         context: &mut Context,
     ) -> Result<Metrics> {
-        let (cluster1, cluster2) = context.cluster.split_n_random(count);
-        let (region1, region2) = (cluster1.into_instances(), cluster2.into_instances());
+        let (cluster1, cluster2) = context.cluster.split_n_validators_random(count);
+        let (region1, region2) = (
+            cluster1.into_validator_instances(),
+            cluster2.into_validator_instances(),
+        );
         let (smaller_region, larger_region);
         if region1.len() < region2.len() {
             smaller_region = &region1;
@@ -202,7 +205,7 @@ impl Experiment for MultiRegionSimulation {
                 for cross_region_latency in &self.params.cross_region_latencies {
                     let job = emitter
                         .start_job(EmitJobRequest {
-                            instances: context.cluster.instances().clone(),
+                            instances: context.cluster.validator_instances().clone(),
                             accounts_per_client: 10,
                             thread_params: EmitThreadParams::default(),
                         })

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -50,14 +50,14 @@ pub struct PacketLossRandomValidatorsParams {
 impl ExperimentParam for PacketLossRandomValidatorsParams {
     type E = PacketLossRandomValidators;
     fn build(self, cluster: &Cluster) -> Self::E {
-        let total_instances = cluster.instances().len();
+        let total_instances = cluster.validator_instances().len();
         let packet_loss_num_instances: usize = std::cmp::min(
             ((self.percent_instances / 100.0) * total_instances as f32).ceil() as usize,
             total_instances,
         );
-        let (test_cluster, _) = cluster.split_n_random(packet_loss_num_instances);
+        let (test_cluster, _) = cluster.split_n_validators_random(packet_loss_num_instances);
         Self::E {
-            instances: test_cluster.into_instances(),
+            instances: test_cluster.into_validator_instances(),
             percent: self.packet_loss_percent,
             duration: Duration::from_secs(self.duration_secs),
         }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -28,6 +28,11 @@ pub struct PerformanceBenchmarkNodesDownParams {
         help = "Number of nodes which should be down"
     )]
     pub num_nodes_down: usize,
+    #[structopt(
+        long,
+        help = "Whether cluster test should run against validators or full nodes"
+    )]
+    pub is_fullnode: bool,
 }
 
 pub struct PerformanceBenchmarkNodesDown {
@@ -39,10 +44,10 @@ pub struct PerformanceBenchmarkNodesDown {
 impl ExperimentParam for PerformanceBenchmarkNodesDownParams {
     type E = PerformanceBenchmarkNodesDown;
     fn build(self, cluster: &Cluster) -> Self::E {
-        let (down_instances, up_instances) = cluster.split_n_random(self.num_nodes_down);
+        let (down_instances, up_instances) = cluster.split_n_validators_random(self.num_nodes_down);
         Self::E {
-            down_instances: down_instances.into_instances(),
-            up_instances: up_instances.into_instances(),
+            down_instances: down_instances.into_validator_instances(),
+            up_instances: up_instances.into_validator_instances(),
             num_nodes_down: self.num_nodes_down,
         }
     }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -39,13 +39,13 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
         context: &'a mut Context,
     ) -> BoxFuture<'a, anyhow::Result<Option<String>>> {
         async move {
-            let (us, euro) = self.cluster.split_n_random(80);
-            let (us_west, us_east) = us.split_n_random(40);
+            let (us, euro) = self.cluster.split_n_validators_random(80);
+            let (us_west, us_east) = us.split_n_validators_random(40);
             let network_effects = three_region_simulation_effects(
                 (
-                    us_west.instances().clone(),
-                    us_east.instances().clone(),
-                    euro.instances().clone(),
+                    us_west.validator_instances().clone(),
+                    us_east.validator_instances().clone(),
+                    euro.validator_instances().clone(),
                 ),
                 (
                     Duration::from_millis(60), // us_east<->eu one way delay
@@ -59,7 +59,7 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
                 .tx_emitter
                 .emit_txn_for(
                     window + Duration::from_secs(60),
-                    self.cluster.instances().clone(),
+                    self.cluster.validator_instances().clone(),
                 )
                 .await?;
             let end = unix_timestamp_now();

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -34,15 +34,15 @@ pub struct RebootRandomValidators {
 impl ExperimentParam for RebootRandomValidatorsParams {
     type E = RebootRandomValidators;
     fn build(self, cluster: &Cluster) -> Self::E {
-        if self.count > cluster.instances().len() {
+        if self.count > cluster.validator_instances().len() {
             panic!(
                 "Can not reboot {} validators in cluster with {} instances",
                 self.count,
-                cluster.instances().len()
+                cluster.validator_instances().len()
             );
         }
         let mut instances = Vec::with_capacity(self.count);
-        let mut all_instances = cluster.instances().clone();
+        let mut all_instances = cluster.validator_instances().clone();
         let mut rnd = rand::thread_rng();
         for _i in 0..self.count {
             let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -37,7 +37,7 @@ pub struct RecoveryTime {
 impl ExperimentParam for RecoveryTimeParams {
     type E = RecoveryTime;
     fn build(self, cluster: &Cluster) -> Self::E {
-        let instance = cluster.random_instance().clone();
+        let instance = cluster.random_validator_instance().clone();
         Self::E {
             params: self,
             instance,
@@ -60,7 +60,7 @@ impl Experiment for RecoveryTime {
                 .tx_emitter
                 .mint_accounts(
                     &EmitJobRequest {
-                        instances: context.cluster.instances().to_vec(),
+                        instances: context.cluster.validator_instances().to_vec(),
                         accounts_per_client: 100,
                         thread_params: EmitThreadParams::default(),
                     },

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -30,7 +30,7 @@ impl DebugPortLogThread {
     pub fn spawn_new(cluster: &Cluster) -> LogTail {
         let (event_sender, event_receiver) = mpsc::channel();
         let mut started_receivers = vec![];
-        for instance in cluster.instances() {
+        for instance in cluster.validator_instances() {
             let (started_sender, started_receiver) = mpsc::channel();
             started_receivers.push(started_receiver);
             let client = NodeDebugClient::new(instance.ip(), 6191);

--- a/testsuite/cluster-test/src/health/liveness_check.rs
+++ b/testsuite/cluster-test/src/health/liveness_check.rs
@@ -24,7 +24,7 @@ struct LastCommitInfo {
 impl LivenessHealthCheck {
     pub fn new(cluster: &Cluster) -> Self {
         let mut last_committed = HashMap::new();
-        for instance in cluster.instances() {
+        for instance in cluster.validator_instances() {
             last_committed.insert(instance.peer_name().clone(), LastCommitInfo::default());
         }
         Self { last_committed }

--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -111,7 +111,7 @@ impl HealthCheckRunner {
         print_failures: PrintFailures,
     ) -> Result<Vec<String>> {
         let mut node_health = HashMap::new();
-        for instance in self.cluster.instances() {
+        for instance in self.cluster.validator_instances() {
             node_health.insert(instance.peer_name().clone(), true);
         }
         let mut messages = vec![];

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -30,17 +30,25 @@ impl ExperimentSuite {
                 .build(cluster),
             ));
         }
-        let count = min(3, cluster.instances().len() / 3);
+        let count = min(3, cluster.validator_instances().len() / 3);
         // Reboot different sets of 3 validators *100 times
         for _ in 0..10 {
             let b = Box::new(RebootRandomValidatorsParams { count }.build(cluster));
             experiments.push(b);
         }
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 }.build(cluster),
+            PerformanceBenchmarkNodesDownParams {
+                num_nodes_down: 0,
+                is_fullnode: false,
+            }
+            .build(cluster),
         ));
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 }.build(cluster),
+            PerformanceBenchmarkNodesDownParams {
+                num_nodes_down: 10,
+                is_fullnode: false,
+            }
+            .build(cluster),
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
@@ -51,10 +59,18 @@ impl ExperimentSuite {
     pub fn new_perf_suite(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 0 }.build(cluster),
+            PerformanceBenchmarkNodesDownParams {
+                num_nodes_down: 0,
+                is_fullnode: false,
+            }
+            .build(cluster),
         ));
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams { num_nodes_down: 10 }.build(cluster),
+            PerformanceBenchmarkNodesDownParams {
+                num_nodes_down: 10,
+                is_fullnode: false,
+            }
+            .build(cluster),
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),


### PR DESCRIPTION
## Motivation

We want to add full nodes to cluster testing. This PR adds full nodes into the instances list in cluster test, so that different experiments can run their experiment with either a validator set or a fullnode set.

This PR should only be separating out the validator and full node instances, and all the tests should still run with validator instances.

## Test Plan

Push docker image of cluster test and run cluster test

`docker tag cluster-test:latest 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:<your tag>`
`docker push 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:<your tag>`
`docker pull 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:<your tag>`

`ct -i 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:fullnode --run performance_benchmark_nodes_down -- --num-nodes-down=0 --is-fullnode=false`

Successful run 

Login Succeeded
Dec 19 22:15:54.506 INFO Discovered 100 peers in sunmilee workspace
Dec 19 22:15:54.815 INFO Log tail thread started in 309 ms
Dec 19 22:15:54.815 INFO Will use sunmilee tag for deployment
Dec 19 22:15:55.170 INFO Starting experiment all up
Dec 19 22:15:56.168 INFO Completed minting seed accounts
Dec 19 22:15:58.042 INFO Mint is done
Dec 19 22:20:00.382 INFO Experiment finished, waiting until all affected validators recover
Dec 19 22:20:05.391 INFO Experiment completed
Dec 19 22:20:05.392 INFO Experiment Result: all up : 587 TPS, 1187.4 ms latency

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
