### PR TITLE
dev-setup: remove unneeded dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,8 @@ commands:
       - run:
           name: Install Dependencies
           command: |
-            sudo sh -c 'echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list'
             sudo apt-get update
             sudo apt-get install -y cmake curl
-            sudo apt-get clean
-            sudo rm -r /var/lib/apt/lists/*
             rustup component add clippy rustfmt
   install_code_coverage_deps:
     steps:

--- a/docker/circleci/circleci.Dockerfile
+++ b/docker/circleci/circleci.Dockerfile
@@ -1,11 +1,6 @@
 FROM circleci/rust:buster
 
-RUN sudo sh -c 'echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list' && \
-        sudo apt-get update && \
-        sudo apt-get install -y protobuf-compiler/buster cmake curl && \
-        sudo apt-get clean && \
-        sudo rm -rf /var/lib/apt/lists/* && \
-        cargo install sccache
+RUN cargo install sccache
 
 RUN cd /tmp && \
         git clone https://github.com/libra/libra && \

--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -3,9 +3,7 @@ FROM debian:buster AS toolchain
 # To use http/https proxy while building, use:
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cmake curl clang git
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/docker/cluster-test/cluster-test.Dockerfile
+++ b/docker/cluster-test/cluster-test.Dockerfile
@@ -9,7 +9,7 @@
 FROM debian:buster AS builder
 ## To use http/https proxy while building, use:
 ## docker build --build-arg https_proxy=http:
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git
+RUN apt-get update && apt-get install -y cmake curl clang git
 RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"
 WORKDIR /libra

--- a/docker/cluster-test/cluster-test.builder.Dockerfile
+++ b/docker/cluster-test/cluster-test.builder.Dockerfile
@@ -3,8 +3,7 @@ FROM debian:buster AS builder
 ## To use http/https proxy while building, use:
 ## docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git
+RUN apt-get update && apt-get install -y cmake curl clang git
 
 RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -3,9 +3,7 @@ FROM debian:buster AS toolchain
 # To use http/https proxy while building, use:
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cmake curl clang git
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -3,9 +3,7 @@ FROM debian:buster AS toolchain
 # To use http/https proxy while building, use:
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cmake curl clang git
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/docker/validator-dynamic/validator-dynamic.Dockerfile
+++ b/docker/validator-dynamic/validator-dynamic.Dockerfile
@@ -3,9 +3,7 @@ FROM debian:buster AS toolchain
 # To use http/https proxy while building, use:
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cmake curl clang git
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -3,9 +3,7 @@ FROM debian:buster AS toolchain
 # To use http/https proxy while building, use:
 # docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list \
-    && apt-get update && apt-get install -y protobuf-compiler/buster cmake curl clang git \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y cmake curl clang git
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -51,7 +51,7 @@ Welcome to Libra!
 This script will download and install the necessary dependencies needed to
 build Libra Core. This includes:
 	* Rust (and the necessary components, e.g. rust-fmt, clippy)
-	* CMake, protobuf
+	* CMake
 
 If you'd prefer to install these dependencies yourself, please exit this script
 now with Ctrl-C.
@@ -99,33 +99,6 @@ else
 		sudo pacman -Syu cmake --noconfirm
 	elif [[ "$PACKAGE_MANAGER" == "brew" ]]; then
 		brew install cmake
-	fi
-fi
-
-echo "Installing Protobuf......"
-if which protoc &>/dev/null; then
-  echo "Protobuf is already installed"
-else
-	if [[ "$OSTYPE" == "linux-gnu" ]]; then
-		if ! which unzip &>/dev/null; then
-			echo "Installing unzip......"
-			if [[ "$PACKAGE_MANAGER" == "yum" ]]; then
-				sudo yum install unzip -y
-			elif [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
-				sudo apt-get install unzip -y
-			elif [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
-				sudo pacman -Syu unzip --noconfirm
-			fi
-		fi
-		PROTOC_VERSION=3.8.0
-		PROTOC_ZIP=protoc-$PROTOC_VERSION-linux-x86_64.zip
-		curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP
-		sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
-		sudo unzip -o $PROTOC_ZIP -d /usr/local include/*
-		rm -f $PROTOC_ZIP
-		echo "protoc is installed to /usr/local/bin/"
-	else
-		brew install protobuf
 	fi
 fi
 


### PR DESCRIPTION
Now that we have finished migrating off of grpcio to using tonic we no
longer need to have developers install a number of extra dependencies
that were necessary to build grpcio (since it is a wrapper around a C
lib).

Remove these extra dependencies from the dev-setup script as well as all
of our Dockerfile.
