### PR TITLE
[safety-rules] Add a benchmark for process

### DIFF
--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -3,9 +3,11 @@
 
 use consensus_types::{block::block_test_utils, block::Block};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use libra_config::config::{OnDiskStorageConfig, SafetyRulesBackend};
 use libra_types::crypto_proxies::ValidatorSigner;
 use rand::Rng;
 use safety_rules::{
+    process_client_wrapper::ProcessClientWrapper,
     test_utils, {InMemoryStorage, OnDiskStorage, SafetyRulesManager, TSafetyRules},
 };
 use tempfile::NamedTempFile;
@@ -68,7 +70,7 @@ fn serializer(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
     let storage = OnDiskStorage::default_storage(file_path).unwrap();
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, signer.clone());
+    let safety_rules_manager = SafetyRulesManager::new_serializer(storage, signer.clone());
     lsr(safety_rules_manager.client(), signer, n);
 }
 
@@ -76,8 +78,20 @@ fn thread(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
     let storage = OnDiskStorage::default_storage(file_path).unwrap();
-    let safety_rules_manager = SafetyRulesManager::new_local(storage, signer.clone());
+    let safety_rules_manager = SafetyRulesManager::new_thread(storage, signer.clone());
     lsr(safety_rules_manager.client(), signer, n);
+}
+
+fn process(n: u64) {
+    let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
+    let mut config = OnDiskStorageConfig::default();
+    config.default = true;
+    config.path = file_path;
+    let backend = SafetyRulesBackend::OnDiskStorage(config);
+    let client_wrapper = ProcessClientWrapper::new(backend);
+    let signer = client_wrapper.signer();
+
+    lsr(Box::new(client_wrapper), signer, n);
 }
 
 pub fn benchmark(c: &mut Criterion) {
@@ -87,6 +101,7 @@ pub fn benchmark(c: &mut Criterion) {
     group.bench_function("OnDisk", |b| b.iter(|| on_disk(black_box(count))));
     group.bench_function("Serializer", |b| b.iter(|| serializer(black_box(count))));
     group.bench_function("Thread", |b| b.iter(|| thread(black_box(count))));
+    group.bench_function("Process", |b| b.iter(|| process(black_box(count))));
 }
 
 criterion_group!(benches, benchmark);

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -28,6 +28,10 @@ pub use crate::{
 };
 
 #[cfg(any(test, feature = "testing"))]
+#[path = "process_client_wrapper.rs"]
+pub mod process_client_wrapper;
+
+#[cfg(any(test, feature = "testing"))]
 #[path = "test_utils.rs"]
 pub mod test_utils;
 

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -1,0 +1,95 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{safety_rules_manager, ConsensusState, Error, SafetyRulesManager, TSafetyRules};
+use consensus_types::{
+    block::Block,
+    block_data::BlockData,
+    common::{Payload, Round},
+    quorum_cert::QuorumCert,
+    timeout::Timeout,
+    vote::Vote,
+    vote_proposal::VoteProposal,
+};
+use libra_config::{
+    config::{ConsensusType, NodeConfig, RemoteService, SafetyRulesBackend, SafetyRulesService},
+    utils,
+};
+use libra_types::crypto_proxies::{Signature, ValidatorSigner};
+use std::{
+    any::TypeId,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+/// This container exists only so that we can kill the spawned process after testing is complete.
+/// Otherwise the process will be killed at the end of the safety_rules function and the test will
+/// fail.
+pub struct ProcessClientWrapper<T> {
+    signer: ValidatorSigner,
+    _safety_rules_manager: SafetyRulesManager<T>,
+    safety_rules: Box<dyn TSafetyRules<T>>,
+}
+
+impl<T: Payload> ProcessClientWrapper<T> {
+    pub fn new(backend: SafetyRulesBackend) -> Self {
+        let server_port = utils::get_available_port();
+        let server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
+
+        let type_id = TypeId::of::<T>();
+        let consensus_type = if type_id == TypeId::of::<Round>() {
+            ConsensusType::Rounds
+        } else if type_id == TypeId::of::<Vec<u8>>() {
+            ConsensusType::Bytes
+        } else {
+            panic!("Invalid type: {:?}", type_id);
+        };
+
+        let remote_service = RemoteService {
+            server_address,
+            consensus_type,
+        };
+        let mut config = NodeConfig::random();
+        config.consensus.safety_rules.backend = backend;
+        config.consensus.safety_rules.service = SafetyRulesService::SpawnedProcess(remote_service);
+
+        let safety_rules_manager = SafetyRulesManager::new(&mut config);
+        let safety_rules = safety_rules_manager.client();
+        let (signer, _) = safety_rules_manager::extract_service_inputs(&mut config);
+
+        Self {
+            signer,
+            _safety_rules_manager: safety_rules_manager,
+            safety_rules,
+        }
+    }
+
+    pub fn signer(&self) -> ValidatorSigner {
+        self.signer.clone()
+    }
+}
+
+impl<T: Payload> TSafetyRules<T> for ProcessClientWrapper<T> {
+    fn consensus_state(&mut self) -> Result<ConsensusState, Error> {
+        self.safety_rules.consensus_state()
+    }
+
+    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        self.safety_rules.update(qc)
+    }
+
+    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
+        self.safety_rules.start_new_epoch(qc)
+    }
+
+    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
+        self.safety_rules.construct_and_sign_vote(vote_proposal)
+    }
+
+    fn sign_proposal(&mut self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
+        self.safety_rules.sign_proposal(block_data)
+    }
+
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Signature, Error> {
+        self.safety_rules.sign_timeout(timeout)
+    }
+}

--- a/consensus/safety-rules/src/tests/spawned_process.rs
+++ b/consensus/safety-rules/src/tests/spawned_process.rs
@@ -1,28 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    safety_rules_manager, tests::suite, ConsensusState, Error, SafetyRulesManager, TSafetyRules,
-};
-use consensus_types::{
-    block::Block,
-    block_data::BlockData,
-    common::{Payload, Round},
-    quorum_cert::QuorumCert,
-    timeout::Timeout,
-    vote::Vote,
-    vote_proposal::VoteProposal,
-};
-use libra_config::{
-    config::{ConsensusType, NodeConfig, RemoteService, SafetyRulesService},
-    utils,
-};
-use libra_types::crypto_proxies::{Signature, ValidatorSigner};
-use std::{
-    any::TypeId,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
-};
+use crate::{process_client_wrapper::ProcessClientWrapper, tests::suite, TSafetyRules};
+use consensus_types::common::{Payload, Round};
+use libra_config::config::SafetyRulesBackend;
+use libra_types::crypto_proxies::ValidatorSigner;
+use std::sync::Arc;
 
 #[test]
 fn test() {
@@ -30,65 +13,7 @@ fn test() {
 }
 
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, Arc<ValidatorSigner>) {
-    let server_port = utils::get_available_port();
-    let server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
-
-    let type_id = TypeId::of::<T>();
-    let consensus_type = if type_id == TypeId::of::<Round>() {
-        ConsensusType::Rounds
-    } else if type_id == TypeId::of::<Vec<u8>>() {
-        ConsensusType::Bytes
-    } else {
-        panic!("Invalid type: {:?}", type_id);
-    };
-
-    let remote_service = RemoteService {
-        server_address,
-        consensus_type,
-    };
-    let mut config = NodeConfig::random();
-    config.consensus.safety_rules.service = SafetyRulesService::SpawnedProcess(remote_service);
-
-    let safety_rules_manager = SafetyRulesManager::new(&mut config);
-    let safety_rules = safety_rules_manager.client();
-    let client_wrapper = Box::new(ProcessClientWrapper {
-        _safety_rules_manager: safety_rules_manager,
-        safety_rules,
-    });
-    let (signer, _) = safety_rules_manager::extract_service_inputs(&mut config);
-    (client_wrapper, Arc::new(signer))
-}
-
-// This container exists only so that we can kill the spawned process after testing is complete.
-// Otherwise the process will be killed at the end of the safety_rules function and the test will
-// fail.
-struct ProcessClientWrapper<T> {
-    _safety_rules_manager: SafetyRulesManager<T>,
-    safety_rules: Box<dyn TSafetyRules<T>>,
-}
-
-impl<T: Payload> TSafetyRules<T> for ProcessClientWrapper<T> {
-    fn consensus_state(&mut self) -> Result<ConsensusState, Error> {
-        self.safety_rules.consensus_state()
-    }
-
-    fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        self.safety_rules.update(qc)
-    }
-
-    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        self.safety_rules.start_new_epoch(qc)
-    }
-
-    fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
-        self.safety_rules.construct_and_sign_vote(vote_proposal)
-    }
-
-    fn sign_proposal(&mut self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
-        self.safety_rules.sign_proposal(block_data)
-    }
-
-    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Signature, Error> {
-        self.safety_rules.sign_timeout(timeout)
-    }
+    let client_wrapper = ProcessClientWrapper::new(SafetyRulesBackend::InMemoryStorage);
+    let signer = client_wrapper.signer();
+    (Box::new(client_wrapper), Arc::new(signer))
 }


### PR DESCRIPTION
Moved the generic process wrapper code into a test util so it can be
leveraged across the test and benchmark. The key point being that the
benchmark only wants a client, but we need to retain a handle on the
process or it will perish.

Also note that historically the benchmarks were /not/ correctly
executing.