### PR TITLE
[language][prover] Introduce the ability to define native move procedures and helper functions.

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
@@ -55,6 +55,8 @@ pub enum SpecExp {
     // TODO: binary operators not supported by Move like implies and iff
     /// Value of expression evaluated in the state before function enter.
     Old(Box<SpecExp>),
+    /// Call to a helper function.
+    Call(String, Vec<SpecExp>),
 }
 
 /// A specification directive to be verified

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1464,6 +1464,26 @@ fn parse_unary_spec_exp<'input>(
             consume_token(tokens, Tok::RParen)?;
             SpecExp::Old(Box::new(exp))
         }
+        Tok::NameValue => {
+            let next = tokens.lookahead();
+            if next.is_err() || next.unwrap() != Tok::LParen {
+                SpecExp::StorageLocation(parse_storage_location(tokens)?)
+            } else {
+                let name = parse_name(tokens)?;
+                let mut args = vec![];
+                consume_token(tokens, Tok::LParen)?;
+                while tokens.peek() != Tok::RParen {
+                    let exp = parse_spec_exp(tokens)?;
+                    args.push(exp);
+                    if tokens.peek() != Tok::Comma {
+                        break;
+                    }
+                    consume_token(tokens, Tok::Comma)?;
+                }
+                consume_token(tokens, Tok::RParen)?;
+                SpecExp::Call(name, args)
+            }
+        }
         _ => SpecExp::StorageLocation(parse_storage_location(tokens)?),
     })
 }

--- a/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
+++ b/language/functional_tests/tests/testsuite/prover/parser/conditions.mvir
@@ -256,4 +256,9 @@ module TestBinaryOps {
       return move(x) % 4;
   }
 
+  public ret_spec_function(x: u64): u64
+  ensures some_function(x, x) > RET
+  {
+      return move(x);
+  }
 }

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -49,6 +49,8 @@ pub struct Options {
     pub boogie_flags: Vec<String>,
     /// Whether to only generate boogie
     pub generate_only: bool,
+    /// Whether to generate stubs for native functions.
+    pub native_stubs: bool,
 }
 
 impl Default for Options {
@@ -64,6 +66,7 @@ impl Default for Options {
             cvc4_exe: "".to_string(),
             boogie_flags: vec![],
             generate_only: false,
+            native_stubs: false,
         }
     }
 }
@@ -107,6 +110,11 @@ impl Options {
                     .short("g")
                     .long("generate-only")
                     .help("only generate boogie file but do not call boogie"),
+            )
+            .arg(
+                Arg::with_name("native-stubs")
+                    .long("native-stubs")
+                    .help("whether to generate stubs for native functions"),
             )
             .arg(
                 Arg::with_name("boogie-exe")
@@ -181,6 +189,7 @@ impl Options {
             _ => unreachable!("should not happen"),
         };
         self.generate_only = matches.is_present("generate-only");
+        self.native_stubs = matches.is_present("native-stubs");
         self.use_cvc4 = matches.is_present("use-cvc4");
         self.boogie_exe = get_with_default("boogie-exe");
         self.z3_exe = get_with_default("z3-exe");

--- a/language/move-prover/bytecode-to-boogie/src/translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/translator.rs
@@ -13,6 +13,7 @@
 //!    for example, how to construct a TypeValue from a SignatureToken, how to access memory,
 //!    and so on.
 
+use crate::cli::Options;
 use crate::spec_translator::SpecTranslator;
 use bytecode_source_map::source_map::ModuleSourceMap;
 use bytecode_verifier::VerifiedModule;
@@ -65,6 +66,7 @@ pub struct FunctionInfo {
 }
 
 pub struct BoogieTranslator<'a> {
+    pub options: &'a Options,
     pub modules: &'a [VerifiedModule],
     pub module_infos: &'a [ModuleInfo],
     pub source_maps: &'a [ModuleSourceMap<Loc>],
@@ -87,6 +89,7 @@ pub struct ModuleTranslator<'a> {
 
 impl<'a> BoogieTranslator<'a> {
     pub fn new(
+        options: &'a Options,
         modules: &'a [VerifiedModule],
         module_infos: &'a [ModuleInfo],
         source_maps: &'a [ModuleSourceMap<Loc>],
@@ -109,6 +112,7 @@ impl<'a> BoogieTranslator<'a> {
             }
         }
         Self {
+            options,
             modules,
             module_infos,
             source_maps,
@@ -311,10 +315,12 @@ impl<'a> ModuleTranslator<'a> {
         // translation of stackless bytecode
         for (idx, function_def) in self.module.function_defs().iter().enumerate() {
             if function_def.is_native() {
-                res.push_str(&self.generate_function_sig(idx, true, &None));
-                res.push_str(";");
-                res.push_str(&self.generate_function_spec(idx, &None));
-                res.push_str("\n");
+                if self.parent.options.native_stubs {
+                    res.push_str(&self.generate_function_sig(idx, true, &None));
+                    res.push_str(";");
+                    res.push_str(&self.generate_function_spec(idx, &None));
+                    res.push_str("\n");
+                }
                 continue;
             }
             res.push_str(&self.translate_function(idx));

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.mvir
@@ -68,4 +68,10 @@ module TestSpecs {
     {
         return (7, false, 10);
     }
+
+    public helper_function(x: u64): u64
+      ensures number_in_range(x) && x < max_u64()
+    {
+        return move(x);
+    }
 }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.prover.bpl
@@ -1,0 +1,9 @@
+// Boogie helper functions for test-specs-translate.mvir
+
+function {:inline} number_in_range(x: Value): Value {
+  Boolean(i#Integer(x) >= 0 && i#Integer(x) < 128)
+}
+
+function {:inline} max_u64(): Value {
+  Integer(MAX_U64)
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/address_util.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/address_util.prover.bpl
@@ -1,0 +1,6 @@
+// Native functions and helpers for address_util
+
+// TODO: fill in implementation
+procedure {:inline 1} AddressUtil_address_to_bytes (arg0: Value) returns (ret0: Value);
+  requires ExistsTxnSenderAccount(m, txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/bytearray_util.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/bytearray_util.prover.bpl
@@ -1,0 +1,6 @@
+// Native functions and helpers for bytearray_util
+
+// TODO: fill in implementation
+procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/hash.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/hash.prover.bpl
@@ -1,0 +1,10 @@
+// Native functions and helpers for hash
+
+// TODO: fill in implementation
+procedure {:inline 1} Hash_sha2_256 (arg0: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+procedure {:inline 1} Hash_sha3_256 (arg0: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
@@ -113,7 +113,7 @@ module LibraAccount {
         aborts_if !global_exists<Self.T>(txn_sender)
         aborts_if !global_exists<Self.T>(payee)
         aborts_if to_deposit.value == 0
-        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > 9223372036854775807
+        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_balance()
         ensures global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + to_deposit.value
     {
         Self.deposit_with_metadata(move(payee), move(to_deposit), h"");
@@ -130,7 +130,7 @@ module LibraAccount {
         aborts_if !global_exists<Self.T>(txn_sender)
         aborts_if !global_exists<Self.T>(payee)
         aborts_if to_deposit.value == 0
-        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > 9223372036854775807
+        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_balance()
         ensures global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + to_deposit.value
     {
         Self.deposit_with_sender_and_metadata(
@@ -154,7 +154,7 @@ module LibraAccount {
         aborts_if !global_exists<Self.T>(payee)
         aborts_if !global_exists<Self.T>(sender)
         aborts_if to_deposit.value == 0
-        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > 9223372036854775807
+        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_balance()
         ensures global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + to_deposit.value
     {
         let deposit_value: u64;
@@ -320,7 +320,7 @@ module LibraAccount {
         aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
         aborts_if txn_sender == payee
         aborts_if amount == 0
-        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > 9223372036854775807
+        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_balance()
         aborts_if global<Self.T>(txn_sender).balance.value < amount
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
@@ -351,7 +351,7 @@ module LibraAccount {
         aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
         aborts_if txn_sender == payee
         aborts_if amount == 0
-        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > 9223372036854775807
+        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_balance()
         aborts_if global<Self.T>(txn_sender).balance.value < amount
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
@@ -468,7 +468,7 @@ module LibraAccount {
         aborts_if global_exists<Self.T>(fresh_address)
         aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
         aborts_if global<Self.T>(txn_sender).balance.value < initial_balance
-        aborts_if initial_balance > 9223372036854775807
+        aborts_if initial_balance > max_balance()
         ensures global_exists<Self.T>(fresh_address)
         ensures global<Self.T>(fresh_address).balance.value == initial_balance
         ensures !global<Self.T>(fresh_address).delegated_withdrawal_capability
@@ -629,7 +629,7 @@ module LibraAccount {
     // hash it with the sender's address, the result is guaranteed to be globally unique.
     fresh_guid(counter: &mut Self.EventHandleGenerator, sender: address): bytearray
         succeeds_if true
-        // aborts_if counter.counter + 1 > 9223372036854775807
+        // aborts_if counter.counter + 1 > max_balance()
     {
         let count: &mut u64;
         let count_bytes: bytearray;
@@ -656,7 +656,7 @@ module LibraAccount {
     // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
     new_event_handle_impl<T: unrestricted>(counter: &mut Self.EventHandleGenerator, sender: address): Self.EventHandle<T>
         succeeds_if true
-        // aborts_if counter.counter + 1 > 9223372036854775807
+        // aborts_if counter.counter + 1 > max_balance()
     {
         return EventHandle<T> {counter: 0, guid: Self.fresh_guid(move(counter), move(sender))};
     }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.prover.bpl
@@ -1,0 +1,18 @@
+// Native functions and helpers for libra_account
+
+// TODO: fill in implementation
+
+procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) returns ();
+  requires ExistsTxnSenderAccount(m, txn);
+  ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
+  ensures !abort_flag ==> b#Boolean(Boolean((Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
+  ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !abort_flag;
+  ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> abort_flag;
+
+procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
+  requires ExistsTxnSenderAccount(m, txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+function {:inline 1} max_balance(): Value {
+  Integer(9223372036854775807)
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/u64_util.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/u64_util.prover.bpl
@@ -1,0 +1,6 @@
+// Native functions and helpers for u64_util
+
+// TODO: fill in implementation
+procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -1,4 +1,55 @@
 
+// ** helpers from test_mvir/verify-stdlib/hash.prover.bpl// Native functions and helpers for hash
+
+// TODO: fill in implementation
+procedure {:inline 1} Hash_sha2_256 (arg0: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+procedure {:inline 1} Hash_sha3_256 (arg0: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+// ** helpers from test_mvir/verify-stdlib/u64_util.prover.bpl// Native functions and helpers for u64_util
+
+// TODO: fill in implementation
+procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+// ** helpers from test_mvir/verify-stdlib/address_util.prover.bpl// Native functions and helpers for address_util
+
+// TODO: fill in implementation
+procedure {:inline 1} AddressUtil_address_to_bytes (arg0: Value) returns (ret0: Value);
+  requires ExistsTxnSenderAccount(m, txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+// ** helpers from test_mvir/verify-stdlib/bytearray_util.prover.bpl// Native functions and helpers for bytearray_util
+
+// TODO: fill in implementation
+procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) returns (ret0: Value);
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+// ** helpers from test_mvir/verify-stdlib/libra_account.prover.bpl// Native functions and helpers for libra_account
+
+// TODO: fill in implementation
+
+procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) returns ();
+  requires ExistsTxnSenderAccount(m, txn);
+  ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
+  ensures !abort_flag ==> b#Boolean(Boolean((Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
+  ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !abort_flag;
+  ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> abort_flag;
+
+procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
+  requires ExistsTxnSenderAccount(m, txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+
+function {:inline 1} max_balance(): Value {
+  Integer(9223372036854775807)
+}
+
 
 // ** structs of module LibraCoin
 
@@ -1123,37 +1174,17 @@ procedure LibraCoin_destroy_zero_verify (arg0: Value) returns ()
 
 // ** functions of module Hash
 
-procedure {:inline 1} Hash_sha2_256 (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
-
-procedure {:inline 1} Hash_sha3_256 (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
-
 
 
 // ** functions of module U64Util
-
-procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
 
 
 
 // ** functions of module AddressUtil
 
-procedure {:inline 1} AddressUtil_address_to_bytes (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
-
 
 
 // ** functions of module BytearrayUtil
-
-procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
 
 
 
@@ -1326,8 +1357,8 @@ procedure LibraAccount_make_verify (arg0: Value) returns (ret0: Value)
 procedure {:inline 1} LibraAccount_deposit (arg0: Value, arg1: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(arg1, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(max_balance()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(max_balance())))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -1380,8 +1411,8 @@ procedure LibraAccount_deposit_verify (arg0: Value, arg1: Value) returns ()
 procedure {:inline 1} LibraAccount_deposit_with_metadata (arg0: Value, arg1: Value, arg2: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(arg1, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(max_balance()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean((SelectField(arg1, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg1, LibraCoin_T_value)))) > i#Integer(max_balance())))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -1442,8 +1473,8 @@ procedure LibraAccount_deposit_with_metadata_verify (arg0: Value, arg1: Value, a
 procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (arg0: Value, arg1: Value, arg2: Value, arg3: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(arg2, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg1)))))) || b#Boolean(Boolean((SelectField(arg2, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg1)))))) || b#Boolean(Boolean((SelectField(arg2, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg1)))))) || b#Boolean(Boolean((SelectField(arg2, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg2, LibraCoin_T_value)))) > i#Integer(max_balance()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg1)))))) || b#Boolean(Boolean((SelectField(arg2, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(arg2, LibraCoin_T_value)))) > i#Integer(max_balance())))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2211,8 +2242,8 @@ requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
 ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(arg1)))))));
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(arg1)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(Integer(9223372036854775807)))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(Integer(9223372036854775807)))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
+ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2327,8 +2358,8 @@ requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
 ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(arg1)))))));
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(arg1)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(Integer(9223372036854775807)))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(Integer(9223372036854775807)))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
+ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))))) ==> !abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (arg0))) || b#Boolean(Boolean((arg1) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(arg1))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1)))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2904,8 +2935,8 @@ ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(),
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_balance), LibraCoin_T_value)) == (arg1)));
 ensures !abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0))), LibraAccount_T_delegated_withdrawal_capability)))));
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(arg1)))));
-ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))) || b#Boolean(Boolean(i#Integer(arg1) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))) || b#Boolean(Boolean(i#Integer(arg1) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))) || b#Boolean(Boolean(i#Integer(arg1) > i#Integer(max_balance()))))) ==> !abort_flag;
+ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(arg1))) || b#Boolean(Boolean(i#Integer(arg1) > i#Integer(max_balance())))) ==> abort_flag;
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2974,13 +3005,6 @@ procedure LibraAccount_create_new_account_verify (arg0: Value, arg1: Value) retu
     assume ExistsTxnSenderAccount(m, txn);
     call LibraAccount_create_new_account(arg0, arg1);
 }
-
-procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) returns ();
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
-ensures !abort_flag ==> b#Boolean(Boolean((Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
-ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> abort_flag;
 
 procedure {:inline 1} LibraAccount_balance_for_account (arg0: Reference) returns (ret0: Value)
 requires ExistsTxnSenderAccount(m, txn);
@@ -4218,10 +4242,6 @@ procedure LibraAccount_emit_event_verify (tv0: TypeValue, arg0: Reference, arg1:
     assume ExistsTxnSenderAccount(m, txn);
     call LibraAccount_emit_event(tv0: TypeValue, arg0, arg1);
 }
-
-procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
 
 procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, arg0: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);

--- a/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
@@ -42,7 +42,9 @@ fn test_aborts_if() {
 #[test]
 fn test_lib() {
     test(
-        NO_VERIFY,
+        // We have not yet created .prover.bpl stubs for native functions in library, so instruct
+        // translator to generate them.
+        &["--native-stubs", "-B=-noVerify"],
         &[
             &std_mvir("vector"),
             &std_mvir("u64_util"),


### PR DESCRIPTION
## Motivation

This adds the ability to add a file `<name>.prover.bpl` which lives SxS with `<name>.mvir` and contains boogie definitions for native move functions as well as helper functions for the specifications.

The helper functions are a bit of a hack as we cannot type check them in the spec_translator, but they
should work as long as they result integers and other primitive values.

Existing generation of stubs for native functions is now behind a flag which is by default false.
The feature hasn't been used yet to define a lot of helpers and/or override definitions for native
functions beyond what the compiler also generates, which happens in a separate step.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests pass.

## Related PRs

NA