### PR TITLE
[Move Prover] Finish u8 and u128 support

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
@@ -76,7 +76,9 @@ pub fn boogie_type_check(env: &GlobalEnv, name: &str, sig: &GlobalType) -> Strin
     let mut params = name.to_string();
     let mut ret = String::new();
     let check = match sig {
-        GlobalType::U8 | GlobalType::U64 | GlobalType::U128 => "IsValidInteger",
+        GlobalType::U8 => "IsValidU8",
+        GlobalType::U64 => "IsValidU64",
+        GlobalType::U128 => "IsValidU128",
         GlobalType::Bool => "is#Boolean",
         GlobalType::Address => "is#Address",
         GlobalType::ByteArray => "is#ByteArray",

--- a/language/move-prover/bytecode-to-boogie/src/prelude.bpl
+++ b/language/move-prover/bytecode-to-boogie/src/prelude.bpl
@@ -52,8 +52,12 @@ type ByteArray;
 type String;
 type {:datatype} Value;
 
+const MAX_U8: int;
+axiom MAX_U8 == 255;
 const MAX_U64: int;
 axiom MAX_U64 == 9223372036854775807;
+const MAX_U128: int;
+axiom MAX_U128 == 340282366920938463463374607431768211456;
 
 function {:constructor} Boolean(b: bool): Value;
 function {:constructor} Integer(i: int): Value;
@@ -64,10 +68,17 @@ function {:constructor} Vector(v: ValueArray): Value; // used to both represent 
 const DefaultValue: Value;
 function {:builtin "MapConst"} MapConstValue(v: Value): [int]Value;
 
-function {:inline} IsValidInteger(v: Value): bool {
-  is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= 9223372036854775807
+function {:inline} IsValidU8(v: Value): bool {
+  is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= MAX_U8
 }
 
+function {:inline} IsValidU64(v: Value): bool {
+  is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= MAX_U64
+}
+
+function {:inline} IsValidU128(v: Value): bool {
+  is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= MAX_U128
+}
 
 // Value Array
 // -----------
@@ -460,12 +471,60 @@ procedure {:inline 1} FreezeRef(src: Reference) returns (dst: Reference)
     dst := src;
 }
 
-// Pack and Unpack are auto-generated for each type T
-
-procedure {:inline 1} Add(src1: Value, src2: Value) returns (dst: Value)
+procedure {:inline 1} CastU8(src: Value) returns (dst: Value)
 {
-    assume is#Integer(src1) && is#Integer(src2);
+    assume is#Integer(src);
+    if (i#Integer(src) > MAX_U8) {
+        abort_flag := true;
+        return;
+    }
+    dst := src;
+}
+
+procedure {:inline 1} CastU64(src: Value) returns (dst: Value)
+{
+    assume is#Integer(src);
+    if (i#Integer(src) > MAX_U64) {
+        abort_flag := true;
+        return;
+    }
+    dst := src;
+}
+
+procedure {:inline 1} CastU128(src: Value) returns (dst: Value)
+{
+    assume is#Integer(src);
+    if (i#Integer(src) > MAX_U128) {
+        abort_flag := true;
+        return;
+    }
+    dst := src;
+}
+
+procedure {:inline 1} AddU8(src1: Value, src2: Value) returns (dst: Value)
+{
+    assume IsValidU8(src1) && IsValidU8(src2);
+    if (i#Integer(src1) + i#Integer(src2) > MAX_U8) {
+        abort_flag := true;
+        return;
+    }
+    dst := Integer(i#Integer(src1) + i#Integer(src2));
+}
+
+procedure {:inline 1} AddU64(src1: Value, src2: Value) returns (dst: Value)
+{
+    assume IsValidU64(src1) && IsValidU64(src2);
     if (i#Integer(src1) + i#Integer(src2) > MAX_U64) {
+        abort_flag := true;
+        return;
+    }
+    dst := Integer(i#Integer(src1) + i#Integer(src2));
+}
+
+procedure {:inline 1} AddU128(src1: Value, src2: Value) returns (dst: Value)
+{
+    assume IsValidU128(src1) && IsValidU128(src2);
+    if (i#Integer(src1) + i#Integer(src2) > MAX_U128) {
         abort_flag := true;
         return;
     }
@@ -482,10 +541,30 @@ procedure {:inline 1} Sub(src1: Value, src2: Value) returns (dst: Value)
     dst := Integer(i#Integer(src1) - i#Integer(src2));
 }
 
-procedure {:inline 1} Mul(src1: Value, src2: Value) returns (dst: Value)
+procedure {:inline 1} MulU8(src1: Value, src2: Value) returns (dst: Value)
 {
-    assume is#Integer(src1) && is#Integer(src2);
+    assume IsValidU8(src1) && IsValidU8(src2);
+    if (i#Integer(src1) * i#Integer(src2) > MAX_U8) {
+        abort_flag := true;
+        return;
+    }
+    dst := Integer(i#Integer(src1) * i#Integer(src2));
+}
+
+procedure {:inline 1} MulU64(src1: Value, src2: Value) returns (dst: Value)
+{
+    assume IsValidU64(src1) && IsValidU64(src2);
     if (i#Integer(src1) * i#Integer(src2) > MAX_U64) {
+        abort_flag := true;
+        return;
+    }
+    dst := Integer(i#Integer(src1) * i#Integer(src2));
+}
+
+procedure {:inline 1} MulU128(src1: Value, src2: Value) returns (dst: Value)
+{
+    assume IsValidU128(src1) && IsValidU128(src2);
+    if (i#Integer(src1) * i#Integer(src2) > MAX_U128) {
         abort_flag := true;
         return;
     }
@@ -553,6 +632,8 @@ procedure {:inline 1} Not(src: Value) returns (dst: Value)
     assume is#Boolean(src);
     dst := Boolean(!b#Boolean(src));
 }
+
+// Pack and Unpack are auto-generated for each type T
 
 procedure {:inline 1} LdConst(val: int) returns (ret: Value)
 {

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-aborts-if.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-aborts-if.mvir
@@ -85,6 +85,4 @@ module TestAbortIf {
 
        // try 0 abort_ifs, 2 succeeds_ifs, various combinations.
        // ensures holds whenever it doesn't abort?
-
-
 }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-addition.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-addition.mvir
@@ -1,0 +1,47 @@
+module TestAddition {
+
+    // succeeds because aborts_if is correct
+    public overflow_u8_add_bad(x: u8, y: u8): u8
+        aborts_if false //! postcondition might not hold
+    {
+        return move(x) + move(y);
+    }
+
+    // succeeds because aborts_if is correct
+    public overflow_u8_add_ok(x: u8, y: u8): u8
+        aborts_if x + y > 255u8 // U8_MAX
+    {
+        return move(x) + move(y);
+    }
+
+    // succeeds because aborts_if is correct
+    public overflow_u64_add_bad(x: u64, y: u64): u64
+        aborts_if false //! postcondition might not hold
+    {
+        return move(x) + move(y);
+    }
+
+    // succeeds because aborts_if is correct
+    public overflow_u64_add_ok(x: u64, y: u64): u64
+        aborts_if x + y > 9223372036854775807 // U64_MAX
+    {
+        return move(x) + move(y);
+    }
+
+    // succeeds because aborts_if is correct
+    public overflow_u128_add_bad(x: u128, y: u128): u128
+        aborts_if false //! postcondition might not hold
+    {
+        return move(x) + move(y);
+    }
+
+    // TODO: spec parser crashes on this
+    // succeeds because aborts_if is correct
+    //public overflow_u128_add_ok(x: u128, y: u128): u128
+    //    aborts_if x + y > 340282366920938463463374607431768211456u128 // U128_MAX
+    //{
+    //    return move(x) + move(y);
+    //}
+
+
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-cast.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-cast.mvir
@@ -1,0 +1,31 @@
+module CastBad {
+
+    // fails because can abort with cast failure
+    public aborting_u8_cast_bad(x: u64): u8
+        aborts_if false //! postcondition might not hold
+    {
+        return to_u8(move(x));
+    }
+
+    // succeeds because aborts_if is correct
+    public aborting_u8_cast_ok(x: u64): u8
+        aborts_if x > 255 // U8_MAX
+    {
+        return to_u8(move(x));
+    }
+
+    // fails because can abort with cast failure
+    public aborting_u64_cast_bad(x: u128): u64
+        aborts_if false //! postcondition might not hold
+    {
+        return to_u64(move(x));
+    }
+
+    // succeeds because aborts_if is correct
+    public aborting_u64_cast_ok(x: u128): u64
+        aborts_if x > 9223372036854775807u128 // U64_MAX as a u128 type
+    {
+        return to_u64(move(x));
+    }
+
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-multiplication.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-multiplication.mvir
@@ -1,0 +1,44 @@
+module TestMultiplication {
+  // succeeds because aborts_if is correct
+    public overflow_u8_mul_bad(x: u8, y: u8): u8
+        aborts_if false //! postcondition might not hold
+    {
+        return move(x) * move(y);
+    }
+
+    // succeeds because aborts_if is correct
+    public overflow_u8_mul_ok(x: u8, y: u8): u8
+        aborts_if x * y > 255u8 // U8_MAX
+    {
+        return move(x) * move(y);
+    }
+
+
+    // succeeds because aborts_if is correct
+    public overflow_u64_mul_bad(x: u64, y: u64): u64
+        aborts_if false //! postcondition might not hold
+    {
+        return move(x) * move(y);
+    }
+
+    // TODO: Boogie hangs on this
+    //public overflow_u64_mul_ok(x: u64, y: u64): u64
+    //    aborts_if x * y > 9223372036854775807 // U64_MAX
+    //{
+    //    return move(x) * move(y);
+    //}
+
+    // succeeds because aborts_if is correct
+    public overflow_u128_mul_bad(x: u128, y: u128): u128
+        aborts_if false //! postcondition might not hold
+    {
+        return move(x) * move(y);
+    }
+
+    // TODO: spec parser crashes on this
+    //public overflow_u64_mul_ok(x: u128, y: u128): u128
+    //    aborts_if x * y > 340282366920938463463374607431768211456u128 // U128_MAX
+    //{
+    //    return move(x) * move(y);
+    //}
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -61,7 +61,7 @@ function LibraCoin_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
 
 }
@@ -70,7 +70,7 @@ procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
 {
     assume is#Vector(_struct);
     value := SelectField(_struct, LibraCoin_T_value);
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
 }
 
 const unique LibraCoin_MintCapability: TypeName;
@@ -101,7 +101,7 @@ function LibraCoin_MarketCap_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(total_value);
+    assume IsValidU64(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
 
 }
@@ -110,7 +110,7 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 {
     assume is#Vector(_struct);
     total_value := SelectField(_struct, LibraCoin_MarketCap_total_value);
-    assume IsValidInteger(total_value);
+    assume IsValidU64(total_value);
 }
 
 
@@ -138,7 +138,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapabi
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -214,7 +214,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     assume is#Vector(Dereference(m, capability));
     assume IsValidReferenceParameter(m, local_counter, capability);
 
@@ -236,7 +236,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     call tmp := LdConst(1000000);
     m := UpdateLocal(m, old_size + 7, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    call tmp := MulU64(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 8, tmp);
 
@@ -268,7 +268,7 @@ Label_11:
     call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t15);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 16, tmp);
 
@@ -281,7 +281,7 @@ Label_11:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 18, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
+    call tmp := AddU64(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 19, tmp);
 
@@ -430,7 +430,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -520,7 +520,7 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, coin_ref), Libra
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -562,7 +562,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
 
     // assume arguments are of correct types
     assume is#Vector(coin);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -642,7 +642,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), Li
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, coin_ref));
     assume IsValidReferenceParameter(m, local_counter, coin_ref);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 18;
@@ -654,7 +654,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), Li
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
     call tmp := ReadRef(t4);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 5, tmp);
 
@@ -815,7 +815,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -837,7 +837,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 10, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -995,7 +995,7 @@ procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Va
     assume is#Boolean(delegated_withdrawal_capability);
     assume is#Vector(received_events);
     assume is#Vector(sent_events);
-    assume IsValidInteger(sequence_number);
+    assume IsValidU64(sequence_number);
     assume is#Vector(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
 
@@ -1017,7 +1017,7 @@ procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authenticat
     sent_events := SelectField(_struct, LibraAccount_T_sent_events);
     assume is#Vector(sent_events);
     sequence_number := SelectField(_struct, LibraAccount_T_sequence_number);
-    assume IsValidInteger(sequence_number);
+    assume IsValidU64(sequence_number);
     event_generator := SelectField(_struct, LibraAccount_T_event_generator);
     assume is#Vector(event_generator);
 }
@@ -1074,7 +1074,7 @@ function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
@@ -1085,7 +1085,7 @@ procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) retur
 {
     assume is#Vector(_struct);
     amount := SelectField(_struct, LibraAccount_SentPaymentEvent_amount);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     payee := SelectField(_struct, LibraAccount_SentPaymentEvent_payee);
     assume is#Address(payee);
     metadata := SelectField(_struct, LibraAccount_SentPaymentEvent_metadata);
@@ -1104,7 +1104,7 @@ function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
@@ -1115,7 +1115,7 @@ procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) r
 {
     assume is#Vector(_struct);
     amount := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_amount);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     payer := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_payer);
     assume is#Address(payer);
     metadata := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_metadata);
@@ -1130,7 +1130,7 @@ function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
 
 }
@@ -1139,7 +1139,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) r
 {
     assume is#Vector(_struct);
     counter := SelectField(_struct, LibraAccount_EventHandleGenerator_counter);
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
 }
 
 const unique LibraAccount_EventHandle: TypeName;
@@ -1152,7 +1152,7 @@ function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
 
@@ -1162,7 +1162,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 {
     assume is#Vector(_struct);
     counter := SelectField(_struct, LibraAccount_EventHandle_counter);
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     guid := SelectField(_struct, LibraAccount_EventHandle_guid);
     assume is#ByteArray(guid);
 }
@@ -1489,7 +1489,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t8 := LibraCoin_value(t7);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t8);
+    assume IsValidU64(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
 
@@ -1615,7 +1615,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 9;
@@ -1695,7 +1695,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, a
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, account));
     assume IsValidReferenceParameter(m, local_counter, account);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -1763,7 +1763,7 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 11;
@@ -1849,7 +1849,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, cap));
     assume IsValidReferenceParameter(m, local_counter, cap);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -2096,7 +2096,7 @@ requires ExistsTxnSenderAccount(m, txn);
     assume is#Address(payee);
     assume is#Vector(Dereference(m, cap));
     assume IsValidReferenceParameter(m, local_counter, cap);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#ByteArray(metadata);
 
     old_size := local_counter;
@@ -2198,7 +2198,7 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#ByteArray(metadata);
 
     old_size := local_counter;
@@ -2306,7 +2306,7 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -2860,7 +2860,7 @@ ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(f
 
     // assume arguments are of correct types
     assume is#Address(fresh_address);
-    assume IsValidInteger(initial_balance);
+    assume IsValidU64(initial_balance);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -2941,7 +2941,7 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(m, acco
 
     call t4 := LibraCoin_value(t3);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t4);
+    assume IsValidU64(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
 
@@ -3000,7 +3000,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t3 := LibraAccount_balance_for_account(t2);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t3);
+    assume IsValidU64(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
 
@@ -3048,7 +3048,7 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, account), LibraA
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -3101,7 +3101,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t3);
+    assume IsValidU64(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
 
@@ -3415,10 +3415,10 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(txn_sequence_number);
+    assume IsValidU64(txn_sequence_number);
     assume is#ByteArray(txn_public_key);
-    assume IsValidInteger(txn_gas_price);
-    assume IsValidInteger(txn_max_gas_units);
+    assume IsValidU64(txn_gas_price);
+    assume IsValidU64(txn_max_gas_units);
 
     old_size := local_counter;
     local_counter := local_counter + 50;
@@ -3499,7 +3499,7 @@ Label_21:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 26, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
+    call tmp := MulU64(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 27, tmp);
 
@@ -3516,7 +3516,7 @@ Label_21:
 
     call t31 := LibraAccount_balance_for_account(t30);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t31);
+    assume IsValidU64(t31);
 
     m := UpdateLocal(m, old_size + 31, t31);
 
@@ -3549,7 +3549,7 @@ Label_38:
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t38);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 39, tmp);
 
@@ -3657,10 +3657,10 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(txn_sequence_number);
-    assume IsValidInteger(txn_gas_price);
-    assume IsValidInteger(txn_max_gas_units);
-    assume IsValidInteger(gas_units_remaining);
+    assume IsValidU64(txn_sequence_number);
+    assume IsValidU64(txn_gas_price);
+    assume IsValidU64(txn_max_gas_units);
+    assume IsValidU64(gas_units_remaining);
 
     old_size := local_counter;
     local_counter := local_counter + 37;
@@ -3691,7 +3691,7 @@ requires ExistsTxnSenderAccount(m, txn);
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 14, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
+    call tmp := MulU64(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 15, tmp);
 
@@ -3708,7 +3708,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t19 := LibraAccount_balance_for_account(t18);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t19);
+    assume IsValidU64(t19);
 
     m := UpdateLocal(m, old_size + 19, t19);
 
@@ -3750,7 +3750,7 @@ Label_20:
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 28, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
+    call tmp := AddU64(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 29, tmp);
 
@@ -3853,7 +3853,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -3869,7 +3869,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
@@ -4093,7 +4093,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -4106,7 +4106,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -10,7 +10,7 @@ function LibraCoin_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
 
 }
@@ -19,7 +19,7 @@ procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
 {
     assume is#Vector(_struct);
     value := SelectField(_struct, LibraCoin_T_value);
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
 }
 
 const unique LibraCoin_MintCapability: TypeName;
@@ -50,7 +50,7 @@ function LibraCoin_MarketCap_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(total_value);
+    assume IsValidU64(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
 
 }
@@ -59,7 +59,7 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 {
     assume is#Vector(_struct);
     total_value := SelectField(_struct, LibraCoin_MarketCap_total_value);
-    assume IsValidInteger(total_value);
+    assume IsValidU64(total_value);
 }
 
 
@@ -87,7 +87,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapabi
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -163,7 +163,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     assume is#Vector(Dereference(m, capability));
     assume IsValidReferenceParameter(m, local_counter, capability);
 
@@ -185,7 +185,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     call tmp := LdConst(1000000);
     m := UpdateLocal(m, old_size + 7, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    call tmp := MulU64(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 8, tmp);
 
@@ -217,7 +217,7 @@ Label_11:
     call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t15);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 16, tmp);
 
@@ -230,7 +230,7 @@ Label_11:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 18, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
+    call tmp := AddU64(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 19, tmp);
 
@@ -379,7 +379,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -469,7 +469,7 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, coin_ref), Libra
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -511,7 +511,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
 
     // assume arguments are of correct types
     assume is#Vector(coin);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -591,7 +591,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), Li
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, coin_ref));
     assume IsValidReferenceParameter(m, local_counter, coin_ref);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 18;
@@ -603,7 +603,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), Li
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
     call tmp := ReadRef(t4);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 5, tmp);
 
@@ -764,7 +764,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -786,7 +786,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 10, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 11, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -26,8 +26,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -84,8 +84,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 2;
@@ -124,8 +124,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -181,8 +181,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -244,8 +244,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -307,8 +307,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -370,8 +370,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -438,8 +438,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 11;
@@ -519,8 +519,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -57,7 +57,7 @@ function LibraCoin_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
 
 }
@@ -66,7 +66,7 @@ procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
 {
     assume is#Vector(_struct);
     value := SelectField(_struct, LibraCoin_T_value);
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
 }
 
 const unique LibraCoin_MintCapability: TypeName;
@@ -97,7 +97,7 @@ function LibraCoin_MarketCap_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(total_value);
+    assume IsValidU128(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
 
 }
@@ -106,7 +106,7 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 {
     assume is#Vector(_struct);
     total_value := SelectField(_struct, LibraCoin_MarketCap_total_value);
-    assume IsValidInteger(total_value);
+    assume IsValidU128(total_value);
 }
 
 
@@ -130,7 +130,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -199,7 +199,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     assume is#Vector(Dereference(m, capability));
     assume IsValidReferenceParameter(m, local_counter, capability);
 
@@ -217,7 +217,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(1000000);
     m := UpdateLocal(m, old_size + 5, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
+    call tmp := MulU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -249,16 +249,18 @@ Label_9:
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU128(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 15, tmp);
 
-    m := UpdateLocal(m, old_size + 16, GetLocal(m, old_size + 15));
+    call tmp := CastU128(GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 16, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 16));
+    call tmp := AddU128(GetLocal(m, old_size + 14), GetLocal(m, old_size + 16));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 17, tmp);
 
@@ -397,7 +399,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU128(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -485,7 +487,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -524,7 +526,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Vector(coin);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -600,7 +602,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, coin_ref));
     assume IsValidReferenceParameter(m, local_counter, coin_ref);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 18;
@@ -612,7 +614,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
     call tmp := ReadRef(t4);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 5, tmp);
 
@@ -767,7 +769,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -789,7 +791,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 10, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -913,7 +915,7 @@ procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Va
     assume is#Boolean(delegated_withdrawal_capability);
     assume is#Vector(received_events);
     assume is#Vector(sent_events);
-    assume IsValidInteger(sequence_number);
+    assume IsValidU64(sequence_number);
     assume is#Vector(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
 
@@ -935,7 +937,7 @@ procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authenticat
     sent_events := SelectField(_struct, LibraAccount_T_sent_events);
     assume is#Vector(sent_events);
     sequence_number := SelectField(_struct, LibraAccount_T_sequence_number);
-    assume IsValidInteger(sequence_number);
+    assume IsValidU64(sequence_number);
     event_generator := SelectField(_struct, LibraAccount_T_event_generator);
     assume is#Vector(event_generator);
 }
@@ -992,7 +994,7 @@ function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
@@ -1003,7 +1005,7 @@ procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) retur
 {
     assume is#Vector(_struct);
     amount := SelectField(_struct, LibraAccount_SentPaymentEvent_amount);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     payee := SelectField(_struct, LibraAccount_SentPaymentEvent_payee);
     assume is#Address(payee);
     metadata := SelectField(_struct, LibraAccount_SentPaymentEvent_metadata);
@@ -1022,7 +1024,7 @@ function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
@@ -1033,7 +1035,7 @@ procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) r
 {
     assume is#Vector(_struct);
     amount := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_amount);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     payer := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_payer);
     assume is#Address(payer);
     metadata := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_metadata);
@@ -1048,7 +1050,7 @@ function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
 
 }
@@ -1057,7 +1059,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) r
 {
     assume is#Vector(_struct);
     counter := SelectField(_struct, LibraAccount_EventHandleGenerator_counter);
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
 }
 
 const unique LibraAccount_EventHandle: TypeName;
@@ -1070,7 +1072,7 @@ function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
 
@@ -1080,7 +1082,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 {
     assume is#Vector(_struct);
     counter := SelectField(_struct, LibraAccount_EventHandle_counter);
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     guid := SelectField(_struct, LibraAccount_EventHandle_guid);
     assume is#ByteArray(guid);
 }
@@ -1253,7 +1255,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t8 := LibraCoin_value(t7);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t8);
+    assume IsValidU64(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
 
@@ -1379,7 +1381,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 9;
@@ -1455,7 +1457,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, account));
     assume IsValidReferenceParameter(m, local_counter, account);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -1519,7 +1521,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 11;
@@ -1601,7 +1603,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, cap));
     assume IsValidReferenceParameter(m, local_counter, cap);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -1841,7 +1843,7 @@ requires ExistsTxnSenderAccount(m, txn);
     assume is#Address(payee);
     assume is#Vector(Dereference(m, cap));
     assume IsValidReferenceParameter(m, local_counter, cap);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#ByteArray(metadata);
 
     old_size := local_counter;
@@ -1934,7 +1936,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#ByteArray(metadata);
 
     old_size := local_counter;
@@ -2011,7 +2013,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -2521,7 +2523,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(fresh_address);
-    assume IsValidInteger(initial_balance);
+    assume IsValidU64(initial_balance);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -2604,7 +2606,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t4 := LibraCoin_value(t3);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t4);
+    assume IsValidU64(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
 
@@ -2660,7 +2662,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := LibraAccount_balance_for_account(t2);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t3);
+    assume IsValidU64(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
 
@@ -2707,7 +2709,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -2757,7 +2759,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t3);
+    assume IsValidU64(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
 
@@ -3064,10 +3066,10 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(txn_sequence_number);
+    assume IsValidU64(txn_sequence_number);
     assume is#ByteArray(txn_public_key);
-    assume IsValidInteger(txn_gas_price);
-    assume IsValidInteger(txn_max_gas_units);
+    assume IsValidU64(txn_gas_price);
+    assume IsValidU64(txn_max_gas_units);
 
     old_size := local_counter;
     local_counter := local_counter + 50;
@@ -3148,7 +3150,7 @@ Label_21:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 26, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
+    call tmp := MulU64(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 27, tmp);
 
@@ -3165,7 +3167,7 @@ Label_21:
 
     call t31 := LibraAccount_balance_for_account(t30);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t31);
+    assume IsValidU64(t31);
 
     m := UpdateLocal(m, old_size + 31, t31);
 
@@ -3198,7 +3200,7 @@ Label_38:
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t38);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 39, tmp);
 
@@ -3306,10 +3308,10 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(txn_sequence_number);
-    assume IsValidInteger(txn_gas_price);
-    assume IsValidInteger(txn_max_gas_units);
-    assume IsValidInteger(gas_units_remaining);
+    assume IsValidU64(txn_sequence_number);
+    assume IsValidU64(txn_gas_price);
+    assume IsValidU64(txn_max_gas_units);
+    assume IsValidU64(gas_units_remaining);
 
     old_size := local_counter;
     local_counter := local_counter + 37;
@@ -3340,7 +3342,7 @@ requires ExistsTxnSenderAccount(m, txn);
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 14, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
+    call tmp := MulU64(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 15, tmp);
 
@@ -3357,7 +3359,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t19 := LibraAccount_balance_for_account(t18);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t19);
+    assume IsValidU64(t19);
 
     m := UpdateLocal(m, old_size + 19, t19);
 
@@ -3399,7 +3401,7 @@ Label_20:
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 28, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
+    call tmp := AddU64(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 29, tmp);
 
@@ -3503,7 +3505,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -3519,14 +3521,14 @@ requires ExistsTxnSenderAccount(m, txn);
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 15, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 16, tmp);
 
@@ -3749,7 +3751,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -3762,14 +3764,14 @@ requires ExistsTxnSenderAccount(m, txn);
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 15, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 16, tmp);
 
@@ -3909,7 +3911,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t2 := LibraAccount_balance(GetLocal(m, old_size + 1));
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t2);
+    assume IsValidU64(t2);
 
     m := UpdateLocal(m, old_size + 2, t2);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -27,8 +27,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -42,7 +42,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
+    call tmp := AddU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -98,9 +98,9 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
-    assume IsValidInteger(z);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
+    assume IsValidU64(z);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -115,14 +115,14 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
     m := UpdateLocal(m, old_size + 5, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
+    call tmp := AddU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 6, tmp);
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
     m := UpdateLocal(m, old_size + 7, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
+    call tmp := MulU64(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 8, tmp);
 
@@ -181,8 +181,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(a);
-    assume IsValidInteger(b);
+    assume IsValidU64(a);
+    assume IsValidU64(b);
 
     old_size := local_counter;
     local_counter := local_counter + 23;
@@ -304,8 +304,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(a);
-    assume IsValidInteger(b);
+    assume IsValidU64(a);
+    assume IsValidU64(b);
 
     old_size := local_counter;
     local_counter := local_counter + 21;
@@ -319,7 +319,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(4);
     m := UpdateLocal(m, old_size + 4, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    call tmp := AddU64(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 5, tmp);
 
@@ -333,7 +333,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 8, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
+    call tmp := MulU64(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 9, tmp);
 
@@ -434,7 +434,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 4, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
+    call tmp := AddU64(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 5, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -43,7 +43,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 3, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    call tmp := AddU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 4, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -22,7 +22,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -35,7 +35,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 2, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
+    call tmp := AddU64(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -70,7 +70,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
 
     old_size := local_counter;
     local_counter := local_counter + 4;
@@ -83,7 +83,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(2);
     m := UpdateLocal(m, old_size + 2, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
+    call tmp := AddU64(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -164,7 +164,7 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
 
     call t6 := TestFuncCall_f(GetLocal(m, old_size + 5));
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t6);
+    assume IsValidU64(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
 
@@ -179,7 +179,7 @@ Label_8:
 
     call t8 := TestFuncCall_g(GetLocal(m, old_size + 7));
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t8);
+    assume IsValidU64(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -69,8 +69,8 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x1);
-    assume IsValidInteger(x2);
+    assume IsValidU64(x1);
+    assume IsValidU64(x2);
 
     old_size := local_counter;
     local_counter := local_counter + 12;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -73,8 +73,8 @@ function GasSchedule_Cost_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_GasSchedule_Cost(cpu: Value, storage: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(cpu);
-    assume IsValidInteger(storage);
+    assume IsValidU64(cpu);
+    assume IsValidU64(storage);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, cpu), storage));
 
 }
@@ -83,9 +83,9 @@ procedure {:inline 1} Unpack_GasSchedule_Cost(_struct: Value) returns (cpu: Valu
 {
     assume is#Vector(_struct);
     cpu := SelectField(_struct, GasSchedule_Cost_cpu);
-    assume IsValidInteger(cpu);
+    assume IsValidU64(cpu);
     storage := SelectField(_struct, GasSchedule_Cost_storage);
-    assume IsValidInteger(storage);
+    assume IsValidU64(storage);
 }
 
 const unique GasSchedule_T: TypeName;
@@ -223,7 +223,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t6);
+    assume IsValidU64(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
 
@@ -288,7 +288,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t6);
+    assume IsValidU64(t6);
 
     m := UpdateLocal(m, old_size + 6, t6);
 
@@ -1072,7 +1072,7 @@ function LibraCoin_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
 
 }
@@ -1081,7 +1081,7 @@ procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
 {
     assume is#Vector(_struct);
     value := SelectField(_struct, LibraCoin_T_value);
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
 }
 
 const unique LibraCoin_MintCapability: TypeName;
@@ -1112,7 +1112,7 @@ function LibraCoin_MarketCap_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(total_value);
+    assume IsValidU128(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
 
 }
@@ -1121,7 +1121,7 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 {
     assume is#Vector(_struct);
     total_value := SelectField(_struct, LibraCoin_MarketCap_total_value);
-    assume IsValidInteger(total_value);
+    assume IsValidU128(total_value);
 }
 
 
@@ -1145,7 +1145,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -1214,7 +1214,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     assume is#Vector(Dereference(m, capability));
     assume IsValidReferenceParameter(m, local_counter, capability);
 
@@ -1232,7 +1232,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := LdConst(1000000);
     m := UpdateLocal(m, old_size + 5, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
+    call tmp := MulU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -1264,16 +1264,18 @@ Label_9:
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU128(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
     m := UpdateLocal(m, old_size + 15, tmp);
 
-    m := UpdateLocal(m, old_size + 16, GetLocal(m, old_size + 15));
+    call tmp := CastU128(GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 16, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 16));
+    call tmp := AddU128(GetLocal(m, old_size + 14), GetLocal(m, old_size + 16));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 17, tmp);
 
@@ -1412,7 +1414,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU128(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -1500,7 +1502,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -1539,7 +1541,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Vector(coin);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -1615,7 +1617,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, coin_ref));
     assume IsValidReferenceParameter(m, local_counter, coin_ref);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 18;
@@ -1627,7 +1629,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
     call tmp := ReadRef(t4);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 5, tmp);
 
@@ -1782,7 +1784,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -1804,7 +1806,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 10, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
+    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -1928,7 +1930,7 @@ procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Va
     assume is#Boolean(delegated_withdrawal_capability);
     assume is#Vector(received_events);
     assume is#Vector(sent_events);
-    assume IsValidInteger(sequence_number);
+    assume IsValidU64(sequence_number);
     assume is#Vector(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
 
@@ -1950,7 +1952,7 @@ procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authenticat
     sent_events := SelectField(_struct, LibraAccount_T_sent_events);
     assume is#Vector(sent_events);
     sequence_number := SelectField(_struct, LibraAccount_T_sequence_number);
-    assume IsValidInteger(sequence_number);
+    assume IsValidU64(sequence_number);
     event_generator := SelectField(_struct, LibraAccount_T_event_generator);
     assume is#Vector(event_generator);
 }
@@ -2007,7 +2009,7 @@ function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
@@ -2018,7 +2020,7 @@ procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) retur
 {
     assume is#Vector(_struct);
     amount := SelectField(_struct, LibraAccount_SentPaymentEvent_amount);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     payee := SelectField(_struct, LibraAccount_SentPaymentEvent_payee);
     assume is#Address(payee);
     metadata := SelectField(_struct, LibraAccount_SentPaymentEvent_metadata);
@@ -2037,7 +2039,7 @@ function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
@@ -2048,7 +2050,7 @@ procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) r
 {
     assume is#Vector(_struct);
     amount := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_amount);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     payer := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_payer);
     assume is#Address(payer);
     metadata := SelectField(_struct, LibraAccount_ReceivedPaymentEvent_metadata);
@@ -2063,7 +2065,7 @@ function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
 
 }
@@ -2072,7 +2074,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) r
 {
     assume is#Vector(_struct);
     counter := SelectField(_struct, LibraAccount_EventHandleGenerator_counter);
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
 }
 
 const unique LibraAccount_EventHandle: TypeName;
@@ -2085,7 +2087,7 @@ function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
 }
 procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
 
@@ -2095,7 +2097,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 {
     assume is#Vector(_struct);
     counter := SelectField(_struct, LibraAccount_EventHandle_counter);
-    assume IsValidInteger(counter);
+    assume IsValidU64(counter);
     guid := SelectField(_struct, LibraAccount_EventHandle_guid);
     assume is#ByteArray(guid);
 }
@@ -2268,7 +2270,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t8 := LibraCoin_value(t7);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t8);
+    assume IsValidU64(t8);
 
     m := UpdateLocal(m, old_size + 8, t8);
 
@@ -2394,7 +2396,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 9;
@@ -2470,7 +2472,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, account));
     assume IsValidReferenceParameter(m, local_counter, account);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -2534,7 +2536,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 11;
@@ -2616,7 +2618,7 @@ requires ExistsTxnSenderAccount(m, txn);
     // assume arguments are of correct types
     assume is#Vector(Dereference(m, cap));
     assume IsValidReferenceParameter(m, local_counter, cap);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 10;
@@ -2856,7 +2858,7 @@ requires ExistsTxnSenderAccount(m, txn);
     assume is#Address(payee);
     assume is#Vector(Dereference(m, cap));
     assume IsValidReferenceParameter(m, local_counter, cap);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#ByteArray(metadata);
 
     old_size := local_counter;
@@ -2949,7 +2951,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
     assume is#ByteArray(metadata);
 
     old_size := local_counter;
@@ -3026,7 +3028,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(payee);
-    assume IsValidInteger(amount);
+    assume IsValidU64(amount);
 
     old_size := local_counter;
     local_counter := local_counter + 5;
@@ -3536,7 +3538,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     // assume arguments are of correct types
     assume is#Address(fresh_address);
-    assume IsValidInteger(initial_balance);
+    assume IsValidU64(initial_balance);
 
     old_size := local_counter;
     local_counter := local_counter + 8;
@@ -3619,7 +3621,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t4 := LibraCoin_value(t3);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t4);
+    assume IsValidU64(t4);
 
     m := UpdateLocal(m, old_size + 4, t4);
 
@@ -3675,7 +3677,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := LibraAccount_balance_for_account(t2);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t3);
+    assume IsValidU64(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
 
@@ -3722,7 +3724,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 
@@ -3772,7 +3774,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t3);
+    assume IsValidU64(t3);
 
     m := UpdateLocal(m, old_size + 3, t3);
 
@@ -4079,10 +4081,10 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(txn_sequence_number);
+    assume IsValidU64(txn_sequence_number);
     assume is#ByteArray(txn_public_key);
-    assume IsValidInteger(txn_gas_price);
-    assume IsValidInteger(txn_max_gas_units);
+    assume IsValidU64(txn_gas_price);
+    assume IsValidU64(txn_max_gas_units);
 
     old_size := local_counter;
     local_counter := local_counter + 50;
@@ -4163,7 +4165,7 @@ Label_21:
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
     m := UpdateLocal(m, old_size + 26, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
+    call tmp := MulU64(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 27, tmp);
 
@@ -4180,7 +4182,7 @@ Label_21:
 
     call t31 := LibraAccount_balance_for_account(t30);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t31);
+    assume IsValidU64(t31);
 
     m := UpdateLocal(m, old_size + 31, t31);
 
@@ -4213,7 +4215,7 @@ Label_38:
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
 
     call tmp := ReadRef(t38);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 39, tmp);
 
@@ -4321,10 +4323,10 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(txn_sequence_number);
-    assume IsValidInteger(txn_gas_price);
-    assume IsValidInteger(txn_max_gas_units);
-    assume IsValidInteger(gas_units_remaining);
+    assume IsValidU64(txn_sequence_number);
+    assume IsValidU64(txn_gas_price);
+    assume IsValidU64(txn_max_gas_units);
+    assume IsValidU64(gas_units_remaining);
 
     old_size := local_counter;
     local_counter := local_counter + 37;
@@ -4355,7 +4357,7 @@ requires ExistsTxnSenderAccount(m, txn);
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 14, tmp);
 
-    call tmp := Mul(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
+    call tmp := MulU64(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 15, tmp);
 
@@ -4372,7 +4374,7 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t19 := LibraAccount_balance_for_account(t18);
     if (abort_flag) { goto Label_Abort; }
-    assume IsValidInteger(t19);
+    assume IsValidU64(t19);
 
     m := UpdateLocal(m, old_size + 19, t19);
 
@@ -4414,7 +4416,7 @@ Label_20:
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 28, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
+    call tmp := AddU64(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 29, tmp);
 
@@ -4518,7 +4520,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -4534,14 +4536,14 @@ requires ExistsTxnSenderAccount(m, txn);
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 15, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 16, tmp);
 
@@ -4764,7 +4766,7 @@ requires ExistsTxnSenderAccount(m, txn);
     call t10 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t10);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 11, tmp);
 
@@ -4777,14 +4779,14 @@ requires ExistsTxnSenderAccount(m, txn);
     call t13 := CopyOrMoveRef(t2);
 
     call tmp := ReadRef(t13);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
     call tmp := LdConst(1);
     m := UpdateLocal(m, old_size + 15, tmp);
 
-    call tmp := Add(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
     if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 16, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -10,7 +10,7 @@ function TestReference_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestReference_T(value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
 
 }
@@ -19,7 +19,7 @@ procedure {:inline 1} Unpack_TestReference_T(_struct: Value) returns (value: Val
 {
     assume is#Vector(_struct);
     value := SelectField(_struct, TestReference_T_value);
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
 }
 
 
@@ -41,7 +41,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(Dereference(m, b));
+    assume IsValidU64(Dereference(m, b));
     assume IsValidReferenceParameter(m, local_counter, b);
 
     old_size := local_counter;
@@ -118,7 +118,7 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     call t5 := CopyOrMoveRef(t1);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -42,7 +42,7 @@ function TestSpecs_R_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestSpecs_R(x: Value, s: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
     assume is#Vector(s);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, x), s));
 
@@ -52,7 +52,7 @@ procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value, s: V
 {
     assume is#Vector(_struct);
     x := SelectField(_struct, TestSpecs_R_x);
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
     s := SelectField(_struct, TestSpecs_R_s);
     assume is#Vector(s);
 }
@@ -83,8 +83,8 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> abor
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x1);
-    assume IsValidInteger(x2);
+    assume IsValidU64(x1);
+    assume IsValidU64(x2);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -411,7 +411,7 @@ ensures b#Boolean(Boolean(b#Boolean(number_in_range(x)) && b#Boolean(Boolean(i#I
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
 
     old_size := local_counter;
     local_counter := local_counter + 2;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -13,7 +13,7 @@ function TestStruct_B_type_value(): TypeValue {
 procedure {:inline 1} Pack_TestStruct_B(addr: Value, val: Value) returns (_struct: Value)
 {
     assume is#Address(addr);
-    assume IsValidInteger(val);
+    assume IsValidU64(val);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, addr), val));
 
 }
@@ -24,7 +24,7 @@ procedure {:inline 1} Unpack_TestStruct_B(_struct: Value) returns (addr: Value, 
     addr := SelectField(_struct, TestStruct_B_addr);
     assume is#Address(addr);
     val := SelectField(_struct, TestStruct_B_val);
-    assume IsValidInteger(val);
+    assume IsValidU64(val);
 }
 
 const unique TestStruct_A: TypeName;
@@ -37,7 +37,7 @@ function TestStruct_A_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestStruct_A(val: Value, b: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(val);
+    assume IsValidU64(val);
     assume is#Vector(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, val), b));
 
@@ -47,7 +47,7 @@ procedure {:inline 1} Unpack_TestStruct_A(_struct: Value) returns (val: Value, b
 {
     assume is#Vector(_struct);
     val := SelectField(_struct, TestStruct_A_val);
-    assume IsValidInteger(val);
+    assume IsValidU64(val);
     b := SelectField(_struct, TestStruct_A_b);
     assume is#Vector(b);
 }
@@ -62,7 +62,7 @@ function TestStruct_C_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestStruct_C(val: Value, b: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(val);
+    assume IsValidU64(val);
     assume is#Vector(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, val), b));
 
@@ -72,7 +72,7 @@ procedure {:inline 1} Unpack_TestStruct_C(_struct: Value) returns (val: Value, b
 {
     assume is#Vector(_struct);
     val := SelectField(_struct, TestStruct_C_val);
-    assume IsValidInteger(val);
+    assume IsValidU64(val);
     b := SelectField(_struct, TestStruct_C_b);
     assume is#Vector(b);
 }
@@ -85,7 +85,7 @@ function TestStruct_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestStruct_T(x: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
     _struct := Vector(ExtendValueArray(EmptyValueArray, x));
 
 }
@@ -94,7 +94,7 @@ procedure {:inline 1} Unpack_TestStruct_T(_struct: Value) returns (x: Value)
 {
     assume is#Vector(_struct);
     x := SelectField(_struct, TestStruct_T_x);
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
 }
 
 
@@ -363,7 +363,7 @@ Label_11:
     call t16 := CopyOrMoveRef(t4);
 
     call tmp := ReadRef(t16);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 17, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -12,8 +12,8 @@ function Test3_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_Test3_T(f: Value, g: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(f);
-    assume IsValidInteger(g);
+    assume IsValidU64(f);
+    assume IsValidU64(g);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, f), g));
 
 }
@@ -22,9 +22,9 @@ procedure {:inline 1} Unpack_Test3_T(_struct: Value) returns (f: Value, g: Value
 {
     assume is#Vector(_struct);
     f := SelectField(_struct, Test3_T_f);
-    assume IsValidInteger(f);
+    assume IsValidU64(f);
     g := SelectField(_struct, Test3_T_g);
-    assume IsValidInteger(g);
+    assume IsValidU64(g);
 }
 
 
@@ -201,7 +201,7 @@ Label_28:
     call t32 := CopyOrMoveRef(t5);
 
     call tmp := ReadRef(t32);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 33, tmp);
 
@@ -211,7 +211,7 @@ Label_28:
     call t34 := CopyOrMoveRef(t6);
 
     call tmp := ReadRef(t34);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 35, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
@@ -1,0 +1,267 @@
+
+
+// ** structs of module TestAddition
+
+
+
+// ** functions of module TestAddition
+
+procedure {:inline 1} TestAddition_overflow_u8_add_bad (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU8(x);
+    assume IsValidU8(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := AddU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestAddition_overflow_u8_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestAddition_overflow_u8_add_bad(x, y);
+}
+
+procedure {:inline 1} TestAddition_overflow_u8_add_ok (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255))))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU8(x);
+    assume IsValidU8(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := AddU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestAddition_overflow_u8_add_ok_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestAddition_overflow_u8_add_ok(x, y);
+}
+
+procedure {:inline 1} TestAddition_overflow_u64_add_bad (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU64(x);
+    assume IsValidU64(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := AddU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestAddition_overflow_u64_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestAddition_overflow_u64_add_bad(x, y);
+}
+
+procedure {:inline 1} TestAddition_overflow_u64_add_ok (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU64(x);
+    assume IsValidU64(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := AddU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestAddition_overflow_u64_add_ok_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestAddition_overflow_u64_add_ok(x, y);
+}
+
+procedure {:inline 1} TestAddition_overflow_u128_add_bad (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU128(x);
+    assume IsValidU128(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := AddU128(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestAddition_overflow_u128_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestAddition_overflow_u128_add_bad(x, y);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
@@ -1,0 +1,191 @@
+
+
+// ** structs of module CastBad
+
+
+
+// ** functions of module CastBad
+
+procedure {:inline 1} CastBad_aborting_u8_cast_bad (x: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU64(x);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    m := UpdateLocal(m, old_size + 0, x);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CastU8(GetLocal(m, old_size + 1));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    ret0 := GetLocal(m, old_size + 2);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure CastBad_aborting_u8_cast_bad_verify (x: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := CastBad_aborting_u8_cast_bad(x);
+}
+
+procedure {:inline 1} CastBad_aborting_u8_cast_ok (x: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> abort_flag;
+{
+    // declare local variables
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU64(x);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    m := UpdateLocal(m, old_size + 0, x);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CastU8(GetLocal(m, old_size + 1));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    ret0 := GetLocal(m, old_size + 2);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure CastBad_aborting_u8_cast_ok_verify (x: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := CastBad_aborting_u8_cast_ok(x);
+}
+
+procedure {:inline 1} CastBad_aborting_u64_cast_bad (x: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU128(x);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    m := UpdateLocal(m, old_size + 0, x);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CastU64(GetLocal(m, old_size + 1));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    ret0 := GetLocal(m, old_size + 2);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure CastBad_aborting_u64_cast_bad_verify (x: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := CastBad_aborting_u64_cast_bad(x);
+}
+
+procedure {:inline 1} CastBad_aborting_u64_cast_ok (x: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+{
+    // declare local variables
+    var t1: Value; // IntegerType()
+    var t2: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU128(x);
+
+    old_size := local_counter;
+    local_counter := local_counter + 3;
+    m := UpdateLocal(m, old_size + 0, x);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CastU64(GetLocal(m, old_size + 1));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    ret0 := GetLocal(m, old_size + 2);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure CastBad_aborting_u64_cast_ok_verify (x: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := CastBad_aborting_u64_cast_ok(x);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -10,7 +10,7 @@ function TestSpecs_R_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestSpecs_R(x: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
     _struct := Vector(ExtendValueArray(EmptyValueArray, x));
 
 }
@@ -19,7 +19,7 @@ procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value)
 {
     assume is#Vector(_struct);
     x := SelectField(_struct, TestSpecs_R_x);
-    assume IsValidInteger(x);
+    assume IsValidU64(x);
 }
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
@@ -25,8 +25,8 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !abort
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;
@@ -84,8 +84,8 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(x);
-    assume IsValidInteger(y);
+    assume IsValidU64(x);
+    assume IsValidU64(y);
 
     old_size := local_counter;
     local_counter := local_counter + 7;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -21,7 +21,7 @@ requires ExistsTxnSenderAccount(m, txn);
     saved_m := m;
 
     // assume arguments are of correct types
-    assume IsValidInteger(Dereference(m, b));
+    assume IsValidU64(Dereference(m, b));
     assume IsValidReferenceParameter(m, local_counter, b);
 
     old_size := local_counter;
@@ -97,7 +97,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     call t5 := CopyOrMoveRef(t1);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 
@@ -187,7 +187,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     call t5 := CopyOrMoveRef(t1);
 
     call tmp := ReadRef(t5);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 6, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
@@ -1,0 +1,215 @@
+
+
+// ** structs of module TestMultiplication
+
+
+
+// ** functions of module TestMultiplication
+
+procedure {:inline 1} TestMultiplication_overflow_u8_mul_bad (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU8(x);
+    assume IsValidU8(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := MulU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestMultiplication_overflow_u8_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestMultiplication_overflow_u8_mul_bad(x, y);
+}
+
+procedure {:inline 1} TestMultiplication_overflow_u8_mul_ok (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255)))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255))))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU8(x);
+    assume IsValidU8(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := MulU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestMultiplication_overflow_u8_mul_ok_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestMultiplication_overflow_u8_mul_ok(x, y);
+}
+
+procedure {:inline 1} TestMultiplication_overflow_u64_mul_bad (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU64(x);
+    assume IsValidU64(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := MulU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestMultiplication_overflow_u64_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestMultiplication_overflow_u64_mul_bad(x, y);
+}
+
+procedure {:inline 1} TestMultiplication_overflow_u128_mul_bad (x: Value, y: Value) returns (ret0: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+{
+    // declare local variables
+    var t2: Value; // IntegerType()
+    var t3: Value; // IntegerType()
+    var t4: Value; // IntegerType()
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+    assume IsValidU128(x);
+    assume IsValidU128(y);
+
+    old_size := local_counter;
+    local_counter := local_counter + 5;
+    m := UpdateLocal(m, old_size + 0, x);
+    m := UpdateLocal(m, old_size + 1, y);
+
+    // bytecode translation starts here
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 3, tmp);
+
+    call tmp := MulU128(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+}
+
+procedure TestMultiplication_overflow_u128_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0 := TestMultiplication_overflow_u128_mul_bad(x, y);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -10,7 +10,7 @@ function TestSpecs_T_type_value(): TypeValue {
 }
 procedure {:inline 1} Pack_TestSpecs_T(value: Value) returns (_struct: Value)
 {
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
 
 }
@@ -19,7 +19,7 @@ procedure {:inline 1} Unpack_TestSpecs_T(_struct: Value) returns (value: Value)
 {
     assume is#Vector(_struct);
     value := SelectField(_struct, TestSpecs_T_value);
-    assume IsValidInteger(value);
+    assume IsValidU64(value);
 }
 
 
@@ -55,7 +55,7 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, ref), TestSpecs_
     call t2 := BorrowField(t1, TestSpecs_T_value);
 
     call tmp := ReadRef(t2);
-    assume IsValidInteger(tmp);
+    assume IsValidU64(tmp);
 
     m := UpdateLocal(m, old_size + 3, tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -5,6 +5,16 @@ mod driver;
 use driver::*;
 
 #[test]
+fn verify_addition() {
+    test(VERIFY, &["test_mvir/verify-addition.mvir"]);
+}
+
+#[test]
+fn verify_cast() {
+    test(VERIFY, &["test_mvir/verify-cast.mvir"]);
+}
+
+#[test]
 fn verify_create_resource() {
     test(VERIFY, &["test_mvir/verify-create-resource.mvir"]);
 }
@@ -17,6 +27,11 @@ fn verify_div() {
 #[test]
 fn verify_local_ref() {
     test(VERIFY, &["test_mvir/verify-local-ref.mvir"]);
+}
+
+#[test]
+fn verify_multiplication() {
+    test(VERIFY, &["test_mvir/verify-multiplication.mvir"]);
 }
 
 #[test]


### PR DESCRIPTION
In the current prover, u8 and u128 are only supported by the parser--Boogie still treats every integer like a u64. This PR finishes implementing the semantics for the u8/u128 types, their associated arithmetic operations, and casts.

- Add overflow checks to CastU8 and CastU64
- Migrate arithmetic operators from u64-only to polymorphic in integer operand type
- Appropriate overflow checks in u8 and u128 multiplication
- Added helper functions for type assumes (IsValidU8 and IsValidU128)

There are a lot of goldenfile changes because arithmetic ops are so frequent; apologies for the annoyance of reviewing that.

The tests I wrote for this uncovered two bugs: the spec parser (and maybe the IR parser as a whole) can't parse the literal form of u128_max, and Boogie hangs while checking a fairly simple u128 multiplication overflow spec.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Maintaining feature parity between the Move language and prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

New E2E tests which pass except for the bugs mentioned above. Old tests continue to pass.
