### PR TITLE
[libra-swarm] fix cargo run cluster-test

### DIFF
--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
         .join(",");
     println!("To run transaction generator run:");
     println!(
-        "\tcargo run --bin cluster-test -- --mint-file {:?} --swarm --peers {:?}  --emit-tx",
+        "\tcargo run -p cluster-test -- --mint-file {:?} --swarm --peers {:?}  --emit-tx",
         faucet_key_file_path, node_address_list,
     );
     if let Some(ref swarm) = full_node_swarm {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
"cluster-test" can not run with "--bin" because it is not the "default-members".
```
cargo run --bin cluster-test -- --mint-file "/tmp/aac6c85297ccf3e2155388d686ff67de/mint.key" --swarm --peer
s "localhost:65069"  --emit-tx
error: no bin target named `cluster-test`
```
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

cargo xtest

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
