### PR TITLE
[consensus] convert generics back to trait object

### DIFF
--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -91,8 +91,10 @@ impl ChainedBftProvider {
 impl ConsensusProvider for ChainedBftProvider {
     fn start(&mut self) -> Result<()> {
         debug!("Starting consensus provider.");
-        self.smr
-            .start(self.txn_manager.clone(), Arc::clone(&self.state_computer))
+        self.smr.start(
+            Box::new(self.txn_manager.clone()),
+            Arc::clone(&self.state_computer),
+        )
     }
 
     fn stop(&mut self) {

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -95,10 +95,10 @@ impl<T: Payload> ChainedBftSMR<T> {
         self.block_store.clone()
     }
 
-    fn start_event_processing<TM: TxnManager<Payload = T>>(
+    fn start_event_processing(
         executor: Handle,
-        mut epoch_manager: EpochManager<TM, T>,
-        mut event_processor: EventProcessor<TM, T>,
+        mut epoch_manager: EpochManager<T>,
+        mut event_processor: EventProcessor<T>,
         mut pacemaker_timeout_sender_rx: channel::Receiver<Round>,
         network_task: NetworkTask<T>,
         mut network_receivers: NetworkReceivers<T>,
@@ -164,9 +164,9 @@ impl<T: Payload> StateMachineReplication for ChainedBftSMR<T> {
     /// 1. Construct the EpochManager from the latest libradb state
     /// 2. Construct per-epoch component with the fixed Validators provided by EpochManager including
     /// ProposerElection, Pacemaker, SafetyRules, Network(Populate with known validators), EventProcessor
-    fn start<TM: TxnManager<Payload = Self::Payload>>(
+    fn start(
         &mut self,
-        txn_manager: TM,
+        txn_manager: Box<dyn TxnManager<Payload = Self::Payload>>,
         state_computer: Arc<dyn StateComputer<Payload = Self::Payload>>,
     ) -> Result<()> {
         let mut initial_setup = self

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -112,7 +112,7 @@ impl SMRNode {
         let (mp, commit_receiver) = MockTransactionManager::new();
         let mempool = mp;
         smr.start(
-            mempool.clone(),
+            Box::new(mempool.clone()),
             Arc::new(MockStateComputer::new(
                 commit_cb_sender.clone(),
                 Arc::clone(&storage),

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -66,13 +66,13 @@ pub mod event_processor_fuzzing;
 /// etc.). It is exposing the async processing functions for each event type.
 /// The caller is responsible for running the event loops and driving the execution via some
 /// executors.
-pub struct EventProcessor<TM, T> {
+pub struct EventProcessor<T> {
     block_store: Arc<BlockStore<T>>,
     pacemaker: Pacemaker,
     proposer_election: Box<dyn ProposerElection<T> + Send + Sync>,
-    proposal_generator: ProposalGenerator<TM, T>,
+    proposal_generator: ProposalGenerator<T>,
     safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
-    txn_manager: TM,
+    txn_manager: Box<dyn TxnManager<Payload = T>>,
     network: NetworkSender,
     storage: Arc<dyn PersistentStorage<T>>,
     time_service: Arc<dyn TimeService>,
@@ -81,19 +81,15 @@ pub struct EventProcessor<TM, T> {
     validators: Arc<ValidatorVerifier>,
 }
 
-impl<TM, T> EventProcessor<TM, T>
-where
-    TM: TxnManager<Payload = T>,
-    T: Payload,
-{
+impl<T: Payload> EventProcessor<T> {
     pub fn new(
         block_store: Arc<BlockStore<T>>,
         last_vote: Option<Vote>,
         pacemaker: Pacemaker,
         proposer_election: Box<dyn ProposerElection<T> + Send + Sync>,
-        proposal_generator: ProposalGenerator<TM, T>,
+        proposal_generator: ProposalGenerator<T>,
         safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
-        txn_manager: TM,
+        txn_manager: Box<dyn TxnManager<Payload = T>>,
         network: NetworkSender,
         storage: Arc<dyn PersistentStorage<T>>,
         time_service: Arc<dyn TimeService>,

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -80,7 +80,7 @@ fn create_pacemaker() -> Pacemaker {
 }
 
 // Creates an EventProcessor for fuzzing
-fn create_node_for_fuzzing() -> EventProcessor<MockTransactionManager, TestPayload> {
+fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     // signer is re-used accross fuzzing runs
     let signer = FUZZING_SIGNER.clone();
 
@@ -118,7 +118,7 @@ fn create_node_for_fuzzing() -> EventProcessor<MockTransactionManager, TestPaylo
     let proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        MockTransactionManager::new().0,
+        Box::new(MockTransactionManager::new().0),
         time_service.clone(),
         1,
     );
@@ -137,7 +137,7 @@ fn create_node_for_fuzzing() -> EventProcessor<MockTransactionManager, TestPaylo
         proposer_election,
         proposal_generator,
         Box::new(safety_rules),
-        MockTransactionManager::new().0,
+        Box::new(MockTransactionManager::new().0),
         network,
         storage.clone(),
         time_service,

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -64,7 +64,7 @@ use tokio::runtime::Handle;
 /// Auxiliary struct that is setting up node environment for the test.
 pub struct NodeSetup {
     block_store: Arc<BlockStore<TestPayload>>,
-    event_processor: EventProcessor<MockTransactionManager, TestPayload>,
+    event_processor: EventProcessor<TestPayload>,
     storage: Arc<MockStorage<TestPayload>>,
     signer: ValidatorSigner,
     proposer_author: Author,
@@ -170,7 +170,7 @@ impl NodeSetup {
         let proposal_generator = ProposalGenerator::new(
             author,
             block_store.clone(),
-            MockTransactionManager::new().0,
+            Box::new(MockTransactionManager::new().0),
             time_service.clone(),
             1,
         );
@@ -185,7 +185,7 @@ impl NodeSetup {
             proposer_election,
             proposal_generator,
             safety_rules_manager.client(),
-            MockTransactionManager::new().0,
+            Box::new(MockTransactionManager::new().0),
             network,
             storage.clone(),
             time_service,

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -33,14 +33,14 @@ mod proposal_generator_test;
 ///
 /// TxnManager should be aware of the pending transactions in the branch that it is extending,
 /// such that it will filter them out to avoid transaction duplication.
-pub struct ProposalGenerator<TM, T> {
+pub struct ProposalGenerator<T> {
     // The account address of this validator
     author: Author,
     // Block store is queried both for finding the branch to extend and for generating the
     // proposed block.
     block_store: Arc<dyn BlockReader<Payload = T> + Send + Sync>,
     // Transaction manager is delivering the transactions.
-    txn_manager: TM,
+    txn_manager: Box<dyn TxnManager<Payload = T>>,
     // Time service to generate block timestamps
     time_service: Arc<dyn TimeService>,
     // Max number of transactions to be added to a proposed block.
@@ -49,15 +49,11 @@ pub struct ProposalGenerator<TM, T> {
     last_round_generated: Mutex<Round>,
 }
 
-impl<TM, T> ProposalGenerator<TM, T>
-where
-    TM: TxnManager<Payload = T>,
-    T: Payload,
-{
+impl<T: Payload> ProposalGenerator<T> {
     pub fn new(
         author: Author,
         block_store: Arc<dyn BlockReader<Payload = T> + Send + Sync>,
-        txn_manager: TM,
+        txn_manager: Box<dyn TxnManager<Payload = T>>,
         time_service: Arc<dyn TimeService>,
         max_block_size: u64,
     ) -> Self {

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -29,7 +29,7 @@ fn test_proposal_generation_empty_tree() {
     let mut proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        MockTransactionManager::new().0,
+        Box::new(MockTransactionManager::new().0),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -55,7 +55,7 @@ fn test_proposal_generation_parent() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        MockTransactionManager::new().0,
+        Box::new(MockTransactionManager::new().0),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -96,7 +96,7 @@ fn test_old_proposal_generation() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        MockTransactionManager::new().0,
+        Box::new(MockTransactionManager::new().0),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -115,7 +115,7 @@ fn test_empty_proposal_after_reconfiguration() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        MockTransactionManager::new().0,
+        Box::new(MockTransactionManager::new().0),
         Arc::new(SimulatedTimeService::new()),
         1,
     );

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -72,4 +72,8 @@ impl TxnManager for MockTransactionManager {
             .expect("Failed to notify about mempool commit");
         Ok(())
     }
+
+    fn _clone_box(&self) -> Box<dyn TxnManager<Payload = Self::Payload>> {
+        Box::new(self.clone())
+    }
 }

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -125,4 +125,8 @@ impl TxnManager for MempoolProxy {
             Self::gen_commit_transactions_request(txns.as_slice(), compute_result, timestamp_usecs);
         self.submit_commit_transactions_request(req).await
     }
+
+    fn _clone_box(&self) -> Box<dyn TxnManager<Payload = Self::Payload>> {
+        Box::new(self.clone())
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Generics allow dynamic behavior (similar to trait methods) with static dispatch. As the number of generic type parameters increases, the difficulty of using the type/method also increases (e.g. consider the combination of trait bounds required for this type, duplicate trait bounds on related types, etc.). In order to avoid this complexity, we generally try to avoid using a large number of generic type parameters. We have found that converting code with a large number of generic objects to trait objects with dynamic dispatch often simplifies our code.

I spent surprising amount of time realizing that `Clone: Sized` and prohibits trait objects and figured out I should have asked our good friend stack overflow first(https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object/)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
