### PR TITLE
[docker] remove quote around $seed in mint

### DIFF
--- a/docker/mint/docker-run.sh
+++ b/docker/mint/docker-run.sh
@@ -12,7 +12,7 @@ fi
 
 /opt/libra/bin/config-builder faucet \
     -o /opt/libra/etc \
-    "$seed"
+    $seed
 
 cd /opt/libra/bin && \
 exec gunicorn --bind 0.0.0.0:8000 --access-logfile - --error-logfile - --log-level $LOG_LEVEL server


### PR DESCRIPTION
This was a recommendation from a linter but it breaks mint. Perhaps the
better solution would be either to break this up into different
parameters.