### PR TITLE
[types] Create native wrapper for Sent and Received Payment events.

### DIFF
--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -147,10 +147,10 @@ fn few_peer_to_peer_with_event() {
             for event in txn_output.events() {
                 if let Ok(payload) = SentPaymentEvent::try_from(event) {
                     assert_eq!(transfer_amount, payload.amount());
-                    assert_eq!(sender.address(), &payload.sender());
+                    assert_eq!(receiver.address(), &payload.receiver());
                 } else if let Ok(payload) = ReceivedPaymentEvent::try_from(event) {
                     assert_eq!(transfer_amount, payload.amount());
-                    assert_eq!(receiver.address(), &payload.receiver());
+                    assert_eq!(sender.address(), &payload.sender());
                 } else {
                     panic!("Unexpected Event Type")
                 }

--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -147,12 +147,12 @@ fn few_peer_to_peer_with_event() {
             for event in txn_output.events() {
                 if let Ok(payload) = SentPaymentEvent::try_from(event) {
                     assert_eq!(transfer_amount, payload.amount());
-                    assert_eq!(sender.address(), payload.sender());
+                    assert_eq!(sender.address(), &payload.sender());
                 } else if let Ok(payload) = ReceivedPaymentEvent::try_from(event) {
                     assert_eq!(transfer_amount, payload.amount());
-                    assert_eq!(receiver.address(), payload.receiver());
+                    assert_eq!(receiver.address(), &payload.receiver());
                 } else {
-                    bail!("Unexpected Event Type")
+                    panic!("Unexpected Event Type")
                 }
             }
 

--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -9,11 +9,11 @@ use crate::{
 };
 use libra_config::config::VMPublishingOption;
 use libra_types::{
-    account_config::AccountEvent,
+    account_config::{ReceivedPaymentEvent, SentPaymentEvent},
     transaction::{SignedTransaction, TransactionOutput, TransactionPayload, TransactionStatus},
     vm_error::{StatusCode, VMStatus},
 };
-use std::time::Instant;
+use std::{convert::TryFrom, time::Instant};
 
 #[test]
 fn single_peer_to_peer_with_event() {
@@ -145,13 +145,15 @@ fn few_peer_to_peer_with_event() {
 
             // check events
             for event in txn_output.events() {
-                let account_event: AccountEvent =
-                    AccountEvent::try_from(event.event_data()).expect("event data must parse");
-                assert_eq!(transfer_amount, account_event.amount());
-                assert!(
-                    &account_event.account() == sender.address()
-                        || &account_event.account() == receiver.address()
-                );
+                if let Ok(payload) = SentPaymentEvent::try_from(event) {
+                    assert_eq!(transfer_amount, payload.amount());
+                    assert_eq!(sender.address(), payload.sender());
+                } else if let Ok(payload) = ReceivedPaymentEvent::try_from(event) {
+                    assert_eq!(transfer_amount, payload.amount());
+                    assert_eq!(receiver.address(), payload.receiver());
+                } else {
+                    bail!("Unexpected Event Type")
+                }
             }
 
             let original_sender = executor

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -240,16 +240,16 @@ lazy_static! {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct SentPaymentEvent {
     amount: u64,
-    sender: AccountAddress,
+    receiver: AccountAddress,
     metadata: Vec<u8>,
 }
 
 impl SentPaymentEvent {
     // TODO: should only be used for libra client testing and be removed eventually
-    pub fn new(amount: u64, sender: AccountAddress, metadata: Vec<u8>) -> Self {
+    pub fn new(amount: u64, receiver: AccountAddress, metadata: Vec<u8>) -> Self {
         Self {
             amount,
-            sender,
+            receiver,
             metadata,
         }
     }
@@ -259,8 +259,8 @@ impl SentPaymentEvent {
     }
 
     /// Get the sender of this transaction event.
-    pub fn sender(&self) -> AccountAddress {
-        self.sender
+    pub fn receiver(&self) -> AccountAddress {
+        self.receiver
     }
 
     /// Get the amount sent or received
@@ -278,16 +278,16 @@ impl SentPaymentEvent {
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ReceivedPaymentEvent {
     amount: u64,
-    receiver: AccountAddress,
+    sender: AccountAddress,
     metadata: Vec<u8>,
 }
 
 impl ReceivedPaymentEvent {
     // TODO: should only be used for libra client testing and be removed eventually
-    pub fn new(amount: u64, receiver: AccountAddress, metadata: Vec<u8>) -> Self {
+    pub fn new(amount: u64, sender: AccountAddress, metadata: Vec<u8>) -> Self {
         Self {
             amount,
-            receiver,
+            sender,
             metadata,
         }
     }
@@ -297,8 +297,8 @@ impl ReceivedPaymentEvent {
     }
 
     /// Get the receiver of this transaction event.
-    pub fn receiver(&self) -> AccountAddress {
-        self.receiver
+    pub fn sender(&self) -> AccountAddress {
+        self.sender
     }
 
     /// Get the amount sent or received

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -25,6 +25,10 @@ lazy_static! {
     // Account
     static ref ACCOUNT_MODULE_NAME: Identifier = Identifier::new("LibraAccount").unwrap();
     static ref ACCOUNT_STRUCT_NAME: Identifier = Identifier::new("T").unwrap();
+
+    // Payment Events
+    static ref SENT_EVENT_NAME: Identifier = Identifier::new("SentPaymentEvent").unwrap();
+    static ref RECEIVED_EVENT_NAME: Identifier = Identifier::new("ReceivedPaymentEvent").unwrap();
 }
 
 pub fn coin_module_name() -> &'static IdentStr {
@@ -41,6 +45,14 @@ pub fn account_module_name() -> &'static IdentStr {
 
 pub fn account_struct_name() -> &'static IdentStr {
     &*ACCOUNT_STRUCT_NAME
+}
+
+pub fn sent_event_name() -> &'static IdentStr {
+    &*SENT_EVENT_NAME
+}
+
+pub fn received_event_name() -> &'static IdentStr {
+    &*RECEIVED_EVENT_NAME
 }
 
 pub fn core_code_address() -> AccountAddress {
@@ -72,6 +84,24 @@ pub fn account_struct_tag() -> StructTag {
         address: core_code_address(),
         module: account_module_name().to_owned(),
         name: account_struct_name().to_owned(),
+        type_params: vec![],
+    }
+}
+
+pub fn sent_payment_tag() -> StructTag {
+    StructTag {
+        address: core_code_address(),
+        module: account_module_name().to_owned(),
+        name: sent_event_name().to_owned(),
+        type_params: vec![],
+    }
+}
+
+pub fn received_payment_tag() -> StructTag {
+    StructTag {
+        address: core_code_address(),
+        module: account_module_name().to_owned(),
+        name: received_event_name().to_owned(),
         type_params: vec![],
     }
 }
@@ -206,33 +236,69 @@ lazy_static! {
     };
 }
 
-/// Generic struct that represents an Account event.
-/// Both SentPaymentEvent and ReceivedPaymentEvent are representable with this struct.
-/// They have an AccountAddress for the sender or receiver, the amount transferred, and metadata.
+/// Struct that represents a SentPaymentEvent.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct AccountEvent {
+pub struct SentPaymentEvent {
     amount: u64,
-    account: AccountAddress,
+    sender: AccountAddress,
     metadata: Vec<u8>,
 }
 
-impl AccountEvent {
+impl SentPaymentEvent {
     // TODO: should only be used for libra client testing and be removed eventually
-    pub fn new(amount: u64, account: AccountAddress, metadata: Vec<u8>) -> Self {
+    pub fn new(amount: u64, sender: AccountAddress, metadata: Vec<u8>) -> Self {
         Self {
             amount,
-            account,
+            sender,
             metadata,
         }
     }
 
-    pub fn try_from(bytes: &[u8]) -> Result<AccountEvent> {
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         lcs::from_bytes(bytes).map_err(Into::into)
     }
 
-    /// Get the account related to the event
-    pub fn account(&self) -> AccountAddress {
-        self.account
+    /// Get the sender of this transaction event.
+    pub fn sender(&self) -> AccountAddress {
+        self.sender
+    }
+
+    /// Get the amount sent or received
+    pub fn amount(&self) -> u64 {
+        self.amount
+    }
+
+    /// Get the metadata associated with this event
+    pub fn metadata(&self) -> &Vec<u8> {
+        &self.metadata
+    }
+}
+
+/// Struct that represents a ReceivedPaymentEvent.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ReceivedPaymentEvent {
+    amount: u64,
+    receiver: AccountAddress,
+    metadata: Vec<u8>,
+}
+
+impl ReceivedPaymentEvent {
+    // TODO: should only be used for libra client testing and be removed eventually
+    pub fn new(amount: u64, receiver: AccountAddress, metadata: Vec<u8>) -> Self {
+        Self {
+            amount,
+            receiver,
+            metadata,
+        }
+    }
+
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        lcs::from_bytes(bytes).map_err(Into::into)
+    }
+
+    /// Get the receiver of this transaction event.
+    pub fn receiver(&self) -> AccountAddress {
+        self.receiver
     }
 
     /// Get the amount sent or received


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR aims to address #2064. In the previous implementation, we implemented a struct `AccountEvent` to represent either the SentPayment Event or the ReceivedPayment Event, as they have exactly the same struct layout. This is fragile, however, as it makes distinguishing two types of events. This PR will separate two events with its own Rust implementation.

## Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

cargo test

