### PR TITLE
[language] Move test generation to use MoveVM

### DIFF
--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -35,9 +35,9 @@ use vm::{
     gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS,
     transaction_metadata::TransactionMetadata,
 };
-use vm_cache_map::Arena;
-use vm_runtime::chain_state::TransactionExecutionContext;
-use vm_runtime::{data_cache::BlockDataCache, runtime::VMRuntime};
+use vm_runtime::{
+    chain_state::TransactionExecutionContext, data_cache::BlockDataCache, move_vm::MoveVM,
+};
 use vm_runtime_types::value::Value;
 
 /// This function calls the Bytecode verifier to test it
@@ -91,22 +91,22 @@ fn execute_function_in_module(
         module.identifier_at(entry_name_idx)
     };
     {
-        let arena = Arena::new();
-        let mut runtime = VMRuntime::new(&arena);
+        let mut runtime = MoveVM::new();
         runtime.cache_module(module.clone());
 
         let data_cache = BlockDataCache::new(state_view);
-        let context = TransactionExecutionContext::new(*MAXIMUM_NUMBER_OF_GAS_UNITS, &data_cache);
-        let gas_schedule = runtime.load_gas_schedule(&context, &data_cache)?;
+        let mut context =
+            TransactionExecutionContext::new(*MAXIMUM_NUMBER_OF_GAS_UNITS, &data_cache);
+        let gas_schedule = runtime.load_gas_schedule(&mut context, &data_cache)?;
         let txn_data = TransactionMetadata::default();
         let mut interpreter_context =
             TransactionExecutionContext::new(txn_data.max_gas_amount(), &data_cache);
         runtime.execute_function(
-            &mut interpreter_context,
-            &txn_data,
-            &gas_schedule,
             &module_id,
             &entry_name,
+            &gas_schedule,
+            &mut interpreter_context,
+            &txn_data,
             args,
         )
     }

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -102,7 +102,7 @@ impl MoveVM {
             .rent(|runtime| runtime.resolve_struct_def_by_name(module_id, name, context))
     }
 
-    pub(crate) fn load_gas_schedule<S: ChainState>(
+    pub fn load_gas_schedule<S: ChainState>(
         &self,
         chain_state: &mut S,
         data_view: &dyn RemoteCache,


### PR DESCRIPTION
This should be pretty straightforward and moves test generation to
use `MoveVM` instead of `VMRuntime`.
Cost synthesis is the only tool left to use `VMRuntime` but that
is a much more significant effort and it'll come at a later time