### PR TITLE
[language][prover] Constraint reference parameters

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/prelude.bpl
+++ b/language/move-prover/bytecode-to-boogie/src/prelude.bpl
@@ -114,7 +114,8 @@ function {:inline 1} IsEmpty(a: ValueArray): bool {
 //   prefer to handcode this so its easier to evolve the model independent of the
 //   translator.
 
-// STRATIFICATION_DEPTH: 4
+const StratificationDepth: int;
+axiom StratificationDepth == 4;
 
 function {:inline 1} IsEqual4(v1: Value, v2: Value): bool {
     v1 == v2
@@ -247,6 +248,15 @@ function {:constructor} Local(i: int): Location;
 type {:datatype} Reference;
 function {:constructor} Reference(l: Location, p: Path): Reference;
 const DefaultReference: Reference;
+
+function {:inline} IsValidReferenceParameter(local_counter: int, r: Reference): bool {
+  // If the reference parameter is for a local, its index must be less then the current
+  // local counter. This prevents any aliasing with locals which we create later.
+  (is#Local(l#Reference(r)) ==> i#Local(l#Reference(r)) < local_counter)
+  &&
+  // The path must be in range of current stratification depth.
+  (size#Path(p#Reference(r)) >= 0 && size#Path(p#Reference(r)) < StratificationDepth)
+}
 
 type {:datatype} Memory;
 function {:constructor} Memory(domain: [Location]bool, contents: [Location]Value): Memory;

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -211,7 +211,7 @@ impl<'a> SpecTranslator<'a> {
     /// Translate a dereference.
     fn translate_dref(&mut self, loc: &StorageLocation) -> BoogieExpr {
         let BoogieExpr(s, t) = self.translate_location_as_reference(loc);
-        if let SignatureToken::Reference(sig) = t {
+        if let SignatureToken::Reference(sig) | SignatureToken::MutableReference(sig) = t {
             BoogieExpr(format!("Dereference(m, {})", s), *sig)
         } else {
             self.error(
@@ -412,7 +412,7 @@ impl<'a> SpecTranslator<'a> {
             StorageLocation::AccessPath { base, fields } => {
                 let BoogieExpr(mut res, mut t) = self.translate_location_as_value(base);
                 // If the type of the location is a reference, dref it now.
-                if let SignatureToken::Reference(vt) = t {
+                if let SignatureToken::Reference(vt) | SignatureToken::MutableReference(vt) = t {
                     res = format!("Dereference(m, {})", res);
                     t = *vt;
                 }
@@ -435,7 +435,7 @@ impl<'a> SpecTranslator<'a> {
         match loc {
             StorageLocation::Formal(name) => {
                 let BoogieExpr(s, t) = self.translate_param(name);
-                if let SignatureToken::Reference(_) = t {
+                if let SignatureToken::Reference(_) | SignatureToken::MutableReference(_) = t {
                     BoogieExpr(s, SignatureToken::Reference(Box::new(t)))
                 } else {
                     self.error(

--- a/language/move-prover/bytecode-to-boogie/src/translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/translator.rs
@@ -1134,6 +1134,7 @@ pub fn format_type_checking(
     name: String,
     sig: &SignatureToken,
 ) -> String {
+    let mut params = name;
     let check = match sig {
         SignatureToken::U64 => "is#Integer",
         SignatureToken::Bool => "is#Boolean",
@@ -1141,13 +1142,17 @@ pub fn format_type_checking(
         SignatureToken::ByteArray => "is#ByteArray",
         // Only need to check Struct for top-level; fields will be checked as we extract them.
         SignatureToken::Struct(_, _) => "is#Vector",
-        // Otherwise it is a reference or a type parameter. Will be checked when accessed.
+        SignatureToken::Reference(_) | SignatureToken::MutableReference(_) => {
+            params = format!("local_counter, {}", params);
+            "IsValidReferenceParameter"
+        }
+        // Otherwise it is a type parameter which is opaque
         _ => "",
     };
     if check.is_empty() {
         "".to_string()
     } else {
-        format!("assume {}({});\n", check, name)
+        format!("assume {}({});\n", check, params)
     }
 }
 

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-ref-param.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-ref-param.mvir
@@ -1,0 +1,12 @@
+module TestSpecs {
+
+    resource T {
+      value: u64,
+    }
+
+    public value(ref: &Self.T): u64
+    ensures return == ref/value
+    {
+        return *&move(ref).value;
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -734,6 +734,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -780,6 +781,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -826,6 +828,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -872,6 +875,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -918,6 +922,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -964,6 +969,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -1399,6 +1405,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
+    assume IsValidReferenceParameter(local_counter, arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 24;
@@ -1686,6 +1693,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -1812,7 +1820,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#Integer(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 18;
@@ -1970,7 +1979,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#Vector(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 14;
@@ -2654,7 +2664,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#Integer(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -2800,7 +2811,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#Integer(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -3045,7 +3057,8 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(arg0);
-        assume is#Integer(arg2);
+    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Integer(arg2);
     assume is#ByteArray(arg3);
 
     old_size := local_counter;
@@ -3267,7 +3280,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#ByteArray(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#ByteArray(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -3392,7 +3406,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#ByteArray(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#ByteArray(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -3817,6 +3832,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 6;
@@ -3920,6 +3936,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -4119,6 +4136,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;
@@ -4159,6 +4177,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;
@@ -4702,7 +4721,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#Address(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Address(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 22;
@@ -4814,7 +4834,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-        assume is#Address(arg1);
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Address(arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -4949,6 +4970,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 18;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -42,6 +42,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -313,6 +313,7 @@ ensures b#Boolean(Boolean((SelectField(SelectField(Dereference(m, arg0), TestSpe
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 1;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -22,6 +22,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -1,0 +1,75 @@
+
+
+// ** structs of module TestSpecs
+
+const unique TestSpecs_T: TypeName;
+const TestSpecs_T_value: FieldName;
+axiom TestSpecs_T_value == 0;
+function TestSpecs_T_type_value(): TypeValue {
+    StructType(TestSpecs_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_TestSpecs_T(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_TestSpecs_T(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, TestSpecs_T_value);
+}
+
+
+
+// ** functions of module TestSpecs
+
+procedure {:inline 1} TestSpecs_value (arg0: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, arg0), TestSpecs_T_value))));
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(TestSpecs_T_type_value())
+    var t1: Reference; // ReferenceType(TestSpecs_T_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t1 := CopyOrMoveRef(t0);
+
+    call t2 := BorrowField(t1, TestSpecs_T_value);
+
+    call tmp := ReadRef(t2);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestSpecs_value_verify (arg0: Reference) returns (ret0: Value)
+{
+    call ret0 := TestSpecs_value(arg0);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -18,3 +18,8 @@ fn verify_div() {
 fn verify_local_ref() {
     test(VERIFY, &["test_mvir/verify-local-ref.mvir"]);
 }
+
+#[test]
+fn verify_ref_param() {
+    test(VERIFY, &["test_mvir/verify-ref-param.mvir"]);
+}


### PR DESCRIPTION
## Motivation

Reference parameters need to be constraint in two ways:

1. We need to assume the selection path is in range of the current stratification depth. Otherwise we create a logic inconsistency if the reference is read (e.g. that a value both is#Integer and is#Map).
2. We need to assume that a local index is within the current memory range. Otherwise, newly created locals can be aliases with the passed references, which is not possible in Move.

This change adds those assumptions for ref parameters as part of the generated type checking assumptions.

## Test Plan

Added new test, updated golden files.

## Related PRs

NA
