### PR TITLE
[cluster-test] Add buffer at start,end when measuring tps

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -13,6 +13,7 @@ use crate::{
     util::unix_timestamp_now,
 };
 use futures::future::{join_all, BoxFuture, FutureExt};
+use slog_scope::info;
 use std::{
     collections::HashSet,
     fmt::{Display, Error, Formatter},
@@ -82,14 +83,19 @@ impl Experiment for PerformanceBenchmarkNodesDown {
                 .collect();
             let futures = stop_effects.iter().map(|e| e.activate());
             join_all(futures).await;
-            let window = Duration::from_secs(180);
+            let window = Duration::from_secs(240);
             context
                 .tx_emitter
-                .emit_txn_for(window + Duration::from_secs(60), self.up_instances.clone())
+                .emit_txn_for(window, self.up_instances.clone())
                 .await?;
-            let end = unix_timestamp_now();
-            let start = end - window;
+            let buffer = Duration::from_secs(30);
+            let end = unix_timestamp_now() - buffer;
+            let start = end - window + 2 * buffer;
             let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
+            info!(
+                "Link to dashboard : {}",
+                context.prometheus.link_to_dashboard(start, end)
+            );
             let futures = stop_effects.iter().map(|e| e.deactivate());
             join_all(futures).await;
             Ok(Some(format!(

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -54,16 +54,14 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
                 ),
             );
             join_all(network_effects.iter().map(|e| e.activate())).await;
-            let window = Duration::from_secs(180);
+            let window = Duration::from_secs(240);
             context
                 .tx_emitter
-                .emit_txn_for(
-                    window + Duration::from_secs(60),
-                    self.cluster.validator_instances().clone(),
-                )
+                .emit_txn_for(window, self.cluster.validator_instances().clone())
                 .await?;
-            let end = unix_timestamp_now();
-            let start = end - window;
+            let buffer = Duration::from_secs(30);
+            let end = unix_timestamp_now() - buffer;
+            let start = end - window + 2 * buffer;
             let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
             join_all(network_effects.iter().map(|e| e.deactivate())).await;
             Ok(Some(format!(

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -335,6 +335,7 @@ impl ClusterUtil {
             cluster
                 .prometheus_ip()
                 .expect("Failed to discover prometheus ip in aws"),
+            aws.workspace(),
         );
         info!(
             "Discovered {} peers in {} workspace",
@@ -414,6 +415,7 @@ impl ClusterTestRunner {
             Err(..) => 15,
         };
         let experiment_interval = Duration::from_secs(experiment_interval_sec);
+        let workspace = aws.workspace().clone();
         let deployment_manager = DeploymentManager::new(aws, cluster.clone());
         let slack = SlackClient::new();
         let slack_changelog_url = env::var("SLACK_CHANGELOG_URL")
@@ -424,6 +426,7 @@ impl ClusterTestRunner {
             cluster
                 .prometheus_ip()
                 .expect("Failed to discover prometheus ip in aws"),
+            &workspace,
         );
         let github = GitHub::new();
         let runtime = Runtime::new().expect("Failed to create tokio runtime");

--- a/testsuite/cluster-test/src/prometheus.rs
+++ b/testsuite/cluster-test/src/prometheus.rs
@@ -12,6 +12,7 @@ use std::{collections::HashMap, time::Duration};
 pub struct Prometheus {
     url: Url,
     client: reqwest::blocking::Client,
+    public_url: Url,
 }
 
 pub struct MatrixResponse {
@@ -23,12 +24,28 @@ pub struct TimeSeries {
 }
 
 impl Prometheus {
-    pub fn new(ip: &str) -> Self {
+    pub fn new(ip: &str, workspace: &str) -> Self {
         let url = format!("http://{}:9091", ip)
             .parse()
             .expect("Failed to parse prometheus url");
+        let public_url = format!("http://prometheus.{}.aws.hlw3truzy4ls.com:9091", workspace)
+            .parse()
+            .expect("Failed to parse prometheus public url");
         let client = reqwest::blocking::Client::new();
-        Self { url, client }
+        Self {
+            url,
+            client,
+            public_url,
+        }
+    }
+
+    pub fn link_to_dashboard(&self, start: Duration, end: Duration) -> String {
+        format!(
+            "{}d/overview10/overview?orgId=1&from={}&to={}",
+            self.public_url,
+            start.as_millis(),
+            end.as_millis()
+        )
     }
 
     fn query_range(


### PR DESCRIPTION
## Summary

* Adding a buffer at start and end reduces the probability of incorrect numbers reported.
* Also add link to dashboard for the duration in which average was taken

## Test Plan

Ran cluster-test. It prints the link correctly

```
[ec2-user@cluster-test-runner ~]$ ct -c cluster-test-ci --image "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:$TAG" --deploy $TAG --run bench
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/ec2-user/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
dev_kush_pull_2330: Pulling from libra_cluster_test
Digest: sha256:c0b7a67ff56d4cb225fff5d685302fa2181997b46a08f2b64a763804d9591672
Status: Image is up to date for 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:dev_kush_pull_2330
Using 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:dev_kush_pull_2330 image for cluster-test
Jan 28 06:05:06.081 INFO Discovered 100 peers in cluster-test-ci workspace
Jan 28 06:05:06.420 INFO Log tail thread started in 339 ms
Jan 28 06:05:06.421 INFO Will use cluster-test-ci tag for deployment
Jan 28 06:05:06.451 INFO Cleaning up before deploy
Jan 28 06:05:07.122 INFO Stopping validators
Jan 28 06:05:19.008 INFO Wiping validators
Jan 28 06:05:19.009 INFO Going to wipe db on all validators in cluster!
Jan 28 06:05:19.009 INFO Will use suffix .20200128-060519.gz for log rotation
Jan 28 06:05:48.675 INFO Done
Jan 28 06:05:48.675 INFO Will deploy with digest sha256:b237a7e67f59bfe23a329a5c3f18a6738737f52351ef49b9189e895778890df0
Jan 28 06:07:13.473 INFO Waiting until all validators healthy after deployment
Jan 28 06:12:33.895 INFO Starting experiment all up
Jan 28 06:12:34.865 INFO Completed minting seed accounts
Jan 28 06:12:36.430 INFO Mint is done
Jan 28 06:16:38.440 INFO Link to dashboard : http://prometheus.cluster-test-ci.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1&from=1580191988410&to=1580192168410
Jan 28 06:16:39.124 INFO Experiment finished, waiting until all affected validators recover
Jan 28 06:16:44.133 INFO Experiment completed
Jan 28 06:16:44.133 INFO Experiment Result: all up : 634 TPS, 1046.2 ms latency
```