### PR TITLE
[types] rename timestamp_usec to timestamp_usecs

### DIFF
--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlockMetadata {
     id: HashValue,
-    timestamp_usec: u64,
+    timestamp_usecs: u64,
     // Since Move doesn't support hashmaps, this vote map would be stored as a vector of key value
     // pairs in the Move module. Thus we need a BTreeMap here to define how the values are being
     // ordered.
@@ -33,13 +33,13 @@ pub struct BlockMetadata {
 impl BlockMetadata {
     pub fn new(
         id: HashValue,
-        timestamp_usec: u64,
+        timestamp_usecs: u64,
         previous_block_votes: BTreeMap<AccountAddress, Ed25519Signature>,
         proposer: AccountAddress,
     ) -> Self {
         Self {
             id,
-            timestamp_usec,
+            timestamp_usecs,
             previous_block_votes,
             proposer,
         }
@@ -48,6 +48,6 @@ impl BlockMetadata {
     pub fn into_inner(self) -> Result<(ByteArray, u64, ByteArray, AccountAddress)> {
         let id = ByteArray::new(self.id.to_vec());
         let vote_maps = ByteArray::new(lcs::to_bytes(&self.previous_block_votes)?);
-        Ok((id, self.timestamp_usec, vote_maps, self.proposer))
+        Ok((id, self.timestamp_usecs, vote_maps, self.proposer))
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix typo: rename timestamp_usec to timestamp_usecs

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

cargo xtest

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
