### PR TITLE
[language] Cleanup: remove execute_function_in_module from the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,8 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-e2e-tests 0.1.0",
+ "libra-config 0.1.0",
+ "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -17,6 +17,8 @@ mirai-annotations = "1.4.0"
 structopt = "0.3.2"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+libra-config = { path = "../../../config", version = "0.1.0" }
+libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 utils = { path = "../utils", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 vm-runtime = { path = "../../vm/vm-runtime", version = "0.1.0" }

--- a/language/vm/vm-runtime/src/lib.rs
+++ b/language/vm/vm-runtime/src/lib.rs
@@ -135,7 +135,6 @@ pub mod runtime;
 pub mod txn_executor;
 
 pub use libra_vm::LibraVM;
-pub use txn_executor::execute_function_in_module;
 
 use libra_config::config::VMConfig;
 use libra_state_view::StateView;

--- a/language/vm/vm-runtime/src/runtime.rs
+++ b/language/vm/vm-runtime/src/runtime.rs
@@ -60,7 +60,7 @@ impl<'alloc> VMRuntime<'alloc> {
         }
     }
 
-    pub(crate) fn load_gas_schedule(
+    pub fn load_gas_schedule(
         &self,
         data_cache: &mut BlockDataCache<'_>,
         state_view: &dyn StateView,


### PR DESCRIPTION
execute_function_in_module is used by the test generation only and it's a wrapper that
should live outside of the VM.
