### PR TITLE
[Storage] Rename all client APIs to not end with async

### DIFF
--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -58,7 +58,7 @@ impl AdmissionControlService {
             ledger_consistency_proof,
         ) = self
             .storage_read_client
-            .update_to_latest_ledger_async(rust_req.client_known_version, rust_req.requested_items)
+            .update_to_latest_ledger(rust_req.client_known_version, rust_req.requested_items)
             .await?;
         let rust_resp = libra_types::get_with_proof::UpdateToLatestLedgerResponse::new(
             response_items,

--- a/consensus/src/chained_bft/persistent_storage.rs
+++ b/consensus/src/chained_bft/persistent_storage.rs
@@ -311,7 +311,7 @@ impl<T: Payload> PersistentStorage<T> for StorageWriteProxy {
         // find the block corresponding to storage latest ledger info
         let startup_info = self
             .read_client
-            .get_startup_info_async()
+            .get_startup_info()
             .await
             .expect("unable to read ledger info from storage")
             .expect("startup info is None");

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -45,7 +45,7 @@ fn create_executor(config: &NodeConfig) -> (Executor<MockVM>, ExecutedTrees) {
         config.storage.port,
     ));
     let startup_info = rt
-        .block_on(read_client.get_startup_info_async())
+        .block_on(read_client.get_startup_info())
         .expect("unable to read ledger info from storage")
         .expect("startup info is None");
     let root_executed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
@@ -374,7 +374,7 @@ fn create_transaction_chunks(
     let batches: Vec<_> = chunk_ranges
         .into_iter()
         .map(|range| {
-            rt.block_on(storage_client.get_transactions_async(
+            rt.block_on(storage_client.get_transactions(
                 range.start,
                 range.end - range.start,
                 ledger_version,
@@ -424,7 +424,7 @@ fn test_executor_execute_and_commit_chunk() {
         )
         .unwrap();
     let (_, li, _, _) = rt
-        .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+        .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
@@ -439,7 +439,7 @@ fn test_executor_execute_and_commit_chunk() {
         )
         .unwrap();
     let (_, li, _, _) = rt
-        .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+        .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
@@ -454,7 +454,7 @@ fn test_executor_execute_and_commit_chunk() {
         )
         .unwrap();
     let (_, li, _, _) = rt
-        .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+        .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
@@ -469,7 +469,7 @@ fn test_executor_execute_and_commit_chunk() {
         )
         .unwrap();
     let (_, li, _, _) = rt
-        .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+        .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
     assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
@@ -484,7 +484,7 @@ fn test_executor_execute_and_commit_chunk() {
         )
         .unwrap();
     let (_, li, _, _) = rt
-        .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+        .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li, ledger_info);
 
@@ -525,7 +525,7 @@ fn test_executor_execute_and_commit_chunk_restart() {
             .unwrap();
         synced_trees = committed_trees;
         let (_, li, _, _) = rt
-            .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+            .block_on(storage_client.update_to_latest_ledger(0, vec![]))
             .unwrap();
         assert_eq!(li.ledger_info().version(), 0);
         assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
@@ -545,7 +545,7 @@ fn test_executor_execute_and_commit_chunk_restart() {
             )
             .unwrap();
         let (_, li, _, _) = rt
-            .block_on(storage_client.update_to_latest_ledger_async(0, vec![]))
+            .block_on(storage_client.update_to_latest_ledger(0, vec![]))
             .unwrap();
         assert_eq!(li, ledger_info);
     }

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -323,7 +323,7 @@ where
 
         let startup_info = block_on(executor.rt.spawn(async move {
             storage_read_client
-                .get_startup_info_async()
+                .get_startup_info()
                 .await
                 .expect("Shouldn't fail")
         }))
@@ -536,7 +536,7 @@ where
             let write_client = self.storage_write_client.clone();
             block_on(self.rt.spawn(async move {
                 write_client
-                    .save_transactions_async(
+                    .save_transactions(
                         txns_to_commit,
                         first_version_to_commit,
                         Some(ledger_info_with_sigs),
@@ -643,7 +643,7 @@ where
         let ledger_info = ledger_info_to_commit.clone();
         block_on(self.rt.spawn(async move {
             write_client
-                .save_transactions_async(txns_to_commit, first_version, ledger_info)
+                .save_transactions(txns_to_commit, first_version, ledger_info)
                 .await
         }))
         .unwrap()?;

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -76,7 +76,7 @@ fn create_storage_service_and_executor(
     ));
 
     let startup_info = rt
-        .block_on(storage_read_client.get_startup_info_async())
+        .block_on(storage_read_client.get_startup_info())
         .expect("unable to read ledger info from storage")
         .expect("startup info is None");
     let committed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
@@ -404,10 +404,12 @@ fn test_execution_with_storage() {
         validator_change_proof,
         _ledger_consistency_proof,
     ) = rt
-        .block_on(storage_read_client.update_to_latest_ledger_async(
-            /* client_known_version = */ 0,
-            request_items.clone(),
-        ))
+        .block_on(
+            storage_read_client.update_to_latest_ledger(
+                /* client_known_version = */ 0,
+                request_items.clone(),
+            ),
+        )
         .unwrap();
     verify_update_to_latest_ledger_response(
         &VerifierType::TrustedVerifier(EpochInfo {
@@ -617,10 +619,12 @@ fn test_execution_with_storage() {
         validator_change_proof,
         _ledger_consistency_proof,
     ) = rt
-        .block_on(storage_read_client.update_to_latest_ledger_async(
-            /* client_known_version = */ 0,
-            request_items.clone(),
-        ))
+        .block_on(
+            storage_read_client.update_to_latest_ledger(
+                /* client_known_version = */ 0,
+                request_items.clone(),
+            ),
+        )
         .unwrap();
     verify_update_to_latest_ledger_response(
         &&VerifierType::TrustedVerifier(EpochInfo {

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -70,7 +70,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
     async fn get_local_storage_state(&self) -> Result<SynchronizerState> {
         let storage_info = self
             .storage_read_client
-            .get_startup_info_async()
+            .get_startup_info()
             .await?
             .ok_or_else(|| format_err!("[state sync] Failed to access storage info"))?;
 
@@ -111,7 +111,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
         target_version: u64,
     ) -> Result<TransactionListWithProof> {
         self.storage_read_client
-            .get_transactions_async(known_version + 1, limit, target_version, false)
+            .get_transactions(known_version + 1, limit, target_version, false)
             .await
     }
 
@@ -122,7 +122,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
     ) -> Result<ValidatorChangeProof> {
         let validator_change_proof = self
             .storage_read_client
-            .get_epoch_change_ledger_infos_async(start_epoch, end_epoch)
+            .get_epoch_change_ledger_infos(start_epoch, end_epoch)
             .await?;
         Ok(validator_change_proof)
     }
@@ -130,7 +130,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
     async fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
         let (_, _, li_chain, _) = self
             .storage_read_client
-            .update_to_latest_ledger_async(version, vec![])
+            .update_to_latest_ledger(version, vec![])
             .await?;
         let waypoint_li = li_chain
             .ledger_info_with_sigs

--- a/storage/backup-restore/src/bin/backup.rs
+++ b/storage/backup-restore/src/bin/backup.rs
@@ -28,7 +28,7 @@ async fn main() {
     let client = StorageReadServiceClient::new("localhost", opt.node_port);
 
     let (version, state_root_hash) = client
-        .get_latest_state_root_async()
+        .get_latest_state_root()
         .await
         .expect("Failed to get latest version and state root hash.");
     println!("Latest version: {}", version);

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -71,7 +71,7 @@ impl StorageReadServiceClient {
 
 #[async_trait::async_trait]
 impl StorageRead for StorageReadServiceClient {
-    async fn update_to_latest_ledger_async(
+    async fn update_to_latest_ledger(
         &self,
         client_known_version: Version,
         requested_items: Vec<RequestItem>,
@@ -102,7 +102,7 @@ impl StorageRead for StorageReadServiceClient {
         ))
     }
 
-    async fn get_transactions_async(
+    async fn get_transactions(
         &self,
         start_version: Version,
         batch_size: u64,
@@ -122,7 +122,7 @@ impl StorageRead for StorageReadServiceClient {
         Ok(rust_resp.txn_list_with_proof)
     }
 
-    async fn get_latest_state_root_async(&self) -> Result<(Version, HashValue)> {
+    async fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
         let req = GetLatestStateRootRequest::default();
         let resp = self
             .client()
@@ -134,7 +134,7 @@ impl StorageRead for StorageReadServiceClient {
         Ok(rust_resp.into())
     }
 
-    async fn get_latest_account_state_async(
+    async fn get_latest_account_state(
         &self,
         address: AccountAddress,
     ) -> Result<Option<AccountStateBlob>> {
@@ -150,7 +150,7 @@ impl StorageRead for StorageReadServiceClient {
         Ok(rust_resp.account_state_blob)
     }
 
-    async fn get_account_state_with_proof_by_version_async(
+    async fn get_account_state_with_proof_by_version(
         &self,
         address: AccountAddress,
         version: Version,
@@ -167,7 +167,7 @@ impl StorageRead for StorageReadServiceClient {
         Ok(resp.into())
     }
 
-    async fn get_startup_info_async(&self) -> Result<Option<StartupInfo>> {
+    async fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         let proto_req = GetStartupInfoRequest::default();
         let resp = self
             .client()
@@ -179,7 +179,7 @@ impl StorageRead for StorageReadServiceClient {
         Ok(resp.info)
     }
 
-    async fn get_epoch_change_ledger_infos_async(
+    async fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
         end_epoch: u64,
@@ -266,7 +266,7 @@ impl StorageWriteServiceClient {
 
 #[async_trait::async_trait]
 impl StorageWrite for StorageWriteServiceClient {
-    async fn save_transactions_async(
+    async fn save_transactions(
         &self,
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
@@ -291,7 +291,7 @@ pub trait StorageRead: Send + Sync {
     ///
     /// [`LibraDB::update_to_latest_ledger`]:../libradb/struct.LibraDB.html#method.
     /// update_to_latest_ledger
-    async fn update_to_latest_ledger_async(
+    async fn update_to_latest_ledger(
         &self,
         client_known_version: Version,
         request_items: Vec<RequestItem>,
@@ -305,7 +305,7 @@ pub trait StorageRead: Send + Sync {
     /// See [`LibraDB::get_transactions`].
     ///
     /// [`LibraDB::get_transactions`]: ../libradb/struct.LibraDB.html#method.get_transactions
-    async fn get_transactions_async(
+    async fn get_transactions(
         &self,
         start_version: Version,
         batch_size: u64,
@@ -317,13 +317,13 @@ pub trait StorageRead: Send + Sync {
     ///
     /// [`LibraDB::get_latest_state_root`]:
     /// ../libradb/struct.LibraDB.html#method.get_latest_state_root
-    async fn get_latest_state_root_async(&self) -> Result<(Version, HashValue)>;
+    async fn get_latest_state_root(&self) -> Result<(Version, HashValue)>;
 
     /// See [`LibraDB::get_latest_account_state`].
     ///
     /// [`LibraDB::get_latest_account_state`]:
     /// ../libradb/struct.LibraDB.html#method.get_latest_account_state
-    async fn get_latest_account_state_async(
+    async fn get_latest_account_state(
         &self,
         address: AccountAddress,
     ) -> Result<Option<AccountStateBlob>>;
@@ -332,7 +332,7 @@ pub trait StorageRead: Send + Sync {
     ///
     /// [`LibraDB::get_account_state_with_proof_by_version`]:
     /// ../libradb/struct.LibraDB.html#method.get_account_state_with_proof_by_version
-    async fn get_account_state_with_proof_by_version_async(
+    async fn get_account_state_with_proof_by_version(
         &self,
         address: AccountAddress,
         version: Version,
@@ -342,13 +342,13 @@ pub trait StorageRead: Send + Sync {
     ///
     /// [`LibraDB::get_startup_info`]:
     /// ../libradb/struct.LibraDB.html#method.get_startup_info
-    async fn get_startup_info_async(&self) -> Result<Option<StartupInfo>>;
+    async fn get_startup_info(&self) -> Result<Option<StartupInfo>>;
 
     /// See [`LibraDB::get_epoch_change_ledger_infos`].
     ///
     /// [`LibraDB::get_epoch_change_ledger_infos`]:
     /// ../libradb/struct.LibraDB.html#method.get_epoch_change_ledger_infos
-    async fn get_epoch_change_ledger_infos_async(
+    async fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,
         end_epoch: u64,
@@ -384,7 +384,7 @@ pub trait StorageWrite: Send + Sync {
     /// See [`LibraDB::save_transactions`].
     ///
     /// [`LibraDB::save_transactions`]: ../libradb/struct.LibraDB.html#method.save_transactions
-    async fn save_transactions_async(
+    async fn save_transactions(
         &self,
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,

--- a/storage/storage-client/src/state_view.rs
+++ b/storage/storage-client/src/state_view.rs
@@ -137,9 +137,7 @@ impl<'a> StateView for VerifiedStateView<'a> {
                                 let reader = self.reader.clone();
                                 block_on(self.rt_handle.spawn(async move {
                                     reader
-                                        .get_account_state_with_proof_by_version_async(
-                                            address, version,
-                                        )
+                                        .get_account_state_with_proof_by_version(address, version)
                                         .await
                                 }))
                                 .unwrap()?

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -41,7 +41,7 @@ pub struct MockStorageReadClient;
 
 #[async_trait::async_trait]
 impl StorageRead for MockStorageReadClient {
-    async fn update_to_latest_ledger_async(
+    async fn update_to_latest_ledger(
         &self,
         client_known_version: Version,
         request_items: Vec<RequestItem>,
@@ -69,7 +69,7 @@ impl StorageRead for MockStorageReadClient {
         Ok(ret)
     }
 
-    async fn get_transactions_async(
+    async fn get_transactions(
         &self,
         _start_version: Version,
         _batch_size: u64,
@@ -79,18 +79,18 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
-    async fn get_latest_state_root_async(&self) -> Result<(Version, HashValue)> {
+    async fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
         unimplemented!()
     }
 
-    async fn get_latest_account_state_async(
+    async fn get_latest_account_state(
         &self,
         _address: AccountAddress,
     ) -> Result<Option<AccountStateBlob>> {
         Ok(Some(get_mock_account_state_blob()))
     }
 
-    async fn get_account_state_with_proof_by_version_async(
+    async fn get_account_state_with_proof_by_version(
         &self,
         _address: AccountAddress,
         _version: Version,
@@ -98,11 +98,11 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!();
     }
 
-    async fn get_startup_info_async(&self) -> Result<Option<StartupInfo>> {
+    async fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         unimplemented!()
     }
 
-    async fn get_epoch_change_ledger_infos_async(
+    async fn get_epoch_change_ledger_infos(
         &self,
         _start_epoch: u64,
         _end_epoch: u64,

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -46,7 +46,7 @@ proptest! {
 
         for (txns_to_commit, ledger_info_with_sigs) in &blocks {
             rt.block_on(write_client
-                .save_transactions_async(txns_to_commit.clone(),
+                .save_transactions(txns_to_commit.clone(),
                                    version, /* first_version */
                                    Some(ledger_info_with_sigs.clone()),
                 )).unwrap();
@@ -77,7 +77,7 @@ proptest! {
                 _validator_change_proof,
                 _ledger_consistency_proof,
             ) = rt.block_on(read_client
-                .update_to_latest_ledger_async(0, account_state_request_items)).unwrap();
+                .update_to_latest_ledger(0, account_state_request_items)).unwrap();
             for ((address, blob), response_item) in zip_eq(account_states, response_items) {
                     match response_item {
                         ResponseItem::GetAccountState {

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -51,10 +51,7 @@ impl TransactionValidation for VMValidator {
     type ValidationInstance = LibraVM;
 
     async fn validate_transaction(&self, txn: SignedTransaction) -> Result<Option<VMStatus>> {
-        let (version, state_root) = self
-            .storage_read_client
-            .get_latest_state_root_async()
-            .await?;
+        let (version, state_root) = self.storage_read_client.get_latest_state_root().await?;
         let client = self.storage_read_client.clone();
         let rt_handle = self.rt_handle.clone();
         let vm = self.vm.clone();
@@ -89,7 +86,7 @@ pub async fn get_account_state(
     address: AccountAddress,
 ) -> Result<(u64, u64)> {
     let account_state = storage_read_client
-        .get_latest_account_state_async(address)
+        .get_latest_account_state(address)
         .await?;
     Ok(if let Some(blob) = account_state {
         let account_resource = AccountResource::try_from(&blob)?;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

For each of these APIs, there used to be one async version and one synchronous version, so some are named *_async. Now that there is only the async version, there is no need to put async in the name.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y.

## Test Plan

N/A

## Related PRs

None.