### PR TITLE
[cluster-test] Introducing cti - Cluster Test Interface

### DIFF
--- a/docker/build-aws-base.sh
+++ b/docker/build-aws-base.sh
@@ -69,7 +69,7 @@ while true; do
     CURRENT_PHASE=$(echo $BUILD_JSON | jq -r '.builds[0].currentPhase')
     if [ $BUILD_STATUS = "IN_PROGRESS" ]; then
         echo "Build in progress. Current phase: ${CURRENT_PHASE}..."
-        sleep 10
+        sleep 30
     elif [ $BUILD_STATUS = "SUCCEEDED" ]; then
         echo "Build and push completed successfully"
         exit

--- a/scripts/cti
+++ b/scripts/cti
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+aws codebuild list-projects >/dev/null || (echo "Failed to access codebuild, try awsmfa?"; exit 1)
+ssh ssh.cluster-test-ci.aws.hlw3truzy4ls.com echo "ssh ok" >/dev/null || (echo "Failed to ssh to cluster test instance. Try renew corp canal cert with cc-certs"; exit 1)
+
+PR=""
+
+while (( "$#" )); do
+  case "$1" in
+    -p|--pr)
+      PR=$2
+      shift 2
+      ;;
+    -c|--container|-i|--image|--deploy)
+      echo "$1 command is not allowed in cti"
+      exit 1
+      ;;
+    *) # end argument parsing
+      break
+      ;;
+  esac
+done
+
+if [ -z "$PR" ]
+then
+      echo "No PR specified"
+      echo "Usage:"
+      echo "cti --pr <PR> [cluster test arguments]"
+      echo "Example:"
+      echo "cti --pr <PR> --run bench # Run benchmark"
+      exit 1
+fi
+
+./docker/validator-dynamic/build-aws.sh --version pull/$PR
+
+TAG=dev_${USER}_pull_${PR}
+
+echo "Build succeed, will use tag $TAG"
+echo "**********"
+echo "Dashboard: https://fburl.com/os3pb0ot"
+echo "Logs:"
+echo " * ssh ssh.cluster-test-ci.aws.hlw3truzy4ls.com"
+echo " * ssh-peer"
+echo " * tail -f /data/libra/libra.log"
+echo "**********"
+
+ssh -t ssh.cluster-test-ci.aws.hlw3truzy4ls.com ssh -i /libra_rsa ec2-user@ct.priv.cluster-test-ci.aws.hlw3truzy4ls.com ct -c cluster-test-ci --deploy $TAG $*


### PR DESCRIPTION
cti is command line tool similar to ct that can be used to run cluster test

Unlike `ct`, `cti` is meant to be runt from laptop

It takes git hub pull request number and other cluster test arguments as an input, builds docker image and runs cluster test on this image.

It leverages codebuild to build image, and then invokes ct via ssh to run cluster test

This is initial, very simple version that meant to evolve over time

Known caveats:

* Currently it runs on workspace shared with Circle CI and between all users. If multiple people and/or circle tries to call `cti` at the same time, build stage is done in parallel, but then users are queued. Queueing mechanism is simple and does not provide fairness.

* It uses ssh to run cluster test and provide output to user. If ssh session dies, there is no way to retrieve `cti` output and you would have to run it again
