### PR TITLE
[Consensus] Eliminate ChainedBftSMRConfig

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -11,8 +11,8 @@ pub struct ConsensusConfig {
     pub max_block_size: u64,
     pub proposer_type: ConsensusProposerType,
     pub contiguous_rounds: u32,
-    pub max_pruned_blocks_in_mem: Option<u64>,
-    pub pacemaker_initial_timeout_ms: Option<u64>,
+    pub max_pruned_blocks_in_mem: usize,
+    pub pacemaker_initial_timeout_ms: u64,
     pub safety_rules: SafetyRulesConfig,
 }
 
@@ -22,8 +22,8 @@ impl Default for ConsensusConfig {
             max_block_size: 100,
             proposer_type: ConsensusProposerType::MultipleOrderedProposers,
             contiguous_rounds: 2,
-            max_pruned_blocks_in_mem: None,
-            pacemaker_initial_timeout_ms: None,
+            max_pruned_blocks_in_mem: 10000,
+            pacemaker_initial_timeout_ms: 1000,
             safety_rules: SafetyRulesConfig::default(),
         }
     }

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -14,6 +14,8 @@ role = "validator"
 
 [consensus]
 max_block_size = 100
+max_pruned_blocks_in_mem = 10000
+pacemaker_initial_timeout_ms = 1000
 proposer_type = "multiple_ordered_proposers"
 contiguous_rounds = 2
 

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -55,6 +55,8 @@ seed_peers_file = ""
 
 [consensus]
 max_block_size = 100
+max_pruned_blocks_in_mem = 10000
+pacemaker_initial_timeout_ms = 1000
 proposer_type = "multiple_ordered_proposers"
 contiguous_rounds = 2
 [consensus.safety_rules.backend]

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -4,7 +4,7 @@
 use crate::state_replication::StateComputer;
 use crate::{
     chained_bft::{
-        chained_bft_smr::{ChainedBftSMR, ChainedBftSMRConfig},
+        chained_bft_smr::ChainedBftSMR,
         persistent_storage::{PersistentStorage, StorageWriteProxy},
     },
     consensus_provider::ConsensusProvider,
@@ -57,7 +57,7 @@ impl ChainedBftProvider {
         let author = node_config.validator_network.as_ref().unwrap().peer_id;
         debug!("[Consensus] My peer: {:?}", author);
         let initial_setup = Self::initialize_setup(network_sender, network_events, node_config);
-        let config = ChainedBftSMRConfig::from_node_config(&node_config);
+        let config = node_config.consensus.clone();
         let storage = Arc::new(StorageWriteProxy::new(node_config));
         let initial_data = runtime.block_on(storage.start());
 

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -25,13 +25,6 @@ use std::sync::Arc;
 use tokio::runtime;
 use vm_runtime::LibraVM;
 
-///  The state necessary to begin state machine replication including ValidatorSet, networking etc.
-pub struct InitialSetup {
-    pub network_sender: ConsensusNetworkSender,
-    pub network_events: ConsensusNetworkEvents,
-    pub safety_rules_manager_config: Option<SafetyRulesManagerConfig>,
-}
-
 /// Supports the implementation of ConsensusProvider using LibraBFT.
 pub struct ChainedBftProvider {
     smr: ChainedBftSMR<Vec<SignedTransaction>>,
@@ -56,7 +49,6 @@ impl ChainedBftProvider {
 
         let author = node_config.validator_network.as_ref().unwrap().peer_id;
         debug!("[Consensus] My peer: {:?}", author);
-        let initial_setup = Self::initialize_setup(network_sender, network_events, node_config);
         let config = node_config.consensus.clone();
         let storage = Arc::new(StorageWriteProxy::new(node_config));
         let initial_data = runtime.block_on(storage.start());
@@ -68,7 +60,9 @@ impl ChainedBftProvider {
         let state_computer = Arc::new(ExecutionProxy::new(executor, synchronizer_client));
         let smr = ChainedBftSMR::new(
             author,
-            initial_setup,
+            network_sender,
+            network_events,
+            SafetyRulesManagerConfig::new(node_config),
             runtime,
             config,
             storage,
@@ -78,20 +72,6 @@ impl ChainedBftProvider {
             smr,
             txn_manager,
             state_computer,
-        }
-    }
-
-    /// Retrieve the initial "state" for consensus. This function is synchronous and returns after
-    /// reading the local persistent store and retrieving the initial state from the executor.
-    fn initialize_setup(
-        network_sender: ConsensusNetworkSender,
-        network_events: ConsensusNetworkEvents,
-        node_config: &mut NodeConfig,
-    ) -> InitialSetup {
-        InitialSetup {
-            network_sender,
-            network_events,
-            safety_rules_manager_config: Some(SafetyRulesManagerConfig::new(node_config)),
         }
     }
 }

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -4,7 +4,6 @@
 use crate::{
     chained_bft::{
         block_storage::BlockReader,
-        chained_bft_consensus_provider::InitialSetup,
         chained_bft_smr::ChainedBftSMR,
         network_tests::NetworkPlayground,
         persistent_storage::RecoveryData,
@@ -97,14 +96,11 @@ impl SMRNode {
             signer.clone(),
             &SafetyRulesConfig::default(),
         );
-        let initial_setup = InitialSetup {
-            network_sender,
-            network_events,
-            safety_rules_manager_config: Some(safety_rules_manager_config),
-        };
         let mut smr = ChainedBftSMR::new(
             signer.author(),
-            initial_setup,
+            network_sender,
+            network_events,
+            safety_rules_manager_config,
             runtime,
             config,
             storage.clone(),

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -5,7 +5,7 @@ use crate::{
     chained_bft::{
         block_storage::BlockReader,
         chained_bft_consensus_provider::InitialSetup,
-        chained_bft_smr::{ChainedBftSMR, ChainedBftSMRConfig},
+        chained_bft_smr::ChainedBftSMR,
         network_tests::NetworkPlayground,
         persistent_storage::RecoveryData,
         test_utils::{
@@ -22,6 +22,7 @@ use consensus_types::{
 };
 use futures::{channel::mpsc, executor::block_on, prelude::*};
 use libra_config::config::{
+    ConsensusConfig,
     ConsensusProposerType::{self, FixedProposer, MultipleOrderedProposers, RotatingProposer},
     SafetyRulesConfig,
 };
@@ -38,7 +39,7 @@ use network::{
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
 };
 use safety_rules::SafetyRulesManagerConfig;
-use std::{convert::TryFrom, path::PathBuf, sync::Arc, time::Duration};
+use std::{convert::TryFrom, path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
 use tokio::runtime;
 
@@ -83,13 +84,13 @@ impl SMRNode {
             .build()
             .expect("Failed to create Tokio runtime!");
 
-        let config = ChainedBftSMRConfig {
+        let config = ConsensusConfig {
             max_pruned_blocks_in_mem: 10000,
-            pacemaker_initial_timeout: Duration::from_secs(3),
+            pacemaker_initial_timeout_ms: 3000,
             proposer_type,
             contiguous_rounds: 2,
             max_block_size: 50,
-            author: signer.author(),
+            safety_rules: SafetyRulesConfig::default(),
         };
 
         let safety_rules_manager_config = SafetyRulesManagerConfig::new_with_signer(

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -102,6 +102,7 @@ impl SMRNode {
             safety_rules_manager_config: Some(safety_rules_manager_config),
         };
         let mut smr = ChainedBftSMR::new(
+            signer.author(),
             initial_setup,
             runtime,
             config,


### PR DESCRIPTION
This PR contains two commits (the last two) to remove the ChainedBftSMRConfig as it is largely just a repeat of the ConsensusConfig and likely existed to help facilitate movement of uncopyable keys from the config which no longer exist.

Working on https://github.com/libra/libra/issues/2152