### PR TITLE
[Move-prover] Refine constraints on references.

### DIFF
--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
@@ -220,17 +220,12 @@ module LibraAccount {
     }
 
     // Withdraw `amount` LibraCoin.T from account under cap.account_address
-    // TODO: this currently fails verification (two expected errors marked with below). It appears that we need
-    //   more type assumptions for spec expression.
-    //!  A postcondition might not hold on this return path.
-    //!  A postcondition might not hold on this return path.
     public withdraw_with_capability(
         cap: &Self.WithdrawalCapability, amount: u64
     ): LibraCoin.T acquires T
     aborts_if !global_exists<Self.T>(cap.account_address)
     aborts_if global<Self.T>(cap.account_address).balance.value < amount
     ensures RET.value == amount
-    // this one doesn't pass Boogie
     ensures global<Self.T>(cap.account_address).balance.value == old(global<Self.T>(cap.account_address).balance.value) - amount
     {
         let account: &mut Self.T;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -374,7 +374,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
-    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Vector(Dereference(m, arg1));
+    assume IsValidReferenceParameter(m, local_counter, arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 24;
@@ -672,7 +673,8 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, arg0), LibraCoin
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -803,7 +805,8 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, arg0), LibraC
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -968,7 +971,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Vector(arg1);
 
     old_size := local_counter;
@@ -1675,7 +1679,8 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, a
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -1830,7 +1835,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -2076,7 +2082,8 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(arg0);
-    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Vector(Dereference(m, arg1));
+    assume IsValidReferenceParameter(m, local_counter, arg1);
     assume is#Integer(arg2);
     assume is#ByteArray(arg3);
 
@@ -2299,7 +2306,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#ByteArray(arg1);
 
     old_size := local_counter;
@@ -2425,7 +2433,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#ByteArray(arg1);
 
     old_size := local_counter;
@@ -2851,7 +2860,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 6;
@@ -2955,7 +2965,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -3155,7 +3166,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;
@@ -3196,7 +3208,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;
@@ -3740,7 +3753,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Address(arg1);
 
     old_size := local_counter;
@@ -3853,7 +3867,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Address(arg1);
 
     old_size := local_counter;
@@ -3989,7 +4004,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 18;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -166,7 +166,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
-    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Vector(Dereference(m, arg1));
+    assume IsValidReferenceParameter(m, local_counter, arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 24;
@@ -464,7 +465,8 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, arg0), LibraCoin
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -595,7 +597,8 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, arg0), LibraC
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -760,7 +763,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Vector(arg1);
 
     old_size := local_counter;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -734,7 +734,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -781,7 +782,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -828,7 +830,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -875,7 +878,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -922,7 +926,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -969,7 +974,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -1406,7 +1412,8 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Integer(arg0);
-    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Vector(Dereference(m, arg1));
+    assume IsValidReferenceParameter(m, local_counter, arg1);
 
     old_size := local_counter;
     local_counter := local_counter + 25;
@@ -1696,7 +1703,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -1823,7 +1831,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -1982,7 +1991,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Vector(arg1);
 
     old_size := local_counter;
@@ -2504,7 +2514,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -2651,7 +2662,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Integer(arg1);
 
     old_size := local_counter;
@@ -2897,7 +2909,8 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(arg0);
-    assume IsValidReferenceParameter(local_counter, arg1);
+    assume is#Vector(Dereference(m, arg1));
+    assume IsValidReferenceParameter(m, local_counter, arg1);
     assume is#Integer(arg2);
     assume is#ByteArray(arg3);
 
@@ -3121,7 +3134,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#ByteArray(arg1);
 
     old_size := local_counter;
@@ -3247,7 +3261,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#ByteArray(arg1);
 
     old_size := local_counter;
@@ -3673,7 +3688,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 6;
@@ -3777,7 +3793,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -3977,7 +3994,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;
@@ -4018,7 +4036,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;
@@ -4562,7 +4581,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Address(arg1);
 
     old_size := local_counter;
@@ -4675,7 +4695,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
     assume is#Address(arg1);
 
     old_size := local_counter;
@@ -4811,7 +4832,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 18;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -42,7 +42,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -313,7 +313,8 @@ ensures b#Boolean(Boolean((SelectField(SelectField(Dereference(m, arg0), TestSpe
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 1;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -22,7 +22,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Integer(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 3;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -44,7 +44,8 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, arg0), TestSpecs
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidReferenceParameter(local_counter, arg0);
+    assume is#Vector(Dereference(m, arg0));
+    assume IsValidReferenceParameter(m, local_counter, arg0);
 
     old_size := local_counter;
     local_counter := local_counter + 4;


### PR DESCRIPTION
## Motivation

This makes libra_account verification test pass, based on changes suggested by @cbarrettfb .

We may need to revisit this to fully understand why it's needed and whether a simpler version does exist, but because we have discussed a full elimination of references anyway, this discussion may become obsolete.

## Test Plan

Enables passing of old tests.

## Related PRs

NA
