### PR TITLE
[CI] integrating MIRAI into CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,5 @@
+Workflows/ contain [github actions](https://github.com/features/actions) that can run on specific events.
+
+Below is a list of all actions implemented in this directory:
+
+* [rust-mirai](rust-mirai.yml). An action that runs the [MIRAI](https://github.com/facebookexperimental/MIRAI) static analyzer tool on every **pull request**, and leaves a comment with the MIRAI output.

--- a/.github/workflows/rust-mirai.yml
+++ b/.github/workflows/rust-mirai.yml
@@ -1,0 +1,96 @@
+name: Rust_MIRAI
+
+on:
+  pull_request:
+    types: ['opened', 'synchronize']
+
+jobs:
+  install_and_run_MIRAI:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Z3
+      uses: pavpanchekha/setup-z3@v1.2
+    - name: Checkout MIRAI
+      uses: actions/checkout@v2
+      with:
+        repository: 'facebookexperimental/MIRAI'
+        path: 'MIRAI'
+    - name: Install MIRAI
+      working-directory: ./MIRAI
+      run: |
+        rustup component add rustc-dev
+        RUSTFLAGS='-Clink-arg=-L./binaries -Clink-arg=-lstdc++' cargo install --path ./checker
+    - name: Checkout libra
+      uses: actions/checkout@v2
+      with:
+        path: 'libra'
+    # github base_ref is a lie, we obtain the target base the hard way
+    - name: Obtain base reference
+      id: obtain_base_ref
+      uses: actions/github-script@0.4.0
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        result-encoding: string
+        script: |
+          const commits = await github.pulls.listCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+          });
+          const commit_ref = commits.data[0].sha;
+          const commit = await github.repos.getCommit({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: commit_ref
+          });
+          return commit.data.parents[0].sha;
+    # we build the target base first to only run MIRAI on the changes
+    - name: Build target base then checkout PR
+      working-directory: ./libra
+      env:
+        SHA: ${{ steps.obtain_base_ref.outputs.result }}
+      run: |
+        rustup override set `cat ../MIRAI/rust-toolchain`
+        rustup component add rustc-dev
+        git fetch origin $SHA
+        git checkout $SHA
+        RUSTFLAGS="-Z always_encode_mir" cargo build
+        git checkout -
+    - name: Run MIRAI on PR
+      working-directory: ./libra
+      run: |
+        rustup show
+        RUSTC_WRAPPER=mirai RUSTFLAGS="-Z always_encode_mir" cargo build -q 2> ../mirai_results
+    - name: Post comment with MIRAI warnings
+      if: success()
+      uses: actions/github-script@0.4.0
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const fs = require('fs');
+          fs.readFile('mirai_results', 'utf-8', (err, data) => {
+            if (err) {
+              console.log("err:", err);
+              return;
+            }
+            if (data) {
+              console.log(data);
+              data = `Hello!
+
+          It looks like MIRAI found some warnings:
+
+          \`\`\`
+          ${data}
+          \`\`\`
+
+          `;
+              github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: data
+              });
+            }
+          });


### PR DESCRIPTION
This PR adds a [github action][1] to run the [MIRAI static analyzer][2] against every pull request.
If warnings are emitted, it will post a comment on the pull request.

[1]: https://github.com/features/actions
[2]: https://github.com/facebookexperimental/MIRAI