### PR TITLE
[vm] Unify logic for processing WriteSet.

### DIFF
--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -69,7 +69,10 @@ impl ExecutionConfig {
 mod test {
     use super::*;
     use libra_tools::tempdir::TempPath;
-    use libra_types::{transaction::Transaction, write_set::WriteSetMut};
+    use libra_types::{
+        transaction::{ChangeSet, Transaction},
+        write_set::WriteSetMut,
+    };
 
     #[test]
     fn test_no_genesis() {
@@ -83,7 +86,10 @@ mod test {
 
     #[test]
     fn test_some_and_load_genesis() {
-        let fake_genesis = Transaction::WriteSet(WriteSetMut::new(vec![]).freeze().unwrap());
+        let fake_genesis = Transaction::WriteSet(
+            ChangeSet::new(WriteSetMut::new(vec![]).freeze().unwrap()),
+            vec![],
+        );
         let (mut config, path) = generate_config();
         config.genesis = Some(fake_genesis.clone());
         let root_dir = RootPath::new_path(path.path());

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -113,6 +113,17 @@ impl Arbitrary for WriteSet {
     type Strategy = BoxedStrategy<Self>;
 }
 
+impl Arbitrary for ChangeSet {
+    type Parameters = ();
+    fn arbitrary_with(_args: ()) -> Self::Strategy {
+        (any::<WriteSet>(), vec(any::<ContractEvent>(), 0..10))
+            .prop_map(|(ws, events)| ChangeSet::new(ws, events))
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
 #[derive(Debug)]
 struct AccountInfo {
     address: AccountAddress,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1068,7 +1068,7 @@ pub enum Transaction {
 
     /// Transaction that applies a WriteSet to the current storage. This should be used for ONLY for
     /// genesis right now.
-    WriteSet(WriteSet),
+    WriteSet(ChangeSet),
 
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),


### PR DESCRIPTION
## Motivation

The definition for `Transaction` is a bit outdated. This PR unifies the definition of the two and clean up the transaction processing logic around them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes