### PR TITLE
[move prover] change aborts_if, add more specs to account

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
@@ -222,8 +222,24 @@ impl<'env> ModuleTranslator<'env> {
             "\n\n// ** functions of module {}\n\n",
             self.module_env.get_id().name()
         ));
+        let mut num_fun_specified = 0;
+        let mut num_fun = 0;
         for func_env in self.module_env.get_functions() {
+            if !func_env.is_native() {
+                num_fun += 1;
+            }
+            if !func_env.get_specification().is_empty() && !func_env.is_native() {
+                num_fun_specified += 1;
+            }
             res.push_str(&self.translate_function(&func_env));
+        }
+        if num_fun > 0 {
+            info!(
+                "{} out of {} functions are specified in module {}",
+                num_fun_specified,
+                num_fun,
+                self.module_env.get_id().name()
+            );
         }
         res
     }

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -17,7 +17,11 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub const INLINE_PRELUDE: &str = "<inline-prelude>";
 
 /// Default flags passed to boogie. Additional flags will be added to this via the -B option.
-const DEFAULT_BOOGIE_FLAGS: &[&str] = &["-doModSetAnalysis", "-noinfer"];
+const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
+    "-doModSetAnalysis",
+    "-noinfer",
+    "-printVerifiedProceduresCount:0",
+];
 
 /// Atomic used to prevent re-initialization of logging.
 static LOGGER_CONFIGURED: AtomicBool = AtomicBool::new(false);

--- a/language/move-prover/bytecode-to-boogie/src/prelude.bpl
+++ b/language/move-prover/bytecode-to-boogie/src/prelude.bpl
@@ -72,6 +72,14 @@ function {:inline} IsValidU8(v: Value): bool {
   is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= MAX_U8
 }
 
+function {:inline 1} max_u64(): Value {
+  Integer(9223372036854775807)
+}
+
+function {:inline} IsValidInteger(v: Value): bool {
+  is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= i#Integer(max_u64())
+}
+
 function {:inline} IsValidU64(v: Value): bool {
   is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= MAX_U64
 }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.mvir
@@ -82,7 +82,11 @@ module LibraAccount {
 
     // Creates a new LibraAccount.T
     // Invoked by the `create_account` builtin
-    make(fresh_address: address): Self.T {
+    make(fresh_address: address): Self.T
+        ensures RET.balance.value == 0
+        ensures !RET.delegated_key_rotation_capability && !RET.delegated_withdrawal_capability
+        ensures RET.received_events.counter == 0 && RET.sent_events.counter == 0
+    {
         let zero_balance: LibraCoin.T;
         let generator: Self.EventHandleGenerator;
         let sent_handle: Self.EventHandle<Self.SentPaymentEvent>;
@@ -113,7 +117,9 @@ module LibraAccount {
         aborts_if !global_exists<Self.T>(txn_sender)
         aborts_if !global_exists<Self.T>(payee)
         aborts_if to_deposit.value == 0
-        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_balance()
+        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_u64()
+        aborts_if global<Self.T>(txn_sender).sent_events.counter + 1 > max_u64()
+        aborts_if global<Self.T>(payee).received_events.counter + 1 > max_u64()
         ensures global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + to_deposit.value
     {
         Self.deposit_with_metadata(move(payee), move(to_deposit), h"");
@@ -130,7 +136,9 @@ module LibraAccount {
         aborts_if !global_exists<Self.T>(txn_sender)
         aborts_if !global_exists<Self.T>(payee)
         aborts_if to_deposit.value == 0
-        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_balance()
+        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_u64()
+        aborts_if global<Self.T>(txn_sender).sent_events.counter + 1 > max_u64()
+        aborts_if global<Self.T>(payee).received_events.counter + 1 > max_u64()
         ensures global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + to_deposit.value
     {
         Self.deposit_with_sender_and_metadata(
@@ -154,7 +162,9 @@ module LibraAccount {
         aborts_if !global_exists<Self.T>(payee)
         aborts_if !global_exists<Self.T>(sender)
         aborts_if to_deposit.value == 0
-        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_balance()
+        aborts_if global<Self.T>(payee).balance.value + to_deposit.value > max_u64()
+        aborts_if global<Self.T>(sender).sent_events.counter + 1 > max_u64()
+        aborts_if global<Self.T>(payee).received_events.counter + 1 > max_u64()
         ensures global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + to_deposit.value
     {
         let deposit_value: u64;
@@ -197,7 +207,22 @@ module LibraAccount {
     // and those account will be charged for gas. If those account don't have enough gas to pay
     // for the transaction cost they will fail minting.
     // However those account can also mint to themselves so that is a decent workaround
-    public mint_to_address(payee: address, amount: u64) acquires T {
+    public mint_to_address(payee: address, amount: u64) acquires T
+        aborts_if !global_exists<LibraCoin.MintCapability>(txn_sender)
+        aborts_if !global_exists<LibraCoin.MarketCap>(0xA550C18)
+        // Over mint-able amount
+        aborts_if amount > 1000000000000000
+        aborts_if amount == 0
+        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_u64()
+        aborts_if global<Self.T>(txn_sender).sent_events.counter + 1 > max_u64()
+        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).received_events.counter + 1 > max_u64()
+        // MarketCap overflow
+        aborts_if amount + global<LibraCoin.MarketCap>(0xA550C18).total_value > max_u64()
+        ensures global_exists<Self.T>(payee)
+        ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
+        ensures old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
+        ensures global<LibraCoin.MarketCap>(0xA550C18).total_value == old(global<LibraCoin.MarketCap>(0xA550C18).total_value) + amount
+    {
         // Create an account if it does not exist
         if (!exists<T>(copy(payee))) {
             Self.create_account(copy(payee));
@@ -305,7 +330,18 @@ module LibraAccount {
         cap: &Self.WithdrawalCapability,
         amount: u64,
         metadata: bytearray
-    ) acquires T {
+    ) acquires T
+        // aborts_if amount == 0
+        // aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_u64()
+        // aborts_if global<Self.T>(cap.account_address).sent_events.counter + 1 > max_u64()
+        // aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).received_events.counter + 1 > max_u64()
+        // aborts_if !global_exists<Self.T>(cap.account_address)
+        // aborts_if global<Self.T>(cap.account_address).balance.value < amount
+        ensures global_exists<Self.T>(payee)
+        ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
+        // ensures old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
+        // ensures global<Self.T>(cap.account_address).balance.value == old(global<Self.T>(cap.account_address).balance.value) - amount
+    {
         if (!exists<T>(copy(payee))) {
             Self.create_account(copy(payee));
         }
@@ -330,15 +366,17 @@ module LibraAccount {
         aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
         aborts_if txn_sender == payee
         aborts_if amount == 0
-        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_balance()
+        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_u64()
         aborts_if global<Self.T>(txn_sender).balance.value < amount
+        aborts_if global<Self.T>(txn_sender).sent_events.counter + 1 > max_u64()
+        aborts_if global<Self.T>(payee).received_events.counter + 1 > max_u64()
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
                     global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
         ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
     {
-        // TODO: note we added this assertion. Is it a bug?
+        // note we added this assertion. Is it a bug?
         assert(copy(payee) != get_txn_sender(), 12);
 
         if (!exists<T>(copy(payee))) {
@@ -360,15 +398,17 @@ module LibraAccount {
         aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
         aborts_if txn_sender == payee
         aborts_if amount == 0
-        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_balance()
+        aborts_if global_exists<Self.T>(payee) && global<Self.T>(payee).balance.value + amount > max_u64()
         aborts_if global<Self.T>(txn_sender).balance.value < amount
+        aborts_if global<Self.T>(txn_sender).sent_events.counter + 1 > max_u64()
+        aborts_if global<Self.T>(payee).received_events.counter + 1 > max_u64()
         ensures global_exists<Self.T>(payee)
         ensures old(global_exists<Self.T>(payee)) ==>
             global<Self.T>(payee).balance.value == old(global<Self.T>(payee).balance.value) + amount
         ensures !old(global_exists<Self.T>(payee)) ==> global<Self.T>(payee).balance.value == amount
         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
     {
-        // TODO: note we added this assertion. Is it a bug?
+        // note we added this assertion. Is it a bug?
         assert(copy(payee) != get_txn_sender(), 12);
 
         Self.pay_from_sender_with_metadata(move(payee), move(amount), h"");
@@ -413,7 +453,6 @@ module LibraAccount {
     )
         acquires T
         aborts_if !global_exists<Self.T>(cap.account_address)
-        // TODO: below does not work currently
         // ensures global<Self.T>(cap.account_address).authentication_key == new_authentication_key
     {
         Self.rotate_authentication_key_for_account(
@@ -497,7 +536,7 @@ module LibraAccount {
         aborts_if global_exists<Self.T>(fresh_address)
         aborts_if global<Self.T>(txn_sender).delegated_withdrawal_capability
         aborts_if global<Self.T>(txn_sender).balance.value < initial_balance
-        aborts_if initial_balance > max_balance()
+        aborts_if initial_balance > max_u64()
         ensures global_exists<Self.T>(fresh_address)
         ensures global<Self.T>(fresh_address).balance.value == initial_balance
         ensures !global<Self.T>(fresh_address).delegated_withdrawal_capability
@@ -571,7 +610,7 @@ module LibraAccount {
 
     // Return a reference to the address associated with the given withdrawal capability
     public withdrawal_capability_address(cap: &Self.WithdrawalCapability): &address
-        // TODO: this doesn't work probably because we are returning an address
+        // TODO: we don't support comparing references yet
         // ensures RET == &cap.account_address
     {
         return &move(cap).account_address;
@@ -579,7 +618,7 @@ module LibraAccount {
 
     // Return a reference to the address associated with the given key rotation capability
     public key_rotation_capability_address(cap: &Self.KeyRotationCapability): &address
-        // TODO: this doesn't work probably because we are returning an address
+        // TODO: we don't support comparing references yet
         // ensures RET == &cap.account_address
     {
         return &move(cap).account_address;
@@ -685,8 +724,7 @@ module LibraAccount {
     // such counter is going to give distinct value for each of the new event stream under each sender. And since we
     // hash it with the sender's address, the result is guaranteed to be globally unique.
     fresh_guid(counter: &mut Self.EventHandleGenerator, sender: address): bytearray
-        succeeds_if true
-        // aborts_if counter.counter + 1 > max_balance()
+        aborts_if counter.counter + 1 > max_u64()
     {
         let count: &mut u64;
         let count_bytes: bytearray;
@@ -697,12 +735,7 @@ module LibraAccount {
         sender_bytes = AddressUtil.address_to_bytes(move(sender));
 
         count_bytes = U64Util.u64_to_bytes(*copy(count));
-        // TODO: the below is supposed to be
-        //   *move(count) = *copy(count) + 1;
-        // However, this creates the obligation to deal with potential even counter overflow in about every
-        // precondition. We need to find some way to turn perhaps overflow checking off if its pragmatically
-        // unnecessary.
-        *move(count) = *copy(count);
+        *move(count) = *copy(count) + 1;
 
         // EventHandleGenerator goes first just in case we want to extend address in the future.
         preimage = BytearrayUtil.bytearray_concat(move(count_bytes), move(sender_bytes));
@@ -712,15 +745,14 @@ module LibraAccount {
 
     // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
     new_event_handle_impl<T: unrestricted>(counter: &mut Self.EventHandleGenerator, sender: address): Self.EventHandle<T>
-        succeeds_if true
-        // aborts_if counter.counter + 1 > max_balance()
+        aborts_if counter.counter + 1 > max_u64()
     {
         return EventHandle<T> {counter: 0, guid: Self.fresh_guid(move(counter), move(sender))};
     }
 
     // Use sender's EventHandleGenerator to generate a unique event handle that one can emit an event to.
     public new_event_handle<T: unrestricted>(): Self.EventHandle<T> acquires T
-        succeeds_if true
+        aborts_if global<Self.T>(txn_sender).event_generator.counter + 1 > max_u64()
     {
         let sender_account_ref: &mut Self.T;
         let sender_bytes: bytearray;
@@ -731,7 +763,7 @@ module LibraAccount {
     // Emit an event with payload `msg` by using handle's key and counter. Will change the payload from bytearray to a
     // generic type parameter once we have generics.
     public emit_event<T: unrestricted>(handle_ref: &mut Self.EventHandle<T>, msg: T)
-        succeeds_if true
+        aborts_if handle_ref.counter + 1 > max_u64()
     {
         let count: &mut u64;
         let guid: bytearray;
@@ -740,22 +772,19 @@ module LibraAccount {
         count = &mut move(handle_ref).counter;
 
         Self.write_to_event_store<T>(move(guid), *copy(count), move(msg));
-        // TODO: the below is supposed to be
-        //   *move(count) = *copy(count) + 1;
-        // However, this creates the obligation to deal with potential even counter overflow in about every
-        // precondition. We need to find some way to turn perhaps overflow checking off if its pragmatically
-        // unnecessary.
-        *move(count) = *copy(count);
+        *move(count) = *copy(count) + 1;
         return;
     }
 
     // Native procedure that writes to the actual event stream in Event store
     // This will replace the "native" portion of EmitEvent bytecode
     native write_to_event_store<T: unrestricted>(guid: bytearray, count: u64, msg: T)
-        succeeds_if true;
+        aborts_if false;
 
     // Destroy a unique handle.
-    public destroy_handle<T: unrestricted>(handle: Self.EventHandle<T>) {
+    public destroy_handle<T: unrestricted>(handle: Self.EventHandle<T>)
+        aborts_if false
+    {
         let guid: bytearray;
         let count: u64;
         EventHandle<T> { count, guid } = move(handle);

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.prover.bpl
@@ -12,7 +12,3 @@ procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) retur
 procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
   requires ExistsTxnSenderAccount(m, txn);
   ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
-
-function {:inline 1} max_balance(): Value {
-  Integer(9223372036854775807)
-}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -46,10 +46,6 @@ procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: V
   requires ExistsTxnSenderAccount(m, txn);
   ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
 
-function {:inline 1} max_balance(): Value {
-  Integer(9223372036854775807)
-}
-
 
 // ** structs of module LibraCoin
 
@@ -1173,6 +1169,9 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 
 procedure {:inline 1} LibraAccount_make (fresh_address: Value) returns (ret0: Value)
 requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(Boolean((SelectField(SelectField(ret0, LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0))));
+ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(SelectField(ret0, LibraAccount_T_delegated_key_rotation_capability))))) && b#Boolean(Boolean(!(b#Boolean(SelectField(ret0, LibraAccount_T_delegated_withdrawal_capability)))))));
+ensures b#Boolean(Boolean(b#Boolean(Boolean((SelectField(SelectField(ret0, LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) == (Integer(0)))) && b#Boolean(Boolean((SelectField(SelectField(ret0, LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) == (Integer(0))))));
 {
     // declare local variables
     var t1: Value; // LibraCoin_T_type_value()
@@ -1319,8 +1318,8 @@ procedure LibraAccount_make_verify (fresh_address: Value) returns (ret0: Value)
 procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_balance()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_balance())))) ==> abort_flag;
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -1371,8 +1370,8 @@ procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns 
 procedure {:inline 1} LibraAccount_deposit_with_metadata (payee: Value, to_deposit: Value, metadata: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_balance()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_balance())))) ==> abort_flag;
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t3: Value; // AddressType()
@@ -1430,8 +1429,8 @@ procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: V
 procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_balance()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_balance())))) ==> abort_flag;
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(sender))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(sender))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t4: Value; // IntegerType()
@@ -1596,6 +1595,12 @@ procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, se
 
 procedure {:inline 1} LibraAccount_mint_to_address (payee: Value, amount: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
+ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
+ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
+ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
+ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -2070,6 +2075,8 @@ procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns
 
 procedure {:inline 1} LibraAccount_pay_from_capability (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
+ensures b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
+ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -2170,9 +2177,10 @@ procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (payee: Value, 
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
 ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
+ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t3: Value; // AddressType()
@@ -2283,9 +2291,10 @@ procedure {:inline 1} LibraAccount_pay_from_sender (payee: Value, amount: Value)
 requires ExistsTxnSenderAccount(m, txn);
 ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
 ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
+ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_balance()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -2840,8 +2849,8 @@ ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(),
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_balance), LibraCoin_T_value)) == (initial_balance)));
 ensures !abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_delegated_withdrawal_capability)))));
 ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(initial_balance)))));
-ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_balance()))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_balance())))) ==> abort_flag;
+ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -3793,7 +3802,8 @@ procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_pric
 
 procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
 requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -3809,11 +3819,13 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     var t12: Value; // ByteArrayType()
     var t13: Reference; // ReferenceType(IntegerType())
     var t14: Value; // IntegerType()
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // ByteArrayType()
-    var t17: Value; // ByteArrayType()
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(IntegerType())
     var t18: Value; // ByteArrayType()
     var t19: Value; // ByteArrayType()
+    var t20: Value; // ByteArrayType()
+    var t21: Value; // ByteArrayType()
 
     var tmp: Value;
     var old_size: int;
@@ -3828,7 +3840,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     assume is#Address(sender);
 
     old_size := local_counter;
-    local_counter := local_counter + 20;
+    local_counter := local_counter + 22;
     m := UpdateLocal(m, old_size + 1, sender);
 
     // bytecode translation starts here
@@ -3873,29 +3885,36 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
-    call t15 := CopyOrMoveRef(t2);
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 15, tmp);
 
-    call WriteRef(t15, GetLocal(m, old_size + 14));
-
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
     m := UpdateLocal(m, old_size + 16, tmp);
 
+    call t17 := CopyOrMoveRef(t2);
+
+    call WriteRef(t17, GetLocal(m, old_size + 16));
+
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
+    m := UpdateLocal(m, old_size + 18, tmp);
+
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    m := UpdateLocal(m, old_size + 19, tmp);
 
-    call t18 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 16), GetLocal(m, old_size + 17));
+    call t20 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19));
     if (abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t18);
+    assume is#ByteArray(t20);
 
-    m := UpdateLocal(m, old_size + 18, t18);
+    m := UpdateLocal(m, old_size + 20, t20);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 18));
+    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 20));
     m := UpdateLocal(m, old_size + 4, tmp);
 
     call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    m := UpdateLocal(m, old_size + 21, tmp);
 
-    ret0 := GetLocal(m, old_size + 19);
+    ret0 := GetLocal(m, old_size + 21);
     return;
 
 Label_Abort:
@@ -3912,7 +3931,8 @@ procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) ret
 
 procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
 requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -3972,7 +3992,8 @@ procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Re
 
 procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
 requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -4035,7 +4056,8 @@ procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: V
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, handle_ref), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, handle_ref), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -4051,7 +4073,9 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     var t12: Value; // tv0
     var t13: Reference; // ReferenceType(IntegerType())
     var t14: Value; // IntegerType()
-    var t15: Reference; // ReferenceType(IntegerType())
+    var t15: Value; // IntegerType()
+    var t16: Value; // IntegerType()
+    var t17: Reference; // ReferenceType(IntegerType())
 
     var tmp: Value;
     var old_size: int;
@@ -4065,7 +4089,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     assume IsValidReferenceParameter(m, local_counter, handle_ref);
 
     old_size := local_counter;
-    local_counter := local_counter + 16;
+    local_counter := local_counter + 18;
     m := UpdateLocal(m, old_size + 1, msg);
 
     // bytecode translation starts here
@@ -4110,9 +4134,16 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
 
     m := UpdateLocal(m, old_size + 14, tmp);
 
-    call t15 := CopyOrMoveRef(t2);
+    call tmp := LdConst(1);
+    m := UpdateLocal(m, old_size + 15, tmp);
 
-    call WriteRef(t15, GetLocal(m, old_size + 14));
+    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
+    if (abort_flag) { goto Label_Abort; }
+    m := UpdateLocal(m, old_size + 16, tmp);
+
+    call t17 := CopyOrMoveRef(t2);
+
+    call WriteRef(t17, GetLocal(m, old_size + 16));
 
     return;
 
@@ -4129,6 +4160,8 @@ procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference,
 
 procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, handle: Value) returns ()
 requires ExistsTxnSenderAccount(m, txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
 {
     // declare local variables
     var t1: Value; // ByteArrayType()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR changes our translation of aborts_if from iff to if, adds more specs to LibraAccount module(now we are at 34/36). It also prints information about number of functions specified in each module. 

**UPDATE**: Now the semantics for `aborts_if` is back to iff and we are verifying 32/36 functions. 
  
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

