### PR TITLE
[mint] Always kill client after every request

### DIFF
--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -64,6 +64,7 @@ def send_transaction():
 
         application.client.sendline("a la")
         application.client.expect(r"sequence_number: ([0-9]+)", timeout=1)
+        application.client.terminate(True)
     except pexpect.exceptions.ExceptionPexpect:
         application.client.terminate(True)
         raise


### PR DESCRIPTION


## Motivation
I think the mint server is hanging somehow and python pexpect isn't realize it. We don't need this throughput anyways so just going to kill the client after every mint.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
 
Yes

## Test Plan

eyes
