### PR TITLE
[language][prover] Integrates stdlib specs into upstream repo

### DIFF
--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/address_util.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/address_util.mvir
@@ -1,0 +1,4 @@
+module AddressUtil {
+    // TODO: specify
+    native public address_to_bytes(addr: address): bytearray;
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/bytearray_util.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/bytearray_util.mvir
@@ -1,0 +1,4 @@
+module BytearrayUtil {
+    // TODO: specify
+    native public bytearray_concat(data1: bytearray, data2: bytearray): bytearray;
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/hash.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/hash.mvir
@@ -1,0 +1,5 @@
+module Hash {
+    // TODO: specify
+    native public sha2_256(data: bytearray): bytearray;
+    native public sha3_256(data: bytearray): bytearray;
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
@@ -1,0 +1,621 @@
+// The module for the account resource that governs every Libra account
+module LibraAccount {
+    import 0x0.LibraCoin;
+    import 0x0.Hash;
+    import 0x0.U64Util;
+    import 0x0.AddressUtil;
+    import 0x0.BytearrayUtil;
+
+    // Every Libra account has a LibraAccount.T resource
+    resource T {
+        // The current authentication key.
+        // This can be different than the key used to create the account
+        authentication_key: bytearray,
+        // The coins stored in this account
+        balance: LibraCoin.T,
+        // If true, the authority to rotate the authentication key of this account resides elsewhere
+        delegated_key_rotation_capability: bool,
+        // If true, the authority to withdraw funds from this account resides elsewhere
+        delegated_withdrawal_capability: bool,
+        // Event handle for received event
+        received_events: Self.EventHandle<Self.ReceivedPaymentEvent>,
+        // Event handle for sent event
+        sent_events: Self.EventHandle<Self.SentPaymentEvent>,
+        // The current sequence number.
+        // Incremented by one each time a transaction is submitted
+        sequence_number: u64,
+        // Generator for event handles
+        event_generator: Self.EventHandleGenerator,
+    }
+
+    // The holder of WithdrawalCapability for account_address can withdraw Libra from
+    // account_address/LibraAccount.T/balance.
+    // There is at most one WithdrawalCapability in existence for a given address.
+    resource WithdrawalCapability {
+        account_address: address,
+    }
+
+    // The holder of KeyRotationCapability for account_address can rotate the authentication key for
+    // account_address (i.e., write to account_address/LibraAccount.T/authentication_key).
+    // There is at most one KeyRotationCapability in existence for a given address.
+    resource KeyRotationCapability {
+        account_address: address,
+    }
+
+    // Message for sent events
+    struct SentPaymentEvent {
+        // The amount of LibraCoin.T sent
+        amount: u64,
+        // The address that was paid
+        payee: address,
+        // Metadata associated with the payment
+        metadata: bytearray,
+    }
+
+    // Message for received events
+    struct ReceivedPaymentEvent {
+        // The amount of LibraCoin.T received
+        amount: u64,
+        // The address that sent the coin
+        payer: address,
+        // Metadata associated with the payment
+        metadata: bytearray,
+    }
+
+    /// Events
+    // A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
+    // this resource to guarantee the uniqueness of the generated handle.
+    resource EventHandleGenerator {
+        // A monotonically increasing counter
+        counter: u64,
+    }
+
+    // A handle for a event such that:
+    // 1. Other modules can emit event to this handle.
+    // 2. Storage can use this handle to prove the total number of events that happened in the past.
+    resource EventHandle<T: unrestricted> {
+        // Total number of events emitted to this event stream.
+        counter: u64,
+        // A globally unique ID for this event stream.
+        guid: bytearray,
+    }
+
+    // Creates a new LibraAccount.T
+    // Invoked by the `create_account` builtin
+    make(fresh_address: address): Self.T {
+        let zero_balance: LibraCoin.T;
+        let generator: Self.EventHandleGenerator;
+        let sent_handle: Self.EventHandle<Self.SentPaymentEvent>;
+        let received_handle: Self.EventHandle<Self.ReceivedPaymentEvent>;
+        let auth_key: bytearray;
+
+        auth_key = AddressUtil.address_to_bytes(copy(fresh_address));
+        generator = EventHandleGenerator {counter: 0};
+        sent_handle = Self.new_event_handle_impl<Self.SentPaymentEvent>(&mut generator, copy(fresh_address));
+        received_handle = Self.new_event_handle_impl<Self.ReceivedPaymentEvent>(&mut generator, move(fresh_address));
+        zero_balance = LibraCoin.zero();
+
+        return T {
+            authentication_key: move(auth_key),
+            balance: move(zero_balance),
+            delegated_key_rotation_capability: false,
+            delegated_withdrawal_capability: false,
+            received_events: move(received_handle),
+            sent_events: move(sent_handle),
+            sequence_number: 0,
+            event_generator: move(generator),
+        };
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account
+    public deposit(payee: address, to_deposit: LibraCoin.T) acquires T {
+        Self.deposit_with_metadata(move(payee), move(to_deposit), h"");
+        return;
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account with the attached `metadata`
+    public deposit_with_metadata(
+        payee: address,
+        to_deposit: LibraCoin.T,
+        metadata: bytearray
+    ) acquires T {
+        Self.deposit_with_sender_and_metadata(
+            move(payee),
+            get_txn_sender(),
+            move(to_deposit),
+            move(metadata)
+        );
+        return;
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account with the attached `metadata` and
+    // sender address
+    deposit_with_sender_and_metadata(
+        payee: address,
+        sender: address,
+        to_deposit: LibraCoin.T,
+        metadata: bytearray
+    ) acquires T {
+        let deposit_value: u64;
+        let payee_account_ref: &mut Self.T;
+        let sender_account_ref: &mut Self.T;
+
+        // Check that the `to_deposit` coin is non-zero
+        deposit_value = LibraCoin.value(&to_deposit);
+        assert(copy(deposit_value) > 0, 7);
+
+        // Load the sender's account
+        sender_account_ref = borrow_global_mut<T>(copy(sender));
+        // Log a sent event
+        Self.emit_event<Self.SentPaymentEvent>(
+            &mut move(sender_account_ref).sent_events,
+            SentPaymentEvent {
+                amount: copy(deposit_value),
+                payee: copy(payee),
+                metadata: copy(metadata)
+            },
+        );
+
+        // Load the payee's account
+        payee_account_ref = borrow_global_mut<T>(move(payee));
+        // Deposit the `to_deposit` coin
+        LibraCoin.deposit(&mut copy(payee_account_ref).balance, move(to_deposit));
+        // Log a received event
+        Self.emit_event<Self.ReceivedPaymentEvent>(
+            &mut move(payee_account_ref).received_events,
+            ReceivedPaymentEvent {
+                amount: move(deposit_value),
+                payer: move(sender),
+                metadata: move(metadata)
+            }
+        );
+        return;
+    }
+
+    // mint_to_address can only be called by accounts with MintCapability (see LibraCoin)
+    // and those account will be charged for gas. If those account don't have enough gas to pay
+    // for the transaction cost they will fail minting.
+    // However those account can also mint to themselves so that is a decent workaround
+    public mint_to_address(payee: address, amount: u64) acquires T {
+        // Create an account if it does not exist
+        if (!exists<T>(copy(payee))) {
+            Self.create_account(copy(payee));
+        }
+
+        // Mint and deposit the coin
+        Self.deposit(move(payee), LibraCoin.mint_with_default_capability(move(amount)));
+        return;
+    }
+
+    // Helper to withdraw `amount` from the given `account` and return the resulting LibraCoin.T
+    withdraw_from_account(account: &mut Self.T, amount: u64): LibraCoin.T
+    aborts_if account.balance.value < amount
+    ensures RET.value == amount
+    ensures account.balance.value == old(account.balance.value) - amount
+    {
+        let to_withdraw: LibraCoin.T;
+
+        to_withdraw = LibraCoin.withdraw(&mut move(account).balance, copy(amount));
+        return move(to_withdraw);
+    }
+
+    // Withdraw `amount` LibraCoin.T from the transaction sender's account
+    public withdraw_from_sender(amount: u64): LibraCoin.T acquires T
+    aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
+    aborts_if global<Self.T>(txn_sender).balance.value < amount
+    aborts_if !global_exists<Self.T>(txn_sender)
+    ensures RET.value == amount
+    ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
+    {
+        let sender_account: &mut Self.T;
+
+        sender_account = borrow_global_mut<T>(get_txn_sender());
+        if (*&copy(sender_account).delegated_withdrawal_capability) {
+            // The sender has delegated the privilege to withdraw from her account elsewhere--abort.
+            abort(11);
+        } else {
+            // The sender has retained her withdrawal privileges--proceed.
+            return Self.withdraw_from_account(move(sender_account), move(amount));
+        }
+    }
+
+    // Withdraw `amount` LibraCoin.T from account under cap.account_address
+    // TODO: this currently fails verification (two expected errors marked with below). It appears that we need
+    //   more type assumptions for spec expression.
+    //!  A postcondition might not hold on this return path.
+    //!  A postcondition might not hold on this return path.
+    public withdraw_with_capability(
+        cap: &Self.WithdrawalCapability, amount: u64
+    ): LibraCoin.T acquires T
+    aborts_if !global_exists<Self.T>(cap.account_address)
+    aborts_if global<Self.T>(cap.account_address).balance.value < amount
+    ensures RET.value == amount
+    // this one doesn't pass Boogie
+    ensures global<Self.T>(cap.account_address).balance.value == old(global<Self.T>(cap.account_address).balance.value) - amount
+    {
+        let account: &mut Self.T;
+
+        account = borrow_global_mut<T>(*&move(cap).account_address);
+        return Self.withdraw_from_account(move(account), move(amount));
+    }
+
+    // Return a unique capability granting permission to withdraw from the sender's account balance.
+    public extract_sender_withdrawal_capability(): Self.WithdrawalCapability acquires T {
+        let sender: address;
+        let sender_account: &mut Self.T;
+        let delegated_ref: &mut bool;
+
+        sender = get_txn_sender();
+        sender_account = borrow_global_mut<T>(copy(sender));
+        delegated_ref = &mut move(sender_account).delegated_withdrawal_capability;
+        if (*copy(delegated_ref)) {
+            // We already extracted the unique withdrawal capability for this account.
+            abort(11);
+        } else {
+            *move(delegated_ref) = true; // ensure uniqueness of the capability
+            return WithdrawalCapability { account_address: move(sender) };
+        }
+    }
+
+    // Return the withdrawal capability to the account it originally came from
+    public restore_withdrawal_capability(cap: Self.WithdrawalCapability) acquires T {
+        let account_address: address;
+        let account: &mut Self.T;
+
+        // Destroy the capability
+        WithdrawalCapability { account_address } = move(cap);
+        account = borrow_global_mut<T>(move(account_address));
+        // Update the flag for `account_address` to indicate that the capability has been restored.
+        // The account owner will now be able to call pay_from_sender, withdraw_from_sender, and
+        // extract_sender_withdrawal_capability again.
+        *(&mut move(account).delegated_withdrawal_capability) = false;
+
+        return;
+    }
+
+    // Withdraws `amount` LibraCoin.T using the passed in WithdrawalCapability, and deposits it
+    // into the `payee`'s account. Creates the `payee` account if it doesn't exist.
+    public pay_from_capability(
+        payee: address,
+        cap: &Self.WithdrawalCapability,
+        amount: u64,
+        metadata: bytearray
+    ) acquires T {
+        if (!exists<T>(copy(payee))) {
+            Self.create_account(copy(payee));
+        }
+        Self.deposit_with_sender_and_metadata(
+            move(payee),
+            *&copy(cap).account_address,
+            Self.withdraw_with_capability(move(cap), move(amount)),
+            h""
+        );
+        return;
+    }
+
+    // Withdraw `amount` LibraCoin.T from the transaction sender's account and send the coin
+    // to the `payee` address with the attached `metadata`
+    // Creates the `payee` account if it does not exist
+    public pay_from_sender_with_metadata(
+        payee: address,
+        amount: u64,
+        metadata: bytearray
+    ) acquires T {
+        if (!exists<T>(copy(payee))) {
+            Self.create_account(copy(payee));
+        }
+        Self.deposit_with_metadata(
+            move(payee),
+            Self.withdraw_from_sender(move(amount)),
+            move(metadata)
+        );
+        return;
+    }
+
+    // Withdraw `amount` LibraCoin.T from the transaction sender's account and send the coin
+    // to the `payee` address
+    // Creates the `payee` account if it does not exist
+    public pay_from_sender(payee: address, amount: u64) acquires T {
+        Self.pay_from_sender_with_metadata(move(payee), move(amount), h"");
+        return;
+    }
+
+    rotate_authentication_key_for_account(account: &mut Self.T, new_authentication_key: bytearray) {
+        *(&mut move(account).authentication_key) = move(new_authentication_key);
+        return;
+    }
+
+    // Rotate the transaction sender's authentication key
+    // The new key will be used for signing future transactions
+    public rotate_authentication_key(new_authentication_key: bytearray) acquires T {
+        let sender_account: &mut Self.T;
+
+        sender_account = borrow_global_mut<T>(get_txn_sender());
+        if (*&copy(sender_account).delegated_key_rotation_capability) {
+            // The sender has delegated the privilege to rotate her key elsewhere--abort
+            abort(11);
+        } else {
+            // The sender has retained her key rotation privileges--proceed.
+            Self.rotate_authentication_key_for_account(
+                move(sender_account),
+                move(new_authentication_key)
+            );
+            return;
+        }
+    }
+
+    // Rotate the authentication key for the account under cap.account_address
+    public rotate_authentication_key_with_capability(
+        cap: &Self.KeyRotationCapability,
+        new_authentication_key: bytearray,
+    ) acquires T  {
+        Self.rotate_authentication_key_for_account(
+            borrow_global_mut<T>(*&move(cap).account_address),
+            move(new_authentication_key)
+        );
+        return;
+    }
+
+    // Return a unique capability granting permission to rotate the sender's authentication key
+    public extract_sender_key_rotation_capability(): Self.KeyRotationCapability acquires T {
+        let sender: address;
+        let delegated_ref: &mut bool;
+
+        sender = get_txn_sender();
+        delegated_ref = &mut borrow_global_mut<T>(copy(sender)).delegated_key_rotation_capability;
+        if (*copy(delegated_ref)) {
+            // We already extracted the unique key rotation capability for this account.
+            abort(11);
+        } else {
+            *move(delegated_ref) = true; // ensure uniqueness of the capability
+            return KeyRotationCapability { account_address: move(sender) };
+        }
+    }
+
+    // Return the key rotation capability to the account it originally came from
+    public restore_key_rotation_capability(cap: Self.KeyRotationCapability) acquires T {
+        let account_address: address;
+        let account: &mut Self.T;
+
+        // Destroy the capability
+        KeyRotationCapability { account_address } = move(cap);
+        account = borrow_global_mut<T>(move(account_address));
+        // Update the flag for `account_address` to indicate that the capability has been restored.
+        // The account owner will now be able to call rotate_authentication_key and
+        // extract_sender_key_rotation_capability again
+        *(&mut move(account).delegated_key_rotation_capability) = false;
+
+        return;
+    }
+
+    // Creates a new account at `fresh_address` with an initial balance of zero
+    public create_account(fresh_address: address) {
+        let generator: Self.EventHandleGenerator;
+
+        generator = EventHandleGenerator {counter: 0};
+        Self.save_account(
+            copy(fresh_address),
+            T {
+                authentication_key: AddressUtil.address_to_bytes(copy(fresh_address)),
+                balance: LibraCoin.zero(),
+                delegated_key_rotation_capability: false,
+                delegated_withdrawal_capability: false,
+                received_events: Self.new_event_handle_impl<Self.ReceivedPaymentEvent>(&mut generator, copy(fresh_address)),
+                sent_events: Self.new_event_handle_impl<Self.SentPaymentEvent>(&mut generator, move(fresh_address)),
+                sequence_number: 0,
+                event_generator: move(generator),
+            }
+        );
+        return;
+    }
+
+    // Creates a new account at `fresh_address` with the `initial_balance` deducted from the
+    // transaction sender's account
+    public create_new_account(fresh_address: address, initial_balance: u64) acquires T {
+        Self.create_account(copy(fresh_address));
+        if (copy(initial_balance) > 0) {
+            Self.pay_from_sender(move(fresh_address), move(initial_balance));
+        }
+        return;
+    }
+
+    // Save an account to a given address if the address does not have an account resource yet
+    native save_account(addr: address, account: Self.T);
+
+    // Helper to return u64 value of the `balance` field for given `account`
+    balance_for_account(account: &Self.T): u64 {
+        let balance_value: u64;
+        balance_value = LibraCoin.value(&move(account).balance);
+        return move(balance_value);
+    }
+
+    // Return the current balance of the LibraCoin.T in LibraAccount.T at `addr`
+    public balance(addr: address): u64 acquires T {
+        return Self.balance_for_account(borrow_global<T>(move(addr)));
+    }
+
+    // Helper to return the sequence number field for given `account`
+    sequence_number_for_account(account: &Self.T): u64 {
+        return *(&move(account).sequence_number);
+    }
+
+    // Return the current sequence number at `addr`
+    public sequence_number(addr: address): u64 acquires T {
+        return Self.sequence_number_for_account(borrow_global<T>(move(addr)));
+    }
+
+   // Return true if the account at `addr` has delegated its key rotation capability
+    public delegated_key_rotation_capability(addr: address): bool acquires T {
+        return *&(borrow_global<T>(move(addr))).delegated_key_rotation_capability;
+    }
+
+    // Return true if the account at `addr` has delegated its withdrawal capability
+    public delegated_withdrawal_capability(addr: address): bool acquires T {
+        return *&(borrow_global<T>(move(addr))).delegated_withdrawal_capability;
+    }
+
+
+    // Return a reference to the address associated with the given withdrawal capability
+    public withdrawal_capability_address(cap: &Self.WithdrawalCapability): &address {
+        return &move(cap).account_address;
+    }
+
+    // Return a reference to the address associated with the given key rotation capability
+    public key_rotation_capability_address(cap: &Self.KeyRotationCapability): &address {
+        return &move(cap).account_address;
+    }
+
+    // Checks if an account exists at `check_addr`
+    public exists(check_addr: address): bool {
+        return exists<T>(move(check_addr));
+    }
+
+    // The prologue is invoked at the beginning of every transaction
+    // It verifies:
+    // - The account's auth key matches the transaction's public key
+    // - That the account has enough balance to pay for all of the gas
+    // - That the sequence number matches the transaction's sequence key
+    prologue(
+        txn_sequence_number: u64,
+        txn_public_key: bytearray,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+    ) acquires T {
+        let transaction_sender: address;
+        let sender_account: &mut Self.T;
+        let imm_sender_account: &Self.T;
+        let max_transaction_fee: u64;
+        let balance_amount: u64;
+        let sequence_number_value: u64;
+
+        transaction_sender = get_txn_sender();
+
+        // FUTURE: Make these error codes sequential
+        // Verify that the transaction sender's account exists
+        assert(exists<T>(copy(transaction_sender)), 5);
+
+        // Load the transaction sender's account
+        sender_account = borrow_global_mut<T>(copy(transaction_sender));
+
+        // Check that the hash of the transaction's public key matches the account's auth key
+        assert(
+            Hash.sha3_256(move(txn_public_key)) == *(&copy(sender_account).authentication_key),
+            2
+        );
+
+        // Check that the account has enough balance for all of the gas
+        max_transaction_fee = move(txn_gas_price) * move(txn_max_gas_units);
+        imm_sender_account = freeze(copy(sender_account));
+        balance_amount = Self.balance_for_account(move(imm_sender_account));
+        assert(move(balance_amount) >= move(max_transaction_fee), 6);
+
+        // Check that the transaction sequence number matches the sequence number of the account
+        sequence_number_value = *(&mut move(sender_account).sequence_number);
+        assert(copy(txn_sequence_number) >= copy(sequence_number_value), 3);
+        assert(move(txn_sequence_number) == move(sequence_number_value), 4);
+        return;
+    }
+
+    // The epilogue is invoked at the end of transactions.
+    // It collects gas and bumps the sequence number
+    epilogue(
+        txn_sequence_number: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
+    ) acquires T {
+        let sender_account: &mut Self.T;
+        let transaction_fee_account: &mut Self.T;
+        let imm_sender_account: &Self.T;
+        let transaction_fee_amount: u64;
+        let transaction_fee: LibraCoin.T;
+
+        // Load the transaction sender's account
+        sender_account = borrow_global_mut<T>(get_txn_sender());
+
+        // Charge for gas
+        transaction_fee_amount =
+            move(txn_gas_price) * (move(txn_max_gas_units) - move(gas_units_remaining));
+        imm_sender_account = freeze(copy(sender_account));
+        assert(
+            Self.balance_for_account(move(imm_sender_account)) >= copy(transaction_fee_amount),
+            6
+        );
+        transaction_fee =
+            Self.withdraw_from_account(
+                copy(sender_account),
+                move(transaction_fee_amount)
+            );
+
+        // Bump the sequence number
+        *(&mut move(sender_account).sequence_number) = move(txn_sequence_number) + 1;
+        // Pay the transaction fee into the transaction fee pot
+        transaction_fee_account = borrow_global_mut<T>(0xFEE);
+        LibraCoin.deposit(&mut move(transaction_fee_account).balance, move(transaction_fee));
+        return;
+    }
+
+    /// Events
+    //
+    // Derive a fresh unique id by using sender's EventHandleGenerator. The generated bytearray is indeed unique because it
+    // was derived from the hash(sender's EventHandleGenerator || sender_address). This module guarantees that the
+    // EventHandleGenerator is only going to be monotonically increased and there's no way to revert it or destroy it. Thus
+    // such counter is going to give distinct value for each of the new event stream under each sender. And since we
+    // hash it with the sender's address, the result is guaranteed to be globally unique.
+    fresh_guid(counter: &mut Self.EventHandleGenerator, sender: address): bytearray {
+        let count: &mut u64;
+        let count_bytes: bytearray;
+        let preimage: bytearray;
+        let sender_bytes: bytearray;
+
+        count = &mut move(counter).counter;
+        sender_bytes = AddressUtil.address_to_bytes(move(sender));
+
+        count_bytes = U64Util.u64_to_bytes(*copy(count));
+        *move(count) = *copy(count) + 1;
+
+        // EventHandleGenerator goes first just in case we want to extend address in the future.
+        preimage = BytearrayUtil.bytearray_concat(move(count_bytes), move(sender_bytes));
+
+        return move(preimage);
+    }
+
+    // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
+    new_event_handle_impl<T: unrestricted>(counter: &mut Self.EventHandleGenerator, sender: address): Self.EventHandle<T> {
+        return EventHandle<T> {counter: 0, guid: Self.fresh_guid(move(counter), move(sender))};
+    }
+
+    // Use sender's EventHandleGenerator to generate a unique event handle that one can emit an event to.
+    public new_event_handle<T: unrestricted>(): Self.EventHandle<T> acquires T {
+        let sender_account_ref: &mut Self.T;
+        let sender_bytes: bytearray;
+        sender_account_ref = borrow_global_mut<T>(get_txn_sender());
+        return Self.new_event_handle_impl<T>(&mut (move(sender_account_ref)).event_generator, get_txn_sender());
+    }
+
+    // Emit an event with payload `msg` by using handle's key and counter. Will change the payload from bytearray to a
+    // generic type parameter once we have generics.
+    public emit_event<T: unrestricted>(handle_ref: &mut Self.EventHandle<T>, msg: T) {
+        let count: &mut u64;
+        let guid: bytearray;
+
+        guid = *&copy(handle_ref).guid;
+        count = &mut move(handle_ref).counter;
+
+        Self.write_to_event_store<T>(move(guid), *copy(count), move(msg));
+        *move(count) = *copy(count) + 1;
+        return;
+    }
+
+    // Native procedure that writes to the actual event stream in Event store
+    // This will replace the "native" portion of EmitEvent bytecode
+    native write_to_event_store<T: unrestricted>(guid: bytearray, count: u64, msg: T);
+
+    // Destroy a unique handle.
+    public destroy_handle<T: unrestricted>(handle: Self.EventHandle<T>) {
+        let guid: bytearray;
+        let count: u64;
+        EventHandle<T> { count, guid } = move(handle);
+        return;
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_coin.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_coin.mvir
@@ -1,0 +1,172 @@
+module LibraCoin {
+    // A resource representing the Libra coin
+    resource T {
+        // The value of the coin. May be zero
+        value: u64,
+    }
+
+    // A singleton resource that grants access to `LibraCoin.mint`. Only the Association has one.
+    resource MintCapability {
+        _dummy: bool // dummy field because Move doesn't allow zero-sized structs
+    }
+
+    resource MarketCap {
+        // The sum of the values of all LibraCoin.T resources in the system
+        total_value: u64,
+    }
+
+    // Return a reference to the MintCapability published under the sender's account. Fails if the
+    // sender does not have a MintCapability.
+    // Since only the Association account has a mint capability, this will only succeed if it is
+    // invoked by a transaction sent by that account.
+    public mint_with_default_capability(amount: u64): Self.T acquires MintCapability, MarketCap
+    aborts_if !global_exists<Self.MintCapability>(txn_sender)
+    aborts_if !global_exists<Self.MarketCap>(0xA550C18)
+    // Over mint-able amount
+    aborts_if amount > 1000000000000000
+    // MarketCap overflow
+    aborts_if amount + global<Self.MarketCap>(0xA550C18).total_value > 9223372036854775807
+    ensures global<Self.MarketCap>(0xA550C18).total_value == old(global<Self.MarketCap>(0xA550C18).total_value) + amount
+    ensures RET.value == amount
+    {
+        return Self.mint(move(amount), borrow_global<MintCapability>(get_txn_sender()));
+    }
+
+    // Mint a new LibraCoin.T worth `value`. The caller must have a reference to a MintCapability.
+    // Only the Association account can acquire such a reference, and it can do so only via
+    // `borrow_sender_mint_capability`
+    public mint(value: u64, capability: &Self.MintCapability): Self.T acquires MarketCap
+    aborts_if !global_exists<Self.MarketCap>(0xA550C18)
+    // Over mint-able amount
+    aborts_if value > 1000000000000000
+    // MarketCap overflow
+    aborts_if value + global<Self.MarketCap>(0xA550C18).total_value > 9223372036854775807
+    ensures global<Self.MarketCap>(0xA550C18).total_value == old(global<Self.MarketCap>(0xA550C18).total_value) + value
+    ensures RET.value == value
+    {
+        let market_cap_ref: &mut Self.MarketCap;
+        let market_cap_total_value: u64;
+
+        _ = move(capability);
+
+        // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
+        // this is to prevent the market cap's total value from hitting u64_max due to excessive
+        // minting. This will not be a problem in the production Libra system because coins will
+        // be backed with real-world assets, and thus minting will be correspondingly rarer.
+        assert(copy(value) <= 1000000000 * 1000000, 11); // * 1000000 because the unit is microlibra
+        // update market cap resource to reflect minting
+        market_cap_ref = borrow_global_mut<MarketCap>(0xA550C18);
+        market_cap_total_value = *&copy(market_cap_ref).total_value;
+        *(&mut move(market_cap_ref).total_value) = move(market_cap_total_value) + copy(value);
+
+        return T{value: move(value)};
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public initialize()
+    aborts_if txn_sender != 0xA550C18
+    aborts_if global_exists<Self.MintCapability>(txn_sender)
+    aborts_if global_exists<Self.MarketCap>(txn_sender)
+    ensures global_exists<Self.MintCapability>(txn_sender)
+    ensures global_exists<Self.MarketCap>(txn_sender)
+    ensures global<Self.MarketCap>(txn_sender).total_value == 0
+    // I'm not going to specify _dummy == true because I don't think we care.
+    {
+        // Only callable by the Association address
+        assert(get_txn_sender() == 0xA550C18, 1);
+
+        move_to_sender<MintCapability>(MintCapability{ _dummy: true });
+        move_to_sender<MarketCap>(MarketCap { total_value: 0 });
+
+        return;
+    }
+
+    // Return the total value of all Libra in the system
+    public market_cap(): u64 acquires MarketCap
+    aborts_if !global_exists<Self.MarketCap>(0xA550C18)
+    ensures RET == global<Self.MarketCap>(0xA550C18).total_value
+    {
+        return *&(borrow_global<MarketCap>(0xA550C18)).total_value;
+    }
+
+    // Create a new LibraCoin.T with a value of 0
+    public zero(): Self.T
+    ensures RET.value == 0
+    {
+        return T{value: 0};
+    }
+
+    // Public accessor for the value of a coin
+    public value(coin_ref: &Self.T): u64
+    ensures RET == coin_ref.value
+    {
+        return *&move(coin_ref).value;
+    }
+
+    // Splits the given coin into two and returns them both
+    // It leverages `Self.withdraw` for any verifications of the values
+    public split(coin: Self.T, amount: u64): Self.T * Self.T {
+        let other: Self.T;
+        other = Self.withdraw(&mut coin, move(amount));
+        return move(coin), move(other);
+    }
+
+    // "Divides" the given coin into two, where original coin is modified in place
+    // The original coin will have value = original value - `amount`
+    // The new coin will have a value = `amount`
+    // Fails if the coins value is less than `amount`
+    public withdraw(coin_ref: &mut Self.T, amount: u64): Self.T
+    aborts_if coin_ref.value < amount
+    ensures coin_ref.value == old(coin_ref.value) - amount
+    ensures RET.value == amount
+    {
+        let value: u64;
+
+        // Check that `amount` is less than the coin's value
+        value = *(&mut copy(coin_ref).value);
+        assert(copy(value) >= copy(amount), 10);
+
+        // Split the coin
+        *(&mut move(coin_ref).value) = move(value) - copy(amount);
+        return T{value: move(amount)};
+    }
+
+    // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+    public join(coin1: Self.T, coin2: Self.T): Self.T
+    aborts_if coin1.value + coin2.value > 9223372036854775807
+    ensures RET.value == old(coin1.value) + old(coin2.value)
+    {
+        Self.deposit(&mut coin1, move(coin2));
+        return move(coin1);
+    }
+
+    // "Merges" the two coins
+    // The coin passed in by reference will have a value equal to the sum of the two coins
+    // The `check` coin is consumed in the process
+    public deposit(coin_ref: &mut Self.T, check: Self.T)
+    aborts_if coin_ref.value + check.value > 9223372036854775807
+    ensures coin_ref.value == old(coin_ref.value) + old(check.value)
+    {
+        let value: u64;
+        let check_value: u64;
+
+        value = *(&mut copy(coin_ref).value);
+        T { value: check_value } = move(check);
+        *(&mut move(coin_ref).value)= move(value) + move(check_value);
+        return;
+    }
+
+    // Destroy a coin
+    // Fails if the value is non-zero
+    // The amount of LibraCoin.T in the system is a tightly controlled property,
+    // so you cannot "burn" any non-zero amount of LibraCoin.T
+    public destroy_zero(coin: Self.T)
+    aborts_if coin.value != 0
+    {
+        let value: u64;
+        T { value } = move(coin);
+        assert(move(value) == 0, 11);
+        return;
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/u64_util.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/u64_util.mvir
@@ -1,0 +1,4 @@
+module U64Util {
+    // TODO: specify
+    native public u64_to_bytes(i: u64): bytearray;
+}

--- a/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
@@ -73,6 +73,14 @@ pub fn std_mvir(b: &str) -> String {
     format!("../../stdlib/modules/{}.mvir", b)
 }
 
+/// Helper to create a path to a verified mvir source of the standard library.
+/// We currently maintaining copies of those in `./test_mvir/verify-stdlib`, eventually
+/// we should move this to the (source language based) standard library.
+#[allow(dead_code)]
+pub fn verified_std_mvir(b: &str) -> String {
+    format!("test_mvir/verify-stdlib/{}.mvir", b)
+}
+
 /// Flags to use for test() to do only parsing and type checking of boogie.
 #[allow(dead_code)]
 pub const NO_VERIFY: &[&str] = &["-B=-noVerify"];

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -1,0 +1,4117 @@
+
+
+// ** structs of module LibraCoin
+
+const unique LibraCoin_T: TypeName;
+const LibraCoin_T_value: FieldName;
+axiom LibraCoin_T_value == 0;
+function LibraCoin_T_type_value(): TypeValue {
+    StructType(LibraCoin_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_LibraCoin_T(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraCoin_T(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraCoin_T_value);
+}
+
+const unique LibraCoin_MintCapability: TypeName;
+const LibraCoin_MintCapability__dummy: FieldName;
+axiom LibraCoin_MintCapability__dummy == 0;
+function LibraCoin_MintCapability_type_value(): TypeValue {
+    StructType(LibraCoin_MintCapability, ExtendTypeValueArray(EmptyTypeValueArray, BooleanType()))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MintCapability(v0: Value) returns (v: Value)
+{
+    assume is#Boolean(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraCoin_MintCapability(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraCoin_MintCapability__dummy);
+}
+
+const unique LibraCoin_MarketCap: TypeName;
+const LibraCoin_MarketCap_total_value: FieldName;
+axiom LibraCoin_MarketCap_total_value == 0;
+function LibraCoin_MarketCap_type_value(): TypeValue {
+    StructType(LibraCoin_MarketCap, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MarketCap(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraCoin_MarketCap(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraCoin_MarketCap_total_value);
+}
+
+
+
+// ** structs of module Hash
+
+
+
+// ** structs of module U64Util
+
+
+
+// ** structs of module AddressUtil
+
+
+
+// ** structs of module BytearrayUtil
+
+
+
+// ** structs of module LibraAccount
+
+const unique LibraAccount_T: TypeName;
+const LibraAccount_T_authentication_key: FieldName;
+axiom LibraAccount_T_authentication_key == 0;
+const LibraAccount_T_balance: FieldName;
+axiom LibraAccount_T_balance == 1;
+const LibraAccount_T_delegated_key_rotation_capability: FieldName;
+axiom LibraAccount_T_delegated_key_rotation_capability == 2;
+const LibraAccount_T_delegated_withdrawal_capability: FieldName;
+axiom LibraAccount_T_delegated_withdrawal_capability == 3;
+const LibraAccount_T_received_events: FieldName;
+axiom LibraAccount_T_received_events == 4;
+const LibraAccount_T_sent_events: FieldName;
+axiom LibraAccount_T_sent_events == 5;
+const LibraAccount_T_sequence_number: FieldName;
+axiom LibraAccount_T_sequence_number == 6;
+const LibraAccount_T_event_generator: FieldName;
+axiom LibraAccount_T_event_generator == 7;
+function LibraAccount_T_type_value(): TypeValue {
+    StructType(LibraAccount_T, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, ByteArrayType()), LibraCoin_T_type_value()), BooleanType()), BooleanType()), LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())), LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())), IntegerType()), LibraAccount_EventHandleGenerator_type_value()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_T(v0: Value, v1: Value, v2: Value, v3: Value, v4: Value, v5: Value, v6: Value, v7: Value) returns (v: Value)
+{
+    assume is#ByteArray(v0);
+    assume is#Vector(v1);
+    assume is#Boolean(v2);
+    assume is#Boolean(v3);
+    assume is#Vector(v4);
+    assume is#Vector(v5);
+    assume is#Integer(v6);
+    assume is#Vector(v7);
+    v := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, v0), v1), v2), v3), v4), v5), v6), v7));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_T(v: Value) returns (v0: Value, v1: Value, v2: Value, v3: Value, v4: Value, v5: Value, v6: Value, v7: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_T_authentication_key);
+    v1 := SelectField(v, LibraAccount_T_balance);
+    v2 := SelectField(v, LibraAccount_T_delegated_key_rotation_capability);
+    v3 := SelectField(v, LibraAccount_T_delegated_withdrawal_capability);
+    v4 := SelectField(v, LibraAccount_T_received_events);
+    v5 := SelectField(v, LibraAccount_T_sent_events);
+    v6 := SelectField(v, LibraAccount_T_sequence_number);
+    v7 := SelectField(v, LibraAccount_T_event_generator);
+}
+
+const unique LibraAccount_WithdrawalCapability: TypeName;
+const LibraAccount_WithdrawalCapability_account_address: FieldName;
+axiom LibraAccount_WithdrawalCapability_account_address == 0;
+function LibraAccount_WithdrawalCapability_type_value(): TypeValue {
+    StructType(LibraAccount_WithdrawalCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(v0: Value) returns (v: Value)
+{
+    assume is#Address(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_WithdrawalCapability_account_address);
+}
+
+const unique LibraAccount_KeyRotationCapability: TypeName;
+const LibraAccount_KeyRotationCapability_account_address: FieldName;
+axiom LibraAccount_KeyRotationCapability_account_address == 0;
+function LibraAccount_KeyRotationCapability_type_value(): TypeValue {
+    StructType(LibraAccount_KeyRotationCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(v0: Value) returns (v: Value)
+{
+    assume is#Address(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_KeyRotationCapability_account_address);
+}
+
+const unique LibraAccount_SentPaymentEvent: TypeName;
+const LibraAccount_SentPaymentEvent_amount: FieldName;
+axiom LibraAccount_SentPaymentEvent_amount == 0;
+const LibraAccount_SentPaymentEvent_payee: FieldName;
+axiom LibraAccount_SentPaymentEvent_payee == 1;
+const LibraAccount_SentPaymentEvent_metadata: FieldName;
+axiom LibraAccount_SentPaymentEvent_metadata == 2;
+function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
+    StructType(LibraAccount_SentPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(v0: Value, v1: Value, v2: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    assume is#Address(v1);
+    assume is#ByteArray(v2);
+    v := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, v0), v1), v2));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(v: Value) returns (v0: Value, v1: Value, v2: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_SentPaymentEvent_amount);
+    v1 := SelectField(v, LibraAccount_SentPaymentEvent_payee);
+    v2 := SelectField(v, LibraAccount_SentPaymentEvent_metadata);
+}
+
+const unique LibraAccount_ReceivedPaymentEvent: TypeName;
+const LibraAccount_ReceivedPaymentEvent_amount: FieldName;
+axiom LibraAccount_ReceivedPaymentEvent_amount == 0;
+const LibraAccount_ReceivedPaymentEvent_payer: FieldName;
+axiom LibraAccount_ReceivedPaymentEvent_payer == 1;
+const LibraAccount_ReceivedPaymentEvent_metadata: FieldName;
+axiom LibraAccount_ReceivedPaymentEvent_metadata == 2;
+function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
+    StructType(LibraAccount_ReceivedPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(v0: Value, v1: Value, v2: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    assume is#Address(v1);
+    assume is#ByteArray(v2);
+    v := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, v0), v1), v2));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(v: Value) returns (v0: Value, v1: Value, v2: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_ReceivedPaymentEvent_amount);
+    v1 := SelectField(v, LibraAccount_ReceivedPaymentEvent_payer);
+    v2 := SelectField(v, LibraAccount_ReceivedPaymentEvent_metadata);
+}
+
+const unique LibraAccount_EventHandleGenerator: TypeName;
+const LibraAccount_EventHandleGenerator_counter: FieldName;
+axiom LibraAccount_EventHandleGenerator_counter == 0;
+function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
+    StructType(LibraAccount_EventHandleGenerator, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_EventHandleGenerator_counter);
+}
+
+const unique LibraAccount_EventHandle: TypeName;
+const LibraAccount_EventHandle_counter: FieldName;
+axiom LibraAccount_EventHandle_counter == 0;
+const LibraAccount_EventHandle_guid: FieldName;
+axiom LibraAccount_EventHandle_guid == 1;
+function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
+    StructType(LibraAccount_EventHandle, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), ByteArrayType()))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, v0: Value, v1: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    assume is#ByteArray(v1);
+    v := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, v0), v1));
+
+}
+
+procedure {:inline 1} Unpack_LibraAccount_EventHandle(v: Value) returns (v0: Value, v1: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraAccount_EventHandle_counter);
+    v1 := SelectField(v, LibraAccount_EventHandle_guid);
+}
+
+
+
+// ** functions of module LibraCoin
+
+procedure {:inline 1} LibraCoin_mint_with_default_capability (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(arg0)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg0)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t4: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t4);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_mint_with_default_capability_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_mint_with_default_capability(arg0);
+}
+
+procedure {:inline 1} LibraCoin_mint (arg0: Value, arg1: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(arg0)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg0)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // BooleanType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // AddressType()
+    var t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Value; // IntegerType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
+    var t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t21: Reference; // ReferenceType(IntegerType())
+    var t22: Value; // IntegerType()
+    var t23: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+    assume IsValidReferenceParameter(local_counter, arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 24;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    t1 := arg1;
+
+    // bytecode translation starts here
+    call t4 := CopyOrMoveRef(t1);
+
+    // unimplemented instruction
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := LdConst(1000000000);
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := LdConst(1000000);
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := Le(GetLocal(m, old_size + 5), GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 9));
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    tmp := GetLocal(m, old_size + 10);
+    if (!b#Boolean(tmp)) { goto Label_11; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    goto Label_Abort;
+
+Label_11:
+    call tmp := LdAddr(173345816);
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call t13 := BorrowGlobal(GetLocal(m, old_size + 12), LibraCoin_MarketCap_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := CopyOrMoveRef(t13);
+
+    call t14 := CopyOrMoveRef(t2);
+
+    call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
+
+    call tmp := ReadRef(t15);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 19, tmp);
+
+    call t20 := CopyOrMoveRef(t2);
+
+    call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
+
+    call WriteRef(t21, GetLocal(m, old_size + 19));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 22, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 22));
+
+    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 22));
+    m := UpdateLocal(m, old_size + 23, tmp);
+
+    ret0 := GetLocal(m, old_size + 23);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_mint_verify (arg0: Value, arg1: Reference) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_mint(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_initialize () returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraCoin_MarketCap_total_value)) == (Integer(0))));
+ensures old(!(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // LibraCoin_MintCapability_type_value()
+    var t7: Value; // IntegerType()
+    var t8: Value; // LibraCoin_MarketCap_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 9;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call tmp := LdAddr(173345816);
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    tmp := GetLocal(m, old_size + 3);
+    if (!b#Boolean(tmp)) { goto Label_7; }
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call tmp := LdTrue();
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    assume is#Boolean(GetLocal(m, old_size + 5));
+
+    call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 7));
+
+    call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraCoin_initialize_verify () returns ()
+{
+    call LibraCoin_initialize();
+}
+
+procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+
+    // bytecode translation starts here
+    call tmp := LdAddr(173345816);
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+
+    call tmp := ReadRef(t2);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_market_cap_verify () returns (ret0: Value)
+{
+    call ret0 := LibraCoin_market_cap();
+}
+
+procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(0))));
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 2;
+
+    // bytecode translation starts here
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 0));
+
+    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    ret0 := GetLocal(m, old_size + 1);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_zero_verify () returns (ret0: Value)
+{
+    call ret0 := LibraCoin_zero();
+}
+
+procedure {:inline 1} LibraCoin_value (arg0: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, arg0), LibraCoin_T_value))));
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t1 := CopyOrMoveRef(t0);
+
+    call t2 := BorrowField(t1, LibraCoin_T_value);
+
+    call tmp := ReadRef(t2);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_value_verify (arg0: Reference) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_value(arg0);
+}
+
+procedure {:inline 1} LibraCoin_split (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Value; // IntegerType()
+    var t5: Value; // LibraCoin_T_type_value()
+    var t6: Value; // LibraCoin_T_type_value()
+    var t7: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 8;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t3 := BorrowLoc(old_size+0);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t5);
+
+    m := UpdateLocal(m, old_size + 5, t5);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    ret0 := GetLocal(m, old_size + 6);
+    ret1 := GetLocal(m, old_size + 7);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
+}
+
+procedure LibraCoin_split_verify (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
+{
+    call ret0, ret1 := LibraCoin_split(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_withdraw (arg0: Reference, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, arg0), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, arg0), LibraCoin_T_value))) - i#Integer(arg1)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg1)));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Reference; // ReferenceType(IntegerType())
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // BooleanType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // IntegerType()
+    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 18;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t3 := CopyOrMoveRef(t0);
+
+    call t4 := BorrowField(t3, LibraCoin_T_value);
+
+    call tmp := ReadRef(t4);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    tmp := GetLocal(m, old_size + 9);
+    if (!b#Boolean(tmp)) { goto Label_11; }
+
+    call tmp := LdConst(10);
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    goto Label_Abort;
+
+Label_11:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    call t14 := CopyOrMoveRef(t0);
+
+    call t15 := BorrowField(t14, LibraCoin_T_value);
+
+    call WriteRef(t15, GetLocal(m, old_size + 13));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 16));
+
+    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    ret0 := GetLocal(m, old_size + 17);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_withdraw_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_withdraw(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_join (arg0: Value, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(arg0, LibraCoin_T_value))) + i#Integer(old(SelectField(arg1, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(arg0, LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(arg0, LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t3: Value; // LibraCoin_T_type_value()
+    var t4: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+    assume is#Vector(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t2 := BorrowLoc(old_size+0);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_join_verify (arg0: Value, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_join(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_deposit (arg0: Reference, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, arg0), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, arg0), LibraCoin_T_value))) + i#Integer(old(SelectField(arg1, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t5: Reference; // ReferenceType(IntegerType())
+    var t6: Value; // IntegerType()
+    var t7: Value; // LibraCoin_T_type_value()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t13: Reference; // ReferenceType(IntegerType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 14;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t4 := CopyOrMoveRef(t0);
+
+    call t5 := BorrowField(t4, LibraCoin_T_value);
+
+    call tmp := ReadRef(t5);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
+    assume is#Integer(t8);
+
+    m := UpdateLocal(m, old_size + 8, t8);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := CopyOrMoveRef(t0);
+
+    call t13 := BorrowField(t12, LibraCoin_T_value);
+
+    call WriteRef(t13, GetLocal(m, old_size + 11));
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraCoin_deposit_verify (arg0: Reference, arg1: Value) returns ()
+{
+    call LibraCoin_deposit(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_destroy_zero (arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean((SelectField(arg0, LibraCoin_T_value)) != (Integer(0)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean((SelectField(arg0, LibraCoin_T_value)) != (Integer(0))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // BooleanType()
+    var t8: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 9;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
+    assume is#Integer(t3);
+
+    m := UpdateLocal(m, old_size + 3, t3);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 6));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    tmp := GetLocal(m, old_size + 7);
+    if (!b#Boolean(tmp)) { goto Label_10; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    goto Label_Abort;
+
+Label_10:
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraCoin_destroy_zero_verify (arg0: Value) returns ()
+{
+    call LibraCoin_destroy_zero(arg0);
+}
+
+
+
+// ** functions of module Hash
+
+procedure {:inline 1} Hash_sha2_256 (arg0: Value) returns (ret0: Value);procedure {:inline 1} Hash_sha3_256 (arg0: Value) returns (ret0: Value);
+
+// ** functions of module U64Util
+
+procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
+
+// ** functions of module AddressUtil
+
+procedure {:inline 1} AddressUtil_address_to_bytes (arg0: Value) returns (ret0: Value);
+
+// ** functions of module BytearrayUtil
+
+procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) returns (ret0: Value);
+
+// ** functions of module LibraAccount
+
+procedure {:inline 1} LibraAccount_make (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t3: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t4: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // AddressType()
+    var t7: Value; // ByteArrayType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t11: Value; // AddressType()
+    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t14: Value; // AddressType()
+    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t16: Value; // LibraCoin_T_type_value()
+    var t17: Value; // ByteArrayType()
+    var t18: Value; // LibraCoin_T_type_value()
+    var t19: Value; // BooleanType()
+    var t20: Value; // BooleanType()
+    var t21: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t22: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t23: Value; // IntegerType()
+    var t24: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t25: Value; // LibraAccount_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 26;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call t7 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t7);
+
+    m := UpdateLocal(m, old_size + 7, t7);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 8));
+
+    call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t10 := BorrowLoc(old_size+2);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t12);
+
+    m := UpdateLocal(m, old_size + 12, t12);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t13 := BorrowLoc(old_size+2);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t15);
+
+    m := UpdateLocal(m, old_size + 15, t15);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call t16 := LibraCoin_zero();
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t16);
+
+    m := UpdateLocal(m, old_size + 16, t16);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
+    call tmp := LdFalse();
+    m := UpdateLocal(m, old_size + 19, tmp);
+
+    call tmp := LdFalse();
+    m := UpdateLocal(m, old_size + 20, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 21, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 22, tmp);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 23, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 24, tmp);
+
+    assume is#ByteArray(GetLocal(m, old_size + 17));
+
+    assume is#Vector(GetLocal(m, old_size + 18));
+
+    assume is#Boolean(GetLocal(m, old_size + 19));
+
+    assume is#Boolean(GetLocal(m, old_size + 20));
+
+    assume is#Vector(GetLocal(m, old_size + 21));
+
+    assume is#Vector(GetLocal(m, old_size + 22));
+
+    assume is#Integer(GetLocal(m, old_size + 23));
+
+    assume is#Vector(GetLocal(m, old_size + 24));
+
+    call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20), GetLocal(m, old_size + 21), GetLocal(m, old_size + 22), GetLocal(m, old_size + 23), GetLocal(m, old_size + 24));
+    m := UpdateLocal(m, old_size + 25, tmp);
+
+    ret0 := GetLocal(m, old_size + 25);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_make_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_make(arg0);
+}
+
+procedure {:inline 1} LibraAccount_deposit (arg0: Value, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // AddressType()
+    var t3: Value; // LibraCoin_T_type_value()
+    var t4: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Vector(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    // unimplemented instruction
+
+    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_deposit_verify (arg0: Value, arg1: Value) returns ()
+{
+    call LibraAccount_deposit(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_deposit_with_metadata (arg0: Value, arg1: Value, arg2: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // AddressType()
+    var t4: Value; // AddressType()
+    var t5: Value; // LibraCoin_T_type_value()
+    var t6: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Vector(arg1);
+    assume is#ByteArray(arg2);
+
+    old_size := local_counter;
+    local_counter := local_counter + 7;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+    m := UpdateLocal(m, old_size + 2, arg2);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4), GetLocal(m, old_size + 5), GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_deposit_with_metadata_verify (arg0: Value, arg1: Value, arg2: Value) returns ()
+{
+    call LibraAccount_deposit_with_metadata(arg0, arg1, arg2);
+}
+
+procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Value; // ByteArrayType()
+    var t4: Value; // IntegerType()
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // BooleanType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // IntegerType()
+    var t14: Value; // AddressType()
+    var t15: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
+    var t18: Value; // IntegerType()
+    var t19: Value; // AddressType()
+    var t20: Value; // ByteArrayType()
+    var t21: Value; // LibraAccount_SentPaymentEvent_type_value()
+    var t22: Value; // AddressType()
+    var t23: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t25: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t26: Value; // LibraCoin_T_type_value()
+    var t27: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
+    var t29: Value; // IntegerType()
+    var t30: Value; // AddressType()
+    var t31: Value; // ByteArrayType()
+    var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Address(arg1);
+    assume is#Vector(arg2);
+    assume is#ByteArray(arg3);
+
+    old_size := local_counter;
+    local_counter := local_counter + 33;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+    m := UpdateLocal(m, old_size + 2, arg2);
+    m := UpdateLocal(m, old_size + 3, arg3);
+
+    // bytecode translation starts here
+    call t7 := BorrowLoc(old_size+2);
+
+    call t8 := LibraCoin_value(t7);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Integer(t8);
+
+    m := UpdateLocal(m, old_size + 8, t8);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    call tmp := Gt(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 11));
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    tmp := GetLocal(m, old_size + 12);
+    if (!b#Boolean(tmp)) { goto Label_10; }
+
+    call tmp := LdConst(7);
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    goto Label_Abort;
+
+Label_10:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    call t15 := BorrowGlobal(GetLocal(m, old_size + 14), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t6 := CopyOrMoveRef(t15);
+
+    call t16 := CopyOrMoveRef(t6);
+
+    call t17 := BorrowField(t16, LibraAccount_T_sent_events);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 19, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 20, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 18));
+
+    assume is#Address(GetLocal(m, old_size + 19));
+
+    assume is#ByteArray(GetLocal(m, old_size + 20));
+
+    call tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
+    m := UpdateLocal(m, old_size + 21, tmp);
+
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(m, old_size + 21));
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 22, tmp);
+
+    call t23 := BorrowGlobal(GetLocal(m, old_size + 22), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t5 := CopyOrMoveRef(t23);
+
+    call t24 := CopyOrMoveRef(t5);
+
+    call t25 := BorrowField(t24, LibraAccount_T_balance);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 26, tmp);
+
+    call LibraCoin_deposit(t25, GetLocal(m, old_size + 26));
+    if (abort_flag) { goto Label_Abort; }
+
+    call t27 := CopyOrMoveRef(t5);
+
+    call t28 := BorrowField(t27, LibraAccount_T_received_events);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 29, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 30, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 31, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 29));
+
+    assume is#Address(GetLocal(m, old_size + 30));
+
+    assume is#ByteArray(GetLocal(m, old_size + 31));
+
+    call tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(m, old_size + 29), GetLocal(m, old_size + 30), GetLocal(m, old_size + 31));
+    m := UpdateLocal(m, old_size + 32, tmp);
+
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(m, old_size + 32));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_deposit_with_sender_and_metadata_verify (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
+{
+    call LibraAccount_deposit_with_sender_and_metadata(arg0, arg1, arg2, arg3);
+}
+
+procedure {:inline 1} LibraAccount_mint_to_address (arg0: Value, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // AddressType()
+    var t6: Value; // AddressType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 9;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := Exists(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    tmp := GetLocal(m, old_size + 4);
+    if (!b#Boolean(tmp)) { goto Label_6; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call LibraAccount_create_account(GetLocal(m, old_size + 5));
+    if (abort_flag) { goto Label_Abort; }
+
+Label_6:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t8 := LibraCoin_mint_with_default_capability(GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t8);
+
+    m := UpdateLocal(m, old_size + 8, t8);
+
+    call LibraAccount_deposit(GetLocal(m, old_size + 6), GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_mint_to_address_verify (arg0: Value, arg1: Value) returns ()
+{
+    call LibraAccount_mint_to_address(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_withdraw_from_account (arg0: Reference, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg1)));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, arg0), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, arg0), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(arg1)))));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, arg0), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, arg0), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t5: Value; // IntegerType()
+    var t6: Value; // LibraCoin_T_type_value()
+    var t7: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 8;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t3 := CopyOrMoveRef(t0);
+
+    call t4 := BorrowField(t3, LibraAccount_T_balance);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call t6 := LibraCoin_withdraw(t4, GetLocal(m, old_size + 5));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t6);
+
+    m := UpdateLocal(m, old_size + 6, t6);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    ret0 := GetLocal(m, old_size + 7);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_withdraw_from_account_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_withdraw_from_account(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_withdraw_from_sender (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg0)));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(arg0)))));
+ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg0))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))))) ==> !abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg0))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(BooleanType())
+    var t6: Value; // BooleanType()
+    var t7: Value; // IntegerType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Value; // IntegerType()
+    var t10: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 11;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t1 := CopyOrMoveRef(t3);
+
+    call t4 := CopyOrMoveRef(t1);
+
+    call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
+
+    call tmp := ReadRef(t5);
+    assume is#Boolean(tmp);
+
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    tmp := GetLocal(m, old_size + 6);
+    if (!b#Boolean(tmp)) { goto Label_9; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    goto Label_Abort;
+
+Label_9:
+    call t8 := CopyOrMoveRef(t1);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(m, old_size + 9));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t10);
+
+    m := UpdateLocal(m, old_size + 10, t10);
+
+    ret0 := GetLocal(m, old_size + 10);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_withdraw_from_sender_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_withdraw_from_sender(arg0);
+}
+
+procedure {:inline 1} LibraAccount_withdraw_with_capability (arg0: Reference, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg1)));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, arg0), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, arg0), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(arg1)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, arg0), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, arg0), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, arg0), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, arg0), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t4: Reference; // ReferenceType(AddressType())
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 10;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t3 := CopyOrMoveRef(t0);
+
+    call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
+
+    call tmp := ReadRef(t4);
+    assume is#Address(tmp);
+
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := CopyOrMoveRef(t6);
+
+    call t7 := CopyOrMoveRef(t2);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t9);
+
+    m := UpdateLocal(m, old_size + 9, t9);
+
+    ret0 := GetLocal(m, old_size + 9);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_withdraw_with_capability_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_withdraw_with_capability(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Reference; // ReferenceType(BooleanType())
+    var t3: Value; // AddressType()
+    var t4: Value; // AddressType()
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Reference; // ReferenceType(BooleanType())
+    var t8: Reference; // ReferenceType(BooleanType())
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // BooleanType()
+    var t12: Reference; // ReferenceType(BooleanType())
+    var t13: Value; // AddressType()
+    var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 15;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t1 := CopyOrMoveRef(t5);
+
+    call t6 := CopyOrMoveRef(t1);
+
+    call t7 := BorrowField(t6, LibraAccount_T_delegated_withdrawal_capability);
+
+    call t2 := CopyOrMoveRef(t7);
+
+    call t8 := CopyOrMoveRef(t2);
+
+    call tmp := ReadRef(t8);
+    assume is#Boolean(tmp);
+
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    tmp := GetLocal(m, old_size + 9);
+    if (!b#Boolean(tmp)) { goto Label_13; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    goto Label_Abort;
+
+Label_13:
+    call tmp := LdTrue();
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := CopyOrMoveRef(t2);
+
+    call WriteRef(t12, GetLocal(m, old_size + 11));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    assume is#Address(GetLocal(m, old_size + 13));
+
+    call tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 13));
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    ret0 := GetLocal(m, old_size + 14);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
+{
+    call ret0 := LibraAccount_extract_sender_withdrawal_capability();
+}
+
+procedure {:inline 1} LibraAccount_restore_withdrawal_capability (arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var t4: Value; // AddressType()
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Value; // BooleanType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Reference; // ReferenceType(BooleanType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 10;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 3));
+    assume is#Address(t4);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := CopyOrMoveRef(t6);
+
+    call tmp := LdFalse();
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t8 := CopyOrMoveRef(t2);
+
+    call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
+
+    call WriteRef(t9, GetLocal(m, old_size + 7));
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_restore_withdrawal_capability_verify (arg0: Value) returns ()
+{
+    call LibraAccount_restore_withdrawal_capability(arg0);
+}
+
+procedure {:inline 1} LibraAccount_pay_from_capability (arg0: Value, arg1: Reference, arg2: Value, arg3: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t2: Value; // IntegerType()
+    var t3: Value; // ByteArrayType()
+    var t4: Value; // AddressType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // AddressType()
+    var t8: Value; // AddressType()
+    var t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t10: Reference; // ReferenceType(AddressType())
+    var t11: Value; // AddressType()
+    var t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t13: Value; // IntegerType()
+    var t14: Value; // LibraCoin_T_type_value()
+    var t15: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Integer(arg2);
+    assume is#ByteArray(arg3);
+
+    old_size := local_counter;
+    local_counter := local_counter + 16;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    t1 := arg1;
+    m := UpdateLocal(m, old_size + 2, arg2);
+    m := UpdateLocal(m, old_size + 3, arg3);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := Exists(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    tmp := GetLocal(m, old_size + 6);
+    if (!b#Boolean(tmp)) { goto Label_6; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call LibraAccount_create_account(GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
+
+Label_6:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call t9 := CopyOrMoveRef(t1);
+
+    call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
+
+    call tmp := ReadRef(t10);
+    assume is#Address(tmp);
+
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := CopyOrMoveRef(t1);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(m, old_size + 13));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t14);
+
+    m := UpdateLocal(m, old_size + 14, t14);
+
+    // unimplemented instruction
+
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 8), GetLocal(m, old_size + 11), GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_pay_from_capability_verify (arg0: Value, arg1: Reference, arg2: Value, arg3: Value) returns ()
+{
+    call LibraAccount_pay_from_capability(arg0, arg1, arg2, arg3);
+}
+
+procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (arg0: Value, arg1: Value, arg2: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // ByteArrayType()
+    var t3: Value; // AddressType()
+    var t4: Value; // BooleanType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // AddressType()
+    var t7: Value; // AddressType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // LibraCoin_T_type_value()
+    var t10: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Integer(arg1);
+    assume is#ByteArray(arg2);
+
+    old_size := local_counter;
+    local_counter := local_counter + 11;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+    m := UpdateLocal(m, old_size + 2, arg2);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := Exists(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    tmp := GetLocal(m, old_size + 5);
+    if (!b#Boolean(tmp)) { goto Label_6; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call LibraAccount_create_account(GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+
+Label_6:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call t9 := LibraAccount_withdraw_from_sender(GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t9);
+
+    m := UpdateLocal(m, old_size + 9, t9);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 7), GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_pay_from_sender_with_metadata_verify (arg0: Value, arg1: Value, arg2: Value) returns ()
+{
+    call LibraAccount_pay_from_sender_with_metadata(arg0, arg1, arg2);
+}
+
+procedure {:inline 1} LibraAccount_pay_from_sender (arg0: Value, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    // unimplemented instruction
+
+    call LibraAccount_pay_from_sender_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_pay_from_sender_verify (arg0: Value, arg1: Value) returns ()
+{
+    call LibraAccount_pay_from_sender(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (arg0: Reference, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // ByteArrayType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(ByteArrayType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#ByteArray(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := CopyOrMoveRef(t0);
+
+    call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
+
+    call WriteRef(t4, GetLocal(m, old_size + 2));
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_rotate_authentication_key_for_account_verify (arg0: Reference, arg1: Value) returns ()
+{
+    call LibraAccount_rotate_authentication_key_for_account(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_rotate_authentication_key (arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // ByteArrayType()
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(BooleanType())
+    var t6: Value; // BooleanType()
+    var t7: Value; // IntegerType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#ByteArray(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 10;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t1 := CopyOrMoveRef(t3);
+
+    call t4 := CopyOrMoveRef(t1);
+
+    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+
+    call tmp := ReadRef(t5);
+    assume is#Boolean(tmp);
+
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    tmp := GetLocal(m, old_size + 6);
+    if (!b#Boolean(tmp)) { goto Label_9; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    goto Label_Abort;
+
+Label_9:
+    call t8 := CopyOrMoveRef(t1);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(m, old_size + 9));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_rotate_authentication_key_verify (arg0: Value) returns ()
+{
+    call LibraAccount_rotate_authentication_key(arg0);
+}
+
+procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (arg0: Reference, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t3: Reference; // ReferenceType(AddressType())
+    var t4: Value; // AddressType()
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#ByteArray(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 7;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t2 := CopyOrMoveRef(t0);
+
+    call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
+
+    call tmp := ReadRef(t3);
+    assume is#Address(tmp);
+
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_rotate_authentication_key_with_capability_verify (arg0: Reference, arg1: Value) returns ()
+{
+    call LibraAccount_rotate_authentication_key_with_capability(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(BooleanType())
+    var t2: Value; // AddressType()
+    var t3: Value; // AddressType()
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(BooleanType())
+    var t6: Reference; // ReferenceType(BooleanType())
+    var t7: Value; // BooleanType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Reference; // ReferenceType(BooleanType())
+    var t11: Value; // AddressType()
+    var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 13;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t4 := BorrowGlobal(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+
+    call t1 := CopyOrMoveRef(t5);
+
+    call t6 := CopyOrMoveRef(t1);
+
+    call tmp := ReadRef(t6);
+    assume is#Boolean(tmp);
+
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    tmp := GetLocal(m, old_size + 7);
+    if (!b#Boolean(tmp)) { goto Label_11; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    goto Label_Abort;
+
+Label_11:
+    call tmp := LdTrue();
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call t10 := CopyOrMoveRef(t1);
+
+    call WriteRef(t10, GetLocal(m, old_size + 9));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    assume is#Address(GetLocal(m, old_size + 11));
+
+    call tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 11));
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    ret0 := GetLocal(m, old_size + 12);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
+{
+    call ret0 := LibraAccount_extract_sender_key_rotation_capability();
+}
+
+procedure {:inline 1} LibraAccount_restore_key_rotation_capability (arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var t4: Value; // AddressType()
+    var t5: Value; // AddressType()
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Value; // BooleanType()
+    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t9: Reference; // ReferenceType(BooleanType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 10;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 3));
+    assume is#Address(t4);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := CopyOrMoveRef(t6);
+
+    call tmp := LdFalse();
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t8 := CopyOrMoveRef(t2);
+
+    call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
+
+    call WriteRef(t9, GetLocal(m, old_size + 7));
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_restore_key_rotation_capability_verify (arg0: Value) returns ()
+{
+    call LibraAccount_restore_key_rotation_capability(arg0);
+}
+
+procedure {:inline 1} LibraAccount_create_account (arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t2: Value; // IntegerType()
+    var t3: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t4: Value; // AddressType()
+    var t5: Value; // AddressType()
+    var t6: Value; // ByteArrayType()
+    var t7: Value; // LibraCoin_T_type_value()
+    var t8: Value; // BooleanType()
+    var t9: Value; // BooleanType()
+    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t11: Value; // AddressType()
+    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t14: Value; // AddressType()
+    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var t18: Value; // LibraAccount_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 19;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 2));
+
+    call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call t6 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 5));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t6);
+
+    m := UpdateLocal(m, old_size + 6, t6);
+
+    call t7 := LibraCoin_zero();
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t7);
+
+    m := UpdateLocal(m, old_size + 7, t7);
+
+    call tmp := LdFalse();
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := LdFalse();
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call t10 := BorrowLoc(old_size+1);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t12);
+
+    m := UpdateLocal(m, old_size + 12, t12);
+
+    call t13 := BorrowLoc(old_size+1);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t15);
+
+    m := UpdateLocal(m, old_size + 15, t15);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    assume is#ByteArray(GetLocal(m, old_size + 6));
+
+    assume is#Vector(GetLocal(m, old_size + 7));
+
+    assume is#Boolean(GetLocal(m, old_size + 8));
+
+    assume is#Boolean(GetLocal(m, old_size + 9));
+
+    assume is#Vector(GetLocal(m, old_size + 12));
+
+    assume is#Vector(GetLocal(m, old_size + 15));
+
+    assume is#Integer(GetLocal(m, old_size + 16));
+
+    assume is#Vector(GetLocal(m, old_size + 17));
+
+    call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 12), GetLocal(m, old_size + 15), GetLocal(m, old_size + 16), GetLocal(m, old_size + 17));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
+    call LibraAccount_save_account(GetLocal(m, old_size + 4), GetLocal(m, old_size + 18));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_create_account_verify (arg0: Value) returns ()
+{
+    call LibraAccount_create_account(arg0);
+}
+
+procedure {:inline 1} LibraAccount_create_new_account (arg0: Value, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // AddressType()
+    var t7: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 8;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call LibraAccount_create_account(GetLocal(m, old_size + 2));
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := Gt(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    tmp := GetLocal(m, old_size + 5);
+    if (!b#Boolean(tmp)) { goto Label_9; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call LibraAccount_pay_from_sender(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
+
+Label_9:
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_create_new_account_verify (arg0: Value, arg1: Value) returns ()
+{
+    call LibraAccount_create_new_account(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) returns ();procedure {:inline 1} LibraAccount_balance_for_account (arg0: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 6;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t2 := CopyOrMoveRef(t0);
+
+    call t3 := BorrowField(t2, LibraAccount_T_balance);
+
+    call t4 := LibraCoin_value(t3);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Integer(t4);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    ret0 := GetLocal(m, old_size + 5);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_balance_for_account_verify (arg0: Reference) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_balance_for_account(arg0);
+}
+
+procedure {:inline 1} LibraAccount_balance (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t3 := LibraAccount_balance_for_account(t2);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Integer(t3);
+
+    m := UpdateLocal(m, old_size + 3, t3);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_balance_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_balance(arg0);
+}
+
+procedure {:inline 1} LibraAccount_sequence_number_for_account (arg0: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t1 := CopyOrMoveRef(t0);
+
+    call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
+
+    call tmp := ReadRef(t2);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_sequence_number_for_account_verify (arg0: Reference) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_sequence_number_for_account(arg0);
+}
+
+procedure {:inline 1} LibraAccount_sequence_number (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t3 := LibraAccount_sequence_number_for_account(t2);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Integer(t3);
+
+    m := UpdateLocal(m, old_size + 3, t3);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_sequence_number_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_sequence_number(arg0);
+}
+
+procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(BooleanType())
+    var t4: Value; // BooleanType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
+
+    call tmp := ReadRef(t3);
+    assume is#Boolean(tmp);
+
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_delegated_key_rotation_capability_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_delegated_key_rotation_capability(arg0);
+}
+
+procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t3: Reference; // ReferenceType(BooleanType())
+    var t4: Value; // BooleanType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
+
+    call tmp := ReadRef(t3);
+    assume is#Boolean(tmp);
+
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_delegated_withdrawal_capability_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_delegated_withdrawal_capability(arg0);
+}
+
+procedure {:inline 1} LibraAccount_withdrawal_capability_address (arg0: Reference) returns (ret0: Reference)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var t2: Reference; // ReferenceType(AddressType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t1 := CopyOrMoveRef(t0);
+
+    call t2 := BorrowField(t1, LibraAccount_WithdrawalCapability_account_address);
+
+    ret0 := t2;
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultReference;
+}
+
+procedure LibraAccount_withdrawal_capability_address_verify (arg0: Reference) returns (ret0: Reference)
+{
+    call ret0 := LibraAccount_withdrawal_capability_address(arg0);
+}
+
+procedure {:inline 1} LibraAccount_key_rotation_capability_address (arg0: Reference) returns (ret0: Reference)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var t2: Reference; // ReferenceType(AddressType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t1 := CopyOrMoveRef(t0);
+
+    call t2 := BorrowField(t1, LibraAccount_KeyRotationCapability_account_address);
+
+    ret0 := t2;
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultReference;
+}
+
+procedure LibraAccount_key_rotation_capability_address_verify (arg0: Reference) returns (ret0: Reference)
+{
+    call ret0 := LibraAccount_key_rotation_capability_address(arg0);
+}
+
+procedure {:inline 1} LibraAccount_exists (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Address(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := Exists(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    ret0 := GetLocal(m, old_size + 2);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_exists_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_exists(arg0);
+}
+
+procedure {:inline 1} LibraAccount_prologue (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // AddressType()
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // AddressType()
+    var t11: Value; // AddressType()
+    var t12: Value; // BooleanType()
+    var t13: Value; // BooleanType()
+    var t14: Value; // IntegerType()
+    var t15: Value; // AddressType()
+    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t17: Value; // ByteArrayType()
+    var t18: Value; // ByteArrayType()
+    var t19: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t20: Reference; // ReferenceType(ByteArrayType())
+    var t21: Value; // ByteArrayType()
+    var t22: Value; // BooleanType()
+    var t23: Value; // BooleanType()
+    var t24: Value; // IntegerType()
+    var t25: Value; // IntegerType()
+    var t26: Value; // IntegerType()
+    var t27: Value; // IntegerType()
+    var t28: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t29: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t31: Value; // IntegerType()
+    var t32: Value; // IntegerType()
+    var t33: Value; // IntegerType()
+    var t34: Value; // BooleanType()
+    var t35: Value; // BooleanType()
+    var t36: Value; // IntegerType()
+    var t37: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t38: Reference; // ReferenceType(IntegerType())
+    var t39: Value; // IntegerType()
+    var t40: Value; // IntegerType()
+    var t41: Value; // IntegerType()
+    var t42: Value; // BooleanType()
+    var t43: Value; // BooleanType()
+    var t44: Value; // IntegerType()
+    var t45: Value; // IntegerType()
+    var t46: Value; // IntegerType()
+    var t47: Value; // BooleanType()
+    var t48: Value; // BooleanType()
+    var t49: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+    assume is#ByteArray(arg1);
+    assume is#Integer(arg2);
+    assume is#Integer(arg3);
+
+    old_size := local_counter;
+    local_counter := local_counter + 50;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+    m := UpdateLocal(m, old_size + 2, arg2);
+    m := UpdateLocal(m, old_size + 3, arg3);
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call tmp := Exists(GetLocal(m, old_size + 11), LibraAccount_T_type_value());
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 12));
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    tmp := GetLocal(m, old_size + 13);
+    if (!b#Boolean(tmp)) { goto Label_8; }
+
+    call tmp := LdConst(5);
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    goto Label_Abort;
+
+Label_8:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 15, tmp);
+
+    call t16 := BorrowGlobal(GetLocal(m, old_size + 15), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t5 := CopyOrMoveRef(t16);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    call t18 := Hash_sha3_256(GetLocal(m, old_size + 17));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t18);
+
+    m := UpdateLocal(m, old_size + 18, t18);
+
+    call t19 := CopyOrMoveRef(t5);
+
+    call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
+
+    call tmp := ReadRef(t20);
+    assume is#ByteArray(tmp);
+
+    m := UpdateLocal(m, old_size + 21, tmp);
+
+    tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 21)));
+    m := UpdateLocal(m, old_size + 22, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 22));
+    m := UpdateLocal(m, old_size + 23, tmp);
+
+    tmp := GetLocal(m, old_size + 23);
+    if (!b#Boolean(tmp)) { goto Label_21; }
+
+    call tmp := LdConst(2);
+    m := UpdateLocal(m, old_size + 24, tmp);
+
+    goto Label_Abort;
+
+Label_21:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 25, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 26, tmp);
+
+    call tmp := Mul(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 27, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 27));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t28 := CopyOrMoveRef(t5);
+
+    call t29 := FreezeRef(t28);
+
+    call t6 := CopyOrMoveRef(t29);
+
+    call t30 := CopyOrMoveRef(t6);
+
+    call t31 := LibraAccount_balance_for_account(t30);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Integer(t31);
+
+    m := UpdateLocal(m, old_size + 31, t31);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 31));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 32, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 33, tmp);
+
+    call tmp := Ge(GetLocal(m, old_size + 32), GetLocal(m, old_size + 33));
+    m := UpdateLocal(m, old_size + 34, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 34));
+    m := UpdateLocal(m, old_size + 35, tmp);
+
+    tmp := GetLocal(m, old_size + 35);
+    if (!b#Boolean(tmp)) { goto Label_38; }
+
+    call tmp := LdConst(6);
+    m := UpdateLocal(m, old_size + 36, tmp);
+
+    goto Label_Abort;
+
+Label_38:
+    call t37 := CopyOrMoveRef(t5);
+
+    call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
+
+    call tmp := ReadRef(t38);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 39, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 39));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 40, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
+    m := UpdateLocal(m, old_size + 41, tmp);
+
+    call tmp := Ge(GetLocal(m, old_size + 40), GetLocal(m, old_size + 41));
+    m := UpdateLocal(m, old_size + 42, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 42));
+    m := UpdateLocal(m, old_size + 43, tmp);
+
+    tmp := GetLocal(m, old_size + 43);
+    if (!b#Boolean(tmp)) { goto Label_49; }
+
+    call tmp := LdConst(3);
+    m := UpdateLocal(m, old_size + 44, tmp);
+
+    goto Label_Abort;
+
+Label_49:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 45, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
+    m := UpdateLocal(m, old_size + 46, tmp);
+
+    tmp := Boolean(IsEqual(GetLocal(m, old_size + 45), GetLocal(m, old_size + 46)));
+    m := UpdateLocal(m, old_size + 47, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 47));
+    m := UpdateLocal(m, old_size + 48, tmp);
+
+    tmp := GetLocal(m, old_size + 48);
+    if (!b#Boolean(tmp)) { goto Label_56; }
+
+    call tmp := LdConst(4);
+    m := UpdateLocal(m, old_size + 49, tmp);
+
+    goto Label_Abort;
+
+Label_56:
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_prologue_verify (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
+{
+    call LibraAccount_prologue(arg0, arg1, arg2, arg3);
+}
+
+procedure {:inline 1} LibraAccount_epilogue (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t7: Value; // IntegerType()
+    var t8: Value; // LibraCoin_T_type_value()
+    var t9: Value; // AddressType()
+    var t10: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t11: Value; // IntegerType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // IntegerType()
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t18: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t19: Value; // IntegerType()
+    var t20: Value; // IntegerType()
+    var t21: Value; // BooleanType()
+    var t22: Value; // BooleanType()
+    var t23: Value; // IntegerType()
+    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t25: Value; // IntegerType()
+    var t26: Value; // LibraCoin_T_type_value()
+    var t27: Value; // IntegerType()
+    var t28: Value; // IntegerType()
+    var t29: Value; // IntegerType()
+    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t31: Reference; // ReferenceType(IntegerType())
+    var t32: Value; // AddressType()
+    var t33: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t36: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+    assume is#Integer(arg1);
+    assume is#Integer(arg2);
+    assume is#Integer(arg3);
+
+    old_size := local_counter;
+    local_counter := local_counter + 37;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+    m := UpdateLocal(m, old_size + 2, arg2);
+    m := UpdateLocal(m, old_size + 3, arg3);
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call t10 := BorrowGlobal(GetLocal(m, old_size + 9), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t4 := CopyOrMoveRef(t10);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    call tmp := Sub(GetLocal(m, old_size + 12), GetLocal(m, old_size + 13));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    call tmp := Mul(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 15, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t16 := CopyOrMoveRef(t4);
+
+    call t17 := FreezeRef(t16);
+
+    call t6 := CopyOrMoveRef(t17);
+
+    call t18 := CopyOrMoveRef(t6);
+
+    call t19 := LibraAccount_balance_for_account(t18);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Integer(t19);
+
+    m := UpdateLocal(m, old_size + 19, t19);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 20, tmp);
+
+    call tmp := Ge(GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
+    m := UpdateLocal(m, old_size + 21, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 21));
+    m := UpdateLocal(m, old_size + 22, tmp);
+
+    tmp := GetLocal(m, old_size + 22);
+    if (!b#Boolean(tmp)) { goto Label_20; }
+
+    call tmp := LdConst(6);
+    m := UpdateLocal(m, old_size + 23, tmp);
+
+    goto Label_Abort;
+
+Label_20:
+    call t24 := CopyOrMoveRef(t4);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 25, tmp);
+
+    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(m, old_size + 25));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t26);
+
+    m := UpdateLocal(m, old_size + 26, t26);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 26));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 27, tmp);
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 28, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 29, tmp);
+
+    call t30 := CopyOrMoveRef(t4);
+
+    call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
+
+    call WriteRef(t31, GetLocal(m, old_size + 29));
+
+    call tmp := LdAddr(4078);
+    m := UpdateLocal(m, old_size + 32, tmp);
+
+    call t33 := BorrowGlobal(GetLocal(m, old_size + 32), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t5 := CopyOrMoveRef(t33);
+
+    call t34 := CopyOrMoveRef(t5);
+
+    call t35 := BorrowField(t34, LibraAccount_T_balance);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 36, tmp);
+
+    call LibraCoin_deposit(t35, GetLocal(m, old_size + 36));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_epilogue_verify (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
+{
+    call LibraAccount_epilogue(arg0, arg1, arg2, arg3);
+}
+
+procedure {:inline 1} LibraAccount_fresh_guid (arg0: Reference, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t1: Value; // AddressType()
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // ByteArrayType()
+    var t4: Value; // ByteArrayType()
+    var t5: Value; // ByteArrayType()
+    var t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t7: Reference; // ReferenceType(IntegerType())
+    var t8: Value; // AddressType()
+    var t9: Value; // ByteArrayType()
+    var t10: Reference; // ReferenceType(IntegerType())
+    var t11: Value; // IntegerType()
+    var t12: Value; // ByteArrayType()
+    var t13: Reference; // ReferenceType(IntegerType())
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(IntegerType())
+    var t18: Value; // ByteArrayType()
+    var t19: Value; // ByteArrayType()
+    var t20: Value; // ByteArrayType()
+    var t21: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Address(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 22;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t6 := CopyOrMoveRef(t0);
+
+    call t7 := BorrowField(t6, LibraAccount_EventHandleGenerator_counter);
+
+    call t2 := CopyOrMoveRef(t7);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call t9 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t9);
+
+    m := UpdateLocal(m, old_size + 9, t9);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call t10 := CopyOrMoveRef(t2);
+
+    call tmp := ReadRef(t10);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := U64Util_u64_to_bytes(GetLocal(m, old_size + 11));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t12);
+
+    m := UpdateLocal(m, old_size + 12, t12);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t13 := CopyOrMoveRef(t2);
+
+    call tmp := ReadRef(t13);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 15, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    call t17 := CopyOrMoveRef(t2);
+
+    call WriteRef(t17, GetLocal(m, old_size + 16));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 19, tmp);
+
+    call t20 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t20);
+
+    m := UpdateLocal(m, old_size + 20, t20);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 20));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 21, tmp);
+
+    ret0 := GetLocal(m, old_size + 21);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_fresh_guid_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_fresh_guid(arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, arg0: Reference, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t1: Value; // AddressType()
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t4: Value; // AddressType()
+    var t5: Value; // ByteArrayType()
+    var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Address(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 7;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := CopyOrMoveRef(t0);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call t5 := LibraAccount_fresh_guid(t3, GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#ByteArray(t5);
+
+    m := UpdateLocal(m, old_size + 5, t5);
+
+    assume is#Integer(GetLocal(m, old_size + 2));
+
+    assume is#ByteArray(GetLocal(m, old_size + 5));
+
+    call tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(m, old_size + 2), GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    ret0 := GetLocal(m, old_size + 6);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, arg0: Reference, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_new_event_handle_impl(tv0: TypeValue, arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var t6: Value; // AddressType()
+    var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 8;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t0 := CopyOrMoveRef(t3);
+
+    call t4 := CopyOrMoveRef(t0);
+
+    call t5 := BorrowField(t4, LibraAccount_T_event_generator);
+
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t7);
+
+    m := UpdateLocal(m, old_size + 7, t7);
+
+    ret0 := GetLocal(m, old_size + 7);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
+{
+    call ret0 := LibraAccount_new_event_handle(tv0: TypeValue);
+}
+
+procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, arg0: Reference, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var t1: Value; // tv0
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // ByteArrayType()
+    var t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var t5: Reference; // ReferenceType(ByteArrayType())
+    var t6: Value; // ByteArrayType()
+    var t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var t8: Reference; // ReferenceType(IntegerType())
+    var t9: Value; // ByteArrayType()
+    var t10: Reference; // ReferenceType(IntegerType())
+    var t11: Value; // IntegerType()
+    var t12: Value; // tv0
+    var t13: Reference; // ReferenceType(IntegerType())
+    var t14: Value; // IntegerType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(IntegerType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 18;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t4 := CopyOrMoveRef(t0);
+
+    call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
+
+    call tmp := ReadRef(t5);
+    assume is#ByteArray(tmp);
+
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t7 := CopyOrMoveRef(t0);
+
+    call t8 := BorrowField(t7, LibraAccount_EventHandle_counter);
+
+    call t2 := CopyOrMoveRef(t8);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call t10 := CopyOrMoveRef(t2);
+
+    call tmp := ReadRef(t10);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call LibraAccount_write_to_event_store(tv0, GetLocal(m, old_size + 9), GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
+    if (abort_flag) { goto Label_Abort; }
+
+    call t13 := CopyOrMoveRef(t2);
+
+    call tmp := ReadRef(t13);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 14, tmp);
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 15, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    call t17 := CopyOrMoveRef(t2);
+
+    call WriteRef(t17, GetLocal(m, old_size + 16));
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_emit_event_verify (tv0: TypeValue, arg0: Reference, arg1: Value) returns ()
+{
+    call LibraAccount_emit_event(tv0: TypeValue, arg0, arg1);
+}
+
+procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var t1: Value; // ByteArrayType()
+    var t2: Value; // IntegerType()
+    var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var t4: Value; // IntegerType()
+    var t5: Value; // ByteArrayType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 6;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(m, old_size + 3));
+    assume is#Integer(t4);
+
+    assume is#ByteArray(t5);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+    m := UpdateLocal(m, old_size + 5, t5);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, arg0: Value) returns ()
+{
+    call LibraAccount_destroy_handle(tv0: TypeValue, arg0);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -1,0 +1,896 @@
+
+
+// ** structs of module LibraCoin
+
+const unique LibraCoin_T: TypeName;
+const LibraCoin_T_value: FieldName;
+axiom LibraCoin_T_value == 0;
+function LibraCoin_T_type_value(): TypeValue {
+    StructType(LibraCoin_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_LibraCoin_T(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraCoin_T(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraCoin_T_value);
+}
+
+const unique LibraCoin_MintCapability: TypeName;
+const LibraCoin_MintCapability__dummy: FieldName;
+axiom LibraCoin_MintCapability__dummy == 0;
+function LibraCoin_MintCapability_type_value(): TypeValue {
+    StructType(LibraCoin_MintCapability, ExtendTypeValueArray(EmptyTypeValueArray, BooleanType()))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MintCapability(v0: Value) returns (v: Value)
+{
+    assume is#Boolean(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraCoin_MintCapability(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraCoin_MintCapability__dummy);
+}
+
+const unique LibraCoin_MarketCap: TypeName;
+const LibraCoin_MarketCap_total_value: FieldName;
+axiom LibraCoin_MarketCap_total_value == 0;
+function LibraCoin_MarketCap_type_value(): TypeValue {
+    StructType(LibraCoin_MarketCap, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MarketCap(v0: Value) returns (v: Value)
+{
+    assume is#Integer(v0);
+    v := Vector(ExtendValueArray(EmptyValueArray, v0));
+
+}
+
+procedure {:inline 1} Unpack_LibraCoin_MarketCap(v: Value) returns (v0: Value)
+{
+    assume is#Vector(v);
+    v0 := SelectField(v, LibraCoin_MarketCap_total_value);
+}
+
+
+
+// ** functions of module LibraCoin
+
+procedure {:inline 1} LibraCoin_mint_with_default_capability (arg0: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(arg0)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg0)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // IntegerType()
+    var t2: Value; // AddressType()
+    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t4: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t4);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_mint_with_default_capability_verify (arg0: Value) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_mint_with_default_capability(arg0);
+}
+
+procedure {:inline 1} LibraCoin_mint (arg0: Value, arg1: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(arg0)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg0)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(arg0) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(arg0) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // IntegerType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // BooleanType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // AddressType()
+    var t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Value; // IntegerType()
+    var t17: Value; // IntegerType()
+    var t18: Value; // IntegerType()
+    var t19: Value; // IntegerType()
+    var t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t21: Reference; // ReferenceType(IntegerType())
+    var t22: Value; // IntegerType()
+    var t23: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Integer(arg0);
+    assume IsValidReferenceParameter(local_counter, arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 24;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    t1 := arg1;
+
+    // bytecode translation starts here
+    call t4 := CopyOrMoveRef(t1);
+
+    // unimplemented instruction
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := LdConst(1000000000);
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := LdConst(1000000);
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := Le(GetLocal(m, old_size + 5), GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 9));
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    tmp := GetLocal(m, old_size + 10);
+    if (!b#Boolean(tmp)) { goto Label_11; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    goto Label_Abort;
+
+Label_11:
+    call tmp := LdAddr(173345816);
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call t13 := BorrowGlobal(GetLocal(m, old_size + 12), LibraCoin_MarketCap_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := CopyOrMoveRef(t13);
+
+    call t14 := CopyOrMoveRef(t2);
+
+    call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
+
+    call tmp := ReadRef(t15);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 19, tmp);
+
+    call t20 := CopyOrMoveRef(t2);
+
+    call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
+
+    call WriteRef(t21, GetLocal(m, old_size + 19));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 22, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 22));
+
+    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 22));
+    m := UpdateLocal(m, old_size + 23, tmp);
+
+    ret0 := GetLocal(m, old_size + 23);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_mint_verify (arg0: Value, arg1: Reference) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_mint(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_initialize () returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraCoin_MarketCap_total_value)) == (Integer(0))));
+ensures old(!(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Value; // AddressType()
+    var t2: Value; // BooleanType()
+    var t3: Value; // BooleanType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // BooleanType()
+    var t6: Value; // LibraCoin_MintCapability_type_value()
+    var t7: Value; // IntegerType()
+    var t8: Value; // LibraCoin_MarketCap_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 9;
+
+    // bytecode translation starts here
+    call tmp := GetTxnSenderAddress();
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call tmp := LdAddr(173345816);
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    tmp := GetLocal(m, old_size + 3);
+    if (!b#Boolean(tmp)) { goto Label_7; }
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call tmp := LdTrue();
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    assume is#Boolean(GetLocal(m, old_size + 5));
+
+    call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 7));
+
+    call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
+    if (abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraCoin_initialize_verify () returns ()
+{
+    call LibraCoin_initialize();
+}
+
+procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // AddressType()
+    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+
+    // bytecode translation starts here
+    call tmp := LdAddr(173345816);
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
+    if (abort_flag) { goto Label_Abort; }
+
+    call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+
+    call tmp := ReadRef(t2);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_market_cap_verify () returns (ret0: Value)
+{
+    call ret0 := LibraCoin_market_cap();
+}
+
+procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(0))));
+{
+    // declare local variables
+    var t0: Value; // IntegerType()
+    var t1: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 2;
+
+    // bytecode translation starts here
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 0));
+
+    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    ret0 := GetLocal(m, old_size + 1);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_zero_verify () returns (ret0: Value)
+{
+    call ret0 := LibraCoin_zero();
+}
+
+procedure {:inline 1} LibraCoin_value (arg0: Reference) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, arg0), LibraCoin_T_value))));
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t2: Reference; // ReferenceType(IntegerType())
+    var t3: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 4;
+    t0 := arg0;
+
+    // bytecode translation starts here
+    call t1 := CopyOrMoveRef(t0);
+
+    call t2 := BorrowField(t1, LibraCoin_T_value);
+
+    call tmp := ReadRef(t2);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    ret0 := GetLocal(m, old_size + 3);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_value_verify (arg0: Reference) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_value(arg0);
+}
+
+procedure {:inline 1} LibraCoin_split (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
+requires ExistsTxnSenderAccount(m, txn);
+{
+    // declare local variables
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Value; // IntegerType()
+    var t5: Value; // LibraCoin_T_type_value()
+    var t6: Value; // LibraCoin_T_type_value()
+    var t7: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 8;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t3 := BorrowLoc(old_size+0);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t5);
+
+    m := UpdateLocal(m, old_size + 5, t5);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    ret0 := GetLocal(m, old_size + 6);
+    ret1 := GetLocal(m, old_size + 7);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
+}
+
+procedure LibraCoin_split_verify (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
+{
+    call ret0, ret1 := LibraCoin_split(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_withdraw (arg0: Reference, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, arg0), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, arg0), LibraCoin_T_value))) - i#Integer(arg1)))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (arg1)));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t4: Reference; // ReferenceType(IntegerType())
+    var t5: Value; // IntegerType()
+    var t6: Value; // IntegerType()
+    var t7: Value; // IntegerType()
+    var t8: Value; // BooleanType()
+    var t9: Value; // BooleanType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Value; // IntegerType()
+    var t13: Value; // IntegerType()
+    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t15: Reference; // ReferenceType(IntegerType())
+    var t16: Value; // IntegerType()
+    var t17: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 18;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t3 := CopyOrMoveRef(t0);
+
+    call t4 := BorrowField(t3, LibraCoin_T_value);
+
+    call tmp := ReadRef(t4);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    tmp := GetLocal(m, old_size + 9);
+    if (!b#Boolean(tmp)) { goto Label_11; }
+
+    call tmp := LdConst(10);
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    goto Label_Abort;
+
+Label_11:
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 12, tmp);
+
+    call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 13, tmp);
+
+    call t14 := CopyOrMoveRef(t0);
+
+    call t15 := BorrowField(t14, LibraCoin_T_value);
+
+    call WriteRef(t15, GetLocal(m, old_size + 13));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    assume is#Integer(GetLocal(m, old_size + 16));
+
+    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
+    m := UpdateLocal(m, old_size + 17, tmp);
+
+    ret0 := GetLocal(m, old_size + 17);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_withdraw_verify (arg0: Reference, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_withdraw(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_join (arg0: Value, arg1: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(arg0, LibraCoin_T_value))) + i#Integer(old(SelectField(arg1, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(arg0, LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(arg0, LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t3: Value; // LibraCoin_T_type_value()
+    var t4: Value; // LibraCoin_T_type_value()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+    assume is#Vector(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, arg0);
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t2 := BorrowLoc(old_size+0);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure LibraCoin_join_verify (arg0: Value, arg1: Value) returns (ret0: Value)
+{
+    call ret0 := LibraCoin_join(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_deposit (arg0: Reference, arg1: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, arg0), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, arg0), LibraCoin_T_value))) + i#Integer(old(SelectField(arg1, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, arg0), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t1: Value; // LibraCoin_T_type_value()
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t5: Reference; // ReferenceType(IntegerType())
+    var t6: Value; // IntegerType()
+    var t7: Value; // LibraCoin_T_type_value()
+    var t8: Value; // IntegerType()
+    var t9: Value; // IntegerType()
+    var t10: Value; // IntegerType()
+    var t11: Value; // IntegerType()
+    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var t13: Reference; // ReferenceType(IntegerType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(arg1);
+
+    old_size := local_counter;
+    local_counter := local_counter + 14;
+    t0 := arg0;
+    m := UpdateLocal(m, old_size + 1, arg1);
+
+    // bytecode translation starts here
+    call t4 := CopyOrMoveRef(t0);
+
+    call t5 := BorrowField(t4, LibraCoin_T_value);
+
+    call tmp := ReadRef(t5);
+    assume is#Integer(tmp);
+
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
+    assume is#Integer(t8);
+
+    m := UpdateLocal(m, old_size + 8, t8);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 11, tmp);
+
+    call t12 := CopyOrMoveRef(t0);
+
+    call t13 := BorrowField(t12, LibraCoin_T_value);
+
+    call WriteRef(t13, GetLocal(m, old_size + 11));
+
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraCoin_deposit_verify (arg0: Reference, arg1: Value) returns ()
+{
+    call LibraCoin_deposit(arg0, arg1);
+}
+
+procedure {:inline 1} LibraCoin_destroy_zero (arg0: Value) returns ()
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean((SelectField(arg0, LibraCoin_T_value)) != (Integer(0)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean((SelectField(arg0, LibraCoin_T_value)) != (Integer(0))))) ==> abort_flag;
+{
+    // declare local variables
+    var t0: Value; // LibraCoin_T_type_value()
+    var t1: Value; // IntegerType()
+    var t2: Value; // LibraCoin_T_type_value()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+    var t5: Value; // IntegerType()
+    var t6: Value; // BooleanType()
+    var t7: Value; // BooleanType()
+    var t8: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume is#Vector(arg0);
+
+    old_size := local_counter;
+    local_counter := local_counter + 9;
+    m := UpdateLocal(m, old_size + 0, arg0);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
+    assume is#Integer(t3);
+
+    m := UpdateLocal(m, old_size + 3, t3);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := LdConst(0);
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call tmp := Not(GetLocal(m, old_size + 6));
+    m := UpdateLocal(m, old_size + 7, tmp);
+
+    tmp := GetLocal(m, old_size + 7);
+    if (!b#Boolean(tmp)) { goto Label_10; }
+
+    call tmp := LdConst(11);
+    m := UpdateLocal(m, old_size + 8, tmp);
+
+    goto Label_Abort;
+
+Label_10:
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+}
+
+procedure LibraCoin_destroy_zero_verify (arg0: Value) returns ()
+{
+    call LibraCoin_destroy_zero(arg0);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -23,3 +23,23 @@ fn verify_local_ref() {
 fn verify_ref_param() {
     test(VERIFY, &["test_mvir/verify-ref-param.mvir"]);
 }
+
+#[test]
+fn verify_libra_coin() {
+    test(VERIFY, &[verified_std_mvir("libra_coin").as_str()])
+}
+
+#[test]
+fn verify_libra_account() {
+    test(
+        VERIFY,
+        &[
+            verified_std_mvir("libra_coin").as_str(),
+            verified_std_mvir("hash").as_str(),
+            verified_std_mvir("u64_util").as_str(),
+            verified_std_mvir("address_util").as_str(),
+            verified_std_mvir("bytearray_util").as_str(),
+            verified_std_mvir("libra_account").as_str(),
+        ],
+    )
+}


### PR DESCRIPTION
## Motivation

This copies the specs for libra coin and account over from the CAV paper repo and adapts them to recent changes to return value notation in post conditions.

Moreover, this sets up the verification tests for those files. A user which has Z3_EXE and BOOGIE_EXE set should be able to run those tests. The tests currently verify what we have specified for `libra_coin`, but for `libra_account` there is a failure for `withdraw_with_capability`, solution for which is discussed elsewhere and pending. This one was marked with a TODO and the currently expected diagnosis was marked in the mvir source so it passes as a test for the remaining part of the `libra_account`.

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

This is a test.

## Related PRs

NA
