### PR TITLE
[docker/tf] Add fullnode support (back) to tf workspaces

### DIFF
--- a/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
+++ b/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+declare -a params
+if [ -n "${CFG_BASE_CONFIG}" ]; then # Path to base config
+	    params+="-t ${CFG_BASE_CONFIG} "
+fi
+if [ -n "${CFG_LISTEN_ADDR}" ]; then # Advertised listen address for network config
+	    params+="-a /ip4/${CFG_LISTEN_ADDR}/tcp/6180 "
+fi
+if [ -n "${CFG_LISTEN_ADDR}" ]; then # Listen address for node
+	    params+="-l /ip4/0.0.0.0/tcp/6180 "
+fi
+if [ -n "${CFG_FULLNODE_INDEX}" ]; then
+	    params+="-i ${CFG_FULLNODE_INDEX} "
+fi
+if [ -n "${CFG_NUM_VALIDATORS}" ]; then # Total number of nodes in this network
+	    params+="-n ${CFG_NUM_VALIDATORS} "
+fi
+if [ -n "${CFG_SEED}" ]; then # Random seed to use for validator network
+	    params+="-s ${CFG_SEED} "
+fi
+if [ -n "${CFG_FULLNODE_SEED}" ]; then # Random seed to use for fullnode network
+	    params+="-c ${CFG_FULLNODE_SEED} "
+fi
+if [ -n "${CFG_SEED_PEER_IP}" ]; then # Seed peer ip for discovery
+	    params+="--bootstrap /ip4/${CFG_SEED_PEER_IP}/tcp/6181 "
+fi
+if [ -n "${CFG_NUM_FULLNODES}" ]; then # Random seed to use for fullnode network
+	    params+="-f ${CFG_NUM_FULLNODES} "
+fi
+
+
+/opt/libra/bin/config-builder full-node create \
+	--data-dir /opt/libra/data/common \
+	--output-dir /opt/libra/etc/ \
+	${params[@]}
+
+exec /opt/libra/bin/libra-node -f /opt/libra/etc/node.config.toml

--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -31,4 +31,23 @@ fi
     --output-dir /opt/libra/etc/ \
     ${params[@]}
 
+
+if [ -n "${CFG_FULLNODE_SEED}" ]; then # We have a full node seed, add fullnode network
+	declare -a fullnode_params
+	    fullnode_params+="-s ${CFG_FULLNODE_SEED} "
+	    fullnode_params+="-a /ip4/${CFG_LISTEN_ADDR}/tcp/6181 "
+	    fullnode_params+="-l /ip4/0.0.0.0/tcp/6181 "
+	    fullnode_params+="-b /ip4/127.0.0.1/tcp/6180 "
+	    fullnode_params+="-n ${CFG_NUM_VALIDATORS} "
+	    fullnode_params+="-f ${CFG_NUM_FULLNODES} "
+	    fullnode_params+="-c ${CFG_FULLNODE_SEED} "
+
+
+	/opt/libra/bin/config-builder full-node extend \
+	    --data-dir /opt/libra/data/common \
+	    --output-dir /opt/libra/etc/ \
+	    ${fullnode_params[@]}
+
+fi
+
 exec /opt/libra/bin/libra-node -f /opt/libra/etc/node.config.toml

--- a/docker/validator-dynamic/validator-dynamic.Dockerfile
+++ b/docker/validator-dynamic/validator-dynamic.Dockerfile
@@ -24,6 +24,8 @@ RUN cargo build --release -p libra-node -p client -p config-builder && cd target
 FROM libra_e2e:latest as validator_with_config
 COPY --from=config_builder /libra/target/release/config-builder /opt/libra/bin
 COPY docker/validator-dynamic/docker-run-dynamic.sh /
+COPY docker/validator-dynamic/docker-run-dynamic-fullnode.sh /
+
 CMD /docker-run-dynamic.sh
 
 ARG BUILD_DATE

--- a/terraform/templates/dashboards/overview_dashboard.json
+++ b/terraform/templates/dashboards/overview_dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1576441758834,
+  "iteration": 1578690296023,
   "links": [
     {
       "icon": "external link",
@@ -26,13 +26,27 @@
   ],
   "panels": [
     {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 349,
+      "panels": [],
+      "title": "Row title",
+      "type": "row"
+    },
+    {
       "content": "# Workspace: $workspace",
       "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 9,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 61,
       "links": [],
@@ -66,7 +80,7 @@
         "h": 2,
         "w": 2,
         "x": 9,
-        "y": 0
+        "y": 1
       },
       "id": 62,
       "interval": null,
@@ -150,7 +164,7 @@
         "h": 2,
         "w": 3,
         "x": 11,
-        "y": 0
+        "y": 1
       },
       "id": 65,
       "interval": null,
@@ -235,7 +249,7 @@
         "h": 2,
         "w": 3,
         "x": 14,
-        "y": 0
+        "y": 1
       },
       "id": 66,
       "interval": null,
@@ -305,7 +319,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 3
       },
       "id": 92,
       "panels": [],
@@ -325,7 +339,7 @@
         "h": 7,
         "w": 4,
         "x": 0,
-        "y": 3
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 275,
@@ -361,7 +375,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "legendFormat": "{{validator_peer_id}}",
           "refId": "A"
         }
       ],
@@ -419,7 +433,7 @@
         "h": 7,
         "w": 4,
         "x": 4,
-        "y": 3
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 118,
@@ -455,7 +469,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "legendFormat": "{{validator_peer_id}}",
           "refId": "A"
         }
       ],
@@ -513,7 +527,7 @@
         "h": 7,
         "w": 4,
         "x": 8,
-        "y": 3
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 119,
@@ -548,7 +562,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "legendFormat": "{{validator_peer_id}}",
           "refId": "A"
         }
       ],
@@ -606,7 +620,7 @@
         "h": 7,
         "w": 4,
         "x": 12,
-        "y": 3
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 120,
@@ -636,12 +650,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(mempool_duration_sum{op='e2e.latency'}[1m])/irate(mempool_duration_count{op='e2e.latency'}[1m])",
+          "expr": "irate(mempool_duration_sum{op='e2e.latency'}[1m])/irate(mempool_duration_count{op='e2e.latency'}[1m])  ",
           "format": "time_series",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "legendFormat": "{{validator_peer_id}}",
           "refId": "A"
         }
       ],
@@ -699,7 +713,7 @@
         "h": 7,
         "w": 4,
         "x": 16,
-        "y": 3
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 121,
@@ -734,7 +748,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "legendFormat": "{{validator_peer_id}}",
           "refId": "A"
         }
       ],
@@ -793,7 +807,7 @@
         "h": 7,
         "w": 4,
         "x": 20,
-        "y": 3
+        "y": 4
       },
       "hiddenSeries": false,
       "id": 122,
@@ -881,7 +895,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 50,
       "panels": [],
@@ -896,7 +910,7 @@
         "h": 2,
         "w": 2,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 51,
       "links": [],
@@ -929,7 +943,7 @@
         "h": 2,
         "w": 2,
         "x": 2,
-        "y": 11
+        "y": 12
       },
       "id": 52,
       "interval": null,
@@ -1010,7 +1024,7 @@
         "h": 2,
         "w": 2,
         "x": 4,
-        "y": 11
+        "y": 12
       },
       "id": 53,
       "interval": null,
@@ -1096,7 +1110,7 @@
         "h": 2,
         "w": 2,
         "x": 6,
-        "y": 11
+        "y": 12
       },
       "id": 54,
       "interval": null,
@@ -1186,7 +1200,7 @@
         "h": 2,
         "w": 2,
         "x": 8,
-        "y": 11
+        "y": 12
       },
       "id": 63,
       "interval": null,
@@ -1269,7 +1283,7 @@
         "h": 2,
         "w": 2,
         "x": 10,
-        "y": 11
+        "y": 12
       },
       "id": 64,
       "interval": null,
@@ -1337,13 +1351,13 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 2,
       "panels": [],
-      "repeat": "peer_id",
+      "repeat": "validator_peer_id",
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1374,7 +1388,7 @@
         "h": 2,
         "w": 2,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 44,
       "interval": null,
@@ -1406,7 +1420,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1421,11 +1435,8 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "build_info{peer_id=\"$peer_id\"}",
-          "format": "time_series",
-          "instant": true,
-          "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "expr": "$validator_peer_id",
+          "panelId": 429,
           "refId": "A"
         }
       ],
@@ -1466,7 +1477,7 @@
         "h": 2,
         "w": 2,
         "x": 2,
-        "y": 14
+        "y": 15
       },
       "id": 59,
       "interval": null,
@@ -1500,7 +1511,7 @@
       ],
       "repeatDirection": "v",
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1515,7 +1526,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1554,7 +1565,7 @@
         "h": 2,
         "w": 2,
         "x": 4,
-        "y": 14
+        "y": 15
       },
       "id": 45,
       "interval": null,
@@ -1587,7 +1598,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1602,7 +1613,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1647,7 +1658,7 @@
         "h": 2,
         "w": 2,
         "x": 6,
-        "y": 14
+        "y": 15
       },
       "id": 48,
       "interval": null,
@@ -1679,7 +1690,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1694,17 +1705,10 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
-        },
-        {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "B"
         }
       ],
       "thresholds": "70, 90",
@@ -1744,7 +1748,7 @@
         "h": 2,
         "w": 2,
         "x": 8,
-        "y": 14
+        "y": 15
       },
       "id": 58,
       "interval": null,
@@ -1776,7 +1780,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1791,7 +1795,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1834,7 +1838,7 @@
         "h": 2,
         "w": 2,
         "x": 10,
-        "y": 14
+        "y": 15
       },
       "id": 57,
       "interval": null,
@@ -1866,7 +1870,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1881,7 +1885,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1924,7 +1928,7 @@
         "h": 2,
         "w": 2,
         "x": 12,
-        "y": 14
+        "y": 15
       },
       "id": 300,
       "interval": null,
@@ -1956,7 +1960,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1971,7 +1975,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2014,7 +2018,7 @@
         "h": 2,
         "w": 2,
         "x": 14,
-        "y": 14
+        "y": 15
       },
       "id": 56,
       "interval": null,
@@ -2046,7 +2050,7 @@
         }
       ],
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -2061,7 +2065,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
+          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2090,18 +2094,18 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 17
       },
-      "id": 301,
+      "id": 487,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 2,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "title": "Validators",
@@ -2129,9 +2133,9 @@
         "h": 2,
         "w": 2,
         "x": 0,
-        "y": 17
+        "y": 18
       },
-      "id": 302,
+      "id": 488,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2160,14 +2164,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2179,11 +2183,8 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "build_info{peer_id=\"$peer_id\"}",
-          "format": "time_series",
-          "instant": true,
-          "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "expr": "$validator_peer_id",
+          "panelId": 429,
           "refId": "A"
         }
       ],
@@ -2224,9 +2225,9 @@
         "h": 2,
         "w": 2,
         "x": 2,
-        "y": 17
+        "y": 18
       },
-      "id": 303,
+      "id": 489,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2257,14 +2258,14 @@
         }
       ],
       "repeatDirection": "v",
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 59,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2276,7 +2277,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2315,9 +2316,9 @@
         "h": 2,
         "w": 2,
         "x": 4,
-        "y": 17
+        "y": 18
       },
-      "id": 304,
+      "id": 490,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2347,14 +2348,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2366,7 +2367,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2411,9 +2412,9 @@
         "h": 2,
         "w": 2,
         "x": 6,
-        "y": 17
+        "y": 18
       },
-      "id": 305,
+      "id": 491,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2442,14 +2443,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 48,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2461,17 +2462,10 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
-        },
-        {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "B"
         }
       ],
       "thresholds": "70, 90",
@@ -2511,9 +2505,9 @@
         "h": 2,
         "w": 2,
         "x": 8,
-        "y": 17
+        "y": 18
       },
-      "id": 306,
+      "id": 492,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2542,14 +2536,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 58,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2561,7 +2555,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2604,9 +2598,9 @@
         "h": 2,
         "w": 2,
         "x": 10,
-        "y": 17
+        "y": 18
       },
-      "id": 307,
+      "id": 493,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2635,14 +2629,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 57,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2654,7 +2648,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2697,9 +2691,9 @@
         "h": 2,
         "w": 2,
         "x": 12,
-        "y": 17
+        "y": 18
       },
-      "id": 308,
+      "id": 494,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2728,14 +2722,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 300,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2747,7 +2741,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2790,9 +2784,9 @@
         "h": 2,
         "w": 2,
         "x": 14,
-        "y": 17
+        "y": 18
       },
-      "id": 309,
+      "id": 495,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2821,14 +2815,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 56,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "2",
-          "value": "2"
+          "text": "0",
+          "value": "0"
         }
       },
       "sparkline": {
@@ -2840,7 +2834,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
+          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2869,18 +2863,18 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 20
       },
-      "id": 310,
+      "id": 496,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 2,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "title": "Validators",
@@ -2908,9 +2902,9 @@
         "h": 2,
         "w": 2,
         "x": 0,
-        "y": 20
+        "y": 21
       },
-      "id": 311,
+      "id": 497,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2939,14 +2933,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -2958,11 +2952,8 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "build_info{peer_id=\"$peer_id\"}",
-          "format": "time_series",
-          "instant": true,
-          "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "expr": "$validator_peer_id",
+          "panelId": 429,
           "refId": "A"
         }
       ],
@@ -3003,9 +2994,9 @@
         "h": 2,
         "w": 2,
         "x": 2,
-        "y": 20
+        "y": 21
       },
-      "id": 312,
+      "id": 498,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3036,14 +3027,14 @@
         }
       ],
       "repeatDirection": "v",
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 59,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3055,7 +3046,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3094,9 +3085,9 @@
         "h": 2,
         "w": 2,
         "x": 4,
-        "y": 20
+        "y": 21
       },
-      "id": 313,
+      "id": 499,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3126,14 +3117,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3145,7 +3136,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3190,9 +3181,9 @@
         "h": 2,
         "w": 2,
         "x": 6,
-        "y": 20
+        "y": 21
       },
-      "id": 314,
+      "id": 500,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3221,14 +3212,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 48,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3240,17 +3231,10 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
-        },
-        {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "B"
         }
       ],
       "thresholds": "70, 90",
@@ -3290,9 +3274,9 @@
         "h": 2,
         "w": 2,
         "x": 8,
-        "y": 20
+        "y": 21
       },
-      "id": 315,
+      "id": 501,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3321,14 +3305,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 58,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3340,7 +3324,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3383,9 +3367,9 @@
         "h": 2,
         "w": 2,
         "x": 10,
-        "y": 20
+        "y": 21
       },
-      "id": 316,
+      "id": 502,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3414,14 +3398,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 57,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3433,7 +3417,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3476,9 +3460,9 @@
         "h": 2,
         "w": 2,
         "x": 12,
-        "y": 20
+        "y": 21
       },
-      "id": 317,
+      "id": 503,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3507,14 +3491,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 300,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3526,7 +3510,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3569,9 +3553,9 @@
         "h": 2,
         "w": 2,
         "x": 14,
-        "y": 20
+        "y": 21
       },
-      "id": 318,
+      "id": 504,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3600,14 +3584,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 56,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "0",
-          "value": "0"
+          "text": "1",
+          "value": "1"
         }
       },
       "sparkline": {
@@ -3619,7 +3603,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
+          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3648,18 +3632,18 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 23
       },
-      "id": 319,
+      "id": 505,
       "panels": [],
       "repeat": null,
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 2,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "title": "Validators",
@@ -3687,9 +3671,9 @@
         "h": 2,
         "w": 2,
         "x": 0,
-        "y": 23
+        "y": 24
       },
-      "id": 320,
+      "id": 506,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3718,14 +3702,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -3737,11 +3721,8 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "build_info{peer_id=\"$peer_id\"}",
-          "format": "time_series",
-          "instant": true,
-          "intervalFactor": 1,
-          "legendFormat": "{{peer_id}}",
+          "expr": "$validator_peer_id",
+          "panelId": 429,
           "refId": "A"
         }
       ],
@@ -3782,9 +3763,9 @@
         "h": 2,
         "w": 2,
         "x": 2,
-        "y": 23
+        "y": 24
       },
-      "id": 321,
+      "id": 507,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3815,14 +3796,14 @@
         }
       ],
       "repeatDirection": "v",
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 59,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -3834,7 +3815,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3873,9 +3854,9 @@
         "h": 2,
         "w": 2,
         "x": 4,
-        "y": 23
+        "y": 24
       },
-      "id": 322,
+      "id": 508,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -3905,14 +3886,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -3924,7 +3905,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3969,9 +3950,9 @@
         "h": 2,
         "w": 2,
         "x": 6,
-        "y": 23
+        "y": 24
       },
-      "id": 323,
+      "id": 509,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -4000,14 +3981,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 48,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -4019,17 +4000,10 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
-        },
-        {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
-          "format": "time_series",
-          "hide": true,
-          "intervalFactor": 1,
-          "refId": "B"
         }
       ],
       "thresholds": "70, 90",
@@ -4069,9 +4043,9 @@
         "h": 2,
         "w": 2,
         "x": 8,
-        "y": 23
+        "y": 24
       },
-      "id": 324,
+      "id": 510,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -4100,14 +4074,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 58,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -4119,7 +4093,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4162,9 +4136,9 @@
         "h": 2,
         "w": 2,
         "x": 10,
-        "y": 23
+        "y": 24
       },
-      "id": 325,
+      "id": 511,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -4193,14 +4167,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 57,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -4212,7 +4186,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4255,9 +4229,9 @@
         "h": 2,
         "w": 2,
         "x": 12,
-        "y": 23
+        "y": 24
       },
-      "id": 326,
+      "id": 512,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -4286,14 +4260,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 300,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -4305,7 +4279,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4348,9 +4322,9 @@
         "h": 2,
         "w": 2,
         "x": 14,
-        "y": 23
+        "y": 24
       },
-      "id": 327,
+      "id": 513,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -4379,14 +4353,14 @@
           "to": "null"
         }
       ],
-      "repeatIteration": 1576441758834,
+      "repeatIteration": 1578690296023,
       "repeatPanelId": 56,
       "repeatedByRow": true,
       "scopedVars": {
-        "peer_id": {
+        "validator_peer_id": {
           "selected": false,
-          "text": "1",
-          "value": "1"
+          "text": "2",
+          "value": "2"
         }
       },
       "sparkline": {
@@ -4398,7 +4372,750 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{role_type='validator',state='connected',peer_id='$peer_id',role='validator'}",
+          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "3,2",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connected Peers",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 355,
+      "panels": [],
+      "repeat": "fullnode_peer_id",
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "title": "Fullnodes",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 0,
+        "y": 27
+      },
+      "id": 486,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "$fullnode_peer_id",
+          "panelId": 429,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "peer_id",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "name"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 27
+      },
+      "id": 361,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "pluginVersion": "6.2.2",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "repeatDirection": "v",
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"fullnode\", fullnode_peer_id=\"$fullnode_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{short_rev}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Revision",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [],
+      "valueName": "name"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "dtdurations",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 4,
+        "y": 27
+      },
+      "id": 363,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "pluginVersion": "6.2.2",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"fullnode\", fullnode_peer_id=\"$fullnode_peer_id\"}",
+          "format": "time_series",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "86400",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 6,
+        "y": 27
+      },
+      "id": 365,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='fullnode_instances',mode='idle',fullnode_peer_id='$fullnode_peer_id'}[5m]))))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "70, 90",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Util",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 8,
+        "y": 27
+      },
+      "id": 367,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',fullnode_peer_id='$fullnode_peer_id', role='fullnode'} + node_memory_Cached_bytes{workspace='$workspace',fullnode_peer_id='$fullnode_peer_id', role='fullnode'} + node_memory_Buffers_bytes{workspace='$workspace',fullnode_peer_id='$fullnode_peer_id', role='fullnode'}) / node_memory_MemTotal_bytes{workspace='$workspace',fullnode_peer_id='$fullnode_peer_id', role='fullnode'} * 100) by (peer_id)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "70, 90",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mem Util",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 10,
+        "y": 27
+      },
+      "id": 369,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='fullnode_instances',fullnode_peer_id='$fullnode_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='fullnode_instances', mountpoint='/'} * 100) by (fullnode_peer_id)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "70, 90",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "/ Util",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 12,
+        "y": 27
+      },
+      "id": 371,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='fullnode_instances',fullnode_peer_id='$fullnode_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='fullnode_instances',mountpoint='/data'} * 100) by (fullnode_peer_id)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "70, 90",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "/data Util",
+      "type": "singlestat",
+      "valueFontSize": "50%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 14,
+        "y": 27
+      },
+      "id": 418,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "scopedVars": {
+        "fullnode_peer_id": {
+          "selected": false,
+          "text": "0",
+          "value": "0"
+        }
+      },
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "libra_network_peers{state='connected',fullnode_peer_id='$fullnode_peer_id',role='fullnode'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -4421,6 +5138,7 @@
       "valueName": "current"
     }
   ],
+  "refresh": false,
   "schemaVersion": 21,
   "style": "dark",
   "tags": [
@@ -4457,21 +5175,47 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "All",
           "value": [
             "$__all"
           ]
         },
         "datasource": "Prometheus",
-        "definition": "label_values(node_boot_time_seconds{peer_id=~\"[0-9]{1,3}\"}, peer_id)",
+        "definition": "label_values(node_boot_time_seconds{validator_peer_id=~\"[0-9]{1,3}\"}, validator_peer_id)",
         "hide": 0,
         "includeAll": true,
-        "label": "Peer",
+        "label": "Validator Peer",
         "multi": true,
-        "name": "peer_id",
+        "name": "validator_peer_id",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{peer_id=~\"[0-9]{1,3}\"}, peer_id)",
+        "query": "label_values(node_boot_time_seconds{validator_peer_id=~\"[0-9]{1,3}\"}, validator_peer_id)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(node_boot_time_seconds{fullnode_peer_id=~\"[0-9]{1,3}\"}, fullnode_peer_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Fullnode Peer",
+        "multi": true,
+        "name": "fullnode_peer_id",
+        "options": [],
+        "query": "label_values(node_boot_time_seconds{fullnode_peer_id=~\"[0-9]{1,3}\"}, fullnode_peer_id)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -4485,7 +5229,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {
@@ -4517,5 +5261,5 @@
   "timezone": "",
   "title": "Overview",
   "uid": "overview10",
-  "version": 2
+  "version": 17
 }

--- a/terraform/templates/fullnode.json
+++ b/terraform/templates/fullnode.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "validator",
+        "name": "fullnode",
         "image": "${image}${image_version}",
         "cpu": ${cpu},
         %{ if command != "" }
@@ -19,14 +19,12 @@
             {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
         ],
         "environment": [
-        %{ if cfg_fullnode_seed != "" }
-	    {"name": "CFG_FULLNODE_SEED", "value": "${cfg_fullnode_seed}"},
-	    {"name": "CFG_NUM_FULLNODES", "value": "${cfg_num_fullnodes}"},
-	%{ endif }
 	    {"name": "CFG_LISTEN_ADDR", "value": "${cfg_listen_addr}"},
-            {"name": "CFG_NODE_INDEX", "value": "${cfg_node_index}"},
+            {"name": "CFG_FULLNODE_INDEX", "value": "${cfg_fullnode_index}"},
             {"name": "CFG_NUM_VALIDATORS", "value": "${cfg_num_validators}"},
+            {"name": "CFG_NUM_FULLNODES", "value": "${cfg_num_fullnodes}"},
             {"name": "CFG_SEED", "value": "${cfg_seed}"},
+            {"name": "CFG_FULLNODE_SEED", "value": "${cfg_fullnode_seed}"},
             {"name": "CFG_SEED_PEER_IP", "value": "${cfg_seed_peer_ip}"},
             {"name": "RUST_LOG", "value": "${log_level}"}
         ],

--- a/terraform/templates/prometheus.yml
+++ b/terraform/templates/prometheus.yml
@@ -51,7 +51,7 @@ scrape_configs:
       %{ for target in split(",", validators) }
       - targets: ['${element(split(":", target), 0)}:9100']
         labels:
-          peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          validator_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
           role: 'validator'
           workspace: '${workspace}'
       %{ endfor }
@@ -68,7 +68,7 @@ scrape_configs:
       %{ for target in split(",", validators) }
       - targets: ['${element(split(":", target), 0)}:9101']
         labels:
-          peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          validator_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
           role: 'validator'
           workspace: '${workspace}'
       %{ endfor }
@@ -85,7 +85,7 @@ scrape_configs:
       %{ for target in split(",", fullnodes) }
       - targets: ['${element(split(":", target), 0)}:9100']
         labels:
-          peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          fullnode_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
           role: 'fullnode'
           workspace: '${workspace}'
       %{ endfor }
@@ -102,7 +102,7 @@ scrape_configs:
       %{ for target in split(",", fullnodes) }
       - targets: ['${element(split(":", target), 0)}:9101']
         labels:
-          peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          fullnode_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
           role: 'fullnode'
           workspace: '${workspace}'
       %{ endfor }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,5 +1,7 @@
-num_validators = 4
-num_fullnodes = 0
+# This file contains commonly used variables you may wish to override
+#num_validators = 4
+#num_fullnodes = 1
+#num_fullnode_networks = 1
 
 
 #api_sources_ipv4 = []  # Specify a list of IPv4 IPs/CIDRs which can access API load balancers

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -191,7 +191,10 @@ data "template_file" "ecs_task_definition" {
     cfg_num_validators = var.cfg_num_validators_override == 0 ? var.num_validators : var.cfg_num_validators_override
     cfg_seed         = var.config_seed
     cfg_seed_peer_ip = local.seed_peer_ip
-    cfg_upstream_node_index = ""
+
+    cfg_fullnode_seed = count.index < var.num_fullnode_networks ? var.fullnode_seed : ""
+    cfg_num_fullnodes = var.num_fullnodes
+
     log_level        = var.validator_log_level
     log_group        = var.cloudwatch_logs ? aws_cloudwatch_log_group.testnet.name : ""
     log_region       = var.region

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,7 +58,17 @@ variable "cfg_num_validators_override" {
 
 variable "num_fullnodes" {
   default     = 1
-  description = "Number of full nodes to run on validators"
+  description = "Number of full nodes to run per fullnode network"
+}
+
+variable "num_fullnode_networks" {
+  default     = 1
+  description = "Number of full nodes networks to run (must be <= num_validators)"
+}
+
+variable "fullnode_seed" {
+  default     = 2674267426742674267426742674267426742674267426742674267426742674
+  description = "Default seed for fullnode network"
 }
 
 variable "fullnode_distribution" {


### PR DESCRIPTION
## Motivation

When moving to dynamic configs, the full-node support wasn't quite ready, so we removed it to speed up deployment. This add support back.

The two variables to control this are
num_fullnode_networks: Which defines how many fullnode networks to run
num_fullnodes: How many fullnodes to run per fullnode network

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Live on personal and dev workspaces.
