### PR TITLE
[libra_channel] Implement clone for libra_channel::Sender

### DIFF
--- a/common/channel/src/libra_channel.rs
+++ b/common/channel/src/libra_channel.rs
@@ -41,7 +41,7 @@ struct SharedState<K: Eq + Hash + Clone, M> {
 }
 
 /// The sending end of the libra_channel.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Sender<K: Eq + Hash + Clone, M> {
     shared_state: Arc<Mutex<SharedState<K, M>>>,
 }
@@ -58,6 +58,14 @@ impl<K: Eq + Hash + Clone, M> Sender<K, M> {
             w.wake();
         }
         Ok(())
+    }
+}
+
+impl<K: Eq + Hash + Clone, M> Clone for Sender<K, M> {
+    fn clone(&self) -> Self {
+        Sender {
+            shared_state: self.shared_state.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Implementing `Clone` using the derive attribute has the disadvantage that it requires all the generic types to implement `Clone` as well.
By explicitly implementing Clone trait for Sender we can remove this need and therefore make the implementation more general.

Closes: #2122