### PR TITLE
[crypto] unify serialization for x25519 / ed25519

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     config::{PersistableConfig, RoleType, RootPath},
-    keys::{self, KeyPair},
+    keys::KeyPair,
     utils,
 };
 use anyhow::{anyhow, ensure, Result};
@@ -253,12 +253,8 @@ impl std::fmt::Debug for NetworkPeersConfig {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct NetworkPeerInfo {
-    #[serde(serialize_with = "keys::serialize_key")]
-    #[serde(deserialize_with = "keys::deserialize_key")]
     #[serde(rename = "ns")]
     pub signing_public_key: Ed25519PublicKey,
-    #[serde(serialize_with = "keys::serialize_key")]
-    #[serde(deserialize_with = "keys::deserialize_key")]
     #[serde(rename = "ni")]
     pub identity_public_key: X25519StaticPublicKey,
 }

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -43,7 +43,7 @@ where
         S: Serializer,
     {
         match self {
-            PrivateKeyContainer::Present(key) => serialize_key(key, serializer),
+            PrivateKeyContainer::Present(key) => key.serialize(serializer),
             _ => serializer.serialize_str(""),
         }
     }
@@ -51,14 +51,14 @@ where
 
 impl<'de, T> Deserialize<'de> for PrivateKeyContainer<T>
 where
-    T: ValidKeyStringExt + DeserializeOwned + 'static,
+    T: ValidKeyStringExt,
 {
     fn deserialize<D>(deserializer: D) -> std::result::Result<PrivateKeyContainer<T>, D::Error>
     where
         D: Deserializer<'de>,
     {
         // Note: Any error in parsing is assumed to be due to the private key being absent.
-        deserialize_key(deserializer)
+        T::deserialize(deserializer)
             .map(PrivateKeyContainer::Present)
             .or_else(|_| Ok(PrivateKeyContainer::Absent))
     }
@@ -69,12 +69,9 @@ where
 pub struct KeyPair<T>
 where
     T: PrivateKey + Serialize + ValidKeyStringExt,
-    T::PublicKeyMaterial: DeserializeOwned + 'static + Serialize + ValidKeyStringExt,
 {
     #[serde(bound(deserialize = "PrivateKeyContainer<T>: Deserialize<'de>"))]
     private_key: PrivateKeyContainer<T>,
-    #[serde(serialize_with = "serialize_key")]
-    #[serde(deserialize_with = "deserialize_key")]
     public_key: T::PublicKeyMaterial,
 }
 
@@ -115,24 +112,4 @@ where
     pub fn take_private(&mut self) -> Option<T> {
         self.private_key.take()
     }
-}
-
-pub fn serialize_key<S, K>(key: &K, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    K: Serialize + ValidKeyStringExt,
-{
-    key.to_encoded_string()
-        .map_err(<S::Error as serde::ser::Error>::custom)
-        .and_then(|str| serializer.serialize_str(&str[..]))
-}
-
-pub fn deserialize_key<'de, D, K>(deserializer: D) -> Result<K, D::Error>
-where
-    D: Deserializer<'de>,
-    K: ValidKeyStringExt + DeserializeOwned + 'static,
-{
-    let encoded_key: &str = Deserialize::deserialize(deserializer)?;
-    ValidKeyStringExt::from_encoded_string(encoded_key)
-        .map_err(<D::Error as serde::de::Error>::custom)
 }

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -38,7 +38,13 @@ pub enum CryptoMaterialError {
     PointNotOnCurveError,
 }
 
-/// Key material with a notion of byte validation.
+/// The serialized length of the data that enables macro derived serialization and deserialization.
+pub trait Length {
+    /// The serialized length of the data
+    const LENGTH: usize;
+}
+
+/// Key or more generally crypto material with a notion of byte validation.
 ///
 /// A type family for material that knows how to serialize and
 /// deserialize, as well as validate byte-encoded material. The
@@ -52,7 +58,6 @@ pub trait ValidKey:
     // The for<'a> exactly matches the assumption "deserializable from any lifetime".
     for<'a> TryFrom<&'a [u8], Error = CryptoMaterialError> + Debug + Serialize + DeserializeOwned
 {
-
     /// Convert the valid key to bytes.
     fn to_bytes(&self) -> Vec<u8>;
 }


### PR DESCRIPTION
There was a lot of boiler plate serialization code that isn't necessary. We also wanted to serialize as strings and that required a helper function that wasn't colocated in the crypto. This set of commits unifies the code into a macro remove a lot of duplicate code.