### PR TITLE
[perf] Enable LTO for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ default-members = [
 
 [profile.release]
 debug = true
+lto = true
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
LTO(link time optimization) enables optimization on linker stage, providing additional performance benefits and smaller binary size

This gives quite a bit of perf bump
With diff: `all up : 667 TPS, 954.6 ms latency`
Last master: `all up : 579 TPS, 1216.6 ms latency `

Build time is increased with this flag, particularly linking stage takes longer, but with code build its not significant
