### PR TITLE
[Swarm] Fix arguments to start client

### DIFF
--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -43,7 +43,6 @@ impl InteractiveClient {
         port: u16,
         faucet_key_file_path: &Path,
         mnemonic_file_path: &Path,
-        validator_set_file: String,
     ) -> Self {
         // We need to call canonicalize on the path because we are running client from
         // workspace root and the function calling new_with_inherit_io isn't necessarily
@@ -73,8 +72,6 @@ impl InteractiveClient {
                     )
                     .arg("-a")
                     .arg("localhost")
-                    .arg("-s")
-                    .arg(validator_set_file)
                     .stdin(Stdio::inherit())
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
@@ -88,7 +85,6 @@ impl InteractiveClient {
         port: u16,
         faucet_key_file_path: &Path,
         mnemonic_file_path: &Path,
-        validator_set_file: String,
     ) -> Self {
         Self {
             /// Note: For easier debugging it's convenient to see the output
@@ -117,8 +113,6 @@ impl InteractiveClient {
                     )
                     .arg("-a")
                     .arg("localhost")
-                    .arg("-s")
-                    .arg(validator_set_file)
                     .stdin(Stdio::piped())
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -78,18 +78,12 @@ fn main() {
 
     let faucet_key_file_path = &validator_swarm.config.faucet_key_path;
     let validator_config = NodeConfig::load(&validator_swarm.config.config_files[0]).unwrap();
-    let validator_set_file = validator_swarm
-        .dir
-        .as_ref()
-        .join("0")
-        .join(&validator_config.consensus.consensus_peers_file);
     println!("To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:");
     println!(
-        "\tcargo run --bin client -- -a localhost -p {} -s {:?} -m {:?}",
+        "\tcargo run --bin client -- -a localhost -p {} -m {:?}",
         validator_config
             .admission_control
             .admission_control_service_port,
-        validator_set_file,
         faucet_key_file_path,
     );
     let node_address_list = validator_swarm
@@ -114,11 +108,10 @@ fn main() {
         let full_node_config = NodeConfig::load(&swarm.config.config_files[0]).unwrap();
         println!("To connect to the full nodes you just spawned, use this command:");
         println!(
-            "\tcargo run --bin client -- -a localhost -p {} -s {:?} -m {:?}",
+            "\tcargo run --bin client -- -a localhost -p {} -m {:?}",
             full_node_config
                 .admission_control
                 .admission_control_service_port,
-            validator_set_file,
             faucet_key_file_path,
         );
     }
@@ -130,7 +123,6 @@ fn main() {
             validator_swarm.get_ac_port(0),
             Path::new(&faucet_key_file_path),
             &tmp_mnemonic_file.path(),
-            validator_set_file.into_os_string().into_string().unwrap(),
         );
         println!("Loading client...");
         let _output = client.output().expect("Failed to wait on child");


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It looks like https://github.com/libra/libra/pull/2002 removed `-s` argument for the client so I was unable to use the [instructions](https://developers.libra.org/docs/run-local-network#run-a-local-network) to run a client locally.

This change removes the extra argument and now

```
cargo run -p libra-swarm -- -s -n 4
```

succeeds.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Maybe.

## Test Plan

Run the command locally:

```
cargo run -p libra-swarm -- -s -n 4
```

## Related PRs

None.
