### PR TITLE
[language][vm] fix serialization for u8/u128

### DIFF
--- a/language/functional_tests/tests/testsuite/publish/publish_resource_with_u128_field.mvir
+++ b/language/functional_tests/tests/testsuite/publish/publish_resource_with_u128_field.mvir
@@ -1,0 +1,33 @@
+module M {
+    resource Foo {
+        x: u128,
+    }
+
+    public foo() {
+        move_to_sender<Foo>(Foo {x: 100u128});
+        return;
+    }
+
+    public bar(): u128 acquires Foo {
+        let x: u128;
+        Foo { x } = move_from<Foo>(get_txn_sender());
+        return move(x);
+    }
+}
+
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    M.foo();
+    return;
+}
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    assert(M.bar() == 100u128, 42);
+    return;
+}

--- a/language/functional_tests/tests/testsuite/publish/publish_resource_with_u64_field.mvir
+++ b/language/functional_tests/tests/testsuite/publish/publish_resource_with_u64_field.mvir
@@ -1,0 +1,33 @@
+module M {
+    resource Foo {
+        x: u64,
+    }
+
+    public foo() {
+        move_to_sender<Foo>(Foo {x: 100u64});
+        return;
+    }
+
+    public bar(): u64 acquires Foo {
+        let x: u64;
+        Foo { x } = move_from<Foo>(get_txn_sender());
+        return move(x);
+    }
+}
+
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    M.foo();
+    return;
+}
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    assert(M.bar() == 100u64, 42);
+    return;
+}

--- a/language/functional_tests/tests/testsuite/publish/publish_resource_with_u8_field.mvir
+++ b/language/functional_tests/tests/testsuite/publish/publish_resource_with_u8_field.mvir
@@ -1,0 +1,33 @@
+module M {
+    resource Foo {
+        x: u8,
+    }
+
+    public foo() {
+        move_to_sender<Foo>(Foo {x: 100u8});
+        return;
+    }
+
+    public bar(): u8 acquires Foo {
+        let x: u8;
+        Foo { x } = move_from<Foo>(get_txn_sender());
+        return move(x);
+    }
+}
+
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    M.foo();
+    return;
+}
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    assert(M.bar() == 100u8, 42);
+    return;
+}

--- a/language/vm/vm-runtime/vm-runtime-types/src/value.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/value.rs
@@ -1509,7 +1509,9 @@ impl Serialize for ValueImpl {
     {
         use serde::ser::SerializeTuple;
         match self {
+            ValueImpl::U8(val) => serializer.serialize_u8(*val),
             ValueImpl::U64(val) => serializer.serialize_u64(*val),
+            ValueImpl::U128(val) => serializer.serialize_u128(*val),
             ValueImpl::Address(addr) => {
                 // TODO: this is serializing as a vector but we want just raw bytes
                 // however the AccountAddress story is a bit difficult to work with right now
@@ -1525,7 +1527,10 @@ impl Serialize for ValueImpl {
             }
             ValueImpl::ByteArray(bytearray) => bytearray.serialize(serializer),
             ValueImpl::NativeStruct(v) => v.serialize(serializer),
-            _ => unreachable!("invalid type to serialize"),
+            ValueImpl::Invalid
+            | ValueImpl::Reference(_)
+            | ValueImpl::GlobalRef(_)
+            | ValueImpl::PromotedReference(_) => unreachable!("invalid type to serialize"),
         }
     }
 }


### PR DESCRIPTION
## Summary
Serialization of u8 and u128 was left implemented, causing publishing resources containing these types to fail. This gets it fixed. 

## Test Plan
cargo  test