### PR TITLE
[cluster-test] ct: use master image by default

### DIFF
--- a/terraform/templates/cluster-test/ct
+++ b/terraform/templates/cluster-test/ct
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
-DOCKER_IMAGE="cluster-test:latest"
+DOCKER_IMAGE=""
 WAIT_TO="45m"
 export CONTAINER="cluster-test-$RANDOM"
 
@@ -27,6 +27,10 @@ while (( "$#" )); do
       WAIT_TO=$2
       shift 2
       ;;
+    -L|--latest)
+      DOCKER_IMAGE="cluster-test:latest"
+      shift 1
+      ;;
     --) # end argument parsing
       shift
       break
@@ -36,6 +40,14 @@ while (( "$#" )); do
       ;;
   esac
 done
+
+if [ -z "$DOCKER_IMAGE" ]
+then
+      echo "Using master cluster test image"
+      $(aws ecr get-login --no-include-email --region us-west-2)
+      DOCKER_IMAGE="853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:master"
+      docker pull $DOCKER_IMAGE
+fi
 
 # Waiting for other runs to finish
 timeout $WAIT_TO bash -c 'while [ $(docker ps --quiet --filter name=$CONTAINER) ]; do echo "Another container is running, waiting..."; sleep 1m; done'


### PR DESCRIPTION
Most of people don't want to build cluster test, only use it, so for them best option is to use latest master image

Added `-L` flag to use latest image built on host
