### PR TITLE
[AC + SMP] redirect AC endpoint requests to shared mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,7 @@ dependencies = [
 name = "libra-mempool"
 version = "0.1.0"
 dependencies = [
+ "admission-control-proto 0.1.0",
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bounded-executor 0.1.0",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2142,6 +2143,7 @@ dependencies = [
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -181,6 +181,26 @@ impl NodeConfig {
         }
     }
 
+    /// Determines whether a node `peer_id` is an upstream peer of a node with this NodeConfig.
+    /// For a validator node, any of its validator peers are considered an upstream peer
+    /// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
+    /// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
+    /// Here, `network_id` is the ID of the network that the peer and this node belong to.
+    pub fn is_upstream_peer(&self, peer_id: PeerId, network_id: PeerId) -> bool {
+        match self.base.role {
+            RoleType::Validator => self
+                .validator_network
+                .as_ref()
+                .map(|cfg| cfg.peer_id == network_id)
+                .unwrap_or_default(),
+            RoleType::FullNode => self
+                .state_sync
+                .upstream_peers
+                .upstream_peers
+                .contains(&peer_id),
+        }
+    }
+
     /// Reads the config file and returns the configuration object in addition to doing some
     /// post-processing of the config
     /// Paths used in the config are either absolute or relative to the config location

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "0.2.8", features = ["full"] }
 tonic = "0.1"
 ttl_cache = "0.4.2"
 
+admission-control-proto = { path = "../admission_control/admission-control-proto", version = "0.1.0" }
 libra-mempool-shared-proto = { path = "mempool-shared-proto", version = "0.1.0" }
 bounded-executor = { path = "../common/bounded-executor", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
@@ -37,6 +38,7 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 rand = "0.6.5"
 channel = { path = "../common/channel", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+parity-multiaddr = { version = "0.6.0", default-features = false }
 
 [build-dependencies]
 tonic-build = "0.1"

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+// Increase recursion limit to allow for use of select! macro.
+#![recursion_limit = "1024"]
 
 //! Mempool is used to hold transactions that have been submitted but not yet agreed upon and
 //! executed.

--- a/mempool/src/runtime.rs
+++ b/mempool/src/runtime.rs
@@ -5,6 +5,11 @@ use crate::{
     core_mempool::CoreMempool, mempool_service::MempoolService, proto::mempool,
     shared_mempool::start_shared_mempool,
 };
+use admission_control_proto::proto::admission_control::{
+    SubmitTransactionRequest, SubmitTransactionResponse,
+};
+use anyhow::Result;
+use futures::channel::{mpsc::Receiver, oneshot};
 use libra_config::config::NodeConfig;
 use network::validator_network::{MempoolNetworkEvents, MempoolNetworkSender};
 use std::{
@@ -28,7 +33,11 @@ impl MempoolRuntime {
     pub fn bootstrap(
         config: &NodeConfig,
         network_sender: MempoolNetworkSender,
-        network_events: MempoolNetworkEvents,
+        network_events: Vec<MempoolNetworkEvents>,
+        ac_endpoint_listener: Receiver<(
+            SubmitTransactionRequest,
+            oneshot::Sender<Result<SubmitTransactionResponse>>,
+        )>,
     ) -> Self {
         let mempool_service_rt = Builder::new()
             .thread_name("mempool-service-")
@@ -55,6 +64,7 @@ impl MempoolRuntime {
             mempool,
             network_sender,
             network_events,
+            ac_endpoint_listener,
             storage_client,
             vm_validator,
             vec![],

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -39,7 +39,7 @@ use network::{
     validator_network::{Event, MempoolNetworkEvents, MempoolNetworkSender},
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     convert::{TryFrom, TryInto},
     ops::Deref,
     pin::Pin,
@@ -60,8 +60,10 @@ use vm_validator::vm_validator::{get_account_state, TransactionValidation};
 struct PeerSyncState {
     timeline_id: u64,
     is_alive: bool,
+    network_id: PeerId,
 }
 
+/// stores only peers that receive txns from this node
 type PeerInfo = HashMap<PeerId, PeerSyncState>;
 
 /// Outbound peer syncing event emitted by [`IntervalStream`].
@@ -84,11 +86,10 @@ where
     V: TransactionValidation + 'static,
 {
     mempool: Arc<Mutex<CoreMempool>>,
-    network_sender: MempoolNetworkSender,
     config: MempoolConfig,
+    network_senders: HashMap<PeerId, MempoolNetworkSender>,
     storage_read_client: Arc<dyn StorageRead>,
     validator: Arc<V>,
-    validator_peers: HashSet<PeerId>, // read-only and immutable, so thread-safe
     peer_info: Arc<Mutex<PeerInfo>>,
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
 }
@@ -110,7 +111,8 @@ fn default_timer(tick_ms: u64) -> IntervalStream {
 
 /// new peer discovery handler
 /// adds new entry to `peer_info`
-fn new_peer(peer_info: &Mutex<PeerInfo>, peer_id: PeerId) {
+/// `network_id` is the ID of the mempool network the peer belongs to
+fn new_peer(peer_info: &Mutex<PeerInfo>, peer_id: PeerId, network_id: PeerId) {
     peer_info
         .lock()
         .expect("[shared mempool] failed to acquire peer_info lock")
@@ -118,6 +120,7 @@ fn new_peer(peer_info: &Mutex<PeerInfo>, peer_id: PeerId) {
         .or_insert(PeerSyncState {
             timeline_id: 0,
             is_alive: true,
+            network_id,
         })
         .is_alive = true;
 }
@@ -138,7 +141,7 @@ fn lost_peer(peer_info: &Mutex<PeerInfo>, peer_id: PeerId) {
 async fn sync_with_peers<'a>(
     peer_info: &'a Mutex<PeerInfo>,
     mempool: &'a Mutex<CoreMempool>,
-    network_sender: &'a mut MempoolNetworkSender,
+    mut network_senders: HashMap<PeerId, MempoolNetworkSender>,
     batch_size: usize,
 ) {
     // Clone the underlying peer_info map and use this to sync and collect
@@ -149,7 +152,6 @@ async fn sync_with_peers<'a>(
         .expect("[shared mempool] failed to acquire peer_info lock")
         .deref()
         .clone();
-
     let mut state_updates = vec![];
 
     for (peer_id, peer_state) in peer_info_copy.into_iter() {
@@ -170,14 +172,11 @@ async fn sync_with_peers<'a>(
                     .map(|txn| txn.try_into().unwrap())
                     .collect();
 
-                trace!(
-                    "MempoolNetworkSender.send_to peer {} msg {:?}",
-                    peer_id,
-                    msg
-                );
                 // Since this is a direct-send, this will only error if the network
                 // module has unexpectedly crashed or shutdown.
+                let network_sender = network_senders.get_mut(&peer_state.network_id).unwrap();
                 network_sender
+                    .clone()
                     .send_to(peer_id, msg)
                     .await
                     .expect("[shared mempool] failed to direct-send mempool sync message");
@@ -211,28 +210,17 @@ fn convert_txn_from_proto(txn_proto: SignedTransactionProto) -> Option<SignedTra
     }
 }
 
-/// submits a list of SignedTransaction to the local mempool,
-/// and returns an AdmissionControlStatus if `is_ac_endpoint_submission`
-/// if `is_ac_endpoint_submission`, we expect a single transaction to be submitted
+/// submits a list of SignedTransaction to the local mempool
+/// and returns a vector containing AdmissionControlStatus
 async fn process_incoming_transactions<V>(
     smp: SharedMempool<V>,
-    peer_id: Option<PeerId>,
     transactions: Vec<SignedTransaction>,
-) -> Option<Status>
+    timeline_state: TimelineState,
+) -> Vec<Status>
 where
     V: TransactionValidation,
 {
-    let (peer_id, is_ac_endpoint_submission, timeline_state) = match peer_id {
-        Some(peer_id) => {
-            if smp.validator_peers.contains(&peer_id) {
-                (peer_id.to_string(), false, TimelineState::NonQualified)
-            } else {
-                (peer_id.to_string(), false, TimelineState::NotReady)
-            }
-        }
-        None => ("client".to_string(), true, TimelineState::NotReady),
-    };
-    let mut status = None;
+    let mut statuses = vec![];
 
     let account_states = join_all(
         transactions
@@ -252,7 +240,7 @@ where
                 }
             } else {
                 // failed to get transaction
-                status = Some(Status::VmStatus(VmStatusProto::from(
+                statuses.push(Status::VmStatus(VmStatusProto::from(
                     VMStatus::new(RESOURCE_DOES_NOT_EXIST)
                         .with_message("[shared mempool] failed to get account state".to_string()),
                 )));
@@ -260,9 +248,6 @@ where
             None
         })
         .collect();
-    if is_ac_endpoint_submission && status.is_some() {
-        return status;
-    }
 
     let validations = join_all(
         transactions
@@ -288,37 +273,27 @@ where
                     timeline_state,
                 );
                 OP_COUNTERS.inc(&format!(
-                    "smp.transactions.status.{:?}.{:?}",
-                    mempool_status.code, peer_id
+                    "smp.transactions.status.{:?}",
+                    mempool_status.code
                 ));
 
-                if is_ac_endpoint_submission {
-                    if mempool_status.code == MempoolAddTransactionStatusCode::Valid {
-                        status = Some(Status::AcStatus(AdmissionControlStatus::Accepted.into()));
-                    } else {
-                        status = Some(Status::MempoolStatus(
-                            MempoolAddTransactionStatusProto::from(mempool_status),
-                        ));
-                    }
+                if mempool_status.code == MempoolAddTransactionStatusCode::Valid {
+                    statuses.push(Status::AcStatus(AdmissionControlStatus::Accepted.into()));
+                } else {
+                    statuses.push(Status::MempoolStatus(
+                        MempoolAddTransactionStatusProto::from(mempool_status),
+                    ));
                 }
             } else if let Ok(Some(validation_status)) = &validations[idx] {
-                OP_COUNTERS.inc(&format!(
-                    "smp.transactions.status.validation_failed.{:?}",
-                    peer_id
-                ));
-                status = Some(Status::VmStatus(VmStatusProto::from(
+                OP_COUNTERS.inc("smp.transactions.status.validation_failed");
+                statuses.push(Status::VmStatus(VmStatusProto::from(
                     validation_status.clone(),
                 )));
             }
         }
     }
-
-    if !is_ac_endpoint_submission {
-        notify_subscribers(SharedMempoolNotification::NewTransactions, &smp.subscribers);
-        None
-    } else {
-        status
-    }
+    notify_subscribers(SharedMempoolNotification::NewTransactions, &smp.subscribers);
+    statuses
 }
 
 async fn process_client_transaction_submission<V>(
@@ -334,24 +309,21 @@ async fn process_client_transaction_submission<V>(
         .clone()
         .unwrap_or_else(SignedTransactionProto::default);
 
-    let transaction = convert_txn_from_proto(txn_proto);
     // get status from attempt to submit txns
-    match transaction {
+    match convert_txn_from_proto(txn_proto) {
         None => {
             response.status = Some(Status::AcStatus(
                 AdmissionControlStatus::Rejected("submit txn rejected".to_string()).into(),
             ));
         }
         Some(txn) => {
-            let result = process_incoming_transactions(smp.clone(), None, vec![txn]).await;
-            match result {
-                Some(status) => {
-                    response.status = Some(status);
-                }
-                None => {
-                    error!("[shared mempool] unexpected error happened");
-                    // TODO set unexpected error status code in response
-                }
+            let mut statuses =
+                process_incoming_transactions(smp.clone(), vec![txn], TimelineState::NotReady)
+                    .await;
+            if statuses.is_empty() {
+                error!("[shared mempool] unexpected error happened");
+            } else {
+                response.status = Some(statuses.remove(0));
             }
         }
     }
@@ -372,13 +344,13 @@ where
 {
     let peer_info = smp.peer_info;
     let mempool = smp.mempool;
-    let mut network_sender = smp.network_sender;
+    let network_senders = smp.network_senders;
     let batch_size = smp.config.shared_mempool_batch_size;
     let subscribers = smp.subscribers;
 
     while let Some(sync_event) = interval.next().await {
         trace!("SyncEvent: {:?}", sync_event);
-        sync_with_peers(&peer_info, &mempool, &mut network_sender, batch_size).await;
+        sync_with_peers(&peer_info, &mempool, network_senders.clone(), batch_size).await;
         notify_subscribers(SharedMempoolNotification::Sync, &subscribers);
     }
 
@@ -389,27 +361,30 @@ where
 async fn inbound_network_task<V>(
     smp: SharedMempool<V>,
     executor: Handle,
-    network_events: Vec<MempoolNetworkEvents>,
+    network_events: Vec<(PeerId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
         SubmitTransactionRequest,
         oneshot::Sender<Result<SubmitTransactionResponse>>,
     )>,
+    node_config: NodeConfig,
 ) where
     V: TransactionValidation,
 {
     let peer_info = smp.peer_info.clone();
     let subscribers = smp.subscribers.clone();
+    let smp_events: Vec<_> = network_events
+        .into_iter()
+        .map(|(network_id, events)| events.map(move |e| (network_id, e)))
+        .collect();
+    let mut events = select_all(smp_events).fuse();
 
     // Use a BoundedExecutor to restrict only `workers_available` concurrent
     // worker tasks that can process incoming transactions.
     let workers_available = smp.config.shared_mempool_max_concurrent_inbound_syncs;
     let bounded_executor = BoundedExecutor::new(workers_available, executor);
 
-    let mut events = select_all(network_events).fuse();
-
     loop {
         ::futures::select! {
-            // client events
             (mut msg, callback) = client_events.select_next_some() => {
                 bounded_executor
                 .spawn(process_client_transaction_submission(
@@ -418,46 +393,56 @@ async fn inbound_network_task<V>(
                     callback,
                 ))
                 .await;
-            }
-            event = events.select_next_some() => {
+            },
+            (network_id, event) = events.select_next_some() => {
                 match event {
-                    Ok(network_event) => match network_event {
-                        Event::NewPeer(peer_id) => {
-                            OP_COUNTERS.inc("smp.event.new_peer");
-                            new_peer(&peer_info, peer_id);
-                            notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
-                        }
-                        Event::LostPeer(peer_id) => {
-                            OP_COUNTERS.inc("smp.event.lost_peer");
-                            lost_peer(&peer_info, peer_id);
-                            notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
-                        }
-                        Event::Message((peer_id, msg)) => {
-                            OP_COUNTERS.inc("smp.event.message");
-                            let transactions: Vec<_> = msg
-                                .transactions
-                                .clone()
-                                .into_iter()
-                                .filter_map(|txn| convert_txn_from_proto(txn))
-                                .collect();
-                            OP_COUNTERS.inc_by(
-                                &format!("smp.transactions.received.{:?}", peer_id),
-                                transactions.len(),
-                            );
-                            bounded_executor
-                                .spawn(process_incoming_transactions(
-                                    smp.clone(),
-                                    Some(peer_id),
-                                    transactions,
-                                ))
-                                .await;
-                        }
-                        _ => {
-                            security_log(SecurityEvent::InvalidNetworkEventMP)
-                                .error("UnexpectedNetworkEvent")
-                                .data(&network_event)
-                                .log();
-                            debug_assert!(false, "Unexpected network event");
+                    Ok(network_event) => {
+                        match network_event {
+                            Event::NewPeer(peer_id) => {
+                                OP_COUNTERS.inc("smp.event.new_peer");
+                                if node_config.is_upstream_peer(peer_id, network_id) {
+                                    new_peer(&peer_info, peer_id, network_id);
+                                }
+                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
+                            }
+                            Event::LostPeer(peer_id) => {
+                                OP_COUNTERS.inc("smp.event.lost_peer");
+                                if node_config.is_upstream_peer(peer_id, network_id) {
+                                    lost_peer(&peer_info, peer_id);
+                                }
+                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
+                            }
+                            Event::Message((peer_id, msg)) => {
+                                OP_COUNTERS.inc("smp.event.message");
+                                let transactions: Vec<_> = msg
+                                    .transactions
+                                    .clone()
+                                    .into_iter()
+                                    .filter_map(|txn| convert_txn_from_proto(txn))
+                                    .collect();
+                                OP_COUNTERS.inc_by(
+                                    &format!("smp.transactions.received.{:?}", peer_id),
+                                    transactions.len(),
+                                );
+                                let timeline_state = match node_config.is_upstream_peer(peer_id, network_id) {
+                                    true => TimelineState::NonQualified,
+                                    false => TimelineState::NotReady
+                                };
+                                bounded_executor
+                                    .spawn(process_incoming_transactions(
+                                        smp.clone(),
+                                        transactions,
+                                        timeline_state,
+                                    ))
+                                    .await;
+                            }
+                            _ => {
+                                security_log(SecurityEvent::InvalidNetworkEventMP)
+                                    .error("UnexpectedNetworkEvent")
+                                    .data(&network_event)
+                                    .log();
+                                debug_assert!(false, "Unexpected network event");
+                            }
                         }
                     },
                     Err(e) => {
@@ -465,10 +450,12 @@ async fn inbound_network_task<V>(
                             .error(&e)
                             .log();
                     }
-                }
-            }
+                };
+            },
+            complete => break,
         }
     }
+    crit!("[shared mempool] inbound_network_task terminated");
 }
 
 /// GC all expired transactions by SystemTTL
@@ -492,9 +479,10 @@ async fn gc_task(mempool: Arc<Mutex<CoreMempool>>, gc_interval_ms: u64) {
 pub(crate) fn start_shared_mempool<V>(
     config: &NodeConfig,
     mempool: Arc<Mutex<CoreMempool>>,
-    network_sender: MempoolNetworkSender,
-    network_events: Vec<MempoolNetworkEvents>,
-    ac_client_events: mpsc::Receiver<(
+    // First element in tuple is the network ID
+    // See `NodeConfig::is_upstream_peer` for the definition of network ID
+    mempool_network_handles: Vec<(PeerId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    client_events: mpsc::Receiver<(
         SubmitTransactionRequest,
         oneshot::Sender<Result<SubmitTransactionResponse>>,
     )>,
@@ -513,26 +501,23 @@ where
         .build()
         .expect("[shared mempool] failed to create runtime");
     let executor = runtime.handle();
-
     let peer_info = Arc::new(Mutex::new(PeerInfo::new()));
-    let validator_peers;
-    match &config.validator_network {
-        Some(v) => {
-            validator_peers = v.network_peers.peers.iter().map(|(key, _)| *key).collect();
-        }
-        None => {
-            validator_peers = HashSet::new();
-        }
+    let config_clone = config.clone_for_template();
+
+    let mut all_network_events = vec![];
+    let mut network_senders = HashMap::new();
+    for (network_id, network_sender, network_events) in mempool_network_handles.into_iter() {
+        all_network_events.push((network_id, network_events));
+        network_senders.insert(network_id, network_sender);
     }
 
     let smp = SharedMempool {
         mempool: mempool.clone(),
         config: config.mempool.clone(),
-        network_sender,
+        network_senders,
         storage_read_client,
         validator,
         peer_info,
-        validator_peers,
         subscribers,
     };
 
@@ -548,8 +533,9 @@ where
     executor.spawn(inbound_network_task(
         smp,
         executor.clone(),
-        network_events,
-        ac_client_events,
+        all_network_events,
+        client_events,
+        config_clone,
     ));
 
     executor.spawn(gc_task(


### PR DESCRIPTION
## Summary

Currently AC endpoint transaction submission requests are directed to `upstream_proxy`. This PR redirects AC endpoint txn submission requests to SMP instead. 
- The added networking config setup in `shared_mempool_test` is necessary to distinguish which network the SMP is functioning in, since in addition to validator networks it is now accepting transactions from full node network, which changes the transaction status in mempool upon insertion. 
- A later PR will remove deprecated `upstream_proxy` code. 

## Test Plan

Existing tests
