### PR TITLE
[language] Fix copy of structures nested inside other structures

### DIFF
--- a/language/functional_tests/src/config/global.rs
+++ b/language/functional_tests/src/config/global.rs
@@ -125,7 +125,6 @@ impl Config {
                 .iter_mut()
                 .map(|c| {
                     let peer_id = c.validator_network.as_ref().unwrap().peer_id;
-                    println!("{:?}", peer_id);
                     let account_keypair =
                         c.test.as_mut().unwrap().account_keypair.as_mut().unwrap();
                     let privkey = account_keypair.take_private().unwrap();

--- a/language/functional_tests/tests/testsuite/references/copy_nested.mvir
+++ b/language/functional_tests/tests/testsuite/references/copy_nested.mvir
@@ -1,0 +1,65 @@
+module Test {
+
+    struct Config { b: bool }
+
+    // A current or prospective validator should publish one of these under their address
+    resource T {
+        config: Self.Config,
+    }
+
+    public publish_config(b: bool) {
+        move_to_sender<T>(T { config: Config { b: move(b) } });
+        return;
+    }
+
+    // Retrieve a read-only instance of a specific accounts ValidatorConfig.T.config
+    public config(addr: address): Self.Config acquires T {
+        let t_ref: &Self.T;
+
+        t_ref = borrow_global<T>(move(addr));
+        return *&move(t_ref).config;
+    }
+
+    public value(config: &Self.Config): bool {
+        return *&move(config).b;
+    }
+
+    public set(b: bool) acquires T {
+        let t_ref: &mut Self.T;
+        let config_ref: &mut Self.Config;
+        let b_ref: &mut bool;
+
+        t_ref = borrow_global_mut<T>(get_txn_sender());
+        config_ref = &mut move(t_ref).config;
+        b_ref = &mut move(config_ref).b;
+        *move(b_ref) = move(b);
+
+        return;
+    }
+
+}
+
+// check: EXECUTED
+
+//! new-transaction
+import {{default}}.Test;
+
+main() {
+    let config: Test.Config;
+    let config1: Test.Config;
+
+    Test.publish_config(false);
+
+    config = Test.config(get_txn_sender());
+    assert(Test.value(&config) == false, 77);
+
+    Test.set(true); // shouldn't affect local config variable
+    assert(Test.value(&config) == false, 88);
+
+    config1 = Test.config(get_txn_sender());
+    assert(Test.value(&config1) == true, 99);
+
+    return;
+}
+
+// check: EXECUTED

--- a/language/functional_tests/tests/testsuite/references/vec_copy_nested.mvir
+++ b/language/functional_tests/tests/testsuite/references/vec_copy_nested.mvir
@@ -1,0 +1,110 @@
+module DeepCopy {
+    import 0x0.Vector;
+
+    struct Config { i: u64 }
+    struct Nested { c: Self.Config }
+
+    public test_struct_shallow() {
+        let c1: Self.Config;
+        let c2: Self.Config;
+
+        c1 = Config { i: 0 };
+        c2 = copy(c1);
+
+        // mutate c1.i to 1
+        *(&mut (&mut c1).i) = 1;
+        // c2.i should still be 0
+        assert(*&(&c2).i == 0, 77);
+
+        // mutate c2.i to 2
+        *(&mut (&mut c2).i) = 2;
+        // c1.i should still be 1
+        assert(*&(&c1).i == 1, 78);
+
+        return;
+    }
+
+    public test_struct_deep() {
+        let n1: Self.Nested;
+        let n2: Self.Nested;
+
+        n1 = Nested { c: Config { i: 0 } };
+        n2 = copy(n1);
+
+        // mutate n1.c.i to 1
+        *(&mut (&mut (&mut n1).c).i) = 1;
+        // n2.c.i should still be 0
+        assert(*&(&(&n2).c).i == 0, 79);
+        // n1.c.i is 1
+        assert(*&(&(&n1).c).i == 1, 80);
+
+        // mutate n2.c.i to 2
+        *(&mut (&mut (&mut n2).c).i) = 2;
+        // n1.c.i should still be 1
+        assert(*&(&(&n1).c).i == 1, 81);
+        // n2.c.i is 2
+        assert(*&(&(&n2).c).i == 2, 82);
+
+        return;
+    }
+
+    public test_vector() {
+        let v1: Vector.T<u64>;
+        let v2: Vector.T<u64>;
+
+        v1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut v1, 0);
+        v2 = copy(v1);
+        *Vector.borrow_mut<u64>(&mut v1, 0) = 1;
+        assert(*Vector.borrow<u64>(&v2, 0) == 0, 83);
+
+        *Vector.borrow_mut<u64>(&mut v2, 0) = 2;
+        assert(*Vector.borrow<u64>(&v1, 0) == 1, 84);
+
+        return;
+    }
+
+    public test_vector_to_struct() {
+        let v1: Vector.T<Self.Config>;
+        let v2: Vector.T<Self.Config>;
+        let c1: Self.Config;
+        let c2: Self.Config;
+        let r1: &mut Self.Config;
+        let r2: &mut Self.Config;
+        let ri1: &mut u64;
+
+        c1 = Config { i: 0 };
+        c2 = copy(c1);
+        *(&mut (&mut c2).i) = 1;
+
+        v1 = Vector.empty<Self.Config>();
+        Vector.push_back<Self.Config>(&mut v1, move(c1));
+        Vector.push_back<Self.Config>(&mut v1, move(c2));
+        v2 = copy(v1);
+
+        r1 = Vector.borrow_mut<Self.Config>(&mut v1, 0);
+        r2 = Vector.borrow_mut<Self.Config>(&mut v2, 0);
+        assert(*&copy(r1).i == 0, 90);
+        assert(*&copy(r1).i == *&move(r2).i, 91);
+        r2 = Vector.borrow_mut<Self.Config>(&mut v2, 1);
+        assert(*&copy(r2).i == 1, 91);
+        assert(*&copy(r1).i != *&copy(r2).i, 91);
+        *&mut copy(r1).i = 1;
+        assert(*&copy(r1).i == *&copy(r2).i, 92);
+
+        return;
+    }
+}
+
+//! new-transaction
+import {{default}}.DeepCopy;
+
+main() {
+    DeepCopy.test_struct_shallow();
+    DeepCopy.test_struct_deep();
+    DeepCopy.test_vector();
+    DeepCopy.test_vector_to_struct();
+    return;
+}
+
+// check: EXECUTED

--- a/language/functional_tests/tests/testsuite/validator_set/register_validator.mvir
+++ b/language/functional_tests/tests/testsuite/validator_set/register_validator.mvir
@@ -53,11 +53,14 @@ main() {
     config = ValidatorConfig.config(get_txn_sender());
     assert(ValidatorConfig.consensus_pubkey(&config) == h"10", 11);
     ValidatorConfig.rotate_consensus_pubkey(h"70");
-    assert(ValidatorConfig.consensus_pubkey(&config) == h"70", 12);
+    assert(ValidatorConfig.consensus_pubkey(&config) == h"10", 12);
+    config = ValidatorConfig.config(get_txn_sender());
+    assert(ValidatorConfig.consensus_pubkey(&config) == h"70", 15);
 
     // Rotating the validator_network_pubkey should work
     assert(ValidatorConfig.validator_network_identity_pubkey(&config) == h"30", 13);
     ValidatorConfig.rotate_validator_network_identity_pubkey(h"80");
+    config = ValidatorConfig.config(get_txn_sender());
     assert(ValidatorConfig.validator_network_identity_pubkey(&config) == h"80", 14);
 
     return;

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/def.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/def.rs
@@ -1,11 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::value::{MutVal, Value};
 use crate::{
     loaded_data::{struct_def::StructDef, types::Type},
     native_structs::vector::NativeVector,
 };
 use serde::{ser, Deserialize, Serialize};
+use vm::errors::VMResult;
 use vm::gas_schedule::{AbstractMemorySize, GasCarrier};
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
@@ -70,6 +72,20 @@ impl NativeStructValue {
                     .map(|v| v.to_type_FOR_TESTING())
                     .unwrap_or(Type::Bool),
             )),
+        }
+    }
+
+    pub(crate) fn copy_value(&self) -> VMResult<Value> {
+        match self {
+            NativeStructValue::Vector(v) => {
+                let mut values: Vec<MutVal> = vec![];
+                for value in &v.0 {
+                    values.push(MutVal::new(value.copy_value()?));
+                }
+                Ok(Value::native_struct(NativeStructValue::Vector(
+                    NativeVector(values),
+                )))
+            }
         }
     }
 }


### PR DESCRIPTION
We were moving around a reference to a nested structure instead of a copy
when reading a reference to a structure inside another structure (see test).
That implied that changes to what were logically different copies ended up
changing the same value.
