### PR TITLE
[test generation] Parallelize test generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "network 0.1.0",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -213,7 +213,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libradb 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -515,7 +515,7 @@ version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -934,6 +934,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +976,16 @@ name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1211,18 +1229,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "env_logger"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,7 +1432,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1624,6 +1630,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,14 +1705,6 @@ dependencies = [
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "humantime"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "hyper"
@@ -2807,9 +2813,10 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3347,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3522,7 +3529,7 @@ dependencies = [
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4206,7 +4213,7 @@ dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4510,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4559,7 +4566,7 @@ name = "test-generation"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
- "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4569,7 +4576,12 @@ dependencies = [
  "libra-types 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-envlogger 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-scope 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
@@ -4707,7 +4719,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4737,7 +4749,7 @@ dependencies = [
  "mio 0.6.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4840,7 +4852,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4930,7 +4942,7 @@ dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5065,7 +5077,7 @@ dependencies = [
  "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-discover 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5875,10 +5887,12 @@ dependencies = [
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
 "checksum crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
 "checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+"checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
@@ -5902,7 +5916,6 @@ dependencies = [
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "79906e1ad1f7f8bc48864fcc6ffd58336fb5992e627bf61928099cb25fdf4314"
 "checksum endian-type 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -5938,6 +5951,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
@@ -5947,7 +5961,6 @@ dependencies = [
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum http-body 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11f5aaac2428368dbf2a8b63f7f3ef30173ed4692777ae91f4e3bbf492aacdb6"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)" = "898a87371a3999b2f731b9af636cd76aa20de10e69c2daf3e71388326b619fe0"
 "checksum hyper 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31aca065a2f6049464bb9a37dd316e51d9b7f502469e0e02e18586931f0cfcdf"
 "checksum hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952"
@@ -6005,7 +6018,7 @@ dependencies = [
 "checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
 "checksum num-rational 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2885278d5fe2adc2f75ced642d52d879bffaceb5a2e0b1d4309ffdfb239b454"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+"checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
 "checksum num_enum 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47c0ae6c262e0c0adb0ffe6b30bf4025aca4983009d6027b377d13a14aa149a2"
 "checksum num_enum_derive 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "47b3a6cd5b8ac2ca83258cbaf693f740aca5681818b4720497305fd642447eb0"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
@@ -6062,7 +6075,7 @@ dependencies = [
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 "checksum rand04 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "58595cc8bb12add45412667f9b422d5a9842d61d36e8607bc7c84ff738bf9263"
 "checksum rand04_compat 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e4cc0eb4bbb0cbc6c2a8081aa11303b9520369eea474cf865f7b7e3f11b284b"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -12,12 +12,18 @@ edition = "2018"
 [dependencies]
 rand = "0.6.5"
 log = "0.4"
-env_logger = "0.6"
+num_cpus = "1.11.1"
 mirai-annotations = "1.4.0"
 structopt = "0.3.2"
 itertools = "0.8.2"
 hex = "0.3.1"
 getrandom = "0.1.13"
+crossbeam-channel = "0.4.0"
+
+slog = { version = "2.5.0", features = ["max_level_debug", "release_max_level_debug"] }
+slog-term = "2.4.1"
+slog-scope = "4.0"
+slog-envlogger = "2.1.0"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 libra-config = { path = "../../../config", version = "0.1.0" }

--- a/language/tools/test-generation/src/bytecode_generator.rs
+++ b/language/tools/test-generation/src/bytecode_generator.rs
@@ -4,13 +4,14 @@
 use crate::{
     abstract_state::{AbstractState, BorrowState, CallGraph, InstantiableModule},
     config::{
-        CALL_STACK_LIMIT, MAX_CFG_BLOCKS, MUTATION_TOLERANCE, NEGATE_PRECONDITIONS,
-        NEGATION_PROBABILITY, VALUE_STACK_LIMIT,
+        CALL_STACK_LIMIT, INHABITATION_INSTRUCTION_LIMIT, MAX_CFG_BLOCKS, MUTATION_TOLERANCE,
+        NEGATE_PRECONDITIONS, NEGATION_PROBABILITY, VALUE_STACK_LIMIT,
     },
     control_flow_graph::CFG,
     summaries,
 };
 use rand::{rngs::StdRng, Rng};
+use slog_scope::{debug, error, warn};
 use vm::access::ModuleAccess;
 use vm::file_format::{
     AddressPoolIndex, ByteArrayPoolIndex, Bytecode, CodeOffset, CompiledModuleMut,
@@ -106,6 +107,7 @@ pub struct FunctionGenerationContext {
     pub function_handle_index: FunctionHandleIndex,
     pub starting_call_height: usize,
     pub locals_len: usize,
+    pub bytecode_len: u64,
 }
 
 impl FunctionGenerationContext {
@@ -113,12 +115,22 @@ impl FunctionGenerationContext {
         function_handle_index: FunctionHandleIndex,
         starting_call_height: usize,
         locals_len: usize,
+        bytecode_len: u64,
     ) -> Self {
         Self {
             function_handle_index,
             starting_call_height,
             locals_len,
+            bytecode_len,
         }
+    }
+
+    pub fn incr_instruction_count(&mut self) -> Option<()> {
+        self.bytecode_len += 1;
+        if self.bytecode_len >= (u16::max_value() - 1) as u64 {
+            return None;
+        }
+        Some(())
     }
 }
 
@@ -512,12 +524,12 @@ impl<'a> BytecodeGenerator<'a> {
     /// to the bytecode sequence
     pub fn apply_instruction(
         &self,
-        fn_context: &FunctionGenerationContext,
+        fn_context: &mut FunctionGenerationContext,
         mut state: AbstractState,
         bytecode: &mut Vec<Bytecode>,
         instruction: Bytecode,
         exact: bool,
-    ) -> AbstractState {
+    ) -> Option<AbstractState> {
         // Bytecode will never be generated this large
         assume!(bytecode.len() < usize::max_value());
         debug!("**********************");
@@ -534,19 +546,20 @@ impl<'a> BytecodeGenerator<'a> {
                 .add_call(fn_context.function_handle_index, index);
         }
         bytecode.push(instruction);
+        fn_context.incr_instruction_count()?;
         debug!("**********************\n");
-        state
+        Some(state)
     }
 
     /// Given a valid starting state `abstract_state_in`, generate a valid sequence of
     /// bytecode instructions such that `abstract_state_out` is reached.
     pub fn generate_block(
         &mut self,
-        fn_context: &FunctionGenerationContext,
+        fn_context: &mut FunctionGenerationContext,
         abstract_state_in: AbstractState,
         abstract_state_out: AbstractState,
         module: &CompiledModuleMut,
-    ) -> (Vec<Bytecode>, AbstractState) {
+    ) -> Option<(Vec<Bytecode>, AbstractState)> {
         debug!("Abstract state in: {}", abstract_state_in.clone());
         debug!("Abstract state out: {}", abstract_state_out.clone());
         let mut bytecode: Vec<Bytecode> = Vec::new();
@@ -566,7 +579,7 @@ impl<'a> BytecodeGenerator<'a> {
                         &mut bytecode,
                         next_instruction,
                         false,
-                    );
+                    )?;
                     if state.is_final() {
                         break;
                     } else if state.has_aborted() {
@@ -576,21 +589,21 @@ impl<'a> BytecodeGenerator<'a> {
                             &mut bytecode,
                             Bytecode::LdU64(0),
                             true,
-                        );
+                        )?;
                         state = self.apply_instruction(
                             fn_context,
                             state,
                             &mut bytecode,
                             Bytecode::Abort,
                             true,
-                        );
-                        return (bytecode, state);
+                        )?;
+                        return Some((bytecode, state));
                     }
                 }
                 Err(err) => {
                     // Could not complete the bytecode sequence; reset to empty
                     error!("{}", err);
-                    return (Vec::new(), abstract_state_in);
+                    return Some((Vec::new(), abstract_state_in));
                 }
             }
         }
@@ -606,24 +619,30 @@ impl<'a> BytecodeGenerator<'a> {
                         "local availability instructions: {:#?} for token {:#?}",
                         next_instructions, &abstract_value.token
                     );
-                    state = next_instructions
-                        .into_iter()
-                        .fold(state, |state, instruction| {
-                            self.apply_instruction(
-                                fn_context,
-                                state,
-                                &mut bytecode,
-                                instruction,
-                                true,
-                            )
-                        });
+                    if next_instructions.len() >= INHABITATION_INSTRUCTION_LIMIT {
+                        return None;
+                    }
+                    state =
+                        next_instructions
+                            .into_iter()
+                            .fold(Some(state), |state, instruction| {
+                                state.and_then(|state| {
+                                    self.apply_instruction(
+                                        fn_context,
+                                        state,
+                                        &mut bytecode,
+                                        instruction,
+                                        true,
+                                    )
+                                })
+                            })?;
                     state = self.apply_instruction(
                         fn_context,
                         state,
                         &mut bytecode,
                         Bytecode::StLoc(*i as u8),
                         true,
-                    );
+                    )?;
                 } else if *target_availability == BorrowState::Unavailable
                     && *current_availability == BorrowState::Available
                 {
@@ -633,21 +652,21 @@ impl<'a> BytecodeGenerator<'a> {
                         &mut bytecode,
                         Bytecode::MoveLoc(*i as u8),
                         true,
-                    );
+                    )?;
                     state = self.apply_instruction(
                         fn_context,
                         state,
                         &mut bytecode,
                         Bytecode::Pop,
                         true,
-                    );
+                    )?;
                 }
             } else {
                 unreachable!("Target locals out contains new local");
             }
         }
         // Update the module to be the module that we've been building in our abstract state
-        (bytecode, state)
+        Some((bytecode, state))
     }
 
     /// Generate the body of a function definition given a set of starting `locals` and a target
@@ -655,13 +674,13 @@ impl<'a> BytecodeGenerator<'a> {
     /// `target_max` instructions.
     pub fn generate(
         &mut self,
-        fn_context: &FunctionGenerationContext,
+        fn_context: &mut FunctionGenerationContext,
         locals: &[SignatureToken],
         signature: &FunctionSignature,
         acquires_global_resources: &[StructDefinitionIndex],
         module: &mut CompiledModuleMut,
         call_graph: &mut CallGraph,
-    ) -> Vec<Bytecode> {
+    ) -> Option<Vec<Bytecode>> {
         let number_of_blocks = self.rng.gen_range(1, MAX_CFG_BLOCKS + 1);
         // The number of basic blocks must be at least one based on the
         // generation range.
@@ -688,7 +707,7 @@ impl<'a> BytecodeGenerator<'a> {
                 call_graph.clone(),
             );
             let (mut bytecode, mut state_f) =
-                self.generate_block(fn_context, state1, state2.clone(), module);
+                self.generate_block(fn_context, state1, state2.clone(), module)?;
             state_f.allow_control_flow();
             if !state_f.has_aborted() {
                 state_f = if cfg_copy.num_children(*block_id) == 2 {
@@ -699,7 +718,7 @@ impl<'a> BytecodeGenerator<'a> {
                         &mut bytecode,
                         Bytecode::LdFalse,
                         true,
-                    );
+                    )?;
                     if self.rng.gen_bool(0.5) {
                         self.apply_instruction(
                             fn_context,
@@ -707,7 +726,7 @@ impl<'a> BytecodeGenerator<'a> {
                             &mut bytecode,
                             Bytecode::BrTrue(0),
                             true,
-                        )
+                        )?
                     } else {
                         self.apply_instruction(
                             fn_context,
@@ -715,7 +734,7 @@ impl<'a> BytecodeGenerator<'a> {
                             &mut bytecode,
                             Bytecode::BrFalse(0),
                             true,
-                        )
+                        )?
                     }
                 } else if cfg_copy.num_children(*block_id) == 1 {
                     // Branch: Add branch instruction
@@ -725,7 +744,7 @@ impl<'a> BytecodeGenerator<'a> {
                         &mut bytecode,
                         Bytecode::Branch(0),
                         true,
-                    )
+                    )?
                 } else if cfg_copy.num_children(*block_id) == 0 {
                     // Return: Add return types to last block
                     for token_type in signature.return_types.iter() {
@@ -735,10 +754,10 @@ impl<'a> BytecodeGenerator<'a> {
                             "Return value instructions: {:#?} for token {:#?}",
                             next_instructions, &token_type
                         );
-                        state_f =
-                            next_instructions
-                                .into_iter()
-                                .fold(state_f, |state_f, instruction| {
+                        state_f = next_instructions.into_iter().fold(
+                            Some(state_f),
+                            |state_f, instruction| {
+                                state_f.and_then(|state_f| {
                                     self.apply_instruction(
                                         fn_context,
                                         state_f,
@@ -746,9 +765,11 @@ impl<'a> BytecodeGenerator<'a> {
                                         instruction,
                                         true,
                                     )
-                                });
+                                })
+                            },
+                        )?;
                     }
-                    self.apply_instruction(fn_context, state_f, &mut bytecode, Bytecode::Ret, true)
+                    self.apply_instruction(fn_context, state_f, &mut bytecode, Bytecode::Ret, true)?
                 } else {
                     state_f
                 };
@@ -760,10 +781,10 @@ impl<'a> BytecodeGenerator<'a> {
         // The CFG will be non-empty if we set the number of basic blocks to generate
         // to be non-zero
         verify!(number_of_blocks > 0 || cfg.get_basic_blocks().is_empty());
-        cfg.serialize()
+        Some(cfg.serialize())
     }
 
-    pub fn generate_module(&mut self, mut module: CompiledModuleMut) -> CompiledModuleMut {
+    pub fn generate_module(&mut self, mut module: CompiledModuleMut) -> Option<CompiledModuleMut> {
         let mut fdefs = module.function_defs.clone();
         let mut call_graph = CallGraph::new(module.function_handles.len());
         for fdef in fdefs.iter_mut() {
@@ -772,22 +793,23 @@ impl<'a> BytecodeGenerator<'a> {
             let locals_sigs = module.locals_signatures[fdef.code.locals.0 as usize]
                 .0
                 .clone();
-            let fn_context = FunctionGenerationContext::new(
+            let mut fn_context = FunctionGenerationContext::new(
                 fdef.function,
                 call_graph.max_calling_depth(fdef.function),
                 locals_sigs.len(),
+                0,
             );
             fdef.code.code = self.generate(
-                &fn_context,
+                &mut fn_context,
                 &locals_sigs,
                 &func_sig,
                 &fdef.acquires_global_resources,
                 &mut module,
                 &mut call_graph,
-            );
+            )?;
         }
         module.function_defs = fdefs;
-        module
+        Some(module)
     }
 
     /// Generate a sequence of instructions whose overall effect is to push a single value of type token

--- a/language/tools/test-generation/src/control_flow_graph.rs
+++ b/language/tools/test-generation/src/control_flow_graph.rs
@@ -3,6 +3,7 @@
 
 use crate::abstract_state::{AbstractValue, BorrowState};
 use rand::{rngs::StdRng, Rng};
+use slog_scope::debug;
 use std::collections::{HashMap, VecDeque};
 use vm::file_format::{Bytecode, FunctionSignature, Kind, SignatureToken};
 

--- a/language/tools/test-generation/src/main.rs
+++ b/language/tools/test-generation/src/main.rs
@@ -3,10 +3,26 @@
 
 #![forbid(unsafe_code)]
 
+use slog::{o, Drain};
+use std::env;
 use structopt::StructOpt;
 use test_generation::{config::Args, run_generation};
 
+fn setup_log() {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "info");
+    }
+    let decorator = slog_term::PlainDecorator::new(std::io::stdout());
+    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+    let drain = slog_envlogger::new(drain);
+    let drain = std::sync::Mutex::new(drain).fuse();
+    let logger = slog::Logger::root(drain, o!());
+    let logger_guard = slog_scope::set_global_logger(logger);
+    std::mem::forget(logger_guard);
+}
+
 pub fn main() {
+    setup_log();
     let args = Args::from_args();
     run_generation(args);
 }

--- a/language/tools/test-generation/src/transitions.rs
+++ b/language/tools/test-generation/src/transitions.rs
@@ -504,7 +504,7 @@ pub fn stack_struct_popn(
     let struct_def = state_copy.module.module.struct_def_at(struct_index);
     let struct_def_view = StructDefinitionView::new(&state_copy.module.module, struct_def);
     for _ in struct_def_view.fields().unwrap() {
-        state = stack_pop(&state)?;
+        state.stack_pop()?;
     }
     Ok(state)
 }
@@ -774,7 +774,7 @@ pub fn stack_function_popn(
         .function_signature_at(function_handle.signature);
     let number_of_pops = function_signature.arg_types.iter().len();
     for _ in 0..number_of_pops {
-        state = stack_pop(&state)?;
+        state.stack_pop()?;
     }
     Ok(state)
 }


### PR DESCRIPTION
This PR parallelizes the test generation process and setups the framework to allow us to continually run it (at least up until we hit the maximum value of `u128`...but that shouldn't happen).

The parallelization is pretty basic, but follows the general workload pretty well. The TL;DR is:
* SPMC parallelism, with the producer being the module frames (since this is relatively low work compared to bytecode generation, verification, and execution).
* We have `num_cpus` (or a user-defined number) of consumer threads running generation and checking.
* The producing thread is also responsible for tracking and reporting statistics.

This has a number of advantages. The primary of which is that due to the uneven (and random) workload the previous model could lead to some threads starving, while others still have stealable work. This makes sure this doesn't happen. 

Additionally, I've added logic to disallow generation of instruction sequences beyond the maximum expressible code offset.

**NB:** This is stacked on the call graph PR, so only review the top commit in this PR.