### PR TITLE
Revert "ac: convert to tonic"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,13 +23,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-mempool-shared-proto 0.1.0",
  "libra-types 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
- "tonic-build 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -44,6 +45,7 @@ dependencies = [
  "channel 0.1.0",
  "executable-helpers 0.1.0",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpc-helpers 0.1.0",
  "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
@@ -634,7 +636,6 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.1.0-alpha.6 (git+https://github.com/hyperium/tonic.git)",
  "transaction-builder 0.1.0",
 ]
 
@@ -658,6 +659,7 @@ dependencies = [
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generate-keypair 0.1.0",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",

--- a/admission_control/admission-control-proto/Cargo.toml
+++ b/admission_control/admission-control-proto/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 bytes = "0.4.12"
-tonic = { git = "https://github.com/hyperium/tonic.git" }
-tokio = { version = "0.2", features = ["full"] }
+futures = "0.1.28"
+grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 prost = "0.5.0"
 
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
@@ -21,7 +21,8 @@ libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto", vers
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [build-dependencies]
-tonic-build = { git = "https://github.com/hyperium/tonic.git" }
+grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
+prost-build = "0.5.0"
 
 [features]
 default = []

--- a/admission_control/admission-control-proto/build.rs
+++ b/admission_control/admission-control-proto/build.rs
@@ -10,7 +10,10 @@ fn main() {
         "../../mempool/mempool-shared-proto/src/proto",
     ];
 
-    tonic_build::configure()
-        .compile(&protos, &includes)
-        .unwrap();
+    grpcio_compiler::prost_codegen::compile_protos(
+        &protos,
+        &includes,
+        &std::env::var("OUT_DIR").unwrap(),
+    )
+    .unwrap();
 }

--- a/admission_control/admission-control-proto/src/proto/mod.rs
+++ b/admission_control/admission-control-proto/src/proto/mod.rs
@@ -5,85 +5,11 @@
 
 use ::libra_types::proto::*;
 use libra_mempool_shared_proto::proto::mempool_status;
-use tokio::runtime::{Builder, Runtime};
 
 pub mod admission_control {
-    tonic::include_proto!("admission_control");
+    include!(concat!(env!("OUT_DIR"), "/admission_control.rs"));
 }
 
 pub use self::admission_control::{
-    admission_control_client::AdmissionControlClient, AdmissionControlMsg,
-    SubmitTransactionRequest, SubmitTransactionResponse,
+    AdmissionControlMsg, SubmitTransactionRequest, SubmitTransactionResponse,
 };
-
-pub struct AdmissionControlClientBlocking {
-    // Currently the runtime but be ordered before the tonic client to ensure that the runtime is
-    // dropped last when this struct is dropped.
-    // See https://github.com/tokio-rs/tokio/issues/1948 for more info.
-    rt: Runtime,
-    addr: String,
-    client: Option<AdmissionControlClient<tonic::transport::Channel>>,
-}
-
-impl AdmissionControlClientBlocking {
-    pub fn new<A: AsRef<str>>(address: A, port: u16) -> Self {
-        let rt = Builder::new()
-            .basic_scheduler()
-            .enable_all()
-            .build()
-            .unwrap();
-        let addr = format!("http://{}:{}", address.as_ref(), port);
-
-        Self {
-            client: None,
-            addr,
-            rt,
-        }
-    }
-
-    fn client(
-        &mut self,
-    ) -> Result<
-        (
-            &mut Runtime,
-            &mut AdmissionControlClient<tonic::transport::Channel>,
-        ),
-        tonic::Status,
-    > {
-        if self.client.is_none() {
-            self.client = Some(
-                self.rt
-                    .block_on(AdmissionControlClient::connect(self.addr.clone()))
-                    .map_err(|e| tonic::Status::new(tonic::Code::Unavailable, e.to_string()))?,
-            );
-        }
-
-        // client is guaranteed to be populated by the time we reach here
-        Ok((&mut self.rt, self.client.as_mut().unwrap()))
-    }
-
-    pub fn submit_transaction(
-        &mut self,
-        request: SubmitTransactionRequest,
-    ) -> Result<SubmitTransactionResponse, tonic::Status> {
-        let (rt, client) = self.client()?;
-        rt.block_on(client.submit_transaction(request))
-            .map(tonic::Response::into_inner)
-    }
-
-    pub fn update_to_latest_ledger(
-        &mut self,
-        request: types::UpdateToLatestLedgerRequest,
-    ) -> Result<types::UpdateToLatestLedgerResponse, tonic::Status> {
-        let (rt, client) = self.client()?;
-        rt.block_on(async {
-            tokio::time::timeout(
-                std::time::Duration::from_millis(5000),
-                client.update_to_latest_ledger(request),
-            )
-            .await
-        })
-        .map_err(|_| tonic::Status::new(tonic::Code::DeadlineExceeded, ""))?
-        .map(tonic::Response::into_inner)
-    }
-}

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -26,6 +26,7 @@ admission-control-proto = { path = "../admission-control-proto", version = "0.1.
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 executable-helpers = { path = "../../common/executable-helpers", version = "0.1.0" }
+grpc-helpers = { path = "../../common/grpc-helpers", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-mempool = { path = "../../mempool", version = "0.1.0" }
 libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto", version = "0.1.0" }

--- a/admission_control/admission-control-service/src/runtime.rs
+++ b/admission_control/admission-control-service/src/runtime.rs
@@ -6,13 +6,14 @@ use crate::{
     counters,
     upstream_proxy::{process_network_messages, UpstreamProxyData},
 };
-use admission_control_proto::proto::admission_control::admission_control_server::AdmissionControlServer;
+use admission_control_proto::proto::admission_control::create_admission_control;
 use futures::channel::mpsc;
-use grpcio::EnvBuilder;
+use grpc_helpers::ServerHandle;
+use grpcio::{EnvBuilder, ServerBuilder};
 use libra_config::config::{NodeConfig, RoleType};
 use libra_mempool::proto::mempool_client::MempoolClientWrapper;
 use network::validator_network::{AdmissionControlNetworkEvents, AdmissionControlNetworkSender};
-use std::{collections::HashMap, net::ToSocketAddrs, sync::Arc};
+use std::{cmp::min, collections::HashMap, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient};
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::vm_validator::VMValidator;
@@ -20,7 +21,7 @@ use vm_validator::vm_validator::VMValidator;
 /// Handle for AdmissionControl Runtime
 pub struct AdmissionControlRuntime {
     /// gRPC server to serve request between client and AC
-    _ac_service_rt: Runtime,
+    _grpc_server: ServerHandle,
     /// separate AC runtime
     _upstream_proxy: Runtime,
 }
@@ -34,6 +35,12 @@ impl AdmissionControlRuntime {
     ) -> Self {
         let (ac_sender, ac_receiver) = mpsc::channel(1_024);
 
+        let env = Arc::new(
+            EnvBuilder::new()
+                .name_prefix("grpc-ac-")
+                .cq_count(min(num_cpus::get() * 2, 32))
+                .build(),
+        );
         let port = config.admission_control.admission_control_service_port;
 
         // Create mempool client if the node is validator.
@@ -58,22 +65,12 @@ impl AdmissionControlRuntime {
 
         let vm_validator = Arc::new(VMValidator::new(&config, Arc::clone(&storage_client)));
 
-        let ac_service_rt = Builder::new()
-            .thread_name("ac-service-")
-            .threaded_scheduler()
-            .enable_all()
+        let service = create_admission_control(admission_control_service);
+        let server = ServerBuilder::new(Arc::clone(&env))
+            .register_service(service)
+            .bind(config.admission_control.address.clone(), port)
             .build()
-            .expect("[admission control] failed to create runtime");
-        let addr = format!("{}:{}", config.admission_control.address, port)
-            .to_socket_addrs()
-            .unwrap()
-            .next()
-            .unwrap();
-        ac_service_rt.spawn(
-            tonic::transport::Server::builder()
-                .add_service(AdmissionControlServer::new(admission_control_service))
-                .serve(addr),
-        );
+            .expect("Unable to create grpc server");
 
         let upstream_proxy_runtime = Builder::new()
             .thread_name("ac-upstream-proxy-")
@@ -111,7 +108,7 @@ impl AdmissionControlRuntime {
         ));
 
         Self {
-            _ac_service_rt: ac_service_rt,
+            _grpc_server: ServerHandle::setup(server),
             _upstream_proxy: upstream_proxy_runtime,
         }
     }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0"
 chrono = "0.4.7"
 futures = "0.1.28"
 grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
-tonic = { git = "https://github.com/hyperium/tonic.git" }
 hex = "0.3.2"
 itertools = "0.8.0"
 proptest = { version = "0.9.2", optional = true }

--- a/client/src/commands.rs
+++ b/client/src/commands.rs
@@ -17,14 +17,15 @@ pub fn report_error(msg: &str, e: Error) {
 }
 
 fn pretty_format_error(e: Error) -> String {
-    if let Some(grpc_error) = e.downcast_ref::<tonic::Status>() {
-        match grpc_error.code() {
-            tonic::Code::DeadlineExceeded | tonic::Code::Unavailable => {
+    if let Some(grpc_error) = e.downcast_ref::<grpcio::Error>() {
+        if let grpcio::Error::RpcFailure(grpc_rpc_failure) = grpc_error {
+            if grpc_rpc_failure.status == grpcio::RpcStatusCode::UNAVAILABLE
+                || grpc_rpc_failure.status == grpcio::RpcStatusCode::DEADLINE_EXCEEDED
+            {
                 return "Server unavailable, please retry and/or check \
                         if host passed to the client is running"
                     .to_string();
             }
-            _ => {}
         }
     }
 

--- a/client/src/grpc_client.rs
+++ b/client/src/grpc_client.rs
@@ -3,10 +3,15 @@
 
 use crate::AccountData;
 use admission_control_proto::{
-    proto::admission_control::SubmitTransactionRequest, proto::AdmissionControlClientBlocking,
+    proto::admission_control::{
+        AdmissionControlClient, SubmitTransactionRequest,
+        SubmitTransactionResponse as ProtoSubmitTransactionResponse,
+    },
     AdmissionControlStatus, SubmitTransactionResponse,
 };
 use anyhow::{bail, Result};
+use futures::Future;
+use grpcio::{CallOption, ChannelBuilder, EnvBuilder};
 use libra_logger::prelude::*;
 use libra_types::crypto_proxies::EpochInfo;
 use libra_types::{
@@ -29,14 +34,19 @@ const MAX_GRPC_RETRY_COUNT: u64 = 1;
 /// Struct holding dependencies of client, known_version_and_epoch is updated when learning about
 /// new LedgerInfo
 pub struct GRPCClient {
-    client: AdmissionControlClientBlocking,
+    client: AdmissionControlClient,
     known_version_and_epoch: Arc<Mutex<(Version, EpochInfo)>>,
 }
 
 impl GRPCClient {
     /// Construct a new Client instance.
     pub fn new(host: &str, port: u16, initial_epoch_info: EpochInfo) -> Result<Self> {
-        let client = AdmissionControlClientBlocking::new(host, port);
+        let conn_addr = format!("{}:{}", host, port);
+
+        // Create a GRPC client
+        let env = Arc::new(EnvBuilder::new().name_prefix("grpc-client-").build());
+        let ch = ChannelBuilder::new(env).connect(&conn_addr);
+        let client = AdmissionControlClient::new(ch);
 
         Ok(GRPCClient {
             client,
@@ -47,21 +57,15 @@ impl GRPCClient {
     /// Submits a transaction and bumps the sequence number for the sender, pass in `None` for
     /// sender_account if sender's address is not managed by the client.
     pub fn submit_transaction(
-        &mut self,
+        &self,
         sender_account_opt: Option<&mut AccountData>,
         req: &SubmitTransactionRequest,
     ) -> Result<()> {
-        let mut resp = self
-            .client
-            .submit_transaction(req.clone())
-            .map_err(Into::into);
+        let mut resp = self.submit_transaction_opt(req);
 
         let mut try_cnt = 0_u64;
         while Self::need_to_retry(&mut try_cnt, &resp) {
-            resp = self
-                .client
-                .submit_transaction(req.clone())
-                .map_err(Into::into);
+            resp = self.submit_transaction_opt(&req);
         }
 
         let completed_resp = SubmitTransactionResponse::try_from(resp?)?;
@@ -101,10 +105,34 @@ impl GRPCClient {
         Ok(())
     }
 
-    fn get_with_proof(
-        &mut self,
+    /// Async version of submit_transaction
+    pub fn submit_transaction_async(
+        &self,
+        req: &SubmitTransactionRequest,
+    ) -> Result<(impl Future<Item = SubmitTransactionResponse, Error = anyhow::Error>)> {
+        let resp = self
+            .client
+            .submit_transaction_async_opt(&req, Self::get_default_grpc_call_option())?
+            .then(|proto_resp| {
+                let ret = SubmitTransactionResponse::try_from(proto_resp?)?;
+                Ok(ret)
+            });
+        Ok(resp)
+    }
+
+    fn submit_transaction_opt(
+        &self,
+        resp: &SubmitTransactionRequest,
+    ) -> Result<ProtoSubmitTransactionResponse> {
+        Ok(self
+            .client
+            .submit_transaction_opt(resp, Self::get_default_grpc_call_option())?)
+    }
+
+    fn get_with_proof_async(
+        &self,
         requested_items: Vec<RequestItem>,
-    ) -> Result<UpdateToLatestLedgerResponse> {
+    ) -> Result<impl Future<Item = UpdateToLatestLedgerResponse, Error = anyhow::Error>> {
         let known_version_and_epoch = Arc::clone(&self.known_version_and_epoch);
         let req = UpdateToLatestLedgerRequest::new(
             known_version_and_epoch.lock().unwrap().0,
@@ -112,56 +140,61 @@ impl GRPCClient {
         );
         debug!("get_with_proof with request: {:?}", req);
         let proto_req = req.clone().into();
-        let resp = self.client.update_to_latest_ledger(proto_req)?;
-        let resp = UpdateToLatestLedgerResponse::try_from(resp)?;
-        let mut wlock = known_version_and_epoch.lock().unwrap();
-        if let Some(new_epoch_info) = resp.verify(&wlock.1, &req)? {
-            info!("Trusted epoch change to :{}", new_epoch_info);
-            wlock.1 = new_epoch_info;
-        }
-        wlock.0 = resp.ledger_info_with_sigs.ledger_info().version();
-        Ok(resp)
+        let ret = self
+            .client
+            .update_to_latest_ledger_async_opt(&proto_req, Self::get_default_grpc_call_option())?
+            .then(move |get_with_proof_resp| {
+                let resp = UpdateToLatestLedgerResponse::try_from(get_with_proof_resp?)?;
+                let mut wlock = known_version_and_epoch.lock().unwrap();
+                if let Some(new_epoch_info) = resp.verify(&wlock.1, &req)? {
+                    info!("Trusted epoch change to :{}", new_epoch_info);
+                    wlock.1 = new_epoch_info;
+                }
+                wlock.0 = resp.ledger_info_with_sigs.ledger_info().version();
+                Ok(resp)
+            });
+        Ok(ret)
     }
 
     fn need_to_retry<T>(try_cnt: &mut u64, ret: &Result<T>) -> bool {
         if *try_cnt <= MAX_GRPC_RETRY_COUNT {
             *try_cnt += 1;
             if let Err(error) = ret {
-                if let Some(grpc_error) = error.downcast_ref::<tonic::Status>() {
-                    // Only retry when the connection is down to make sure we won't
-                    // send one txn twice.
-                    return grpc_error.code() == tonic::Code::Unavailable
-                        || grpc_error.code() == tonic::Code::Unknown;
+                if let Some(grpc_error) = error.downcast_ref::<grpcio::Error>() {
+                    if let grpcio::Error::RpcFailure(grpc_rpc_failure) = grpc_error {
+                        // Only retry when the connection is down to make sure we won't
+                        // send one txn twice.
+                        return grpc_rpc_failure.status == grpcio::RpcStatusCode::UNAVAILABLE;
+                    }
                 }
             }
         }
         false
     }
-
     /// Sync version of get_with_proof
     pub(crate) fn get_with_proof_sync(
-        &mut self,
+        &self,
         requested_items: Vec<RequestItem>,
     ) -> Result<UpdateToLatestLedgerResponse> {
         let mut resp: Result<UpdateToLatestLedgerResponse> =
-            self.get_with_proof(requested_items.clone());
+            self.get_with_proof_async(requested_items.clone())?.wait();
         let mut try_cnt = 0_u64;
 
         while Self::need_to_retry(&mut try_cnt, &resp) {
-            resp = self.get_with_proof(requested_items.clone());
+            resp = self.get_with_proof_async(requested_items.clone())?.wait();
         }
 
         Ok(resp?)
     }
 
     /// Get the latest account sequence number for the account specified.
-    pub fn get_sequence_number(&mut self, address: AccountAddress) -> Result<u64> {
+    pub fn get_sequence_number(&self, address: AccountAddress) -> Result<u64> {
         Ok(get_account_resource_or_default(&self.get_account_blob(address)?.0)?.sequence_number())
     }
 
     /// Get the latest account state blob from validator.
     pub(crate) fn get_account_blob(
-        &mut self,
+        &self,
         address: AccountAddress,
     ) -> Result<(Option<AccountStateBlob>, Version)> {
         let req_item = RequestItem::GetAccountState { address };
@@ -180,7 +213,7 @@ impl GRPCClient {
 
     /// Get transaction from validator by account and sequence number.
     pub fn get_txn_by_acc_seq(
-        &mut self,
+        &self,
         account: AccountAddress,
         sequence_number: u64,
         fetch_events: bool,
@@ -202,7 +235,7 @@ impl GRPCClient {
 
     /// Get transactions in range (start_version..start_version + limit - 1) from validator.
     pub fn get_txn_by_range(
-        &mut self,
+        &self,
         start_version: u64,
         limit: u64,
         fetch_events: bool,
@@ -233,7 +266,7 @@ impl GRPCClient {
     /// 1. No event is available. 2. Ascending and available event number < limit.
     /// 3. Descending and start_seq_num > latest account event sequence number.
     pub fn get_events_by_access_path(
-        &mut self,
+        &self,
         access_path: AccessPath,
         start_event_seq_num: u64,
         ascending: bool,
@@ -258,5 +291,11 @@ impl GRPCClient {
                 value_with_proof
             ),
         }
+    }
+
+    fn get_default_grpc_call_option() -> CallOption {
+        CallOption::default()
+            .wait_for_ready(true)
+            .timeout(std::time::Duration::from_millis(5000))
     }
 }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
+grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 itertools = "0.8.0"
 rand = "0.6.5"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -4,9 +4,10 @@
 #![forbid(unsafe_code)]
 
 use crate::{cluster::Cluster, instance::Instance};
-use admission_control_proto::proto::{
-    admission_control::SubmitTransactionRequest, AdmissionControlClientBlocking,
+use admission_control_proto::proto::admission_control::{
+    AdmissionControlClient, SubmitTransactionRequest,
 };
+use grpcio::{ChannelBuilder, EnvBuilder};
 use std::{
     convert::TryFrom,
     slice,
@@ -44,7 +45,7 @@ use slog_scope::{debug, info};
 
 use std::cmp::{max, min};
 use std::fmt;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use util::retry;
@@ -144,7 +145,7 @@ impl TxEmitter {
             return Ok(()); // Early return to skip printing 'Minting ...' logs
         }
         let mut faucet_account = load_faucet_account(
-            &mut Self::pick_mint_client(&req.instances),
+            &Self::pick_mint_client(&req.instances),
             self.mint_key_pair.clone(),
         )?;
         let faucet_address = faucet_account.address;
@@ -154,7 +155,7 @@ impl TxEmitter {
             LIBRA_PER_NEW_ACCOUNT * num_accounts as u64,
         );
         execute_and_wait_transactions(
-            &mut Self::pick_mint_client(&req.instances),
+            &Self::pick_mint_client(&req.instances),
             &mut faucet_account,
             vec![mint_txn],
         )?;
@@ -217,8 +218,11 @@ impl TxEmitter {
         }
     }
 
-    fn make_client(instance: &Instance) -> AdmissionControlClientBlocking {
-        AdmissionControlClientBlocking::new(instance.ip(), instance.ac_port() as u16)
+    fn make_client(instance: &Instance) -> AdmissionControlClient {
+        let address = format!("{}:{}", instance.ip(), instance.ac_port());
+        let env_builder = Arc::new(EnvBuilder::new().name_prefix("ac-grpc-").build());
+        let ch = ChannelBuilder::new(env_builder).connect(&address);
+        AdmissionControlClient::new(ch)
     }
 
     pub fn emit_txn_for(&mut self, duration: Duration, instances: Vec<Instance>) -> Result<()> {
@@ -240,7 +244,7 @@ struct Worker {
 struct SubmissionThread {
     accounts: Vec<AccountData>,
     instance: Instance,
-    client: AdmissionControlClientBlocking,
+    client: AdmissionControlClient,
     all_addresses: Arc<Vec<AccountAddress>>,
     stop: Arc<AtomicBool>,
     params: EmitThreadParams,
@@ -255,7 +259,7 @@ impl SubmissionThread {
             let requests = self.gen_requests(&mut rng);
             for request in requests {
                 let wait_util = Instant::now() + wait;
-                let resp = self.client.submit_transaction(request);
+                let resp = self.client.submit_transaction(&request);
                 match resp {
                     Err(e) => {
                         info!("[{}] Failed to submit request: {:?}", self.instance, e);
@@ -276,7 +280,7 @@ impl SubmissionThread {
                 }
             }
             if self.params.wait_committed {
-                if wait_for_accounts_sequence(&mut self.client, &mut self.accounts).is_err() {
+                if wait_for_accounts_sequence(&self.client, &mut self.accounts).is_err() {
                     info!(
                         "[{}] Some transactions were not committed before expiration",
                         self.instance
@@ -304,7 +308,7 @@ impl SubmissionThread {
 }
 
 fn wait_for_accounts_sequence(
-    client: &mut AdmissionControlClientBlocking,
+    client: &AdmissionControlClient,
     accounts: &mut [AccountData],
 ) -> Result<(), ()> {
     let deadline = Instant::now() + TXN_MAX_WAIT;
@@ -339,7 +343,7 @@ fn is_sequence_equal(accounts: &[AccountData], sequence_numbers: &[u64]) -> bool
 }
 
 fn query_sequence_numbers(
-    client: &mut AdmissionControlClientBlocking,
+    client: &AdmissionControlClient,
     addresses: &[AccountAddress],
 ) -> Result<Vec<u64>> {
     let mut result = vec![];
@@ -355,7 +359,7 @@ fn query_sequence_numbers(
             update_request.requested_items.push(request_item);
         }
         let resp = client
-            .update_to_latest_ledger(update_request)
+            .update_to_latest_ledger(&update_request)
             .map_err(|e| format_err!("update_to_latest_ledger failed: {:?} ", e))?;
 
         for item in resp.response_items.into_iter() {
@@ -458,7 +462,7 @@ fn gen_transfer_txn_requests(
 }
 
 fn execute_and_wait_transactions(
-    client: &mut NamedAdmissionControlClient,
+    client: &NamedAdmissionControlClient,
     account: &mut AccountData,
     txn: Vec<SubmitTransactionRequest>,
 ) -> Result<()> {
@@ -471,8 +475,7 @@ fn execute_and_wait_transactions(
     );
     for request in txn {
         retry::retry(retry::fixed_retry_strategy(5_000, 20), || {
-            let request = request.clone();
-            let resp = client.submit_transaction(request);
+            let resp = client.submit_transaction(&request);
             match resp {
                 Err(e) => {
                     bail!("[{}] Failed to submit request: {:?}", client, e);
@@ -499,7 +502,7 @@ fn execute_and_wait_transactions(
 }
 
 fn load_faucet_account(
-    client: &mut NamedAdmissionControlClient,
+    client: &NamedAdmissionControlClient,
     key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
 ) -> Result<AccountData> {
     let address = association_address();
@@ -524,7 +527,7 @@ fn create_new_accounts(
     num_new_accounts: usize,
     libra_per_new_account: u64,
     max_num_accounts_per_batch: u64,
-    mut client: NamedAdmissionControlClient,
+    client: NamedAdmissionControlClient,
 ) -> Result<Vec<AccountData>> {
     let mut i = 0;
     let mut accounts = vec![];
@@ -534,7 +537,7 @@ fn create_new_accounts(
             min(MAX_TXN_BATCH_SIZE, num_new_accounts - i),
         ));
         let requests = gen_transfer_txn_requests(source_account, &batch, libra_per_new_account);
-        execute_and_wait_transactions(&mut client, source_account, requests)?;
+        execute_and_wait_transactions(&client, source_account, requests)?;
         i += batch.len();
         accounts.append(&mut batch);
     }
@@ -555,7 +558,7 @@ fn is_accepted(resp: &SubmitTransactionResponse) -> bool {
     false
 }
 
-struct NamedAdmissionControlClient(Instance, AdmissionControlClientBlocking);
+struct NamedAdmissionControlClient(Instance, AdmissionControlClient);
 
 impl fmt::Display for NamedAdmissionControlClient {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -564,15 +567,9 @@ impl fmt::Display for NamedAdmissionControlClient {
 }
 
 impl Deref for NamedAdmissionControlClient {
-    type Target = AdmissionControlClientBlocking;
+    type Target = AdmissionControlClient;
 
     fn deref(&self) -> &Self::Target {
         &self.1
-    }
-}
-
-impl DerefMut for NamedAdmissionControlClient {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.1
     }
 }


### PR DESCRIPTION
# Summary

This broke cluster-test

This reverts commit 1b7ae1ecefa45a195f2849c82a6391d580234a1d.

```
Dec 19 05:06:30.545 INFO Starting experiment all up
thread 'tokio-runtime-worker' panicked at 'default Tokio reactor already set for execution context', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/io/driver/mod.rs:92:9
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:76
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:60
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1030
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1412
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:64
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:196
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:210
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:473
  11: std::panicking::begin_panic
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panicking.rs:407
  12: tokio::io::driver::set_default::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/io/driver/mod.rs:92
  13: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
  14: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
  15: tokio::io::driver::set_default
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/io/driver/mod.rs:89
  16: tokio::runtime::io::variant::set_default::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/io.rs:43
  17: core::option::Option<T>::map
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libcore/option.rs:447
  18: tokio::runtime::io::variant::set_default
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/io.rs:43
  19: tokio::runtime::handle::Handle::enter::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/handle.rs:34
  20: tokio::runtime::blocking::pool::Spawner::enter::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:191
  21: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
  22: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
  23: tokio::runtime::blocking::pool::Spawner::enter
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:176
  24: tokio::runtime::handle::Handle::enter
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/handle.rs:33
  25: tokio::runtime::Runtime::block_on
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/mod.rs:406
  26: admission_control_proto::proto::AdmissionControlClientBlocking::client
             at admission_control/admission-control-proto/src/proto/mod.rs:55
  27: admission_control_proto::proto::AdmissionControlClientBlocking::update_to_latest_ledger
             at admission_control/admission-control-proto/src/proto/mod.rs:78
  28: cluster_test::tx_emitter::query_sequence_numbers
             at testsuite/cluster-test/src/tx_emitter.rs:357
  29: cluster_test::tx_emitter::load_faucet_account
             at testsuite/cluster-test/src/tx_emitter.rs:506
  30: cluster_test::tx_emitter::TxEmitter::mint_accounts
             at testsuite/cluster-test/src/tx_emitter.rs:146
  31: cluster_test::tx_emitter::TxEmitter::start_job
             at testsuite/cluster-test/src/tx_emitter.rs:109
  32: cluster_test::tx_emitter::TxEmitter::emit_txn_for
             at testsuite/cluster-test/src/tx_emitter.rs:225
  33: <cluster_test::experiments::performance_benchmark_nodes_down::PerformanceBenchmarkNodesDown as cluster_test::experiments::Experiment>::run::{{closure}}
             at testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs:70
  34: <std::future::GenFuture<T> as core::future::future::Future>::poll::{{closure}}
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:43
  35: std::future::set_task_context
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:79
  36: <std::future::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:43
  37: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libcore/future/future.rs:119
  38: std::future::poll_with_tls_context::{{closure}}
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:121
  39: std::future::get_task_context
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:111
  40: std::future::poll_with_tls_context
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:121
  41: cluster_test::ClusterTestRunner::run_single_experiment::{{closure}}
             at testsuite/cluster-test/src/main.rs:570
  42: <std::future::GenFuture<T> as core::future::future::Future>::poll::{{closure}}
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:43
  43: std::future::set_task_context
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:79
  44: <std::future::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/future.rs:43
  45: tokio::task::core::Core<T>::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/core.rs:128
  46: tokio::task::harness::Harness<T,S>::poll::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/harness.rs:120
  47: core::ops::function::FnOnce::call_once
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libcore/ops/function.rs:227
  48: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panic.rs:315
  49: std::panicking::try::do_call
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panicking.rs:292
  50: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  51: std::panicking::try
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panicking.rs:271
  52: std::panic::catch_unwind
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panic.rs:394
  53: tokio::task::harness::Harness<T,S>::poll::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/harness.rs:101
  54: tokio::loom::std::causal_cell::CausalCell<T>::with_mut
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/loom/std/causal_cell.rs:41
  55: tokio::task::harness::Harness<T,S>::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/harness.rs:100
  56: tokio::task::raw::RawTask::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/raw.rs:113
  57: tokio::task::Task<S>::run
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/mod.rs:370
  58: tokio::runtime::thread_pool::worker::GenerationGuard::run_task
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:466
  59: tokio::runtime::thread_pool::worker::GenerationGuard::process_available_work
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:324
  60: tokio::runtime::thread_pool::worker::GenerationGuard::run
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:289
  61: tokio::runtime::thread_pool::worker::Worker::run::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:175
  62: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
  63: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
  64: tokio::runtime::thread_pool::worker::Worker::run::{{closure}}::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:151
  65: tokio::runtime::blocking::pool::Spawner::enter::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:191
  66: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
  67: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
  68: tokio::runtime::blocking::pool::Spawner::enter
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:176
  69: tokio::runtime::thread_pool::worker::Worker::run::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:150
  70: tokio::runtime::global::with_state::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/global.rs:107
  71: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
  72: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
  73: tokio::runtime::global::with_state
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/global.rs:90
  74: tokio::runtime::global::with_thread_pool
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/global.rs:82
  75: tokio::runtime::thread_pool::worker::Worker::run::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:149
  76: tokio::runtime::thread_pool::current::set::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/current.rs:47
  77: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
  78: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
  79: tokio::runtime::thread_pool::current::set
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/current.rs:29
  80: tokio::runtime::thread_pool::worker::Worker::run
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/worker.rs:145
  81: tokio::runtime::thread_pool::Workers::spawn::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/mod.rs:124
  82: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/task.rs:30
  83: tokio::task::core::Core<T>::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/core.rs:128
  84: tokio::task::harness::Harness<T,S>::poll::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/harness.rs:120
  85: core::ops::function::FnOnce::call_once
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libcore/ops/function.rs:227
  86: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panic.rs:315
  87: std::panicking::try::do_call
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panicking.rs:292
  88: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  89: std::panicking::try
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panicking.rs:271
  90: std::panic::catch_unwind
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/panic.rs:394
  91: tokio::task::harness::Harness<T,S>::poll::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/harness.rs:101
  92: tokio::loom::std::causal_cell::CausalCell<T>::with_mut
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/loom/std/causal_cell.rs:41
  93: tokio::task::harness::Harness<T,S>::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/harness.rs:100
  94: tokio::task::raw::RawTask::poll
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/raw.rs:113
  95: tokio::task::Task<S>::run
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/task/mod.rs:370
  96: tokio::runtime::blocking::pool::run_task
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:352
  97: tokio::runtime::blocking::pool::Inner::run2
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:278
  98: tokio::runtime::blocking::pool::Inner::run::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:263
  99: tokio::runtime::global::with_state::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/global.rs:107
 100: std::thread::local::LocalKey<T>::try_with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:262
 101: std::thread::local::LocalKey<T>::with
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/thread/local.rs:239
 102: tokio::runtime::global::with_state
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/global.rs:90
 103: tokio::runtime::global::with_thread_pool
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/global.rs:82
 104: tokio::runtime::thread_pool::spawner::Spawner::enter
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/thread_pool/spawner.rs:44
 105: tokio::runtime::spawner::Spawner::enter
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/spawner.rs:32
 106: tokio::runtime::blocking::pool::Inner::run::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:263
 107: tokio::time::clock::Clock::enter
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/time/clock.rs:30
 108: tokio::runtime::time::variant::with_default
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/time.rs:43
 109: tokio::runtime::blocking::pool::Inner::run
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:262
 110: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.1/src/runtime/blocking/pool.rs:246
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread 'main' panicked at 'Failed to poll join handle: JoinError::Panic(...)', src/libcore/result.rs:1165:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:76
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:60
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1030
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1412
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:64
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:196
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:210
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:473
  11: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:380
  12: rust_begin_unwind
             at src/libstd/panicking.rs:307
  13: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  14: core::result::unwrap_failed
             at src/libcore/result.rs:1165
  15: core::result::Result<T,E>::expect
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libcore/result.rs:960
  16: cluster_test::ClusterTestRunner::run_single_experiment
             at testsuite/cluster-test/src/main.rs:594
  17: cluster_test::ClusterTestRunner::cleanup_and_run
             at testsuite/cluster-test/src/main.rs:535
  18: cluster_test::main
             at testsuite/cluster-test/src/main.rs:188
  19: std::rt::lang_start::{{closure}}
             at /rustc/4560ea788cb760f0a34127156c78e2552949f734/src/libstd/rt.rs:64
  20: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:49
  21: std::panicking::try::do_call
             at src/libstd/panicking.rs:292
  22: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  23: std::panicking::try
             at src/libstd/panicking.rs:271
  24: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  25: std::rt::lang_start_internal
             at src/libstd/rt.rs:48
  26: main
  27: __libc_start_main
  28: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
