### PR TITLE
[Storage] Implement get_rightmost_leaf properly

### DIFF
--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -95,7 +95,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use tree_cache::TreeCache;
 
 /// The hardcoded maximum height of a [`JellyfishMerkleTree`] in nibbles.
-const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;
+pub const ROOT_NIBBLE_HEIGHT: usize = HashValue::LENGTH * 2;
 
 /// `TreeReader` defines the interface between
 /// [`JellyfishMerkleTree`](struct.JellyfishMerkleTree.html)

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 use anyhow::Result;
 use jellyfish_merkle::{
     node_type::{LeafNode, Node, NodeKey},
-    JellyfishMerkleTree, NodeBatch, TreeReader, TreeWriter,
+    JellyfishMerkleTree, NodeBatch, TreeReader, TreeWriter, ROOT_NIBBLE_HEIGHT,
 };
 use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
@@ -109,6 +109,32 @@ impl StateStore {
     pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
         JellyfishMerkleTree::new(self).get_root_hash(version)
     }
+
+    /// Finds the rightmost leaf by scanning the entire DB.
+    #[cfg(test)]
+    pub fn get_rightmost_leaf_naive(&self) -> Result<Option<(NodeKey, LeafNode)>> {
+        let mut ret = None;
+
+        let mut iter = self
+            .db
+            .iter::<JellyfishMerkleNodeSchema>(Default::default())?;
+        iter.seek_to_first();
+
+        while let Some((node_key, node)) = iter.next().transpose()? {
+            if let Node::Leaf(leaf_node) = node {
+                match ret {
+                    None => ret = Some((node_key, leaf_node)),
+                    Some(ref other) => {
+                        if leaf_node.account_key() > other.1.account_key() {
+                            ret = Some((node_key, leaf_node));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ret)
+    }
 }
 
 impl TreeReader for StateStore {
@@ -117,9 +143,64 @@ impl TreeReader for StateStore {
     }
 
     fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>> {
-        // TODO(wqfish): implement this for real. For now we just assume we never crash in the
-        // middle of restore, then this will only be called before anything is written to DB.
-        Ok(None)
+        // Since everything has the same version during restore, we seek to the first node and get
+        // its version.
+        let mut iter = self
+            .db
+            .iter::<JellyfishMerkleNodeSchema>(Default::default())?;
+        iter.seek_to_first();
+        let version = match iter.next().transpose()? {
+            Some((node_key, _node)) => node_key.version(),
+            None => return Ok(None),
+        };
+
+        // The encoding of key and value in DB looks like:
+        //
+        // | <-------------- key --------------> | <- value -> |
+        // | version | num_nibbles | nibble_path |    node     |
+        //
+        // Here version is fixed. For each num_nibbles, there could be a range of nibble paths
+        // of the same length. If one of them is the rightmost leaf R, it must be at the end of this
+        // range. Otherwise let's assume the R is in the middle of the range, so we
+        // call the node at the end of this range X:
+        //   1. If X is leaf, then X.account_key() > R.account_key(), because the nibble path is a
+        //      prefix of the account key. So R is not the rightmost leaf.
+        //   2. If X is internal node, then X must be on the right side of R, so all its children's
+        //      account keys are larger than R.account_key(). So R is not the rightmost leaf.
+        //
+        // Given that num_nibbles ranges from 0 to ROOT_NIBBLE_HEIGHT, there are only
+        // ROOT_NIBBLE_HEIGHT+1 ranges, so we can just find the node at the end of each range and
+        // then pick the one with the largest account key.
+        let mut ret = None;
+
+        for num_nibbles in 1..=ROOT_NIBBLE_HEIGHT + 1 {
+            let mut iter = self
+                .db
+                .iter::<JellyfishMerkleNodeSchema>(Default::default())?;
+            // nibble_path is always non-empty except for the root, so if we use an empty nibble
+            // path as the seek key, the iterator will end up pointing to the end of the previous
+            // range.
+            let seek_key = (version, num_nibbles as u8);
+            iter.seek_for_prev(&seek_key)?;
+
+            if let Some((node_key, node)) = iter.next().transpose()? {
+                debug_assert_eq!(node_key.version(), version);
+                debug_assert!(node_key.nibble_path().num_nibbles() < num_nibbles);
+
+                if let Node::Leaf(leaf_node) = node {
+                    match ret {
+                        None => ret = Some((node_key, leaf_node)),
+                        Some(ref other) => {
+                            if leaf_node.account_key() > other.1.account_key() {
+                                ret = Some((node_key, leaf_node));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ret)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Previously the implementation is incomplete and does not allow crash recovery during the restore process. Implementing this method means that if we crash in the middle of the restore process, we can find the rightmost leaf and resume from there.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

I forgot.

## Test Plan

CI.

## Related PRs

None.