### PR TITLE
[consensus] Observe proposal size on broadcast

### DIFF
--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -138,13 +138,14 @@ impl NetworkSender {
     /// out. It does not give indication about when the message is delivered to the recipients,
     /// as well as there is no indication about the network failures.
     pub async fn broadcast_proposal<T: Payload>(&mut self, proposal: ProposalMsg<T>) {
-        let proposal = match proposal.try_into() {
+        let proposal: Proposal = match proposal.try_into() {
             Ok(bytes) => bytes,
             Err(e) => {
                 warn!("Fail to serialize VoteMsg: {:?}", e);
                 return;
             }
         };
+        counters::UNWRAPPED_PROPOSAL_SIZE_BYTES.observe(proposal.bytes.len() as f64);
         let msg = ConsensusMsg {
             message: Some(ConsensusMsg_oneof::Proposal(proposal)),
         };

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -318,6 +318,14 @@ pub static BLOCK_EXECUTION_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
     )
 });
 
+pub static UNWRAPPED_PROPOSAL_SIZE_BYTES: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_consensus_unwrapped_proposal_size_bytes",
+        "Histogram of proposal size after LCS but before wrapping with GRPC and libra net."
+    )
+    .unwrap()
+});
+
 /// Histogram of duration of a commit procedure (the time it takes for the execution / storage to
 /// commit a block once we decide to do so).
 pub static BLOCK_COMMIT_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {


### PR DESCRIPTION
There are multiple reasons for this

- This will help to break down where tx finality time is spent on.
- Knowing this we can estimate bandwidth requirements