### PR TITLE
[cluster-test] Add full node logic in performance cluster test

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -44,11 +44,22 @@ pub struct PerformanceBenchmarkNodesDown {
 impl ExperimentParam for PerformanceBenchmarkNodesDownParams {
     type E = PerformanceBenchmarkNodesDown;
     fn build(self, cluster: &Cluster) -> Self::E {
-        let (down_instances, up_instances) = cluster.split_n_validators_random(self.num_nodes_down);
-        Self::E {
-            down_instances: down_instances.into_validator_instances(),
-            up_instances: up_instances.into_validator_instances(),
-            num_nodes_down: self.num_nodes_down,
+        if self.is_fullnode {
+            let (down_instances, up_instances) =
+                cluster.split_n_fullnodes_random(self.num_nodes_down);
+            Self::E {
+                down_instances: down_instances.into_fullnode_instances(),
+                up_instances: up_instances.into_fullnode_instances(),
+                num_nodes_down: self.num_nodes_down,
+            }
+        } else {
+            let (down_instances, up_instances) =
+                cluster.split_n_validators_random(self.num_nodes_down);
+            Self::E {
+                down_instances: down_instances.into_validator_instances(),
+                up_instances: up_instances.into_validator_instances(),
+                num_nodes_down: self.num_nodes_down,
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

Adding full node logic in performance_benchmark_nodes_down so that if we start cluster test with is_fullnode=true, then it runs by connecting to full nodes and not validators

## Test Plan

Push docker image of cluster test and run cluster test

docker tag cluster-test:latest 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:<your tag>
docker push 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:<your tag>
docker pull 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:<your tag>

ct -i 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:fullnode --run performance_benchmark_nodes_down -- --num-nodes-down=0 --is-fullnode=false

Successful run

Login Succeeded
Dec 19 22:15:54.506 INFO Discovered 100 peers in sunmilee workspace
Dec 19 22:15:54.815 INFO Log tail thread started in 309 ms
Dec 19 22:15:54.815 INFO Will use sunmilee tag for deployment
Dec 19 22:15:55.170 INFO Starting experiment all up
Dec 19 22:15:56.168 INFO Completed minting seed accounts
Dec 19 22:15:58.042 INFO Mint is done
Dec 19 22:20:00.382 INFO Experiment finished, waiting until all affected validators recover
Dec 19 22:20:05.391 INFO Experiment completed
Dec 19 22:20:05.392 INFO Experiment Result: all up : 587 TPS, 1187.4 ms latency

## Related PRs
https://github.com/libra/libra/pull/2072