### PR TITLE
[crypto] Add more compact Debug impl for public key types

### DIFF
--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -59,7 +59,7 @@ pub struct Ed25519PrivateKey(ed25519_dalek::SecretKey);
 static_assertions::assert_not_impl_any!(Ed25519PrivateKey: Clone);
 
 /// An Ed25519 public key
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Ed25519PublicKey(ed25519_dalek::PublicKey);
 
 /// An Ed25519 signature
@@ -256,7 +256,13 @@ impl VerifyingKey for Ed25519PublicKey {
 
 impl std::fmt::Display for Ed25519PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&self.0.to_bytes()[..]))
+        write!(f, "{}", hex::encode(&self.0.as_bytes()))
+    }
+}
+
+impl std::fmt::Debug for Ed25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Ed25519PublicKey({})", self)
     }
 }
 

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -85,12 +85,12 @@ pub struct X25519EphemeralPrivateKey(x25519_dalek::EphemeralSecret);
 pub struct X25519StaticPrivateKey(x25519_dalek::StaticSecret);
 
 /// An x25519 public key
-#[derive(Clone, Debug, Deref)]
+#[derive(Clone, Deref)]
 pub struct X25519PublicKey(x25519_dalek::PublicKey);
 
 /// An x25519 public key to match the X25519Static key type, which
 /// dereferences to an X25519PublicKey
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct X25519StaticPublicKey(X25519PublicKey);
 
 /// An x25519 shared key
@@ -288,6 +288,30 @@ impl TryFrom<&[u8]> for X25519StaticPublicKey {
 impl ValidKey for X25519StaticPublicKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.deref().0.as_bytes().to_vec()
+    }
+}
+
+impl std::fmt::Display for X25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0.as_bytes()))
+    }
+}
+
+impl std::fmt::Debug for X25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "X25519PublicKey({})", self)
+    }
+}
+
+impl std::fmt::Display for X25519StaticPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl std::fmt::Debug for X25519StaticPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "X25519StaticPublicKey({})", self)
     }
 }
 


### PR DESCRIPTION
When debug printing `Ed25519PublicKey` and `X25519PublicKey`, we
currently get extremely noisy output as there are many intermediate
wrapping types and rust's debug output for byte slices is too long. With
this diff, we instead print out
`Ed25519PublicKey(<hex-encoded-pubkey>)` for `Debug`, which is more
compact and readable.