### PR TITLE
[consensus] Build a safety rules process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workspace-builder 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workspace-builder 0.1.0",
 ]
 
 [[package]]
@@ -4595,6 +4596,7 @@ dependencies = [
  "rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "statistical 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "workspace-builder 0.1.0",
 ]
 
 [[package]]
@@ -5720,6 +5722,14 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "workspace-builder"
+version = "0.1.0"
+dependencies = [
+ "libra-logger 0.1.0",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-tools 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "common/prost-ext",
     "common/tools",
     "common/util",
+    "common/workspace-builder",
     "config",
     "config/config-builder",
     "config/generate-keypair",

--- a/common/workspace-builder/Cargo.toml
+++ b/common/workspace-builder/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "workspace-builder"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Build binaries within a workspace that can then be called by Command"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+once_cell = "1.2.0"
+libra-logger = { path = "../logger", version = "0.1.0" }

--- a/common/workspace-builder/src/lib.rs
+++ b/common/workspace-builder/src/lib.rs
@@ -45,7 +45,7 @@ pub fn workspace_root() -> PathBuf {
 
 // Path to the directory where build artifacts live.
 //TODO maybe add an Environment Variable which points to built binaries
-pub fn build_dir() -> PathBuf {
+fn build_dir() -> PathBuf {
     env::current_exe()
         .ok()
         .map(|mut path| {

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, net::SocketAddr};
+use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -16,6 +16,7 @@ libra-tools = { path = "../../common/tools", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 serde = { version = "1.0.99", default-features = false }
 thiserror = "1.0"
+workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -12,6 +12,7 @@ consensus-types = { path = "../consensus-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-tools = { path = "../../common/tools", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 serde = { version = "1.0.99", default-features = false }
 thiserror = "1.0"

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -8,10 +8,12 @@ mod error;
 mod local_client;
 mod network;
 mod persistent_storage;
+mod process;
 mod remote_service;
 mod safety_rules;
 mod safety_rules_manager;
 mod serializer;
+mod spawned_process;
 mod t_safety_rules;
 mod thread;
 
@@ -19,6 +21,7 @@ pub use crate::{
     consensus_state::ConsensusState,
     error::Error,
     persistent_storage::{InMemoryStorage, OnDiskStorage},
+    process::ProcessService,
     safety_rules::SafetyRules,
     safety_rules_manager::SafetyRulesManager,
     t_safety_rules::TSafetyRules,

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 mod local_client;
 mod network;
 mod persistent_storage;
+mod remote_service;
 mod safety_rules;
 mod safety_rules_manager;
 mod serializer;

--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -1,0 +1,27 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Usage: ./safety-rules node.config
+
+#![forbid(unsafe_code)]
+
+use libra_config::config::NodeConfig;
+use safety_rules::ProcessService;
+use std::{env, process};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Incorrect number of parameters, expected a path to a config file");
+        process::exit(1);
+    }
+
+    let config = NodeConfig::load(&args[1]).unwrap_or_else(|e| {
+        eprintln!("Unable to read provided config: {}", e);
+        process::exit(1);
+    });
+
+    let mut service = ProcessService::new(config);
+    service.start();
+}

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -1,0 +1,67 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    persistent_storage::PersistentStorage,
+    remote_service::{self, RemoteService},
+    safety_rules_manager,
+};
+use consensus_types::common::{Payload, Round};
+use libra_config::config::{ConsensusType, NodeConfig, SafetyRulesService};
+use libra_types::{crypto_proxies::ValidatorSigner, transaction::SignedTransaction};
+use std::net::SocketAddr;
+
+pub struct ProcessService {
+    consensus_type: ConsensusType,
+    data: Option<ProcessServiceData>,
+    server_addr: SocketAddr,
+}
+
+impl ProcessService {
+    pub fn new(mut config: NodeConfig) -> Self {
+        let (validator_signer, storage) = safety_rules_manager::extract_service_inputs(&mut config);
+
+        let service = &config.consensus.safety_rules.service;
+        let service = match &service {
+            SafetyRulesService::Process(service) => service,
+            SafetyRulesService::SpawnedProcess(service) => service,
+            _ => panic!("Unexpected SafetyRules service: {:?}", service),
+        };
+
+        Self {
+            consensus_type: service.consensus_type,
+            data: Some(ProcessServiceData {
+                validator_signer,
+                storage,
+            }),
+            server_addr: service.server_address,
+        }
+    }
+
+    pub fn start(&mut self) {
+        match self.consensus_type {
+            ConsensusType::Bytes => self.start_internal::<Vec<u8>>(),
+            ConsensusType::Rounds => self.start_internal::<Round>(),
+            ConsensusType::SignedTransactions => self.start_internal::<Vec<SignedTransaction>>(),
+        }
+    }
+
+    fn start_internal<T: Payload>(&mut self) {
+        let data = self
+            .data
+            .take()
+            .expect("Unable to retrieve ProcessServiceData");
+        remote_service::execute::<T>(data.storage, data.validator_signer, self.server_addr);
+    }
+}
+
+impl<T: Payload> RemoteService<T> for ProcessService {
+    fn server_address(&self) -> SocketAddr {
+        self.server_addr
+    }
+}
+
+struct ProcessServiceData {
+    validator_signer: ValidatorSigner,
+    storage: Box<dyn PersistentStorage>,
+}

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    network::{NetworkClient, NetworkServer},
+    persistent_storage::PersistentStorage,
+    serializer::{SafetyRulesInput, SerializerClient, SerializerService, TSerializerClient},
+    Error, SafetyRules,
+};
+use consensus_types::common::Payload;
+use libra_types::crypto_proxies::ValidatorSigner;
+use std::{marker::PhantomData, net::SocketAddr, sync::Arc};
+
+pub trait RemoteService<T: Payload> {
+    fn client(&self) -> SerializerClient<T> {
+        let network_client = NetworkClient::connect(self.server_address()).unwrap();
+        let service = Box::new(RemoteClient::new(network_client));
+        SerializerClient::new_client(service)
+    }
+
+    fn server_address(&self) -> SocketAddr;
+}
+
+pub fn execute<T: Payload>(
+    storage: Box<dyn PersistentStorage>,
+    validator_signer: ValidatorSigner,
+    listen_addr: SocketAddr,
+) {
+    let safety_rules = SafetyRules::<T>::new(storage, Arc::new(validator_signer));
+    let mut serializer_service = SerializerService::new(safety_rules);
+    let mut network_server = NetworkServer::new(listen_addr);
+
+    loop {
+        let request = network_server.read().unwrap();
+        let response = serializer_service.handle_message(request).unwrap();
+        network_server.write(&response).unwrap();
+    }
+}
+
+struct RemoteClient<T> {
+    network_client: NetworkClient,
+    marker: PhantomData<T>,
+}
+
+impl<T> RemoteClient<T> {
+    pub fn new(network_client: NetworkClient) -> Self {
+        Self {
+            network_client,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Payload> TSerializerClient<T> for RemoteClient<T> {
+    fn request(&mut self, input: SafetyRulesInput<T>) -> Result<Vec<u8>, Error> {
+        let input_message = lcs::to_bytes(&input)?;
+        self.network_client.write(&input_message)?;
+        let result = self.network_client.read()?;
+        Ok(result)
+    }
+}

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -14,6 +14,43 @@ use libra_config::config::{NodeConfig, SafetyRulesBackend, SafetyRulesService};
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::{Arc, RwLock};
 
+pub fn extract_service_inputs(
+    config: &mut NodeConfig,
+) -> (ValidatorSigner, Box<dyn PersistentStorage>) {
+    let private_key = config
+        .test
+        .as_mut()
+        .expect("Missing test config")
+        .consensus_keypair
+        .as_mut()
+        .expect("Missing consensus keypair in test config")
+        .take_private()
+        .expect("Failed to take Consensus private key, key absent or already read");
+
+    let author = config
+        .validator_network
+        .as_ref()
+        .expect("Missing validator network")
+        .peer_id;
+
+    let validator_signer = ValidatorSigner::new(author, private_key);
+
+    let storage = match &config.consensus.safety_rules.backend {
+        SafetyRulesBackend::InMemoryStorage => InMemoryStorage::default_storage(),
+        SafetyRulesBackend::OnDiskStorage(config) => {
+            if config.default {
+                OnDiskStorage::default_storage(config.path())
+                    .expect("Unable to allocate SafetyRules storage")
+            } else {
+                OnDiskStorage::new_storage(config.path())
+                    .expect("Unable to instantiate SafetyRules storage")
+            }
+        }
+    };
+
+    (validator_signer, storage)
+}
+
 enum SafetyRulesWrapper<T> {
     Local(Arc<RwLock<SafetyRules<T>>>),
     Serializer(Arc<RwLock<SerializerService<T>>>),
@@ -26,38 +63,8 @@ pub struct SafetyRulesManager<T> {
 
 impl<T: Payload> SafetyRulesManager<T> {
     pub fn new(config: &mut NodeConfig) -> Self {
-        let private_key = config
-            .test
-            .as_mut()
-            .expect("Missing test config")
-            .consensus_keypair
-            .as_mut()
-            .expect("Missing consensus keypair in test config")
-            .take_private()
-            .expect("Failed to take Consensus private key, key absent or already read");
-
-        let author = config
-            .validator_network
-            .as_ref()
-            .expect("Missing validator network")
-            .peer_id;
-
-        let validator_signer = ValidatorSigner::new(author, private_key);
-
+        let (validator_signer, storage) = extract_service_inputs(config);
         let sr_config = &config.consensus.safety_rules;
-        let storage = match &sr_config.backend {
-            SafetyRulesBackend::InMemoryStorage => InMemoryStorage::default_storage(),
-            SafetyRulesBackend::OnDiskStorage(config) => {
-                if config.default {
-                    OnDiskStorage::default_storage(config.path())
-                        .expect("Unable to allocate SafetyRules storage")
-                } else {
-                    OnDiskStorage::new_storage(config.path())
-                        .expect("Unable to instantiate SafetyRules storage")
-                }
-            }
-        };
-
         match sr_config.service {
             SafetyRulesService::Local => Self::new_local(storage, validator_signer),
             SafetyRulesService::Serializer => Self::new_serializer(storage, validator_signer),
@@ -111,6 +118,7 @@ impl<T: Payload> SafetyRulesManager<T> {
                 Box::new(SerializerClient::new(serializer_service.clone()))
             }
             SafetyRulesWrapper::Thread(thread) => Box::new(thread.client()),
+            _ => panic!("Unable to retrieve client for this service"),
         }
     }
 }

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -4,8 +4,9 @@
 use crate::{
     local_client::LocalClient,
     persistent_storage::PersistentStorage,
+    remote_service::RemoteService,
     serializer::{SerializerClient, SerializerService},
-    thread::ThreadClient,
+    thread::ThreadService,
     InMemoryStorage, OnDiskStorage, SafetyRules, TSafetyRules,
 };
 use consensus_types::common::Payload;
@@ -16,7 +17,7 @@ use std::sync::{Arc, RwLock};
 enum SafetyRulesWrapper<T> {
     Local(Arc<RwLock<SafetyRules<T>>>),
     Serializer(Arc<RwLock<SerializerService<T>>>),
-    Thread(ThreadClient<T>),
+    Thread(ThreadService<T>),
 }
 
 pub struct SafetyRulesManager<T> {
@@ -94,7 +95,7 @@ impl<T: Payload> SafetyRulesManager<T> {
         storage: Box<dyn PersistentStorage>,
         validator_signer: ValidatorSigner,
     ) -> Self {
-        let thread = ThreadClient::<T>::new(storage, validator_signer);
+        let thread = ThreadService::<T>::new(storage, validator_signer);
 
         Self {
             internal_safety_rules: SafetyRulesWrapper::Thread(thread),

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -61,6 +61,7 @@ impl<T: Payload> SafetyRulesManager<T> {
             SafetyRulesService::Local => Self::new_local(storage, validator_signer),
             SafetyRulesService::Serializer => Self::new_serializer(storage, validator_signer),
             SafetyRulesService::Thread => Self::new_thread(storage, validator_signer),
+            _ => panic!("Unimplemented SafetyRulesService: {:?}", sr_config.service),
         }
     }
 

--- a/consensus/safety-rules/src/spawned_process.rs
+++ b/consensus/safety-rules/src/spawned_process.rs
@@ -1,0 +1,73 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::remote_service::RemoteService;
+use consensus_types::common::Payload;
+use libra_config::config::{NodeConfig, PersistableConfig, SafetyRulesService};
+use libra_tools::tempdir::TempPath;
+use std::{
+    marker::PhantomData,
+    net::SocketAddr,
+    process::{Child, Command, Stdio},
+};
+use workspace_builder;
+
+const BINARY: &str = "safety-rules";
+
+pub struct SpawnedProcess<T> {
+    handle: Child,
+    server_addr: SocketAddr,
+    _config_path: TempPath,
+    marker: PhantomData<T>,
+}
+
+impl<T: Payload> SpawnedProcess<T> {
+    pub fn new(config: &NodeConfig) -> Self {
+        let mut config_path = TempPath::new();
+        config_path.persist();
+        config_path.create_as_file().unwrap();
+        config.save_config(&config_path).unwrap();
+
+        let service = &config.consensus.safety_rules.service;
+        let server_addr = if let SafetyRulesService::SpawnedProcess(process_config) = service {
+            process_config.server_address
+        } else {
+            panic!("Invalid SafeRulesService, expected SpawnedProcess.");
+        };
+
+        let mut command = Command::new(workspace_builder::get_bin(BINARY));
+        command
+            .arg(config_path.path())
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+        let handle = command.spawn().unwrap();
+
+        Self {
+            handle,
+            server_addr,
+            _config_path: config_path,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Payload> RemoteService<T> for SpawnedProcess<T> {
+    fn server_address(&self) -> SocketAddr {
+        self.server_addr
+    }
+}
+
+/// Kill SafetyRules process upon this object going out of scope
+impl<T> Drop for SpawnedProcess<T> {
+    fn drop(&mut self) {
+        match self.handle.try_wait() {
+            Ok(Some(_)) => {}
+            _ => {
+                if let Err(e) = self.handle.kill() {
+                    panic!("Spawned SafetyRules process could not be killed: '{}'", e);
+                }
+            }
+        }
+    }
+}

--- a/consensus/safety-rules/src/tests/mod.rs
+++ b/consensus/safety-rules/src/tests/mod.rs
@@ -5,5 +5,6 @@ mod local;
 mod network;
 mod safety_rules;
 mod serializer;
+mod spawned_process;
 mod suite;
 mod thread;

--- a/consensus/safety-rules/src/tests/spawned_process.rs
+++ b/consensus/safety-rules/src/tests/spawned_process.rs
@@ -1,0 +1,94 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    safety_rules_manager, tests::suite, ConsensusState, Error, SafetyRulesManager, TSafetyRules,
+};
+use consensus_types::{
+    block::Block,
+    block_data::BlockData,
+    common::{Payload, Round},
+    quorum_cert::QuorumCert,
+    timeout::Timeout,
+    vote::Vote,
+    vote_proposal::VoteProposal,
+};
+use libra_config::{
+    config::{ConsensusType, NodeConfig, RemoteService, SafetyRulesService},
+    utils,
+};
+use libra_types::crypto_proxies::{Signature, ValidatorSigner};
+use std::{
+    any::TypeId,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+
+#[test]
+fn test() {
+    suite::run_test_suite(safety_rules::<Round>, safety_rules::<Vec<u8>>);
+}
+
+fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
+    let server_port = utils::get_available_port();
+    let server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
+
+    let type_id = TypeId::of::<T>();
+    let consensus_type = if type_id == TypeId::of::<Round>() {
+        ConsensusType::Rounds
+    } else if type_id == TypeId::of::<Vec<u8>>() {
+        ConsensusType::Bytes
+    } else {
+        panic!("Invalid type: {:?}", type_id);
+    };
+
+    let remote_service = RemoteService {
+        server_address,
+        consensus_type,
+    };
+    let mut config = NodeConfig::random();
+    config.consensus.safety_rules.service = SafetyRulesService::SpawnedProcess(remote_service);
+
+    let safety_rules_manager = SafetyRulesManager::new(&mut config);
+    let safety_rules = safety_rules_manager.client();
+    let client_wrapper = Box::new(ProcessClientWrapper {
+        _safety_rules_manager: safety_rules_manager,
+        safety_rules,
+    });
+    let (signer, _) = safety_rules_manager::extract_service_inputs(&mut config);
+    (client_wrapper, Arc::new(signer))
+}
+
+// This container exists only so that we can kill the spawned process after testing is complete.
+// Otherwise the process will be killed at the end of the safety_rules function and the test will
+// fail.
+struct ProcessClientWrapper<T> {
+    _safety_rules_manager: SafetyRulesManager<T>,
+    safety_rules: Box<dyn TSafetyRules<T>>,
+}
+
+impl<T: Payload> TSafetyRules<T> for ProcessClientWrapper<T> {
+    fn consensus_state(&mut self) -> Result<ConsensusState, Error> {
+        self.safety_rules.consensus_state()
+    }
+
+    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        self.safety_rules.update(qc)
+    }
+
+    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        self.safety_rules.start_new_epoch(qc)
+    }
+
+    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
+        self.safety_rules.construct_and_sign_vote(vote_proposal)
+    }
+
+    fn sign_proposal(&mut self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
+        self.safety_rules.sign_proposal(block_data)
+    }
+
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Signature, Error> {
+        self.safety_rules.sign_timeout(timeout)
+    }
+}

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -10,10 +10,8 @@
 //! in testing correctness of the communication layer between Consensus and SafetyRules.
 
 use crate::{
-    network::{NetworkClient, NetworkServer},
     persistent_storage::PersistentStorage,
-    serializer::{SafetyRulesInput, SerializerClient, SerializerService, TSerializerClient},
-    Error, SafetyRules,
+    remote_service::{self, RemoteService},
 };
 use consensus_types::common::Payload;
 use libra_config::utils;
@@ -21,25 +19,26 @@ use libra_types::crypto_proxies::ValidatorSigner;
 use std::{
     marker::PhantomData,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
     thread::{self, JoinHandle},
 };
 
 /// ThreadClient is the actual owner of the thread but in the context of Consenus and SafetyRules
 /// is on the client side of the operations as it makes queries / requests to SafetyRules.
-pub struct ThreadClient<T> {
+pub struct ThreadService<T> {
     child: JoinHandle<()>,
     server_addr: SocketAddr,
     marker: PhantomData<T>,
 }
 
-impl<T: Payload> ThreadClient<T> {
+impl<T: Payload> ThreadService<T> {
     pub fn new(storage: Box<dyn PersistentStorage>, validator_signer: ValidatorSigner) -> Self {
         let listen_port = utils::get_available_port();
         let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_port);
         let server_addr = listen_addr;
 
-        let child = thread::spawn(move || Self::execute(storage, validator_signer, listen_addr));
+        let child = thread::spawn(move || {
+            remote_service::execute::<T>(storage, validator_signer, listen_addr)
+        });
 
         Self {
             child,
@@ -47,50 +46,10 @@ impl<T: Payload> ThreadClient<T> {
             marker: PhantomData,
         }
     }
-
-    pub fn client(&self) -> SerializerClient<T> {
-        let network_client = NetworkClient::connect(self.server_addr).unwrap();
-        let service = Box::new(ThreadService::new(network_client));
-        SerializerClient::new_client(service)
-    }
-
-    fn execute(
-        storage: Box<dyn PersistentStorage>,
-        validator_signer: ValidatorSigner,
-        listen_addr: SocketAddr,
-    ) {
-        let safety_rules = SafetyRules::<T>::new(storage, Arc::new(validator_signer));
-        let mut serializer_service = SerializerService::new(safety_rules);
-        let mut network_server = NetworkServer::new(listen_addr);
-
-        loop {
-            let request = network_server.read().unwrap();
-            let response = serializer_service.handle_message(request).unwrap();
-            network_server.write(&response).unwrap();
-        }
-    }
 }
 
-/// ThreadService hosts SafetyRules
-struct ThreadService<T> {
-    network_client: NetworkClient,
-    marker: PhantomData<T>,
-}
-
-impl<T> ThreadService<T> {
-    pub fn new(network_client: NetworkClient) -> Self {
-        Self {
-            network_client,
-            marker: PhantomData,
-        }
-    }
-}
-
-impl<T: Payload> TSerializerClient<T> for ThreadService<T> {
-    fn request(&mut self, input: SafetyRulesInput<T>) -> Result<Vec<u8>, Error> {
-        let input_message = lcs::to_bytes(&input)?;
-        self.network_client.write(&input_message)?;
-        let result = self.network_client.read()?;
-        Ok(result)
+impl<T: Payload> RemoteService<T> for ThreadService<T> {
+    fn server_address(&self) -> SocketAddr {
+        self.server_addr
     }
 }

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
 //! This provides a execution separation between SafetyRules and Consensus without requiring the
 //! use of processes. Rust does not support fork and so the mechanics to actually construct a
 //! SafetyRules that would run together and be started by Consensus requires a separate binary and
@@ -25,7 +23,7 @@ use std::{
 /// ThreadClient is the actual owner of the thread but in the context of Consenus and SafetyRules
 /// is on the client side of the operations as it makes queries / requests to SafetyRules.
 pub struct ThreadService<T> {
-    child: JoinHandle<()>,
+    _child: JoinHandle<()>,
     server_addr: SocketAddr,
     marker: PhantomData<T>,
 }
@@ -41,7 +39,7 @@ impl<T: Payload> ThreadService<T> {
         });
 
         Self {
-            child,
+            _child: child,
             server_addr,
             marker: PhantomData,
         }

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -25,3 +25,4 @@ libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
 libra-tools = { path = "../common/tools", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
+workspace-builder = { path = "../common/workspace-builder", version = "0.1.0" }

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils;
 use client_lib::{client_proxy::ClientProxy, commands};
 use std::{
     collections::HashMap,
@@ -10,6 +9,7 @@ use std::{
     process::{Child, Command, Output, Stdio},
     sync::Arc,
 };
+use workspace_builder;
 
 pub struct InteractiveClient {
     client: Option<Child>,
@@ -50,8 +50,8 @@ impl InteractiveClient {
         // unless we convert it to an absolute path
         Self {
             client: Some(
-                Command::new(utils::get_bin("client"))
-                    .current_dir(utils::workspace_root())
+                Command::new(workspace_builder::get_bin("client"))
+                    .current_dir(workspace_builder::workspace_root())
                     .arg("-p")
                     .arg(port.to_string())
                     .arg("-m")
@@ -91,8 +91,8 @@ impl InteractiveClient {
             /// from the client CLI. Comment the stdout/stderr lines below
             /// and enjoy pretty Matrix-style output.
             client: Some(
-                Command::new(utils::get_bin("client"))
-                    .current_dir(utils::workspace_root())
+                Command::new(workspace_builder::get_bin("client"))
+                    .current_dir(workspace_builder::workspace_root())
                     .arg("-p")
                     .arg(port.to_string())
                     .arg("-m")

--- a/libra-swarm/src/lib.rs
+++ b/libra-swarm/src/lib.rs
@@ -5,4 +5,3 @@
 
 pub mod client;
 pub mod swarm;
-pub mod utils;

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils;
 use anyhow::{Context, Result};
 use config_builder::{FullNodeConfig, SwarmConfig, ValidatorConfig};
 use debug_interface::NodeDebugClient;
@@ -19,6 +18,7 @@ use std::{
     str::FromStr,
 };
 use thiserror::Error;
+use workspace_builder;
 
 const LIBRA_NODE_BIN: &str = "libra-node";
 
@@ -65,9 +65,9 @@ impl LibraNode {
             RoleType::Validator => Some(config.validator_network.unwrap().peer_id),
             RoleType::FullNode => None,
         };
-        let mut node_command = Command::new(utils::get_bin(LIBRA_NODE_BIN));
+        let mut node_command = Command::new(workspace_builder::get_bin(LIBRA_NODE_BIN));
         node_command
-            .current_dir(utils::workspace_root())
+            .current_dir(workspace_builder::workspace_root())
             .arg("-f")
             .arg(config_path);
         if env::var("RUST_LOG").is_err() {
@@ -296,7 +296,8 @@ impl LibraSwarm {
         let swarm_config_dir = Self::setup_config_dir(&config_dir);
         info!("logs at {:?}", swarm_config_dir);
         let mut template = if let Some(template_path) = template_path {
-            NodeConfig::load(utils::workspace_root().join(template_path)).unwrap_or_default()
+            NodeConfig::load(workspace_builder::workspace_root().join(template_path))
+                .unwrap_or_default()
         } else {
             let mut template = NodeConfig::default();
             template.vm_config.publishing_options = VMPublishingOption::Open;

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -15,6 +15,7 @@ num-traits = "0.2"
 rust_decimal = "1.0.2"
 statistical = "1"
 rusty-fork = "0.2.1"
+workspace-builder = { path = "../common/workspace-builder", version = "0.1.0" }
 
 # In order to limit the potential waiting time for binaries to be built while
 # running tests all binaries which are being tested under this testsuite

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -5,10 +5,8 @@ use cli::client_proxy::ClientProxy;
 use libra_config::config::{NodeConfig, RoleType};
 use libra_crypto::{ed25519::*, hash::CryptoHash, test_utils::KeyPair, HashValue, SigningKey};
 use libra_logger::prelude::*;
-use libra_swarm::{
-    swarm::{LibraNode, LibraSwarm},
-    utils,
-};
+use libra_swarm::swarm::LibraNode;
+use libra_swarm::swarm::LibraSwarm;
 use libra_tools::tempdir::TempPath;
 use libra_types::{
     account_address::AccountAddress,
@@ -24,6 +22,7 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::str::FromStr;
 use std::{thread, time};
+use workspace_builder;
 
 struct TestEnvironment {
     validator_swarm: LibraSwarm,
@@ -215,8 +214,8 @@ fn test_execute_custom_module_and_script() {
     let recipient_address = client_proxy.create_next_account(false).unwrap().address;
     client_proxy.mint_coins(&["mintb", "1", "1"], true).unwrap();
 
-    let module_path =
-        utils::workspace_root().join("testsuite/tests/libratest/dev_modules/module.mvir");
+    let module_path = workspace_builder::workspace_root()
+        .join("testsuite/tests/libratest/dev_modules/module.mvir");
     let unwrapped_module_path = module_path.to_str().unwrap();
     let module_params = &["compile", "0", unwrapped_module_path, "module"];
     let module_compiled_path = client_proxy.compile_program(module_params).unwrap();
@@ -225,8 +224,8 @@ fn test_execute_custom_module_and_script() {
         .publish_module(&["publish", "0", &module_compiled_path[..]])
         .unwrap();
 
-    let script_path =
-        utils::workspace_root().join("testsuite/tests/libratest/dev_modules/script.mvir");
+    let script_path = workspace_builder::workspace_root()
+        .join("testsuite/tests/libratest/dev_modules/script.mvir");
     let unwrapped_script_path = script_path.to_str().unwrap();
     let script_params = &["execute", "0", unwrapped_script_path, "script"];
     let script_compiled_path = client_proxy.compile_program(script_params).unwrap();


### PR DESCRIPTION
This is the initial set of commits to build a minimal safety rules process
- Leverage the same building code as swarm to start nodes
- No real logging implemented
- End-to-end integration tests for correct logic only
- No reliability in networking
- Reuse of the core of thread to process mode
- Configuration for both the IP/Port and the type consensus uses (signed transactions for example)