### PR TITLE
[bytecode verifier] Remove revisiting error blocks. Fix error collection and block updating

### DIFF
--- a/language/functional_tests/tests/testsuite/borrow_tests/move_one_branch.mvir
+++ b/language/functional_tests/tests/testsuite/borrow_tests/move_one_branch.mvir
@@ -1,0 +1,26 @@
+module M {
+    t0(cond: bool) {
+        let x: u64;
+        let x_ref: &mut u64;
+        x = 0;
+        x_ref = &mut x;
+        if (move(cond)) {
+            *move(x_ref) = 1;
+        }
+        x = 1;
+        return;
+    }
+
+    t1(cond: bool) {
+        let x: u64;
+        let x_ref: &mut u64;
+        x = 0;
+        x_ref = &mut x;
+        if (move(cond)) {
+        } else {
+            *move(x_ref) = 1;
+        }
+        x = 1;
+        return;
+    }
+}

--- a/language/functional_tests/tests/testsuite/commands/else_assigns_if_doesnt.mvir
+++ b/language/functional_tests/tests/testsuite/commands/else_assigns_if_doesnt.mvir
@@ -10,6 +10,4 @@ main() {
     return;
 }
 
-// TODO: duplicated errors
-// check: COPYLOC_UNAVAILABLE_ERROR
 // check: COPYLOC_UNAVAILABLE_ERROR

--- a/language/functional_tests/tests/testsuite/commands/if_assigns_else_doesnt.mvir
+++ b/language/functional_tests/tests/testsuite/commands/if_assigns_else_doesnt.mvir
@@ -11,6 +11,3 @@ main() {
 }
 
 // check: COPYLOC_UNAVAILABLE_ERROR
-
-// TODO: verifier is producing two identical errors, fix it?
-// check: COPYLOC_UNAVAILABLE_ERROR

--- a/language/functional_tests/tests/testsuite/commands/while_move_local.mvir
+++ b/language/functional_tests/tests/testsuite/commands/while_move_local.mvir
@@ -14,4 +14,3 @@ main() {
 // TODO: fix verifier remove identical errors
 // check: MOVELOC_UNAVAILABLE_ERROR
 // check: MOVELOC_UNAVAILABLE_ERROR
-// check: MOVELOC_UNAVAILABLE_ERROR

--- a/language/functional_tests/tests/testsuite/commands/while_move_local_2.mvir
+++ b/language/functional_tests/tests/testsuite/commands/while_move_local_2.mvir
@@ -18,4 +18,3 @@ main() {
 // TODO: fix verifier remove identical errors
 // check: MOVELOC_UNAVAILABLE_ERROR
 // check: MOVELOC_UNAVAILABLE_ERROR
-// check: MOVELOC_UNAVAILABLE_ERROR


### PR DESCRIPTION
##  Motivation

- Blocks were not revisited if there was previously an error. This is incorrect as a new joined context might make for a correct program
- Collected all errors in a block in a vector and kept them in the post condition
  - The code here is a bit of a mess now. We should split the type_memory_safety into 3 separate passes. This will give a good opportunity to clean up some of this logic.
- Fixed an additional bug where the post condition of a block wasn't actually updated...
- Added a test specifically for this behavior 

## Test Plan

- new tests
- cargo test
