### PR TITLE
[consensus]Move insert vote logic out of Blockstore/Blocktree

### DIFF
--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -13,6 +13,7 @@ mod block_tree;
 mod pending_votes;
 
 pub use block_store::{sync_manager::BlockRetriever, BlockStore};
+pub use pending_votes::PendingVotes;
 
 /// Result of the vote processing. The failure case (Verification error) is returned
 /// as the Error part of the result.
@@ -25,8 +26,6 @@ pub enum VoteReceptionResult {
     DuplicateVote,
     /// The very same author has already voted for another proposal in this round (equivocation).
     EquivocateVote,
-    /// This block has been already certified.
-    OldQuorumCertificate(Arc<QuorumCert>),
     /// This block has just been certified after adding the vote.
     NewQuorumCertificate(Arc<QuorumCert>),
     /// The vote completes a new TimeoutCertificate


### PR DESCRIPTION
## Motivation
Address #1398 

## Summary
1. Removed `insert_vote` from `block_store` and `block_tree`
2. Directly use `pending_vote` to insert vote in `event_processor`
3. Change `insert_vote_and_qc` test util to take `pending_vote` as an injected dependency

## Test Plan
`cargo xtest -p consensus`
