### PR TITLE
[move source language] Added bytecode verification to tests. Fixed bytecode generation issues

### DIFF
--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 /// - References are "released"/popped after their last usage
 ///   - Might prove be a bit tricky to get exactly right as it might happen only at the statement
 ///     level instead of the expression level
-pub fn refine(
+pub fn refine_and_verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -175,7 +175,7 @@ fn function_body(
                 context.error(e);
             }
 
-            cfgir::refine(
+            cfgir::refine_and_verify(
                 &mut context.errors,
                 signature,
                 &locals,

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -660,7 +660,8 @@ fn assign(
                 assert!(idx == decl_idx);
                 let floc = tfa.loc;
                 let borrow_ = E::Borrow(mut_, Box::new(copy_tmp()), f);
-                let borrow = H::exp(H::Type_::base(bt), sp(floc, borrow_));
+                let borrow_ty = H::Type_::single(sp(floc, H::SingleType_::Ref(mut_, bt)));
+                let borrow = H::exp(borrow_ty, sp(floc, borrow_));
                 match assign_command(context, &mut after, floc, sp(floc, vec![tfa]), borrow) {
                     Unreachable { report, loc } => return Unreachable { report, loc },
                     Reachable(()) => (),
@@ -965,13 +966,14 @@ fn maybe_exp_(context: &mut Context, result: &mut Block, e: T::Exp) -> ExpResult
             let e = exp!(context, result, None, *te);
             HE::UnaryExp(op, e)
         }
-        TE::BinopExp(tl, op @ sp!(_, BinOp_::Eq), tr)
-        | TE::BinopExp(tl, op @ sp!(_, BinOp_::Neq), tr) => {
-            let el = exp!(context, result, None, *tl);
-            let er = exp!(context, result, Some(&el.ty), *tr);
+        TE::BinopExp(tl, op @ sp!(_, BinOp_::Eq), toperand_ty, tr)
+        | TE::BinopExp(tl, op @ sp!(_, BinOp_::Neq), toperand_ty, tr) => {
+            let operand_ty = type_(context, *toperand_ty);
+            let el = exp!(context, result, Some(&operand_ty), *tl);
+            let er = exp!(context, result, Some(&operand_ty), *tr);
             HE::BinopExp(el, op, er)
         }
-        TE::BinopExp(tl, op, tr) => {
+        TE::BinopExp(tl, op, _, tr) => {
             let el = exp!(context, result, None, *tl);
             let er = exp!(context, result, None, *tr);
             HE::BinopExp(el, op, er)
@@ -1041,6 +1043,11 @@ fn maybe_exp_(context: &mut Context, result: &mut Block, e: T::Exp) -> ExpResult
             };
             let tmp = bind_exp(context, result, eloc, st, e);
             HE::BorrowLocal(mut_, tmp)
+        }
+
+        TE::Annotate(te, rhs_ty) => {
+            let expected_ty = type_(context, *rhs_ty);
+            return maybe_exp(context, result, Some(&expected_ty), *te);
         }
         TE::UnresolvedError => {
             assert!(context.has_errors());

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -85,6 +85,22 @@ pub fn move_compile(
     }
 }
 
+/// Move check but it returns the errors instead of reporting them to stderr
+pub fn move_compile_no_report(
+    targets: &[&'static str],
+    deps: &[&'static str],
+    sender_opt: Option<Address>,
+) -> io::Result<(
+    FilesSourceText,
+    Result<Vec<to_bytecode::translate::CompiledUnit>, Errors>,
+)> {
+    let (files, pprog_res) = parse_program(targets, deps)?;
+    Ok(match compile_program(pprog_res, sender_opt) {
+        Err(errors) => (files, Err(errors)),
+        Ok(units) => (files, Ok(units)),
+    })
+}
+
 /// Runs the bytecode verifier on the compiled units
 /// Fails if the bytecode verifier errors
 pub fn sanity_check_compiled_units(

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -168,7 +168,7 @@ pub enum UnannotatedExp_ {
 
     Dereference(Box<Exp>),
     UnaryExp(UnaryOp, Box<Exp>),
-    BinopExp(Box<Exp>, BinOp, Box<Exp>),
+    BinopExp(Box<Exp>, BinOp, Box<Type>, Box<Exp>),
 
     Pack(
         ModuleIdent,
@@ -181,6 +181,8 @@ pub enum UnannotatedExp_ {
     Borrow(bool, Box<Exp>, Field),
     TempBorrow(bool, Box<Exp>),
     BorrowLocal(bool, Var),
+
+    Annotate(Box<Exp>, Box<Type>),
 
     UnresolvedError,
 }

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -219,9 +219,14 @@ fn exp(context: &mut Context, e: &mut T::Exp) {
         | E::UnaryExp(_, er)
         | E::Borrow(_, er, _)
         | E::TempBorrow(_, er) => exp(context, er),
-        E::Mutate(el, er) | E::BinopExp(el, _, er) => {
+        E::Mutate(el, er) => {
             exp(context, el);
             exp(context, er)
+        }
+        E::BinopExp(el, _, operand_ty, er) => {
+            exp(context, el);
+            exp(context, er);
+            type_(context, operand_ty)
         }
 
         E::Pack(_, _, bs, fields) => {
@@ -232,6 +237,10 @@ fn exp(context: &mut Context, e: &mut T::Exp) {
             }
         }
         E::ExpList(el) => exp_list(context, el),
+        E::Annotate(el, rhs_ty) => {
+            exp(context, el);
+            type_(context, rhs_ty);
+        }
     }
 }
 

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -131,7 +131,7 @@ fn exp(
         | E::UnaryExp(_, er)
         | E::Borrow(_, er, _)
         | E::TempBorrow(_, er) => exp(context, annotated_acquires, seen, er),
-        E::Mutate(el, er) | E::BinopExp(el, _, er) => {
+        E::Mutate(el, er) | E::BinopExp(el, _, _, er) => {
             exp(context, annotated_acquires, seen, el);
             exp(context, annotated_acquires, seen, er)
         }
@@ -142,6 +142,8 @@ fn exp(
             }
         }
         E::ExpList(el) => exp_list(context, annotated_acquires, seen, el),
+
+        E::Annotate(e, _) => exp(context, annotated_acquires, seen, e),
     }
 }
 

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_lang::{move_check_no_report, shared::Address};
+use move_lang::{move_compile_no_report, shared::Address};
 use std::{fs, path::Path};
 use text_diff;
 
@@ -50,7 +50,11 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, errors) = move_check_no_report(&targets, &deps, sender)?;
+    let (files, units_or_errors) = move_compile_no_report(&targets, &deps, sender)?;
+    let errors = match units_or_errors {
+        Err(errors) => errors,
+        Ok(units) => move_lang::to_bytecode::translate::verify_units(units).1,
+    };
     let has_errors = !errors.is_empty();
     let error_buffer = if has_errors {
         move_lang::errors::report_errors_to_buffer(files, errors)


### PR DESCRIPTION
## Motivation

- Fixed subtyping issues
  - Locals were created with the wrong type for BorrowUnpack
  - Annotations needed to be carried to HLIR for freezing
  - Fixed subtyping around eq and neq
- Fixed labeling assumptions in to_bytecode
  - No longer assume indexes == labels
  - Added remapping
- Fixed not using proper local signature index for global functions

## Test Plan

cargo test