### PR TITLE
[security] Cargo audit to fail on sec warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,18 @@ jobs:
     steps:
       - build_setup
       - run:
-          name: Cargo Audit
+          name: Install Cargo Audit
           command: |
             cargo install --force cargo-audit
-            cargo audit
+      - run:
+          # NOTE ignored advisory rules
+          # RUSTSEC-2018-0015 - term
+          # RUSTSEC-2019-0031 - spin
+          name: Audit crates
+          command: |
+            cargo audit --deny-warnings \
+              --ignore RUSTSEC-2018-0015 \
+              --ignore RUSTSEC-2019-0031
       - build_teardown
   code-coverage:
     description: Run code coverage


### PR DESCRIPTION
## Motivation
Added two advisory rules to the whitelist:
  - RUSTSEC-2018-0015
    The author of the `term` crate does not have time to maintain it
    and is looking for a new maintainer.

  - RUSTSEC-2019-0031
    The author of the `spin` crate does not have time or interest to
    maintain it.

## Test Plan
Tested locally.

## Related PRs
Closes #1535 