### PR TITLE
Avoid duplicating code for creating NetworkPeerInfo in the network config.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -405,13 +405,7 @@ mod test {
 
     fn default_network_peers(keypair: &NetworkKeyPairs, peer_id: PeerId) -> NetworkPeersConfig {
         let mut peers = NetworkPeersConfig::default();
-        peers.peers.insert(
-            peer_id,
-            NetworkPeerInfo {
-                identity_public_key: keypair.identity_keys.public().clone(),
-                signing_public_key: keypair.signing_keys.public().clone(),
-            },
-        );
+        peers.peers.insert(peer_id, keypair.as_peer_info());
         peers
     }
 }


### PR DESCRIPTION
## Motivation

This is a tiny change to clean up the network_config.rs file. Instead of creating the 'NetworkPeerInfo' manually from a given 'NetworkKeyPairs', we just call 'as_peer_info()' on the given 'NetworkKeyPairs'.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A local run of 'cargo xtest' and 'cargo run -p libra-swarm -- -s -n 4' seem to produce the expected output.

## Related PRs

None.
