### PR TITLE
[Storage] fix that get_events_by_query_path() raises when account does not exist

### DIFF
--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -221,7 +221,7 @@ fn test_execution_with_storage() {
     let (_privkey3, pubkey3) = compat::generate_keypair(&mut rng);
     let account3 = AccountAddress::from_public_key(&pubkey3);
     let (_privkey4, pubkey4) = compat::generate_keypair(&mut rng);
-    let account4 = AccountAddress::from_public_key(&pubkey4);  // non-existent account
+    let account4 = AccountAddress::from_public_key(&pubkey4); // non-existent account
     let genesis_account = association_address();
 
     // Create account1 with 2M coins.
@@ -398,9 +398,7 @@ fn test_execution_with_storage() {
             ascending: false,
             limit: 10,
         },
-        RequestItem::GetAccountState {
-            address: account4,
-        },
+        RequestItem::GetAccountState { address: account4 },
         RequestItem::GetAccountTransactionBySequenceNumber {
             account: account4,
             sequence_number: 0,
@@ -411,7 +409,7 @@ fn test_execution_with_storage() {
             start_event_seq_num: 0,
             ascending: true,
             limit: 100,
-        }
+        },
     ];
 
     let (
@@ -587,7 +585,6 @@ fn test_execution_with_storage() {
         .into_get_events_by_access_path_response()
         .unwrap();
     assert!(account4_sent_events.is_empty());
-
 
     // Execution the 2nd block.
     let output2 = executor

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -243,7 +243,7 @@ impl LibraDB {
         let account_resource = if let Some(account_blob) = &account_state_with_proof.blob {
             AccountResource::make_from(&(&account_blob.try_into()?))?
         } else {
-            return Ok((Vec::new(), account_state_with_proof))
+            return Ok((Vec::new(), account_state_with_proof));
         };
 
         let event_key = account_resource

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -123,28 +123,25 @@ prop_compose! {
     }
 }
 
-pub fn arb_blocks_to_commit() -> impl Strategy<
-    Value = Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>
-> {
+pub fn arb_blocks_to_commit(
+) -> impl Strategy<Value = Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>> {
     arb_blocks_to_commit_impl(
-        5 /* num_accounts */,
-        2 /* max_txn_per_block */,
-        10 /* max_blocks */,
+        5,  /* num_accounts */
+        2,  /* max_txn_per_block */
+        10, /* max_blocks */
     )
 }
 
-pub fn arb_mock_genesis() -> impl Strategy<
-    Value = (TransactionToCommit, LedgerInfoWithSignatures)
-> {
+pub fn arb_mock_genesis() -> impl Strategy<Value = (TransactionToCommit, LedgerInfoWithSignatures)>
+{
     arb_blocks_to_commit_impl(
-        1 /* num_accounts */,
-        1 /* max_txn_per_block */,
-        1 /* max_blocks */,
-    ).prop_map(
-        |blocks| {
-            let (block, ledger_info_with_sigs) = &blocks[0];
-
-            (block[0].clone(), ledger_info_with_sigs.clone())
-        }
+        1, /* num_accounts */
+        1, /* max_txn_per_block */
+        1, /* max_blocks */
     )
+    .prop_map(|blocks| {
+        let (block, ledger_info_with_sigs) = &blocks[0];
+
+        (block[0].clone(), ledger_info_with_sigs.clone())
+    })
 }

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -126,13 +126,21 @@ prop_compose! {
 pub fn arb_blocks_to_commit() -> impl Strategy<
     Value = Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>
 > {
-    arb_blocks_to_commit_impl(5, 2, 10)
+    arb_blocks_to_commit_impl(
+        5 /* num_accounts */,
+        2 /* max_txn_per_block */,
+        10 /* max_blocks */,
+    )
 }
 
 pub fn arb_mock_genesis() -> impl Strategy<
     Value = (TransactionToCommit, LedgerInfoWithSignatures)
 > {
-    arb_blocks_to_commit_impl(1, 1, 1).prop_map(
+    arb_blocks_to_commit_impl(
+        1 /* num_accounts */,
+        1 /* max_txn_per_block */,
+        1 /* max_blocks */,
+    ).prop_map(
         |blocks| {
             let (block, ledger_info_with_sigs) = &blocks[0];
 


### PR DESCRIPTION

## Motivation

Client side actually thinks it's an valid case and is not an error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tests added.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
