### PR TITLE
[language][vm] fix <, <=, >, >= for u8 and u128

### DIFF
--- a/language/functional_tests/tests/testsuite/operators/comparison_operators.mvir
+++ b/language/functional_tests/tests/testsuite/operators/comparison_operators.mvir
@@ -1,21 +1,100 @@
 main() {
-  assert((1 == 1) == true, 99);
-  assert((1 == 2) == false, 99);
+    assert(0u8 == 0u8, 1000);
+    assert(0u64 == 0u64, 1001);
+    assert(0u128 == 0u128, 1002);
 
-  assert((1 != 2) == true, 99);
-  assert((1 != 1) == false, 99);
+    assert(!(0u8 == 1u8), 1100);
+    assert(!(0u64 == 1u64), 1101);
+    assert(!(0u128 == 1u128), 1102);
 
-  assert((2 > 1) == true, 99);
-  assert((1 > 1) == false, 99);
-
-  assert((1 >= 1) == true, 99);
-  assert((0 >= 1) == false, 99);
-
-  assert((1 < 2) == true, 99);
-  assert((2 < 1) == false, 99);
-
-  assert((1 <= 1) == true, 99);
-  assert((2 <= 1) == false, 99);
-
-  return;
+    assert(!(1u8 == 0u8), 1200);
+    assert(!(1u64 == 0u64), 1201);
+    assert(!(1u128 == 0u128), 1202);
+    return;
 }
+// check: EXECUTED
+
+//! new-transaction
+main() {
+    assert(0u8 != 1u8, 2000);
+    assert(0u64 != 1u64, 2001);
+    assert(0u128 != 1u128, 2001);
+
+    assert(1u8 != 0u8, 2100);
+    assert(1u64 != 0u64, 2101);
+    assert(1u128 != 0u128, 2101);
+
+    assert(!(0u8 != 0u8), 2200);
+    assert(!(0u64 != 0u64), 2201);
+    assert(!(0u128 != 0u128), 2201);
+    return;
+}
+// check: EXECUTED
+
+//! new-transaction
+main() {
+    assert(0u8 < 1u8, 3000);
+    assert(0u64 < 1u64, 3001);
+    assert(0u128 < 1u128, 3002);
+
+    assert(!(1u8 < 0u8), 3100);
+    assert(!(1u64 < 0u64), 3101);
+    assert(!(1u128 < 0u128), 3102);
+
+    assert(!(0u8 < 0u8), 3200);
+    assert(!(0u64 < 0u64), 3201);
+    assert(!(0u128 < 0u128), 3202);
+    return;
+}
+// check: EXECUTED
+
+//! new-transaction
+main() {
+    assert(1u8 > 0u8, 4000);
+    assert(1u64 > 0u64, 4001);
+    assert(1u128 > 0u128, 4002);
+
+    assert(!(0u8 > 1u8), 4100);
+    assert(!(0u64 > 1u64), 4101);
+    assert(!(0u128 > 1u128), 4102);
+
+    assert(!(0u8 > 0u8), 4200);
+    assert(!(0u64 > 0u64), 4201);
+    assert(!(0u128 > 0u128), 4202);
+    return;
+}
+// check: EXECUTED
+
+//! new-transaction
+main() {
+    assert(0u8 <= 1u8, 5000);
+    assert(0u64 <= 1u64, 5001);
+    assert(0u128 <= 1u128, 5002);
+
+    assert(!(1u8 <= 0u8), 5100);
+    assert(!(1u64 <= 0u64), 5101);
+    assert(!(1u128 <= 0u128), 5102);
+
+    assert(0u8 <= 0u8, 5200);
+    assert(0u64 <= 0u64, 5201);
+    assert(0u128 <= 0u128, 5202);
+    return;
+}
+// check: EXECUTED
+
+//! new-transaction
+main() {
+    assert(1u8 >= 0u8, 6000);
+    assert(1u64 >= 0u64, 6001);
+    assert(1u128 >= 0u128, 6002);
+
+    assert(!(0u8 >= 1u8), 6100);
+    assert(!(0u64 >= 1u64), 6101);
+    assert(!(0u128 >= 1u128), 6102);
+
+    assert(0u8 >= 0u8, 6200);
+    assert(0u64 >= 0u64, 6201);
+    assert(0u128 >= 0u128, 6202);
+    return;
+}
+// check: EXECUTED

--- a/language/functional_tests/tests/testsuite/operators/integer_binary_operators_types_mismatch.mvir
+++ b/language/functional_tests/tests/testsuite/operators/integer_binary_operators_types_mismatch.mvir
@@ -915,6 +915,290 @@ module M {
 // check: EQUALITY_OP_TYPE_MISMATCH_ERROR
 
 
+// operator <
+//! new-transaction
+main() {
+    _ = 0u8 < 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u8 < 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 < 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 < 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 < 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 < 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 < true;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = true < 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 < 0x0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0x0 < 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+// operator >
+//! new-transaction
+main() {
+    _ = 0u8 > 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u8 > 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 > 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 > 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 > 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 > 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 > true;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = true > 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 > 0x0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0x0 > 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+// operator <=
+//! new-transaction
+main() {
+    _ = 0u8 <= 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u8 <= 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 <= 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 <= 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 <= 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 <= 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 <= true;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = true <= 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 <= 0x0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0x0 <= 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+// operator >=
+//! new-transaction
+main() {
+    _ = 0u8 >= 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u8 >= 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 >= 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u64 >= 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 >= 0u8;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0u128 >= 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 >= true;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = true >= 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 >= 0x0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0x0 >= 0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
 // operator <<
 //! new-transaction
 main() {

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -548,27 +548,27 @@ impl<'txn> Interpreter<'txn> {
                     }
                     Bytecode::Or => {
                         gas!(const_instr: context, self, Opcodes::OR)?;
-                        self.binop_bool(|l, r| l || r)?
+                        self.binop_bool(|l, r| Ok(l || r))?
                     }
                     Bytecode::And => {
                         gas!(const_instr: context, self, Opcodes::AND)?;
-                        self.binop_bool(|l, r| l && r)?
+                        self.binop_bool(|l, r| Ok(l && r))?
                     }
                     Bytecode::Lt => {
                         gas!(const_instr: context, self, Opcodes::LT)?;
-                        self.binop_bool(|l: u64, r| l < r)?
+                        self.binop_bool(IntegerValue::lt)?
                     }
                     Bytecode::Gt => {
                         gas!(const_instr: context, self, Opcodes::GT)?;
-                        self.binop_bool(|l: u64, r| l > r)?
+                        self.binop_bool(IntegerValue::gt)?
                     }
                     Bytecode::Le => {
                         gas!(const_instr: context, self, Opcodes::LE)?;
-                        self.binop_bool(|l: u64, r| l <= r)?
+                        self.binop_bool(IntegerValue::le)?
                     }
                     Bytecode::Ge => {
                         gas!(const_instr: context, self, Opcodes::GE)?;
-                        self.binop_bool(|l: u64, r| l >= r)?
+                        self.binop_bool(IntegerValue::ge)?
                     }
                     Bytecode::Abort => {
                         gas!(const_instr: context, self, Opcodes::ABORT)?;
@@ -831,9 +831,9 @@ impl<'txn> Interpreter<'txn> {
     fn binop_bool<F, T>(&mut self, f: F) -> VMResult<()>
     where
         VMResult<T>: From<Value>,
-        F: FnOnce(T, T) -> bool,
+        F: FnOnce(T, T) -> VMResult<bool>,
     {
-        self.binop(|lhs, rhs| Ok(Value::bool(f(lhs, rhs))))
+        self.binop(|lhs, rhs| Ok(Value::bool(f(lhs, rhs)?)))
     }
 
     /// Entry point for all global store operations (effectively opcodes).

--- a/language/vm/vm-runtime/vm-runtime-types/src/value.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/value.rs
@@ -591,6 +591,74 @@ impl IntegerValue {
             U128(x) => IntegerValue::U128(x >> other.into_bits_shifted::<u128>()?),
         })
     }
+
+    pub fn lt(self, other: Self) -> VMResult<bool> {
+        use IntegerValue::*;
+
+        Ok(match (self, other) {
+            (U8(l), U8(r)) => l < r,
+            (U64(l), U64(r)) => l < r,
+            (U128(l), U128(r)) => l < r,
+            (l, r) => {
+                let msg = format!(
+                    "Cannot compare {:?} and {:?}: incompatible integer types",
+                    l, r
+                );
+                return Err(VMStatus::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(msg));
+            }
+        })
+    }
+
+    pub fn le(self, other: Self) -> VMResult<bool> {
+        use IntegerValue::*;
+
+        Ok(match (self, other) {
+            (U8(l), U8(r)) => l <= r,
+            (U64(l), U64(r)) => l <= r,
+            (U128(l), U128(r)) => l <= r,
+            (l, r) => {
+                let msg = format!(
+                    "Cannot compare {:?} and {:?}: incompatible integer types",
+                    l, r
+                );
+                return Err(VMStatus::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(msg));
+            }
+        })
+    }
+
+    pub fn gt(self, other: Self) -> VMResult<bool> {
+        use IntegerValue::*;
+
+        Ok(match (self, other) {
+            (U8(l), U8(r)) => l > r,
+            (U64(l), U64(r)) => l > r,
+            (U128(l), U128(r)) => l > r,
+            (l, r) => {
+                let msg = format!(
+                    "Cannot compare {:?} and {:?}: incompatible integer types",
+                    l, r
+                );
+                return Err(VMStatus::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(msg));
+            }
+        })
+    }
+
+    pub fn ge(self, other: Self) -> VMResult<bool> {
+        use IntegerValue::*;
+
+        Ok(match (self, other) {
+            (U8(l), U8(r)) => l >= r,
+            (U64(l), U64(r)) => l >= r,
+            (U128(l), U128(r)) => l >= r,
+            (l, r) => {
+                let msg = format!(
+                    "Cannot compare {:?} and {:?}: incompatible integer types",
+                    l, r
+                );
+                return Err(VMStatus::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(msg));
+            }
+        })
+    }
 }
 
 //


### PR DESCRIPTION
## Summary
These comparison operators wasn't updated for u8 and u128 when they were added, resulting in vm internal type errors. This gets them fixed and adds the corresponding tests.

## Test Plan
cargo test