### PR TITLE
LibraDB::save_transactions() takes Option<&> instead of &Option<>

### DIFF
--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -362,7 +362,7 @@ impl LibraDB {
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
-        ledger_info_with_sigs: &Option<LedgerInfoWithSignatures>,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
         let num_txns = txns_to_commit.len() as u64;
         // ledger_info_with_sigs could be None if we are doing state synchronization. In this case

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -37,7 +37,7 @@ fn test_save_blocks_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSig
         db.save_transactions(
             &txns_to_commit,
             cur_ver, /* first_version */
-            &Some(ledger_info_with_sigs.clone()),
+            Some(ledger_info_with_sigs),
         )
         .unwrap();
 
@@ -92,14 +92,14 @@ fn test_sync_transactions_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoW
             db.save_transactions(
                 &txns_to_commit[0..batch1_len],
                 cur_ver, /* first_version */
-                &None,
+                None,
             )
             .unwrap();
         }
         db.save_transactions(
             &txns_to_commit[batch1_len..],
             cur_ver + batch1_len as u64, /* first_version */
-            &Some(ledger_info_with_sigs.clone()),
+            Some(&ledger_info_with_sigs),
         )
         .unwrap();
 

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -180,7 +180,7 @@ impl StorageService {
         self.db.save_transactions(
             &rust_req.txns_to_commit,
             rust_req.first_version,
-            &rust_req.ledger_info_with_signatures,
+            rust_req.ledger_info_with_signatures.as_ref(),
         )?;
         Ok(SaveTransactionsResponse::default())
     }


### PR DESCRIPTION


## Motivation

Using `Option<&_>` instead of `&Option<_>` in function parameter lists can avoid some `clone()`s 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan
Existing coverage.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
