### PR TITLE
[language] Move disassembler into language/tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "disassembler"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecode-source-map 0.1.0",
+ "bytecode-verifier 0.1.0",
+ "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ir-to-bytecode-syntax 0.1.0",
+ "libra-types 0.1.0",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm 0.1.0",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "language/compiler/ir-to-bytecode/syntax",
     "language/e2e-tests",
     "language/tools/cost-synthesis",
+    "language/tools/disassembler",
     "language/tools/genesis-viewer",
     "language/tools/utils",
     "language/tools/test-generation",

--- a/language/compiler/bytecode-source-map/src/lib.rs
+++ b/language/compiler/bytecode-source-map/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-pub mod disassembler;
 pub mod mapping;
 pub mod marking;
 pub mod source_map;

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "disassembler"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
+ir-to-bytecode-syntax = { path = "../../compiler/ir-to-bytecode/syntax", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+
+codespan = { version = "0.2.1" }
+codespan-reporting = "0.2.1"
+structopt = "0.3.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/tools/disassembler/src/disassembler.rs
+++ b/language/tools/disassembler/src/disassembler.rs
@@ -1,9 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::mapping::SourceMapping;
-use crate::source_map::{FunctionSourceMap, SourceName};
 use anyhow::{bail, format_err, Result};
+use bytecode_source_map::{
+    mapping::SourceMapping,
+    source_map::{FunctionSourceMap, SourceName},
+};
 use bytecode_verifier::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
 use libra_types::identifier::{IdentStr, Identifier};
 use vm::access::ModuleAccess;

--- a/language/tools/disassembler/src/lib.rs
+++ b/language/tools/disassembler/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod disassembler;

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -3,10 +3,10 @@
 
 #![forbid(unsafe_code)]
 
-use bytecode_source_map::disassembler::{Disassembler, DisassemblerOptions};
-use bytecode_source_map::mapping::SourceMapping;
-use bytecode_source_map::source_map::ModuleSourceMap;
-use bytecode_source_map::utils::module_source_map_from_file;
+use bytecode_source_map::{
+    mapping::SourceMapping, source_map::ModuleSourceMap, utils::module_source_map_from_file,
+};
+use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use ir_to_bytecode_syntax::ast::Loc;
 use libra_types::transaction::Module;
 use serde_json;


### PR DESCRIPTION
in the spirit of moving most of our tools under `language/tools` this is another instance of something that is definitely better suited in that home. 
Discussed with @tzakian already