### PR TITLE
[consensus][easy] fix the epoch race

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -131,10 +131,12 @@ impl<T: Payload> ChainedBftSMR<T> {
                     }
                     ledger_info = network_receivers.epoch_change.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        event_processor = epoch_manager.start_new_epoch(ledger_info).await;
-                        // clean up all the previous messages from the old epochs
-                        network_receivers.clear_prev_epoch_msgs();
-                        event_processor.start().await;
+                        if epoch_manager.epoch() <= ledger_info.ledger_info().epoch() {
+                            event_processor = epoch_manager.start_new_epoch(ledger_info).await;
+                            // clean up all the previous messages from the old epochs
+                            network_receivers.clear_prev_epoch_msgs();
+                            event_processor.start().await;
+                        }
                     }
                     different_epoch_and_peer = network_receivers.different_epoch.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -75,7 +75,7 @@ where
         }
     }
 
-    fn epoch(&self) -> u64 {
+    pub fn epoch(&self) -> u64 {
         self.epoch_info.read().unwrap().epoch
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There's some reace between epoch manager and the networking that results
in starting the same epoch EventProcessor multiple times.

Because we may receive multiple EpochChange messages and before we start
the new epoch they'll all pass the verification and stay in the queue.

This change adds a guard to the avoid this.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
