### PR TITLE
[language][prover] Make use of now supported multiple return values in libra_account.

### DIFF
--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_coin.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_coin.mvir
@@ -20,14 +20,14 @@ module LibraCoin {
     // Since only the Association account has a mint capability, this will only succeed if it is
     // invoked by a transaction sent by that account.
     public mint_with_default_capability(amount: u64): Self.T acquires MintCapability, MarketCap
-    aborts_if !global_exists<Self.MintCapability>(txn_sender)
-    aborts_if !global_exists<Self.MarketCap>(0xA550C18)
-    // Over mint-able amount
-    aborts_if amount > 1000000000000000
-    // MarketCap overflow
-    aborts_if amount + global<Self.MarketCap>(0xA550C18).total_value > 9223372036854775807
-    ensures global<Self.MarketCap>(0xA550C18).total_value == old(global<Self.MarketCap>(0xA550C18).total_value) + amount
-    ensures RET.value == amount
+        aborts_if !global_exists<Self.MintCapability>(txn_sender)
+        aborts_if !global_exists<Self.MarketCap>(0xA550C18)
+        // Over mint-able amount
+        aborts_if amount > 1000000000000000
+        // MarketCap overflow
+        aborts_if amount + global<Self.MarketCap>(0xA550C18).total_value > 9223372036854775807
+        ensures global<Self.MarketCap>(0xA550C18).total_value == old(global<Self.MarketCap>(0xA550C18).total_value) + amount
+        ensures RET.value == amount
     {
         return Self.mint(move(amount), borrow_global<MintCapability>(get_txn_sender()));
     }
@@ -36,13 +36,13 @@ module LibraCoin {
     // Only the Association account can acquire such a reference, and it can do so only via
     // `borrow_sender_mint_capability`
     public mint(value: u64, capability: &Self.MintCapability): Self.T acquires MarketCap
-    aborts_if !global_exists<Self.MarketCap>(0xA550C18)
-    // Over mint-able amount
-    aborts_if value > 1000000000000000
-    // MarketCap overflow
-    aborts_if value + global<Self.MarketCap>(0xA550C18).total_value > 9223372036854775807
-    ensures global<Self.MarketCap>(0xA550C18).total_value == old(global<Self.MarketCap>(0xA550C18).total_value) + value
-    ensures RET.value == value
+        aborts_if !global_exists<Self.MarketCap>(0xA550C18)
+        // Over mint-able amount
+        aborts_if value > 1000000000000000
+        // MarketCap overflow
+        aborts_if value + global<Self.MarketCap>(0xA550C18).total_value > 9223372036854775807
+        ensures global<Self.MarketCap>(0xA550C18).total_value == old(global<Self.MarketCap>(0xA550C18).total_value) + value
+        ensures RET.value == value
     {
         let market_cap_ref: &mut Self.MarketCap;
         let market_cap_total_value: u64;
@@ -65,13 +65,13 @@ module LibraCoin {
     // This can only be invoked by the Association address, and only a single time.
     // Currently, it is invoked in the genesis transaction
     public initialize()
-    aborts_if txn_sender != 0xA550C18
-    aborts_if global_exists<Self.MintCapability>(txn_sender)
-    aborts_if global_exists<Self.MarketCap>(txn_sender)
-    ensures global_exists<Self.MintCapability>(txn_sender)
-    ensures global_exists<Self.MarketCap>(txn_sender)
-    ensures global<Self.MarketCap>(txn_sender).total_value == 0
-    // I'm not going to specify _dummy == true because I don't think we care.
+        aborts_if txn_sender != 0xA550C18
+        aborts_if global_exists<Self.MintCapability>(txn_sender)
+        aborts_if global_exists<Self.MarketCap>(txn_sender)
+        ensures global_exists<Self.MintCapability>(txn_sender)
+        ensures global_exists<Self.MarketCap>(txn_sender)
+        ensures global<Self.MarketCap>(txn_sender).total_value == 0
+        // I'm not going to specify _dummy == true because I don't think we care.
     {
         // Only callable by the Association address
         assert(get_txn_sender() == 0xA550C18, 1);
@@ -84,29 +84,32 @@ module LibraCoin {
 
     // Return the total value of all Libra in the system
     public market_cap(): u64 acquires MarketCap
-    aborts_if !global_exists<Self.MarketCap>(0xA550C18)
-    ensures RET == global<Self.MarketCap>(0xA550C18).total_value
+        aborts_if !global_exists<Self.MarketCap>(0xA550C18)
+        ensures RET == global<Self.MarketCap>(0xA550C18).total_value
     {
         return *&(borrow_global<MarketCap>(0xA550C18)).total_value;
     }
 
     // Create a new LibraCoin.T with a value of 0
     public zero(): Self.T
-    ensures RET.value == 0
+        ensures RET.value == 0
     {
         return T{value: 0};
     }
 
     // Public accessor for the value of a coin
     public value(coin_ref: &Self.T): u64
-    ensures RET == coin_ref.value
+        ensures RET == coin_ref.value
     {
         return *&move(coin_ref).value;
     }
 
     // Splits the given coin into two and returns them both
     // It leverages `Self.withdraw` for any verifications of the values
-    public split(coin: Self.T, amount: u64): Self.T * Self.T {
+    public split(coin: Self.T, amount: u64): Self.T * Self.T
+        aborts_if coin.value < amount
+        ensures RET(1).value == amount && RET(0).value == old(coin.value) - amount
+    {
         let other: Self.T;
         other = Self.withdraw(&mut coin, move(amount));
         return move(coin), move(other);
@@ -117,9 +120,9 @@ module LibraCoin {
     // The new coin will have a value = `amount`
     // Fails if the coins value is less than `amount`
     public withdraw(coin_ref: &mut Self.T, amount: u64): Self.T
-    aborts_if coin_ref.value < amount
-    ensures coin_ref.value == old(coin_ref.value) - amount
-    ensures RET.value == amount
+        aborts_if coin_ref.value < amount
+        ensures coin_ref.value == old(coin_ref.value) - amount
+        ensures RET.value == amount
     {
         let value: u64;
 
@@ -134,8 +137,8 @@ module LibraCoin {
 
     // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
     public join(coin1: Self.T, coin2: Self.T): Self.T
-    aborts_if coin1.value + coin2.value > 9223372036854775807
-    ensures RET.value == old(coin1.value) + old(coin2.value)
+        aborts_if coin1.value + coin2.value > 9223372036854775807
+        ensures RET.value == old(coin1.value) + old(coin2.value)
     {
         Self.deposit(&mut coin1, move(coin2));
         return move(coin1);
@@ -145,8 +148,8 @@ module LibraCoin {
     // The coin passed in by reference will have a value equal to the sum of the two coins
     // The `check` coin is consumed in the process
     public deposit(coin_ref: &mut Self.T, check: Self.T)
-    aborts_if coin_ref.value + check.value > 9223372036854775807
-    ensures coin_ref.value == old(coin_ref.value) + old(check.value)
+        aborts_if coin_ref.value + check.value > 9223372036854775807
+        ensures coin_ref.value == old(coin_ref.value) + old(check.value)
     {
         let value: u64;
         let check_value: u64;
@@ -162,7 +165,7 @@ module LibraCoin {
     // The amount of LibraCoin.T in the system is a tightly controlled property,
     // so you cannot "burn" any non-zero amount of LibraCoin.T
     public destroy_zero(coin: Self.T)
-    aborts_if coin.value != 0
+        aborts_if coin.value != 0
     {
         let value: u64;
         T { value } = move(coin);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -706,6 +706,9 @@ procedure LibraCoin_value_verify (arg0: Reference) returns (ret0: Value)
 
 procedure {:inline 1} LibraCoin_split (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
 requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean((SelectField(ret1, LibraCoin_T_value)) == (arg1))) && b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(arg0, LibraCoin_T_value))) - i#Integer(arg1)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(arg0, LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(arg0, LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // LibraCoin_T_type_value()

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -498,6 +498,9 @@ procedure LibraCoin_value_verify (arg0: Reference) returns (ret0: Value)
 
 procedure {:inline 1} LibraCoin_split (arg0: Value, arg1: Value) returns (ret0: Value, ret1: Value)
 requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean((SelectField(ret1, LibraCoin_T_value)) == (arg1))) && b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(arg0, LibraCoin_T_value))) - i#Integer(arg1)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(arg0, LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(arg0, LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // LibraCoin_T_type_value()


### PR DESCRIPTION
## Motivation

This proof-reads the specs in libra_account and adds spec for split with multiple return values which is now supported.

Also playing with the formatting to keep the code readable. It appears to me that indenting the conditions is better readable.

## Test Plan

New test

## Related PRs

NA

