### PR TITLE
[config] fix full node config

### DIFF
--- a/config/config-builder/src/bin/full-node-config-builder.rs
+++ b/config/config-builder/src/bin/full-node-config-builder.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use config_builder::FullNodeConfig;
-use libra_config::config::{NodeConfig, PersistableConfig};
+use libra_config::config::NodeConfig;
 use parity_multiaddr::Multiaddr;
 use std::{convert::TryInto, fs, path::PathBuf};
 use structopt::StructOpt;
@@ -95,7 +95,7 @@ fn main() {
 
     let config_file = args.output_dir.join("node.config.toml");
 
-    let orig_config = NodeConfig::load_config(&config_file);
+    let orig_config = NodeConfig::load(&config_file);
     let mut node_config = if let Ok(mut orig_config) = orig_config {
         if orig_config.base.role.is_validator() {
             config_builder


### PR DESCRIPTION
The naming of functions must improve! load_config and load do two
different things. Perhaps we should rename load_config to be called
load_toml_from_disk, which makes it more clear that we are not
performing any recursive file loading that load does.

This change fixes the issue where we update contents of a config but
erase those contents which are not loaded by the "load" function.