### PR TITLE
Use ThinLTO instead of full LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ default-members = [
 
 [profile.release]
 debug = true
-lto = true
+lto = 'thin'
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It feels like the build time increase caused by enabling LTO is
significant. ThinLTO is significant faster than full LTO, but the
performance loss should be minimal. I ran cluster test and did not
notice significant perf difference.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y?

## Test Plan

Ran cluster test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
