### PR TITLE
[cluster-test] Simplify running performance test

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -96,12 +96,9 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
         "packet_loss_random_validators",
         f::<PacketLossRandomValidatorsParams>(),
     );
+    known_experiments.insert("bench", f::<PerformanceBenchmarkNodesDownParams>());
     known_experiments.insert(
-        "performance_benchmark_nodes_down",
-        f::<PerformanceBenchmarkNodesDownParams>(),
-    );
-    known_experiments.insert(
-        "performance_benchmark_three_region_simulation",
+        "bench_three_region",
         f::<PerformanceBenchmarkThreeRegionSimulationParams>(),
     );
     known_experiments.insert(

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -24,7 +24,7 @@ use structopt::StructOpt;
 pub struct PerformanceBenchmarkNodesDownParams {
     #[structopt(
         long,
-        default_value = "10",
+        default_value = "0",
         help = "Number of nodes which should be down"
     )]
     pub num_nodes_down: usize,


### PR DESCRIPTION
This diff simplify most common use case of running performance benchmark with no nodes down
- Renames `performance_benchmark_nodes_down` experiment to `bench`
- Sets default node down to 0
- Renames `performance_benchmark_three_region_simulation` to similar naming schema
