### PR TITLE
[prover] Fixing a bug in the spec expression parser.

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1454,7 +1454,7 @@ fn parse_unary_spec_exp<'input>(
         }
         Tok::Exclaim => {
             tokens.advance()?;
-            let exp = parse_spec_exp(tokens)?;
+            let exp = parse_unary_spec_exp(tokens)?;
             SpecExp::Not(Box::new(exp))
         }
         Tok::Old => {

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
@@ -335,8 +335,7 @@ module LibraAccount {
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
                     global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
-        // TODO: we currently cannot verify the case where account did not exist.
-        //   ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
+        ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
     {
         // TODO: note we added this assertion. Is it a bug?
@@ -366,8 +365,7 @@ module LibraAccount {
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
             global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
-        // TODO: we currently cannot verify the case where account did not exist.
-        //   ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
+        ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
     {
         // TODO: note we added this assertion. Is it a bug?


### PR DESCRIPTION
By a little typo logical not (`!`) was parsed with wrong precedence. This fixes two TODO's in libra_account. Kudos to Clark who found the bug.

## Motivation

Get libra_account verified.

## Test Plan

Uncommented previously untested conditions.

## Related PRs

#2308 
