### PR TITLE
[CI] increase no output timeout in docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,7 @@ jobs:
                 echo "$docker_file is renamed or removed in pull request."
               fi
             done
+          no_output_timeout: 45m
 
 workflows:
   commit-workflow:


### PR DESCRIPTION
The link stage takes longer after enabling LTO. Increase the CI timeout
in Docker build so that the CI would not kill the job due to no output.