### PR TITLE
[docker] add local run for validator dynamic

### DIFF
--- a/docker/validator-dynamic/run.sh
+++ b/docker/validator-dynamic/run.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+image="${1:-libra_validator_dynamic:latest}"
+nodes="5"
+base_ip="172.18.0"
+ip_offset="10"
+bootstrap="$base_ip.$ip_offset"
+
+docker network create --subnet 172.18.0.0/24 testnet || true
+
+for ((node=1; node<$nodes; node++)); do
+    nodes_ip_offset="$(expr $ip_offset + $node)"
+    node_ip="$base_ip.$nodes_ip_offset"
+    docker run \
+        -e CFG_LISTEN_ADDR="$node_ip" \
+        -e CFG_NODE_INDEX=$node \
+        -e CFG_NUM_VALIDATORS="$nodes" \
+        -e CFG_SEED_PEER_IP="$bootstrap" \
+        --ip $node_ip \
+        --network testnet \
+        --detach \
+        "$image"
+done
+
+docker run \
+    -e CFG_LISTEN_ADDR="$bootstrap" \
+    -e CFG_NODE_INDEX="0" \
+    -e CFG_NUM_VALIDATORS="$nodes" \
+    -e CFG_SEED_PEER_IP="$bootstrap" \
+    --ip $bootstrap \
+    --network testnet \
+    --publish 8000:8000 \
+    "$image"


### PR DESCRIPTION
Now we can support running an arbitrary number of nodes locally in
docker. This helps facilitate test development rather than immediately
jumping into cluster-test, etc.

Usage:
install docker
build dynamic validator:
  cd libra && \
    ./docker/validator/build.sh && \
    ./docker/validator-dynamic/build-dynamic.sh
run the dynamic validator:
./docker/validator-dynamic/run.sh

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
