### PR TITLE
Proving first simple things.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "stackless-bytecode-generator 0.1.0",
  "stdlib 0.1.0",

--- a/language/move-prover/bytecode-to-boogie/Cargo.toml
+++ b/language/move-prover/bytecode-to-boogie/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.8"
 simplelog = "0.7.4"
 lazy_static = "1.4.0"
 codespan = "0.2.1"
-
+regex = "1.3.1"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub const INLINE_PRELUDE: &str = "<inline-prelude>";
 
 /// Default flags passed to boogie. Additional flags will be added to this via the -B option.
-const DEFAULT_BOOGIE_FLAGS: &[&str] = &["-doModSetAnalysis"];
+const DEFAULT_BOOGIE_FLAGS: &[&str] = &["-doModSetAnalysis", "-noinfer"];
 
 /// Atomic used to prevent re-initialization of logging.
 static LOGGER_CONFIGURED: AtomicBool = AtomicBool::new(false);

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -374,7 +374,7 @@ impl<'a> SpecTranslator<'a> {
             }
             StorageLocation::Ret => self.translate_return(),
             StorageLocation::TxnSenderAddress => BoogieExpr(
-                "Address(TxnSenderAddress())".to_string(),
+                "Address(TxnSenderAddress(txn))".to_string(),
                 SignatureToken::Address,
             ),
             StorageLocation::Address(addr) => BoogieExpr(

--- a/language/move-prover/bytecode-to-boogie/src/translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/translator.rs
@@ -334,7 +334,7 @@ impl<'a> ModuleTranslator<'a> {
         let fun_name = self.function_name_from_definition_index(func_idx);
         let mut var_decls = String::new();
         let mut res = String::new();
-        let stmts = match bytecode {
+        let mut stmts = match bytecode {
             Branch(target) => vec![format!("goto Label_{};", target)],
             BrTrue(target, idx) => {
                 let (dbg_branch_taken_str, dbg_branch_not_taken_str) =
@@ -582,7 +582,6 @@ impl<'a> ModuleTranslator<'a> {
                     struct_def_index,
                     type_actuals,
                 );
-                // DO NOT SUBMIT let struct_str = self.struct_name_from_definition_index(*struct_def_index);
                 vec![
                     format!(
                         "call tmp := MoveFrom(GetLocal(m, old_size + {}), {});",
@@ -731,7 +730,7 @@ impl<'a> ModuleTranslator<'a> {
             BitOr(_, _, _) | BitAnd(_, _, _) | Xor(_, _, _) => {
                 vec!["// bit operation not supported".into()]
             }
-            Abort(_) => vec!["assert false;".into()],
+            Abort(_) => vec!["goto Label_Abort;".into()],
             GetGasRemaining(idx) => vec![
                 "call tmp := GetGasRemaining();".to_string(),
                 format!("m := UpdateLocal(m, old_size + {}, tmp);", idx),
@@ -758,6 +757,7 @@ impl<'a> ModuleTranslator<'a> {
             ],
             _ => vec!["// unimplemented instruction".into()],
         };
+        stmts.push("if (abort_flag) { goto Label_Abort; }".to_string());
         for code in stmts {
             res.push_str(&format!("    {}\n", code));
         }
@@ -955,9 +955,9 @@ impl<'a> ModuleTranslator<'a> {
         }
         var_decls.push_str("\n    var tmp: Value;\n");
         var_decls.push_str("    var old_size: int;\n");
-        //        if !inline {
+        res.push_str("\n    var saved_m: Memory;\n");
         res.push_str("    assume !abort_flag;\n");
-        //        }
+        res.push_str("    saved_m := m;\n");
         res.push_str("\n    // assume arguments are of correct types\n");
         res.push_str(&arg_value_assumption_str);
         res.push_str("\n    old_size := local_counter;\n");
@@ -995,6 +995,16 @@ impl<'a> ModuleTranslator<'a> {
                 self.translate_bytecode(offset, bytecode, idx, arg_names);
             var_decls.push_str(&new_var_decls);
             res.push_str(&new_res);
+        }
+        res.push_str("Label_Abort:\n");
+        res.push_str("    abort_flag := true;\n");
+        res.push_str("    m := saved_m;\n");
+        for (i, sig) in get_return_types(self.module, idx).iter().enumerate() {
+            if let SignatureToken::Reference(_) = sig {
+                res.push_str(&format!("    ret{} := DefaultReference;\n", i));
+            } else {
+                res.push_str(&format!("    ret{} := DefaultValue;\n", i));
+            }
         }
         res.push_str("}\n");
         var_decls.push_str(&res);
@@ -1262,4 +1272,12 @@ pub fn get_field_infos(
             })
             .collect()
     }
+}
+
+/// Get return types of function via definition index.
+pub fn get_return_types(module: &VerifiedModule, idx: usize) -> &[SignatureToken] {
+    let function_def = &module.function_defs()[idx];
+    let function_handle = module.function_handle_at(function_def.function);
+    let function_signature = module.function_signature_at(function_handle.signature);
+    &function_signature.return_types
 }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.mvir
@@ -1,7 +1,7 @@
 module TestSpecs {
 
-    // Note the specs below maybe wrong because we do not provide an implementation. Once things are
-    // more stable, we need to add them.
+    // Note the specs below maybe wrong because we do not provide an implementation. This is mostly for verifying
+    // translation issues, and tested with verification off.
 
     struct S {
       a: address

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-verify.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-verify.mvir
@@ -1,0 +1,46 @@
+module TestSpecs {
+    import 0x0.Vector;
+
+
+    resource R {
+      x: u64,
+    }
+
+    public create_resource()
+      aborts_if global_exists<Self.R>(txn_sender)
+      ensures global_exists<Self.R>(txn_sender)
+    {
+      if (exists<R>(get_txn_sender())) {
+        abort(1);
+      }
+      move_to_sender<R>(R{x:1});
+      return;
+    }
+
+    public create_resource_error()
+      aborts_if global_exists<Self.R>(txn_sender)
+      ensures global_exists<Self.R>(txn_sender) //! postcondition might not hold
+    {
+      if (exists<R>(get_txn_sender())) {
+        abort(1);
+      }
+      move_to_sender<R>(R{x:1});
+      return;
+    }
+
+    public div_by_zero(x: u64, y: u64): u64
+      succeeds_if y > 0
+    {
+      let r: u64;
+      r = copy(x) / copy(y);
+      return move(y);
+    }
+
+    public div_by_zero_error(x: u64, y: u64): u64
+      succeeds_if true //! postcondition might not hold
+    {
+      let r: u64;
+      r = copy(x) / copy(y);
+      return move(y);
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -23,7 +23,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -37,32 +40,46 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(3);
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 8);
     ret1 := GetLocal(m, old_size + 9);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
 }
 
 procedure TestArithmetic_add_two_number_verify (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
@@ -87,7 +104,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -103,28 +123,40 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 9);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestArithmetic_multiple_ops_verify (arg0: Value, arg1: Value, arg2: Value) returns (ret0: Value)
@@ -162,7 +194,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -176,75 +211,102 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Gt(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Ge(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := And(GetLocal(m, old_size + 6), GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Lt(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Le(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Or(GetLocal(m, old_size + 13), GetLocal(m, old_size + 16));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 17));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(!IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19)));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 21);
     if (!b#Boolean(tmp)) { goto Label_23; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_23:
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestArithmetic_bool_ops_verify (arg0: Value, arg1: Value) returns ()
@@ -280,7 +342,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -294,71 +359,98 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(6);
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(4);
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Sub(GetLocal(m, old_size + 5), GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Mul(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(3);
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Div(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(4);
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Mod(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 13));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15)));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 16));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 17);
     if (!b#Boolean(tmp)) { goto Label_19; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_19:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 19);
     ret1 := GetLocal(m, old_size + 20);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
 }
 
 procedure TestArithmetic_arithmetic_ops_verify (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
@@ -379,7 +471,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -389,24 +484,34 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(9223372036854775807);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestArithmetic_overflow_verify () returns ()
@@ -427,7 +532,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -437,24 +545,34 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Sub(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestArithmetic_underflow_verify () returns ()
@@ -475,7 +593,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -485,24 +606,34 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestArithmetic_div_by_zero_verify () returns ()

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -19,7 +19,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Boolean(arg0);
@@ -31,29 +34,41 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 1);
     if (!b#Boolean(tmp)) { goto Label_6; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 4);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_6:
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 5);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestControlFlow_branch_once_verify (arg0: Value) returns (ret0: Value)

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -17,7 +17,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -29,16 +32,24 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestFuncCall_f_verify (arg0: Value) returns (ret0: Value)
@@ -57,7 +68,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -69,16 +83,24 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestFuncCall_g_verify (arg0: Value) returns (ret0: Value)
@@ -117,7 +139,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Boolean(arg0);
@@ -129,96 +154,129 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(3);
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 4);
     if (!b#Boolean(tmp)) { goto Label_8; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := TestFuncCall_f(GetLocal(m, old_size + 5));
     assume is#Integer(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     goto Label_11;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_8:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := TestFuncCall_g(GetLocal(m, old_size + 7));
     assume is#Integer(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
 Label_11:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(4);
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 10), GetLocal(m, old_size + 11)));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := And(GetLocal(m, old_size + 9), GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 14));
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(5);
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 16), GetLocal(m, old_size + 17)));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := And(GetLocal(m, old_size + 15), GetLocal(m, old_size + 18));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Or(GetLocal(m, old_size + 13), GetLocal(m, old_size + 19));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 21);
     if (!b#Boolean(tmp)) { goto Label_27; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_27:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 23);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestFuncCall_h_verify (arg0: Value) returns (ret0: Value)

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -65,7 +65,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -81,42 +84,59 @@ requires ExistsTxnSenderAccount(m, txn);
     assume is#Vector(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowLoc(old_size+2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call Vector_push_back(IntegerType(), t5, GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := BorrowLoc(old_size+2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call Vector_push_back(IntegerType(), t7, GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Vector(GetLocal(m, old_size + 9));
 
     call tmp := Pack_TestGenerics_R(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call MoveToSender(TestGenerics_R_type_value(), GetLocal(m, old_size + 11));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestGenerics_move2_verify (arg0: Value, arg1: Value) returns ()
@@ -138,7 +158,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -151,28 +174,40 @@ requires ExistsTxnSenderAccount(m, txn);
     assume is#Vector(t2);
 
     m := UpdateLocal(m, old_size + 2, t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowLoc(old_size+1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call Vector_push_back(tv0, t3, GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Vector(GetLocal(m, old_size + 5));
 
     call tmp := Pack_TestGenerics_T(tv0, GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 6);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestGenerics_create_verify (tv0: TypeValue, arg0: Value) returns (ret0: Value)
@@ -200,7 +235,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -212,44 +250,60 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := TestGenerics_create(tv0, GetLocal(m, old_size + 5));
     assume is#Vector(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := TestGenerics_create(tv0, GetLocal(m, old_size + 7));
     assume is#Vector(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10)));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 11));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 12);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestGenerics_overcomplicated_equals_verify (tv0: TypeValue, arg0: Value, arg1: Value) returns (ret0: Value)
@@ -269,7 +323,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -279,24 +336,34 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := TestGenerics_overcomplicated_equals(IntegerType(), GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
     assume is#Boolean(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 4);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestGenerics_test_verify () returns (ret0: Value)

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -432,7 +432,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -444,32 +447,45 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdAddr(173345816);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2)));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 4);
     if (!b#Boolean(tmp)) { goto Label_7; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_7:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call MoveToSender(GasSchedule_T_type_value(), GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure GasSchedule_initialize_verify (arg0: Value) returns ()
@@ -492,7 +508,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -502,29 +521,42 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdAddr(173345816);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), GasSchedule_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, GasSchedule_T_instruction_schedule);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
     assume is#Integer(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 7);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure GasSchedule_instruction_table_size_verify () returns (ret0: Value)
@@ -547,7 +579,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -557,29 +592,42 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdAddr(173345816);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), GasSchedule_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, GasSchedule_T_native_schedule);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
     assume is#Integer(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 7);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure GasSchedule_native_table_size_verify () returns (ret0: Value)
@@ -601,7 +649,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -613,13 +664,20 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Exists(GetLocal(m, old_size + 1), ValidatorConfig_T_type_value());
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 2);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_has_verify (arg0: Value) returns (ret0: Value)
@@ -641,7 +699,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -653,23 +714,34 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), ValidatorConfig_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, ValidatorConfig_T_config);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t5);
     assume is#Vector(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 6);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_config_verify (arg0: Value) returns (ret0: Value)
@@ -688,7 +760,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -698,17 +773,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_consensus_pubkey);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_consensus_pubkey_verify (arg0: Reference) returns (ret0: Value)
@@ -727,7 +810,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -737,17 +823,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_signing_pubkey);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_validator_network_signing_pubkey_verify (arg0: Reference) returns (ret0: Value)
@@ -766,7 +860,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -776,17 +873,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_identity_pubkey);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_validator_network_identity_pubkey_verify (arg0: Reference) returns (ret0: Value)
@@ -805,7 +910,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -815,17 +923,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_address);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_validator_network_address_verify (arg0: Reference) returns (ret0: Value)
@@ -844,7 +960,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -854,17 +973,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_fullnodes_network_identity_pubkey);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_fullnodes_network_identity_pubkey_verify (arg0: Reference) returns (ret0: Value)
@@ -883,7 +1010,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -893,17 +1023,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_fullnodes_network_address);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_fullnodes_network_address_verify (arg0: Reference) returns (ret0: Value)
@@ -932,7 +1070,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#ByteArray(arg0);
@@ -954,21 +1095,27 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#ByteArray(GetLocal(m, old_size + 6));
 
@@ -984,16 +1131,23 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_ValidatorConfig_Config(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 10), GetLocal(m, old_size + 11));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Vector(GetLocal(m, old_size + 12));
 
     call tmp := Pack_ValidatorConfig_T(GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call MoveToSender(ValidatorConfig_T_type_value(), GetLocal(m, old_size + 13));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure ValidatorConfig_register_candidate_validator_verify (arg0: Value, arg1: Value, arg2: Value, arg3: Value, arg4: Value, arg5: Value) returns ()
@@ -1020,7 +1174,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#ByteArray(arg0);
@@ -1032,32 +1189,48 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowGlobal(GetLocal(m, old_size + 4), ValidatorConfig_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := BorrowField(t6, ValidatorConfig_T_config);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := BorrowField(t8, ValidatorConfig_Config_consensus_pubkey);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t9);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t11 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t11, GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure ValidatorConfig_rotate_consensus_pubkey_verify (arg0: Value) returns ()
@@ -1084,7 +1257,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#ByteArray(arg0);
@@ -1096,32 +1272,48 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowGlobal(GetLocal(m, old_size + 4), ValidatorConfig_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := BorrowField(t6, ValidatorConfig_T_config);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := BorrowField(t8, ValidatorConfig_Config_validator_network_identity_pubkey);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t9);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t11 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t11, GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure ValidatorConfig_rotate_validator_network_identity_pubkey_verify (arg0: Value) returns ()
@@ -1148,7 +1340,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#ByteArray(arg0);
@@ -1160,32 +1355,48 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowGlobal(GetLocal(m, old_size + 4), ValidatorConfig_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := BorrowField(t6, ValidatorConfig_T_config);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := BorrowField(t8, ValidatorConfig_Config_validator_network_address);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t9);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t11 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t11, GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure ValidatorConfig_rotate_validator_network_address_verify (arg0: Value) returns ()
@@ -1209,7 +1420,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -1221,20 +1435,29 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
     assume is#Vector(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 4);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (arg0: Value) returns (ret0: Value)
@@ -1273,7 +1496,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -1285,81 +1511,112 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     // unimplemented instruction
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1000000000);
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1000000);
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Le(GetLocal(m, old_size + 5), GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 10);
     if (!b#Boolean(tmp)) { goto Label_11; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(11);
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_11:
     call tmp := LdAddr(173345816);
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t13 := BorrowGlobal(GetLocal(m, old_size + 12), LibraCoin_MarketCap_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t13);
+    if (abort_flag) { goto Label_Abort; }
 
     call t14 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t15);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t20 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t21, GetLocal(m, old_size + 19));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 22));
 
     call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 22));
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 23);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_verify (arg0: Value, arg1: Reference) returns (ret0: Value)
@@ -1383,7 +1640,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -1393,47 +1653,64 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdAddr(173345816);
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 3);
     if (!b#Boolean(tmp)) { goto Label_7; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_7:
     call tmp := LdTrue();
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Boolean(GetLocal(m, old_size + 5));
 
     call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 7));
 
     call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraCoin_initialize_verify () returns ()
@@ -1452,7 +1729,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -1462,19 +1742,28 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdAddr(173345816);
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_market_cap_verify () returns (ret0: Value)
@@ -1491,7 +1780,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -1501,15 +1793,22 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 0));
 
     call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 1);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_zero_verify () returns (ret0: Value)
@@ -1528,7 +1827,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -1538,17 +1840,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraCoin_T_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_value_verify (arg0: Reference) returns (ret0: Value)
@@ -1571,7 +1881,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -1584,28 +1897,40 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t3 := BorrowLoc(old_size+0);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
     assume is#Vector(t5);
 
     m := UpdateLocal(m, old_size + 5, t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 6);
     ret1 := GetLocal(m, old_size + 7);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
 }
 
 procedure LibraCoin_split_verify (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
@@ -1638,7 +1963,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#Integer(arg1);
@@ -1650,64 +1978,88 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := BorrowField(t3, LibraCoin_T_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t4);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 9);
     if (!b#Boolean(tmp)) { goto Label_11; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(10);
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_11:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t14 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := BorrowField(t14, LibraCoin_T_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t15, GetLocal(m, old_size + 13));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 16));
 
     call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 17);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_withdraw_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
@@ -1727,7 +2079,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -1740,18 +2095,27 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t2 := BorrowLoc(old_size+0);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 4);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraCoin_join_verify (arg0: Value, arg1: Value) returns (ret0: Value)
@@ -1780,7 +2144,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#Vector(arg1);
@@ -1792,45 +2159,62 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraCoin_T_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t5);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
     assume is#Integer(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t13 := BorrowField(t12, LibraCoin_T_value);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t13, GetLocal(m, old_size + 11));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraCoin_deposit_verify (arg0: Reference, arg1: Value) returns ()
@@ -1854,7 +2238,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -1866,38 +2253,52 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
     assume is#Integer(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 7);
     if (!b#Boolean(tmp)) { goto Label_10; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(11);
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_10:
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraCoin_destroy_zero_verify (arg0: Value) returns ()
@@ -1942,7 +2343,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -1954,83 +2358,107 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 6));
     assume is#ByteArray(t7);
 
     m := UpdateLocal(m, old_size + 7, t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 8));
 
     call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := BorrowLoc(old_size+2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
     assume is#Vector(t12);
 
     m := UpdateLocal(m, old_size + 12, t12);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t13 := BorrowLoc(old_size+2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
     assume is#Vector(t15);
 
     m := UpdateLocal(m, old_size + 15, t15);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t16 := LibraCoin_zero();
     assume is#Vector(t16);
 
     m := UpdateLocal(m, old_size + 16, t16);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 24, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#ByteArray(GetLocal(m, old_size + 17));
 
@@ -2050,10 +2478,16 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20), GetLocal(m, old_size + 21), GetLocal(m, old_size + 22), GetLocal(m, old_size + 23), GetLocal(m, old_size + 24));
     m := UpdateLocal(m, old_size + 25, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 25);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_make_verify (arg0: Value) returns (ret0: Value)
@@ -2073,7 +2507,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -2087,16 +2524,24 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     // unimplemented instruction
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_deposit_verify (arg0: Value, arg1: Value) returns ()
@@ -2145,7 +2590,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -2160,61 +2608,81 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t7 := BorrowLoc(old_size+1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := LibraCoin_value(t7);
     assume is#Integer(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Gt(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 11));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 12);
     if (!b#Boolean(tmp)) { goto Label_10; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(7);
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_10:
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 14));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t16 := BorrowGlobal(GetLocal(m, old_size + 15), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t16);
+    if (abort_flag) { goto Label_Abort; }
 
     call t17 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call t18 := BorrowField(t17, LibraAccount_T_sent_events);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 19));
 
@@ -2224,37 +2692,51 @@ Label_10:
 
     call tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(m, old_size + 19), GetLocal(m, old_size + 20), GetLocal(m, old_size + 21));
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t18, GetLocal(m, old_size + 22));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t24 := BorrowGlobal(GetLocal(m, old_size + 23), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t24);
+    if (abort_flag) { goto Label_Abort; }
 
     call t25 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call t26 := BorrowField(t25, LibraAccount_T_balance);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 27, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraCoin_deposit(t26, GetLocal(m, old_size + 27));
+    if (abort_flag) { goto Label_Abort; }
 
     call t28 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call t29 := BorrowField(t28, LibraAccount_T_received_events);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 30, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 31, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 32, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 30));
 
@@ -2264,11 +2746,17 @@ Label_10:
 
     call tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(m, old_size + 30), GetLocal(m, old_size + 31), GetLocal(m, old_size + 32));
     m := UpdateLocal(m, old_size + 33, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t29, GetLocal(m, old_size + 33));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_deposit_with_metadata_verify (arg0: Value, arg1: Value, arg2: Value) returns ()
@@ -2292,7 +2780,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -2306,37 +2797,51 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Exists(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 4);
     if (!b#Boolean(tmp)) { goto Label_6; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_create_account(GetLocal(m, old_size + 5));
+    if (abort_flag) { goto Label_Abort; }
 
 Label_6:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := LibraCoin_mint_with_default_capability(GetLocal(m, old_size + 7));
     assume is#Vector(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_deposit(GetLocal(m, old_size + 6), GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_mint_to_address_verify (arg0: Value, arg1: Value) returns ()
@@ -2359,7 +2864,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#Integer(arg1);
@@ -2371,26 +2879,37 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := BorrowField(t3, LibraAccount_T_balance);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := LibraCoin_withdraw(t4, GetLocal(m, old_size + 5));
     assume is#Vector(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 7);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_account_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
@@ -2416,7 +2935,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -2428,42 +2950,59 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t5);
     assume is#Boolean(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 6);
     if (!b#Boolean(tmp)) { goto Label_9; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(11);
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(m, old_size + 9));
     assume is#Vector(t10);
 
     m := UpdateLocal(m, old_size + 10, t10);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 10);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (arg0: Value) returns (ret0: Value)
@@ -2488,7 +3027,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#Integer(arg1);
@@ -2500,31 +3042,44 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t4);
     assume is#Address(tmp);
 
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(m, old_size + 8));
     assume is#Vector(t9);
 
     m := UpdateLocal(m, old_size + 9, t9);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 9);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
@@ -2554,7 +3109,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -2564,57 +3122,80 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := BorrowField(t6, LibraAccount_T_delegated_withdrawal_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t8);
     assume is#Boolean(tmp);
 
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 9);
     if (!b#Boolean(tmp)) { goto Label_13; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(11);
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_13:
     call tmp := LdTrue();
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t12, GetLocal(m, old_size + 11));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Address(GetLocal(m, old_size + 13));
 
     call tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 13));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 14);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
@@ -2639,7 +3220,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -2651,33 +3235,47 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 3));
     assume is#Address(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t9, GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_restore_withdrawal_capability_verify (arg0: Value) returns ()
@@ -2703,7 +3301,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -2719,40 +3320,55 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Exists(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 5);
     if (!b#Boolean(tmp)) { goto Label_6; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_create_account(GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
 
 Label_6:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := LibraAccount_withdraw_from_sender(GetLocal(m, old_size + 8));
     assume is#Vector(t9);
 
     m := UpdateLocal(m, old_size + 9, t9);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 7), GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (arg0: Value, arg1: Value, arg2: Value) returns ()
@@ -2772,7 +3388,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -2786,16 +3405,24 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     // unimplemented instruction
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_pay_from_sender_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_verify (arg0: Value, arg1: Value) returns ()
@@ -2815,7 +3442,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#ByteArray(arg1);
@@ -2828,15 +3458,23 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t4, GetLocal(m, old_size + 2));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (arg0: Reference, arg1: Value) returns ()
@@ -2861,7 +3499,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#ByteArray(arg0);
@@ -2873,38 +3514,54 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t5);
     assume is#Boolean(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 6);
     if (!b#Boolean(tmp)) { goto Label_9; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(11);
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(m, old_size + 9));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_verify (arg0: Value) returns ()
@@ -2926,7 +3583,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#ByteArray(arg1);
@@ -2938,23 +3598,33 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t3);
     assume is#Address(tmp);
 
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (arg0: Reference, arg1: Value) returns ()
@@ -2982,7 +3652,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -2992,53 +3665,74 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := BorrowGlobal(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t6);
     assume is#Boolean(tmp);
 
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 7);
     if (!b#Boolean(tmp)) { goto Label_11; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(11);
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_11:
     call tmp := LdTrue();
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t10, GetLocal(m, old_size + 9));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Address(GetLocal(m, old_size + 11));
 
     call tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 11));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 12);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
@@ -3063,7 +3757,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -3075,33 +3772,47 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 3));
     assume is#Address(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t9, GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_restore_key_rotation_capability_verify (arg0: Value) returns ()
@@ -3135,7 +3846,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3147,62 +3861,79 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 2));
 
     call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 5));
     assume is#ByteArray(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := LibraCoin_zero();
     assume is#Vector(t7);
 
     m := UpdateLocal(m, old_size + 7, t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := BorrowLoc(old_size+1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
     assume is#Vector(t12);
 
     m := UpdateLocal(m, old_size + 12, t12);
+    if (abort_flag) { goto Label_Abort; }
 
     call t13 := BorrowLoc(old_size+1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
     assume is#Vector(t15);
 
     m := UpdateLocal(m, old_size + 15, t15);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#ByteArray(GetLocal(m, old_size + 6));
 
@@ -3222,11 +3953,17 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 12), GetLocal(m, old_size + 15), GetLocal(m, old_size + 16), GetLocal(m, old_size + 17));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_save_account(GetLocal(m, old_size + 4), GetLocal(m, old_size + 18));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_create_account_verify (arg0: Value) returns ()
@@ -3249,7 +3986,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3263,32 +4003,45 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_create_account(GetLocal(m, old_size + 2));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Gt(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 5);
     if (!b#Boolean(tmp)) { goto Label_9; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_pay_from_sender(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
 
 Label_9:
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_create_new_account_verify (arg0: Value, arg1: Value) returns ()
@@ -3309,7 +4062,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -3319,23 +4075,33 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_balance);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := LibraCoin_value(t3);
     assume is#Integer(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 5);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_for_account_verify (arg0: Reference) returns (ret0: Value)
@@ -3354,7 +4120,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3366,17 +4135,25 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_balance_for_account(t2);
     assume is#Integer(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_verify (arg0: Value) returns (ret0: Value)
@@ -3395,7 +4172,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -3405,17 +4185,25 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t2);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (arg0: Reference) returns (ret0: Value)
@@ -3434,7 +4222,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3446,17 +4237,25 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
     assume is#Integer(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_verify (arg0: Value) returns (ret0: Value)
@@ -3476,7 +4275,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3488,19 +4290,28 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t3);
     assume is#Boolean(tmp);
 
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 4);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (arg0: Value) returns (ret0: Value)
@@ -3520,7 +4331,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3532,19 +4346,28 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t3);
     assume is#Boolean(tmp);
 
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 4);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (arg0: Value) returns (ret0: Value)
@@ -3562,7 +4385,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -3572,12 +4398,19 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraAccount_WithdrawalCapability_account_address);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := t2;
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultReference;
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (arg0: Reference) returns (ret0: Reference)
@@ -3595,7 +4428,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -3605,12 +4441,19 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraAccount_KeyRotationCapability_account_address);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := t2;
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultReference;
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (arg0: Reference) returns (ret0: Reference)
@@ -3628,7 +4471,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -3640,13 +4486,20 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Exists(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 2);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_exists_verify (arg0: Value) returns (ret0: Value)
@@ -3711,7 +4564,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -3729,172 +4585,232 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Exists(GetLocal(m, old_size + 11), LibraAccount_T_type_value());
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 13);
     if (!b#Boolean(tmp)) { goto Label_8; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(5);
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_8:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t16 := BorrowGlobal(GetLocal(m, old_size + 15), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t16);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t18 := Hash_sha3_256(GetLocal(m, old_size + 17));
     assume is#ByteArray(t18);
 
     m := UpdateLocal(m, old_size + 18, t18);
+    if (abort_flag) { goto Label_Abort; }
 
     call t19 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t20);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 21)));
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 22));
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 23);
     if (!b#Boolean(tmp)) { goto Label_21; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 24, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_21:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 25, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 26, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Mul(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
     m := UpdateLocal(m, old_size + 27, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 27));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t28 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t29 := FreezeRef(t28);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t29);
+    if (abort_flag) { goto Label_Abort; }
 
     call t30 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call t31 := LibraAccount_balance_for_account(t30);
     assume is#Integer(t31);
 
     m := UpdateLocal(m, old_size + 31, t31);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 31));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 32, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 33, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Ge(GetLocal(m, old_size + 32), GetLocal(m, old_size + 33));
     m := UpdateLocal(m, old_size + 34, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 34));
     m := UpdateLocal(m, old_size + 35, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 35);
     if (!b#Boolean(tmp)) { goto Label_38; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(6);
     m := UpdateLocal(m, old_size + 36, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_38:
     call t37 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t38);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 39, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 39));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 40, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 41, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Ge(GetLocal(m, old_size + 40), GetLocal(m, old_size + 41));
     m := UpdateLocal(m, old_size + 42, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 42));
     m := UpdateLocal(m, old_size + 43, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 43);
     if (!b#Boolean(tmp)) { goto Label_49; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(3);
     m := UpdateLocal(m, old_size + 44, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_49:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 45, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 46, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 45), GetLocal(m, old_size + 46)));
     m := UpdateLocal(m, old_size + 47, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 47));
     m := UpdateLocal(m, old_size + 48, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 48);
     if (!b#Boolean(tmp)) { goto Label_56; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(4);
     m := UpdateLocal(m, old_size + 49, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_56:
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_prologue_verify (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
@@ -3946,7 +4862,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -3964,106 +4883,147 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := BorrowGlobal(GetLocal(m, old_size + 9), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t10);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Sub(GetLocal(m, old_size + 12), GetLocal(m, old_size + 13));
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Mul(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t16 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call t17 := FreezeRef(t16);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t17);
+    if (abort_flag) { goto Label_Abort; }
 
     call t18 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call t19 := LibraAccount_balance_for_account(t18);
     assume is#Integer(t19);
 
     m := UpdateLocal(m, old_size + 19, t19);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Ge(GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 21));
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 22);
     if (!b#Boolean(tmp)) { goto Label_20; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(6);
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_20:
     call t24 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 25, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(m, old_size + 25));
     assume is#Vector(t26);
 
     m := UpdateLocal(m, old_size + 26, t26);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 26));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 27, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 28, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
     m := UpdateLocal(m, old_size + 29, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t30 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t31, GetLocal(m, old_size + 29));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdAddr(4078);
     m := UpdateLocal(m, old_size + 32, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t33 := BorrowGlobal(GetLocal(m, old_size + 32), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t33);
+    if (abort_flag) { goto Label_Abort; }
 
     call t34 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call t35 := BorrowField(t34, LibraAccount_T_balance);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 36, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraCoin_deposit(t35, GetLocal(m, old_size + 36));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_epilogue_verify (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
@@ -4100,7 +5060,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#Address(arg1);
@@ -4112,74 +5075,100 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t6 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := BorrowField(t6, LibraAccount_EventHandleGenerator_counter);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t7);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t9 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 8));
     assume is#ByteArray(t9);
 
     m := UpdateLocal(m, old_size + 9, t9);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t10);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := U64Util_u64_to_bytes(GetLocal(m, old_size + 11));
     assume is#ByteArray(t12);
 
     m := UpdateLocal(m, old_size + 12, t12);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t13 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t13);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t17 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t17, GetLocal(m, old_size + 16));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t20 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19));
     assume is#ByteArray(t20);
 
     m := UpdateLocal(m, old_size + 20, t20);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 21);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_fresh_guid_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
@@ -4201,7 +5190,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
         assume is#Address(arg1);
@@ -4214,16 +5206,20 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := LibraAccount_fresh_guid(t3, GetLocal(m, old_size + 4));
     assume is#ByteArray(t5);
 
     m := UpdateLocal(m, old_size + 5, t5);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 2));
 
@@ -4231,10 +5227,16 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(m, old_size + 2), GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 6);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, arg0: Reference, arg1: Value) returns (ret0: Value)
@@ -4257,7 +5259,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -4267,26 +5272,38 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_event_generator);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := GetTxnSenderAddress();
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(m, old_size + 6));
     assume is#Vector(t7);
 
     m := UpdateLocal(m, old_size + 7, t7);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 7);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
@@ -4319,7 +5336,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -4330,57 +5350,79 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t5);
     assume is#ByteArray(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t7 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8 := BorrowField(t7, LibraAccount_EventHandle_counter);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t8);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t10 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t10);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call LibraAccount_write_to_event_store(tv0, GetLocal(m, old_size + 9), GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
+    if (abort_flag) { goto Label_Abort; }
 
     call t13 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t13);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t17 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t17, GetLocal(m, old_size + 16));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, arg0: Reference, arg1: Value) returns ()
@@ -4401,7 +5443,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -4413,6 +5458,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(m, old_size + 3));
     assume is#Integer(t4);
@@ -4421,15 +5467,22 @@ requires ExistsTxnSenderAccount(m, txn);
 
     m := UpdateLocal(m, old_size + 4, t4);
     m := UpdateLocal(m, old_size + 5, t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, arg0: Value) returns ()

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -36,7 +36,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -47,13 +50,20 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(10);
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t0);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t2, GetLocal(m, old_size + 1));
+    if (abort_flag) { goto Label_Abort; }
 
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestReference_mut_b_verify (arg0: Reference) returns ()
@@ -80,7 +90,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -90,51 +103,71 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(20);
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowLoc(old_size+0);
+    if (abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call TestReference_mut_b(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t1);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t5);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(10);
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8)));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 10);
     if (!b#Boolean(tmp)) { goto Label_16; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_16:
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestReference_mut_ref_verify () returns ()

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -68,7 +68,10 @@ ensures (b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1))))) && !(b#Boo
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
@@ -82,22 +85,32 @@ ensures (b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1))))) && !(b#Boo
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 6);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestSpecs_div_verify (arg0: Value, arg1: Value) returns (ret0: Value)
@@ -114,7 +127,10 @@ ensures !(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Addres
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -123,7 +139,11 @@ ensures !(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Addres
 
     // bytecode translation starts here
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestSpecs_create_resource_verify () returns ()
@@ -139,7 +159,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -148,7 +171,11 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // bytecode translation starts here
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestSpecs_select_from_global_resource_verify () returns ()
@@ -166,7 +193,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -178,10 +208,16 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 1);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestSpecs_select_from_resource_verify (arg0: Value) returns (ret0: Value)
@@ -199,7 +235,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -211,10 +250,16 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 1);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestSpecs_select_from_resource_nested_verify (arg0: Value) returns (ret0: Value)
@@ -232,7 +277,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -244,10 +292,16 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 1);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestSpecs_select_from_global_resource_dynamic_address_verify (arg0: Value) returns (ret0: Value)
@@ -265,7 +319,10 @@ ensures b#Boolean(Boolean((SelectField(SelectField(Dereference(m, arg0), TestSpe
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
 
@@ -275,7 +332,11 @@ ensures b#Boolean(Boolean((SelectField(SelectField(Dereference(m, arg0), TestSpe
 
     // bytecode translation starts here
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure TestSpecs_select_from_reference_verify (arg0: Reference) returns ()

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-verify.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-verify.bpl
@@ -1,0 +1,301 @@
+
+
+// ** structs of module TestSpecs
+
+const unique TestSpecs_R: TypeName;
+const TestSpecs_R_x: FieldName;
+axiom TestSpecs_R_x == 0;
+function TestSpecs_R_type_value(): TypeValue {
+    StructType(TestSpecs_R, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_TestSpecs_R(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_TestSpecs_R(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, TestSpecs_R_x);
+}
+
+
+
+// ** functions of module TestSpecs
+
+procedure {:inline 1} TestSpecs_create_resource () returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
+ensures !(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> !abort_flag;
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // BooleanType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // TestSpecs_R_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := Exists(GetLocal(m, old_size + 0), TestSpecs_R_type_value());
+    m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    tmp := GetLocal(m, old_size + 1);
+    if (!b#Boolean(tmp)) { goto Label_5; }
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
+
+Label_5:
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    assume is#Integer(GetLocal(m, old_size + 3));
+
+    call tmp := Pack_TestSpecs_R(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call MoveToSender(TestSpecs_R_type_value(), GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+    if (abort_flag) { goto Label_Abort; }
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure TestSpecs_create_resource_verify () returns ()
+{
+    call TestSpecs_create_resource();
+}
+
+procedure {:inline 1} TestSpecs_create_resource_error () returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
+ensures !(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> !abort_flag;
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // BooleanType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // TestSpecs_R_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 0, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := Exists(GetLocal(m, old_size + 0), TestSpecs_R_type_value());
+    m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    tmp := GetLocal(m, old_size + 1);
+    if (!b#Boolean(tmp)) { goto Label_5; }
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
+
+Label_5:
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    assume is#Integer(GetLocal(m, old_size + 3));
+
+    call tmp := Pack_TestSpecs_R(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call MoveToSender(TestSpecs_R_type_value(), GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+    if (abort_flag) { goto Label_Abort; }
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure TestSpecs_create_resource_error_verify () returns ()
+{
+    call TestSpecs_create_resource_error();
+}
+
+procedure {:inline 1} TestSpecs_div_by_zero (arg0: Value, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !old(b#Boolean(Boolean(i#Integer(arg1) > i#Integer(Integer(0))))) ==> abort_flag;
+ensures (b#Boolean(Boolean(i#Integer(arg1) > i#Integer(Integer(0))))) ==> !abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 7;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    ret0 := GetLocal(m, old_size + 6);
+    return;
+    if (abort_flag) { goto Label_Abort; }
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestSpecs_div_by_zero_verify (arg0: Value, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := TestSpecs_div_by_zero(arg0, arg1);
+}
+
+procedure {:inline 1} TestSpecs_div_by_zero_error (arg0: Value, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !old(b#Boolean(Boolean(true))) ==> abort_flag;
+ensures (b#Boolean(Boolean(true))) ==> !abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 7;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
+
+    ret0 := GetLocal(m, old_size + 6);
+    return;
+    if (abort_flag) { goto Label_Abort; }
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestSpecs_div_by_zero_error_verify (arg0: Value, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := TestSpecs_div_by_zero_error(arg0, arg1);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -109,7 +109,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Vector(arg0);
@@ -123,14 +126,22 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 2);
     ret1 := GetLocal(m, old_size + 3);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
 }
 
 procedure TestStruct_identity_verify (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
@@ -165,7 +176,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -177,72 +191,101 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Exists(GetLocal(m, old_size + 5), TestStruct_T_type_value());
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 8);
     if (!b#Boolean(tmp)) { goto Label_8; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_8:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t11 := BorrowGlobal(GetLocal(m, old_size + 10), TestStruct_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t11);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     // unimplemented instruction
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t14 := BorrowGlobal(GetLocal(m, old_size + 13), TestStruct_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t14);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     // unimplemented instruction
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 16, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := MoveFrom(GetLocal(m, old_size + 16), TestStruct_T_type_value());
     m := UpdateLocal(m, old_size + 17, tmp);
     assume is#Vector(t17);
 
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 17));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call MoveToSender(TestStruct_T_type_value(), GetLocal(m, old_size + 18));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 19);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestStruct_module_builtins_verify (arg0: Value) returns (ret0: Value)
@@ -281,7 +324,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -293,15 +339,19 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdFalse();
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 6);
     if (!b#Boolean(tmp)) { goto Label_7; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Address(GetLocal(m, old_size + 7));
 
@@ -309,18 +359,23 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_TestStruct_B(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     goto Label_11;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_7:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Address(GetLocal(m, old_size + 10));
 
@@ -328,58 +383,81 @@ Label_7:
 
     call tmp := Pack_TestStruct_B(GetLocal(m, old_size + 10), GetLocal(m, old_size + 11));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
 Label_11:
     call t13 := BorrowLoc(old_size+2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t13);
+    if (abort_flag) { goto Label_Abort; }
 
     call t14 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := BorrowField(t14, TestStruct_B_val);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t15);
+    if (abort_flag) { goto Label_Abort; }
 
     call t16 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t16);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 17, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 17));
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 19, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19)));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 21);
     if (!b#Boolean(tmp)) { goto Label_26; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 22, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_26:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 23, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 23);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestStruct_nested_struct_verify (arg0: Value) returns (ret0: Value)
@@ -410,7 +488,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Address(arg0);
@@ -422,9 +503,11 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 4, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 5, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Address(GetLocal(m, old_size + 4));
 
@@ -432,12 +515,15 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_TestStruct_B(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     m := UpdateLocal(m, old_size + 6, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
     m := UpdateLocal(m, old_size + 2, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t8, t9 := Unpack_TestStruct_B(GetLocal(m, old_size + 7));
     assume is#Address(t8);
@@ -446,40 +532,56 @@ requires ExistsTxnSenderAccount(m, txn);
 
     m := UpdateLocal(m, old_size + 8, t8);
     m := UpdateLocal(m, old_size + 9, t9);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 3, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 10), GetLocal(m, old_size + 11)));
     m := UpdateLocal(m, old_size + 12, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 12));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 13);
     if (!b#Boolean(tmp)) { goto Label_15; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 14, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_15:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 15, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     ret0 := GetLocal(m, old_size + 15);
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
 }
 
 procedure TestStruct_try_unpack_verify (arg0: Value) returns (ret0: Value)

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -94,7 +94,10 @@ requires ExistsTxnSenderAccount(m, txn);
 
     var tmp: Value;
     var old_size: int;
+
+    var saved_m: Memory;
     assume !abort_flag;
+    saved_m := m;
 
     // assume arguments are of correct types
     assume is#Boolean(arg0);
@@ -106,9 +109,11 @@ requires ExistsTxnSenderAccount(m, txn);
     // bytecode translation starts here
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 9, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(0);
     m := UpdateLocal(m, old_size + 10, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     assume is#Integer(GetLocal(m, old_size + 9));
 
@@ -116,202 +121,278 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call tmp := Pack_Test3_T(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     m := UpdateLocal(m, old_size + 11, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 11));
     m := UpdateLocal(m, old_size + 1, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t12 := BorrowLoc(old_size+1);
+    if (abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t12);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 13, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 13);
     if (!b#Boolean(tmp)) { goto Label_12; }
+    if (abort_flag) { goto Label_Abort; }
 
     call t14 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t15 := BorrowField(t14, Test3_T_f);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t15);
+    if (abort_flag) { goto Label_Abort; }
 
     goto Label_15;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_12:
     call t16 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t17 := BorrowField(t16, Test3_T_g);
+    if (abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t17);
+    if (abort_flag) { goto Label_Abort; }
 
 Label_15:
     call tmp := LdConst(10);
     m := UpdateLocal(m, old_size + 18, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t19 := CopyOrMoveRef(t3);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t19, GetLocal(m, old_size + 18));
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 20, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 21, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 21);
     if (!b#Boolean(tmp)) { goto Label_25; }
+    if (abort_flag) { goto Label_Abort; }
 
     call t22 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t23 := BorrowField(t22, Test3_T_f);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t23);
+    if (abort_flag) { goto Label_Abort; }
 
     goto Label_28;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_25:
     call t24 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t25 := BorrowField(t24, Test3_T_g);
+    if (abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t25);
+    if (abort_flag) { goto Label_Abort; }
 
 Label_28:
     call tmp := LdConst(20);
     m := UpdateLocal(m, old_size + 26, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t27 := CopyOrMoveRef(t4);
+    if (abort_flag) { goto Label_Abort; }
 
     call WriteRef(t27, GetLocal(m, old_size + 26));
+    if (abort_flag) { goto Label_Abort; }
 
     call t28 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t29 := BorrowField(t28, Test3_T_f);
+    if (abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t29);
+    if (abort_flag) { goto Label_Abort; }
 
     call t30 := CopyOrMoveRef(t2);
+    if (abort_flag) { goto Label_Abort; }
 
     call t31 := BorrowField(t30, Test3_T_g);
+    if (abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t31);
+    if (abort_flag) { goto Label_Abort; }
 
     call t32 := CopyOrMoveRef(t5);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t32);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 33, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 33));
     m := UpdateLocal(m, old_size + 7, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call t34 := CopyOrMoveRef(t6);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := ReadRef(t34);
     assume is#Integer(tmp);
 
     m := UpdateLocal(m, old_size + 35, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 35));
     m := UpdateLocal(m, old_size + 8, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 36, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 36);
     if (!b#Boolean(tmp)) { goto Label_60; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 37, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(10);
     m := UpdateLocal(m, old_size + 38, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 37), GetLocal(m, old_size + 38)));
     m := UpdateLocal(m, old_size + 39, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 39));
     m := UpdateLocal(m, old_size + 40, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 40);
     if (!b#Boolean(tmp)) { goto Label_52; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 41, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_52:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 42, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(20);
     m := UpdateLocal(m, old_size + 43, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 42), GetLocal(m, old_size + 43)));
     m := UpdateLocal(m, old_size + 44, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 44));
     m := UpdateLocal(m, old_size + 45, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 45);
     if (!b#Boolean(tmp)) { goto Label_59; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 46, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_59:
     goto Label_74;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_60:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
     m := UpdateLocal(m, old_size + 47, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(20);
     m := UpdateLocal(m, old_size + 48, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 47), GetLocal(m, old_size + 48)));
     m := UpdateLocal(m, old_size + 49, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 49));
     m := UpdateLocal(m, old_size + 50, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 50);
     if (!b#Boolean(tmp)) { goto Label_67; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 51, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_67:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
     m := UpdateLocal(m, old_size + 52, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(10);
     m := UpdateLocal(m, old_size + 53, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := Boolean(IsEqual(GetLocal(m, old_size + 52), GetLocal(m, old_size + 53)));
     m := UpdateLocal(m, old_size + 54, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := Not(GetLocal(m, old_size + 54));
     m := UpdateLocal(m, old_size + 55, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
     tmp := GetLocal(m, old_size + 55);
     if (!b#Boolean(tmp)) { goto Label_74; }
+    if (abort_flag) { goto Label_Abort; }
 
     call tmp := LdConst(42);
     m := UpdateLocal(m, old_size + 56, tmp);
+    if (abort_flag) { goto Label_Abort; }
 
-    assert false;
+    goto Label_Abort;
+    if (abort_flag) { goto Label_Abort; }
 
 Label_74:
     return;
+    if (abort_flag) { goto Label_Abort; }
 
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
 }
 
 procedure Test3_test3_verify (arg0: Value) returns ()

--- a/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
@@ -8,62 +8,76 @@ fn std_mvir(b: &str) -> String {
     format!("../../stdlib/modules/{}.mvir", b)
 }
 
+const NO_VERIFY: &[&str] = &["-B=-noVerify"];
+const VERIFY: &[&str] = &[];
+
 #[test]
 fn test3() {
-    test(&["test_mvir/test3.mvir"]);
+    test(NO_VERIFY, &["test_mvir/test3.mvir"]);
 }
 
 #[test]
 fn test_arithmetic() {
-    test(&["test_mvir/test-arithmetic.mvir"]);
+    test(NO_VERIFY, &["test_mvir/test-arithmetic.mvir"]);
 }
 
 #[test]
 fn test_control_flow() {
-    test(&["test_mvir/test-control-flow.mvir"]);
+    test(NO_VERIFY, &["test_mvir/test-control-flow.mvir"]);
 }
 
 #[test]
 fn test_func_call() {
-    test(&["test_mvir/test-func-call.mvir"]);
+    test(NO_VERIFY, &["test_mvir/test-func-call.mvir"]);
 }
 
 #[test]
 fn test_reference() {
-    test(&["test_mvir/test-reference.mvir"]);
+    test(NO_VERIFY, &["test_mvir/test-reference.mvir"]);
 }
 
 #[test]
 fn test_struct() {
-    test(&["test_mvir/test-struct.mvir"]);
+    test(NO_VERIFY, &["test_mvir/test-struct.mvir"]);
 }
 
 #[test]
 fn test_lib() {
-    test(&[
-        &std_mvir("vector"),
-        &std_mvir("u64_util"),
-        &std_mvir("address_util"),
-        &std_mvir("bytearray_util"),
-        &std_mvir("hash"),
-        &std_mvir("signature"),
-        &std_mvir("gas_schedule"),
-        &std_mvir("validator_config"),
-        &std_mvir("libra_coin"),
-        &std_mvir("libra_account"),
-        // TODO(wrwg): this currently fails with boogie compilation errors
-        //   call to undeclared procedure: Vector_contains (etc)
-        // &std_mvir("libra_system"),
-        "test_mvir/test-lib.mvir",
-    ]);
+    test(
+        NO_VERIFY,
+        &[
+            &std_mvir("vector"),
+            &std_mvir("u64_util"),
+            &std_mvir("address_util"),
+            &std_mvir("bytearray_util"),
+            &std_mvir("hash"),
+            &std_mvir("signature"),
+            &std_mvir("gas_schedule"),
+            &std_mvir("validator_config"),
+            &std_mvir("libra_coin"),
+            &std_mvir("libra_account"),
+            // TODO(wrwg): this currently fails with boogie compilation errors
+            //   call to undeclared procedure: Vector_contains (etc)
+            // &std_mvir("libra_system"),
+            "test_mvir/test-lib.mvir",
+        ],
+    );
 }
 
 #[test]
 fn test_generics() {
-    test(&[&std_mvir("vector"), "test_mvir/test-generics.mvir"]);
+    test(
+        NO_VERIFY,
+        &[&std_mvir("vector"), "test_mvir/test-generics.mvir"],
+    );
 }
 
 #[test]
-fn test_specs() {
-    test(&["test_mvir/test-specs.mvir"]);
+fn test_specs_translate() {
+    test(NO_VERIFY, &["test_mvir/test-specs-translate.mvir"]);
+}
+
+#[test]
+fn test_specs_verify() {
+    test(VERIFY, &["test_mvir/test-specs-verify.mvir"]);
 }


### PR DESCRIPTION
## Motivation

Getting first simple things work with actual proving:

- New test_mvir/test-specs-verify.mvir with simple prove targets
- Fixing treatment of abort in the translator
- Extending driver to recognize boogie errors. Extending test infra to allow expected boogie diagnosis to be annotated in the source.

The approach to deal with abort is:

- Have an exit goto label for abort.
- Goto this label when abort instructions is executed.
- After call of a procedure, check abort flag and goto abort label if set.
- Save global memory on procedure entry and restore in abort case.

## Test Plan

New test infra for checking verification results, and new test case.

## Related PRs

NA

