### PR TITLE
[move][bytecode verifier] Fix bug in generics check. Turn on generics tests

### DIFF
--- a/language/functional_tests/tests/testsuite/generics/builtins.mvir
+++ b/language/functional_tests/tests/testsuite/generics/builtins.mvir
@@ -1,24 +1,47 @@
-//! no-run: verifier, runtime
-
 module M {
-    struct Foo<T> { x: T }
+    resource Foo<T> { x: T }
 
-    foo() {
-        let x: &Self.Foo<u64>;
+    foo() acquires Foo {
+        let x: &mut Self.Foo<u64>;
         let y: Self.Foo<u64>;
 
-        x = borrow_global_mut<Foo<u64>>();
+        x = borrow_global_mut<Foo<u64>>(get_txn_sender());
         _ = move(x);
 
-        exists<Foo<u64>>();
+        _ = exists<Foo<u64>>(get_txn_sender());
 
-        y = move_from<Foo<u64>>();
+        y = move_from<Foo<u64>>(get_txn_sender());
         move_to_sender<Foo<u64>>(move(y));
+        return;
     }
-}
 
-// check: [LocalsSignature([Reference(Struct(StructHandleIndex(0), [U64])), Struct(StructHandleIndex(0), [U64])]), LocalsSignature([U64])]
-// check: MutBorrowGlobal(0, LocalsSignatureIndex(1))
-// check: Exists(0, LocalsSignatureIndex(1))
-// check: MoveFrom(0, LocalsSignatureIndex(1))
-// check: MoveToSender(0, LocalsSignatureIndex(1))
+    foo2<T>() acquires Foo {
+        let x: &mut Self.Foo<T>;
+        let y: Self.Foo<T>;
+
+        x = borrow_global_mut<Foo<T>>(get_txn_sender());
+        _ = move(x);
+
+        _ = exists<Foo<T>>(get_txn_sender());
+
+        y = move_from<Foo<T>>(get_txn_sender());
+        move_to_sender<Foo<T>>(move(y));
+        return;
+    }
+
+
+    foo3<T>() acquires Foo {
+        let x: &mut Self.Foo<Self.Foo<T>>;
+        let y: Self.Foo<Self.Foo<T>>;
+
+        x = borrow_global_mut<Foo<Self.Foo<T>>>(get_txn_sender());
+        _ = move(x);
+
+        _ = exists<Foo<Self.Foo<T>>>(get_txn_sender());
+
+        y = move_from<Foo<Self.Foo<T>>>(get_txn_sender());
+        move_to_sender<Foo<Self.Foo<T>>>(move(y));
+        return;
+    }
+
+}

--- a/language/functional_tests/tests/testsuite/generics/call.mvir
+++ b/language/functional_tests/tests/testsuite/generics/call.mvir
@@ -1,28 +1,20 @@
-//! no-run: verifier, runtime
-
 module M {
-    resource Foo {}
+    resource Foo { f: bool }
 
-    public id<T>(x: T) {
+    public id<T>(x: T): T {
         return move(x);
     }
 
     public bar<T1, T2>(x: T1, y: T2) {
+        abort 0;
     }
 
     foo() {
-        let x: u64;
-        let y: Self.Foo;
+        let x: Self.Foo;
 
-        x = Self.id<u64>(3);
-        y = Self.id<Self.Foo>(Foo {});
-        Self.bar<Self.Foo, bool>();
+        _ = Self.id<u64>(3);
+        x = Self.id<Self.Foo>(Foo { f: false });
+        Self.bar<Self.Foo, bool>(move(x), false);
+        return;
     }
 }
-
-// check: [LocalsSignature([TypeParameter(0)]), LocalsSignature([TypeParameter(0), TypeParameter(1)]), LocalsSignature([U64, Struct(StructHandleIndex(0), [])]), LocalsSignature([U64]), LocalsSignature([]), LocalsSignature([Struct(StructHandleIndex(0), [])]), LocalsSignature([Struct(StructHandleIndex(0), []), Bool])]
-
-// check: Call(0, LocalsSignatureIndex(3))
-// check: Pack(0, LocalsSignatureIndex(4))
-// check: Call(0, LocalsSignatureIndex(5))
-// check: Call(1, LocalsSignatureIndex(6))

--- a/language/functional_tests/tests/testsuite/generics/function_def.mvir
+++ b/language/functional_tests/tests/testsuite/generics/function_def.mvir
@@ -2,40 +2,14 @@
 //   1) type parameters have correct kind constraints
 //   2) variables have correct types
 
-//! no-run: verifier, runtime
-
 module M {
-    public id<T> (x: T) {
+    public id<T>(x: T): T {
         return move(x);
     }
-}
 
-// check: FunctionSignature
-
-// check: type_formals
-// check: [All]
-
-// check: LocalsSignature([TypeParameter(0)])
-
-
-
-//! new-transaction
-//! no-run: verifier, runtime
-
-module M {
     public foo<T1, T2, T3: resource, T4: unrestricted>(x1: T4, x2: T3) {
         let x3: T2;
         let x4: T1;
+        abort 0;
     }
 }
-
-// check: FunctionSignature
-
-// check: type_formals
-// check: [All, All, Resource, Unrestricted]
-
-// check: LocalsSignature
-// check: TypeParameter(3)
-// check: TypeParameter(2)
-// check: TypeParameter(1)
-// check: TypeParameter(0)

--- a/language/functional_tests/tests/testsuite/generics/import_function.mvir
+++ b/language/functional_tests/tests/testsuite/generics/import_function.mvir
@@ -1,47 +1,35 @@
-//! no-run: verifier, runtime
-
 module M {
-    resource R {}
+    resource R { f: bool }
 
     public foo<T>(x: T) {
-        return;
+        abort 0;
     }
 
     public bar<T1, T2: resource, T3: unrestricted>(x: T3, y: T2, z: T1) {
-        return;
+        abort 0;
+    }
+
+    public r(): Self.R {
+        return R { f: false };
     }
 }
 
-
-
-
 //! new-transaction
-//! no-run: verifier, runtime
+//! no-run: runtime
 
 import {{default}}.M;
 
 main() {
-    M.foo<u64>();
-    return;
+    M.foo<u64>(0);
+    abort 0;
 }
 
-//! check: FunctionSignature
-//! check: TypeParameter(0)
-//! check: [All]
-
-
-
-
 //! new-transaction
-//! no-run: verifier, runtime
+//! no-run: runtime
 
 import {{default}}.M;
 
 main() {
-    M.bar<u64, M.R, bool>();
-    return;
+    M.bar<u64, M.R, bool>(false, M.r(), 0);
+    abort 0;
 }
-
-//! check: FunctionSignature
-//! check: [TypeParameter(2), TypeParameter(1), TypeParameter(0)]
-//! check: [Unrestricted, Resource, All]

--- a/language/functional_tests/tests/testsuite/generics/import_struct.mvir
+++ b/language/functional_tests/tests/testsuite/generics/import_struct.mvir
@@ -1,16 +1,11 @@
-//! no-run: verifier, runtime
-
 module M {
-    struct Foo<T> { x: T }
+    resource Foo<T> { x: T }
 
     struct Bar<T1, T2: resource, T3: unrestricted> { x: T3, y: T2, z: T1 }
 }
 
-
-
-
 //! new-transaction
-//! no-run: verifier, runtime
+//! no-run: runtime
 
 import {{default}}.M;
 
@@ -19,14 +14,8 @@ main() {
     return;
 }
 
-// check: StructHandle
-// check: [All]
-
-
-
-
 //! new-transaction
-//! no-run: verifier, runtime
+//! no-run: runtime
 
 import {{default}}.M;
 
@@ -34,6 +23,3 @@ main() {
     let x: M.Bar<u64, M.Foo<u64>, bool>;
     return;
 }
-
-// check: StructHandle
-// check: [All, Resource, Unrestricted]

--- a/language/functional_tests/tests/testsuite/generics/pack.mvir
+++ b/language/functional_tests/tests/testsuite/generics/pack.mvir
@@ -1,33 +1,22 @@
-//! no-run: verifier, runtime
-
 module M {
     resource Foo<T> { x: T }
 
     foo() {
         let x: Self.Foo<u64>;
-
         x = Foo<u64> { x : 42 };
+        abort 0;
     }
 }
 
-// check: [LocalsSignature([Struct(StructHandleIndex(0), [U64])]), LocalsSignature([U64])]
-// check: Pack(0, LocalsSignatureIndex(1))
-
-
-
 //! new-transaction
-//! no-run: verifier, runtime
 
-module M {
+module N {
     resource Foo<T1, T2: resource> { x: T1, y: T2 }
-    resource Bar {}
+    resource Bar { f: bool }
 
     foo() {
         let x: Self.Foo<u64, Self.Bar>;
-
-        x = Foo<u64, Self.Bar> { x : 42, y: Bar {} };
+        x = Foo<u64, Self.Bar> { x : 42, y: Bar { f: false } };
+        abort 0;
     }
 }
-
-// check: LocalsSignature([U64, Struct(StructHandleIndex(1), [])]), LocalsSignature([])]
-// check: Pack(0, LocalsSignatureIndex(1))

--- a/language/functional_tests/tests/testsuite/generics/struct_def.mvir
+++ b/language/functional_tests/tests/testsuite/generics/struct_def.mvir
@@ -2,30 +2,7 @@
 //   1) type parameters have correct kind constraints
 //   2) fields have correct types
 
-//! no-run: verifier, runtime
-
 module M {
     struct Foo<T> { x: T }
+    struct Bar<T1, T2, T3: resource, T4: unrestricted> { x1: T2, x2: T3, x3: T4, x4: T1 }
 }
-
-// check: StructHandle
-// check: type_formals: [All]
-// check: type_signatures
-// check: [TypeSignature(TypeParameter(0))]
-
-
-
-//! new-transaction
-//! no-run: verifier, runtime
-
-module M {
-    struct Foo<T1, T2, T3: resource, T4: unrestricted> { x1: T2, x2: T3, x3: T4, x4: T1 }
-}
-
-// check: StructHandle
-// check: type_formals: [All, All, Resource, Unrestricted]
-// check: type_signatures
-// check: TypeSignature(TypeParameter(1))
-// check: TypeSignature(TypeParameter(2))
-// check: TypeSignature(TypeParameter(3))
-// check: TypeSignature(TypeParameter(0))

--- a/language/functional_tests/tests/testsuite/generics/unpack.mvir
+++ b/language/functional_tests/tests/testsuite/generics/unpack.mvir
@@ -1,37 +1,23 @@
-//! no-run: verifier, runtime
-
 module M {
     resource Foo<T> { x: T }
 
     foo() {
-        let x: Self.Foo<u64>;
-        let y: u64;
-
-        x = Foo<u64> { x: 42 };
-        Foo<u64> { y } = move(x);
+        let x: u64;
+        Foo<u64> { x: x } = Foo<u64> { x: 42 };
+        return;
     }
 }
 
-// check: [LocalsSignature([Struct(StructHandleIndex(0), [U64]), U64]), LocalsSignature([U64])]
-// check: Unpack(0, LocalsSignatureIndex(1))
-
-
-
 //! new-transaction
-//! no-run: verifier, runtime
 
-module M {
+module N {
     resource Foo<T1: unrestricted, T2> { x: T1, y: T2 }
 
     foo() {
-        let x: Self.Foo<u64, bool>;
-        let y: u64;
-        let z: bool;
+        let x: u64;
+        let y: bool;
 
-        x = Foo<u64, bool> { x: 42, y: true };
-        Foo<u64, bool> { x: y, y: z } = move(x);
+        Foo<u64, bool> { x: x, y: y }  = Foo<u64, bool> { x: 42, y: true };
+        return;
     }
 }
-
-// check: [LocalsSignature([Struct(StructHandleIndex(0), [U64, Bool]), U64, Bool]), LocalsSignature([U64, Bool])]
-// check: Unpack(0, LocalsSignatureIndex(1))

--- a/language/vm/src/views.rs
+++ b/language/vm/src/views.rs
@@ -621,12 +621,8 @@ impl<'a, T: ModuleAccess> SignatureTokenView<'a, T> {
             | SignatureToken::U64
             | SignatureToken::U128
             | SignatureToken::ByteArray
-            | SignatureToken::Address => false,
-
-            SignatureToken::TypeParameter(idx) => match type_formals[*idx as usize] {
-                Kind::Resource => true,
-                Kind::All | Kind::Unrestricted => false,
-            },
+            | SignatureToken::Address
+            | SignatureToken::TypeParameter(_) => false,
         }
     }
 


### PR DESCRIPTION
##  Motivation
- There was a bug in the logic of `contains_nominal_resource`
- The tests for generics were not being run

## Test Plan

Ran em
