### PR TITLE
[client] Fix NOT overwrite exsiting file if it can't be parsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "libra-swarm 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-wallet 0.1.0",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -21,6 +21,7 @@ workspace-builder = { path = "../common/workspace-builder", version = "0.1.0" }
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
 cli = { path = "../client/cli", version = "0.1.0", features = ["fuzzing"] }
+libra-wallet = { path = "../client/libra_wallet", version = "0.1.0" }
 generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-swarm = { path = "../libra-swarm", version = "0.1.0" }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -16,6 +16,7 @@ use libra_types::{
     transaction::{TransactionArgument, TransactionPayload},
     waypoint::Waypoint,
 };
+use libra_wallet::{io_utils, WalletLibrary};
 use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
 use std::fs::{self, File};
@@ -51,6 +52,8 @@ impl TestEnvironment {
         mnemonic_file
             .create_as_file()
             .expect("could not create temporary mnemonic_file_path");
+        let new_wallet = WalletLibrary::new();
+        io_utils::write_recovery(&new_wallet, &mnemonic_file).expect("failed to write to file");
 
         let mut key_file = File::open(&validator_swarm.config.faucet_key_path)
             .expect("Unable to create faucet key file");


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

when I start the client with --mnemonic-file <mnemonic-file>, if the mnemonic-file can't be parsed, it will be overwirte by client with auto generated contents. This is dangerous. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

For examle:
```
./scripts/cli/start_cli_testnet.sh -- --mnemonic-file README.md
```
above command will overwrite README.md.
After been patched, the output will be:
```
Error: Custom { kind: Other, error: "Can\'t parse mnemonic file: \"README.md\"" }
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
