### PR TITLE
[move-prover] Use dots instead of slash for field access in Move specifications

### DIFF
--- a/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
+++ b/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
@@ -1,5 +1,9 @@
 // Tests for parsing specifications
 
+// TODO: (DD, 1/6/20) This file could be integrated with the prover test framework
+// in language/move-prover/byte-code-to-boogie/tests
+// so we could run these through boogie.
+
 // Test parsing the conditions themselves relative to return values, acquires clauses
 //! no-run: runtime
 module TestConditions {
@@ -19,7 +23,7 @@ module TestConditions {
   }
 
   public aborts_if_alone()
-  aborts_if true
+  aborts_if true   //! postcondition might not hold
   {
       return;
   }
@@ -166,37 +170,37 @@ module TestEnsuresAccessPath {
 
 
   public ensures_access_path(t: Self.T): Self.T
-  ensures t/b
+  ensures t.b
   {
       return move(t);
   }
 
   public ensures_access_path2(t: Self.T1): Self.T1
-  ensures t/y/b
+  ensures t.y.b
   {
       return move(t);
   }
 
   public ensures_access_path3(t: Self.T2): Self.T2
-  ensures t/x/y/b
+  ensures t.x.y.b
   {
       return move(t);
   }
 
   public ensures_old_access_path(t: Self.T): Self.T
-  ensures old(t/b)
+  ensures old(t.b)
   {
       return move(t);
   }
 
   public ensures_exists_access_path(t: Self.T): Self.T
-  ensures global_exists<Self.T>(t/a)
+  ensures global_exists<Self.T>(t.a)
   {
       return move(t);
   }
 
   public ensures_global_access_path(t: Self.T): Self.T
-  ensures global<Self.T>(t/a)
+  ensures global<Self.T>(t.a)
   {
       return move(t);
   }
@@ -240,7 +244,7 @@ module TestBinaryOps {
   }
 
   public ret_access_path_exp(p: &Self.Pair): u64
-  ensures RET == p/x + p/y
+  ensures RET == p.x + p.y
   {
       return *&copy(p).x + *&move(p).y;
   }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.mvir
@@ -31,32 +31,32 @@ module TestSpecs {
     }
 
     public select_from_global_resource()
-      requires global<Self.R>(0x1)/x > 0
+      requires global<Self.R>(0x1).x > 0
     {
       return;
     }
 
     public select_from_resource(r: Self.R): Self.R
-      requires r/x > 0
+      requires r.x > 0
     {
       return move(r);
     }
 
     public select_from_resource_nested(r: Self.R): Self.R
-      requires r/s/a == 0x1
+      requires r.s.a == 0x1
     {
       return move(r);
     }
 
     public select_from_global_resource_dynamic_address(r: Self.R): Self.R
-      requires global<Self.R>(r/s/a)/x > 0
+      requires global<Self.R>(r.s.a).x > 0
     {
       return move(r);
     }
 
     public select_from_reference(r: &Self.R)
-        requires r/s/a == 0x1
-        ensures r/s/a == old(r/s/a)
+        requires r.s.a == 0x1
+        ensures r.s.a == old(r.s.a)
     {
       return;
     }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-ref-param.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-ref-param.mvir
@@ -5,7 +5,7 @@ module TestSpecs {
     }
 
     public value(ref: &Self.T): u64
-    ensures RET == ref/value
+    ensures RET == ref.value
     {
         return *&move(ref).value;
     }


### PR DESCRIPTION
Changes to use dot as a struct/resource field separator in Move specifications. 

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The previous parser used "/" as a field separator for records & structs in Move specifications, because the existing lexing/parser infrastructure made it a bit hard to use dots.  This is a work-around.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

"cargo test" runs test cases, including a test that now has dots as separators in the spec.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)

#1955 
