### PR TITLE
[monitoring] export metrics port

### DIFF
--- a/docker/validator-dynamic/run.sh
+++ b/docker/validator-dynamic/run.sh
@@ -33,4 +33,6 @@ docker run \
     --ip $bootstrap \
     --network testnet \
     --publish 8000:8000 \
+    --publish 9101:9101 \
+    --publish 9102:9102 \
     "$image"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Libra export prometheus  metrics  data use port 9101, 9102,  current run.sh script's  implement just only export port 8000 but not include metrics port 9101,9102,  so we can not access metrics data when run validator  in docker mode.  This PR  publish  container's ports  9101, 9102 to the host, so we can  use  host ip to access validator metrics data from another host.

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
Yes. I read already

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

just curl http://127.0.0.1:9101/metrics

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
