### PR TITLE
[move][bytecode verifier] Relaxed CopyLoc for Immutable Borrows

### DIFF
--- a/language/bytecode-verifier/src/abstract_state.rs
+++ b/language/bytecode-verifier/src/abstract_state.rs
@@ -211,12 +211,19 @@ impl AbstractState {
         !self.borrow_graph.all_borrows(nonce).is_empty()
     }
 
+    fn local_borrows(&self, idx: LocalIndex) -> BTreeSet<Nonce> {
+        self.borrow_graph
+            .consistent_borrows(self.frame_root(), LabelElem::Local(idx))
+    }
+
     /// checks if a local is borrowed
     pub fn is_local_borrowed(&self, idx: LocalIndex) -> bool {
-        !self
-            .borrow_graph
-            .consistent_borrows(self.frame_root(), LabelElem::Local(idx))
-            .is_empty()
+        !self.local_borrows(idx).is_empty()
+    }
+
+    /// checks if a local is mutably borrowed
+    pub fn is_local_mutably_borrowed(&self, idx: LocalIndex) -> bool {
+        !self.all_nonces_immutable(self.local_borrows(idx))
     }
 
     /// checks if a global is borrowed

--- a/language/bytecode-verifier/src/type_memory_safety.rs
+++ b/language/bytecode-verifier/src/type_memory_safety.rs
@@ -460,7 +460,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
                             Err(err_at_offset(StatusCode::COPYLOC_RESOURCE_ERROR, offset))
                         }
                         Kind::Unrestricted => {
-                            if !state.is_local_borrowed(*idx) {
+                            if !state.is_local_mutably_borrowed(*idx) {
                                 self.stack.push(TypedAbstractValue {
                                     signature: signature_view.as_inner().clone(),
                                     value: AbstractValue::Value(Kind::Unrestricted),

--- a/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed.mvir
@@ -1,0 +1,13 @@
+module Tester {
+    t() {
+        let x: u64;
+        let r1: &u64;
+        let r2: &u64;
+
+        x = 0;
+        r1 = &x;
+        r2 = &x;
+        _ = copy(x) + copy(x);
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_field.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_field.mvir
@@ -1,0 +1,15 @@
+module Tester {
+    struct T { f: u64 }
+
+    t() {
+        let x: Self.T;
+        let r1: &u64;
+        let r2: &u64;
+
+        x = T { f: 0 };
+        r1 = &(&x).f;
+        r2 = &(&x).f;
+        _ = copy(x);
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_field_invalid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_field_invalid.mvir
@@ -1,0 +1,15 @@
+module Tester {
+    struct T { f: u64 }
+
+    t() {
+        let x: Self.T;
+        let r1: &mut u64;
+
+        x = T { f: 0 };
+        r1 = &mut (&mut x).f;
+        _ = copy(x);
+        return;
+    }
+}
+
+// check: COPYLOC_EXISTS_BORROW_ERROR

--- a/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_indirect.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_indirect.mvir
@@ -1,0 +1,20 @@
+module Tester {
+    t() {
+        let x: u64;
+        let y: u64;
+        let r1: &u64;
+        let r2: &u64;
+
+        x = 0;
+        y = 0;
+        r1 = Self.foo(&x, &y);
+        r2 = Self.foo(&x, &y);
+        _ = copy(x) + copy(x);
+        _ = copy(y) + copy(y);
+        return;
+    }
+
+    foo(r: &u64, r2: &u64): &u64 {
+        return move(r2);
+    }
+}

--- a/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_indirect_invalid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_indirect_invalid.mvir
@@ -1,0 +1,19 @@
+module Tester {
+    t() {
+        let x: u64;
+        let y: u64;
+        let r1: &mut u64;
+
+        x = 0;
+        y = 0;
+        r1 = Self.foo(&mut x, &mut y);
+        _ = copy(x);
+        return;
+    }
+
+    foo(r: &mut u64, r2: &mut u64): &mut u64 {
+        return move(r2);
+    }
+}
+
+// check: COPYLOC_EXISTS_BORROW_ERROR

--- a/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_invalid.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/copy_loc_borrowed_invalid.mvir
@@ -1,0 +1,13 @@
+module Tester {
+    t() {
+        let x: u64;
+        let r1: &mut u64;
+
+        x = 0;
+        r1 = &mut x;
+        _ = copy(x);
+        return;
+    }
+}
+
+// check: COPYLOC_EXISTS_BORROW_ERROR


### PR DESCRIPTION
##  Motivation

- Allowed CopyLoc on a borrowed local, if all outstanding borrows are immutable
- Added tests

## Test Plan

- New Tests
- cargo test
