### PR TITLE
[language] require shl and shr to take number of bits shifted in u8

### DIFF
--- a/language/bytecode-verifier/src/type_memory_safety.rs
+++ b/language/bytecode-verifier/src/type_memory_safety.rs
@@ -806,7 +806,7 @@ impl<'a> TypeAndMemorySafetyAnalysis<'a> {
             Bytecode::Shl | Bytecode::Shr => {
                 let operand1 = self.stack.pop().unwrap();
                 let operand2 = self.stack.pop().unwrap();
-                if operand1.signature.is_integer() && operand2.signature.is_integer() {
+                if operand2.signature.is_integer() && operand1.signature == SignatureToken::U8 {
                     self.stack.push(TypedAbstractValue {
                         signature: operand2.signature,
                         value: AbstractValue::Value(Kind::Unrestricted),

--- a/language/functional_tests/tests/testsuite/operators/integer_binary_operators_types_mismatch.mvir
+++ b/language/functional_tests/tests/testsuite/operators/integer_binary_operators_types_mismatch.mvir
@@ -1209,7 +1209,28 @@ main() {
 
 //! new-transaction
 main() {
-    _ = true << 0;
+    _ = 0 << 0x0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 << 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 << 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = true << 0u8;
     return;
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
@@ -1223,14 +1244,7 @@ main() {
 
 //! new-transaction
 main() {
-    _ = 0 << 0x0;
-    return;
-}
-// check: INTEGER_OP_TYPE_MISMATCH_ERROR
-
-//! new-transaction
-main() {
-    _ = 0x0 << 0;
+    _ = 0x0 << 0u8;
     return;
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
@@ -1273,7 +1287,28 @@ main() {
 
 //! new-transaction
 main() {
-    _ = true >> 0;
+    _ = 0 >> 0x0;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 >> 0u64;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = 0 >> 0u128;
+    return;
+}
+// check: INTEGER_OP_TYPE_MISMATCH_ERROR
+
+//! new-transaction
+main() {
+    _ = true >> 0u8;
     return;
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR
@@ -1287,14 +1322,7 @@ main() {
 
 //! new-transaction
 main() {
-    _ = 0 >> 0x0;
-    return;
-}
-// check: INTEGER_OP_TYPE_MISMATCH_ERROR
-
-//! new-transaction
-main() {
-    _ = 0x0 >> 0;
+    _ = 0x0 >> 0u8;
     return;
 }
 // check: INTEGER_OP_TYPE_MISMATCH_ERROR

--- a/language/functional_tests/tests/testsuite/operators/shift_operators.mvir
+++ b/language/functional_tests/tests/testsuite/operators/shift_operators.mvir
@@ -7,35 +7,7 @@ main() {
 
 //! new-transaction
 main() {
-    _ = 0u8 << 8u64;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u8 << 8u128;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
     _ = 0u64 << 64u8;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u64 << 64u64;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u64 << 64u128;
     return;
 }
 // check: ARITHMETIC_ERROR
@@ -49,35 +21,7 @@ main() {
 
 //! new-transaction
 main() {
-    _ = 0u128 << 128u64;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u128 << 128u128;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
     _ = 0u8 >> 8u8;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u8 >> 8u64;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u8 >> 8u128;
     return;
 }
 // check: ARITHMETIC_ERROR
@@ -91,35 +35,7 @@ main() {
 
 //! new-transaction
 main() {
-    _ = 0u64 >> 64u64;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u64 >> 64u128;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
     _ = 0u128 >> 128u8;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u128 >> 128u64;
-    return;
-}
-// check: ARITHMETIC_ERROR
-
-//! new-transaction
-main() {
-    _ = 0u128 >> 128u128;
     return;
 }
 // check: ARITHMETIC_ERROR
@@ -179,7 +95,7 @@ main() {
 main() {
     assert(1234u64 >> 63u8 == 0u64, 4000);
     assert(3u8 >> 5u8 == 0u8, 4001);
-    assert(43152365326753472145312542634526753u128 >> 127 == 0u128, 4002);
+    assert(43152365326753472145312542634526753u128 >> 127u8 == 0u128, 4002);
     return;
 }
 // check: EXECUTED

--- a/language/tools/cost-synthesis/src/bytecode_specifications/stack_transition_info.rs
+++ b/language/tools/cost-synthesis/src/bytecode_specifications/stack_transition_info.rs
@@ -224,14 +224,8 @@ pub fn call_details(op: &Bytecode) -> Vec<CallDetails> {
         // TODO: rewrite in a more efficient way.
         Bytecode::Shl | Bytecode::Shr => type_transition! {
             vec![ty_of_sig_tok(SignatureToken::U8), ty_of_sig_tok(SignatureToken::U8)] => u8s(1),
-            vec![ty_of_sig_tok(SignatureToken::U8), ty_of_sig_tok(SignatureToken::U64)] => u8s(1),
-            vec![ty_of_sig_tok(SignatureToken::U8), ty_of_sig_tok(SignatureToken::U128)] => u8s(1),
             vec![ty_of_sig_tok(SignatureToken::U64), ty_of_sig_tok(SignatureToken::U8)] => u64s(1),
-            vec![ty_of_sig_tok(SignatureToken::U64), ty_of_sig_tok(SignatureToken::U64)] => u64s(1),
-            vec![ty_of_sig_tok(SignatureToken::U64), ty_of_sig_tok(SignatureToken::U128)] => u64s(1),
-            vec![ty_of_sig_tok(SignatureToken::U128), ty_of_sig_tok(SignatureToken::U8)] => u128s(1),
-            vec![ty_of_sig_tok(SignatureToken::U128), ty_of_sig_tok(SignatureToken::U64)] => u128s(1),
-            vec![ty_of_sig_tok(SignatureToken::U128), ty_of_sig_tok(SignatureToken::U128)] => u128s(1)
+            vec![ty_of_sig_tok(SignatureToken::U128), ty_of_sig_tok(SignatureToken::U8)] => u128s(1)
         },
         Bytecode::Eq | Bytecode::Neq => type_transition! {
             fixed: non_variable_values(2) => bools(1)

--- a/language/tools/test-generation/src/summaries.rs
+++ b/language/tools/test-generation/src/summaries.rs
@@ -232,7 +232,10 @@ pub fn instruction_summary(instruction: Bytecode, exact: bool) -> Summary {
             effects: Effects::NoTyParams(vec![state_stack_bin_op!()]),
         },
         Bytecode::Shl | Bytecode::Shr => Summary {
-            preconditions: vec![state_stack_has_integer!(0), state_stack_has_integer!(1)],
+            preconditions: vec![
+                state_stack_has!(0, Some(AbstractValue::new_primitive(SignatureToken::U8))),
+                state_stack_has_integer!(1),
+            ],
             effects: Effects::NoTyParams(vec![state_stack_bin_op!()]),
         },
         Bytecode::Or | Bytecode::And => Summary {

--- a/language/tools/test-generation/tests/integer_instructions.rs
+++ b/language/tools/test-generation/tests/integer_instructions.rs
@@ -43,18 +43,17 @@ fn bytecode_bin_ops() {
 
 #[test]
 fn bytecode_shl_shr() {
-    let tys = INTEGER_TYPES
+    for (op, ty) in [Bytecode::Shl, Bytecode::Shr]
         .iter()
         .cartesian_product(INTEGER_TYPES.iter())
-        .filter(|(ty1, ty2)| ty1 != ty2);
-    for (op, (ty1, ty2)) in [Bytecode::Shl, Bytecode::Shr].iter().cartesian_product(tys) {
+    {
         let mut state1 = AbstractState::new();
-        state1.stack_push(AbstractValue::new_primitive(ty1.clone()));
-        state1.stack_push(AbstractValue::new_primitive(ty2.clone()));
+        state1.stack_push(AbstractValue::new_primitive(ty.clone()));
+        state1.stack_push(AbstractValue::new_primitive(SignatureToken::U8));
         let (state2, _) = common::run_instruction(op.clone(), state1);
         assert_eq!(
             state2.stack_peek(0),
-            Some(AbstractValue::new_primitive(ty1.clone())),
+            Some(AbstractValue::new_primitive(ty.clone())),
             "stack type postcondition not met"
         );
     }

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -540,11 +540,17 @@ impl<'txn> Interpreter<'txn> {
                     }
                     Bytecode::Shl => {
                         gas!(const_instr: context, self, Opcodes::SHL)?;
-                        self.binop_int(IntegerValue::shl_checked)?
+                        let rhs = self.operand_stack.pop_as::<u8>()?;
+                        let lhs = self.operand_stack.pop_as::<IntegerValue>()?;
+                        self.operand_stack
+                            .push(lhs.shl_checked(rhs)?.into_value())?;
                     }
                     Bytecode::Shr => {
                         gas!(const_instr: context, self, Opcodes::SHR)?;
-                        self.binop_int(IntegerValue::shr_checked)?
+                        let rhs = self.operand_stack.pop_as::<u8>()?;
+                        let lhs = self.operand_stack.pop_as::<IntegerValue>()?;
+                        self.operand_stack
+                            .push(lhs.shr_checked(rhs)?.into_value())?;
                     }
                     Bytecode::Or => {
                         gas!(const_instr: context, self, Opcodes::OR)?;


### PR DESCRIPTION
## Summary
Shl & Shr used to accept any integer type as the second operand. This led to unnecessarily complicated designs in various places so this changed it to accept only u8.

## Test Plan
cargo test