### PR TITLE
[libra_channel] Add feedback mechansim to libra_channel for msg delivery

### DIFF
--- a/common/channel/src/libra_channel.rs
+++ b/common/channel/src/libra_channel.rs
@@ -9,10 +9,10 @@
 //! Internally, it uses the `PerKeyQueue` to store messages
 use crate::message_queues::{PerKeyQueue, QueueStyle};
 use anyhow::{ensure, Result};
-use futures::{async_await::FusedStream, stream::Stream};
+use futures::{async_await::FusedStream, channel::oneshot, stream::Stream};
 use libra_metrics::IntCounterVec;
 use std::{
-    fmt::Debug,
+    fmt::{Debug, Formatter},
     hash::Hash,
     pin::Pin,
     sync::{Arc, Mutex},
@@ -24,8 +24,7 @@ use std::{
 #[derive(Debug)]
 struct SharedState<K: Eq + Hash + Clone, M> {
     /// The internal queue of messages in this Channel
-    internal_queue: PerKeyQueue<K, M>,
-
+    internal_queue: PerKeyQueue<K, (M, Option<oneshot::Sender<ElementStatus<M>>>)>,
     /// Waker is needed so that the Sender can notify the task executor/scheduler
     /// that something has been pushed to the internal_queue and it ready for
     /// consumption by the Receiver and then the executor/scheduler will wake up
@@ -46,14 +45,57 @@ pub struct Sender<K: Eq + Hash + Clone, M> {
     shared_state: Arc<Mutex<SharedState<K, M>>>,
 }
 
+/// The status of an element inserted into a libra_channel. If the element is successfully
+/// dequeued, ElementStatus::Dequeued is sent to the sender. If it is dropped
+/// ElementStatus::Dropped is sent to the sender along with the dropped element.
+pub enum ElementStatus<M> {
+    Dequeued,
+    Dropped(M),
+}
+
+impl<M: PartialEq> PartialEq for ElementStatus<M> {
+    fn eq(&self, other: &ElementStatus<M>) -> bool {
+        match (self, other) {
+            (ElementStatus::Dequeued, ElementStatus::Dequeued) => true,
+            (ElementStatus::Dropped(a), ElementStatus::Dropped(b)) => a.eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl<M: Debug> Debug for ElementStatus<M> {
+    fn fmt(&self, f: &mut Formatter) -> std::result::Result<(), std::fmt::Error> {
+        match self {
+            ElementStatus::Dequeued => write!(f, "Dequeued"),
+            ElementStatus::Dropped(v) => write!(f, "Dropped({:?})", v),
+        }
+    }
+}
+
 impl<K: Eq + Hash + Clone, M> Sender<K, M> {
     /// This adds the message into the internal queue data structure. This is a
     /// synchronous call.
-    /// TODO: We can have this return a boolean if the queue of a key is capacity
     pub fn push(&mut self, key: K, message: M) -> Result<()> {
+        self.push_with_feedback(key, message, None)
+    }
+
+    /// Same as `push`, but this function also accepts a oneshot::Sender over which the sender can
+    /// be notified when the message eventually gets delivered or dropped.
+    pub fn push_with_feedback(
+        &mut self,
+        key: K,
+        message: M,
+        status_ch: Option<oneshot::Sender<ElementStatus<M>>>,
+    ) -> Result<()> {
         let mut shared_state = self.shared_state.lock().unwrap();
         ensure!(!shared_state.receiver_dropped, "Channel is closed");
-        shared_state.internal_queue.push(key, message);
+        let dropped = shared_state.internal_queue.push(key, (message, status_ch));
+        // If this or an existing message had to be dropped because of the queue being full, we
+        // notify the corresponding status channel if it was registered.
+        if let Some((dropped_val, Some(dropped_status_ch))) = dropped {
+            // Ignore errors.
+            let _err = dropped_status_ch.send(ElementStatus::Dropped(dropped_val));
+        }
         if let Some(w) = shared_state.waker.take() {
             w.wake();
         }
@@ -98,9 +140,11 @@ impl<K: Eq + Hash + Clone, M> Stream for Receiver<K, M> {
     /// it sets the waker passed to it by the scheduler/executor and returns Pending
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut shared_state = self.shared_state.lock().unwrap();
-        if let Some(val) = shared_state.internal_queue.pop() {
+        if let Some((val, status_ch)) = shared_state.internal_queue.pop() {
+            if let Some(status_ch) = status_ch {
+                let _err = status_ch.send(ElementStatus::Dequeued);
+            }
             Poll::Ready(Some(val))
-
         // if the only Arc reference to `shared_state` is 1, which is this receiver,
         // this must mean all senders have been dropped (and so the stream is terminated)
         } else if Arc::strong_count(&self.shared_state) == 1 {


### PR DESCRIPTION
## Motivation

Currently, it is difficult for the sender to know when the message is delivered, if at all. By adding an optional oneshot channel for feedback, the sender can request libra_channel to notify it when the message is delivered to the receiver, or dropped.

Closes: #2123

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y