### PR TITLE
[language][move] Improve error diagnostic for missing space before less-than

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -181,7 +181,7 @@ fn address_directive(
         (None, Some(addr)) => addr,
         (None, None) => {
             context.error(vec![
-                    (loc, format!("Invalid module declration. No sender address was given as a command line argument. Add one using --{}. Or set the address at the top of the file using 'address _:'", crate::command_line::SENDER)),
+                    (loc, format!("Invalid module declaration. No sender address was given as a command line argument. Add one using --{}. Or set the address at the top of the file using 'address _:'", crate::command_line::SENDER)),
                 ]);
             Address::LIBRA_CORE
         }

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -471,7 +471,14 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
                     // assume that the "<" is a boolean operator.
                     let next_start = tokens.lookahead_start_loc();
                     if next_start == start_loc + tokens.content().len() {
-                        parse_pack_or_call(tokens)?
+                        match parse_pack_or_call(tokens) {
+                            Ok(x) => x,
+                            Err(mut e) => {
+                                let loc = make_loc(tokens.file_name(), next_start, next_start);
+                                e.push((loc, "Perhaps you need a blank space before this '<' operator?".to_string()));
+                                return Err(e)
+                            },
+                        }
                     } else {
                         Exp_::Name(parse_name(tokens)?)
                     }

--- a/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
@@ -1,11 +1,14 @@
 error: 
 
-   ┌── tests/move_check/expansion/standalone_mname_with_type_args.move:3:27 ───
+   ┌── tests/move_check/expansion/standalone_mname_with_type_args.move:3:22 ───
    │
  3 │         let _ = 0 + M<u64>;
    │                           ^ Unexpected token: ';'
    ·
  3 │         let _ = 0 + M<u64>;
    │                           - Expected: '{', '('
+   ·
+ 3 │         let _ = 0 + M<u64>;
+   │                      - Perhaps you need a blank space before this '<' operator?
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
@@ -1,11 +1,14 @@
 error: 
 
-   ┌── tests/move_check/expansion/standalone_name_with_type_args.move:3:23 ───
+   ┌── tests/move_check/expansion/standalone_name_with_type_args.move:3:18 ───
    │
  3 │         let _ = n<u64>;
    │                       ^ Unexpected token: ';'
    ·
  3 │         let _ = n<u64>;
    │                       - Expected: '{', '('
+   ·
+ 3 │         let _ = n<u64>;
+   │                  - Perhaps you need a blank space before this '<' operator?
    │
 

--- a/language/move-lang/tests/move_check/parser/less_than_space.exp
+++ b/language/move-lang/tests/move_check/parser/less_than_space.exp
@@ -1,0 +1,14 @@
+error: 
+
+   ┌── tests/move_check/parser/less_than_space.move:5:14 ───
+   │
+ 5 │         if (v< 10) return v;
+   │                ^^ Unexpected token: '10'
+   ·
+ 5 │         if (v< 10) return v;
+   │                -- Expected: '[Name]', '[Address]'
+   ·
+ 5 │         if (v< 10) return v;
+   │              - Perhaps you need a blank space before this '<' operator?
+   │
+

--- a/language/move-lang/tests/move_check/parser/less_than_space.move
+++ b/language/move-lang/tests/move_check/parser/less_than_space.move
@@ -1,0 +1,8 @@
+module M {
+    f(v: u64): u64 {
+        if (v < 5) return 5;
+	// Check for a useful diagnostic message when missing a space before "<"
+        if (v< 10) return v;
+        0
+    }
+}


### PR DESCRIPTION
Whitespace is generally not significant in Move but the exception is that space is required between an identifier and a '<' less-than operator. When parsing fails possibly due to a missing space, add a message to suggest adding a space.

## Motivation

Improve usability for a potentially common user error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test and updated existing tests.