### PR TITLE
cluster-test: temporary fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "admission-control-proto-grpcio"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-logger 0.1.0",
+ "libra-mempool-shared-proto 0.1.0",
+ "libra-types 0.1.0",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "admission-control-service"
 version = "0.1.0"
 dependencies = [
@@ -650,7 +665,7 @@ dependencies = [
 name = "cluster-test"
 version = "0.1.0"
 dependencies = [
- "admission-control-proto 0.1.0",
+ "admission-control-proto-grpcio 0.1.0",
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
@@ -658,6 +673,7 @@ dependencies = [
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generate-keypair 0.1.0",
+ "grpcio 0.5.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "admission_control/admission-control-service",
     "admission_control/admission-control-proto",
+    "admission_control/admission-control-proto-grpcio",
     "client",
     "client/libra_wallet",
     "common/bounded-executor",

--- a/admission_control/admission-control-proto-grpcio/Cargo.toml
+++ b/admission_control/admission-control-proto-grpcio/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "admission-control-proto-grpcio"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra admission control proto"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+bytes = "0.4.12"
+futures = "0.1.28"
+grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
+prost = "0.5.0"
+
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-mempool-shared-proto = { path = "../../mempool/mempool-shared-proto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+
+[build-dependencies]
+grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/admission_control/admission-control-proto-grpcio/build.rs
+++ b/admission_control/admission-control-proto-grpcio/build.rs
@@ -1,0 +1,19 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    let protos = ["../admission-control-proto/src/proto/admission_control.proto"];
+
+    let includes = [
+        "../../types/src/proto",
+        "../admission-control-proto/src/proto",
+        "../../mempool/mempool-shared-proto/src/proto",
+    ];
+
+    grpcio_compiler::prost_codegen::compile_protos(
+        &protos,
+        &includes,
+        &std::env::var("OUT_DIR").unwrap(),
+    )
+    .unwrap();
+}

--- a/admission_control/admission-control-proto-grpcio/src/lib.rs
+++ b/admission_control/admission-control-proto-grpcio/src/lib.rs
@@ -1,0 +1,126 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod proto;
+
+use anyhow::{format_err, Error, Result};
+use libra_logger::prelude::*;
+use libra_mempool_shared_proto::MempoolAddTransactionStatus;
+use libra_types::vm_error::VMStatus;
+use std::convert::TryFrom;
+
+/// AC response status of submit_transaction to clients.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum AdmissionControlStatus {
+    /// Validator accepted the transaction.
+    Accepted,
+    /// The sender is blacklisted.
+    Blacklisted(String),
+    /// The transaction is rejected, e.g. due to incorrect signature.
+    Rejected(String),
+}
+
+impl TryFrom<crate::proto::admission_control::AdmissionControlStatus> for AdmissionControlStatus {
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::admission_control::AdmissionControlStatus) -> Result<Self> {
+        use crate::proto::admission_control::AdmissionControlStatusCode as ProtoStatusCode;
+        let ret = match proto.code() {
+            ProtoStatusCode::Accepted => AdmissionControlStatus::Accepted,
+            ProtoStatusCode::Blacklisted => {
+                let msg = proto.message;
+                AdmissionControlStatus::Blacklisted(msg)
+            }
+            ProtoStatusCode::Rejected => {
+                let msg = proto.message;
+                AdmissionControlStatus::Rejected(msg)
+            }
+        };
+        Ok(ret)
+    }
+}
+
+impl From<AdmissionControlStatus> for crate::proto::admission_control::AdmissionControlStatus {
+    fn from(status: AdmissionControlStatus) -> Self {
+        use crate::proto::admission_control::AdmissionControlStatusCode as ProtoStatusCode;
+        let mut admission_control_status = Self::default();
+        match status {
+            AdmissionControlStatus::Accepted => {
+                admission_control_status.set_code(ProtoStatusCode::Accepted)
+            }
+            AdmissionControlStatus::Blacklisted(msg) => {
+                admission_control_status.message = msg;
+                admission_control_status.set_code(ProtoStatusCode::Blacklisted)
+            }
+            AdmissionControlStatus::Rejected(msg) => {
+                admission_control_status.message = msg;
+                admission_control_status.set_code(ProtoStatusCode::Rejected)
+            }
+        }
+        admission_control_status
+    }
+}
+
+/// Rust structure for SubmitTransactionResponse protobuf definition.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SubmitTransactionResponse {
+    /// AC status returned to client if any - it can be one of: accepted, blacklisted, or rejected.
+    pub ac_status: Option<AdmissionControlStatus>,
+    /// Mempool error status if any.
+    pub mempool_error: Option<MempoolAddTransactionStatus>,
+    /// VM error status if any.
+    pub vm_error: Option<VMStatus>,
+    /// The id of validator associated with this AC.
+    pub validator_id: Vec<u8>,
+}
+
+impl TryFrom<crate::proto::admission_control::SubmitTransactionResponse>
+    for SubmitTransactionResponse
+{
+    type Error = Error;
+
+    fn try_from(proto: crate::proto::admission_control::SubmitTransactionResponse) -> Result<Self> {
+        use crate::proto::admission_control::submit_transaction_response::Status::*;
+
+        let validator_id = proto.validator_id;
+        let status = proto.status.ok_or_else(|| format_err!("Missing status"))?;
+        let (ac_status, mempool_error, vm_error) = match status {
+            VmStatus(status) => (None, None, Some(VMStatus::try_from(status)?)),
+            AcStatus(status) => (Some(AdmissionControlStatus::try_from(status)?), None, None),
+            MempoolStatus(status) => (
+                None,
+                Some(MempoolAddTransactionStatus::try_from(status)?),
+                None,
+            ),
+        };
+        Ok(SubmitTransactionResponse {
+            ac_status,
+            mempool_error,
+            vm_error,
+            validator_id,
+        })
+    }
+}
+
+impl From<SubmitTransactionResponse>
+    for crate::proto::admission_control::SubmitTransactionResponse
+{
+    fn from(status: SubmitTransactionResponse) -> Self {
+        use crate::proto::admission_control::submit_transaction_response::Status::*;
+
+        let mut proto = Self::default();
+        if let Some(ac_st) = status.ac_status {
+            proto.status = Some(AcStatus(ac_st.into()));
+        } else if let Some(mem_err) = status.mempool_error {
+            proto.status = Some(MempoolStatus(mem_err.into()));
+        } else if let Some(vm_st) = status.vm_error {
+            proto.status = Some(VmStatus(vm_st.into()));
+        } else {
+            error!("No status is available in SubmitTransactionResponse!");
+        }
+        proto.validator_id = status.validator_id;
+        proto
+    }
+}

--- a/admission_control/admission-control-proto-grpcio/src/proto/mod.rs
+++ b/admission_control/admission-control-proto-grpcio/src/proto/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(bare_trait_objects)]
+
+use ::libra_types::proto::*;
+use libra_mempool_shared_proto::proto::mempool_status;
+
+pub mod admission_control {
+    include!(concat!(env!("OUT_DIR"), "/admission_control.rs"));
+}
+
+pub use self::admission_control::{
+    AdmissionControlMsg, SubmitTransactionRequest, SubmitTransactionResponse,
+};

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
+grpcio = { version = "=0.5.0-alpha.4", default-features = false, features = ["prost-codec"] }
 itertools = "0.8.0"
 rand = "0.6.5"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
@@ -32,7 +33,7 @@ slog-scope = "4.0"
 slog-envlogger = "2.1.0"
 
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
-admission-control-proto = { path = "../../admission_control/admission-control-proto", version = "0.1.0" }
+admission-control-proto-grpcio = { path = "../../admission_control/admission-control-proto-grpcio", version = "0.1.0" }
 util = { path = "../../common/util", version = "0.1.0", package = "libra-util" }
 
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }


### PR DESCRIPTION
During the migration process to using tonic for the AC grpc endpoint I
was under the impression that all uses of the ac client from within
cluster-test were done in sync contexts. This turned out to be incorrect
and resulted in trying to build two tokio runtimes (one within another)
which results in the code panicing.

Longer-term we'll need to do some refactoring so that cluster-test can
use the new clients, but in the short term lets just reintroduce a
grpcio version of the AC client that cluster-test can use.