### PR TITLE
[smoke-test] Adding multiple chunk sync for state sync smoke test

### DIFF
--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
         num_nodes,
         RoleType::Validator,
         args.config_dir.clone(),
-        None, /* template_path */
+        None, /* template config */
         None, /* upstream_config_dir */
     )
     .expect("Failed to configure validator swarm");
@@ -54,7 +54,7 @@ fn main() {
                 num_full_nodes,
                 RoleType::FullNode,
                 None, /* config dir */
-                None, /* template_path */
+                None, /* template config */
                 Some(String::from(
                     validator_swarm
                         .dir

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use config_builder::{FullNodeConfig, SwarmConfig, ValidatorConfig};
 use debug_interface::NodeDebugClient;
-use libra_config::config::{NodeConfig, RoleType, VMPublishingOption};
+use libra_config::config::{NodeConfig, RoleType};
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::account_address::AccountAddress;
@@ -235,18 +235,24 @@ impl LibraSwarm {
         role: RoleType,
         disable_logging: bool,
         config_dir: Option<String>,
-        template_path: Option<String>,
+        template: Option<NodeConfig>,
         upstream_config_dir: Option<String>,
     ) -> Self {
         let num_launch_attempts = 5;
         for i in 0..num_launch_attempts {
             info!("Launch swarm attempt: {} of {}", i, num_launch_attempts);
 
+            let node_config = if let Some(template) = template.clone() {
+                template
+            } else {
+                NodeConfig::default()
+            };
+
             if let Ok(mut swarm) = Self::configure_swarm(
                 num_nodes,
                 role,
                 config_dir.clone(),
-                template_path.clone(),
+                Some(node_config),
                 upstream_config_dir.clone(),
             ) {
                 match swarm.launch_attempt(role, disable_logging) {
@@ -290,25 +296,23 @@ impl LibraSwarm {
         num_nodes: usize,
         role: RoleType,
         config_dir: Option<String>,
-        template_path: Option<String>,
+        template: Option<NodeConfig>,
         upstream_config_dir: Option<String>,
     ) -> Result<LibraSwarm> {
         let swarm_config_dir = Self::setup_config_dir(&config_dir);
         info!("logs at {:?}", swarm_config_dir);
-        let mut template = if let Some(template_path) = template_path {
-            NodeConfig::load(workspace_builder::workspace_root().join(template_path))
-                .unwrap_or_default()
-        } else {
-            let mut template = NodeConfig::default();
-            template.vm_config.publishing_options = VMPublishingOption::Open;
+
+        let mut node_config = if let Some(template) = template {
             template
+        } else {
+            NodeConfig::default()
         };
-        template.base.role = role;
+        node_config.base.role = role;
 
         let config_path = &swarm_config_dir.as_ref().to_path_buf();
         let config = if role.is_validator() {
             let mut validator_builder = ValidatorConfig::new();
-            validator_builder.template(template).nodes(num_nodes);
+            validator_builder.template(node_config).nodes(num_nodes);
             SwarmConfig::build(&validator_builder, config_path)?
         } else {
             let upstream_config_dir = upstream_config_dir.expect("No upstream node for full nodes");
@@ -319,7 +323,7 @@ impl LibraSwarm {
             full_node_builder
                 .full_nodes(num_nodes)
                 .genesis(genesis.expect("Missing genesis from validator").clone())
-                .template(template);
+                .template(node_config);
             full_node_builder.extend_validator(&mut validator_config)?;
             validator_config.save(&upstream_config_file)?;
             full_node_builder.bootstrap(


### PR DESCRIPTION
### Motivation

For state synchronization, we want to test both single chunk sync and multiple chunk sync. However with prod sized chunks, we need to submit thousands of transactions to test multiple chunk sync. To avoid doing this, we override the config in smoke test to have chunk_limit =2 and test both cases.

This PR also refactors smoke test and swarm to take in NodeConfig rather than filepaths. 

## Test Plan

cargo test -- test_basic_state_synchronization
