### PR TITLE
[docker] Add script to run Vault in development mode

### DIFF
--- a/docker/vault/run.sh
+++ b/docker/vault/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+docker run --cap-add=IPC_LOCK --publish 8200:8200 --detach vault


### PR DESCRIPTION
# Motivation

We're going to explore Hashicorp Vault as the secrets manager component. This simple script runs Vault in development mode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Ran it, curled `localhost:8200`.