### PR TITLE
[codebuild] Add a buildspec to build and push validator images

### DIFF
--- a/docker/tag-and-push.sh
+++ b/docker/tag-and-push.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+# tag-and-push.sh is used tag an image with multiple tags and push them to the target repo
+# Example:
+# SOURCE=libra_validator:latest TARGET_REPO=1234567890.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test TARGET_TAGS=master,master_39cnja0 tag-and-push.sh
+
+set -e
+
+TARGET_TAGS_ARR=(${TARGET_TAGS//,/ })
+for TAG in "${TARGET_TAGS_ARR[@]}"
+do
+  TARGET=${TARGET_REPO}:${TAG}
+  echo "Tagging ${SOURCE} to ${TARGET}"
+  docker tag ${SOURCE} ${TARGET}
+  echo "Pushing ${SOURCE} to ${TARGET}"
+  docker push ${TARGET}
+done

--- a/docker/validator-dynamic/buildspec.yaml
+++ b/docker/validator-dynamic/buildspec.yaml
@@ -1,0 +1,23 @@
+# This buildspec is for AWS Codebuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker/validator/build.sh
+      - docker/validator-dynamic/build-dynamic.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # Tag and push the docker images
+      - SOURCE=libra_e2e:latest TARGET_REPO=$LIBRA_E2E_REPO TARGET_TAGS=$TAGS docker/tag-and-push.sh
+      - SOURCE=libra_validator_dynamic:latest TARGET_REPO=$LIBRA_VALIDATOR_REPO TARGET_TAGS=$TAGS docker/tag-and-push.sh


### PR DESCRIPTION
## Summary

This buildspec will be used to build and push docker images using the AWS Codebuild service. Using AWS Codebuild, we can reduce build + push time of validator images to < 5 minutes