### PR TITLE
[move source lang] Added Liveness. Used Analysis to Fix Copies, Dead Assignments, and Dead References

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -10,7 +10,7 @@ use crate::{
     shared::unique_map::UniqueMap,
     shared::*,
 };
-use std::collections::{BTreeMap, BTreeSet, LinkedList};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 // HLIR + Unstructured Control Flow + CFG
 
@@ -117,7 +117,7 @@ pub type Type = Spanned<Type_>;
 
 pub type Blocks = BTreeMap<Label, BasicBlock>;
 
-pub type BasicBlock = LinkedList<Command>;
+pub type BasicBlock = VecDeque<Command>;
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, PartialOrd, Ord)]
 pub struct Label(pub usize);
@@ -219,6 +219,12 @@ pub enum ExpListItem {
 //**************************************************************************************************
 // impls
 //**************************************************************************************************
+
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl Command_ {
     pub fn is_terminal(&self) -> bool {

--- a/language/move-lang/src/cfgir/borrows/state.rs
+++ b/language/move-lang/src/cfgir/borrows/state.rs
@@ -332,7 +332,7 @@ impl BorrowState {
 
     pub fn mutate(&mut self, loc: Loc, rvalue: Value) -> Errors {
         let id = match rvalue {
-            Value::NonRef => panic!("ICE type checking failed"),
+            Value::NonRef => panic!("ICE type checking failed {:#?}", loc),
             Value::Ref(id) => id,
         };
 
@@ -456,7 +456,7 @@ impl BorrowState {
 
     pub fn dereference(&mut self, loc: Loc, rvalue: Value) -> (Errors, Value) {
         let id = match rvalue {
-            Value::NonRef => panic!("ICE type checking failed"),
+            Value::NonRef => panic!("ICE type checking failed {:#?}", loc),
             Value::Ref(id) => id,
         };
 
@@ -684,5 +684,42 @@ impl AbstractDomain for BorrowState {
         } else {
             JoinResult::Unchanged
         }
+    }
+}
+
+//**************************************************************************************************
+// Display
+//**************************************************************************************************
+
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Label::Local(s) => write!(f, "local%{}", s),
+            Label::Resource(s) => write!(f, "resource%{}", s),
+            Label::Field(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::NonRef => write!(f, "_"),
+            Value::Ref(id) => write!(f, "{:?}", id),
+        }
+    }
+}
+
+impl BorrowState {
+    #[allow(dead_code)]
+    pub fn display(&self) {
+        println!("NEXT ID: {}", self.next_id);
+        println!("LOCALS:");
+        for (var, value) in &self.locals {
+            println!("  {}: {}", var.value(), value)
+        }
+        println!("BORROWS: ");
+        self.borrows.display();
+        println!();
     }
 }

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -1,0 +1,459 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod state;
+
+use super::{
+    absint::*,
+    ast,
+    ast::*,
+    cfg::{BlockCFG, ReverseBlockCFG, CFG},
+};
+use crate::shared::unique_map::UniqueMap;
+use crate::{errors::*, parser::ast::Var, shared::*};
+use state::*;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+//**************************************************************************************************
+// Entry and trait bindings
+//**************************************************************************************************
+
+type PerCommandStates = BTreeMap<Label, VecDeque<LivenessState>>;
+type ForwardIntersections = BTreeMap<Label, LivenessState>;
+type FinalInvariants = BTreeMap<Label, LivenessState>;
+
+struct Liveness {
+    states: PerCommandStates,
+}
+
+impl Liveness {
+    fn new(cfg: &super::cfg::ReverseBlockCFG) -> Self {
+        let states = cfg
+            .blocks()
+            .iter()
+            .map(|(lbl, block)| {
+                let init = block.iter().map(|_| LivenessState::initial()).collect();
+                (*lbl, init)
+            })
+            .collect();
+        Liveness { states }
+    }
+}
+
+impl TransferFunctions for Liveness {
+    type State = LivenessState;
+
+    fn execute(
+        &mut self,
+        state: &mut Self::State,
+        label: Label,
+        idx: usize,
+        cmd: &Command,
+    ) -> Errors {
+        command(state, cmd);
+        // set current [label][command_idx] data with the new liveness data
+        let cur_label_states = self.states.get_mut(&label).unwrap();
+        cur_label_states[idx] = state.clone();
+        Errors::new()
+    }
+}
+
+impl AbstractInterpreter for Liveness {}
+
+pub fn refine_and_verify(
+    errors: &mut Errors,
+    _signature: &FunctionSignature,
+    locals: &UniqueMap<Var, SingleType>,
+    cfg: &mut BlockCFG,
+    infinite_loop_starts: &BTreeSet<Label>,
+) {
+    let (_, per_command_states) = analyze(cfg, &infinite_loop_starts);
+    last_usage(errors, locals, per_command_states, cfg.blocks_mut());
+    let (final_invariants, per_command_states) = analyze(cfg, &infinite_loop_starts);
+    let forward_intersections = build_forward_intersections(cfg, final_invariants);
+    release_dead_refs(
+        locals,
+        forward_intersections,
+        per_command_states,
+        cfg.blocks_mut(),
+    );
+}
+
+//**************************************************************************************************
+// Analysis
+//**************************************************************************************************
+
+fn analyze(
+    cfg: &mut BlockCFG,
+    infinite_loop_starts: &BTreeSet<Label>,
+) -> (FinalInvariants, PerCommandStates) {
+    let reverse = &mut ReverseBlockCFG::new(cfg, infinite_loop_starts);
+    let initial_state = LivenessState::initial();
+    let mut liveness = Liveness::new(reverse);
+    let final_invariants = liveness.analyze_function(reverse, initial_state).unwrap();
+    (final_invariants, liveness.states)
+}
+
+fn command(state: &mut LivenessState, sp!(_, cmd_): &Command) {
+    use Command_ as C;
+    match cmd_ {
+        C::Assign(ls, e) => {
+            lvalues(state, ls);
+            exp(state, e);
+        }
+        C::Mutate(el, er) => {
+            exp(state, er);
+            exp(state, el)
+        }
+        C::Return(e) | C::Abort(e) | C::IgnoreAndPop { exp: e, .. } | C::JumpIf { cond: e, .. } => {
+            exp(state, e)
+        }
+
+        C::Jump(_) => (),
+    }
+}
+
+fn lvalues(state: &mut LivenessState, ls: &[LValue]) {
+    ls.iter().for_each(|l| lvalue(state, l))
+}
+
+fn lvalue(state: &mut LivenessState, sp!(_, l_): &LValue) {
+    use LValue_ as L;
+    match l_ {
+        L::Ignore => (),
+        L::Var(v, _) => {
+            state.0.remove(v);
+        }
+        L::Unpack(_, _, fields) => fields.iter().for_each(|(_, l)| lvalue(state, l)),
+    }
+}
+
+fn exp(state: &mut LivenessState, parent_e: &Exp) {
+    use UnannotatedExp_ as E;
+    match &parent_e.exp.value {
+        E::Unit | E::Value(_) | E::UnresolvedError => (),
+
+        E::BorrowLocal(_, var) | E::Copy { var, .. } | E::Move { var, .. } => {
+            state.0.insert(var.clone());
+        }
+
+        E::ModuleCall(mcall) => exp(state, &mcall.arguments),
+        E::Builtin(_, e)
+        | E::Freeze(e)
+        | E::Dereference(e)
+        | E::UnaryExp(_, e)
+        | E::Borrow(_, e, _) => exp(state, e),
+
+        E::BinopExp(e1, _, e2) => {
+            exp(state, e1);
+            exp(state, e2)
+        }
+
+        E::Pack(_, _, fields) => fields.iter().for_each(|(_, _, e)| exp(state, e)),
+
+        E::ExpList(es) => es.iter().for_each(|item| exp_list_item(state, item)),
+    }
+}
+
+fn exp_list_item(state: &mut LivenessState, item: &ExpListItem) {
+    match item {
+        ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => exp(state, e),
+    }
+}
+
+//**************************************************************************************************
+// Copy Refinement
+//**************************************************************************************************
+
+/// This pass:
+/// - Switches the last inferred `copy` to a `move`.
+///   It will error if the `copy` was specified by the user
+/// - Reports an error if an assignment/let was not used
+///   Switches it to an `Ignore` if it is not a resource (helps with error messages for borrows)
+
+fn last_usage(
+    errors: &mut Errors,
+    locals: &UniqueMap<Var, SingleType>,
+    block_command_states: PerCommandStates,
+    blocks: &mut Blocks,
+) {
+    for (lbl, block) in blocks {
+        let command_states = block_command_states.get(lbl).unwrap();
+        last_usage::block(errors, locals, command_states, block)
+    }
+}
+
+mod last_usage {
+    use crate::cfgir::ast::*;
+    use crate::cfgir::liveness::state::LivenessState;
+    use crate::hlir::translate::{display_var, DisplayVar};
+    use crate::{errors::*, parser::ast::Var, shared::unique_map::*, shared::*};
+    use std::collections::{BTreeSet, VecDeque};
+
+    struct Context<'a, 'b> {
+        errors: &'a mut Errors,
+        locals: &'a UniqueMap<Var, SingleType>,
+        next_live: &'b BTreeSet<Var>,
+        dropped_live: BTreeSet<Var>,
+    }
+
+    impl<'a, 'b> Context<'a, 'b> {
+        fn new(
+            errors: &'a mut Errors,
+            locals: &'a UniqueMap<Var, SingleType>,
+            next_live: &'b BTreeSet<Var>,
+            dropped_live: BTreeSet<Var>,
+        ) -> Self {
+            Context {
+                errors,
+                locals,
+                next_live,
+                dropped_live,
+            }
+        }
+
+        fn is_resourceful(&self, local: &Var) -> bool {
+            let ty = self.locals.get(local).unwrap();
+            let k = ty.value.kind(ty.loc);
+            k.value.is_resourceful()
+        }
+
+        fn error(&mut self, e: Vec<(Loc, impl Into<String>)>) {
+            self.errors
+                .push(e.into_iter().map(|(loc, msg)| (loc, msg.into())).collect())
+        }
+    }
+
+    pub fn block(
+        errors: &mut Errors,
+        locals: &UniqueMap<Var, SingleType>,
+        command_states: &VecDeque<LivenessState>,
+        block: &mut BasicBlock,
+    ) {
+        let len = block.len();
+        let last_cmd = block.get(len - 1).unwrap();
+        assert!(
+            last_cmd.value.is_terminal(),
+            "ICE malformed block. missing jump"
+        );
+        for idx in 0..(len - 1) {
+            let cmd = block.get_mut(idx).unwrap();
+            let cur_data = command_states.get(idx).unwrap();
+            let next_data = command_states.get(idx + 1).unwrap();
+
+            let dropped_live = cur_data
+                .0
+                .difference(&next_data.0)
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            command(
+                &mut Context::new(errors, locals, &next_data.0, dropped_live),
+                cmd,
+            )
+        }
+    }
+
+    fn command(context: &mut Context, sp!(_, cmd_): &mut Command) {
+        use Command_ as C;
+        match cmd_ {
+            C::Assign(ls, e) => {
+                lvalues(context, ls);
+                exp(context, e);
+            }
+            C::Mutate(el, er) => {
+                exp(context, el);
+                exp(context, er)
+            }
+            C::Return(e)
+            | C::Abort(e)
+            | C::IgnoreAndPop { exp: e, .. }
+            | C::JumpIf { cond: e, .. } => exp(context, e),
+
+            C::Jump(_) => (),
+        }
+    }
+
+    fn lvalues(context: &mut Context, ls: &mut [LValue]) {
+        ls.iter_mut().for_each(|l| lvalue(context, l))
+    }
+
+    fn lvalue(context: &mut Context, l: &mut LValue) {
+        use LValue_ as L;
+        match &mut l.value {
+            L::Ignore => (),
+            L::Var(v, _) => {
+                context.dropped_live.insert(v.clone());
+                if !context.next_live.contains(v) {
+                    match display_var(v.value()) {
+                        DisplayVar::Tmp => (),
+                        DisplayVar::Orig(v_str) => {
+                            let msg = format!("Unused assignment or binding for local '{}'. Consider removing or replacing it with '_'", v_str);
+                            context.error(vec![(l.loc, msg)]);
+                            if !context.is_resourceful(v) {
+                                l.value = L::Ignore
+                            }
+                        }
+                    }
+                }
+            }
+            L::Unpack(_, _, fields) => fields.iter_mut().for_each(|(_, l)| lvalue(context, l)),
+        }
+    }
+
+    fn exp(context: &mut Context, parent_e: &mut Exp) {
+        use UnannotatedExp_ as E;
+        match &mut parent_e.exp.value {
+            E::Unit | E::Value(_) | E::UnresolvedError => (),
+
+            E::BorrowLocal(_, var) | E::Move { var, .. } => {
+                // remove it from context to prevent accidental dropping in previous usages
+                context.dropped_live.remove(var);
+            }
+
+            E::Copy { var, from_user } => {
+                // Even if not switched to a move:
+                // remove it from dropped_live to prevent accidental dropping in previous usages
+                let var_is_dead = context.dropped_live.remove(var);
+                if var_is_dead && *from_user {
+                    match display_var(var.value()) {
+                        DisplayVar::Tmp => (),
+                        DisplayVar::Orig(v_str) => {
+                            let msg = format!("Invalid 'copy'. The local '{}' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'", v_str);
+                            context.error(vec![(parent_e.exp.loc, msg)])
+                        }
+                    }
+                }
+                if var_is_dead {
+                    parent_e.exp.value = E::Move {
+                        var: var.clone(),
+                        from_user: *from_user,
+                    };
+                }
+            }
+
+            E::ModuleCall(mcall) => exp(context, &mut mcall.arguments),
+            E::Builtin(_, e)
+            | E::Freeze(e)
+            | E::Dereference(e)
+            | E::UnaryExp(_, e)
+            | E::Borrow(_, e, _) => exp(context, e),
+
+            E::BinopExp(e1, _, e2) => {
+                exp(context, e2);
+                exp(context, e1)
+            }
+
+            E::Pack(_, _, fields) => fields
+                .iter_mut()
+                .rev()
+                .for_each(|(_, _, e)| exp(context, e)),
+
+            E::ExpList(es) => es
+                .iter_mut()
+                .rev()
+                .for_each(|item| exp_list_item(context, item)),
+        }
+    }
+
+    fn exp_list_item(context: &mut Context, item: &mut ExpListItem) {
+        match item {
+            ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => exp(context, e),
+        }
+    }
+}
+
+//**************************************************************************************************
+// Refs Refinement
+//**************************************************************************************************
+
+/// This refinement releases dead reference values by adding a move + pop. In other words, if a
+/// reference `r` is dead, it will insert `_ = move r` after the last usage
+///
+/// However, due to the previous `last_usage` analysis. Any last usage of a reference is a move.
+/// And any unused assignment to a reference holding local is switched to a `Ignore`.
+/// Thus the only way a reference could still be dead is if it was live in a loop
+/// Additionally, the borrow checker will consider any reference to be released if it was released
+/// in any predecessor.
+/// As such, the only references that need to be released by an added `_ = move r` are references
+/// at the beginning of a block given that
+/// (1) The reference is live in the predecessor and the predecessor is a loop
+/// (2)  The reference is live in ALL predecessors (otherwise the borrow checker will release them)
+///
+/// Because of this, `build_forward_intersections` intersects all of the forward post states of
+/// predecessors.
+/// Then `release_dead_refs_block` adds a release at the beginning of the block if the reference
+/// satisfies (1) and (2)
+
+fn release_dead_refs(
+    locals: &UniqueMap<Var, SingleType>,
+    forward_intersections: ForwardIntersections,
+    block_command_states: PerCommandStates,
+    blocks: &mut Blocks,
+) {
+    for (lbl, block) in &mut *blocks {
+        let initial = forward_intersections.get(lbl).unwrap();
+        let command_states = block_command_states.get(lbl).unwrap();
+        release_dead_refs_block(locals, initial, command_states, block)
+    }
+}
+
+fn build_forward_intersections(
+    cfg: &BlockCFG,
+    final_invariants: FinalInvariants,
+) -> ForwardIntersections {
+    cfg.blocks()
+        .keys()
+        .map(|lbl| {
+            let mut states = cfg
+                .predecessors(*lbl)
+                .iter()
+                .flat_map(|pred| final_invariants.get(pred))
+                .map(|state| &state.0);
+            let intersection = states
+                .next()
+                .map(|init| states.fold(init.clone(), |acc, s| &acc & s))
+                .unwrap_or_else(BTreeSet::new);
+            (*lbl, LivenessState(intersection))
+        })
+        .collect()
+}
+
+fn release_dead_refs_block(
+    locals: &UniqueMap<Var, SingleType>,
+    initial: &LivenessState,
+    command_states: &VecDeque<LivenessState>,
+    block: &mut BasicBlock,
+) {
+    let cmd_loc = block.get(0).unwrap().loc;
+    let cur_data = command_states.get(0).unwrap();
+    let dead_refs = initial
+        .0
+        .difference(&cur_data.0)
+        .map(|var| (var, locals.get(var).unwrap()))
+        .filter(is_ref);
+    for (dead_ref, ty) in dead_refs {
+        block.push_front(pop_ref(cmd_loc, dead_ref.clone(), ty.clone()));
+    }
+}
+
+fn is_ref((_local, sp!(_, local_ty_)): &(&Var, &SingleType)) -> bool {
+    match local_ty_ {
+        SingleType_::Ref(_, _) => true,
+        SingleType_::Base(_) => false,
+    }
+}
+
+fn pop_ref(loc: Loc, var: Var, ty: SingleType) -> Command {
+    use Command_ as C;
+    use UnannotatedExp_ as E;
+    let move_e_ = E::Move {
+        from_user: false,
+        var,
+    };
+    let move_e = ast::exp(Type_::single(ty), sp(loc, move_e_));
+    let pop_ = C::IgnoreAndPop {
+        pop_num: 1,
+        exp: move_e,
+    };
+    sp(loc, pop_)
+}

--- a/language/move-lang/src/cfgir/liveness/state.rs
+++ b/language/move-lang/src/cfgir/liveness/state.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//**************************************************************************************************
+// Abstract state
+//**************************************************************************************************
+
+use crate::{cfgir::absint::*, parser::ast::Var};
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LivenessState(pub BTreeSet<Var>);
+
+//**************************************************************************************************
+// impls
+//**************************************************************************************************
+
+impl LivenessState {
+    pub fn initial() -> Self {
+        LivenessState(BTreeSet::new())
+    }
+
+    pub fn extend(&mut self, other: &Self) {
+        self.0.extend(other.0.iter().cloned());
+    }
+}
+
+impl AbstractDomain for LivenessState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let before = self.0.len();
+        self.extend(other);
+        let after = self.0.len();
+        match before.cmp(&after) {
+            Ordering::Less => JoinResult::Changed,
+            Ordering::Equal => JoinResult::Unchanged,
+            Ordering::Greater => panic!("ICE set union made a set smaller than before"),
+        }
+    }
+}

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -68,7 +68,13 @@ impl<'a, 'b> Context<'a, 'b> {
 impl<'a> TransferFunctions for LocalsSafety<'a> {
     type State = LocalStates;
 
-    fn execute(&mut self, pre: &mut Self::State, cmd: &Command) -> Errors {
+    fn execute(
+        &mut self,
+        pre: &mut Self::State,
+        _lbl: Label,
+        _idx: usize,
+        cmd: &Command,
+    ) -> Errors {
         let mut context = Context::new(self, pre);
         command(&mut context, cmd);
         context.get_errors()
@@ -81,11 +87,12 @@ pub fn verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut super::cfg::BlockCFG,
+    cfg: &super::cfg::BlockCFG,
 ) {
     let initial_state = LocalStates::initial(&signature.parameters, locals);
     let mut locals_safety = LocalsSafety::new(locals);
-    errors.append(&mut locals_safety.analyze_function(cfg, initial_state));
+    let result = locals_safety.analyze_function(cfg, initial_state);
+    errors.append(&mut result.err().unwrap_or_else(Errors::new));
 }
 
 //**************************************************************************************************

--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -5,6 +5,7 @@ mod absint;
 pub mod ast;
 mod borrows;
 pub mod cfg;
+mod liveness;
 mod locals;
 pub mod translate;
 
@@ -21,19 +22,20 @@ use std::collections::BTreeSet;
 ///   - Might prove be a bit tricky to get exactly right as it might happen only at the statement
 ///     level instead of the expression level
 pub fn refine(
-    _signature: &FunctionSignature,
-    _locals: &UniqueMap<Var, SingleType>,
+    errors: &mut Errors,
+    signature: &FunctionSignature,
+    locals: &UniqueMap<Var, SingleType>,
     cfg: &mut BlockCFG,
-    infinite_loop_starts: BTreeSet<Label>,
+    infinite_loop_starts: &BTreeSet<Label>,
 ) {
-    ReverseBlockCFG::new(cfg, infinite_loop_starts);
+    liveness::refine_and_verify(errors, signature, locals, cfg, infinite_loop_starts);
 }
 
 pub fn verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
-    cfg: &mut BlockCFG,
+    cfg: &BlockCFG,
 ) {
     locals::verify(errors, signature, locals, cfg);
     borrows::verify(errors, signature, locals, cfg)

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -175,7 +175,13 @@ fn function_body(
                 context.error(e);
             }
 
-            cfgir::refine(signature, &locals, &mut cfg, infinite_loop_starts);
+            cfgir::refine(
+                &mut context.errors,
+                signature,
+                &locals,
+                &mut cfg,
+                &infinite_loop_starts,
+            );
             cfgir::verify(&mut context.errors, signature, &locals, &mut cfg);
 
             GB::Defined {

--- a/language/move-lang/stdlib/modules/libra_account.move
+++ b/language/move-lang/stdlib/modules/libra_account.move
@@ -286,7 +286,7 @@ module LibraAccount {
         );
 
         // Bump the sequence number
-        move sender_account.sequence_number = sender_account.sequence_number + 1;
+        sender_account.sequence_number = sender_account.sequence_number + 1;
         // Pay the transaction fee into the transaction fee pot
         LibraCoin::deposit(&mut borrow_global_mut<T>(0xFEE).balance, transaction_fee);
     }

--- a/language/move-lang/tests/move_check/liveness/copy_after_move.exp
+++ b/language/move-lang/tests/move_check/liveness/copy_after_move.exp
@@ -1,0 +1,19 @@
+error: 
+
+   ┌── tests/move_check/liveness/copy_after_move.move:5:9 ───
+   │
+ 5 │         copy x;
+   │         ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/copy_after_move.move:4:9 ───
+   │
+ 5 │         copy x;
+   │         ^^^^^^ Invalid usage of local 'x'
+   ·
+ 4 │         move x;
+   │         ------ The local does not have a value due to this position. The local must be assigned a value before being used
+   │
+

--- a/language/move-lang/tests/move_check/liveness/copy_after_move.move
+++ b/language/move-lang/tests/move_check/liveness/copy_after_move.move
@@ -1,0 +1,7 @@
+module M {
+    t0() {
+        let x = 0;
+        move x;
+        copy x;
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch.move
@@ -1,0 +1,45 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+        } else {
+            *x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t2(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *move x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t3(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *move x_ref = 0;
+        } else {
+            _ = move x_ref;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_both.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_both.move
@@ -1,0 +1,26 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *x_ref = 0;
+        } else {
+            _ = x_ref;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            _ = x_ref;
+        } else {
+            *x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_both_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_both_invalid.exp
@@ -1,0 +1,44 @@
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:4:21 ───
+    │
+ 10 │         _ = x;
+    │             ^ Invalid copy of local 'x'
+    ·
+ 4 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:4:21 ───
+    │
+ 11 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
+    ·
+ 4 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:17:21 ───
+    │
+ 23 │         _ = x;
+    │             ^ Invalid copy of local 'x'
+    ·
+ 17 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:17:21 ───
+    │
+ 24 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
+    ·
+ 17 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_both_invalid.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_both_invalid.move
@@ -1,0 +1,28 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *x_ref = 0;
+        } else {
+            _ = x_ref;
+        };
+        _ = x;
+        _ = move x;
+        *x_ref = 0;
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            _ = x_ref;
+        } else {
+            *x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+        _ = *x_ref;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_invalid.exp
@@ -1,0 +1,44 @@
+error: 
+
+   ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:4:21 ───
+   │
+ 8 │         _ = x;
+   │             ^ Invalid copy of local 'x'
+   ·
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:4:21 ───
+   │
+ 9 │         _ = move x;
+   │             ^^^^^^ Invalid move of local 'x'
+   ·
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:15:21 ───
+    │
+ 20 │         _ = x;
+    │             ^ Invalid copy of local 'x'
+    ·
+ 15 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:15:21 ───
+    │
+ 21 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
+    ·
+ 15 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_invalid.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_invalid.move
@@ -1,0 +1,25 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+        *x_ref = 0;
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+        } else {
+            *x_ref = 0;
+        };
+        _ = x;
+        _ = move x;
+        _ = *x_ref;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_loop.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_loop.move
@@ -1,0 +1,33 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        while (cond) {
+            _ = x_ref;
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+           _ = x_ref;
+           break
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t2(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+            if (cond) break else  { _ = copy x_ref; }
+        };
+        _ = x;
+        _ = move x;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_loop_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_loop_invalid.exp
@@ -1,0 +1,33 @@
+error: 
+
+   ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:4:21 ───
+   │
+ 6 │             _ = x;
+   │                 ^ Invalid copy of local 'x'
+   ·
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:13:21 ───
+    │
+ 16 │            _ = x;
+    │                ^ Invalid copy of local 'x'
+    ·
+ 13 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:22:21 ───
+    │
+ 25 │             _ = x;
+    │                 ^ Invalid copy of local 'x'
+    ·
+ 22 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/liveness/dead_refs_loop_invalid.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_loop_invalid.move
@@ -1,0 +1,28 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        while (cond) {
+            _ = x;
+            _ = x_ref;
+        }
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+           _ = x_ref;
+           _ = x;
+        }
+    }
+
+    t2(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+            if (cond) break else  { _ = x_ref; };
+            _ = x;
+        }
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_nested.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_nested.move
@@ -1,0 +1,36 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        while (cond) {
+            while (cond) {
+                _ = x_ref
+            }
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+           _ = x_ref;
+           loop {
+               _ = x_ref;
+               break
+           };
+           break
+        };
+        _ = x;
+        _ = move x;
+    }
+
+    t2(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+            if (cond) { _ = x; break } else { while (!cond) { _ = x_ref } }
+        }
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_nested_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_nested_invalid.exp
@@ -1,0 +1,33 @@
+error: 
+
+   ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:4:21 ───
+   │
+ 9 │             _ = x;
+   │                 ^ Invalid copy of local 'x'
+   ·
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:15:21 ───
+    │
+ 19 │                _ = x;
+    │                    ^ Invalid copy of local 'x'
+    ·
+ 15 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:27:21 ───
+    │
+ 29 │             if (cond) { _ = x_ref; break } else { while (!cond) { _ = x } }
+    │                                                                       ^ Invalid copy of local 'x'
+    ·
+ 27 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/liveness/dead_refs_nested_invalid.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_nested_invalid.move
@@ -1,0 +1,32 @@
+module M {
+    t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        while (cond) {
+            while (cond) {
+                _ = x_ref
+            };
+            _ = x;
+        }
+    }
+
+    t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+           _ = x_ref;
+           loop {
+               _ = x;
+               break
+           }
+        }
+    }
+
+    t2(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        loop {
+            if (cond) { _ = x_ref; break } else { while (!cond) { _ = x } }
+        }
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_simple.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_simple.move
@@ -1,0 +1,9 @@
+module M {
+    t() {
+        let x = 0;
+        let x_ref = &mut x;
+        *x_ref = 0;
+        _ = x;
+        _ = move x;
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/dead_refs_simple_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_simple_invalid.exp
@@ -1,0 +1,44 @@
+error: 
+
+   ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:4:21 ───
+   │
+ 5 │         _ = x;
+   │             ^ Invalid copy of local 'x'
+   ·
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:4:21 ───
+   │
+ 6 │         _ = move x;
+   │             ^^^^^^ Invalid move of local 'x'
+   ·
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:12:21 ───
+    │
+ 13 │         _ = x;
+    │             ^ Invalid copy of local 'x'
+    ·
+ 12 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:12:21 ───
+    │
+ 14 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
+    ·
+ 12 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/liveness/dead_refs_simple_invalid.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_simple_invalid.move
@@ -1,0 +1,18 @@
+module M {
+    t0() {
+        let x = 0;
+        let x_ref = &mut x;
+        _ = x;
+        _ = move x;
+        *x_ref = 0;
+    }
+
+    t1() {
+        let x = 0;
+        let x_ref = &mut x;
+        _ = x;
+        _ = move x;
+        _ = *x_ref;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/explicit_last_copy.exp
+++ b/language/move-lang/tests/move_check/liveness/explicit_last_copy.exp
@@ -1,0 +1,56 @@
+error: 
+
+   ┌── tests/move_check/liveness/explicit_last_copy.move:4:9 ───
+   │
+ 4 │         copy x;
+   │         ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/explicit_last_copy.move:9:17 ───
+   │
+ 9 │         let x = copy x;
+   │                 ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/explicit_last_copy.move:16:13 ───
+    │
+ 16 │             copy x;
+    │             ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/explicit_last_copy.move:24:13 ───
+    │
+ 24 │             copy x;
+    │             ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/explicit_last_copy.move:31:13 ───
+    │
+ 31 │             copy x;
+    │             ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/explicit_last_copy.move:33:13 ───
+    │
+ 33 │             copy x;
+    │             ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/explicit_last_copy.move:49:9 ───
+    │
+ 49 │         copy x;
+    │         ^^^^^^ Invalid 'copy'. The local 'x' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+

--- a/language/move-lang/tests/move_check/liveness/explicit_last_copy.move
+++ b/language/move-lang/tests/move_check/liveness/explicit_last_copy.move
@@ -1,0 +1,52 @@
+module M {
+    t0() {
+        let x = 0;
+        copy x;
+    }
+
+    t1() {
+        let x = 0;
+        let x = copy x;
+        x;
+    }
+
+    t2(cond: bool) {
+        if (cond) {
+            let x = 0;
+            copy x;
+        }
+    }
+
+    t3(cond: bool) {
+        let x = 0;
+        copy x;
+        if (cond) {
+            copy x;
+        }
+    }
+
+    t4(cond: bool) {
+        let x = 0;
+        if (cond) {
+            copy x;
+        } else {
+            copy x;
+        }
+    }
+
+    t5(cond: bool) {
+        let x = 0;
+        while (cond) {
+            copy x;
+        };
+    }
+
+    t6(cond: bool) {
+        let x = 0;
+        while (cond) {
+            copy x;
+        };
+        copy x;
+    }
+
+}

--- a/language/move-lang/tests/move_check/liveness/unused_assignment.exp
+++ b/language/move-lang/tests/move_check/liveness/unused_assignment.exp
@@ -1,0 +1,72 @@
+error: 
+
+   ┌── tests/move_check/liveness/unused_assignment.move:3:13 ───
+   │
+ 3 │         let x = 0;
+   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/unused_assignment.move:7:13 ───
+   │
+ 7 │         let x = 0;
+   │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/unused_assignment.move:8:9 ───
+   │
+ 8 │         x = 0;
+   │         ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/unused_assignment.move:13:17 ───
+    │
+ 13 │             let x = 0;
+    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/unused_assignment.move:21:13 ───
+    │
+ 21 │             x = 0;
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/unused_assignment.move:26:13 ───
+    │
+ 26 │         let x = 0;
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/unused_assignment.move:28:13 ───
+    │
+ 28 │             x = 1;
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/unused_assignment.move:30:13 ───
+    │
+ 30 │             x = 2;
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/unused_assignment.move:41:13 ───
+    │
+ 41 │             x = 1;
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+

--- a/language/move-lang/tests/move_check/liveness/unused_assignment.move
+++ b/language/move-lang/tests/move_check/liveness/unused_assignment.move
@@ -1,0 +1,45 @@
+module M {
+    t0() {
+        let x = 0;
+    }
+
+    t1() {
+        let x = 0;
+        x = 0;
+    }
+
+    t2(cond: bool) {
+        if (cond) {
+            let x = 0;
+        }
+    }
+
+    t3(cond: bool) {
+        let x = 0;
+        x;
+        if (cond) {
+            x = 0;
+        }
+    }
+
+    t4(cond: bool) {
+        let x = 0;
+        if (cond) {
+            x = 1;
+        } else {
+            x = 2;
+        }
+    }
+
+    t5(cond: bool) {
+        let x;
+        while (cond) {
+            x = 0;
+            if (cond) {
+                x;
+            };
+            x = 1;
+        }
+    }
+
+}

--- a/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
@@ -2,6 +2,14 @@ error:
 
    ┌── tests/move_check/locals/assign_partial_resource.move:6:21 ───
    │
+ 6 │         if (cond) { r = R{}; };
+   │                     ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/locals/assign_partial_resource.move:6:21 ───
+   │
  7 │         r = R{};
    │         ^ Invalid assignment to local 'r'
    ·
@@ -13,11 +21,27 @@ error:
 
     ┌── tests/move_check/locals/assign_partial_resource.move:13:29 ───
     │
+ 13 │         if (cond) {} else { r = R{}; };
+    │                             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/assign_partial_resource.move:13:29 ───
+    │
  14 │         r = R{};
     │         ^ Invalid assignment to local 'r'
     ·
  13 │         if (cond) {} else { r = R{}; };
-    │                             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+    │                             - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/assign_partial_resource.move:20:24 ───
+    │
+ 20 │         while (cond) { r = R{} };
+    │                        ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
@@ -40,6 +64,14 @@ error:
     ·
  20 │         while (cond) { r = R{} };
     │                        - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/assign_partial_resource.move:27:16 ───
+    │
+ 27 │         loop { r = R{} }
+    │                ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/assign_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_resource.exp
@@ -2,6 +2,14 @@ error:
 
    ┌── tests/move_check/locals/assign_resource.move:5:13 ───
    │
+ 5 │         let r = R{};
+   │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/locals/assign_resource.move:5:13 ───
+   │
  6 │         r = R{};
    │         ^ Invalid assignment to local 'r'
    ·
@@ -40,6 +48,14 @@ error:
     ·
  23 │         let r = R{};
     │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/assign_resource.move:29:13 ───
+    │
+ 29 │         let r = R{};
+    │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -14,6 +14,14 @@ error:
 
 error: 
 
+   ┌── tests/move_check/locals/unused_resource.move:5:13 ───
+   │
+ 5 │         let r = R{};
+   │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
     ┌── tests/move_check/locals/unused_resource.move:8:20 ───
     │
  8 │       t1(cond: bool) {
@@ -29,6 +37,14 @@ error:
 
 error: 
 
+    ┌── tests/move_check/locals/unused_resource.move:10:21 ───
+    │
+ 10 │         if (cond) { r = R{}; };
+    │                     ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
     ┌── tests/move_check/locals/unused_resource.move:13:20 ───
     │
  13 │       t2(cond: bool) {
@@ -39,7 +55,15 @@ error:
     │ ╰─────^ Invalid return
     ·
  15 │         if (cond) {} else { r = R{}; };
-    │                             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+    │                             - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/unused_resource.move:15:29 ───
+    │
+ 15 │         if (cond) {} else { r = R{}; };
+    │                             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
@@ -62,10 +86,26 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:20:24 ───
     │
  20 │         while (cond) { r = R{} };
+    │                        ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/unused_resource.move:20:24 ───
+    │
+ 20 │         while (cond) { r = R{} };
     │                        ^ Invalid assignment to local 'r'
     ·
  20 │         while (cond) { r = R{} };
     │                        - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/unused_resource.move:24:20 ───
+    │
+ 24 │         loop { let r = R{}; }
+    │                    ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
     │
 
 error: 
@@ -85,11 +125,11 @@ error:
     │
  27 │       t5() {
     │ ╭──────────^
- 28 │ │         let x = &R{};
+ 28 │ │         let _ = &R{};
  29 │ │     }
     │ ╰─────^ Invalid return
     ·
- 28 │         let x = &R{};
+ 28 │         let _ = &R{};
     │                 ---- The resource is created but not used. The resource must be consumed before the function returns
     │
 

--- a/language/move-lang/tests/move_check/locals/unused_resource.move
+++ b/language/move-lang/tests/move_check/locals/unused_resource.move
@@ -25,7 +25,7 @@ module M {
     }
 
     t5() {
-        let x = &R{};
+        let _ = &R{};
     }
 
     t6<T>(x: T) {

--- a/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
@@ -2,6 +2,14 @@ error:
 
    ┌── tests/move_check/locals/unused_resource_explicit_return.move:5:13 ───
    │
+ 5 │         let r = R{};
+   │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+   │
+
+error: 
+
+   ┌── tests/move_check/locals/unused_resource_explicit_return.move:5:13 ───
+   │
  6 │         return ()
    │         ^^^^^^^^^ Invalid return
    ·
@@ -46,11 +54,27 @@ error:
 
     ┌── tests/move_check/locals/unused_resource_explicit_return.move:28:13 ───
     │
+ 28 │         let r = R{};
+    │             ^ Unused assignment or binding for local 'r'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:28:13 ───
+    │
  29 │         loop { return () }
     │                ^^^^^^^^^ Invalid return
     ·
  28 │         let r = R{};
     │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:33:13 ───
+    │
+ 33 │         let x = &R{};
+    │             ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/use_after_move_if.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_after_move_if.move:4:25 ───
    │
- 5 │         let y = move x + 1;
+ 5 │         let _ = move x + 1;
    │                 ^^^^^^ Invalid usage of local 'x'
    ·
  4 │         if (cond) { _ = move x };
@@ -13,7 +13,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if.move:10:25 ───
     │
- 11 │         let y = x + 1;
+ 11 │         let _ = x + 1;
     │                 ^ Invalid usage of local 'x'
     ·
  10 │         if (cond) { _ = move x };
@@ -24,7 +24,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if.move:16:25 ───
     │
- 17 │         let y = &x;
+ 17 │         let _ = &x;
     │                 ^^ Invalid usage of local 'x'
     ·
  16 │         if (cond) { _ = move x };

--- a/language/move-lang/tests/move_check/locals/use_after_move_if.move
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if.move
@@ -2,19 +2,19 @@ module M {
     tmove(cond: bool) {
         let x = 0;
         if (cond) { _ = move x };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
     tcopy(cond: bool) {
         let x = 0;
         if (cond) { _ = move x };
-        let y = x + 1;
+        let _ = x + 1;
     }
 
     tborrow(cond: bool) {
         let x = 0;
         if (cond) { _ = move x };
-        let y = &x;
+        let _ = &x;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_after_move_if_else.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if_else.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_after_move_if_else.move:4:45 ───
    │
- 5 │         let y = move x + 1;
+ 5 │         let _ = move x + 1;
    │                 ^^^^^^ Invalid usage of local 'x'
    ·
  4 │         if (cond) { _ = move x } else { _ = move x };
@@ -13,7 +13,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if_else.move:10:25 ───
     │
- 11 │         let y = move x + 1;
+ 11 │         let _ = move x + 1;
     │                 ^^^^^^ Invalid usage of local 'x'
     ·
  10 │         if (cond) { _ = move x } else { _ = x };
@@ -24,7 +24,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if_else.move:16:45 ───
     │
- 17 │         let y = x + 1;
+ 17 │         let _ = x + 1;
     │                 ^ Invalid usage of local 'x'
     ·
  16 │         if (cond) { _ = move x } else { _ = move x };
@@ -35,7 +35,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if_else.move:23:25 ───
     │
- 24 │         let y = x + 1;
+ 24 │         let _ = x + 1;
     │                 ^ Invalid usage of local 'x'
     ·
  23 │         if (cond) { _ = move x } else { _ = x };
@@ -46,7 +46,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if_else.move:29:45 ───
     │
- 30 │         let y = &x;
+ 30 │         let _ = &x;
     │                 ^^ Invalid usage of local 'x'
     ·
  29 │         if (cond) { _ = move x } else { _ = move x };
@@ -57,7 +57,7 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_if_else.move:35:25 ───
     │
- 36 │         let y = &x;
+ 36 │         let _ = &x;
     │                 ^^ Invalid usage of local 'x'
     ·
  35 │         if (cond) { _ = move x } else { _ = x };

--- a/language/move-lang/tests/move_check/locals/use_after_move_if_else.move
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if_else.move
@@ -2,38 +2,38 @@ module M {
     tmove1(cond: bool) {
         let x = 0;
         if (cond) { _ = move x } else { _ = move x };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
     tmove2(cond: bool) {
         let x = 0;
         if (cond) { _ = move x } else { _ = x };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
     tcopy1(cond: bool) {
         let x = 0;
         if (cond) { _ = move x } else { _ = move x };
-        let y = x + 1;
+        let _ = x + 1;
     }
 
     tcopy2(cond: bool) {
 
         let x = 0;
         if (cond) { _ = move x } else { _ = x };
-        let y = x + 1;
+        let _ = x + 1;
     }
 
     tborrow1(cond: bool) {
         let x = 0;
         if (cond) { _ = move x } else { _ = move x };
-        let y = &x;
+        let _ = &x;
     }
 
     tborrow2(cond: bool) {
         let x = 0;
         if (cond) { _ = move x } else { _ = x };
-        let y = &x;
+        let _ = &x;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
@@ -36,10 +36,10 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_loop.move:14:24 ───
     │
- 14 │         loop { let y = x; _ = move x }
+ 14 │         loop { let y = x; _ = move x; y; }
     │                        ^ Invalid usage of local 'x'
     ·
- 14 │         loop { let y = x; _ = move x }
+ 14 │         loop { let y = x; _ = move x; y; }
     │                               ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -47,10 +47,10 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_loop.move:14:31 ───
     │
- 14 │         loop { let y = x; _ = move x }
+ 14 │         loop { let y = x; _ = move x; y; }
     │                               ^^^^^^ Invalid usage of local 'x'
     ·
- 14 │         loop { let y = x; _ = move x }
+ 14 │         loop { let y = x; _ = move x; y; }
     │                               ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -58,10 +58,10 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_loop.move:19:24 ───
     │
- 19 │         loop { let y = x; if (cond) continue; _ = move x }
+ 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
     │                        ^ Invalid usage of local 'x'
     ·
- 19 │         loop { let y = x; if (cond) continue; _ = move x }
+ 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
     │                                                   ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.move
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.move
@@ -11,12 +11,12 @@ module M {
 
     tcopy1(cond: bool) {
         let x = 0;
-        loop { let y = x; _ = move x }
+        loop { let y = x; _ = move x; y; }
     }
 
     tcopy2(cond: bool) {
         let x = 0;
-        loop { let y = x; if (cond) continue; _ = move x }
+        loop { let y = x; if (cond) continue; _ = move x; y; }
     }
 
     tborrow1(cond: bool) {

--- a/language/move-lang/tests/move_check/locals/use_after_move_simple.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_simple.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_after_move_simple.move:6:9 ───
    │
- 7 │         let y = move x + 1;
+ 7 │         let _ = move x + 1;
    │                 ^^^^^^ Invalid usage of local 'x'
    ·
  6 │         move x;
@@ -11,20 +11,20 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:10:18 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:10:19 ───
     │
- 11 │         let s3 = s;
-    │                  ^ Invalid usage of local 's'
+ 11 │         let _s3 = s;
+    │                   ^ Invalid usage of local 's'
     ·
- 10 │         let s2 = s;
-    │                  - The local does not have a value due to this position. The local must be assigned a value before being used
+ 10 │         let _s2 = s;
+    │                   - The local does not have a value due to this position. The local must be assigned a value before being used
     │
 
 error: 
 
     ┌── tests/move_check/locals/use_after_move_simple.move:16:9 ───
     │
- 17 │         let y = x + 1;
+ 17 │         let _ = x + 1;
     │                 ^ Invalid usage of local 'x'
     ·
  16 │         move x;
@@ -33,20 +33,28 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:20:18 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:21:19 ───
     │
- 21 │         let s3 = copy s;
-    │                  ^^^^^^ Invalid usage of local 's'
+ 21 │         let _s3 = copy s;
+    │                   ^^^^^^ Invalid 'copy'. The local 's' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/use_after_move_simple.move:20:19 ───
+    │
+ 21 │         let _s3 = copy s;
+    │                   ^^^^^^ Invalid usage of local 's'
     ·
- 20 │         let s2 = s;
-    │                  - The local does not have a value due to this position. The local must be assigned a value before being used
+ 20 │         let _s2 = s;
+    │                   - The local does not have a value due to this position. The local must be assigned a value before being used
     │
 
 error: 
 
     ┌── tests/move_check/locals/use_after_move_simple.move:26:9 ───
     │
- 27 │         let y = &x;
+ 27 │         let _ = &x;
     │                 ^^ Invalid usage of local 'x'
     ·
  26 │         move x;
@@ -55,12 +63,12 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:30:18 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:30:19 ───
     │
- 31 │         let s3 = &s;
-    │                  ^^ Invalid usage of local 's'
+ 31 │         let _s3 = &s;
+    │                   ^^ Invalid usage of local 's'
     ·
- 30 │         let s2 = s;
-    │                  - The local does not have a value due to this position. The local must be assigned a value before being used
+ 30 │         let _s2 = s;
+    │                   - The local does not have a value due to this position. The local must be assigned a value before being used
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_simple.move
+++ b/language/move-lang/tests/move_check/locals/use_after_move_simple.move
@@ -4,31 +4,31 @@ module M {
     tmove() {
         let x = 0;
         move x;
-        let y = move x + 1;
+        let _ = move x + 1;
 
         let s = S{};
-        let s2 = s;
-        let s3 = s;
+        let _s2 = s;
+        let _s3 = s;
     }
 
     tcopy() {
         let x = 0;
         move x;
-        let y = x + 1;
+        let _ = x + 1;
 
         let s = S{};
-        let s2 = s;
-        let s3 = copy s;
+        let _s2 = s;
+        let _s3 = copy s;
     }
 
     tborrow() {
         let x = 0;
         move x;
-        let y = &x;
+        let _ = &x;
 
         let s = S{};
-        let s2 = s;
-        let s3 = &s;
+        let _s2 = s;
+        let _s3 = &s;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_after_move_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_while.exp
@@ -24,10 +24,10 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_while.move:14:32 ───
     │
- 14 │         while (cond) { let y = x; _ = move x };
+ 14 │         while (cond) { let y = x; _ = move x; y; };
     │                                ^ Invalid usage of local 'x'
     ·
- 14 │         while (cond) { let y = x; _ = move x };
+ 14 │         while (cond) { let y = x; _ = move x; y; };
     │                                       ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -35,10 +35,10 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_while.move:14:39 ───
     │
- 14 │         while (cond) { let y = x; _ = move x };
+ 14 │         while (cond) { let y = x; _ = move x; y; };
     │                                       ^^^^^^ Invalid usage of local 'x'
     ·
- 14 │         while (cond) { let y = x; _ = move x };
+ 14 │         while (cond) { let y = x; _ = move x; y; };
     │                                       ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -46,10 +46,10 @@ error:
 
     ┌── tests/move_check/locals/use_after_move_while.move:19:32 ───
     │
- 19 │         while (cond) { let y = x; if (cond) continue; _ = move x };
+ 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
     │                                ^ Invalid usage of local 'x'
     ·
- 19 │         while (cond) { let y = x; if (cond) continue; _ = move x };
+ 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
     │                                                           ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_while.move
+++ b/language/move-lang/tests/move_check/locals/use_after_move_while.move
@@ -11,12 +11,12 @@ module M {
 
     tcopy1(cond: bool) {
         let x = 0;
-        while (cond) { let y = x; _ = move x };
+        while (cond) { let y = x; _ = move x; y; };
     }
 
     tcopy2(cond: bool) {
         let x = 0;
-        while (cond) { let y = x; if (cond) continue; _ = move x };
+        while (cond) { let y = x; if (cond) continue; _ = move x; y; };
     }
 
     tborrow1(cond: bool) {
@@ -26,7 +26,7 @@ module M {
 
     tborrow2(cond: bool) {
         let x = 0;
-        while (cond) { let y = &x; _ = move y; if (cond) {_ = move x }; break };
+        while (cond) { let y = &x; _ = move y; if (cond) { _ = move x }; break };
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if.exp
@@ -2,32 +2,32 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_if.move:3:13 ───
    │
- 5 │         let y = move x + 1;
+ 5 │         let _ = move x + 1;
    │                 ^^^^^^ Invalid usage of local 'x'
    ·
  3 │         let x: u64;
-   │             - The local does not have a value due to this position. The local must be assigned a value before being used
+   │             - The local might not have a value due to this position. The local must be assigned a value before being used
    │
 
 error: 
 
     ┌── tests/move_check/locals/use_before_assign_if.move:9:13 ───
     │
- 11 │         let y = x + 1;
+ 11 │         let _ = x + 1;
     │                 ^ Invalid usage of local 'x'
     ·
  9 │         let x: u64;
-    │             - The local does not have a value due to this position. The local must be assigned a value before being used
+    │             - The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
 error: 
 
     ┌── tests/move_check/locals/use_before_assign_if.move:15:13 ───
     │
- 17 │         let y = &x;
+ 17 │         let _ = &x;
     │                 ^^ Invalid usage of local 'x'
     ·
  15 │         let x: u64;
-    │             - The local does not have a value due to this position. The local must be assigned a value before being used
+    │             - The local might not have a value due to this position. The local must be assigned a value before being used
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if.move
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if.move
@@ -2,19 +2,19 @@ module M {
     tmove(cond: bool) {
         let x: u64;
         if (cond) { x = 0 };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
     tcopy(cond: bool) {
         let x: u64;
         if (cond) { x = 0 };
-        let y = x + 1;
+        let _ = x + 1;
     }
 
     tborrow(cond: bool) {
         let x: u64;
         if (cond) { x = 0 };
-        let y = &x;
+        let _ = &x;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if_else.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if_else.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_if_else.move:3:13 ───
    │
- 5 │         let y = move x + 1;
+ 5 │         let _ = move x + 1;
    │                 ^^^^^^ Invalid usage of local 'x'
    ·
  3 │         let x: u64;
@@ -13,7 +13,7 @@ error:
 
     ┌── tests/move_check/locals/use_before_assign_if_else.move:9:13 ───
     │
- 11 │         let y = move x + 1;
+ 11 │         let _ = move x + 1;
     │                 ^^^^^^ Invalid usage of local 'x'
     ·
  9 │         let x: u64;
@@ -24,7 +24,7 @@ error:
 
     ┌── tests/move_check/locals/use_before_assign_if_else.move:15:13 ───
     │
- 17 │         let y = move x + 1;
+ 17 │         let _ = move x + 1;
     │                 ^^^^^^ Invalid usage of local 'x'
     ·
  15 │         let x: u64;

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if_else.move
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if_else.move
@@ -2,19 +2,19 @@ module M {
     tmove(cond: bool) {
         let x: u64;
         if (cond) { } else { x = 0 };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
     tcopy(cond: bool) {
         let x: u64;
         if (cond) { } else { x = 0 };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
     tborrow(cond: bool) {
         let x: u64;
         if (cond) { } else { x = 0 };
-        let y = move x + 1;
+        let _ = move x + 1;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_loop.move:3:13 ───
    │
- 4 │         loop { let y = move x + 1; x = 0 }
+ 4 │         loop { let y = move x + 1; x = 0; y; }
    │                        ^^^^^^ Invalid usage of local 'x'
    ·
  3 │         let x: u64;
@@ -13,7 +13,7 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_loop.move:8:13 ───
    │
- 9 │         loop { let y = x + 1; if (cond) { continue }; x = 0 }
+ 9 │         loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
    │                        ^ Invalid usage of local 'x'
    ·
  8 │         let x: u64;
@@ -35,7 +35,7 @@ error:
 
     ┌── tests/move_check/locals/use_before_assign_loop.move:18:13 ───
     │
- 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+ 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
     │                        ^^ Invalid usage of local 'x'
     ·
  18 │         let x: u64;

--- a/language/move-lang/tests/move_check/locals/use_before_assign_loop.move
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_loop.move
@@ -1,12 +1,12 @@
 module M {
     tmove(cond: bool) {
         let x: u64;
-        loop { let y = move x + 1; x = 0 }
+        loop { let y = move x + 1; x = 0; y; }
     }
 
     tcopy(cond: bool) {
         let x: u64;
-        loop { let y = x + 1; if (cond) { continue }; x = 0 }
+        loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
     }
 
     tborrow1(cond: bool) {
@@ -16,7 +16,8 @@ module M {
 
     tborrow2(cond: bool) {
         let x: u64;
-        loop { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+        loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
+        x;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_before_assign_simple.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_simple.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_simple.move:5:13 ───
    │
- 6 │         let y = move x + 1;
+ 6 │         let _ = move x + 1;
    │                 ^^^^^^ Invalid usage of local 'x'
    ·
  5 │         let x: u64;
@@ -13,8 +13,8 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_simple.move:8:13 ───
    │
- 9 │         let s2 = s;
-   │                  ^ Invalid usage of local 's'
+ 9 │         let _s2 = s;
+   │                   ^ Invalid usage of local 's'
    ·
  8 │         let s: S;
    │             - The local does not have a value due to this position. The local must be assigned a value before being used
@@ -24,7 +24,7 @@ error:
 
     ┌── tests/move_check/locals/use_before_assign_simple.move:13:13 ───
     │
- 14 │         let y = x + 1;
+ 14 │         let _ = x + 1;
     │                 ^ Invalid usage of local 'x'
     ·
  13 │         let x: u64;
@@ -33,10 +33,18 @@ error:
 
 error: 
 
+    ┌── tests/move_check/locals/use_before_assign_simple.move:17:19 ───
+    │
+ 17 │         let _s3 = copy s;
+    │                   ^^^^^^ Invalid 'copy'. The local 's' is not live following this expression. Remove the 'copy' annotation or re-annotate as 'move'
+    │
+
+error: 
+
     ┌── tests/move_check/locals/use_before_assign_simple.move:16:13 ───
     │
- 17 │         let s3 = copy s;
-    │                  ^^^^^^ Invalid usage of local 's'
+ 17 │         let _s3 = copy s;
+    │                   ^^^^^^ Invalid usage of local 's'
     ·
  16 │         let s: S;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
@@ -46,7 +54,7 @@ error:
 
     ┌── tests/move_check/locals/use_before_assign_simple.move:21:13 ───
     │
- 22 │         let y = &x;
+ 22 │         let _ = &x;
     │                 ^^ Invalid usage of local 'x'
     ·
  21 │         let x: u64;
@@ -57,8 +65,8 @@ error:
 
     ┌── tests/move_check/locals/use_before_assign_simple.move:24:13 ───
     │
- 25 │         let s2 = &s;
-    │                  ^^ Invalid usage of local 's'
+ 25 │         let _s2 = &s;
+    │                   ^^ Invalid usage of local 's'
     ·
  24 │         let s: S;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used

--- a/language/move-lang/tests/move_check/locals/use_before_assign_simple.move
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_simple.move
@@ -3,26 +3,26 @@ module M {
 
     tmove() {
         let x: u64;
-        let y = move x + 1;
+        let _ = move x + 1;
 
         let s: S;
-        let s2 = s;
+        let _s2 = s;
     }
 
     tcopy() {
         let x: u64;
-        let y = x + 1;
+        let _ = x + 1;
 
         let s: S;
-        let s3 = copy s;
+        let _s3 = copy s;
     }
 
     tborrow() {
         let x: u64;
-        let y = &x;
+        let _ = &x;
 
         let s: S;
-        let s2 = &s;
+        let _s2 = &s;
     }
 
 }

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_while.move:3:13 ───
    │
- 4 │         while (cond) { let y = move x + 1; x = 0 }
+ 4 │         while (cond) { let y = move x + 1; x = 0; y; }
    │                                ^^^^^^ Invalid usage of local 'x'
    ·
  3 │         let x: u64;
@@ -13,7 +13,7 @@ error:
 
    ┌── tests/move_check/locals/use_before_assign_while.move:8:13 ───
    │
- 9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0 }
+ 9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
    │                                ^^^^^^ Invalid usage of local 'x'
    ·
  8 │         let x: u64;
@@ -40,5 +40,13 @@ error:
     ·
  18 │         let x: u64;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/use_before_assign_while.move:19:60 ───
+    │
+ 19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+    │                                                            ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.move
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.move
@@ -1,12 +1,12 @@
 module M {
     tmove(cond: bool) {
         let x: u64;
-        while (cond) { let y = move x + 1; x = 0 }
+        while (cond) { let y = move x + 1; x = 0; y; }
     }
 
     tcopy(cond: bool) {
         let x: u64;
-        while (cond) { let y = move x + 1; if (cond) { continue }; x = 0 }
+        while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
     }
 
     tborrow1(cond: bool) {

--- a/language/move-lang/tests/move_check/naming/generics_shadowing.move
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing.move
@@ -5,7 +5,7 @@ module M {
 
     foo<S: copyable>(s: S): S {
         let s: S = (s: S);
-        let s: S = copy s;
+        let s: S = s;
         s
     }
 

--- a/language/move-lang/tests/move_check/naming/struct_in_current_module.move
+++ b/language/move-lang/tests/move_check/naming/struct_in_current_module.move
@@ -3,7 +3,7 @@ module M {
     resource struct R { f: u64 }
 
     foo() {
-        let s: Self::S = S { f: 0 };
+        let _ : Self::S = S { f: 0 };
         let R { f: _ } : Self::R = R { f: 0 };
     }
 }

--- a/language/move-lang/tests/move_check/parser/expr_unary_ops.move
+++ b/language/move-lang/tests/move_check/parser/expr_unary_ops.move
@@ -1,5 +1,6 @@
 module M {
     f(v: u64) {
         let x = *&mut *&v; // Test borrows and dereferences
+        x;
     }
 }

--- a/language/move-lang/tests/move_check/parser/let_binding.move
+++ b/language/move-lang/tests/move_check/parser/let_binding.move
@@ -16,10 +16,21 @@ module M {
         let (v3) = 3; // for consistency, check a single variable inside parens
         let (x1, x2) = (1, 2);
         let (x3, x4): (u64, u64) = (3, 4);
+        v1;
+        v2;
+        v3;
+        x1;
+        x2;
+        x3;
+        x4;
     }
     g(r: R, g: Generic<R>) {
         let R { f } = copy r;
-        let (R { f: f1 }, R { f: f2 }) = (copy r, copy r);
+        let (R { f: f1 }, R { f: f2 }) = (copy r, move r);
         let Generic<R> { g: R { f: f3 } } = g;
+        f;
+        f1;
+        f2;
+        f3;
     }
 }

--- a/language/move-lang/tests/move_check/parser/let_binding_trailing_comma.move
+++ b/language/move-lang/tests/move_check/parser/let_binding_trailing_comma.move
@@ -1,5 +1,7 @@
 module M {
     f() {
         let (x1, x2,) = (1, 2); // Test a trailing comma in the let binding
+        x1;
+        x2;
     }
 }

--- a/language/move-lang/tests/move_check/typing/assign_unpack_references.move
+++ b/language/move-lang/tests/move_check/typing/assign_unpack_references.move
@@ -5,24 +5,28 @@ module M {
     t0() {
         let f;
         let s2;
-        R { s1: S { f }, s2 } = R { s1: S{f: 0}, s2: S{f: 1} };
+        R { s1: S { f }, s2 } = R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
         f = 0;
-        s2 = S { f: 0 }
+        s2 = S { f: 0 };
+        f; s2;
     }
 
     t1() {
         let f;
         let s2;
-        R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
+        R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
         f = &0;
-        s2 = &S { f: 0 }
+        s2 = &S { f: 0 };
+        f; s2;
+
     }
 
     t2() {
         let f;
         let s2;
-        R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+        R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
         f = &mut 0;
-        s2 = &mut S { f: 0 }
+        s2 = &mut S { f: 0 };
+        f; s2;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_add.move
+++ b/language/move-lang/tests/move_check/typing/binary_add.move
@@ -11,6 +11,6 @@ module M {
         copy x + move x;
         r.f + r.f;
         1 + r.f + r.f + 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_and.move
+++ b/language/move-lang/tests/move_check/typing/binary_and.move
@@ -11,6 +11,6 @@ module M {
         copy x && move x;
         r.f && r.f;
         true && false && (true && false);
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_bit_and.move
+++ b/language/move-lang/tests/move_check/typing/binary_bit_and.move
@@ -11,6 +11,6 @@ module M {
         copy x & move x;
         r.f & r.f;
         1 & r.f & r.f & 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_bit_or.move
+++ b/language/move-lang/tests/move_check/typing/binary_bit_or.move
@@ -11,6 +11,6 @@ module M {
         copy x | move x;
         r.f | r.f;
         1 | r.f | r.f | 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_div.move
+++ b/language/move-lang/tests/move_check/typing/binary_div.move
@@ -11,6 +11,6 @@ module M {
         copy x / move x;
         r.f / r.f;
         1 / r.f / r.f / 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_geq.move
+++ b/language/move-lang/tests/move_check/typing/binary_geq.move
@@ -11,6 +11,6 @@ module M {
         copy x < move x;
         r.f < r.f;
         (1 < r.f) && (r.f < 0);
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_gt.move
+++ b/language/move-lang/tests/move_check/typing/binary_gt.move
@@ -11,6 +11,6 @@ module M {
         copy x > move x;
         r.f > r.f;
         (1 > r.f) && (r.f > 0);
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_leq.move
+++ b/language/move-lang/tests/move_check/typing/binary_leq.move
@@ -11,6 +11,6 @@ module M {
         copy x <= move x;
         r.f <= r.f;
         (1 <= r.f) && (r.f <= 0);
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_lt.move
+++ b/language/move-lang/tests/move_check/typing/binary_lt.move
@@ -11,6 +11,6 @@ module M {
         copy x < move x;
         r.f < r.f;
         (1 < r.f) && (r.f < 0);
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_mod.move
+++ b/language/move-lang/tests/move_check/typing/binary_mod.move
@@ -11,6 +11,6 @@ module M {
         copy x % move x;
         r.f % r.f;
         1 % r.f % r.f % 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_mul.move
+++ b/language/move-lang/tests/move_check/typing/binary_mul.move
@@ -11,6 +11,6 @@ module M {
         copy x * move x;
         r.f * r.f;
         1 * r.f * r.f * 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_or.move
+++ b/language/move-lang/tests/move_check/typing/binary_or.move
@@ -11,6 +11,6 @@ module M {
         copy x || move x;
         r.f || r.f;
         true || false || (true || false);
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_sub.move
+++ b/language/move-lang/tests/move_check/typing/binary_sub.move
@@ -11,6 +11,6 @@ module M {
         copy x - move x;
         r.f - r.f;
         1 - r.f - r.f - 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/binary_xor.move
+++ b/language/move-lang/tests/move_check/typing/binary_xor.move
@@ -11,6 +11,6 @@ module M {
         copy x ^ move x;
         r.f ^ r.f;
         1 ^ r.f ^ r.f ^ 0;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }

--- a/language/move-lang/tests/move_check/typing/bind_unpack_references.move
+++ b/language/move-lang/tests/move_check/typing/bind_unpack_references.move
@@ -3,20 +3,23 @@ module M {
     struct R { s1: S, s2: S }
 
     t0() {
-        let R { s1: S { f }, s2 }: R = R { s1: S{f: 0}, s2: S{f: 1} };
+        let R { s1: S { f }, s2 }: R = R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
         f = 0;
-        s2 = S { f: 0 }
+        s2 = S { f: 0 };
+        f; s2;
     }
 
     t1() {
-        let R { s1: S { f }, s2 }: &R = &R { s1: S{f: 0}, s2: S{f: 1} };
+        let R { s1: S { f }, s2 }: &R = &R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
         f = &0;
-        s2 = &S { f: 0 }
+        s2 = &S { f: 0 };
+        f; s2;
     }
 
     t2() {
-        let R { s1: S { f }, s2 }: &mut R = &mut R { s1: S{f: 0}, s2: S{f: 1} };
+        let R { s1: S { f }, s2 }: &mut R = &mut R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
         f = &mut 0;
-        s2 = &mut S { f: 0 }
+        s2 = &mut S { f: 0 };
+        f; s2;
     }
 }

--- a/language/move-lang/tests/move_check/typing/bind_with_type_annot.move
+++ b/language/move-lang/tests/move_check/typing/bind_with_type_annot.move
@@ -3,7 +3,7 @@ module M {
 
     t0() {
         let (): () = ();
-        let x: u64 = 0;
-        let (x, b, R{f}): (u64, bool, R) = (0, false, R { f: 0 });
+        let x: u64 = 0; x;
+        let (x, b, R{f}): (u64, bool, R) = (0, false, R { f: 0 }); x; b; f;
     }
 }

--- a/language/move-lang/tests/move_check/typing/decl_unpack_references.move
+++ b/language/move-lang/tests/move_check/typing/decl_unpack_references.move
@@ -4,19 +4,19 @@ module M {
 
     t0() {
         let R { s1: S { f }, s2 }: R;
-        f = 0;
-        s2 = S { f: 0 }
+        f = 0; f;
+        s2 = S { f: 0 }; s2;
     }
 
     t1() {
         let R { s1: S { f }, s2 }: &R;
-        f = &0;
-        s2 = &S { f: 0 };
+        f = &0; f;
+        s2 = &S { f: 0 }; s2;
     }
 
     t2() {
         let R { s1: S { f }, s2 }: &mut R;
-        f = &mut 0;
-        s2 = &mut S { f: 0 };
+        f = &mut 0; f;
+        s2 = &mut S { f: 0 }; s2;
     }
 }

--- a/language/move-lang/tests/move_check/typing/explicit_copy.move
+++ b/language/move-lang/tests/move_check/typing/explicit_copy.move
@@ -7,5 +7,7 @@ module M {
         let s = S{};
         (copy u: u64);
         (copy s: S);
+        s;
+        u;
     }
 }

--- a/language/move-lang/tests/move_check/typing/if_default_else.move
+++ b/language/move-lang/tests/move_check/typing/if_default_else.move
@@ -2,6 +2,6 @@ module M {
     t0(cond: bool) {
         if (cond) ();
         let () = if (cond) ();
-        let () = if (cond) { let x = 0; };
+        let () = if (cond) { let x = 0; x; };
     }
 }

--- a/language/move-lang/tests/move_check/typing/loop_result_type.move
+++ b/language/move-lang/tests/move_check/typing/loop_result_type.move
@@ -12,7 +12,7 @@ module M {
     }
 
     t1(): u64 {
-        loop { let x = 0; }
+        loop { let x = 0; x; }
     }
 
     t2() {

--- a/language/move-lang/tests/move_check/typing/module_call_complicated_rhs.move
+++ b/language/move-lang/tests/move_check/typing/module_call_complicated_rhs.move
@@ -21,7 +21,7 @@ module M {
 
     t2() {
         foo({});
-        foo({ let x = 0; });
+        foo({ let _x = 0; });
 
         let x = 0;
         bar({ x });
@@ -34,7 +34,7 @@ module M {
 
     t3() {
         foo({});
-        foo({ let x = 0; });
+        foo({ let _x = 0; });
 
         let x = 0;
         bar({ x });

--- a/language/move-lang/tests/move_check/typing/shadowing.move
+++ b/language/move-lang/tests/move_check/typing/shadowing.move
@@ -4,7 +4,7 @@ module M {
     t0() {
         let x = 0;
 
-        { let x = false; };
+        { let x = false; x; };
         (x: u64);
 
         { let x = false; (x: bool); };

--- a/language/move-lang/tests/move_check/typing/subtype_assign.move
+++ b/language/move-lang/tests/move_check/typing/subtype_assign.move
@@ -4,17 +4,21 @@ module M {
     t0() {
         let x: &u64;
         x = &mut 0;
+        x;
     }
 
     t1() {
         let (x, y): (&mut u64, &u64);
         (x, y) = (&mut 0, &mut 0);
+        x; y;
 
         let (x, y): (&u64, &mut u64);
         (x, y) = (&mut 0, &mut 0);
+        x; y;
 
         let (x, y): (&u64, &u64);
         (x, y) = (&mut 0, &mut 0);
+        x; y;
     }
 
 }

--- a/language/move-lang/tests/move_check/typing/subtype_bind.move
+++ b/language/move-lang/tests/move_check/typing/subtype_bind.move
@@ -2,13 +2,13 @@ module M {
     struct S {}
 
     t0() {
-        let x: &u64 = &mut 0;
+        let x: &u64 = &mut 0; x;
     }
 
     t1() {
-        let (x, y): (&mut u64, &u64) = (&mut 0, &mut 0);
-        let (x, y): (&u64, &mut u64) = (&mut 0, &mut 0);
-        let (x, y): (&u64, &u64) = (&mut 0, &mut 0);
+        let (x, y): (&mut u64, &u64) = (&mut 0, &mut 0); x; y;
+        let (x, y): (&u64, &mut u64) = (&mut 0, &mut 0); x; y;
+        let (x, y): (&u64, &u64) = (&mut 0, &mut 0); x; y;
     }
 
 }

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack.move
@@ -28,7 +28,7 @@ module M {
 
     t0(): u64 {
         let v = Container::new();
-        let Box { f1, f2 }  = Container::get(&v);
+        let Box { f1, f2 }  = Container::get(&v); f2;
         Container::put(&mut v, Box { f1: 0, f2: 0});
         f1
     }

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign.move
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign.move
@@ -31,6 +31,7 @@ module M {
         let f1;
         let f2;
         Box { f1, f2 }  = Container::get(&v);
+        f2;
         Container::put(&mut v, Box { f1: 0, f2: 0});
         f1
     }

--- a/language/move-lang/tests/move_check/typing/unary_not.move
+++ b/language/move-lang/tests/move_check/typing/unary_not.move
@@ -10,6 +10,6 @@ module M {
         !copy x;
         !move x;
         !r.f;
-        let R {f} = r;
+        let R {f: _} = r;
     }
 }


### PR DESCRIPTION
##  Motivation

- Added liveness analysis
  - Made some minor changes to keep more state in abs. int. framework
- Used liveness data to switch last copy to a move
  - Error if inproperly annotated by the user
- Added errors for unused assignments/let
  - Switches to Ignore of not a resource, to help with error messages on borrows
- Inserted inferred releases/pops of references that were live during a loop, but dead after

More detail:

After Liveness:
- Switches the last inferred `copy` to a `move`.
  -  It will error if the `copy` was specified by the user
- Reports an error if an assignment/let was not used
  -   Switches it to an `Ignore` if it is not a resource (helps with error messages for borrows)

After that pass, liveness is run again, and another pass occurs that releases dead reference values by adding a move + pop. In other words, if a reference `r` is dead, it will insert `_ = move r` after the last usage.
However, due to the previous `last_usage` analysis. Any last usage of a reference is a move. And any unused assignment to a reference holding local is switched to a `Ignore`. Thus the only way a reference could still be dead is if it was live in a loop. Additionally, the borrow checker will consider any reference to be released if it was released in any predecessor. As such, the only references that need to be released by an added `_ = move r` are references at the beginning of a block given that
  1. The reference is live in the predecessor and the predecessor is a loop
  2. The reference is live in ALL predecessors (otherwise the borrow checker will release them)

Because of this, `build_forward_intersections` intersects all of the forward post states of predecessors. Then `release_dead_refs_block` adds a release at the beginning of the block if the reference satisfies (1) and (2)


## Test Plan

- Added tests
- cargo test
