### PR TITLE
[vm] Add tests for processing block prologue

### DIFF
--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -199,6 +199,13 @@ impl FakeExecutor {
             .expect("A block with one transaction should have one output")
     }
 
+    pub fn execute_transaction_block(
+        &self,
+        block: Vec<Transaction>,
+    ) -> Result<Vec<TransactionOutput>, VMStatus> {
+        LibraVM::execute_block(block, &self.config, &self.data_store)
+    }
+
     /// Get the blob for the associated AccessPath
     pub fn read_from_access_path(&self, path: &AccessPath) -> Option<Vec<u8>> {
         StateView::get(&self.data_store, path).unwrap()

--- a/language/e2e-tests/src/tests.rs
+++ b/language/e2e-tests/src/tests.rs
@@ -10,6 +10,7 @@
 //! benefit.
 
 mod account_universe;
+mod block_prologue;
 mod create_account;
 mod genesis;
 mod mint;

--- a/language/e2e-tests/src/tests/block_prologue.rs
+++ b/language/e2e-tests/src/tests/block_prologue.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::executor::FakeExecutor;
+use libra_config::generator;
+use libra_crypto::HashValue;
+use libra_types::{
+    account_config::core_code_address,
+    block_metadata::BlockMetadata,
+    transaction::{Transaction, TransactionOutput, TransactionStatus},
+    vm_error::{StatusCode, VMStatus},
+};
+use std::collections::btree_map::BTreeMap;
+
+fn is_discarded(output: &TransactionOutput) -> bool {
+    match output.status() {
+        TransactionStatus::Discard(_) => true,
+        _ => false,
+    }
+}
+
+#[test]
+fn execute_block_prologue() {
+    // create a FakeExecutor with a genesis from file
+    // We can't run mint test on terraform genesis as we don't have the private key to sign the
+    // mint transaction.
+    let mut executor = FakeExecutor::from_genesis_file();
+    let swarm = generator::validator_swarm_for_testing(10);
+    let validator_addr = *swarm.validator_set.iter().nth(0).unwrap().account_address();
+    let validator_addr_2 = *swarm.validator_set.iter().nth(1).unwrap().account_address();
+
+    // A proposer proposed a new block. Time should proceed.
+    let block1 = BlockMetadata::new(HashValue::zero(), 1, BTreeMap::new(), validator_addr);
+    let output = executor
+        .execute_transaction_block(vec![Transaction::BlockMetadata(block1)])
+        .unwrap();
+    assert!(output[0].status() == &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)));
+    executor.apply_write_set(output[0].write_set());
+
+    // A proposer proposed a block with old time. Should be rejected.
+    let block1 = BlockMetadata::new(HashValue::zero(), 0, BTreeMap::new(), validator_addr);
+    let output = executor
+        .execute_transaction_block(vec![Transaction::BlockMetadata(block1)])
+        .unwrap();
+    assert!(is_discarded(&output[0]));
+
+    // A nil proposer proposed a new block. Time should remain the same.
+    let block1 = BlockMetadata::new(HashValue::zero(), 1, BTreeMap::new(), core_code_address());
+    let output = executor
+        .execute_transaction_block(vec![Transaction::BlockMetadata(block1)])
+        .unwrap();
+    assert_eq!(
+        output[0].status(),
+        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+    );
+    executor.apply_write_set(output[0].write_set());
+
+    // A nil proposer proposed a new block with a different timestamp. Should be rejected.
+    let block1 = BlockMetadata::new(HashValue::zero(), 2, BTreeMap::new(), core_code_address());
+    let output = executor
+        .execute_transaction_block(vec![Transaction::BlockMetadata(block1)])
+        .unwrap();
+    assert!(is_discarded(&output[0]));
+
+    // A new proposer proposed a new block.
+    let block1 = BlockMetadata::new(HashValue::zero(), 2, BTreeMap::new(), validator_addr_2);
+    let output = executor
+        .execute_transaction_block(vec![Transaction::BlockMetadata(block1)])
+        .unwrap();
+    assert_eq!(
+        output[0].status(),
+        &TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
+    );
+}

--- a/language/vm/vm-runtime/src/libra_vm.rs
+++ b/language/vm/vm-runtime/src/libra_vm.rs
@@ -415,11 +415,13 @@ impl LibraVM {
                         self.execute_user_transactions(txns, &mut data_cache, state_view)?;
                     result.append(&mut outs);
                 }
-                TransactionBlock::BlockPrologue(block_metadata) => {
-                    result.push(self.move_vm.execute_runtime(|runtime| {
-                        process_block_metadata(block_metadata, runtime, &mut data_cache)
-                    })?)
-                }
+                TransactionBlock::BlockPrologue(block_metadata) => result.push(
+                    self.move_vm
+                        .execute_runtime(|runtime| {
+                            process_block_metadata(block_metadata, runtime, &mut data_cache)
+                        })
+                        .unwrap_or_else(discard_error_output),
+                ),
                 TransactionBlock::WriteSet(change_set) => result.push(
                     self.check_change_set(&change_set, state_view)
                         .map(|_| self.process_change_set(&mut data_cache, change_set))


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

There weren't any tests around block prologue logic in the language e2e tests and such logic is only tested in the LibraSwarm testsuite, which made it hard for us to debug. This PR will add more tests for processing block prologue in the language e2e testsuite. 

## Test Plan

cargo test