### PR TITLE
[vm] Fix the charging logic for a transaction

### DIFF
--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -227,4 +227,7 @@ impl FakeExecutor {
     pub fn get_state_view(&self) -> &FakeDataStore {
         &self.data_store
     }
+    pub fn config(&self) -> &VMConfig {
+        &self.config
+    }
 }

--- a/language/e2e-tests/src/tests.rs
+++ b/language/e2e-tests/src/tests.rs
@@ -11,6 +11,7 @@
 
 mod account_universe;
 mod create_account;
+mod failed_transaction_tests;
 mod genesis;
 mod mint;
 mod module_publishing;

--- a/language/e2e-tests/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-tests/src/tests/failed_transaction_tests.rs
@@ -20,7 +20,7 @@ fn failed_transaction_cleanup_test() {
     libra_vm.load_gas_schedule(&data_cache);
 
     let mut txn_data = TransactionMetadata::default();
-    txn_data.sender = sender.address().clone();
+    txn_data.sender = *sender.address();
     txn_data.max_gas_amount = GasUnits::new(100_000);
     txn_data.gas_unit_price = GasPrice::new(2);
 

--- a/language/e2e-tests/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-tests/src/tests/failed_transaction_tests.rs
@@ -1,0 +1,58 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{account::AccountData, executor::FakeExecutor};
+use libra_types::vm_error::{StatusCode, VMStatus};
+use vm::{
+    gas_schedule::{GasAlgebra, GasPrice, GasUnits},
+    transaction_metadata::TransactionMetadata,
+};
+use vm_runtime::{data_cache::BlockDataCache, LibraVM};
+
+#[test]
+fn failed_transaction_cleanup_test() {
+    let mut fake_executor = FakeExecutor::from_genesis_file();
+    let sender = AccountData::new(1_000_000, 10);
+    fake_executor.add_account_data(&sender);
+
+    let mut libra_vm = LibraVM::new(fake_executor.config());
+    let mut data_cache = BlockDataCache::new(fake_executor.get_state_view());
+    libra_vm.load_gas_schedule(&data_cache);
+
+    let mut txn_data = TransactionMetadata::default();
+    txn_data.sender = sender.address().clone();
+    txn_data.max_gas_amount = GasUnits::new(100_000);
+    txn_data.gas_unit_price = GasPrice::new(2);
+
+    let gas_left = GasUnits::new(10_000);
+
+    // TYPE_MISMATCH should be kept and charged.
+    let out1 = libra_vm.failed_transaction_cleanup(
+        VMStatus::new(StatusCode::TYPE_MISMATCH),
+        gas_left,
+        &txn_data,
+        &mut data_cache,
+    );
+    assert!(!out1.write_set().is_empty());
+    assert!(out1.gas_used() == 180_000);
+    assert!(!out1.status().is_discarded());
+    assert_eq!(
+        out1.status().vm_status().major_status,
+        StatusCode::TYPE_MISMATCH
+    );
+
+    // OUT_OF_BOUNDS_INDEX should be discarded and not charged.
+    let out2 = libra_vm.failed_transaction_cleanup(
+        VMStatus::new(StatusCode::OUT_OF_BOUNDS_INDEX),
+        gas_left,
+        &txn_data,
+        &mut data_cache,
+    );
+    assert!(out2.write_set().is_empty());
+    assert!(out2.gas_used() == 0);
+    assert!(out2.status().is_discarded());
+    assert_eq!(
+        out2.status().vm_status().major_status,
+        StatusCode::OUT_OF_BOUNDS_INDEX
+    );
+}

--- a/language/vm/vm-runtime/src/chain_state.rs
+++ b/language/vm/vm-runtime/src/chain_state.rs
@@ -97,7 +97,7 @@ impl<'txn> TransactionExecutionContext<'txn> {
     pub fn get_transaction_output(
         &mut self,
         txn_data: &TransactionMetadata,
-        result: VMResult<()>,
+        status: VMStatus,
     ) -> VMResult<TransactionOutput> {
         let gas_used: u64 = txn_data
             .max_gas_amount()
@@ -106,15 +106,11 @@ impl<'txn> TransactionExecutionContext<'txn> {
             .get();
         let write_set = self.make_write_set()?;
         record_stats!(observe | TXN_TOTAL_GAS_USAGE | gas_used);
-
         Ok(TransactionOutput::new(
             write_set,
             self.events().to_vec(),
             gas_used,
-            match result {
-                Ok(()) => TransactionStatus::from(VMStatus::new(StatusCode::EXECUTED)),
-                Err(err) => TransactionStatus::from(err),
-            },
+            TransactionStatus::Keep(status),
         ))
     }
 }
@@ -188,9 +184,9 @@ impl<'txn> SystemExecutionContext<'txn> {
     pub fn get_transaction_output(
         &mut self,
         txn_data: &TransactionMetadata,
-        result: VMResult<()>,
+        status: VMStatus,
     ) -> VMResult<TransactionOutput> {
-        self.0.get_transaction_output(txn_data, result)
+        self.0.get_transaction_output(txn_data, status)
     }
 }
 

--- a/language/vm/vm-runtime/src/libra_vm.rs
+++ b/language/vm/vm-runtime/src/libra_vm.rs
@@ -294,6 +294,8 @@ impl LibraVM {
         })
     }
 
+    /// Generates a transaction output for a transaction that encountered errors during the
+    /// execution process. This is public for now only for tests.
     pub fn failed_transaction_cleanup(
         &self,
         error_code: VMStatus,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -577,6 +577,13 @@ impl TransactionStatus {
             TransactionStatus::Discard(vm_status) | TransactionStatus::Keep(vm_status) => vm_status,
         }
     }
+
+    pub fn is_discarded(&self) -> bool {
+        match self {
+            TransactionStatus::Discard(_) => true,
+            TransactionStatus::Keep(_) => false,
+        }
+    }
 }
 
 impl From<VMStatus> for TransactionStatus {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The transaction cleanup logic was buggy previously. The main reason is that the logic for charging gas (execute epilogue) is misaligned with whether a transaction should be kept or not. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
