### PR TITLE
[consensus] Cleanup SafetyRulesManager and ChainedBftSmr

### DIFF
--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -21,11 +21,12 @@ pub struct TestConfig {
     temp_dir: Option<TempPath>,
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
 impl Clone for TestConfig {
     fn clone(&self) -> Self {
         Self {
-            account_keypair: None,
-            consensus_keypair: None,
+            account_keypair: self.account_keypair.clone(),
+            consensus_keypair: self.consensus_keypair.clone(),
             temp_dir: None,
         }
     }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -66,4 +66,4 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = ["proptest", "consensus-types/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]
+fuzzing = ["proptest", "consensus-types/fuzzing", "libra-config/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::{
     error::Error,
     persistent_storage::{InMemoryStorage, OnDiskStorage},
     safety_rules::SafetyRules,
-    safety_rules_manager::{SafetyRulesManager, SafetyRulesManagerConfig},
+    safety_rules_manager::SafetyRulesManager,
     t_safety_rules::TSafetyRules,
 };
 

--- a/consensus/src/chained_bft/chained_bft_consensus_provider.rs
+++ b/consensus/src/chained_bft/chained_bft_consensus_provider.rs
@@ -19,7 +19,6 @@ use libra_logger::prelude::*;
 use libra_mempool::proto::mempool_client::MempoolClientWrapper;
 use libra_types::transaction::SignedTransaction;
 use network::validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender};
-use safety_rules::SafetyRulesManagerConfig;
 use state_synchronizer::StateSyncClient;
 use std::sync::Arc;
 use tokio::runtime;
@@ -49,7 +48,6 @@ impl ChainedBftProvider {
 
         let author = node_config.validator_network.as_ref().unwrap().peer_id;
         debug!("[Consensus] My peer: {:?}", author);
-        let config = node_config.consensus.clone();
         let storage = Arc::new(StorageWriteProxy::new(node_config));
         let initial_data = runtime.block_on(storage.start());
 
@@ -62,9 +60,8 @@ impl ChainedBftProvider {
             author,
             network_sender,
             network_events,
-            SafetyRulesManagerConfig::new(node_config),
+            node_config,
             runtime,
-            config,
             storage,
             initial_data,
         );

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -76,6 +76,11 @@ impl<T: Payload> ChainedBftSMR<T> {
     }
 
     #[cfg(test)]
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    #[cfg(test)]
     pub fn block_store(&self) -> Option<Arc<BlockStore<T>>> {
         self.block_store.clone()
     }

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -38,8 +38,7 @@ use network::{
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
 };
 use safety_rules::SafetyRulesManagerConfig;
-use std::{convert::TryFrom, path::PathBuf, sync::Arc};
-use tempfile::NamedTempFile;
+use std::{convert::TryFrom, sync::Arc};
 use tokio::runtime;
 
 /// Auxiliary struct that is preparing SMR for the test
@@ -53,7 +52,6 @@ struct SMRNode {
     mempool: MockTransactionManager,
     mempool_notif_receiver: mpsc::Receiver<usize>,
     storage: Arc<MockStorage<TestPayload>>,
-    safety_rules_path: PathBuf,
 }
 
 impl SMRNode {
@@ -65,7 +63,6 @@ impl SMRNode {
         initial_data: RecoveryData<TestPayload>,
         proposer_type: ConsensusProposerType,
         executor_with_reconfig: Option<ValidatorSet>,
-        safety_rules_path: PathBuf,
     ) -> Self {
         let validators = initial_data.validators();
         let author = signer.author();
@@ -128,7 +125,6 @@ impl SMRNode {
             mempool,
             mempool_notif_receiver: commit_receiver,
             storage,
-            safety_rules_path,
         }
     }
 
@@ -146,7 +142,6 @@ impl SMRNode {
             recover_data,
             self.proposer_type,
             None,
-            self.safety_rules_path,
         )
     }
 
@@ -166,7 +161,6 @@ impl SMRNode {
         let mut nodes = vec![];
         for smr_id in 0..num_nodes {
             let (initial_data, storage) = MockStorage::start_for_testing(validator_set.clone());
-            let safety_rules_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
             nodes.push(Self::start(
                 playground,
                 signers.remove(0),
@@ -175,7 +169,6 @@ impl SMRNode {
                 initial_data,
                 proposer_type,
                 executor_validator_set.clone(),
-                safety_rules_path,
             ));
         }
         nodes

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -36,7 +36,6 @@ use network::{
     proto::ConsensusMsg_oneof,
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
 };
-use safety_rules::SafetyRulesManagerConfig;
 use std::{convert::TryFrom, sync::Arc};
 use tokio::runtime;
 
@@ -77,15 +76,12 @@ impl SMRNode {
             .build()
             .expect("Failed to create Tokio runtime!");
 
-        let safety_rules_manager_config = SafetyRulesManagerConfig::new(&mut config.clone());
-
         let mut smr = ChainedBftSMR::new(
             author,
             network_sender,
             network_events,
-            safety_rules_manager_config,
+            &mut config.clone(),
             runtime,
-            config.consensus.clone(),
             storage.clone(),
             initial_data,
         );


### PR DESCRIPTION
The goal was to eliminate SafetyRulesManagerConfig and do some broad cleanup in consensus along the way. As a result, ChainedBftSmr is a little bit tidier as it reduces its multiple configuration inputs to a single 1, SafetyRulesManagerConfig is gone, chained_bft_smr_tests have been simplified as they move less data around on restart.

Note: this is a third stack of commits, rather than rebase all of them it seems prudent to get some reviews and restack if all is good.