### PR TITLE
[language][prover] Added a test and fixed bugs related to vectors.

### DIFF
--- a/language/move-prover/README.md
+++ b/language/move-prover/README.md
@@ -1,9 +1,15 @@
 ---
 id: move-prover
 title: Formal verification code
-custom_edit_url: https://github.com/libra/libra/edit/master/language/README.md
+custom_edit_url: https://github.com/libra/libra/edit/master/language/move-prover/README.md
 ---
 
 # Code supporting formal verification for Move programs
 
 ## Code under this subtree is experimental. It is out of scope for [the Libra Bug Bounty](https://hackerone.com/libra) until it is no longer marked experimental.
+
+## Debugging tips
+
+During development, we sometimes want to edit the boogie file and run boogie on it explicitly.  You can see the boogie command line by cd'ing to the bytecode-to-boogie subdirectory and typing something like:
+
+cargo run -- --verbose debug ../../stdlib/modules/vector.mvir test_mvir/verify_vector.mvir

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -17,8 +17,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub const INLINE_PRELUDE: &str = "<inline-prelude>";
 
 /// Default flags passed to boogie. Additional flags will be added to this via the -B option.
+
 const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-doModSetAnalysis",
+    "-useArrayTheory",
     "-noinfer",
     "-printVerifiedProceduresCount:0",
 ];

--- a/language/move-prover/bytecode-to-boogie/src/prelude.bpl
+++ b/language/move-prover/bytecode-to-boogie/src/prelude.bpl
@@ -30,7 +30,9 @@ function {:constructor} ByteArrayType() : TypeValue;
 function {:constructor} StrType() : TypeValue;
 function {:constructor} VectorType(t: TypeValue) : TypeValue;
 function {:constructor} StructType(name: TypeName, ts: TypeValueArray) : TypeValue;
+function {:constructor} ErrorType() : TypeValue;
 const DefaultTypeValue: TypeValue;
+axiom DefaultTypeValue == ErrorType();
 function {:builtin "MapConst"} MapConstTypeValue(tv: TypeValue): [int]TypeValue;
 
 type {:datatype} TypeValueArray;
@@ -65,7 +67,9 @@ function {:constructor} Address(a: Address): Value;
 function {:constructor} ByteArray(b: ByteArray): Value;
 function {:constructor} Str(a: String): Value;
 function {:constructor} Vector(v: ValueArray): Value; // used to both represent move Struct and Vector
+function {:constructor} Error(): Value;
 const DefaultValue: Value;
+axiom DefaultValue == Error();
 function {:builtin "MapConst"} MapConstValue(v: Value): [int]Value;
 
 function {:inline} IsValidU8(v: Value): bool {
@@ -103,7 +107,7 @@ function {:inline 1} AddValueArray(a: ValueArray, v: Value): ValueArray {
 }
 
 function {:inline 1} RemoveValueArray(a: ValueArray): ValueArray {
-    ValueArray(v#ValueArray(a)[l#ValueArray(a) := DefaultValue], l#ValueArray(a) - 1)
+    ValueArray(v#ValueArray(a)[l#ValueArray(a) - 1 := DefaultValue], l#ValueArray(a) - 1)
 }
 function {:inline 1} ConcatValueArray(a1: ValueArray, a2: ValueArray): ValueArray {
     ValueArray(

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/vector.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/vector.mvir
@@ -1,0 +1,134 @@
+// A variable-sized container that can hold both unrestricted types and resources.
+
+// Except for this comment, this file is just a copy of language/stdlib/modules/vector.mvir
+// This hasn't been specified, yet.  This is only needed for MVIR type checking, since the definitions
+// for vectors are included in prelude.bpl
+// test_mvir/verify-vector.mvir uses this.
+
+module Vector {
+
+  // Vector containing data of type Item.
+  native struct T<Element>;
+
+  native public empty<Element>(): Self.T<Element>;
+
+  // Return the length of the vector.
+  native public length<Element>(v: &Self.T<Element>): u64;
+
+  // Acquire an immutable reference to the ith element of the vector.
+  native public borrow<Element>(v: &Self.T<Element>, i: u64): &Element;
+
+  // Add an element to the end of the vector.
+  native public push_back<Element>(v: &mut Self.T<Element>, e: Element);
+
+  // Get mutable reference to the ith element in the vector, abort if out of bound.
+  native public borrow_mut<Element>(v: &mut Self.T<Element>, idx: u64): &mut Element;
+
+  // Pop an element from the end of vector, abort if the vector is empty.
+  native public pop_back<Element>(v: &mut Self.T<Element>): Element;
+
+  // Destroy the vector, abort if not empty.
+  native public destroy_empty<Element>(v: Self.T<Element>);
+
+  // Swaps the elements at the `i`th and `j`th indices in the vector.
+  // Aborts if either index is out of bounds.
+  native public swap<Element>(v: &mut Self.T<Element>, i: u64, j: u64);
+
+  // Reverses the order of the elements in the vector in place.
+  public reverse<Element>(v: &mut Self.T<Element>) {
+      let front_index: u64;
+      let back_index: u64;
+      let len: u64;
+
+      len = Self.length<Element>(freeze(copy(v)));
+
+      if (copy(len) == 0) {
+          return;
+      }
+      assert(copy(len) > 0, 0);
+
+      front_index = 0;
+      back_index = move(len) - 1;
+
+      while (copy(front_index) < copy(back_index)) {
+          Self.swap<Element>(copy(v), copy(front_index), copy(back_index));
+          front_index = move(front_index) + 1;
+          back_index = move(back_index) - 1;
+      }
+
+      return;
+  }
+
+  // Moves all of the elements of the `other` vector into the `lhs` vector.
+  public append<Element>(lhs: &mut Self.T<Element>, other: Self.T<Element>) {
+
+      Self.reverse<Element>(&mut other);
+
+      while (!Self.is_empty<Element>(&other)) {
+          Self.push_back<Element>(
+              copy(lhs),
+              Self.pop_back<Element>(&mut other)
+          );
+      }
+
+      Self.destroy_empty<Element>(move(other));
+      return;
+  }
+
+  // Return true if the vector has no elements
+  public is_empty<Element>(v: &Self.T<Element>): bool {
+    return Self.length<Element>(move(v)) == 0;
+  }
+
+  // Return the `i`th element of the vector. Only available for vectors that contain unrestricted
+  // values.
+  public get<Element: unrestricted>(v: &Self.T<Element>, i: u64): Element {
+    return *Self.borrow<Element>(move(v), move(i));
+  }
+
+  // Replace the `i`th element of the vector with the value `v`. Only available for vectors that
+  // contain unrestricted values.
+  public set<Element: unrestricted>(v: &mut Self.T<Element>, i: u64, e: Element) {
+    *(Self.borrow_mut<Element>(move(v), move(i))) = move(e);
+    return;
+  }
+
+  // Return true if `e` is in the vector `v`
+  public contains<Element>(v: &Self.T<Element>, e: &Element): bool {
+    let len: u64;
+    let i: u64;
+
+    i = 0;
+    len = Self.length<Element>(copy(v));
+
+    while (copy(i) < copy(len)) {
+      if (copy(e) == Self.borrow<Element>(copy(v), copy(i))) {
+        return true;
+      }
+      i = move(i) + 1;
+    }
+
+    return false;
+  }
+
+  // Remove the `i`th element E of the vector by swapping it with the last element L, popping E
+  // off the back of the vector, and returning it. L will now be stored at index i.
+  // Note: this may violate any ordering invariant that has been established for the vector (e.g.,
+  // sorting).
+  // Aborts if `i` is out of bounds.
+  public remove_unstable<Element>(v: &mut Self.T<Element>, i: u64): Element {
+    let last_index: u64;
+
+    if (Self.is_empty<Element>(freeze(copy(v)))) {
+        // i out of bounds; abort
+        abort(10);
+    }
+
+    last_index = Self.length<Element>(freeze(copy(v))) - 1;
+    if (copy(i) != copy(last_index)) {
+        Self.swap<Element>(copy(v), move(i), move(last_index));
+    } // else, no need for swap, since i is already the last index
+    return Self.pop_back<Element>(move(v));
+  }
+
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-vector.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-vector.mvir
@@ -1,0 +1,28 @@
+module VerifyVector {
+    import 0x0.Vector;
+
+    public test_empty1() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+	let ev1: Vector.T<u64>;
+	let ev2: Vector.T<u64>;
+	ev1 = Vector.empty<u64>();
+	ev2 = Vector.empty<u64>();
+	return (move(ev1), move(ev2));
+    }
+
+
+    public test_empty2() : Vector.T<u64> * Vector.T<u64>
+    // This fails to verify due to a mystery bug in the verifier
+    ensures RET(0) == RET(1)
+    {
+	let ev1: Vector.T<u64>;
+	let ev2: Vector.T<u64>;
+	let x: u64;
+	ev1 = Vector.empty<u64>();
+	ev2 = Vector.empty<u64>();
+	Vector.push_back<u64>(&mut ev1, 1);
+	x = Vector.pop_back<u64>(&mut ev1);
+	return (move(ev1), move(ev2));
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -1,0 +1,163 @@
+
+
+// ** structs of module VerifyVector
+
+
+
+// ** functions of module VerifyVector
+
+procedure {:inline 1} VerifyVector_test_empty1 () returns (ret0: Value, ret1: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((ret0) == (ret1)));
+{
+    // declare local variables
+    var t0: Value; // Vector_T_type_value(IntegerType())
+    var t1: Value; // Vector_T_type_value(IntegerType())
+    var t2: Value; // Vector_T_type_value(IntegerType())
+    var t3: Value; // Vector_T_type_value(IntegerType())
+    var t4: Value; // Vector_T_type_value(IntegerType())
+    var t5: Value; // Vector_T_type_value(IntegerType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 6;
+
+    // bytecode translation starts here
+    call t2 := Vector_empty(IntegerType());
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t2);
+
+    m := UpdateLocal(m, old_size + 2, t2);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call t3 := Vector_empty(IntegerType());
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t3);
+
+    m := UpdateLocal(m, old_size + 3, t3);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 4, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 5, tmp);
+
+    ret0 := GetLocal(m, old_size + 4);
+    ret1 := GetLocal(m, old_size + 5);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
+}
+
+procedure VerifyVector_test_empty1_verify () returns (ret0: Value, ret1: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0, ret1 := VerifyVector_test_empty1();
+}
+
+procedure {:inline 1} VerifyVector_test_empty2 () returns (ret0: Value, ret1: Value)
+requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((ret0) == (ret1)));
+{
+    // declare local variables
+    var t0: Value; // Vector_T_type_value(IntegerType())
+    var t1: Value; // Vector_T_type_value(IntegerType())
+    var t2: Value; // IntegerType()
+    var t3: Value; // Vector_T_type_value(IntegerType())
+    var t4: Value; // Vector_T_type_value(IntegerType())
+    var t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var t6: Value; // IntegerType()
+    var t7: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var t8: Value; // IntegerType()
+    var t9: Value; // Vector_T_type_value(IntegerType())
+    var t10: Value; // Vector_T_type_value(IntegerType())
+
+    var tmp: Value;
+    var old_size: int;
+
+    var saved_m: Memory;
+    assume !abort_flag;
+    saved_m := m;
+
+    // assume arguments are of correct types
+
+    old_size := local_counter;
+    local_counter := local_counter + 11;
+
+    // bytecode translation starts here
+    call t3 := Vector_empty(IntegerType());
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t3);
+
+    m := UpdateLocal(m, old_size + 3, t3);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 0, tmp);
+
+    call t4 := Vector_empty(IntegerType());
+    if (abort_flag) { goto Label_Abort; }
+    assume is#Vector(t4);
+
+    m := UpdateLocal(m, old_size + 4, t4);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
+    m := UpdateLocal(m, old_size + 1, tmp);
+
+    call t5 := BorrowLoc(old_size+0);
+
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 6, tmp);
+
+    call Vector_push_back(IntegerType(), t5, GetLocal(m, old_size + 6));
+    if (abort_flag) { goto Label_Abort; }
+
+    call t7 := BorrowLoc(old_size+0);
+
+    call t8 := Vector_pop_back(IntegerType(), t7);
+    if (abort_flag) { goto Label_Abort; }
+    assume IsValidU64(t8);
+
+    m := UpdateLocal(m, old_size + 8, t8);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
+    m := UpdateLocal(m, old_size + 2, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
+    m := UpdateLocal(m, old_size + 9, tmp);
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
+    m := UpdateLocal(m, old_size + 10, tmp);
+
+    ret0 := GetLocal(m, old_size + 9);
+    ret1 := GetLocal(m, old_size + 10);
+    return;
+
+Label_Abort:
+    abort_flag := true;
+    m := saved_m;
+    ret0 := DefaultValue;
+    ret1 := DefaultValue;
+}
+
+procedure VerifyVector_test_empty2_verify () returns (ret0: Value, ret1: Value)
+{
+    assume ExistsTxnSenderAccount(m, txn);
+    call ret0, ret1 := VerifyVector_test_empty2();
+}

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -40,6 +40,17 @@ fn verify_ref_param() {
 }
 
 #[test]
+fn verify_vector() {
+    test(
+        VERIFY,
+        &[
+            "test_mvir/verify-stdlib/vector.mvir",
+            "test_mvir/verify-vector.mvir",
+        ],
+    );
+}
+
+#[test]
 fn verify_libra_coin() {
     test(VERIFY, &[verified_std_mvir("libra_coin").as_str()])
 }


### PR DESCRIPTION
The actual changes are small.  There is no need to carefully review vector.mvir (just a copy of the standard lib version, with an extra comment) or it's goldenfile.

1. Added basic tests test_mvir/verify-vector.mvir
2. Fixed an off-by-one error in src/prelude.bpl: RemoveValueArray
3. Added Boogie command-line option "-useArrayTheory" because Z3 array
extension we rely on need it. Otherwise, Boogie does not set invalid
elements of arrays to DefaultValue
4. Added a new variant ErrorType() to TypeValue and a new variant
Error() to Value, and added axioms to make the DefaultTypeValue=ErrorType()
and DefaultValue=Error().  The purpose of this change is to make it a little
easier to understand Boogie counter-models -- otherwise, Boogie assigns
random values that change with every change to the .bpl file, making it
much harder to see errors.
5. Added some short instructions for generating output.bpl in README.md.
I expect that this will be short-lived because there will be a better way.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Another test and some bug fixes related to vectors

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cd bytecode-to-boogie
cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
