### PR TITLE
Fix two specifications in libra account

### DIFF
--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
@@ -335,8 +335,7 @@ module LibraAccount {
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
                     global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
-        // TODO: we currently cannot verify the case where account did not exist.
-        //   ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
+        ensures old(global_exists<Self.T>(payee)) || global<Self.T>(payee).balance.value == amount
         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
     {
         // TODO: note we added this assertion. Is it a bug?
@@ -366,8 +365,7 @@ module LibraAccount {
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
             global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
-        // TODO: we currently cannot verify the case where account did not exist.
-        //   ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
+        ensures old(global_exists<Self.T>(payee)) || global<Self.T>(payee).balance.value == amount
         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
     {
         // TODO: note we added this assertion. Is it a bug?


### PR DESCRIPTION
This fixes two "TODO's" in the libra account specification.  It also reveals what I believe is a bug in the specification parser.  The unary negation (!) operator was being given lower precedence than the ==> operator, resulting in the old specification, of the form !A ==> B being parsed as !(A ==> B).