### PR TITLE
[consensus] fix the sequence number in test_e2e_reconfiguration

### DIFF
--- a/client/src/client_proxy.rs
+++ b/client/src/client_proxy.rs
@@ -344,7 +344,10 @@ impl ClientProxy {
     /// Waits for the next transaction for a specific address and prints it
     pub fn wait_for_transaction(&mut self, account: AccountAddress, sequence_number: u64) {
         let mut max_iterations = 5000;
-        print!("waiting ");
+        print!(
+            "waiting for {} with sequence number {}",
+            account, sequence_number
+        );
         loop {
             stdout().flush().unwrap();
 

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -720,7 +720,7 @@ fn test_e2e_reconfiguration() {
         Decimal::from_str(&client_proxy_1.get_balance(&["b", "0"]).unwrap()).ok()
     );
     // wait for the mint txn in node 0
-    client_proxy_0.wait_for_transaction(association_address(), 1);
+    client_proxy_0.wait_for_transaction(association_address(), 2);
     assert_eq!(
         Decimal::from_f64(10.0),
         Decimal::from_str(&client_proxy_0.get_balance(&["b", "0"]).unwrap()).ok()
@@ -751,8 +751,8 @@ fn test_e2e_reconfiguration() {
     client_proxy_1
         .add_validator(&["add_validator", &peer_id], true)
         .unwrap();
-    // Wait for it catches up, mint1 + remove + mint2 + add => seq == 4
-    client_proxy_0.wait_for_transaction(association_address(), 4);
+    // Wait for it catches up, mint1 + remove + mint2 + add => seq == 5
+    client_proxy_0.wait_for_transaction(association_address(), 5);
     assert_eq!(
         Decimal::from_f64(20.0),
         Decimal::from_str(&client_proxy_0.get_balance(&["b", "0"]).unwrap()).ok()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`wait_for_transaction` is using `sequence_number - 1` and results in flakiness like https://circleci.com/gh/libra/libra/25774#tests/containers/3

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

smoke test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
