### PR TITLE
Make a smoke test for cluster-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,10 @@ jobs:
           command: |
             [[ $CIRCLE_NODE_INDEX =~ [023] ]] || RUST_BACKTRACE=1 cargo build -j 16 --release
       - run:
+          name: Run Cluster Smoke Test
+          command: |
+            [[ $CIRCLE_NODE_INDEX =~ [023] ]] || scripts/smoke-test-swarm-cluster.sh
+      - run:
           name: Build Dev
           command: |
             [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16

--- a/scripts/smoke-test-swarm-cluster.sh
+++ b/scripts/smoke-test-swarm-cluster.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Launch a 4 node libra swarm and run cluster test against it for a short period
+
+set -e
+
+RUST_BACKTRACE=1 cargo run -p libra-swarm -- -n 4 -l > swarm.out &
+while [ true ]; do
+    sleep 5;
+    if [ ! -z "$(cat swarm.out | grep cluster-test | xargs )" ]; then
+        break
+    fi
+done
+ls -l swarm.out
+CMD=$(cat swarm.out | grep cluster-test | xargs)
+eval "RUST_BACKTRACE=1 $CMD --swarm-duration 90"
+kill %1
+rm -f swarm.out

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -58,6 +58,8 @@ struct Args {
         help = "If set, tries to connect to a libra-swarm instead of aws"
     )]
     swarm: bool,
+    #[structopt(long, help = "Time to run swarm test for in seconds")]
+    swarm_duration: Option<u64>,
 
     #[structopt(long, group = "action")]
     wipe_all_db: bool,
@@ -130,7 +132,8 @@ pub fn main() {
         };
         if args.swarm {
             let util = BasicSwarmUtil::setup(&args);
-            rt.block_on(util.emit_tx(args.accounts_per_client, thread_params));
+            let duration = args.swarm_duration.map(Duration::from_secs);
+            rt.block_on(util.emit_tx(args.accounts_per_client, thread_params, duration));
             return;
         } else {
             let util = ClusterUtil::setup(&args);
@@ -295,9 +298,14 @@ impl BasicSwarmUtil {
         }
     }
 
-    pub async fn emit_tx(self, accounts_per_client: usize, thread_params: EmitThreadParams) {
+    pub async fn emit_tx(
+        self,
+        accounts_per_client: usize,
+        thread_params: EmitThreadParams,
+        duration: Option<Duration>,
+    ) {
         let mut emitter = TxEmitter::new(&self.cluster);
-        emitter
+        let job = emitter
             .start_job(EmitJobRequest {
                 instances: self.cluster.validator_instances().to_vec(),
                 accounts_per_client,
@@ -305,7 +313,12 @@ impl BasicSwarmUtil {
             })
             .await
             .expect("Failed to start emit job");
-        thread::park();
+        if let Some(duration) = duration {
+            thread::sleep(duration);
+            emitter.stop_job(job);
+        } else {
+            thread::park();
+        }
     }
 }
 


### PR DESCRIPTION
This adds a `--swarm-duration` flag to cluster test, which makes it terminate after some number of seconds. This is used to create a new CI step that launches a 4 node swarm and runs cluster test against it for 90 seconds.

This should help prevent spurious breakage to cluster-test, but will not provide any performance information.