### PR TITLE
[terraform] Fix peer_id in dashboards

### DIFF
--- a/terraform/templates/dashboards/overview_dashboard.json
+++ b/terraform/templates/dashboards/overview_dashboard.json
@@ -375,7 +375,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{validator_peer_id}}",
+          "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
       ],
@@ -469,7 +469,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{validator_peer_id}}",
+          "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
       ],
@@ -562,7 +562,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{validator_peer_id}}",
+          "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
       ],
@@ -655,7 +655,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{validator_peer_id}}",
+          "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
       ],
@@ -748,7 +748,7 @@
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{validator_peer_id}}",
+          "legendFormat": "{{peer_id}}",
           "refId": "A"
         }
       ],
@@ -1355,9 +1355,9 @@
       },
       "id": 2,
       "panels": [],
-      "repeat": "validator_peer_id",
+      "repeat": "peer_id",
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1420,7 +1420,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1435,7 +1435,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "$validator_peer_id",
+          "expr": "$peer_id",
           "panelId": 429,
           "refId": "A"
         }
@@ -1511,7 +1511,7 @@
       ],
       "repeatDirection": "v",
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1526,7 +1526,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1598,7 +1598,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1613,7 +1613,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -1690,7 +1690,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1705,7 +1705,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1780,7 +1780,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1795,7 +1795,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1870,7 +1870,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1885,7 +1885,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -1960,7 +1960,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -1975,7 +1975,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2050,7 +2050,7 @@
         }
       ],
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "3",
           "value": "3"
@@ -2065,7 +2065,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
+          "expr": "libra_network_peers{state='connected',peer_id='$peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2102,7 +2102,7 @@
       "repeatIteration": 1578690296023,
       "repeatPanelId": 2,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2168,7 +2168,7 @@
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2183,7 +2183,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "$validator_peer_id",
+          "expr": "$peer_id",
           "panelId": 429,
           "refId": "A"
         }
@@ -2262,7 +2262,7 @@
       "repeatPanelId": 59,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2277,7 +2277,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2352,7 +2352,7 @@
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2367,7 +2367,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2447,7 +2447,7 @@
       "repeatPanelId": 48,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2462,7 +2462,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2540,7 +2540,7 @@
       "repeatPanelId": 58,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2555,7 +2555,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2633,7 +2633,7 @@
       "repeatPanelId": 57,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2648,7 +2648,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2726,7 +2726,7 @@
       "repeatPanelId": 300,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2741,7 +2741,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -2819,7 +2819,7 @@
       "repeatPanelId": 56,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "0",
           "value": "0"
@@ -2834,7 +2834,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
+          "expr": "libra_network_peers{state='connected',peer_id='$peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -2871,7 +2871,7 @@
       "repeatIteration": 1578690296023,
       "repeatPanelId": 2,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -2937,7 +2937,7 @@
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -2952,7 +2952,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "$validator_peer_id",
+          "expr": "$peer_id",
           "panelId": 429,
           "refId": "A"
         }
@@ -3031,7 +3031,7 @@
       "repeatPanelId": 59,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3046,7 +3046,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3121,7 +3121,7 @@
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3136,7 +3136,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3216,7 +3216,7 @@
       "repeatPanelId": 48,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3231,7 +3231,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3309,7 +3309,7 @@
       "repeatPanelId": 58,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3324,7 +3324,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3402,7 +3402,7 @@
       "repeatPanelId": 57,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3417,7 +3417,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3495,7 +3495,7 @@
       "repeatPanelId": 300,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3510,7 +3510,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -3588,7 +3588,7 @@
       "repeatPanelId": 56,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "1",
           "value": "1"
@@ -3603,7 +3603,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
+          "expr": "libra_network_peers{state='connected',peer_id='$peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3640,7 +3640,7 @@
       "repeatIteration": 1578690296023,
       "repeatPanelId": 2,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -3706,7 +3706,7 @@
       "repeatPanelId": 44,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -3721,7 +3721,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "$validator_peer_id",
+          "expr": "$peer_id",
           "panelId": 429,
           "refId": "A"
         }
@@ -3800,7 +3800,7 @@
       "repeatPanelId": 59,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -3815,7 +3815,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
+          "expr": "label_replace(build_info{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}, \"short_rev\", \"$1\", \"revision\", \"(.{7}).*\")",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3890,7 +3890,7 @@
       "repeatPanelId": 45,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -3905,7 +3905,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", validator_peer_id=\"$validator_peer_id\"}",
+          "expr": "time() - ecs_start_time_seconds{workspace=\"$workspace\", role=\"validator\", peer_id=\"$peer_id\"}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -3985,7 +3985,7 @@
       "repeatPanelId": 48,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -4000,7 +4000,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',validator_peer_id='$validator_peer_id'}[5m]))))",
+          "expr": "100 * (1 - avg((irate(node_cpu_seconds_total{job='validator_instances',mode='idle',peer_id='$peer_id'}[5m]))))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4078,7 +4078,7 @@
       "repeatPanelId": 58,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -4093,7 +4093,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Cached_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',validator_peer_id='$validator_peer_id'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - (node_memory_MemFree_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Cached_bytes{workspace='$workspace',peer_id='$peer_id'} + node_memory_Buffers_bytes{workspace='$workspace',peer_id='$peer_id'}) / node_memory_MemTotal_bytes{workspace='$workspace',peer_id='$peer_id'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4171,7 +4171,7 @@
       "repeatPanelId": 57,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -4186,7 +4186,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (validator_peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/data'} / node_filesystem_size_bytes{job='validator_instances',mountpoint='/data'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4264,7 +4264,7 @@
       "repeatPanelId": 300,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -4279,7 +4279,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',validator_peer_id='$validator_peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
+          "expr": "avg(100 - node_filesystem_avail_bytes{job='validator_instances',peer_id='$peer_id',mountpoint='/'} / node_filesystem_size_bytes{job='validator_instances', mountpoint='/'} * 100) by (peer_id)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -4357,7 +4357,7 @@
       "repeatPanelId": 56,
       "repeatedByRow": true,
       "scopedVars": {
-        "validator_peer_id": {
+        "peer_id": {
           "selected": false,
           "text": "2",
           "value": "2"
@@ -4372,7 +4372,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "libra_network_peers{state='connected',validator_peer_id='$validator_peer_id',role_type='validator'}",
+          "expr": "libra_network_peers{state='connected',peer_id='$peer_id',role_type='validator'}",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -5181,14 +5181,14 @@
           ]
         },
         "datasource": "Prometheus",
-        "definition": "label_values(node_boot_time_seconds{validator_peer_id=~\"[0-9]{1,3}\"}, validator_peer_id)",
+        "definition": "label_values(node_boot_time_seconds{peer_id=~\"[0-9]{1,3}\"}, peer_id)",
         "hide": 0,
         "includeAll": true,
         "label": "Validator Peer",
         "multi": true,
-        "name": "validator_peer_id",
+        "name": "peer_id",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{validator_peer_id=~\"[0-9]{1,3}\"}, validator_peer_id)",
+        "query": "label_values(node_boot_time_seconds{peer_id=~\"[0-9]{1,3}\"}, peer_id)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/terraform/templates/prometheus.yml
+++ b/terraform/templates/prometheus.yml
@@ -51,7 +51,7 @@ scrape_configs:
       %{ for target in split(",", validators) }
       - targets: ['${element(split(":", target), 0)}:9100']
         labels:
-          validator_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          peer_id: 'val-${substr(element(split(":", target), 1), 0, 8)}'
           role: 'validator'
           workspace: '${workspace}'
       %{ endfor }
@@ -68,7 +68,7 @@ scrape_configs:
       %{ for target in split(",", validators) }
       - targets: ['${element(split(":", target), 0)}:9101']
         labels:
-          validator_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          peer_id: 'val-${substr(element(split(":", target), 1), 0, 8)}'
           role: 'validator'
           workspace: '${workspace}'
       %{ endfor }
@@ -85,7 +85,7 @@ scrape_configs:
       %{ for target in split(",", fullnodes) }
       - targets: ['${element(split(":", target), 0)}:9100']
         labels:
-          fullnode_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          peer_id: 'fn-${substr(element(split(":", target), 1), 0, 8)}'
           role: 'fullnode'
           workspace: '${workspace}'
       %{ endfor }
@@ -102,7 +102,7 @@ scrape_configs:
       %{ for target in split(",", fullnodes) }
       - targets: ['${element(split(":", target), 0)}:9101']
         labels:
-          fullnode_peer_id: '${substr(element(split(":", target), 1), 0, 8)}'
+          peer_id: 'fn-${substr(element(split(":", target), 1), 0, 8)}'
           role: 'fullnode'
           workspace: '${workspace}'
       %{ endfor }


### PR DESCRIPTION
The dynamic config changes changed peer_id to validator_peer_id, but
didn't update all the dashboards. This changes back to `peer_id` for
both validators and fullnodes, since we have the `role` label to
distinguish them.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Deployed to my workspace.