### PR TITLE
[safety-rules] Replace original persistent store with secure store [3/n]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,6 +3925,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-secure-net 0.1.0",
+ "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -13,6 +13,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-secure-net = { path = "../../secure/net", version = "0.1.0" }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 serde = { version = "1.0.99", default-features = false }

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -17,12 +17,8 @@ mod t_safety_rules;
 mod thread;
 
 pub use crate::{
-    consensus_state::ConsensusState,
-    error::Error,
-    persistent_storage::{InMemoryStorage, OnDiskStorage},
-    process::ProcessService,
-    safety_rules::SafetyRules,
-    safety_rules_manager::SafetyRulesManager,
+    consensus_state::ConsensusState, error::Error, persistent_storage::PersistentStorage,
+    process::ProcessService, safety_rules::SafetyRules, safety_rules_manager::SafetyRulesManager,
     t_safety_rules::TSafetyRules,
 };
 

--- a/consensus/safety-rules/src/persistent_storage.rs
+++ b/consensus/safety-rules/src/persistent_storage.rs
@@ -3,213 +3,105 @@
 
 use anyhow::Result;
 use consensus_types::common::Round;
-use libra_config::config::PersistableConfig;
-use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, path::PathBuf};
-#[cfg(test)]
-use tempfile::NamedTempFile;
+use libra_secure_storage::{InMemoryStorage, Permissions, Storage, Value};
 
 /// SafetyRules needs an abstract storage interface to act as a common utility for storing
 /// persistent data to local disk, cloud, secrets managers, or even memory (for tests)
 /// Any set function is expected to sync to the remote system before returning.
 /// @TODO add access to private key from persistent store
 /// @TODO add retrieval of private key based upon public key to persistent store
-pub trait PersistentStorage: Send + Sync {
-    fn epoch(&self) -> u64;
-    fn set_epoch(&mut self, epoch: u64) -> Result<()>;
-    fn last_voted_round(&self) -> Round;
-    fn set_last_voted_round(&mut self, last_voted_round: Round) -> Result<()>;
-    fn preferred_round(&self) -> Round;
-    fn set_preferred_round(&mut self, last_voted_round: Round) -> Result<()>;
+pub struct PersistentStorage {
+    internal_store: Box<dyn Storage>,
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, PartialOrd, Serialize)]
-pub struct InMemoryStorage {
-    epoch: u64,
-    last_voted_round: Round,
-    preferred_round: Round,
-}
+const EPOCH: &str = "epoch";
+const LAST_VOTED_ROUND: &str = "last_voted_round";
+const PREFERRED_ROUND: &str = "preferred_round";
 
-impl InMemoryStorage {
-    pub fn new(epoch: u64, last_voted_round: Round, preferred_round: Round) -> Self {
-        Self {
-            epoch,
-            last_voted_round,
-            preferred_round,
-        }
+impl PersistentStorage {
+    pub fn in_memory() -> Self {
+        let storage = Box::new(InMemoryStorage::new());
+        Self::initialize(storage)
     }
 
-    pub fn default_storage() -> Box<dyn PersistentStorage> {
-        Box::new(Self::default())
-    }
-}
-
-impl Default for InMemoryStorage {
-    fn default() -> Self {
-        Self {
-            epoch: 1,
-            last_voted_round: 0,
-            preferred_round: 0,
-        }
-    }
-}
-
-impl Ord for InMemoryStorage {
-    fn cmp(&self, other: &InMemoryStorage) -> Ordering {
-        let epoch = self.epoch.cmp(&other.epoch);
-        if epoch != Ordering::Equal {
-            return epoch;
-        }
-
-        let last_voted_round = self.last_voted_round.cmp(&other.last_voted_round);
-        if last_voted_round != Ordering::Equal {
-            return last_voted_round;
-        }
-
-        self.preferred_round.cmp(&other.preferred_round)
-    }
-}
-
-impl PersistentStorage for InMemoryStorage {
-    fn epoch(&self) -> u64 {
-        self.epoch
+    /// Use this to instantiate a PersistentStorage for a new data store, one that has no
+    /// SafetyRules values set.
+    pub fn initialize(mut internal_store: Box<dyn Storage>) -> Self {
+        let perms = Permissions::anyone();
+        internal_store
+            .create_if_not_exists(EPOCH, Value::U64(1), &perms)
+            .expect("Unable to initialize backend storage");
+        internal_store
+            .create_if_not_exists(LAST_VOTED_ROUND, Value::U64(0), &perms)
+            .expect("Unable to initialize backend storage");
+        internal_store
+            .create_if_not_exists(PREFERRED_ROUND, Value::U64(0), &perms)
+            .expect("Unable to initialize backend storage");
+        Self { internal_store }
     }
 
-    fn set_epoch(&mut self, epoch: u64) -> Result<()> {
-        self.epoch = epoch;
+    /// Use this to instantiate a PersistentStorage with an existing data store. This is intended
+    /// for constructed environments.
+    pub fn new(internal_store: Box<dyn Storage>) -> Self {
+        Self { internal_store }
+    }
+
+    pub fn epoch(&self) -> Result<u64> {
+        Ok(self
+            .internal_store
+            .get(EPOCH)
+            .and_then(|value| value.u64())?)
+    }
+
+    pub fn set_epoch(&mut self, epoch: u64) -> Result<()> {
+        self.internal_store.set(EPOCH, Value::U64(epoch))?;
         Ok(())
     }
 
-    fn preferred_round(&self) -> Round {
-        self.preferred_round
+    pub fn last_voted_round(&self) -> Result<Round> {
+        Ok(self
+            .internal_store
+            .get(LAST_VOTED_ROUND)
+            .and_then(|value| value.u64())?)
     }
 
-    fn set_preferred_round(&mut self, preferred_round: Round) -> Result<()> {
-        self.preferred_round = preferred_round;
+    pub fn set_last_voted_round(&mut self, last_voted_round: Round) -> Result<()> {
+        self.internal_store
+            .set(LAST_VOTED_ROUND, Value::U64(last_voted_round))?;
         Ok(())
     }
 
-    fn last_voted_round(&self) -> Round {
-        self.last_voted_round
+    pub fn preferred_round(&self) -> Result<Round> {
+        Ok(self
+            .internal_store
+            .get(PREFERRED_ROUND)
+            .and_then(|value| value.u64())?)
     }
 
-    fn set_last_voted_round(&mut self, last_voted_round: Round) -> Result<()> {
-        self.last_voted_round = last_voted_round;
+    pub fn set_preferred_round(&mut self, preferred_round: Round) -> Result<()> {
+        self.internal_store
+            .set(PREFERRED_ROUND, Value::U64(preferred_round))?;
         Ok(())
     }
 }
 
-#[test]
-fn test_in_memory_storage() {
-    let mut storage: Box<dyn PersistentStorage> = InMemoryStorage::default_storage();
-    assert_eq!(storage.epoch(), 1);
-    assert_eq!(storage.last_voted_round(), 0);
-    assert_eq!(storage.preferred_round(), 0);
-    storage.set_epoch(9).unwrap();
-    storage.set_last_voted_round(8).unwrap();
-    storage.set_preferred_round(1).unwrap();
-    assert_eq!(storage.epoch(), 9);
-    assert_eq!(storage.last_voted_round(), 8);
-    assert_eq!(storage.preferred_round(), 1);
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libra_secure_storage::InMemoryStorage;
 
-pub struct OnDiskStorage {
-    file_path: PathBuf,
-    file_path_alt: PathBuf,
-    internal_data: InMemoryStorage,
-}
-
-impl OnDiskStorage {
-    pub fn new_storage(file_path: PathBuf) -> Result<Box<dyn PersistentStorage>> {
-        Self::new_internal(file_path, false)
+    #[test]
+    fn test() {
+        let internal = Box::new(InMemoryStorage::new());
+        let mut storage = PersistentStorage::initialize(internal);
+        assert_eq!(storage.epoch().unwrap(), 1);
+        assert_eq!(storage.last_voted_round().unwrap(), 0);
+        assert_eq!(storage.preferred_round().unwrap(), 0);
+        storage.set_epoch(9).unwrap();
+        storage.set_last_voted_round(8).unwrap();
+        storage.set_preferred_round(1).unwrap();
+        assert_eq!(storage.epoch().unwrap(), 9);
+        assert_eq!(storage.last_voted_round().unwrap(), 8);
+        assert_eq!(storage.preferred_round().unwrap(), 1);
     }
-
-    pub fn default_storage(file_path: PathBuf) -> Result<Box<dyn PersistentStorage>> {
-        Self::new_internal(file_path, true)
-    }
-
-    fn new_internal(mut file_path: PathBuf, default: bool) -> Result<Box<dyn PersistentStorage>> {
-        let mut file_path_alt = PathBuf::from(format!("{}.alt", file_path.to_str().unwrap()));
-        let internal_data = InMemoryStorage::load_config(&file_path);
-        let internal_data_alt = InMemoryStorage::load_config(&file_path_alt);
-
-        if !default && internal_data.is_err() && internal_data_alt.is_err() {
-            if let Err(err) = internal_data {
-                return Err(err);
-            }
-        }
-
-        let mut internal_data = internal_data.unwrap_or_default();
-        let internal_data_alt = internal_data_alt.unwrap_or_default();
-
-        if internal_data < internal_data_alt {
-            internal_data = internal_data_alt;
-            std::mem::swap(&mut file_path, &mut file_path_alt);
-        }
-
-        Ok(Box::new(Self {
-            file_path,
-            file_path_alt,
-            internal_data,
-        }))
-    }
-
-    fn save_and_swap(&mut self) -> Result<()> {
-        self.internal_data.save_config(&self.file_path)?;
-        std::mem::swap(&mut self.file_path, &mut self.file_path_alt);
-        Ok(())
-    }
-}
-
-impl PersistentStorage for OnDiskStorage {
-    fn epoch(&self) -> u64 {
-        self.internal_data.epoch()
-    }
-
-    fn set_epoch(&mut self, epoch: u64) -> Result<()> {
-        self.internal_data.set_epoch(epoch)?;
-        self.save_and_swap()?;
-        Ok(())
-    }
-
-    fn preferred_round(&self) -> Round {
-        self.internal_data.preferred_round()
-    }
-
-    fn set_preferred_round(&mut self, preferred_round: Round) -> Result<()> {
-        self.internal_data.set_preferred_round(preferred_round)?;
-        self.save_and_swap()?;
-        Ok(())
-    }
-
-    fn last_voted_round(&self) -> Round {
-        self.internal_data.last_voted_round()
-    }
-
-    fn set_last_voted_round(&mut self, last_voted_round: Round) -> Result<()> {
-        self.internal_data.set_last_voted_round(last_voted_round)?;
-        self.save_and_swap()?;
-        Ok(())
-    }
-}
-
-#[test]
-fn test_on_disk_storage() {
-    let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
-    let mut storage: Box<dyn PersistentStorage> =
-        OnDiskStorage::default_storage(file_path.clone()).unwrap();
-    assert_eq!(storage.epoch(), 1);
-    assert_eq!(storage.last_voted_round(), 0);
-    assert_eq!(storage.preferred_round(), 0);
-    storage.set_epoch(9).unwrap();
-    storage.set_last_voted_round(8).unwrap();
-    storage.set_preferred_round(1).unwrap();
-    assert_eq!(storage.epoch(), 9);
-    assert_eq!(storage.last_voted_round(), 8);
-    assert_eq!(storage.preferred_round(), 1);
-
-    let storage: Box<dyn PersistentStorage> = OnDiskStorage::default_storage(file_path).unwrap();
-    assert_eq!(storage.epoch(), 9);
-    assert_eq!(storage.last_voted_round(), 8);
-    assert_eq!(storage.preferred_round(), 1);
 }

--- a/consensus/safety-rules/src/process.rs
+++ b/consensus/safety-rules/src/process.rs
@@ -63,5 +63,5 @@ impl<T: Payload> RemoteService<T> for ProcessService {
 
 struct ProcessServiceData {
     validator_signer: ValidatorSigner,
-    storage: Box<dyn PersistentStorage>,
+    storage: PersistentStorage,
 }

--- a/consensus/safety-rules/src/remote_service.rs
+++ b/consensus/safety-rules/src/remote_service.rs
@@ -22,7 +22,7 @@ pub trait RemoteService<T: Payload> {
 }
 
 pub fn execute<T: Payload>(
-    storage: Box<dyn PersistentStorage>,
+    storage: PersistentStorage,
     validator_signer: ValidatorSigner,
     listen_addr: SocketAddr,
 ) {

--- a/consensus/safety-rules/src/tests/local.rs
+++ b/consensus/safety-rules/src/tests/local.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tests::suite, InMemoryStorage, SafetyRulesManager, TSafetyRules};
+use crate::{tests::suite, PersistentStorage, SafetyRulesManager, TSafetyRules};
 use consensus_types::common::{Payload, Round};
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ fn test() {
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
     let signer = ValidatorSigner::from_int(0);
     let safety_rules_manager =
-        SafetyRulesManager::new_local(Box::new(InMemoryStorage::default()), signer.clone());
+        SafetyRulesManager::new_local(PersistentStorage::in_memory(), signer.clone());
     let safety_rules = safety_rules_manager.client();
     (safety_rules, Arc::new(signer))
 }

--- a/consensus/safety-rules/src/tests/safety_rules.rs
+++ b/consensus/safety-rules/src/tests/safety_rules.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tests::suite, InMemoryStorage, SafetyRules, TSafetyRules};
+use crate::{tests::suite, PersistentStorage, SafetyRules, TSafetyRules};
 use consensus_types::common::{Payload, Round};
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ fn test() {
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
     let signer = Arc::new(ValidatorSigner::from_int(0));
     let safety_rules = Box::new(SafetyRules::<T>::new(
-        InMemoryStorage::default_storage(),
+        PersistentStorage::in_memory(),
         signer.clone(),
     ));
     (safety_rules, signer)

--- a/consensus/safety-rules/src/tests/serializer.rs
+++ b/consensus/safety-rules/src/tests/serializer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tests::suite, InMemoryStorage, SafetyRulesManager, TSafetyRules};
+use crate::{tests::suite, PersistentStorage, SafetyRulesManager, TSafetyRules};
 use consensus_types::common::{Payload, Round};
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ fn test() {
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
     let signer = ValidatorSigner::from_int(0);
     let safety_rules_manager =
-        SafetyRulesManager::new_serializer(Box::new(InMemoryStorage::default()), signer.clone());
+        SafetyRulesManager::new_serializer(PersistentStorage::in_memory(), signer.clone());
     let safety_rules = safety_rules_manager.client();
     (safety_rules, Arc::new(signer))
 }

--- a/consensus/safety-rules/src/tests/thread.rs
+++ b/consensus/safety-rules/src/tests/thread.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tests::suite, InMemoryStorage, SafetyRulesManager, TSafetyRules};
+use crate::{tests::suite, PersistentStorage, SafetyRulesManager, TSafetyRules};
 use consensus_types::common::{Payload, Round};
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::sync::Arc;
@@ -14,7 +14,7 @@ fn test() {
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
     let signer = ValidatorSigner::from_int(0);
     let safety_rules_manager =
-        SafetyRulesManager::new_thread(Box::new(InMemoryStorage::default()), signer.clone());
+        SafetyRulesManager::new_thread(PersistentStorage::in_memory(), signer.clone());
     let safety_rules = safety_rules_manager.client();
     (safety_rules, Arc::new(signer))
 }

--- a/consensus/safety-rules/src/thread.rs
+++ b/consensus/safety-rules/src/thread.rs
@@ -29,7 +29,7 @@ pub struct ThreadService<T> {
 }
 
 impl<T: Payload> ThreadService<T> {
-    pub fn new(storage: Box<dyn PersistentStorage>, validator_signer: ValidatorSigner) -> Self {
+    pub fn new(storage: PersistentStorage, validator_signer: ValidatorSigner) -> Self {
         let listen_port = utils::get_available_port();
         let listen_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_port);
         let server_addr = listen_addr;

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -23,7 +23,7 @@ use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, Val
 use network::{proto::Proposal, validator_network::ConsensusNetworkSender};
 use once_cell::sync::Lazy;
 use prost::Message as _;
-use safety_rules::{InMemoryStorage, SafetyRules};
+use safety_rules::{PersistentStorage as SafetyStorage, SafetyRules};
 use std::convert::TryFrom;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -90,8 +90,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     let (initial_data, storage) = MockStorage::<TestPayload>::start_for_testing(validator_set);
 
     // TODO: remove
-    let safety_rules =
-        SafetyRules::new(InMemoryStorage::default_storage(), Arc::new(signer.clone()));
+    let safety_rules = SafetyRules::new(SafetyStorage::in_memory(), Arc::new(signer.clone()));
 
     // TODO: mock channels
     let (network_reqs_tx, _network_reqs_rx) = channel::new_test(8);

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -56,7 +56,7 @@ use network::{
     validator_network::{ConsensusNetworkEvents, ConsensusNetworkSender},
 };
 use prost::Message as _;
-use safety_rules::{ConsensusState, InMemoryStorage, SafetyRulesManager};
+use safety_rules::{ConsensusState, PersistentStorage as SafetyStorage, SafetyRulesManager};
 use std::sync::RwLock;
 use std::{collections::HashMap, convert::TryFrom, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
@@ -99,7 +99,7 @@ impl NodeSetup {
                 MockStorage::<TestPayload>::start_for_testing((&validators).into());
 
             let safety_rules_manager =
-                SafetyRulesManager::new_local(Box::new(InMemoryStorage::default()), signer.clone());
+                SafetyRulesManager::new_local(SafetyStorage::in_memory(), signer.clone());
 
             nodes.push(Self::new(
                 playground,

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -14,8 +14,6 @@ pub struct InMemoryStorage {
     data: HashMap<String, Value>,
 }
 
-// @TODO make some non-test calls into this
-#[cfg(test)]
 impl InMemoryStorage {
     pub fn new() -> Self {
         Self {

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -10,5 +10,14 @@ mod permissions;
 mod storage;
 mod value;
 
+pub use crate::{
+    error::Error,
+    in_memory::InMemoryStorage,
+    on_disk::OnDiskStorage,
+    permissions::{Id, Permission, Permissions},
+    storage::Storage,
+    value::Value,
+};
+
 #[cfg(test)]
 mod tests;

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -22,9 +22,7 @@ pub struct OnDiskStorage {
     temp_path: TempPath,
 }
 
-// @TODO make some non-test calls into this
 impl OnDiskStorage {
-    #[cfg(test)]
     pub fn new(file_path: PathBuf) -> Self {
         if !file_path.exists() {
             File::create(&file_path).expect("Unable to create storage");

--- a/secure/storage/src/permissions.rs
+++ b/secure/storage/src/permissions.rs
@@ -24,3 +24,12 @@ pub enum Permission {
 /// intended for only safety_rules to own. The specifics are left to the implementation of the
 /// storage backend interface layer.
 pub type Id = String;
+
+impl Permissions {
+    pub fn anyone() -> Self {
+        Self {
+            readers: Permission::Anyone,
+            writers: Permission::Anyone,
+        }
+    }
+}

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -1,13 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error, permissions::Permissions, value::Value};
+use crate::{Error, Permissions, Value};
 
 /// Libra interface into storage. Create takes a set of permissions that are enforced internally by
 /// the actual backend. The permissions contain public identities that the backend can translate
 /// into a unique and private token for another service. Hence get and set internally will pass the
 /// current service private token to the backend to gain its permissions.
-pub trait Storage {
+pub trait Storage: Send + Sync {
     /// Creates a new value if it does not exist fails only if there is some other issue.
     fn create_if_not_exists(
         &mut self,

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(test)]
 use crate::error::Error;
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,6 @@ pub enum Value {
     U64(u64),
 }
 
-#[cfg(test)]
 impl Value {
     pub fn u64(self) -> Result<u64, Error> {
         if let Value::U64(value) = self {


### PR DESCRIPTION
Follows https://github.com/libra/libra/pull/2313

Secure store is a generic key/value store for multiple purposes (key
management). This commit replaces the safety rules specific storage with
this general purpose storage. There is a bit more work to be done:
- config for secure storage
- integrate the key into storage