### PR TITLE
[consensus] fix safety rules storage issues

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -300,6 +300,8 @@ pub trait PersistableConfig: Serialize + DeserializeOwned {
         let contents = toml::to_vec(&self)?;
         let mut file = File::create(output_file)?;
         file.write_all(&contents)?;
+        // @TODO This causes a major perf regression that needs to be evaluated before enabling
+        // file.sync_all()?;
         Ok(())
     }
 


### PR DESCRIPTION
- Make all writes sync to ensure we don't leave partial or incomplete
data (TBD, needs cluster testing and announcement before enabling)
- swap between writing to files so that we always have one that is
correct

Addresses #2092 