### PR TITLE
[test generation] Add call graph to disallow recursive loops.

### DIFF
--- a/language/tools/test-generation/src/bytecode_generator.rs
+++ b/language/tools/test-generation/src/bytecode_generator.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    abstract_state::{AbstractState, BorrowState, InstantiableModule},
-    config::{MAX_CFG_BLOCKS, MUTATION_TOLERANCE, NEGATE_PRECONDITIONS, NEGATION_PROBABILITY},
+    abstract_state::{AbstractState, BorrowState, CallGraph, InstantiableModule},
+    config::{
+        CALL_STACK_LIMIT, MAX_CFG_BLOCKS, MUTATION_TOLERANCE, NEGATE_PRECONDITIONS,
+        NEGATION_PROBABILITY, VALUE_STACK_LIMIT,
+    },
     control_flow_graph::CFG,
     summaries,
 };
@@ -95,6 +98,28 @@ enum StackEffect {
 
     /// Represents no change in stack size
     Nop,
+}
+
+/// Context containing information about a function
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct FunctionGenerationContext {
+    pub function_handle_index: FunctionHandleIndex,
+    pub starting_call_height: usize,
+    pub locals_len: usize,
+}
+
+impl FunctionGenerationContext {
+    pub fn new(
+        function_handle_index: FunctionHandleIndex,
+        starting_call_height: usize,
+        locals_len: usize,
+    ) -> Self {
+        Self {
+            function_handle_index,
+            starting_call_height,
+            locals_len,
+        }
+    }
 }
 
 /// Generates a sequence of bytecode instructions.
@@ -246,13 +271,48 @@ impl<'a> BytecodeGenerator<'a> {
         }
     }
 
+    // Soft cutoff: We starting making it less likely for the stack size to be increased once it
+    // becomes greater than VALUE_STACK_LIMIT - 24. Once we reach the stack limit then we have a
+    // hard cutoff.
+    fn value_backpressure(state: &AbstractState, probability: f32) -> f32 {
+        let len = state.stack_len();
+
+        if len <= VALUE_STACK_LIMIT - 24 {
+            return probability;
+        }
+
+        if len > VALUE_STACK_LIMIT - 24 {
+            return probability * 0.5;
+        }
+
+        0.0
+    }
+
+    // Tight cutoff: calls can be generated as long as it's less than the max call stack height. If
+    // the call would cause the call stack to overflow then it can't be generated.
+    fn call_stack_backpressure(
+        state: &AbstractState,
+        fn_context: &FunctionGenerationContext,
+        call: FunctionHandleIndex,
+    ) -> Option<FunctionHandleIndex> {
+        if let Some(call_size) = state
+            .call_graph
+            .call_depth(fn_context.function_handle_index, call)
+        {
+            if call_size + fn_context.starting_call_height <= CALL_STACK_LIMIT {
+                return Some(call);
+            }
+        }
+        None
+    }
+
     /// Given an `AbstractState`, `state`, and a the number of locals the function has,
     /// this function returns a list of instructions whose preconditions are satisfied for
     /// the state.
     fn candidate_instructions(
         &mut self,
+        fn_context: &FunctionGenerationContext,
         state: AbstractState,
-        locals_len: usize,
         module: CompiledModuleMut,
     ) -> Vec<(StackEffect, Bytecode)> {
         let mut matches: Vec<(StackEffect, Bytecode)> = Vec::new();
@@ -262,8 +322,10 @@ impl<'a> BytecodeGenerator<'a> {
                 BytecodeType::NoArg(instruction) => Some(instruction.clone()),
                 BytecodeType::LocalIndex(instruction) => {
                     // Generate a random index into the locals
-                    if locals_len > 0 {
-                        Some(instruction(self.rng.gen_range(0, locals_len) as LocalIndex))
+                    if fn_context.locals_len > 0 {
+                        Some(instruction(
+                            self.rng.gen_range(0, fn_context.locals_len) as LocalIndex
+                        ))
                     } else {
                         None
                     }
@@ -311,13 +373,22 @@ impl<'a> BytecodeGenerator<'a> {
                 }
                 BytecodeType::FunctionAndLocalIndex(instruction) => {
                     // Select a random function handle and local signature
-                    Self::index_or_none(&module.function_handles, &mut self.rng).map(|x| {
-                        instruction(
-                            FunctionHandleIndex::new(x),
-                            // Set 0 as the signature index. This index will be filled in/changed later
-                            LocalsSignatureIndex::new(0),
-                        )
-                    })
+                    let callable_fns = &state.call_graph.can_call(fn_context.function_handle_index);
+                    Self::index_or_none(callable_fns, &mut self.rng)
+                        .and_then(|handle_idx| {
+                            Self::call_stack_backpressure(
+                                &state,
+                                fn_context,
+                                callable_fns[handle_idx as usize],
+                            )
+                        })
+                        .map(|handle| {
+                            instruction(
+                                handle,
+                                // Set 0 as the signature index. This index will be filled in/changed later
+                                LocalsSignatureIndex::new(0),
+                            )
+                        })
                 }
             };
             if let Some(instruction) = instruction {
@@ -358,6 +429,7 @@ impl<'a> BytecodeGenerator<'a> {
         } else {
             1.0
         };
+        let prob_add = Self::value_backpressure(&state, prob_add);
         debug!("Pr[add] = {:?}", prob_add);
         let next_instruction_index;
         if self.rng.gen_range(0.0, 1.0) <= prob_add {
@@ -440,6 +512,7 @@ impl<'a> BytecodeGenerator<'a> {
     /// to the bytecode sequence
     pub fn apply_instruction(
         &self,
+        fn_context: &FunctionGenerationContext,
         mut state: AbstractState,
         bytecode: &mut Vec<Bytecode>,
         instruction: Bytecode,
@@ -455,6 +528,11 @@ impl<'a> BytecodeGenerator<'a> {
         let instruction = step.1;
         debug!("Affected: {}", state);
         debug!("Actual instr: {:?}", instruction);
+        if let Bytecode::Call(index, _) = instruction {
+            state
+                .call_graph
+                .add_call(fn_context.function_handle_index, index);
+        }
         bytecode.push(instruction);
         debug!("**********************\n");
         state
@@ -464,6 +542,7 @@ impl<'a> BytecodeGenerator<'a> {
     /// bytecode instructions such that `abstract_state_out` is reached.
     pub fn generate_block(
         &mut self,
+        fn_context: &FunctionGenerationContext,
         abstract_state_in: AbstractState,
         abstract_state_out: AbstractState,
         module: &CompiledModuleMut,
@@ -474,24 +553,37 @@ impl<'a> BytecodeGenerator<'a> {
         let mut state = abstract_state_in.clone();
         // Generate block body
         loop {
-            let candidates = self.candidate_instructions(
-                state.clone(),
-                abstract_state_in.get_locals().len(),
-                module.clone(),
-            );
+            let candidates = self.candidate_instructions(fn_context, state.clone(), module.clone());
             if candidates.is_empty() {
                 warn!("No candidates found for state: [{:?}]", state);
                 break;
             }
             match self.select_candidate(0, &state, &candidates) {
                 Ok(next_instruction) => {
-                    state = self.apply_instruction(state, &mut bytecode, next_instruction, false);
+                    state = self.apply_instruction(
+                        fn_context,
+                        state,
+                        &mut bytecode,
+                        next_instruction,
+                        false,
+                    );
                     if state.is_final() {
                         break;
                     } else if state.has_aborted() {
-                        state =
-                            self.apply_instruction(state, &mut bytecode, Bytecode::LdU64(0), true);
-                        state = self.apply_instruction(state, &mut bytecode, Bytecode::Abort, true);
+                        state = self.apply_instruction(
+                            fn_context,
+                            state,
+                            &mut bytecode,
+                            Bytecode::LdU64(0),
+                            true,
+                        );
+                        state = self.apply_instruction(
+                            fn_context,
+                            state,
+                            &mut bytecode,
+                            Bytecode::Abort,
+                            true,
+                        );
                         return (bytecode, state);
                     }
                 }
@@ -517,9 +609,16 @@ impl<'a> BytecodeGenerator<'a> {
                     state = next_instructions
                         .into_iter()
                         .fold(state, |state, instruction| {
-                            self.apply_instruction(state, &mut bytecode, instruction, true)
+                            self.apply_instruction(
+                                fn_context,
+                                state,
+                                &mut bytecode,
+                                instruction,
+                                true,
+                            )
                         });
                     state = self.apply_instruction(
+                        fn_context,
                         state,
                         &mut bytecode,
                         Bytecode::StLoc(*i as u8),
@@ -529,12 +628,19 @@ impl<'a> BytecodeGenerator<'a> {
                     && *current_availability == BorrowState::Available
                 {
                     state = self.apply_instruction(
+                        fn_context,
                         state,
                         &mut bytecode,
                         Bytecode::MoveLoc(*i as u8),
                         true,
                     );
-                    state = self.apply_instruction(state, &mut bytecode, Bytecode::Pop, true);
+                    state = self.apply_instruction(
+                        fn_context,
+                        state,
+                        &mut bytecode,
+                        Bytecode::Pop,
+                        true,
+                    );
                 }
             } else {
                 unreachable!("Target locals out contains new local");
@@ -549,10 +655,12 @@ impl<'a> BytecodeGenerator<'a> {
     /// `target_max` instructions.
     pub fn generate(
         &mut self,
+        fn_context: &FunctionGenerationContext,
         locals: &[SignatureToken],
         signature: &FunctionSignature,
         acquires_global_resources: &[StructDefinitionIndex],
         module: &mut CompiledModuleMut,
+        call_graph: &mut CallGraph,
     ) -> Vec<Bytecode> {
         let number_of_blocks = self.rng.gen_range(1, MAX_CFG_BLOCKS + 1);
         // The number of basic blocks must be at least one based on the
@@ -570,28 +678,54 @@ impl<'a> BytecodeGenerator<'a> {
                 block.get_locals_in().clone(),
                 signature.type_formals.clone(),
                 acquires_global_resources.to_vec(),
+                call_graph.clone(),
             );
             let state2 = AbstractState::from_locals(
                 module.clone(),
                 block.get_locals_out().clone(),
                 signature.type_formals.clone(),
                 acquires_global_resources.to_vec(),
+                call_graph.clone(),
             );
-            let (mut bytecode, mut state_f) = self.generate_block(state1, state2.clone(), module);
+            let (mut bytecode, mut state_f) =
+                self.generate_block(fn_context, state1, state2.clone(), module);
             state_f.allow_control_flow();
             if !state_f.has_aborted() {
                 state_f = if cfg_copy.num_children(*block_id) == 2 {
                     // BrTrue, BrFalse: Add bool and branching instruction randomly
-                    state_f =
-                        self.apply_instruction(state_f, &mut bytecode, Bytecode::LdFalse, true);
+                    state_f = self.apply_instruction(
+                        fn_context,
+                        state_f,
+                        &mut bytecode,
+                        Bytecode::LdFalse,
+                        true,
+                    );
                     if self.rng.gen_bool(0.5) {
-                        self.apply_instruction(state_f, &mut bytecode, Bytecode::BrTrue(0), true)
+                        self.apply_instruction(
+                            fn_context,
+                            state_f,
+                            &mut bytecode,
+                            Bytecode::BrTrue(0),
+                            true,
+                        )
                     } else {
-                        self.apply_instruction(state_f, &mut bytecode, Bytecode::BrFalse(0), true)
+                        self.apply_instruction(
+                            fn_context,
+                            state_f,
+                            &mut bytecode,
+                            Bytecode::BrFalse(0),
+                            true,
+                        )
                     }
                 } else if cfg_copy.num_children(*block_id) == 1 {
                     // Branch: Add branch instruction
-                    self.apply_instruction(state_f, &mut bytecode, Bytecode::Branch(0), true)
+                    self.apply_instruction(
+                        fn_context,
+                        state_f,
+                        &mut bytecode,
+                        Bytecode::Branch(0),
+                        true,
+                    )
                 } else if cfg_copy.num_children(*block_id) == 0 {
                     // Return: Add return types to last block
                     for token_type in signature.return_types.iter() {
@@ -606,6 +740,7 @@ impl<'a> BytecodeGenerator<'a> {
                                 .into_iter()
                                 .fold(state_f, |state_f, instruction| {
                                     self.apply_instruction(
+                                        fn_context,
                                         state_f,
                                         &mut bytecode,
                                         instruction,
@@ -613,13 +748,14 @@ impl<'a> BytecodeGenerator<'a> {
                                     )
                                 });
                     }
-                    self.apply_instruction(state_f, &mut bytecode, Bytecode::Ret, true)
+                    self.apply_instruction(fn_context, state_f, &mut bytecode, Bytecode::Ret, true)
                 } else {
                     state_f
                 };
             }
             block.set_instructions(bytecode);
-            *module = state_f.instantiate_module();
+            *module = state_f.module.instantiate();
+            *call_graph = state_f.call_graph;
         }
         // The CFG will be non-empty if we set the number of basic blocks to generate
         // to be non-zero
@@ -629,17 +765,25 @@ impl<'a> BytecodeGenerator<'a> {
 
     pub fn generate_module(&mut self, mut module: CompiledModuleMut) -> CompiledModuleMut {
         let mut fdefs = module.function_defs.clone();
+        let mut call_graph = CallGraph::new(module.function_handles.len());
         for fdef in fdefs.iter_mut() {
             let f_handle = &module.function_handles[fdef.function.0 as usize].clone();
             let func_sig = module.function_signatures[f_handle.signature.0 as usize].clone();
             let locals_sigs = module.locals_signatures[fdef.code.locals.0 as usize]
                 .0
                 .clone();
+            let fn_context = FunctionGenerationContext::new(
+                fdef.function,
+                call_graph.max_calling_depth(fdef.function),
+                locals_sigs.len(),
+            );
             fdef.code.code = self.generate(
+                &fn_context,
                 &locals_sigs,
                 &func_sig,
                 &fdef.acquires_global_resources,
                 &mut module,
+                &mut call_graph,
             );
         }
         module.function_defs = fdefs;

--- a/language/tools/test-generation/src/config.rs
+++ b/language/tools/test-generation/src/config.rs
@@ -44,6 +44,14 @@ pub const EXECUTE_UNVERIFIED_MODULE: bool = false;
 /// Default is `true`
 pub const GAS_METERING: bool = true;
 
+/// Call stack height limit. This is defined in the VM, and is replicated here. This should track
+/// that constant.
+pub const CALL_STACK_LIMIT: usize = 1024;
+
+/// The value stack size limit. This is defined in the VM and is replicated here. This should
+/// remain in sync with the constant for this defined in the VM.
+pub const VALUE_STACK_LIMIT: usize = 1024;
+
 /// Command line arguments for the tool
 #[derive(Debug, StructOpt)]
 #[structopt(

--- a/language/tools/test-generation/tests/call_graph.rs
+++ b/language/tools/test-generation/tests/call_graph.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate test_generation;
+use test_generation::abstract_state::CallGraph;
+use vm::file_format::FunctionHandleIndex;
+
+#[test]
+fn call_graph_no_self_call_recursive() {
+    let call_graph = CallGraph::new(10);
+    let can_call = call_graph.can_call(FunctionHandleIndex(0));
+    assert!(can_call.len() == 9);
+    assert!(!can_call.iter().any(|fh| *fh == FunctionHandleIndex(0)));
+}
+
+#[test]
+fn call_graph_simple_recursive_call() {
+    let mut call_graph = CallGraph::new(10);
+    call_graph.add_call(FunctionHandleIndex(0), FunctionHandleIndex(1));
+    let can_call0 = call_graph.can_call(FunctionHandleIndex(0));
+    let can_call1 = call_graph.can_call(FunctionHandleIndex(1));
+    assert!(can_call0.len() == 9);
+    assert!(can_call1.len() == 8);
+    assert!(!can_call0.iter().any(|fh| *fh == FunctionHandleIndex(0)));
+    assert!(!can_call1
+        .iter()
+        .any(|fh| *fh == FunctionHandleIndex(0) || *fh == FunctionHandleIndex(1)));
+}
+
+#[test]
+fn call_graph_transitive_recursive_call() {
+    let mut call_graph = CallGraph::new(10);
+    call_graph.add_call(FunctionHandleIndex(1), FunctionHandleIndex(2));
+    call_graph.add_call(FunctionHandleIndex(2), FunctionHandleIndex(0));
+    let can_call0 = call_graph.can_call(FunctionHandleIndex(0));
+    assert!(can_call0.len() == 7);
+}
+
+#[test]
+fn call_graph_call_graph_depth() {
+    let mut call_graph = CallGraph::new(10);
+    call_graph.add_call(FunctionHandleIndex(0), FunctionHandleIndex(1));
+    call_graph.add_call(FunctionHandleIndex(1), FunctionHandleIndex(2));
+    call_graph.add_call(FunctionHandleIndex(1), FunctionHandleIndex(3));
+    call_graph.add_call(FunctionHandleIndex(3), FunctionHandleIndex(2));
+    assert!(
+        call_graph
+            .call_depth(FunctionHandleIndex(0), FunctionHandleIndex(1))
+            .unwrap()
+            == 3
+    );
+}
+
+#[test]
+fn call_graph_call_call_into_graph_depth() {
+    let mut call_graph = CallGraph::new(10);
+    call_graph.add_call(FunctionHandleIndex(0), FunctionHandleIndex(1));
+    call_graph.add_call(FunctionHandleIndex(1), FunctionHandleIndex(2));
+    call_graph.add_call(FunctionHandleIndex(1), FunctionHandleIndex(3));
+    call_graph.add_call(FunctionHandleIndex(3), FunctionHandleIndex(2));
+    assert!(call_graph.max_calling_depth(FunctionHandleIndex(2)) == 3);
+}

--- a/language/tools/test-generation/tests/control_flow_instructions.rs
+++ b/language/tools/test-generation/tests/control_flow_instructions.rs
@@ -4,7 +4,7 @@
 extern crate test_generation;
 use libra_types::identifier::Identifier;
 use std::collections::HashMap;
-use test_generation::abstract_state::{AbstractState, AbstractValue};
+use test_generation::abstract_state::{AbstractState, AbstractValue, CallGraph};
 use vm::file_format::{
     empty_module, Bytecode, CompiledModuleMut, FunctionHandle, FunctionHandleIndex,
     FunctionSignature, FunctionSignatureIndex, IdentifierIndex, LocalsSignature,
@@ -48,7 +48,8 @@ fn generate_module_with_function() -> CompiledModuleMut {
 #[test]
 fn bytecode_call() {
     let module = generate_module_with_function();
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let (state2, _) = common::run_instruction(
@@ -66,7 +67,8 @@ fn bytecode_call() {
 #[should_panic]
 fn bytecode_call_function_signature_not_satisfied() {
     let module = generate_module_with_function();
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::Call(FunctionHandleIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -77,7 +79,8 @@ fn bytecode_call_function_signature_not_satisfied() {
 #[should_panic]
 fn bytecode_call_return_not_pushed() {
     let module = generate_module_with_function();
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::U64));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Bool));
     let (state2, _) = common::run_instruction(

--- a/language/tools/test-generation/tests/struct_instructions.rs
+++ b/language/tools/test-generation/tests/struct_instructions.rs
@@ -4,7 +4,7 @@
 extern crate test_generation;
 use libra_types::identifier::Identifier;
 use std::collections::HashMap;
-use test_generation::abstract_state::{AbstractState, AbstractValue};
+use test_generation::abstract_state::{AbstractState, AbstractValue, CallGraph};
 use vm::{
     access::ModuleAccess,
     file_format::{
@@ -105,7 +105,8 @@ fn create_struct_value(module: &CompiledModule) -> (AbstractValue, Vec<Signature
 #[should_panic]
 fn bytecode_pack_signature_not_satisfied() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::Pack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -115,7 +116,8 @@ fn bytecode_pack_signature_not_satisfied() {
 #[test]
 fn bytecode_pack() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let (struct_value1, tokens) = create_struct_value(&state1.module.module);
     for token in tokens {
         let abstract_value = AbstractValue {
@@ -139,7 +141,8 @@ fn bytecode_pack() {
 #[should_panic]
 fn bytecode_unpack_signature_not_satisfied() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::Unpack(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -149,7 +152,8 @@ fn bytecode_unpack_signature_not_satisfied() {
 #[test]
 fn bytecode_unpack() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let (struct_value, tokens) = create_struct_value(&state1.module.module);
     state1.stack_push(struct_value);
     let (state2, _) = common::run_instruction(
@@ -166,7 +170,8 @@ fn bytecode_unpack() {
 #[test]
 fn bytecode_exists() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     let (state2, _) = common::run_instruction(
         Bytecode::Exists(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -183,7 +188,8 @@ fn bytecode_exists() {
 #[should_panic]
 fn bytecode_exists_struct_is_not_resource() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     common::run_instruction(
         Bytecode::Exists(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -195,7 +201,8 @@ fn bytecode_exists_struct_is_not_resource() {
 #[should_panic]
 fn bytecode_exists_no_address_on_stack() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::Exists(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -210,6 +217,7 @@ fn bytecode_movefrom() {
         HashMap::new(),
         vec![],
         vec![StructDefinitionIndex::new(0)],
+        CallGraph::new(0),
     );
     let state1_copy = state1.clone();
     let struct_def = state1_copy
@@ -235,7 +243,8 @@ fn bytecode_movefrom() {
 #[should_panic]
 fn bytecode_movefrom_struct_is_not_resource() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     common::run_instruction(
         Bytecode::MoveFrom(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -247,7 +256,8 @@ fn bytecode_movefrom_struct_is_not_resource() {
 #[should_panic]
 fn bytecode_movefrom_no_address_on_stack() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::MoveFrom(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -257,7 +267,8 @@ fn bytecode_movefrom_no_address_on_stack() {
 #[test]
 fn bytecode_movetosender() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(create_struct_value(&state1.module.module).0);
     let (state2, _) = common::run_instruction(
         Bytecode::MoveToSender(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -270,7 +281,8 @@ fn bytecode_movetosender() {
 #[should_panic]
 fn bytecode_movetosender_struct_is_not_resource() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(create_struct_value(&state1.module.module).0);
     common::run_instruction(
         Bytecode::MoveToSender(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -282,7 +294,8 @@ fn bytecode_movetosender_struct_is_not_resource() {
 #[should_panic]
 fn bytecode_movetosender_no_struct_on_stack() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::MoveToSender(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,
@@ -292,7 +305,8 @@ fn bytecode_movetosender_no_struct_on_stack() {
 #[test]
 fn bytecode_mutborrowfield() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let struct_value = create_struct_value(&state1.module.module).0;
     state1.stack_push(AbstractValue {
         token: SignatureToken::MutableReference(Box::new(struct_value.token)),
@@ -320,7 +334,8 @@ fn bytecode_mutborrowfield() {
 #[should_panic]
 fn bytecode_mutborrowfield_stack_has_no_reference() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let field_index = FieldDefinitionIndex::new(0);
     common::run_instruction(Bytecode::MutBorrowField(field_index), state1);
 }
@@ -329,7 +344,8 @@ fn bytecode_mutborrowfield_stack_has_no_reference() {
 #[should_panic]
 fn bytecode_mutborrowfield_ref_is_immutable() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let struct_value = create_struct_value(&state1.module.module).0;
     state1.stack_push(AbstractValue {
         token: SignatureToken::Reference(Box::new(struct_value.token)),
@@ -342,7 +358,8 @@ fn bytecode_mutborrowfield_ref_is_immutable() {
 #[test]
 fn bytecode_immborrowfield() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let struct_value = create_struct_value(&state1.module.module).0;
     state1.stack_push(AbstractValue {
         token: SignatureToken::Reference(Box::new(struct_value.token)),
@@ -370,7 +387,8 @@ fn bytecode_immborrowfield() {
 #[should_panic]
 fn bytecode_immborrowfield_stack_has_no_reference() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let field_index = FieldDefinitionIndex::new(0);
     common::run_instruction(Bytecode::ImmBorrowField(field_index), state1);
 }
@@ -379,7 +397,8 @@ fn bytecode_immborrowfield_stack_has_no_reference() {
 #[should_panic]
 fn bytecode_immborrowfield_ref_is_mutable() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let struct_value = create_struct_value(&state1.module.module).0;
     state1.stack_push(AbstractValue {
         token: SignatureToken::MutableReference(Box::new(struct_value.token)),
@@ -392,7 +411,8 @@ fn bytecode_immborrowfield_ref_is_mutable() {
 #[test]
 fn bytecode_borrowglobal() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     let struct_value = create_struct_value(&state1.module.module).0;
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     let (state2, _) = common::run_instruction(
@@ -413,7 +433,8 @@ fn bytecode_borrowglobal() {
 #[should_panic]
 fn bytecode_borrowglobal_struct_is_not_resource() {
     let module: CompiledModuleMut = generate_module_with_struct(false);
-    let mut state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let mut state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     state1.stack_push(AbstractValue::new_primitive(SignatureToken::Address));
     common::run_instruction(
         Bytecode::MutBorrowGlobal(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
@@ -425,7 +446,8 @@ fn bytecode_borrowglobal_struct_is_not_resource() {
 #[should_panic]
 fn bytecode_borrowglobal_no_address_on_stack() {
     let module: CompiledModuleMut = generate_module_with_struct(true);
-    let state1 = AbstractState::from_locals(module, HashMap::new(), vec![], vec![]);
+    let state1 =
+        AbstractState::from_locals(module, HashMap::new(), vec![], vec![], CallGraph::new(0));
     common::run_instruction(
         Bytecode::MutBorrowGlobal(StructDefinitionIndex::new(0), LocalsSignatureIndex::new(0)),
         state1,


### PR DESCRIPTION
This PR adds a call graph along with backpressure for the call and value stacks in order to prevent recursion, call stack overflows, and value stack overflows.

Adds new tests to make sure the call graph is tracking things correclyt. Also, in a run of 10k no call or value stack overflows were encountered (encountered quite frequently before). 
