### PR TITLE
[executor] Move config-builder to dev dependencies

### DIFF
--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 backoff = { version = "0.1.5", default-features = false }
-config-builder = { path = "../config/config-builder", version = "0.1.0" }
 futures = "0.3.0"
 itertools = { version = "0.8.0", default-features = false }
 once_cell = "1.2.0"
@@ -42,6 +41,7 @@ lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-se
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
 
 [features]
 default = []


### PR DESCRIPTION
This removes 8 first party crates from the TCB, as they are no longer used in
the release code.