### PR TITLE
[RFC][consensus] Add InitialSync mode to block retrieval request

### DIFF
--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -2,32 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block::Block, common::Payload};
-use anyhow::ensure;
+use anyhow::{bail, ensure};
 use libra_crypto::hash::HashValue;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt;
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum BlockRetrievalMode {
+    Ancestor(u64),
+    // Initial Sync mode is used when initializing from empty consensus db.
+    // This mode will retrieve 3 child blocks of the latest commited block from peers
+    InitialSync,
+}
+
 /// RPC to get a chain of block of the given length starting from the given block id.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct BlockRetrievalRequest {
     block_id: HashValue,
-    num_blocks: u64,
+    mode: BlockRetrievalMode,
 }
 
 impl BlockRetrievalRequest {
-    pub fn new(block_id: HashValue, num_blocks: u64) -> Self {
-        Self {
-            block_id,
-            num_blocks,
-        }
+    pub fn new(block_id: HashValue, mode: BlockRetrievalMode) -> Self {
+        Self { block_id, mode }
     }
     pub fn block_id(&self) -> HashValue {
         self.block_id
     }
-    pub fn num_blocks(&self) -> u64 {
-        self.num_blocks
+    pub fn retrieval_mode(&self) -> BlockRetrievalMode {
+        self.mode.clone()
     }
 }
 
@@ -35,8 +40,8 @@ impl fmt::Display for BlockRetrievalRequest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "[BlockRetrievalRequest starting from id {} with {} blocks]",
-            self.block_id, self.num_blocks
+            "[BlockRetrievalRequest starting from id {}, retrieval model {:?}]",
+            self.block_id, self.mode
         )
     }
 }
@@ -92,6 +97,21 @@ impl<T: Payload> BlockRetrievalResponse<T> {
 
     pub fn verify(
         &self,
+        req: &BlockRetrievalRequest,
+        sig_verifier: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        match req.mode {
+            BlockRetrievalMode::Ancestor(num_blocks) => {
+                self.verify_ancester_retrieval(req.block_id(), num_blocks, sig_verifier)
+            }
+            BlockRetrievalMode::InitialSync => {
+                self.verify_initial_sync(req.block_id(), sig_verifier)
+            }
+        }
+    }
+
+    fn verify_ancester_retrieval(
+        &self,
         block_id: HashValue,
         num_blocks: u64,
         sig_verifier: &ValidatorVerifier,
@@ -103,9 +123,53 @@ impl<T: Payload> BlockRetrievalResponse<T> {
             num_blocks,
             self.blocks.len(),
         );
+        self.verify_chain_well_formed(block_id, sig_verifier)
+    }
+
+    fn verify_initial_sync(
+        &self,
+        block_id: HashValue,
+        sig_verifier: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        ensure!(
+            self.status() == BlockRetrievalStatus::Succeeded,
+            "Initial Sync Request Failed"
+        );
+        // Things to verify:
+        // 1) the last block is the target
+        // 2) the chain carries a ledger info to the target
+        // 3) the chain is well formed
+        ensure!(
+            self.blocks().last().map_or(false, |b| b.id() == block_id),
+            "Initial Sync block retrieval doesn't end with target block id {}",
+            block_id
+        );
+
+        ensure!(
+            self.blocks()
+                .iter()
+                .any(|b| b.quorum_cert().commit_info().id() == block_id),
+            "Descendants block retrieval does not carry a commit for target id {}",
+            block_id
+        );
+
+        let highest_block_id = match self.blocks.first() {
+            Some(b) => b.id(),
+            None => {
+                bail!("No blocks retrieved but status is Success");
+            }
+        };
+        self.verify_chain_well_formed(highest_block_id, sig_verifier)
+    }
+
+    fn verify_chain_well_formed(
+        &self,
+        first_block_id: HashValue,
+        sig_verifier: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
         self.blocks
             .iter()
-            .try_fold(block_id, |expected_id, block| {
+            .try_fold(first_block_id, |expected_id, block| {
                 block.validate_signatures(sig_verifier)?;
                 block.verify_well_formed()?;
                 ensure!(

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -367,6 +367,16 @@ impl<T: Payload> BlockReader for BlockStore<T> {
         self.inner.read().unwrap().get_block(&block_id)
     }
 
+    fn get_chain_for_committed_block(&self, block_id: HashValue) -> Vec<Block<T>> {
+        self.inner
+            .read()
+            .unwrap()
+            .get_chain_for_committed_block(block_id)
+            .iter()
+            .map(|b| b.block().clone())
+            .collect()
+    }
+
     fn root(&self) -> Arc<ExecutedBlock<T>> {
         self.inner.read().unwrap().root()
     }

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -437,3 +437,78 @@ fn test_empty_reconfiguration_suffix() {
     );
     assert!(a6.verify_well_formed().is_err());
 }
+
+#[test]
+fn test_chain_for_committed_block() {
+    // Use the following tree:
+    // Genesis<--a1<--a2<--a3<------a5<-----a7
+    //                  `-------a4<------a6<-----a8<--a9<--a10<--a11
+    let mut inserter = TreeInserter::default();
+    let block_store = inserter.block_store();
+    let genesis = block_store.root();
+    let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
+    let a2 = inserter.insert_block(&a1, 2, None);
+    let a3 = inserter.insert_block(&a2, 3, None);
+    let a4 = inserter.insert_block(&a2, 4, None);
+    let a5 = inserter.insert_block(&a3, 5, Some(a1.block_info()));
+    let a6 = inserter.insert_block(&a4, 6, None);
+    let _a7 = inserter.insert_block(&a5, 7, None);
+    let a8 = inserter.insert_block(&a6, 8, None);
+
+    // Just verify that the quorum certificate carried by a5 is a proof of commit for a1
+    assert_eq!(
+        block_store
+            .get_block(a5.id())
+            .unwrap()
+            .quorum_cert()
+            .commit_info()
+            .id(),
+        a1.id()
+    );
+
+    assert_eq!(block_store.get_chain_for_committed_block(a2.id()), vec![]);
+    assert_eq!(block_store.get_chain_for_committed_block(a4.id()), vec![]);
+    assert_eq!(
+        block_store.get_chain_for_committed_block(HashValue::random()),
+        vec![]
+    );
+
+    let descendants_for_a1 = block_store
+        .get_chain_for_committed_block(a1.id())
+        .iter()
+        .map(|b| b.id())
+        .collect::<Vec<HashValue>>();
+    assert_eq!(descendants_for_a1, vec![a5.id(), a3.id(), a2.id(), a1.id()]);
+    // Verify that the tree is working fine after pruning: add more nodes to commit the whole a2
+    // and prune the tree to get to the root
+    let a9 = inserter.insert_block(&a8, 9, None);
+    let a10 = inserter.insert_block(&a9, 10, None);
+    let a11 = inserter.insert_block(&a10, 11, Some(a8.block_info()));
+    block_store.prune_tree(a8.id());
+
+    // Descendants of the root
+    let descendants_for_a8 = block_store
+        .get_chain_for_committed_block(a8.id())
+        .iter()
+        .map(|b| b.id())
+        .collect::<Vec<HashValue>>();
+    assert_eq!(
+        descendants_for_a8,
+        vec![a11.id(), a10.id(), a9.id(), a8.id()]
+    );
+
+    // Descendants of a1 are still in another branch (not the highest QC one) because it carries
+    // the ledger info with the commit of a1.
+    let descendants_for_a1 = block_store
+        .get_chain_for_committed_block(a1.id())
+        .iter()
+        .map(|b| b.id())
+        .collect::<Vec<HashValue>>();
+    assert_eq!(descendants_for_a1, vec![a5.id(), a3.id(), a2.id(), a1.id()]);
+
+    // No descendants of a2: even though it's committed there is no direct proof.
+    assert_eq!(block_store.get_chain_for_committed_block(a2.id()), vec![]);
+
+    // Descendants of a node that has not been committed eventually
+    assert_eq!(block_store.get_chain_for_committed_block(a3.id()), vec![]);
+}

--- a/consensus/src/chained_bft/block_storage/mod.rs
+++ b/consensus/src/chained_bft/block_storage/mod.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use consensus_types::{
-    executed_block::ExecutedBlock, quorum_cert::QuorumCert, timeout_certificate::TimeoutCertificate,
+    block::Block, executed_block::ExecutedBlock, quorum_cert::QuorumCert,
+    timeout_certificate::TimeoutCertificate,
 };
 use libra_crypto::HashValue;
 use libra_types::validator_verifier::VerifyError;
@@ -42,6 +43,12 @@ pub trait BlockReader: Send + Sync {
 
     /// Try to get a block with the block_id, return an Arc of it if found.
     fn get_block(&self, block_id: HashValue) -> Option<Arc<ExecutedBlock<Self::Payload>>>;
+
+    /// Retrieve the chain of descendants of a committed block.
+    /// The chain ends with the given block id, and includes
+    /// the LedgerInfo certifying the commit of the target block
+    /// In case no such chain can be found, an empty vector is returned.
+    fn get_chain_for_committed_block(&self, block_id: HashValue) -> Vec<Block<Self::Payload>>;
 
     /// Get the current root block of the BlockTree.
     fn root(&self) -> Arc<ExecutedBlock<Self::Payload>>;

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -9,7 +9,9 @@ use crate::{
     counters,
 };
 use anyhow::{bail, format_err};
-use consensus_types::block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus};
+use consensus_types::block_retrieval::{
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalStatus,
+};
 use consensus_types::{
     block::Block,
     common::{Author, Payload},
@@ -246,7 +248,7 @@ impl BlockRetriever {
             let response = self
                 .network
                 .request_block(
-                    BlockRetrievalRequest::new(block_id, num_blocks),
+                    BlockRetrievalRequest::new(block_id, BlockRetrievalMode::Ancestor(num_blocks)),
                     peer,
                     timeout,
                 )

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -103,7 +103,6 @@ impl NetworkSender {
         timeout: Duration,
     ) -> anyhow::Result<BlockRetrievalResponse<T>> {
         ensure!(from != self.author, "Retrieve block from self");
-        counters::BLOCK_RETRIEVAL_COUNT.inc_by(retrieval_request.num_blocks() as i64);
         let pre_retrieval_instant = Instant::now();
         let req_msg = RequestBlock::try_from(retrieval_request.clone())?;
         let response_msg = self
@@ -113,11 +112,7 @@ impl NetworkSender {
         counters::BLOCK_RETRIEVAL_DURATION_S.observe_duration(pre_retrieval_instant.elapsed());
         let response = BlockRetrievalResponse::<T>::try_from(response_msg)?;
         response
-            .verify(
-                retrieval_request.block_id(),
-                retrieval_request.num_blocks(),
-                &self.validators,
-            )
+            .verify(&retrieval_request, &self.validators)
             .map_err(|e| {
                 security_log(SecurityEvent::InvalidRetrievedBlock)
                     .error(&e)
@@ -125,6 +120,7 @@ impl NetworkSender {
                     .log();
                 e
             })?;
+        counters::BLOCK_RETRIEVAL_COUNT.inc_by(response.blocks().len() as i64);
 
         Ok(response)
     }

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -331,7 +331,7 @@ impl DropConfig {
 use crate::chained_bft::network::NetworkTask;
 use crate::chained_bft::test_utils::TestPayload;
 use consensus_types::block_retrieval::{
-    BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus,
+    BlockRetrievalMode, BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus,
 };
 use libra_crypto::HashValue;
 #[cfg(test)]
@@ -488,7 +488,7 @@ fn test_rpc() {
     block_on(async move {
         let response = nodes[0]
             .request_block::<TestPayload>(
-                BlockRetrievalRequest::new(HashValue::zero(), 1),
+                BlockRetrievalRequest::new(HashValue::zero(), BlockRetrievalMode::Ancestor(1)),
                 peer,
                 Duration::from_secs(5),
             )


### PR DESCRIPTION
## Motivation

#2188 In order to start from an empty consensus db we will need the ability to retrieve
3-chain that results in a commit of a block from peers. This pr adds that ability.

High level overview of changes:
+ Split block retrieval into two mode: `Ancestor` and `InitialSync`. `Ancestor` mode is just normal block retrieval we already had. `InitialSync` will retrieves the chain of blocks that results in the commit of given block.
+ A helper function `get_chain_for_committed_block` in `block_tree` that construct the chain

## Test Plan

Unit tests are added in block_store_test and event_processor_test
`cargo x test -p consensus`
