### PR TITLE
[jellyfish-merkle] Test consecutive contiguous account updates

### DIFF
--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -638,6 +638,44 @@ proptest! {
     }
 
     #[test]
+    fn test_put_blob_with_proof2(
+        key1 in any::<HashValue>()
+            .prop_filter(
+                "Can't be 0xffffff...",
+                |key| *key != HashValue::new([0xff; HashValue::LENGTH]),
+            ),
+        accounts in vec(any::<AccountStateBlob>(), 2),
+    ) {
+        let db = MockTreeStore::default();
+        let tree = JellyfishMerkleTree::new(&db);
+        let mut version = 0;
+        let mut kvs = HashMap::new();
+
+        kvs.insert(key1.clone(), accounts[0].clone());
+        let (new_root_hash, batch) = tree
+            .put_blob_set(vec![(key1, accounts[0].clone())], version)
+            .unwrap();
+        db.write_tree_update_batch(batch).unwrap();
+
+        let root_hash = tree.get_root_hash(version).unwrap();
+        assert_eq!(root_hash, new_root_hash);
+        test_existent_keys_impl(&tree, version, &kvs);
+
+        let key2 = plus_one(key1);
+        version = version + 1;
+
+        kvs.insert(key2.clone(), accounts[1].clone());
+        let (new_root_hash, batch) = tree
+            .put_blob_set(vec![(key2, accounts[1].clone())], version)
+            .unwrap();
+        db.write_tree_update_batch(batch).unwrap();
+
+        let root_hash = tree.get_root_hash(version).unwrap();
+        assert_eq!(root_hash, new_root_hash);
+        test_existent_keys_impl(&tree, version, &kvs);
+    }
+
+    #[test]
     fn test_get_range_proof(
         (btree, n) in btree_map(any::<HashValue>(), any::<AccountStateBlob>(), 1..1000)
             .prop_flat_map(|btree| {


### PR DESCRIPTION
Testing a modified Jellyfish tree revealed some strange behavior
in this edge case.  Adding a test to Libra to make sure we have
coverage.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
