### PR TITLE
Config builder

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -47,7 +47,7 @@ can either be added to existing configs or generate completely new configs.
 
 Each peer, I, can then generate their own configurations by:
 
-    validator-config-builder \
+    config-builder validator \
         -a $PUBLIC_MULTIADDR_FOR_NODE_I \
         -b $PUBLIC_MULTIADDR_FOR_NODE_0 \
         -d /opt/libra/data \
@@ -59,7 +59,7 @@ Each peer, I, can then generate their own configurations by:
 
 As an example, this is the 2nd node (offset 1) in a set of 4:
 
-    validator-config-builder \
+    config-builder validator \
         -a "/ip4/1.1.1.2/tcp/7000" \
         -b "/ip4/1.1.1.1/tcp/7000" \
         -d /opt/libra/data \
@@ -69,24 +69,23 @@ As an example, this is the 2nd node (offset 1) in a set of 4:
         -o /opt/libra/etc \
         -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627
 
-To create a mint service's consensus peer config and key that connects to
-this service:
+To create a mint service's key:
 
-    faucet-config-builder \
-        -n 4 \
+    config-builder faucet \
         -o /opt/libra/etc \
         -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627
 
-Adding a full node network is similar to instantiating a validator config. The
-difference is that if a config already exists at that path, the assumption is
-to append the full node network, if the network isn't already defined.
-Secondly, full nodes support public or permissioned networks. The former
-requires no further configuration, whereas the latter needs a full node
-specific seed, total number of full nodes, and index into the configuration
-set. The total number includes the upstream peer which is indexed into the
-first position (0).
+Adding a full node network is similar to instantiating a validator config.
+Though there are three possible routes: 1) creating a new node config, 2)
+extending an existing full node with another network, 3) extending a validator
+with a full node network. The input is similar for all three cases with only
+the command (create, extend) differing them. When extending the validator, the
+tool assumes that there are n + 1 full nodes and gives the n + 1 identity to
+the validator. This is also the same peer id set in state sychronization for
+pure full nodes. Note: the current tool does not support the creation of trees
+of full node networks.
 
-    full-node-config-builder \
+    config-builder full-node (create | extend) \
         -a $PUBLIC_MULTIADDR_FOR_NODE_I \
         -b $PUBLIC_MULTIADDR_FOR_NODE_0 \
         -d /opt/libra/data \
@@ -99,7 +98,7 @@ first position (0).
 As an example a of adding 4 membered permissioned network connecting to the
 node above:
 
-    full-node-config-builder \
+    config-builder full-node create \
         -a "/ip4/1.1.1.2/tcp/7100" \
         -b "/ip4/1.1.1.2/tcp/7100" \
         -d /opt/libra/fn/data \
@@ -113,13 +112,13 @@ node above:
 
 Similarly a public network could be added via:
 
-    full-node-config-builder \
+    config-builder full-node create \
         -a "/ip4/1.1.1.2/tcp/7100" \
         -b "/ip4/1.1.1.2/tcp/7100" \
         -d /opt/libra/fn/data \
         -l "/ip4/0.0.0.0/tcp/7100" \
         -n 4 \
-        -o /opt/libra/fn/etc \
+        -o /opt/libra/etc \
         -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627 \
         -p
 

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -1,0 +1,275 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use config_builder::{FullNodeConfig, ValidatorConfig};
+use libra_config::config::NodeConfig;
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::KeyPair,
+};
+use parity_multiaddr::Multiaddr;
+use std::{
+    convert::TryInto,
+    fs::{self, File},
+    io::Write,
+    path::PathBuf,
+};
+use structopt::StructOpt;
+
+const NODE_CONFIG: &str = "node.config.toml";
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, StructOpt)]
+#[structopt(about = "Tool to create and extend Libra Configs")]
+enum Args {
+    #[structopt(about = "Generate a Libra faucet key")]
+    Faucet(FaucetArgs),
+    #[structopt(about = "Create or extend a FullNode network")]
+    FullNode(FullNodeCommand),
+    #[structopt(about = "Create a new validator config")]
+    Validator(ValidatorArgs),
+}
+
+#[derive(Debug, StructOpt)]
+struct FaucetArgs {
+    #[structopt(short = "o", long, parse(from_os_str))]
+    /// The output directory
+    output_dir: PathBuf,
+    #[structopt(short = "s", long)]
+    /// Use the provided seed for generating keys for each of the validators
+    seed: Option<String>,
+}
+
+#[derive(Debug, StructOpt)]
+enum FullNodeCommand {
+    #[structopt(about = "Create a new config")]
+    Create(FullNodeArgs),
+    #[structopt(about = "Create a new config")]
+    Extend(FullNodeArgs),
+}
+
+#[derive(Debug, StructOpt)]
+struct FullNodeArgs {
+    // Describe the validator networrk
+    #[structopt(short = "n", long, default_value = "1")]
+    /// Specify the number of nodes to configure
+    nodes: usize,
+    #[structopt(short = "s", long)]
+    /// Use the provided seed for generating keys for each of the validators
+    seed: Option<String>,
+
+    // Parameters for this full node config
+    #[structopt(short = "a", long, parse(from_str = parse_addr))]
+    /// Advertised address for this node, if this is null, listen is reused
+    advertised: Multiaddr,
+    #[structopt(short = "b", long, parse(from_str = parse_addr))]
+    /// Advertised address for the first node in this test net
+    bootstrap: Multiaddr,
+    #[structopt(short = "d", long, parse(from_os_str))]
+    /// The data directory for the configs (e.g. /opt/libra/data)
+    data_dir: PathBuf,
+    #[structopt(short = "c", long)]
+    /// Use the provided seed for generating keys for each of the FullNodes
+    full_node_seed: Option<String>,
+    #[structopt(short = "f", long, default_value = "1")]
+    /// Total number of full nodes
+    full_nodes: usize,
+    #[structopt(short = "i", long, default_value = "0")]
+    /// Specify the index into the number of nodes to write to output dir
+    index: usize,
+    #[structopt(short = "l", long, parse(from_str = parse_addr))]
+    /// Listening address for this node
+    listen: Multiaddr,
+    #[structopt(short = "o", long, parse(from_os_str))]
+    /// The output directory, note if a config exists already here, it will be updated to include
+    /// this full node network
+    output_dir: PathBuf,
+    #[structopt(short = "p", long)]
+    /// Public network, doesn't use any authentication or encryption
+    public: bool,
+    #[structopt(short = "t", long, parse(from_os_str))]
+    /// Path to a template NodeConfig
+    template: Option<PathBuf>,
+}
+
+#[derive(Debug, StructOpt)]
+struct ValidatorArgs {
+    #[structopt(short = "a", long, parse(from_str = parse_addr))]
+    /// Advertised address for this node, if this is null, listen is reused
+    advertised: Multiaddr,
+    #[structopt(short = "b", long, parse(from_str = parse_addr))]
+    /// Advertised address for the first node in this test net
+    bootstrap: Multiaddr,
+    #[structopt(short = "d", long, parse(from_os_str))]
+    /// The data directory for the configs (e.g. /opt/libra/etc)
+    data_dir: PathBuf,
+    #[structopt(short = "i", long, default_value = "0")]
+    /// Specify the index into the number of nodes to write to output dir
+    index: usize,
+    #[structopt(short = "l", long, parse(from_str = parse_addr))]
+    /// Listening address for this node
+    listen: Multiaddr,
+    #[structopt(short = "n", long, default_value = "1")]
+    /// Specify the number of nodes to configure
+    nodes: usize,
+    #[structopt(short = "o", long, parse(from_os_str))]
+    /// The output directory
+    output_dir: PathBuf,
+    #[structopt(short = "s", long)]
+    /// Use the provided seed for generating keys for each of the validators
+    seed: Option<String>,
+    #[structopt(short = "t", long, parse(from_os_str))]
+    /// Path to a template NodeConfig
+    template: Option<PathBuf>,
+}
+
+fn parse_addr(src: &str) -> Multiaddr {
+    src.parse::<Multiaddr>().unwrap()
+}
+
+fn main() {
+    let args = Args::from_args();
+
+    match args {
+        Args::Faucet(faucet_args) => build_faucet(faucet_args),
+        Args::FullNode(full_node_args) => build_full_node(full_node_args),
+        Args::Validator(validator_args) => build_validator(validator_args),
+    };
+}
+
+fn build_faucet(args: FaucetArgs) {
+    let mut config_builder = ValidatorConfig::new();
+
+    if let Some(seed) = args.seed.as_ref() {
+        let seed = hex::decode(seed).expect("Invalid hex in seed.");
+        config_builder.seed(seed[..32].try_into().expect("Invalid seed"));
+    }
+
+    let (_, faucet_key) = config_builder
+        .build_faucet_client()
+        .expect("ConfigBuilder failed");
+
+    let key_path = args.output_dir.join("mint.key");
+    let faucet_keypair = KeyPair::<Ed25519PrivateKey, Ed25519PublicKey>::from(faucet_key);
+    let serialized_keys = lcs::to_bytes(&faucet_keypair).expect("Unable to serialize keys");
+
+    fs::create_dir_all(&args.output_dir).expect("Unable to create output directory");
+    let mut key_file = File::create(key_path).expect("Unable to create key file");
+    key_file
+        .write_all(&serialized_keys)
+        .expect("Unable to write to key file");
+}
+
+fn build_full_node(command: FullNodeCommand) {
+    let config_builder = match &command {
+        FullNodeCommand::Create(args) => build_full_node_config_builder(&args),
+        FullNodeCommand::Extend(args) => build_full_node_config_builder(&args),
+    };
+
+    match command {
+        FullNodeCommand::Create(args) => {
+            if node_config_exists(&args.output_dir) {
+                eprintln!("Node config already exists in this directory");
+                return;
+            }
+            let mut new_config = config_builder.build().expect("ConfigBuilder failed");
+            new_config.set_data_dir(args.data_dir);
+            save_config(new_config, &args.output_dir);
+        },
+        FullNodeCommand::Extend(args) => {
+            if !node_config_exists(&args.output_dir) {
+                eprintln!("No node config in this directory");
+                return;
+            }
+
+            let config_file = args.output_dir.join(NODE_CONFIG);
+            let mut orig_config = NodeConfig::load(&config_file).expect("Unable to load node config");
+            if orig_config.base.role.is_validator() {
+                config_builder
+                    .extend_validator(&mut orig_config)
+                    .expect("Unable to add full node network to validator");
+            } else {
+                config_builder
+                    .extend(&mut orig_config)
+                    .expect("Unable to append full node network");
+            }
+            save_config(orig_config, &args.output_dir);
+        },
+    };
+}
+
+fn build_full_node_config_builder(args: &FullNodeArgs) -> FullNodeConfig {
+    let mut config_builder = FullNodeConfig::new();
+    config_builder
+        .advertised(args.advertised.clone())
+        .bootstrap(args.bootstrap.clone())
+        .full_node_index(args.index)
+        .full_nodes(args.full_nodes)
+        .listen(args.listen.clone())
+        .nodes(args.nodes)
+        .template(load_template(args.template.clone()));
+
+    if let Some(fn_seed) = args.full_node_seed.as_ref() {
+        config_builder.full_node_seed(parse_seed(fn_seed));
+    }
+
+    if args.public {
+        config_builder.public();
+    }
+
+    if let Some(seed) = args.seed.as_ref() {
+        config_builder.seed(parse_seed(seed));
+    }
+
+    config_builder
+}
+
+fn build_validator(args: ValidatorArgs) {
+    if node_config_exists(&args.output_dir) {
+        eprintln!("Node config already exists in this directory");
+        return;
+    }
+
+    let mut config_builder = ValidatorConfig::new();
+    config_builder
+        .advertised(args.advertised)
+        .bootstrap(args.bootstrap)
+        .index(args.index)
+        .listen(args.listen)
+        .nodes(args.nodes)
+        .template(load_template(args.template));
+
+    if let Some(seed) = args.seed.as_ref() {
+        config_builder.seed(parse_seed(seed));
+    }
+
+    let mut node_config = config_builder.build().expect("ConfigBuilder failed");
+    node_config.set_data_dir(args.data_dir);
+    save_config(node_config, &args.output_dir);
+}
+
+fn node_config_exists(output_dir: &PathBuf) -> bool {
+    output_dir.join(NODE_CONFIG).exists()
+}
+
+fn load_template(template: Option<PathBuf>) -> NodeConfig {
+    if let Some(template_path) = template {
+        NodeConfig::load(template_path).expect("Unable to load template")
+    } else {
+        NodeConfig::default()
+    }
+}
+
+fn parse_seed(seed: &str) -> [u8; 32] {
+    let seed = hex::decode(seed).expect("Invalid hex in seed.");
+    seed[..32].try_into().expect("Invalid seed")
+}
+
+fn save_config(mut node_config: NodeConfig, output_dir: &PathBuf) {
+    fs::create_dir_all(output_dir).expect("Unable to create output directory");
+    node_config
+        .save(output_dir.join(NODE_CONFIG))
+        .expect("Unable to save configs");
+}

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -177,7 +177,7 @@ fn build_full_node(command: FullNodeCommand) {
             let mut new_config = config_builder.build().expect("ConfigBuilder failed");
             new_config.set_data_dir(args.data_dir);
             save_config(new_config, &args.output_dir);
-        },
+        }
         FullNodeCommand::Extend(args) => {
             if !node_config_exists(&args.output_dir) {
                 eprintln!("No node config in this directory");
@@ -185,7 +185,8 @@ fn build_full_node(command: FullNodeCommand) {
             }
 
             let config_file = args.output_dir.join(NODE_CONFIG);
-            let mut orig_config = NodeConfig::load(&config_file).expect("Unable to load node config");
+            let mut orig_config =
+                NodeConfig::load(&config_file).expect("Unable to load node config");
             if orig_config.base.role.is_validator() {
                 config_builder
                     .extend_validator(&mut orig_config)
@@ -196,7 +197,7 @@ fn build_full_node(command: FullNodeCommand) {
                     .expect("Unable to append full node network");
             }
             save_config(orig_config, &args.output_dir);
-        },
+        }
     };
 }
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -132,12 +132,10 @@ impl NetworkConfig {
             self.peer_id = key_peer_id;
         }
 
-        if !network_role.is_validator() {
-            ensure!(
-                self.peer_id == key_peer_id,
-                "For non-validators, the peer_id should be derived from the identity key.",
-            );
-        }
+        ensure!(
+            network_role.is_validator() || !self.is_permissioned || self.peer_id == key_peer_id,
+            "For permissioned, full-node networks, the peer_id should be derived from the identity key.",
+        );
         Ok(())
     }
 

--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -26,7 +26,7 @@ if [ -n "${CFG_SEED_PEER_IP}" ]; then # Seed peer ip for discovery
 	    params+="--bootstrap /ip4/${CFG_SEED_PEER_IP}/tcp/6180 "
 fi
 
-/opt/libra/bin/validator-config-builder \
+/opt/libra/bin/config-builder validator \
     --data-dir /opt/libra/data/common \
     --output-dir /opt/libra/etc/ \
     ${params[@]}

--- a/docker/validator-dynamic/validator-dynamic.Dockerfile
+++ b/docker/validator-dynamic/validator-dynamic.Dockerfile
@@ -22,7 +22,7 @@ RUN cargo build --release -p libra-node -p client -p config-builder && cd target
 
 ### Production Image ###
 FROM libra_e2e:latest as validator_with_config
-COPY --from=config_builder /libra/target/release/validator-config-builder /opt/libra/bin
+COPY --from=config_builder /libra/target/release/config-builder /opt/libra/bin
 COPY docker/validator-dynamic/docker-run-dynamic.sh /
 CMD /docker-run-dynamic.sh
 


### PR DESCRIPTION
First commit fixes a bug in reading public full-node networks

Second commit: After taking the time to really understand structopt, I was able to
produce a config-builder that hosts all the utilities in one file.
This config-builder also exports two subcommands for building
full-nodes: create and extend. This improves safety for full-nodes so
that a user is explicitly either creating a new node config or extending
an existing one. In addition, this commit checks to see if a config
exists prior to creating a new one on top of it, so we don't end up
accidentally overwritting an existing config.

Third commit: updates dynamic validator

Verified by building new dynamic-validator and using local run.