### PR TITLE
[secure] introduce a secure storage interface and dummy backends [2/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-secure-storage"
+version = "0.1.0"
+dependencies = [
+ "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-state-view"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,9 +2253,11 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-temppath 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "mempool",
     "mempool/mempool-shared-proto",
     "secure/net",
+    "secure/storage",
     "state-synchronizer",
     "storage/accumulator",
     "storage/backup-restore",

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "libra-secure-storage"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+repository = "https://github.com/libra/libra"
+description = "Libra's Persistent, Secure Storage"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+serde = { version = "1.0.99", features = ["rc"], default-features = false }
+thiserror = "1.0"
+
+[dev-dependencies]
+libra-config = { path = "../../config", version = "0.1.0" }
+rand = "0.6.5"
+
+[features]
+fuzzing = ["libra-crypto/fuzzing"]

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -12,8 +12,10 @@ edition = "2018"
 [dependencies]
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 serde = { version = "1.0.99", features = ["rc"], default-features = false }
 thiserror = "1.0"
+toml = { version = "0.5.3", default-features = false }
 
 [dev-dependencies]
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Internal error: {}", 0)]
+    InternalError(String),
+    #[error("Key not set: {}", 0)]
+    KeyAlreadyExists(String),
+    #[error("Key already exists: {}", 0)]
+    KeyNotSet(String),
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+    #[error("Unexpected value type")]
+    UnexpectedValueType,
+}
+
+impl From<lcs::Error> for Error {
+    fn from(error: lcs::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::io;
 use thiserror::Error;
+use toml;
 
 #[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
 pub enum Error {
@@ -16,6 +18,24 @@ pub enum Error {
     SerializationError(String),
     #[error("Unexpected value type")]
     UnexpectedValueType,
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        Self::InternalError(format!("{}", error))
+    }
+}
+
+impl From<toml::de::Error> for Error {
+    fn from(error: toml::de::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}
+
+impl From<toml::ser::Error> for Error {
+    fn from(error: toml::ser::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
 }
 
 impl From<lcs::Error> for Error {

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Error, permissions::Permissions, storage::Storage, value::Value};
+use std::collections::HashMap;
+
+/// InMemoryStorage represents a key value store that is purely in memory and intended for single
+/// threads (or must be wrapped by a Arc<RwLock<>>). This provides no permission checks and simply
+/// is a proof of concept to unblock building of applications without more complex data stores.
+/// Internally, it retains all data, which means that it must make copies of all key material which
+/// violates the Libra code base. It violates it because the anticipation is that data stores would
+/// securely handle key material. This should not be used in production.
+pub struct InMemoryStorage {
+    data: HashMap<String, Value>,
+}
+
+// @TODO make some non-test calls into this
+#[cfg(test)]
+impl InMemoryStorage {
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+}
+
+impl Storage for InMemoryStorage {
+    fn create(&mut self, key: &str, value: Value, _permissions: &Permissions) -> Result<(), Error> {
+        if self.data.contains_key(key) {
+            return Err(Error::KeyAlreadyExists(key.to_string()));
+        }
+        self.data.insert(key.to_string(), value);
+        Ok(())
+    }
+
+    fn get(&self, key: &str) -> Result<Value, Error> {
+        let value = self
+            .data
+            .get(key)
+            .ok_or_else(|| Error::KeyNotSet(key.to_string()))?;
+
+        let value = match value {
+            Value::Ed25519PrivateKey(value) => {
+                // Hack because Ed25519PrivateKey does not support clone / copy
+                let bytes = lcs::to_bytes(value)?;
+                let key = lcs::from_bytes(&bytes)?;
+                Value::Ed25519PrivateKey(key)
+            }
+            Value::U64(value) => Value::U64(*value),
+        };
+
+        Ok(value)
+    }
+
+    fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        if !self.data.contains_key(key) {
+            return Err(Error::KeyNotSet(key.to_string()));
+        }
+        self.data.insert(key.to_string(), value);
+        Ok(())
+    }
+}

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod error;
 mod in_memory;
+mod on_disk;
 mod permissions;
 mod storage;
 mod value;

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+mod error;
+mod in_memory;
+mod permissions;
+mod storage;
+mod value;
+
+#[cfg(test)]
+mod tests;

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -1,0 +1,80 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Error, permissions::Permissions, storage::Storage, value::Value};
+use libra_temppath::TempPath;
+use std::collections::HashMap;
+use std::{
+    fs::{self, File},
+    io::{Read, Write},
+    path::PathBuf,
+};
+use toml;
+
+/// InMemoryStorage represents a key value store that is purely in memory and intended for single
+/// threads (or must be wrapped by a Arc<RwLock<>>). This provides no permission checks and simply
+/// is a proof of concept to unblock building of applications without more complex data stores.
+/// Internally, it retains all data, which means that it must make copies of all key material which
+/// violates the Libra code base. It violates it because the anticipation is that data stores would
+/// securely handle key material. This should not be used in production.
+pub struct OnDiskStorage {
+    file_path: PathBuf,
+    temp_path: TempPath,
+}
+
+// @TODO make some non-test calls into this
+impl OnDiskStorage {
+    #[cfg(test)]
+    pub fn new(file_path: PathBuf) -> Self {
+        if !file_path.exists() {
+            File::create(&file_path).expect("Unable to create storage");
+        }
+
+        Self {
+            file_path,
+            temp_path: TempPath::new(),
+        }
+    }
+
+    fn read(&self) -> Result<HashMap<String, Value>, Error> {
+        let mut file = File::open(&self.file_path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let data = toml::from_str(&contents)?;
+        Ok(data)
+    }
+
+    fn write(&self, data: &HashMap<String, Value>) -> Result<(), Error> {
+        let contents = toml::to_vec(data)?;
+        let mut file = File::create(self.temp_path.path())?;
+        file.write_all(&contents)?;
+        fs::rename(&self.temp_path, &self.file_path)?;
+        Ok(())
+    }
+}
+
+impl Storage for OnDiskStorage {
+    fn create(&mut self, key: &str, value: Value, _permissions: &Permissions) -> Result<(), Error> {
+        let mut data = self.read()?;
+        if data.contains_key(key) {
+            return Err(Error::KeyAlreadyExists(key.to_string()));
+        }
+        data.insert(key.to_string(), value);
+        self.write(&data)
+    }
+
+    fn get(&self, key: &str) -> Result<Value, Error> {
+        let mut data = self.read()?;
+        data.remove(key)
+            .ok_or_else(|| Error::KeyNotSet(key.to_string()))
+    }
+
+    fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        let mut data = self.read()?;
+        if !data.contains_key(key) {
+            return Err(Error::KeyNotSet(key.to_string()));
+        }
+        data.insert(key.to_string(), value);
+        self.write(&data)
+    }
+}

--- a/secure/storage/src/permissions.rs
+++ b/secure/storage/src/permissions.rs
@@ -1,0 +1,26 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+/// Permissions dictate which Ids may perform different operations.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Permissions {
+    pub readers: Permission,
+    pub writers: Permission,
+}
+
+/// Different possibilities for permissions, a set of Ids that are eligible, Any Id, or No Ids.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Permission {
+    Users(Vec<Id>),
+    Anyone,
+    NoOne,
+}
+
+/// Id represents a Libra internal identifier for a given process. For example, safety_rules or
+/// key_manager. It is up to the Storage and its deployment to translate these identifiers into
+/// verifiable material. For example, the process running safety_rules may have a token that is
+/// intended for only safety_rules to own. The specifics are left to the implementation of the
+/// storage backend interface layer.
+pub type Id = String;

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -1,0 +1,32 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Error, permissions::Permissions, value::Value};
+
+/// Libra interface into storage. Create takes a set of permissions that are enforced internally by
+/// the actual backend. The permissions contain public identities that the backend can translate
+/// into a unique and private token for another service. Hence get and set internally will pass the
+/// current service private token to the backend to gain its permissions.
+pub trait Storage {
+    /// Creates a new value if it does not exist fails only if there is some other issue.
+    fn create_if_not_exists(
+        &mut self,
+        key: &str,
+        value: Value,
+        permissions: &Permissions,
+    ) -> Result<(), Error> {
+        self.create(key, value, permissions).or_else(|err| {
+            if let Error::KeyAlreadyExists(_) = err {
+                Ok(())
+            } else {
+                Err(err)
+            }
+        })
+    }
+    /// Creates a new value in storage and fails if it already exists
+    fn create(&mut self, key: &str, value: Value, permissions: &Permissions) -> Result<(), Error>;
+    /// Retreives a value from storage and fails if invalid permiossions or it does not exist
+    fn get(&self, key: &str) -> Result<Value, Error>;
+    /// Sets a value in storage and fails if invalid permissions or it does not exist
+    fn set(&mut self, key: &str, value: Value) -> Result<(), Error>;
+}

--- a/secure/storage/src/tests/in_memory.rs
+++ b/secure/storage/src/tests/in_memory.rs
@@ -1,0 +1,10 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{in_memory::InMemoryStorage, tests::suite};
+
+#[test]
+fn in_memory() {
+    let storage = Box::new(InMemoryStorage::new());
+    suite::run_test_suite(storage);
+}

--- a/secure/storage/src/tests/mod.rs
+++ b/secure/storage/src/tests/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod in_memory;
+mod on_disk;
 mod suite;

--- a/secure/storage/src/tests/mod.rs
+++ b/secure/storage/src/tests/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod in_memory;
+mod suite;

--- a/secure/storage/src/tests/on_disk.rs
+++ b/secure/storage/src/tests/on_disk.rs
@@ -1,0 +1,12 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{on_disk::OnDiskStorage, tests::suite};
+use libra_temppath::TempPath;
+
+#[test]
+fn on_disk() {
+    let temp_path = TempPath::new();
+    let storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
+    suite::run_test_suite(storage);
+}

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -1,0 +1,96 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::Error,
+    permissions::{Permission, Permissions},
+    storage::Storage,
+    value::Value,
+};
+use libra_crypto::{ed25519::Ed25519PrivateKey, Uniform};
+use rand::{rngs::StdRng, SeedableRng};
+
+const KEY_KEY: &str = "key";
+const U64_KEY: &str = "u64";
+
+pub fn run_test_suite(mut storage: Box<dyn Storage>) {
+    let no_perms = Permissions {
+        readers: Permission::Anyone,
+        writers: Permission::Anyone,
+    };
+    let u64_value_0 = 5;
+    let u64_value_1 = 2322;
+
+    let mut rng = StdRng::from_seed([13u8; 32]);
+    let key_value_0 = Ed25519PrivateKey::generate_for_testing(&mut rng);
+    let key_value_1 = Ed25519PrivateKey::generate_for_testing(&mut rng);
+
+    assert_eq!(
+        storage.get(KEY_KEY).unwrap_err(),
+        Error::KeyNotSet(KEY_KEY.to_string())
+    );
+    assert_eq!(
+        storage.get(U64_KEY).unwrap_err(),
+        Error::KeyNotSet(U64_KEY.to_string())
+    );
+
+    assert_eq!(
+        storage
+            .set(KEY_KEY, Value::Ed25519PrivateKey(key_value_0.clone()))
+            .unwrap_err(),
+        Error::KeyNotSet(KEY_KEY.to_string())
+    );
+    assert_eq!(
+        storage.set(U64_KEY, Value::U64(u64_value_0)).unwrap_err(),
+        Error::KeyNotSet(U64_KEY.to_string())
+    );
+
+    storage
+        .create_if_not_exists(U64_KEY, Value::U64(u64_value_1), &no_perms)
+        .unwrap();
+    storage
+        .create(
+            KEY_KEY,
+            Value::Ed25519PrivateKey(key_value_1.clone()),
+            &no_perms,
+        )
+        .unwrap();
+
+    assert_eq!(storage.get(U64_KEY).unwrap().u64().unwrap(), u64_value_1);
+    assert_eq!(
+        &storage.get(KEY_KEY).unwrap().ed25519_private_key().unwrap(),
+        &key_value_1
+    );
+
+    storage.set(U64_KEY, Value::U64(u64_value_0)).unwrap();
+    storage
+        .set(KEY_KEY, Value::Ed25519PrivateKey(key_value_0.clone()))
+        .unwrap();
+
+    assert_eq!(&storage.get(U64_KEY).unwrap().u64().unwrap(), &u64_value_0);
+    assert_eq!(
+        &storage.get(KEY_KEY).unwrap().ed25519_private_key().unwrap(),
+        &key_value_0
+    );
+
+    // Should not affect the above computation
+    storage
+        .create_if_not_exists(U64_KEY, Value::U64(u64_value_1), &no_perms)
+        .unwrap();
+    storage
+        .create_if_not_exists(KEY_KEY, Value::Ed25519PrivateKey(key_value_1), &no_perms)
+        .unwrap();
+
+    assert_eq!(
+        storage
+            .get(U64_KEY)
+            .unwrap()
+            .ed25519_private_key()
+            .unwrap_err(),
+        Error::UnexpectedValueType
+    );
+    assert_eq!(
+        storage.get(KEY_KEY).unwrap().u64().unwrap_err(),
+        Error::UnexpectedValueType
+    );
+}

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -1,0 +1,33 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+use crate::error::Error;
+use libra_crypto::ed25519::Ed25519PrivateKey;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[serde(content = "value", rename_all = "snake_case", tag = "type")]
+pub enum Value {
+    Ed25519PrivateKey(Ed25519PrivateKey),
+    U64(u64),
+}
+
+#[cfg(test)]
+impl Value {
+    pub fn u64(self) -> Result<u64, Error> {
+        if let Value::U64(value) = self {
+            Ok(value)
+        } else {
+            Err(Error::UnexpectedValueType)
+        }
+    }
+
+    pub fn ed25519_private_key(self) -> Result<Ed25519PrivateKey, Error> {
+        if let Value::Ed25519PrivateKey(value) = self {
+            Ok(value)
+        } else {
+            Err(Error::UnexpectedValueType)
+        }
+    }
+}


### PR DESCRIPTION
Follows https://github.com/libra/libra/pull/2312

This introduces a generic storage layer both in memory and on disk that is intended to eventually mirror how our secure services communicate with arbitrary secure backends like Vault, Amazon, etc. This does not introduce the security primitives but glosses over them in the Id / Permissions context. The primary intent is to replace the SafetyRules specific storage with a generic one that has the correct properties to support authenticated / encrypted storage.