### PR TITLE
[prover] use qualified struct names with optional type parameters in …

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ast::{BinOp, CopyableVal, Field, StructName};
+use crate::ast::{BinOp, CopyableVal, Field, QualifiedStructIdent, Type};
 use libra_types::account_address::AccountAddress;
 
 /// AST for the Move Prover specification language. Just postconditions for now
@@ -13,7 +13,8 @@ pub enum StorageLocation {
     Formal(String),
     /// A resource of type `type_` stored in global storage at `address`
     GlobalResource {
-        type_: StructName,
+        type_: QualifiedStructIdent,
+        type_actuals: Vec<Type>,
         address: Box<StorageLocation>,
     },
     /// An access path rooted at `base` with nonempty offsets in `fields`
@@ -31,7 +32,6 @@ pub enum StorageLocation {
     /// The return value of the current procedure
     Ret,
     // TODO: useful constants like U64_MAX
-    // TODO: add generics to GlobalResource
 }
 
 /// An expression in the specification language
@@ -43,7 +43,8 @@ pub enum SpecExp {
     StorageLocation(StorageLocation),
     /// Lifting the Move exists operator to a storage location
     GlobalExists {
-        type_: StructName,
+        type_: QualifiedStructIdent,
+        type_actuals: Vec<Type>,
         address: StorageLocation,
     },
     /// Dereference of a storage location (written *s)
@@ -54,7 +55,6 @@ pub enum SpecExp {
     Not(Box<SpecExp>),
     /// Binary operators also suported by Move
     Binop(Box<SpecExp>, BinOp, Box<SpecExp>),
-    // TODO: add generics to GlobalExists
     // TODO: binary operators not supported by Move like implies and iff
 }
 

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1264,12 +1264,17 @@ fn parse_storage_location<'input>(
         Tok::AccountAddressValue => StorageLocation::Address(parse_account_address(tokens)?),
         Tok::Global => {
             tokens.advance()?; // this consumes 'global<' due to parser funkiness
-            let type_ = parse_struct_name(tokens)?;
+            let type_ = parse_qualified_struct_ident(tokens)?;
+            let type_actuals = parse_type_actuals(tokens)?;
             consume_token(tokens, Tok::Greater)?;
             consume_token(tokens, Tok::LParen)?;
             let address = Box::new(parse_storage_location(tokens)?);
             consume_token(tokens, Tok::RParen)?;
-            StorageLocation::GlobalResource { type_, address }
+            StorageLocation::GlobalResource {
+                type_,
+                type_actuals,
+                address,
+            }
         }
         Tok::Old => {
             tokens.advance()?;
@@ -1309,12 +1314,17 @@ fn parse_unary_spec_exp<'input>(
         }
         Tok::GlobalExists => {
             tokens.advance()?; // this consumes 'global_exists<' due to parser funkiness
-            let type_ = parse_struct_name(tokens)?;
+            let type_ = parse_qualified_struct_ident(tokens)?;
+            let type_actuals = parse_type_actuals(tokens)?;
             consume_token(tokens, Tok::Greater)?;
             consume_token(tokens, Tok::LParen)?;
             let address = parse_storage_location(tokens)?;
             consume_token(tokens, Tok::RParen)?;
-            SpecExp::GlobalExists { type_, address }
+            SpecExp::GlobalExists {
+                type_,
+                type_actuals,
+                address,
+            }
         }
         Tok::Star => {
             tokens.advance()?;

--- a/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
+++ b/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
@@ -82,6 +82,9 @@ module TestConditions {
 //! no-run: runtime
 module TestSpecExp {
 
+  resource T { b: bool }
+  resource T1<Name> { b: Name }
+
   public ensures_ret()
   ensures return
   {
@@ -106,13 +109,26 @@ module TestSpecExp {
   }
 
   public ensures_global(a: address)
-  ensures global<T>(a)
+  ensures global<Self.T>(a)
+  {
+      return;
+  }
+
+
+  public ensures_generic_global(a: address)
+  ensures global<Self.T1<bool>>(a)
   {
       return;
   }
 
   public ensures_exists(a: address)
-  ensures global_exists<T>(a)
+  ensures global_exists<Self.T>(a)
+  {
+      return;
+  }
+
+  public ensures_exists_generic(a: address)
+  ensures global_exists<Self.T1<bool>>(a)
   {
       return;
   }
@@ -124,7 +140,7 @@ module TestSpecExp {
   }
 
   public ensures_old_global(a: address)
-  ensures old(global<T>(a))
+  ensures old(global<Self.T>(a))
   {
       return;
   }
@@ -166,13 +182,13 @@ module TestEnsuresAccessPath {
   }
 
   public ensures_exists_access_path(t: Self.T): Self.T
-  ensures global_exists<T>(t/a)
+  ensures global_exists<Self.T>(t/a)
   {
       return move(t);
   }
 
   public ensures_global_access_path(t: Self.T): Self.T
-  ensures global<T>(t/a)
+  ensures global<Self.T>(t/a)
   {
       return move(t);
   }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs.mvir
@@ -19,8 +19,8 @@ module TestSpecs {
     }
 
     public create_resource()
-      aborts_if global_exists<R>(0x1)
-      ensures global_exists<R>(0x1)
+      aborts_if global_exists<Self.R>(0x1)
+      ensures global_exists<Self.R>(0x1)
     {
       return;
     }


### PR DESCRIPTION
…global and global_exists

- The Move instructions `exists<T>` and `borrow_global<T>` require a `StructDefinitionIndex`, since they must always refer to a struct type declared in the current module.
- However the equivalent prover spec language constructs `global_exists<>` and `global<>` need to take fully qualified types. The reason:

```
module M1 { // published at 0x0
  resource T { ... }

  public exists_wrapper(a: addr): bool { return exists<T>(a) } 
}

import 0x0.M1;
module M2 {
  public call_M1_exists(a: addr): bool {
    return M1.exists_wrapper(a);
  }
}
```

We would like the postcondition for `call_M1_exists` to be something like `global_exists<M1.T>`. This PR makes it possible to write this postcondition.

## Motivation

Fixing TODO in the spec language AST.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

E2E tests that exercise new behavior.