### PR TITLE
[dev-infra][build] Add buildspec and script for cluster-test

### DIFF
--- a/docker/build-aws-base.sh
+++ b/docker/build-aws-base.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+# build-aws-base.sh is a common script shared by mutiple build-aws.sh scripts
+
+if ! which jq &>/dev/null; then
+  echo "jq is not installed. Please install jq"
+  exit 1
+fi
+
+function print_usage() {
+  echo "Usage:"
+  echo "build-aws.sh --version pull/123 --addl_tags test_tag"
+  echo "build-aws.sh --version u29a020 --addl_tags test_tag"
+  exit 1
+}
+
+while [[ "$1" =~ ^- ]]; do case $1 in
+  --version )
+    shift;
+    if [[ "$1" =~ ^pull ]]; then
+      SOURCE_VERSION="refs/${1}/head"
+      TAGS="dev_${USER}_${1/\//_}"
+    else
+      SOURCE_VERSION="${1}"
+      TAGS="dev_${USER}_${1}"
+    fi
+    ;;
+  --addl_tags )
+    shift;
+    ADDL_TAGS="${1}"
+    ;;
+  --project )
+    shift;
+    PROJECT="${1}"
+    ;;
+  --help )
+    shift;
+    print_usage
+    ;;
+esac; shift; done
+
+if [ -z "${SOURCE_VERSION}" ]; then
+    print_usage
+fi
+
+if [[ -n "${ADDL_TAGS}" ]]; then
+  TAGS="${TAGS},${ADDL_TAGS}"
+fi
+
+echo "Building with SOURCE_VERSION=${SOURCE_VERSION} TAGS=${TAGS}"
+
+# Use : as the separator because environment-variables-override does not allow
+# comma in its specification
+BUILD_ID=$(aws codebuild start-build --project-name "${PROJECT}" \
+ --environment-variables-override name=TAGS,value=${TAGS//,/:} \
+ --source-version ${SOURCE_VERSION} | jq -r .build.id)
+
+if [ -z "${BUILD_ID}" ]; then
+  echo "Failed to submit build. Make sure you have proper AWS credentials in your environment."
+  exit 1
+fi
+
+echo "Started build with ID ${BUILD_ID}. Link to the build https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/${PROJECT}/build/${BUILD_ID}/"
+
+while true; do
+    BUILD_JSON=$(aws codebuild batch-get-builds --ids ${BUILD_ID})
+    BUILD_STATUS=$(echo $BUILD_JSON | jq -r '.builds[0].buildStatus')
+    CURRENT_PHASE=$(echo $BUILD_JSON | jq -r '.builds[0].currentPhase')
+    if [ $BUILD_STATUS = "IN_PROGRESS" ]; then
+        echo "Build in progress. Current phase: ${CURRENT_PHASE}..."
+        sleep 10
+    elif [ $BUILD_STATUS = "SUCCEEDED" ]; then
+        echo "Build and push completed successfully"
+        exit
+    else
+        echo "Build failed with status : ${BUILD_STATUS}"
+        exit 1
+    fi
+done

--- a/docker/cluster-test/build-aws.sh
+++ b/docker/cluster-test/build-aws.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-# build-aws.sh builds the validator-dynamic image on AWS Codebuild and pushes the image to AWS ECR.
+# build-aws.sh builds the cluster-test image on AWS Codebuild and pushes the image to AWS ECR.
 # Examples:
 # build-aws.sh --version pull/123 --addl_tags test_tag # Builds the image from pull request 123 and tags it with dev_pull_123,dev_u29a020,test_tag
 # build-aws.sh --version u29a020  --addl_tags test_tag # Builds the image from commit u29a020 and tags it with dev_u29a020,test_tag
 
-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../build-aws-base.sh --project libra-validator "$@"
+$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../build-aws-base.sh --project libra-cluster-test "$@"

--- a/docker/cluster-test/buildspec.yaml
+++ b/docker/cluster-test/buildspec.yaml
@@ -1,0 +1,21 @@
+# This buildspec is for AWS Codebuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker/cluster-test/build.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # Tag and push the docker images
+      - SOURCE=cluster-test:latest TARGET_REPO=$LIBRA_CLUSTER_TEST_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
## Summary

* This adds a buildspec which will be used to define the build for `cluster-test` on AWS Codebuild
* This also adds a script which can be invoked to trigger the build
* The `validator-dynamic/build-aws.sh` and `cluster-test/build-aws.sh` share a common base script `docker/build-aws-base.sh`