### PR TITLE
[language][move] Remove the NameBeginArgsValue token

### DIFF
--- a/language/move-lang/tests/move_check/expansion/type_arguments_on_field_access.exp
+++ b/language/move-lang/tests/move_check/expansion/type_arguments_on_field_access.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/expansion/type_arguments_on_field_access.move:6:11 ───
+   ┌── tests/move_check/expansion/type_arguments_on_field_access.move:6:17 ───
    │
  6 │         x.f<u64>;
-   │           ^^ Unexpected token: 'f<'
+   │                 ^ Unexpected token: ';'
    ·
  6 │         x.f<u64>;
-   │           -- Expected: a name value
+   │                 - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_abort_missing_value.exp
+++ b/language/move-lang/tests/move_check/parser/expr_abort_missing_value.exp
@@ -6,6 +6,6 @@ error:
    │     ^ Unexpected token: '}'
    ·
  5 │     }
-   │     - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
+   │     - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_return_missing_value.exp
+++ b/language/move-lang/tests/move_check/parser/expr_return_missing_value.exp
@@ -6,6 +6,6 @@ error:
    │     ^ Unexpected token: '}'
    ·
  5 │     }
-   │     - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
+   │     - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_incomplete.exp
+++ b/language/move-lang/tests/move_check/parser/function_incomplete.exp
@@ -6,6 +6,6 @@ error:
    │ ^ Unexpected token: ''
    ·
  3 │ 
-   │ - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Name<Types>]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
+   │ - Expected: 'move', 'copy', 'break', 'continue', '[Name]', '[Address]', 'true', 'false', '[U64]', '(', '{', '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_return_type_missing.exp
+++ b/language/move-lang/tests/move_check/parser/function_return_type_missing.exp
@@ -6,6 +6,6 @@ error:
    │          ^ Unexpected token: '{'
    ·
  3 │     f(): { }
-   │          - Expected: '[Name]', '[Name<Types>]', '[Address]'
+   │          - Expected: '[Name]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
@@ -6,6 +6,6 @@ error:
    │                 ^ Unexpected token: '='
    ·
  3 │         let x : = 0;
-   │                 - Expected: '[Name]', '[Name<Types>]', '[Address]'
+   │                 - Expected: '[Name]', '[Address]'
    │
 

--- a/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
@@ -64,7 +64,7 @@ error:
     │                                  - The type: 'u64'
     ·
  13 │         let _ : bool = exists<R>(0);
-    │                        ------- Is not compatible with: 'address'
+    │                        ------ Is not compatible with: 'address'
     │
 
 error: 
@@ -103,7 +103,7 @@ error:
     │                                       - The type: 'u64'
     ·
  16 │         let _ : &R = borrow_global<R>(0);
-    │                      -------------- Is not compatible with: 'address'
+    │                      ------------- Is not compatible with: 'address'
     │
 
 error: 
@@ -117,7 +117,7 @@ error:
     │                                               - The type: 'u64'
     ·
  17 │         let _ : &mut R = borrow_global_mut<R>(0);
-    │                          ------------------ Is not compatible with: 'address'
+    │                          ----------------- Is not compatible with: 'address'
     │
 
 error: 
@@ -131,7 +131,7 @@ error:
     │                                 - The type: 'u64'
     ·
  18 │         let R {} = move_from<R>(0);
-    │                    ---------- Is not compatible with: 'address'
+    │                    --------- Is not compatible with: 'address'
     │
 
 error: 


### PR DESCRIPTION
There is an ambiguity in the grammar for Move where a "<" character following a name in an expression term may be either a binary operator or the start of a list of type arguments. The Move parser does not currently have the capability to use name lookup to resolve this ambiguity based on the type of the name. Instead we have been relying on the presence of whitespace before the "<" character when it is used as a binary operator. This change continues that approach but does so by adding a targeted check for whitespace in the one place where the ambiguity exists, instead of the previous approach where the "<" character was "glued" to the name as a special NameBeginArgsValue token.

## Motivation

Simplifying the Move parser.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This changes the output for some parser errors, and I've updated the expected results. It would be good to have a more targeted test for the ambiguous case, but I haven't come up with one yet.