### PR TITLE
[docker] fix and improve mint

### DIFF
--- a/docker/mint/docker-run.sh
+++ b/docker/mint/docker-run.sh
@@ -4,9 +4,15 @@
 
 set -ex
 export RUST_BACKTRACE=full
+
+seed=""
+if [ -n "${CFG_SEED}" ]; then
+    seed="-s $CFG_SEED"
+fi
+
 /opt/libra/bin/config-builder faucet \
     -o /opt/libra/etc \
-    -s $CFG_SEED
+    $seed
 
 cd /opt/libra/bin && \
 exec gunicorn --bind 0.0.0.0:8000 --access-logfile - --error-logfile - --log-level $LOG_LEVEL server

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -34,7 +34,7 @@ RUN pip3 install -r /libra/docker/mint/requirements.txt
 RUN mkdir -p /opt/libra/bin  /libra/client/data/wallet/
 
 COPY --from=builder /libra/target/release/client /opt/libra/bin
-COPY --from=builder /libra/target/release/faucet-config-builder /opt/libra/bin
+COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
 COPY docker/mint/server.py /opt/libra/bin
 COPY docker/mint/docker-run.sh /opt/libra/bin
 

--- a/docker/mint/run.sh
+++ b/docker/mint/run.sh
@@ -16,6 +16,9 @@ CONFIGDIR="$(dirname "$0")/../../terraform/validator-sets/dev"
 
 docker network create --subnet 172.18.0.0/24 testnet || true
 
-docker run -e AC_HOST="$AC_HOST" -e AC_PORT="$AC_PORT" -e LOG_LEVEL="$LOG_LEVEL" \
+docker run \
+    -e AC_HOST="$AC_HOST" \
+    -e AC_PORT="$AC_PORT" \
+    -e LOG_LEVEL="$LOG_LEVEL" \
 	-e MINT_KEY="$(base64 $CONFIGDIR/mint.key)" \
 	--network testnet --publish 8080:8000 "$IMAGE"


### PR DESCRIPTION
mint.Dockerfile didn't copy in config-builder, now it does.
run.sh was aesthetically improved.
docker-run.sh expected a seed when others did not, this makes it
compatible with other local runs.