### PR TITLE
[move-prover] Source level error reporting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "functional-tests 0.1.0",
  "goldenfile 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode 0.1.0",

--- a/language/compiler/ir-to-bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::spec_language_ast::Condition;
+use crate::spec_language_ast::Condition_;
 use crate::syntax::ParseError;
 use codespan::{ByteIndex, Span};
 use libra_types::{
@@ -295,7 +295,7 @@ pub struct Function {
     /// of references into global storage
     pub acquires: Vec<StructName>,
     /// List of specifications for the Move prover (experimental)
-    pub specifications: Vec<Condition>,
+    pub specifications: Vec<Condition_>,
     /// The code for the procedure
     pub body: FunctionBody,
 }
@@ -851,7 +851,7 @@ impl Function {
         return_type: Vec<Type>,
         type_formals: Vec<(TypeVar_, Kind)>,
         acquires: Vec<StructName>,
-        specifications: Vec<Condition>,
+        specifications: Vec<Condition_>,
         body: FunctionBody,
     ) -> Self {
         let signature = FunctionSignature::new(formals, return_type, type_formals);

--- a/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ast::{BinOp, CopyableVal, Field, QualifiedStructIdent, Type};
+use crate::ast::{BinOp, CopyableVal, Field, QualifiedStructIdent, Spanned, Type};
 use libra_types::account_address::AccountAddress;
 
 /// AST for the Move Prover specification language. Just postconditions for now
@@ -71,3 +71,6 @@ pub enum Condition {
     /// If the given expression is true, the procedure *must* terminate in a succeeding state
     SucceedsIf(SpecExp),
 }
+
+/// Specification directive with span.
+pub type Condition_ = Spanned<Condition>;

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1647,7 +1647,10 @@ fn parse_function_decl<'input>(
     // parse each specification directive--there may be zero or more
     let mut specifications = Vec::new();
     while tokens.peek().is_spec_directive() {
-        specifications.push(parse_spec_condition(tokens)?)
+        let start_loc = tokens.start_loc();
+        let cond = parse_spec_condition(tokens)?;
+        let end_loc = tokens.previous_end_loc();
+        specifications.push(spanned(start_loc, end_loc, cond));
     }
 
     let func_name = FunctionName::parse(name)?;

--- a/language/move-prover/bytecode-to-boogie/Cargo.toml
+++ b/language/move-prover/bytecode-to-boogie/Cargo.toml
@@ -25,6 +25,7 @@ clap = "2.33.0"
 log = "0.4.8"
 simplelog = "0.7.4"
 codespan = "0.2.1"
+codespan-reporting = "0.2.1"
 regex = "1.3.1"
 
 [dev-dependencies]

--- a/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
@@ -85,10 +85,9 @@ pub fn boogie_type_check(env: &GlobalEnv, name: &str, sig: &GlobalType) -> Strin
         // Only need to check Struct for top-level; fields will be checked as we extract them.
         GlobalType::Struct(_, _, _) => "is#Vector",
         GlobalType::Reference(rtype) | GlobalType::MutableReference(rtype) => {
-            let n = format!("Dereference(m, {})", params);
+            let n = format!("Dereference(__m, {})", params);
             ret = boogie_type_check(env, &n, rtype);
-            ret += "    ";
-            params = format!("m, local_counter, {}", params);
+            params = format!("__m, __frame, {}", params);
             "IsValidReferenceParameter"
         }
         // Otherwise it is a type parameter which is opaque

--- a/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
@@ -1,0 +1,286 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wrapper around the boogie program. Allows to call boogie and analyze the output.
+
+use crate::cli::{abort_on_error, abort_with_error};
+use crate::code_writer::CodeWriter;
+use crate::driver::PSEUDO_PRELUDE_MODULE;
+use crate::env::{GlobalEnv, ModuleIndex};
+use codespan::{ByteIndex, ByteSpan, CodeMap, ColumnIndex, FileName, LineIndex};
+use codespan_reporting::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::{Diagnostic, Label, Severity};
+use ir_to_bytecode_syntax::ast::Loc;
+use itertools::Itertools;
+use log::{debug, error, info};
+use regex::Regex;
+use std::fs;
+use std::process::Command;
+
+/// Represents the boogie wrapper.
+pub struct BoogieWrapper<'env> {
+    pub env: &'env GlobalEnv,
+    pub writer: &'env CodeWriter,
+}
+
+/// Output of a boogie run.
+pub struct BoogieOutput {
+    /// All errors which could be parsed from the output.
+    pub errors: Vec<BoogieError>,
+
+    /// Full output as a string.
+    pub all_output: String,
+}
+
+/// Line/Column pair position reported by boogie.
+pub type Position = (LineIndex, ColumnIndex);
+
+/// Kind of boogie error.
+#[derive(PartialEq)]
+pub enum BoogieErrorKind {
+    Compilation,
+    Verification,
+}
+
+pub struct BoogieLocation {
+    pub position: Position,
+}
+
+/// A boogie error.
+pub struct BoogieError {
+    pub kind: BoogieErrorKind,
+    pub position: Position,
+    pub message: String,
+    pub execution_trace: Vec<(Position, String)>,
+}
+
+impl<'env> BoogieWrapper<'env> {
+    /// Calls boogie on the given file. On success, returns a struct representing the analyzed
+    /// output of boogie.
+    pub fn call_boogie(&self, boogie_file: &str) -> Option<BoogieOutput> {
+        let args = self.env.options.get_boogie_command(boogie_file);
+        info!("calling boogie");
+        debug!("command line: {}", args.iter().join(" "));
+        let output = abort_on_error(
+            Command::new(&args[0]).args(&args[1..]).output(),
+            "error executing boogie",
+        );
+        if !output.status.success() {
+            error!("boogie exited with status {:?}", output.status.code());
+            None
+        } else {
+            let out = String::from_utf8_lossy(&output.stdout).to_string();
+            let mut errors = self.extract_verification_errors(&out);
+            errors.extend(self.extract_compilation_errors(&out));
+            Some(BoogieOutput {
+                errors,
+                all_output: out,
+            })
+        }
+    }
+
+    /// Calls boogie and analyzes output. Errors which can be associated with source modules
+    /// will be added to the environment. Any other errors will be reported directly. Returns true
+    /// if verification succeeded.
+    pub fn call_boogie_and_verify_output(&self, boogie_file: &str) -> bool {
+        match self.call_boogie(boogie_file) {
+            None => {
+                abort_with_error("exiting") // we already reported boogie error
+            }
+            Some(BoogieOutput { errors, all_output }) => {
+                let boogie_log_file = self.env.options.get_boogie_log_file(boogie_file);
+                info!("writing boogie log to {}", boogie_log_file);
+                abort_on_error(
+                    fs::write(&boogie_log_file, &all_output),
+                    "cannot write boogie log file",
+                );
+
+                let mut diag_on_target = vec![];
+                for error in &errors {
+                    self.add_error(error, &mut diag_on_target);
+                }
+                if !diag_on_target.is_empty() {
+                    // Report diagnostic which could not be associated with a module directly
+                    // on the boogie source.
+                    self.writer.process_result(|boogie_code| {
+                        let mut codemap = CodeMap::new();
+                        codemap.add_filemap(
+                            FileName::real(&self.env.options.output_path),
+                            boogie_code.to_string(),
+                        );
+                        for diag in &diag_on_target {
+                            let writer = StandardStream::stderr(ColorChoice::Auto);
+                            codespan_reporting::emit(writer, &codemap, diag)
+                                .expect("emitting diagnostic failed")
+                        }
+                    });
+                }
+                errors.is_empty()
+            }
+        }
+    }
+
+    /// Helper to add a boogie error as a codespan Diagnostic.
+    fn add_error(&self, error: &BoogieError, diags_on_target: &mut Vec<Diagnostic>) {
+        let (index, location) = self.get_locations(error.position);
+        let on_source = location.is_some() && location.unwrap().0 != PSEUDO_PRELUDE_MODULE;
+        let label = Label::new_primary(if on_source {
+            // Location is on original source.
+            location.unwrap().1
+        } else {
+            // Location is on generated boogie.
+            ByteSpan::new(index, index)
+        });
+        let mut add_diag = |diag| {
+            if on_source {
+                self.env.get_module(location.unwrap().0).add_diag(diag);
+            } else {
+                diags_on_target.push(diag);
+            }
+        };
+        add_diag(Diagnostic::new(Severity::Error, &error.message).with_label(label));
+        if error.kind == BoogieErrorKind::Verification && !error.execution_trace.is_empty() {
+            let mut trace = error
+                .execution_trace
+                .iter()
+                .filter_map(|(pos, _)| {
+                    let (_, trace_location) = self.get_locations(*pos);
+                    if self.env.options.minimize_execution_trace
+                        && (trace_location.is_none()
+                            || trace_location.unwrap().0 == PSEUDO_PRELUDE_MODULE)
+                    {
+                        // trace entry has no source location or is from prelude, skip
+                        return None;
+                    }
+                    let (file, act_pos) = if on_source
+                        && trace_location.is_some()
+                        && trace_location.unwrap().0 != PSEUDO_PRELUDE_MODULE
+                    {
+                        // Calculate line/column source position from (ModuleIndex, Loc).
+                        if let Some((module_idx, loc)) = trace_location {
+                            self.env.get_module(module_idx).get_position(loc)
+                        } else {
+                            unreachable!()
+                        }
+                    } else {
+                        // Use boogie target position
+                        (self.env.options.output_path.clone(), *pos)
+                    };
+                    Some(format!(
+                        "    at {}:{}:{}",
+                        file,
+                        (act_pos.0).0 + 1,
+                        (act_pos.1).0 + 1,
+                    ))
+                })
+                .collect_vec();
+            if self.env.options.minimize_execution_trace {
+                // Removes consecutive entries which point to the same line.
+                trace.dedup();
+            }
+            add_diag(Diagnostic::new(
+                Severity::Help,
+                &format!("Execution trace for previous error:\n{}", trace.join("\n")),
+            ))
+        }
+    }
+
+    /// Gets the target byte index and source location (if available) from a target line/column
+    /// position.
+    fn get_locations(&self, pos: Position) -> (ByteIndex, Option<(ModuleIndex, Loc)>) {
+        let index = self.writer.get_output_byte_index(pos.0, pos.1).unwrap();
+        (index, self.writer.get_source_location(index))
+    }
+
+    /// Extracts verification errors from Boogie output.
+    ///
+    /// This parses the output for errors of the form:
+    ///
+    /// ```ignore
+    /// (0,0): Error BP5003: A postcondition might not hold on this return path.
+    /// output.bpl(2964,1): Related location: This is the postcondition that might not hold.
+    /// Execution trace:
+    ///    output.bpl(3068,5): anon0
+    ///    output.bpl(2960,23): inline$LibraAccount_pay_from_sender_with_metadata$0$Entry
+    ///    output.bpl(2989,5): inline$LibraAccount_pay_from_sender_with_metadata$0$anon0
+    ///    ...
+    /// ```
+    fn extract_verification_errors(&self, out: &str) -> Vec<BoogieError> {
+        let verification_diag_start = Regex::new(r"(?m)^.*Error BP\d+:(?P<msg>.*)$").unwrap();
+        let verification_diag_cond =
+            Regex::new(r"(?m)^.+\((?P<line>\d+),(?P<col>\d+)\): Related.*$").unwrap();
+        let verification_diag_trace = Regex::new(r"(?m)^Execution trace:$").unwrap();
+        let verification_diag_trace_entry =
+            Regex::new(r"(?m)^    .*\((?P<line>\d+),(?P<col>\d+)\): (?P<msg>.*)$").unwrap();
+        let mut errors = vec![];
+        let mut at: usize = 0;
+        while let Some(cap) = verification_diag_start.captures(&out[at..]) {
+            let msg = cap.name("msg").unwrap().as_str();
+            at += cap.get(0).unwrap().end();
+            if let Some(cap) = verification_diag_cond.captures(&out[at..]) {
+                let line = cap.name("line").unwrap().as_str();
+                let col = cap.name("col").unwrap().as_str();
+                let mut trace = vec![];
+                at += cap.get(0).unwrap().end();
+                if let Some(m) = verification_diag_trace.find(&out[at..]) {
+                    at += m.end();
+                    while let Some(cap) = verification_diag_trace_entry.captures(&out[at..]) {
+                        let line = cap.name("line").unwrap().as_str();
+                        let col = cap.name("col").unwrap().as_str();
+                        let msg = cap.name("msg").unwrap().as_str();
+                        trace.push((make_position(line, col), msg.to_string()));
+                        at += cap.get(0).unwrap().end();
+                        if !out[at..].starts_with("\n  ") && !out[at..].starts_with("\r\n  ") {
+                            // Don't read further if this line does not start with an indent,
+                            // as all trace entries do. Otherwise we would match the trace entry
+                            // for the next error.
+                            break;
+                        }
+                    }
+                }
+                errors.push(BoogieError {
+                    kind: BoogieErrorKind::Verification,
+                    position: make_position(line, col),
+                    message: msg.to_string(),
+                    execution_trace: trace,
+                });
+            }
+        }
+        errors
+    }
+
+    /// Extracts compilation errors. This captures any kind of errors different than the
+    /// verification errors (as seen so far).
+    fn extract_compilation_errors(&self, out: &str) -> Vec<BoogieError> {
+        let diag_re =
+            Regex::new(r"(?m)^.*\((?P<line>\d+),(?P<col>\d+)\).*(Error:|error:).*$").unwrap();
+        diag_re
+            .captures_iter(&out)
+            .map(|cap| {
+                let line = cap.name("line").unwrap().as_str();
+                let col = cap.name("col").unwrap().as_str();
+                let msg = cap.get(0).unwrap().as_str();
+                BoogieError {
+                    kind: BoogieErrorKind::Compilation,
+                    position: make_position(line, col),
+                    message: msg.to_string(),
+                    execution_trace: vec![],
+                }
+            })
+            .collect_vec()
+    }
+}
+
+/// Creates a position (line/column pair) from strings which are known to consist only of digits.
+fn make_position(line_str: &str, col_str: &str) -> Position {
+    // This will crash on overflow.
+    let mut line = line_str.parse::<u32>().unwrap();
+    let mut col = col_str.parse::<u32>().unwrap();
+    if line > 0 {
+        line -= 1;
+    }
+    if col > 0 {
+        col -= 1;
+    }
+    (LineIndex(line), ColumnIndex(col))
+}

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -20,7 +20,6 @@ pub const INLINE_PRELUDE: &str = "<inline-prelude>";
 
 const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-doModSetAnalysis",
-    "-useArrayTheory",
     "-noinfer",
     "-printVerifiedProceduresCount:0",
 ];
@@ -57,6 +56,8 @@ pub struct Options {
     pub generate_only: bool,
     /// Whether to generate stubs for native functions.
     pub native_stubs: bool,
+    /// Whether to minimize execution traces in errors.
+    pub minimize_execution_trace: bool,
 }
 
 impl Default for Options {
@@ -73,6 +74,7 @@ impl Default for Options {
             boogie_flags: vec![],
             generate_only: false,
             native_stubs: false,
+            minimize_execution_trace: true,
         }
     }
 }
@@ -247,6 +249,11 @@ impl Options {
         }
         add(&[boogie_file]);
         result
+    }
+
+    /// Returns name of file where to log boogie output.
+    pub fn get_boogie_log_file(&self, boogie_file: &str) -> String {
+        format!("{}.log", boogie_file)
     }
 }
 

--- a/language/move-prover/bytecode-to-boogie/src/code_writer.rs
+++ b/language/move-prover/bytecode-to-boogie/src/code_writer.rs
@@ -1,0 +1,188 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A helper to emit code. Supports indentation and maintains source to target location information.
+
+use std::collections::{BTreeMap, Bound};
+
+use codespan::{ByteIndex, ColumnIndex, FileName, LineIndex};
+
+use ir_to_bytecode_syntax::ast::Loc;
+
+use crate::env::ModuleIndex;
+use std::cell::RefCell;
+
+struct CodeWriterData {
+    /// The generated output string.
+    output: String,
+
+    /// Current active indentation.
+    indent: usize,
+
+    /// Current active module.
+    current_module: ModuleIndex,
+
+    /// Current active location.
+    current_location: Loc,
+
+    /// A sparse mapping from byte index in written output to location in source file.
+    /// Any index not in this map is approximated by the next smaller index on lookup.
+    /// Note that the boogie source contains information from multiple modules, so this
+    /// information needs to be combined with `output_module_map`.
+    output_location_map: BTreeMap<ByteIndex, Loc>,
+
+    /// A sparse mapping from byte index in written output to module which generated the code.
+    /// Any index not in this map is approximated by the next smaller index on lookup.
+    output_module_map: BTreeMap<ByteIndex, ModuleIndex>,
+}
+
+pub struct CodeWriter(RefCell<CodeWriterData>);
+
+impl CodeWriter {
+    /// Creates new code writer.
+    pub fn new(module: ModuleIndex, loc: Loc) -> CodeWriter {
+        let zero = ByteIndex(0);
+        let mut output_module_map = BTreeMap::new();
+        let mut output_location_map = BTreeMap::new();
+        output_module_map.insert(zero, module);
+        output_location_map.insert(zero, loc);
+        Self(RefCell::new(CodeWriterData {
+            output: String::new(),
+            indent: 0,
+            current_module: module,
+            current_location: loc,
+            output_location_map,
+            output_module_map,
+        }))
+    }
+
+    /// Calls a function to process the code written so far. This is embedded into a function
+    /// so we ensure correct scoping of borrowed RefCell content.
+    pub fn process_result<T, F: Fn(&str) -> T>(&self, f: F) -> T {
+        f(&self.0.borrow().output)
+    }
+
+    /// Sets the current location. This location will be associated with all subsequently written
+    /// code so we can map back from the generated code to this location. If current module or loc
+    /// is already the passed one, nothing will be updated, so it is ok to call this method
+    /// repeatedly with the same values.
+    pub fn set_location(&self, module: ModuleIndex, loc: Loc) {
+        let mut data = self.0.borrow_mut();
+        let code_at = ByteIndex(data.output.len() as u32);
+        if data.current_module != module {
+            data.output_module_map.insert(code_at, module);
+            data.current_module = module;
+        }
+        if data.current_location != loc {
+            data.output_location_map.insert(code_at, loc);
+            data.current_location = loc;
+        }
+    }
+
+    /// Given a byte index in the written output, return the best approximation of the source
+    /// which generated this output.
+    pub fn get_source_location(&self, output_index: ByteIndex) -> Option<(ModuleIndex, Loc)> {
+        let data = self.0.borrow();
+        if let Some(module) = data
+            .output_module_map
+            .range((Bound::Unbounded, Bound::Included(&output_index)))
+            .next_back()
+            .map(|(_, v)| v)
+        {
+            if let Some(loc) = data
+                .output_location_map
+                .range((Bound::Unbounded, Bound::Included(&output_index)))
+                .next_back()
+                .map(|(_, v)| v)
+            {
+                return Some((*module, *loc));
+            }
+        }
+        None
+    }
+
+    /// Given line/column location, determine ByteIndex of that location.
+    pub fn get_output_byte_index(&self, line: LineIndex, column: ColumnIndex) -> Option<ByteIndex> {
+        self.process_result(|s| {
+            let fmap = codespan::FileMap::new(FileName::real("dummy"), s);
+            if let Ok(index) = fmap.byte_index(line, column) {
+                Some(index)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Indents any subsequently written output. The current line of output and any subsequent ones
+    /// will be indented. Note this works after the last output was `\n` but the line is still
+    /// empty.
+    pub fn indent(&self) {
+        let mut data = self.0.borrow_mut();
+        data.indent += 4;
+    }
+
+    /// Undo previously done indentation.
+    pub fn unindent(&self) {
+        let mut data = self.0.borrow_mut();
+        assert!(data.indent >= 4);
+        data.indent -= 4;
+    }
+
+    /// Emit a string. The string will be broken down into lines to apply current indentation.
+    pub fn emit(&self, s: &str) {
+        let mut first = true;
+        // str::lines ignores trailing newline, so deal with this ad-hoc
+        let end_newl = s.ends_with('\n');
+        for l in s.lines() {
+            if first {
+                first = false
+            } else {
+                self.0.borrow_mut().output.push_str("\n");
+            }
+            self.emit_str(l)
+        }
+        if end_newl {
+            self.0.borrow_mut().output.push_str("\n");
+        }
+    }
+
+    /// Emits a string and then terminates the line.
+    pub fn emit_line(&self, s: &str) {
+        self.emit(s);
+        self.emit("\n");
+    }
+
+    /// Helper for emitting a string for a single line.
+    fn emit_str(&self, s: &str) {
+        let mut data = self.0.borrow_mut();
+        // If we are looking at the beginning of a new line, emit indent now.
+        if data.indent > 0 && (data.output.is_empty() || data.output.ends_with('\n')) {
+            let n = data.indent;
+            data.output.push_str(&" ".repeat(n));
+        }
+        data.output.push_str(s);
+    }
+}
+
+/// Macro to emit a simple or formatted string.
+macro_rules! emit {
+    ($target:expr, $s:expr) => (
+       $target.emit($s)
+    );
+    ($target:expr, $s:tt, $($arg:tt)+) => (
+       $target.emit(&format!($s, $($arg)+))
+    )
+}
+
+/// Macro to emit a simple or formatted string followed by a new line.
+macro_rules! emitln {
+    ($target:expr) => (
+       $target.emit_line("")
+    );
+    ($target:expr, $s:expr) => (
+       $target.emit_line($s)
+    );
+    ($target:expr, $s:tt, $($arg:tt)+) => (
+       $target.emit_line(&format!($s, $($arg)+))
+    )
+}

--- a/language/move-prover/bytecode-to-boogie/src/lib.rs
+++ b/language/move-prover/bytecode-to-boogie/src/lib.rs
@@ -5,7 +5,10 @@
 
 //! Move prover modules
 
+#[macro_use]
+pub mod code_writer;
 pub mod boogie_helpers;
+pub mod boogie_wrapper;
 pub mod bytecode_translator;
 pub mod cli;
 pub mod driver;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-specs-translate.prover.bpl
@@ -3,7 +3,3 @@
 function {:inline} number_in_range(x: Value): Value {
   Boolean(i#Integer(x) >= 0 && i#Integer(x) < 128)
 }
-
-function {:inline} max_u64(): Value {
-  Integer(MAX_U64)
-}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/address_util.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/address_util.prover.bpl
@@ -2,5 +2,5 @@
 
 // TODO: fill in implementation
 procedure {:inline 1} AddressUtil_address_to_bytes (arg0: Value) returns (ret0: Value);
-  requires ExistsTxnSenderAccount(m, txn);
-  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+  requires ExistsTxnSenderAccount(__m, __txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/bytearray_util.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/bytearray_util.prover.bpl
@@ -2,5 +2,5 @@
 
 // TODO: fill in implementation
 procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/hash.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/hash.prover.bpl
@@ -2,9 +2,9 @@
 
 // TODO: fill in implementation
 procedure {:inline 1} Hash_sha2_256 (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
 procedure {:inline 1} Hash_sha3_256 (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/libra_account.prover.bpl
@@ -3,12 +3,16 @@
 // TODO: fill in implementation
 
 procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) returns ();
-  requires ExistsTxnSenderAccount(m, txn);
-  ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
-  ensures !abort_flag ==> b#Boolean(Boolean((Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
-  ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !abort_flag;
-  ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> abort_flag;
+  requires ExistsTxnSenderAccount(__m, __txn);
+  ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(arg0)));
+  ensures !__abort_flag ==> b#Boolean(Boolean((Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
+  ensures old(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !__abort_flag;
+  ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> __abort_flag;
 
 procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
-  requires ExistsTxnSenderAccount(m, txn);
-  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+  requires ExistsTxnSenderAccount(__m, __txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
+
+function {:inline 1} max_balance(): Value {
+  Integer(9223372036854775807)
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/u64_util.prover.bpl
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-stdlib/u64_util.prover.bpl
@@ -2,5 +2,5 @@
 
 // TODO: fill in implementation
 procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-vector.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-vector.mvir
@@ -14,7 +14,7 @@ module VerifyVector {
 
     public test_empty2() : Vector.T<u64> * Vector.T<u64>
     // This fails to verify due to a mystery bug in the verifier
-    ensures RET(0) == RET(1)
+    ensures RET(0) == RET(1) //! A postcondition might not hold
     {
 	let ev1: Vector.T<u64>;
 	let ev2: Vector.T<u64>;

--- a/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
@@ -1,11 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use bytecode_to_boogie::boogie_wrapper::BoogieOutput;
 use bytecode_to_boogie::cli::Options;
 use bytecode_to_boogie::driver::Driver;
 use goldenfile;
 use itertools::Itertools;
 use libra_temppath::TempPath;
+use log::info;
 use prettydiff::{basic::DiffOp, diff_lines};
 use regex::Regex;
 use std::fs::read_to_string;
@@ -51,19 +53,15 @@ pub fn test(flags: &[&str], sources: &[&str]) {
         .unwrap()
         .to_string();
 
-    // In order to debug errors in the output, one may uncomment below to find the output
-    // file at a stable, persistent location.
-    //    let mut boogie_file_path = std::path::PathBuf::new();
-    //    boogie_file_path.push("/tmp/output.bpl").to_string();
-
-    fs::write(&boogie_file_path, boogie_str).expect("cannot write boogie file");
+    fs::write(&boogie_file_path, &boogie_str).expect("cannot write boogie file");
 
     if env::var("BOOGIE_EXE").is_ok() {
         // Call boogie and verify results.
-        let (_, diag) = driver
+        let out = driver
+            .new_boogie_wrapper()
             .call_boogie(&boogie_file_path)
             .expect("boogie execution ok");
-        verify_diag(sources, diag);
+        verify_boogie_output(sources, &boogie_str, out);
     }
 }
 
@@ -90,7 +88,7 @@ pub const NO_VERIFY: &[&str] = &["-B=-noVerify"];
 pub const VERIFY: &[&str] = &[];
 
 /// Extracts expected diags from sources and compares it with actual diags.
-fn verify_diag(sources: &[&str], mut actual_diag: Vec<String>) {
+fn verify_boogie_output(sources: &[&str], boogie_str: &str, mut out: BoogieOutput) {
     // Collect expected diagnosis from source. A comment of the form
     // `//! <text>` represents an expected diag.
     let expect_diag_re = Regex::new(r"(?m)//!\s*(.*)$").unwrap();
@@ -104,30 +102,40 @@ fn verify_diag(sources: &[&str], mut actual_diag: Vec<String>) {
     // Now try to remove expected diags from the actual ones.
     let mut i = 0;
     while i < expected_diag.len() {
-        if actual_diag.is_empty() {
+        if out.errors.is_empty() {
             break;
         }
         let expected = &expected_diag[i];
-        if let Some(pos) = actual_diag
+        if let Some(pos) = out
+            .errors
             .iter()
+            .map(|err| &err.message)
             .position(|actual| actual.contains(expected))
         {
-            actual_diag.remove(pos);
+            out.errors.remove(pos);
             expected_diag.remove(i);
         } else {
             i += 1;
         }
     }
-    if !expected_diag.is_empty() || !actual_diag.is_empty() {
+    if !expected_diag.is_empty() || !out.errors.is_empty() {
         let mut msg = vec![];
         if !expected_diag.is_empty() {
             msg.push("expected boogie diagnosis:".to_string());
             msg.extend_from_slice(&expected_diag);
         };
-        if !actual_diag.is_empty() {
+        if !out.errors.is_empty() {
             msg.push("unexpected boogie diagnosis:".to_string());
-            msg.extend_from_slice(&actual_diag);
+            msg.extend(out.errors.iter().map(|d| d.message.clone()));
         }
+        let mut path = Path::new(sources[sources.len() - 1]);
+        path = Path::new(path.file_name().unwrap());
+        let basename = path.file_stem().unwrap().to_str().unwrap();
+        info!("Test failure for {}!!!", basename);
+        info!("Writing boogie output to `{}.bpl`", basename);
+        fs::write(&format!("{}.bpl", basename), &boogie_str).unwrap_or(());
+        info!("Writing boogie log to `{}.bpl.log`", basename);
+        fs::write(&format!("{}.bpl.log", basename), &out.all_output).unwrap_or(());
         panic!(msg.join("\n"));
     }
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -1,50 +1,59 @@
 
-// ** helpers from test_mvir/verify-stdlib/hash.prover.bpl// Native functions and helpers for hash
+// ** helpers from test_mvir/verify-stdlib/hash.prover.bpl
+// Native functions and helpers for hash
 
 // TODO: fill in implementation
 procedure {:inline 1} Hash_sha2_256 (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
 procedure {:inline 1} Hash_sha3_256 (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
-// ** helpers from test_mvir/verify-stdlib/u64_util.prover.bpl// Native functions and helpers for u64_util
+// ** helpers from test_mvir/verify-stdlib/u64_util.prover.bpl
+// Native functions and helpers for u64_util
 
 // TODO: fill in implementation
 procedure {:inline 1} U64Util_u64_to_bytes (arg0: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
-// ** helpers from test_mvir/verify-stdlib/address_util.prover.bpl// Native functions and helpers for address_util
+// ** helpers from test_mvir/verify-stdlib/address_util.prover.bpl
+// Native functions and helpers for address_util
 
 // TODO: fill in implementation
 procedure {:inline 1} AddressUtil_address_to_bytes (arg0: Value) returns (ret0: Value);
-  requires ExistsTxnSenderAccount(m, txn);
-  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+  requires ExistsTxnSenderAccount(__m, __txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
-// ** helpers from test_mvir/verify-stdlib/bytearray_util.prover.bpl// Native functions and helpers for bytearray_util
+// ** helpers from test_mvir/verify-stdlib/bytearray_util.prover.bpl
+// Native functions and helpers for bytearray_util
 
 // TODO: fill in implementation
 procedure {:inline 1} BytearrayUtil_bytearray_concat (arg0: Value, arg1: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
-// ** helpers from test_mvir/verify-stdlib/libra_account.prover.bpl// Native functions and helpers for libra_account
+// ** helpers from test_mvir/verify-stdlib/libra_account.prover.bpl
+// Native functions and helpers for libra_account
 
 // TODO: fill in implementation
 
 procedure {:inline 1} LibraAccount_save_account (arg0: Value, arg1: Value) returns ();
-  requires ExistsTxnSenderAccount(m, txn);
-  ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)));
-  ensures !abort_flag ==> b#Boolean(Boolean((Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
-  ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !abort_flag;
-  ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> abort_flag;
+  requires ExistsTxnSenderAccount(__m, __txn);
+  ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(arg0)));
+  ensures !__abort_flag ==> b#Boolean(Boolean((Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(arg0)))) == (arg1)));
+  ensures old(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(arg0))))) ==> !__abort_flag;
+  ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(arg0)))) ==> __abort_flag;
 
 procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, arg0: Value, arg1: Value, arg2: Value) returns ();
-  requires ExistsTxnSenderAccount(m, txn);
-  ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+  requires ExistsTxnSenderAccount(__m, __txn);
+  ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
+
+function {:inline 1} max_balance(): Value {
+  Integer(9223372036854775807)
+}
 
 
 // ** structs of module LibraCoin
@@ -59,7 +68,6 @@ procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -79,7 +87,6 @@ procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_str
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -99,7 +106,6 @@ procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_str
 {
     assume IsValidU64(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -114,69 +120,70 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 // ** functions of module LibraCoin
 
 procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // AddressType()
     var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
 procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(value)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (value)));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(value)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (value)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
@@ -201,61 +208,60 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     var t21: Reference; // ReferenceType(IntegerType())
     var t22: Value; // IntegerType()
     var t23: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 24;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(value);
-    assume is#Vector(Dereference(m, capability));
-    assume IsValidReferenceParameter(m, local_counter, capability);
-
-    old_size := local_counter;
-    local_counter := local_counter + 24;
-    m := UpdateLocal(m, old_size + 0, value);
+    __m := UpdateLocal(__m, __frame + 0, value);
+    assume is#Vector(Dereference(__m, capability));
+    assume IsValidReferenceParameter(__m, __frame, capability);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(capability);
 
-    // unimplemented instruction
+    // unimplemented instruction: NoOp
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := LdConst(1000000000);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1000000000);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := LdConst(1000000);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(1000000);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Le(GetLocal(m, old_size + 5), GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Le(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    tmp := GetLocal(m, old_size + 10);
-    if (!b#Boolean(tmp)) { goto Label_11; }
+    __tmp := GetLocal(__m, __frame + 10);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call t13 := BorrowGlobal(GetLocal(m, old_size + 12), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t13 := BorrowGlobal(GetLocal(__m, __frame + 12), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t13);
 
@@ -263,58 +269,58 @@ Label_11:
 
     call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
 
-    call tmp := ReadRef(t15);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t15);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 18, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
     call t20 := CopyOrMoveRef(t2);
 
     call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
 
-    call WriteRef(t21, GetLocal(m, old_size + 19));
+    call WriteRef(t21, GetLocal(__m, __frame + 19));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 22));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 22));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(m, old_size + 23);
+    ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraCoin_MarketCap_total_value)) == (Integer(0))));
-ensures old(!(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))));
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraCoin_MarketCap_total_value)) == (Integer(0))));
+ensures old(!(b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn))))) || b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn))))) || b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -326,220 +332,216 @@ ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(17334
     var t6: Value; // LibraCoin_MintCapability_type_value()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 0), GetLocal(__m, __frame + 1)));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := GetLocal(m, old_size + 3);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 3);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_initialize();
 }
 
 procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
     var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_market_cap_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_market_cap();
 }
 
 procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(0))));
 {
     // declare local variables
     var t0: Value; // IntegerType()
     var t1: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_zero_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_zero();
 }
 
 procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, coin_ref), LibraCoin_T_value))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))));
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(coin_ref);
 
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_value(coin_ref);
 }
 
 procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean((SelectField(ret1, LibraCoin_T_value)) == (amount))) && b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
-ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean((SelectField(ret1, LibraCoin_T_value)) == (amount))) && b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -548,67 +550,67 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, coin);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
-    ret1 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 6);
+    ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := LibraCoin_split(coin, amount);
 }
 
 procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, coin_ref), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -627,153 +629,152 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), Li
     var t15: Reference; // ReferenceType(IntegerType())
     var t16: Value; // IntegerType()
     var t17: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(coin_ref);
 
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
-    call tmp := ReadRef(t4);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t4);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     call t14 := CopyOrMoveRef(coin_ref);
 
     call t15 := BorrowField(t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(m, old_size + 13));
+    call WriteRef(t15, GetLocal(__m, __frame + 13));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(m, old_size + 17);
+    ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
 procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin1);
+    __m := UpdateLocal(__m, __frame + 0, coin1);
     assume is#Vector(coin2);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, coin1);
-    m := UpdateLocal(m, old_size + 1, coin2);
+    __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(old_size+0);
+    call t2 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, coin_ref), LibraCoin_T_value))) + i#Integer(old(SelectField(check, LibraCoin_T_value)))))));
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))) + i#Integer(old(SelectField(check, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -788,78 +789,77 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var t11: Value; // IntegerType()
     var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t13: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 14;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume is#Vector(check);
-
-    old_size := local_counter;
-    local_counter := local_counter + 14;
-    m := UpdateLocal(m, old_size + 1, check);
+    __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(coin_ref);
 
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, t8);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 10, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(coin_ref);
 
     call t13 := BorrowField(t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(m, old_size + 11));
+    call WriteRef(t13, GetLocal(__m, __frame + 11));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_deposit(coin_ref, check);
 }
 
 procedure {:inline 1} LibraCoin_destroy_zero (coin: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -870,48 +870,47 @@ ensures old(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer
     var t6: Value; // BooleanType()
     var t7: Value; // BooleanType()
     var t8: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, t3);
+    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5)));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
@@ -919,13 +918,13 @@ Label_10:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_destroy_zero(coin);
 }
 
@@ -994,7 +993,6 @@ procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Va
     assume IsValidU64(sequence_number);
     assume is#Vector(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value)
@@ -1028,7 +1026,6 @@ procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(account_address: Va
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(_struct: Value) returns (account_address: Value)
@@ -1048,7 +1045,6 @@ procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(account_address: V
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(_struct: Value) returns (account_address: Value)
@@ -1074,7 +1070,6 @@ procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: V
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) returns (amount: Value, payee: Value, metadata: Value)
@@ -1104,7 +1099,6 @@ procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, paye
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) returns (amount: Value, payer: Value, metadata: Value)
@@ -1128,7 +1122,6 @@ procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) ret
 {
     assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) returns (counter: Value)
@@ -1151,7 +1144,6 @@ procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Val
     assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (counter: Value, guid: Value)
@@ -1168,7 +1160,7 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 // ** functions of module LibraAccount
 
 procedure {:inline 1} LibraAccount_make (fresh_address: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean((SelectField(SelectField(ret0, LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0))));
 ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(SelectField(ret0, LibraAccount_T_delegated_key_rotation_capability))))) && b#Boolean(Boolean(!(b#Boolean(SelectField(ret0, LibraAccount_T_delegated_withdrawal_capability)))))));
 ensures b#Boolean(Boolean(b#Boolean(Boolean((SelectField(SelectField(ret0, LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) == (Integer(0)))) && b#Boolean(Boolean((SelectField(SelectField(ret0, LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) == (Integer(0))))));
@@ -1199,238 +1191,238 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean((SelectField(SelectField(ret0, Libra
     var t23: Value; // IntegerType()
     var t24: Value; // LibraAccount_EventHandleGenerator_type_value()
     var t25: Value; // LibraAccount_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 26;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
-
-    old_size := local_counter;
-    local_counter := local_counter + 26;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call t7 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t10 := BorrowLoc(old_size+2);
+    call t10 := BorrowLoc(__frame + 2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t13 := BorrowLoc(old_size+2);
+    call t13 := BorrowLoc(__frame + 2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t15);
 
-    m := UpdateLocal(m, old_size + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, t15);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     call t16 := LibraCoin_zero();
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t16);
 
-    m := UpdateLocal(m, old_size + 16, t16);
+    __m := UpdateLocal(__m, __frame + 16, t16);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 24, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 24, __tmp);
 
-    call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20), GetLocal(m, old_size + 21), GetLocal(m, old_size + 22), GetLocal(m, old_size + 23), GetLocal(m, old_size + 24));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20), GetLocal(__m, __frame + 21), GetLocal(__m, __frame + 22), GetLocal(__m, __frame + 23), GetLocal(__m, __frame + 24));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    ret0 := GetLocal(m, old_size + 25);
+    ret0 := GetLocal(__m, __frame + 25);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_make_verify (fresh_address: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_make(fresh_address);
 }
 
 procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // AddressType()
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Vector(to_deposit);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, to_deposit);
+    __m := UpdateLocal(__m, __frame + 1, to_deposit);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(4, ByteArrayPoolIndex(0))
 
-    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_metadata(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit(payee, to_deposit);
 }
 
 procedure {:inline 1} LibraAccount_deposit_with_metadata (payee: Value, to_deposit: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t3: Value; // AddressType()
     var t4: Value; // AddressType()
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Vector(to_deposit);
+    __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, to_deposit);
-    m := UpdateLocal(m, old_size + 2, metadata);
+    __m := UpdateLocal(__m, __frame + 2, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4), GetLocal(m, old_size + 5), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit_with_metadata(payee, to_deposit, metadata);
 }
 
 procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(sender))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(sender))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(SelectField(to_deposit, LibraCoin_T_value))))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(sender))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(sender)))))) || b#Boolean(Boolean((SelectField(to_deposit, LibraCoin_T_value)) == (Integer(0)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(SelectField(to_deposit, LibraCoin_T_value)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(sender))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t4: Value; // IntegerType()
@@ -1462,65 +1454,64 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t30: Value; // AddressType()
     var t31: Value; // ByteArrayType()
     var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 33;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Address(sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
     assume is#Vector(to_deposit);
+    __m := UpdateLocal(__m, __frame + 2, to_deposit);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 33;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, sender);
-    m := UpdateLocal(m, old_size + 2, to_deposit);
-    m := UpdateLocal(m, old_size + 3, metadata);
+    __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call t7 := BorrowLoc(old_size+2);
+    call t7 := BorrowLoc(__frame + 2);
 
     call t8 := LibraCoin_value(t7);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    tmp := GetLocal(m, old_size + 12);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 12);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(7);
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     goto Label_Abort;
 
 Label_10:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := BorrowGlobal(GetLocal(m, old_size + 14), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t15);
 
@@ -1528,26 +1519,26 @@ Label_10:
 
     call t17 := BorrowField(t16, LibraAccount_T_sent_events);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(m, old_size + 21));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(__m, __frame + 21));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call t23 := BorrowGlobal(GetLocal(m, old_size + 22), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t23);
 
@@ -1555,52 +1546,53 @@ Label_10:
 
     call t25 := BorrowField(t24, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call LibraCoin_deposit(t25, GetLocal(m, old_size + 26));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t25, GetLocal(__m, __frame + 26));
+    if (__abort_flag) { goto Label_Abort; }
 
     call t27 := CopyOrMoveRef(t5);
 
     call t28 := BorrowField(t27, LibraAccount_T_received_events);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 29, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 29, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 30, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 30, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 31, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 31, __tmp);
 
-    call tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(m, old_size + 29), GetLocal(m, old_size + 30), GetLocal(m, old_size + 31));
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(m, old_size + 32));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(__m, __frame + 32));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit_with_sender_and_metadata(payee, sender, to_deposit, metadata);
 }
 
 procedure {:inline 1} LibraAccount_mint_to_address (payee: Value, amount: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -1610,77 +1602,77 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapabi
     var t6: Value; // AddressType()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := GetLocal(m, old_size + 4);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := LibraCoin_mint_with_default_capability(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call LibraAccount_deposit(GetLocal(m, old_size + 6), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_mint_to_address(payee, amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, account), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, account), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, account), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, account), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -1689,64 +1681,64 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, a
     var t5: Value; // IntegerType()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(account);
 
     call t4 := BorrowField(t3, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := LibraCoin_withdraw(t4, GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := LibraCoin_withdraw(t4, GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures old(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -1759,27 +1751,26 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Value; // IntegerType()
     var t10: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -1787,52 +1778,52 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
 
-    call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_9; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t10);
 
-    m := UpdateLocal(m, old_size + 10, t10);
+    __m := UpdateLocal(__m, __frame + 10, t10);
 
-    ret0 := GetLocal(m, old_size + 10);
+    ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -1843,70 +1834,69 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t8: Value; // IntegerType()
     var t9: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(cap);
 
     call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
 
-    call tmp := ReadRef(t4);
-    assume is#Address(tmp);
+    call __tmp := ReadRef(t4);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
-
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
     call t7 := CopyOrMoveRef(t2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    ret0 := GetLocal(m, old_size + 9);
+    ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
 procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraAccount_WithdrawalCapability_account_address)) == (Address(TxnSenderAddress(txn)))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraAccount_WithdrawalCapability_account_address)) == (Address(TxnSenderAddress(__txn)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -1924,31 +1914,30 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t12: Reference; // ReferenceType(BooleanType())
     var t13: Value; // AddressType()
     var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 15;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 15;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -1960,53 +1949,53 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t8 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t8);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t8);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_13; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_13; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_13:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(t2);
 
-    call WriteRef(t12, GetLocal(m, old_size + 11));
+    call WriteRef(t12, GetLocal(__m, __frame + 11));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 13));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    ret0 := GetLocal(m, old_size + 14);
+    ret0 := GetLocal(__m, __frame + 14);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (cap: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_delegated_withdrawal_capability)))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_WithdrawalCapability_account_address))))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_WithdrawalCapability_account_address)))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_delegated_withdrawal_capability)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_WithdrawalCapability_account_address))))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_WithdrawalCapability_account_address)))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -2018,65 +2007,64 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t7: Value; // BooleanType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Reference; // ReferenceType(BooleanType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, cap);
+    __m := UpdateLocal(__m, __frame + 0, cap);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
+    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t8 := CopyOrMoveRef(t2);
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
 
-    call WriteRef(t9, GetLocal(m, old_size + 7));
+    call WriteRef(t9, GetLocal(__m, __frame + 7));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_restore_withdrawal_capability(cap);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_capability (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
-ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)));
+ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -2091,96 +2079,95 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(
     var t13: Value; // IntegerType()
     var t14: Value; // LibraCoin_T_type_value()
     var t15: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 16;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    __m := UpdateLocal(__m, __frame + 0, payee);
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume IsValidU64(amount);
+    __m := UpdateLocal(__m, __frame + 2, amount);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 16;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 2, amount);
-    m := UpdateLocal(m, old_size + 3, metadata);
+    __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call t9 := CopyOrMoveRef(cap);
 
     call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
 
-    call tmp := ReadRef(t10);
-    assume is#Address(tmp);
-
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := ReadRef(t10);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(cap);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
+    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t14);
 
-    m := UpdateLocal(m, old_size + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, t14);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(15, ByteArrayPoolIndex(0))
 
-    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 8), GetLocal(m, old_size + 11), GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_capability_verify (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_capability(payee, cap, amount, metadata);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (payee: Value, amount: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures old(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t3: Value; // AddressType()
@@ -2196,105 +2183,105 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
     var t13: Value; // IntegerType()
     var t14: Value; // LibraCoin_T_type_value()
     var t15: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 16;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 16;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
-    m := UpdateLocal(m, old_size + 2, metadata);
+    __m := UpdateLocal(__m, __frame + 2, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := Boolean(!IsEqual(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4)));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    __tmp := Boolean(!IsEqual(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4)));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(12);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(12);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 8), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 8), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    tmp := GetLocal(m, old_size + 10);
-    if (!b#Boolean(tmp)) { goto Label_13; }
+    __tmp := GetLocal(__m, __frame + 10);
+    if (!b#Boolean(__tmp)) { goto Label_13; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_13:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_from_sender(GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
+    call t14 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t14);
 
-    m := UpdateLocal(m, old_size + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, t14);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 12), GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_metadata(GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (payee: Value, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_sender_with_metadata(payee, amount, metadata);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_sender (payee: Value, amount: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)));
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures old(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value))) + i#Integer(amount)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) == (amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures old(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) == (payee))) || b#Boolean(Boolean((amount) == (Integer(0)))) || b#Boolean(Boolean(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee))) && b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value)) + i#Integer(amount))) > i#Integer(max_u64()))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_sent_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_received_events), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -2305,122 +2292,121 @@ ensures old(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccou
     var t7: Value; // AddressType()
     var t8: Value; // IntegerType()
     var t9: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := Boolean(!IsEqual(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3)));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    __tmp := Boolean(!IsEqual(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3)));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(12);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(12);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(9, ByteArrayPoolIndex(0))
 
-    call LibraAccount_pay_from_sender_with_metadata(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_pay_from_sender_with_metadata(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_sender(payee, amount);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (account: Reference, new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((SelectField(Dereference(m, account), LibraAccount_T_authentication_key)) == (new_authentication_key)));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((SelectField(Dereference(__m, account), LibraAccount_T_authentication_key)) == (new_authentication_key)));
 {
     // declare local variables
     var t2: Value; // ByteArrayType()
     var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t4: Reference; // ReferenceType(ByteArrayType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 1, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     call t3 := CopyOrMoveRef(account);
 
     call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
 
-    call WriteRef(t4, GetLocal(m, old_size + 2));
+    call WriteRef(t4, GetLocal(__m, __frame + 2));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (account: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key_for_account(account, new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key (new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_authentication_key)) == (new_authentication_key)));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_key_rotation_capability)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_key_rotation_capability))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_authentication_key)) == (new_authentication_key)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_key_rotation_capability)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_key_rotation_capability))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -2432,27 +2418,26 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t7: Value; // IntegerType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -2460,45 +2445,45 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_9; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_verify (new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key(new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (cap: Reference, new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_KeyRotationCapability_account_address))))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(m, cap), LibraAccount_KeyRotationCapability_account_address)))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_KeyRotationCapability_account_address))))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_KeyRotationCapability_account_address)))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
@@ -2506,60 +2491,59 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t4: Value; // AddressType()
     var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t6: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 1, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(cap);
 
     call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
 
-    call tmp := ReadRef(t3);
-    assume is#Address(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraAccount_KeyRotationCapability_account_address)) == (Address(TxnSenderAddress(txn)))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_key_rotation_capability)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_key_rotation_capability))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraAccount_KeyRotationCapability_account_address)) == (Address(TxnSenderAddress(__txn)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_key_rotation_capability)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_key_rotation_capability))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2575,31 +2559,30 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t10: Reference; // ReferenceType(BooleanType())
     var t11: Value; // AddressType()
     var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 13;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 13;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := BorrowGlobal(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
@@ -2607,53 +2590,53 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
 
     call t6 := CopyOrMoveRef(t1);
 
-    call tmp := ReadRef(t6);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t6);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    m := UpdateLocal(m, old_size + 7, tmp);
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call t10 := CopyOrMoveRef(t1);
 
-    call WriteRef(t10, GetLocal(m, old_size + 9));
+    call WriteRef(t10, GetLocal(__m, __frame + 9));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(m, old_size + 12);
+    ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (cap: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_KeyRotationCapability_account_address)))), LibraAccount_T_delegated_key_rotation_capability)))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_KeyRotationCapability_account_address))))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_KeyRotationCapability_account_address)))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_KeyRotationCapability_account_address)))), LibraAccount_T_delegated_key_rotation_capability)))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_KeyRotationCapability_account_address))))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(cap, LibraAccount_KeyRotationCapability_account_address)))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -2665,68 +2648,68 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t7: Value; // BooleanType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Reference; // ReferenceType(BooleanType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, cap);
+    __m := UpdateLocal(__m, __frame + 0, cap);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
+    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t8 := CopyOrMoveRef(t2);
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
 
-    call WriteRef(t9, GetLocal(m, old_size + 7));
+    call WriteRef(t9, GetLocal(__m, __frame + 7));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_restore_key_rotation_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_restore_key_rotation_capability(cap);
 }
 
 procedure {:inline 1} LibraAccount_create_account (fresh_address: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address)));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0))));
-ensures !abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_delegated_withdrawal_capability)))));
-ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(fresh_address)));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0))));
+ensures !__abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_delegated_withdrawal_capability)))));
+ensures old(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(fresh_address))))) ==> !__abort_flag;
+ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(fresh_address)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
@@ -2747,110 +2730,110 @@ ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(f
     var t16: Value; // IntegerType()
     var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
     var t18: Value; // LibraAccount_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 19;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
-
-    old_size := local_counter;
-    local_counter := local_counter + 19;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
     call t7 := LibraCoin_zero();
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowLoc(old_size+1);
+    call t10 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call t13 := BorrowLoc(old_size+1);
+    call t13 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t15);
 
-    m := UpdateLocal(m, old_size + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, t15);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 12), GetLocal(m, old_size + 15), GetLocal(m, old_size + 16), GetLocal(m, old_size + 17));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call LibraAccount_save_account(GetLocal(m, old_size + 4), GetLocal(m, old_size + 18));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_save_account(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_create_account_verify (fresh_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_create_account(fresh_address);
 }
 
 procedure {:inline 1} LibraAccount_create_new_account (fresh_address: Value, initial_balance: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address)));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_balance), LibraCoin_T_value)) == (initial_balance)));
-ensures !abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_delegated_withdrawal_capability)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(initial_balance)))));
-ensures old(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(fresh_address)));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_balance), LibraCoin_T_value)) == (initial_balance)));
+ensures !__abort_flag ==> b#Boolean(Boolean(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(fresh_address))), LibraAccount_T_delegated_withdrawal_capability)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(initial_balance)))));
+ensures old(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(fresh_address))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(initial_balance))) || b#Boolean(Boolean(i#Integer(initial_balance) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -2859,68 +2842,67 @@ ensures old(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(f
     var t5: Value; // BooleanType()
     var t6: Value; // AddressType()
     var t7: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume IsValidU64(initial_balance);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
-    m := UpdateLocal(m, old_size + 1, initial_balance);
+    __m := UpdateLocal(__m, __frame + 1, initial_balance);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 2));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 2));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_9; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call LibraAccount_pay_from_sender(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_pay_from_sender(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_9:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_balance: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
 procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(m, account), LibraAccount_T_balance), LibraCoin_T_value))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value))));
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -2928,20 +2910,19 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(m, acco
     var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(account);
@@ -2949,316 +2930,311 @@ ensures b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(m, acco
     call t3 := BorrowField(t2, LibraAccount_T_balance);
 
     call t4 := LibraCoin_value(t3);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(m, old_size + 5);
+    ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_for_account_verify (account: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_balance_for_account(account);
 }
 
 procedure {:inline 1} LibraAccount_balance (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_balance), LibraCoin_T_value))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_balance), LibraCoin_T_value))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_balance_for_account(t2);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_balance(addr);
 }
 
 procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, account), LibraAccount_T_sequence_number))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, account), LibraAccount_T_sequence_number))));
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(account);
 
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
 procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_sequence_number))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_sequence_number))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_sequence_number(addr);
 }
 
 procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_key_rotation_capability))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_key_rotation_capability))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Reference; // ReferenceType(BooleanType())
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
 
-    call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
-
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
 procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_withdrawal_capability))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_withdrawal_capability))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Reference; // ReferenceType(BooleanType())
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
 
-    call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
-
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
 procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (ret0: Reference)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
     var t2: Reference; // ReferenceType(AddressType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(cap);
@@ -3269,37 +3245,36 @@ requires ExistsTxnSenderAccount(m, txn);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultReference;
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
 procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (ret0: Reference)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
     var t2: Reference; // ReferenceType(AddressType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(cap);
@@ -3310,63 +3285,62 @@ requires ExistsTxnSenderAccount(m, txn);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultReference;
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
 procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((ret0) == (ExistsResource(m, LibraAccount_T_type_value(), a#Address(check_addr)))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((ret0) == (ExistsResource(__m, LibraAccount_T_type_value(), a#Address(check_addr)))));
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(check_addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, check_addr);
+    __m := UpdateLocal(__m, __frame + 0, check_addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_exists_verify (check_addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_exists(check_addr);
 }
 
 procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -3415,105 +3389,103 @@ requires ExistsTxnSenderAccount(m, txn);
     var t47: Value; // BooleanType()
     var t48: Value; // BooleanType()
     var t49: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 50;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(txn_sequence_number);
+    __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
     assume is#ByteArray(txn_public_key);
+    __m := UpdateLocal(__m, __frame + 1, txn_public_key);
     assume IsValidU64(txn_gas_price);
+    __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
-
-    old_size := local_counter;
-    local_counter := local_counter + 50;
-    m := UpdateLocal(m, old_size + 0, txn_sequence_number);
-    m := UpdateLocal(m, old_size + 1, txn_public_key);
-    m := UpdateLocal(m, old_size + 2, txn_gas_price);
-    m := UpdateLocal(m, old_size + 3, txn_max_gas_units);
+    __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 11), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 11), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    tmp := GetLocal(m, old_size + 13);
-    if (!b#Boolean(tmp)) { goto Label_8; }
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_8; }
 
-    call tmp := LdConst(5);
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(5);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     goto Label_Abort;
 
 Label_8:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call t16 := BorrowGlobal(GetLocal(m, old_size + 15), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t16);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call t18 := Hash_sha3_256(GetLocal(m, old_size + 17));
-    if (abort_flag) { goto Label_Abort; }
+    call t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t18);
 
-    m := UpdateLocal(m, old_size + 18, t18);
+    __m := UpdateLocal(__m, __frame + 18, t18);
 
     call t19 := CopyOrMoveRef(t5);
 
     call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
 
-    call tmp := ReadRef(t20);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t20);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    m := UpdateLocal(m, old_size + 21, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 21)));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 21)));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 22));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 22));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    __tmp := GetLocal(__m, __frame + 23);
+    if (!b#Boolean(__tmp)) { goto Label_21; }
 
-    tmp := GetLocal(m, old_size + 23);
-    if (!b#Boolean(tmp)) { goto Label_21; }
-
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 24, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 24, __tmp);
 
     goto Label_Abort;
 
 Label_21:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 27, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 25), GetLocal(__m, __frame + 26));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 27));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t28 := CopyOrMoveRef(t5);
 
@@ -3524,31 +3496,31 @@ Label_21:
     call t30 := CopyOrMoveRef(t6);
 
     call t31 := LibraAccount_balance_for_account(t30);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t31);
 
-    m := UpdateLocal(m, old_size + 31, t31);
+    __m := UpdateLocal(__m, __frame + 31, t31);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 31));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 33, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 33, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 32), GetLocal(m, old_size + 33));
-    m := UpdateLocal(m, old_size + 34, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 32), GetLocal(__m, __frame + 33));
+    __m := UpdateLocal(__m, __frame + 34, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 34));
-    m := UpdateLocal(m, old_size + 35, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 34));
+    __m := UpdateLocal(__m, __frame + 35, __tmp);
 
-    tmp := GetLocal(m, old_size + 35);
-    if (!b#Boolean(tmp)) { goto Label_38; }
+    __tmp := GetLocal(__m, __frame + 35);
+    if (!b#Boolean(__tmp)) { goto Label_38; }
 
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 36, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
     goto Label_Abort;
 
@@ -3557,52 +3529,51 @@ Label_38:
 
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
 
-    call tmp := ReadRef(t38);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t38);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 39, __tmp);
 
-    m := UpdateLocal(m, old_size + 39, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 39));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 39));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 40, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 40, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 41, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 41, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 40), GetLocal(__m, __frame + 41));
+    __m := UpdateLocal(__m, __frame + 42, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 40), GetLocal(m, old_size + 41));
-    m := UpdateLocal(m, old_size + 42, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 42));
+    __m := UpdateLocal(__m, __frame + 43, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 42));
-    m := UpdateLocal(m, old_size + 43, tmp);
+    __tmp := GetLocal(__m, __frame + 43);
+    if (!b#Boolean(__tmp)) { goto Label_49; }
 
-    tmp := GetLocal(m, old_size + 43);
-    if (!b#Boolean(tmp)) { goto Label_49; }
-
-    call tmp := LdConst(3);
-    m := UpdateLocal(m, old_size + 44, tmp);
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 44, __tmp);
 
     goto Label_Abort;
 
 Label_49:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 45, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 45, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 46, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 46, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 45), GetLocal(m, old_size + 46)));
-    m := UpdateLocal(m, old_size + 47, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 45), GetLocal(__m, __frame + 46)));
+    __m := UpdateLocal(__m, __frame + 47, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 47));
-    m := UpdateLocal(m, old_size + 48, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 47));
+    __m := UpdateLocal(__m, __frame + 48, __tmp);
 
-    tmp := GetLocal(m, old_size + 48);
-    if (!b#Boolean(tmp)) { goto Label_56; }
+    __tmp := GetLocal(__m, __frame + 48);
+    if (!b#Boolean(__tmp)) { goto Label_56; }
 
-    call tmp := LdConst(4);
-    m := UpdateLocal(m, old_size + 49, tmp);
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 49, __tmp);
 
     goto Label_Abort;
 
@@ -3610,18 +3581,18 @@ Label_56:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units);
 }
 
 procedure {:inline 1} LibraAccount_epilogue (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -3657,55 +3628,54 @@ requires ExistsTxnSenderAccount(m, txn);
     var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t36: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 37;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(txn_sequence_number);
+    __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
     assume IsValidU64(txn_gas_price);
+    __m := UpdateLocal(__m, __frame + 1, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
+    __m := UpdateLocal(__m, __frame + 2, txn_max_gas_units);
     assume IsValidU64(gas_units_remaining);
-
-    old_size := local_counter;
-    local_counter := local_counter + 37;
-    m := UpdateLocal(m, old_size + 0, txn_sequence_number);
-    m := UpdateLocal(m, old_size + 1, txn_gas_price);
-    m := UpdateLocal(m, old_size + 2, txn_max_gas_units);
-    m := UpdateLocal(m, old_size + 3, gas_units_remaining);
+    __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowGlobal(GetLocal(m, old_size + 9), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t10);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 12), GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t16 := CopyOrMoveRef(t4);
 
@@ -3716,64 +3686,64 @@ requires ExistsTxnSenderAccount(m, txn);
     call t18 := CopyOrMoveRef(t6);
 
     call t19 := LibraAccount_balance_for_account(t18);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t19);
 
-    m := UpdateLocal(m, old_size + 19, t19);
+    __m := UpdateLocal(__m, __frame + 19, t19);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 21));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 21));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    tmp := GetLocal(m, old_size + 22);
-    if (!b#Boolean(tmp)) { goto Label_20; }
+    __tmp := GetLocal(__m, __frame + 22);
+    if (!b#Boolean(__tmp)) { goto Label_20; }
 
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     goto Label_Abort;
 
 Label_20:
     call t24 := CopyOrMoveRef(t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(m, old_size + 25));
-    if (abort_flag) { goto Label_Abort; }
+    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(__m, __frame + 25));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t26);
 
-    m := UpdateLocal(m, old_size + 26, t26);
+    __m := UpdateLocal(__m, __frame + 26, t26);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 26));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 27, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 28, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 28, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 29, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 27), GetLocal(__m, __frame + 28));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 29, __tmp);
 
     call t30 := CopyOrMoveRef(t4);
 
     call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
 
-    call WriteRef(t31, GetLocal(m, old_size + 29));
+    call WriteRef(t31, GetLocal(__m, __frame + 29));
 
-    call tmp := LdAddr(4078);
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := LdAddr(4078);
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call t33 := BorrowGlobal(GetLocal(m, old_size + 32), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t33);
 
@@ -3781,29 +3751,30 @@ Label_20:
 
     call t35 := BorrowField(t34, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 36, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call LibraCoin_deposit(t35, GetLocal(m, old_size + 36));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t35, GetLocal(__m, __frame + 36));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
 procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -3826,22 +3797,21 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var t19: Value; // ByteArrayType()
     var t20: Value; // ByteArrayType()
     var t21: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 22;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, counter));
-    assume IsValidReferenceParameter(m, local_counter, counter);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, counter));
+    assume IsValidReferenceParameter(__m, __frame, counter);
     assume is#Address(sender);
-
-    old_size := local_counter;
-    local_counter := local_counter + 22;
-    m := UpdateLocal(m, old_size + 1, sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
     call t6 := CopyOrMoveRef(counter);
@@ -3850,89 +3820,88 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call t2 := CopyOrMoveRef(t7);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     call t10 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t10);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    m := UpdateLocal(m, old_size + 11, tmp);
-
-    call t12 := U64Util_u64_to_bytes(GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 15, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
     call t17 := CopyOrMoveRef(t2);
 
-    call WriteRef(t17, GetLocal(m, old_size + 16));
+    call WriteRef(t17, GetLocal(__m, __frame + 16));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19));
-    if (abort_flag) { goto Label_Abort; }
+    call t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t20);
 
-    m := UpdateLocal(m, old_size + 20, t20);
+    __m := UpdateLocal(__m, __frame + 20, t20);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    ret0 := GetLocal(m, old_size + 21);
+    ret0 := GetLocal(__m, __frame + 21);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
 procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -3940,60 +3909,60 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var t4: Value; // AddressType()
     var t5: Value; // ByteArrayType()
     var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, counter));
-    assume IsValidReferenceParameter(m, local_counter, counter);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, counter));
+    assume IsValidReferenceParameter(__m, __frame, counter);
     assume is#Address(sender);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 1, sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     call t3 := CopyOrMoveRef(counter);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraAccount_fresh_guid(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraAccount_fresh_guid(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(m, old_size + 2), GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
 procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -4004,25 +3973,24 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
     var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
     var t6: Value; // AddressType()
     var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -4030,34 +3998,35 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
 
     call t5 := BorrowField(t4, LibraAccount_T_event_generator);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_new_event_handle(tv0);
 }
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, handle_ref), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, handle_ref), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, handle_ref), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, handle_ref), LibraAccount_EventHandle_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -4076,34 +4045,32 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var t15: Value; // IntegerType()
     var t16: Value; // IntegerType()
     var t17: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, handle_ref));
-    assume IsValidReferenceParameter(m, local_counter, handle_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, msg);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, handle_ref));
+    assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    __m := UpdateLocal(__m, __frame + 1, msg);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(handle_ref);
 
     call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
 
-    call tmp := ReadRef(t5);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call t7 := CopyOrMoveRef(handle_ref);
 
@@ -4111,57 +4078,56 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call t2 := CopyOrMoveRef(t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call t10 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t10);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
-
-    call LibraAccount_write_to_event_store(tv0, GetLocal(m, old_size + 9), GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_write_to_event_store(tv0, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 15, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
     call t17 := CopyOrMoveRef(t2);
 
-    call WriteRef(t17, GetLocal(m, old_size + 16));
+    call WriteRef(t17, GetLocal(__m, __frame + 16));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_emit_event(tv0, handle_ref, msg);
 }
 
 procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, handle: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // ByteArrayType()
@@ -4169,44 +4135,43 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
     var t4: Value; // IntegerType()
     var t5: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(handle);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
-    m := UpdateLocal(m, old_size + 0, handle);
+    __m := UpdateLocal(__m, __frame + 0, handle);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
-    m := UpdateLocal(m, old_size + 5, t5);
+    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_destroy_handle(tv0, handle);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -12,7 +12,6 @@ procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -32,7 +31,6 @@ procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_str
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -52,7 +50,6 @@ procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_str
 {
     assume IsValidU64(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -67,69 +64,70 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 // ** functions of module LibraCoin
 
 procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // AddressType()
     var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
 procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(value)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (value)));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(value)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (value)));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
@@ -154,61 +152,60 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_
     var t21: Reference; // ReferenceType(IntegerType())
     var t22: Value; // IntegerType()
     var t23: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 24;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(value);
-    assume is#Vector(Dereference(m, capability));
-    assume IsValidReferenceParameter(m, local_counter, capability);
-
-    old_size := local_counter;
-    local_counter := local_counter + 24;
-    m := UpdateLocal(m, old_size + 0, value);
+    __m := UpdateLocal(__m, __frame + 0, value);
+    assume is#Vector(Dereference(__m, capability));
+    assume IsValidReferenceParameter(__m, __frame, capability);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(capability);
 
-    // unimplemented instruction
+    // unimplemented instruction: NoOp
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := LdConst(1000000000);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1000000000);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := LdConst(1000000);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(1000000);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Le(GetLocal(m, old_size + 5), GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Le(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    tmp := GetLocal(m, old_size + 10);
-    if (!b#Boolean(tmp)) { goto Label_11; }
+    __tmp := GetLocal(__m, __frame + 10);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call t13 := BorrowGlobal(GetLocal(m, old_size + 12), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t13 := BorrowGlobal(GetLocal(__m, __frame + 12), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t13);
 
@@ -216,58 +213,58 @@ Label_11:
 
     call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
 
-    call tmp := ReadRef(t15);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t15);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 18, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 17), GetLocal(m, old_size + 18));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
     call t20 := CopyOrMoveRef(t2);
 
     call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
 
-    call WriteRef(t21, GetLocal(m, old_size + 19));
+    call WriteRef(t21, GetLocal(__m, __frame + 19));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 22));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 22));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(m, old_size + 23);
+    ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))), LibraCoin_MarketCap_total_value)) == (Integer(0))));
-ensures old(!(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(txn))))) || b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))));
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraCoin_MarketCap_total_value)) == (Integer(0))));
+ensures old(!(b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn))))) || b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(__txn))) != (Address(173345816)))) || b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn))))) || b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -279,220 +276,216 @@ ensures old(b#Boolean(Boolean((Address(TxnSenderAddress(txn))) != (Address(17334
     var t6: Value; // LibraCoin_MintCapability_type_value()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 0), GetLocal(__m, __frame + 1)));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := GetLocal(m, old_size + 3);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 3);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_initialize();
 }
 
 procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
     var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_market_cap_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_market_cap();
 }
 
 procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(0))));
 {
     // declare local variables
     var t0: Value; // IntegerType()
     var t1: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_zero_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_zero();
 }
 
 procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, coin_ref), LibraCoin_T_value))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))));
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(coin_ref);
 
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_value(coin_ref);
 }
 
 procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean((SelectField(ret1, LibraCoin_T_value)) == (amount))) && b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
-ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean((SelectField(ret1, LibraCoin_T_value)) == (amount))) && b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -501,67 +494,67 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, coin);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
-    ret1 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 6);
+    ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := LibraCoin_split(coin, amount);
 }
 
 procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, coin_ref), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
-ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) < i#Integer(amount))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) < i#Integer(amount)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))) - i#Integer(amount)))));
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (amount)));
+ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -580,153 +573,152 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, coin_ref), Li
     var t15: Reference; // ReferenceType(IntegerType())
     var t16: Value; // IntegerType()
     var t17: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(coin_ref);
 
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
-    call tmp := ReadRef(t4);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t4);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     call t14 := CopyOrMoveRef(coin_ref);
 
     call t15 := BorrowField(t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(m, old_size + 13));
+    call WriteRef(t15, GetLocal(__m, __frame + 13));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(m, old_size + 17);
+    ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
 procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(ret0, LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin1);
+    __m := UpdateLocal(__m, __frame + 0, coin1);
     assume is#Vector(coin2);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, coin1);
-    m := UpdateLocal(m, old_size + 1, coin2);
+    __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(old_size+0);
+    call t2 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(m, coin_ref), LibraCoin_T_value))) + i#Integer(old(SelectField(check, LibraCoin_T_value)))))));
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) == (Integer(i#Integer(old(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))) + i#Integer(old(SelectField(check, LibraCoin_T_value)))))));
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) + i#Integer(SelectField(check, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -741,78 +733,77 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var t11: Value; // IntegerType()
     var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t13: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 14;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume is#Vector(check);
-
-    old_size := local_counter;
-    local_counter := local_counter + 14;
-    m := UpdateLocal(m, old_size + 1, check);
+    __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(coin_ref);
 
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, t8);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 10, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(coin_ref);
 
     call t13 := BorrowField(t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(m, old_size + 11));
+    call WriteRef(t13, GetLocal(__m, __frame + 11));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_deposit(coin_ref, check);
 }
 
 procedure {:inline 1} LibraCoin_destroy_zero (coin: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer(0))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -823,48 +814,47 @@ ensures old(b#Boolean(Boolean((SelectField(coin, LibraCoin_T_value)) != (Integer
     var t6: Value; // BooleanType()
     var t7: Value; // BooleanType()
     var t8: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, t3);
+    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5)));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
@@ -872,12 +862,12 @@ Label_10:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_destroy_zero(coin);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -7,9 +7,10 @@
 // ** functions of module TestAbortIf
 
 procedure {:inline 1} TestAbortIf_abort1 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -17,41 +18,40 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
     var t4: Value; // BooleanType()
     var t5: Value; // BooleanType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
@@ -59,91 +59,91 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort1_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort1(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort2 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort2_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort2(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort3 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // BooleanType()
     var t3: Value; // BooleanType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := GetLocal(m, old_size + 3);
-    if (!b#Boolean(tmp)) { goto Label_5; }
+    __tmp := GetLocal(__m, __frame + 3);
+    if (!b#Boolean(__tmp)) { goto Label_5; }
 
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     goto Label_Abort;
 
@@ -151,20 +151,21 @@ Label_5:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort3_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort3(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort4 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -172,41 +173,40 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     var t4: Value; // BooleanType()
     var t5: Value; // BooleanType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
@@ -214,20 +214,21 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort4_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort4(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort5 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -235,41 +236,40 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> abort_flag;
     var t4: Value; // BooleanType()
     var t5: Value; // BooleanType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
@@ -277,20 +277,21 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort5_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort5(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort6 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -298,41 +299,40 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     var t4: Value; // BooleanType()
     var t5: Value; // BooleanType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
@@ -340,20 +340,21 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort6_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort6(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort7 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) >= i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) >= i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -361,41 +362,40 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     var t4: Value; // BooleanType()
     var t5: Value; // BooleanType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
@@ -403,21 +403,22 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort7_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort7(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort8 (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (Boolean(true))));
-ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (Boolean(true))));
+ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -429,80 +430,80 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
     var t8: Value; // IntegerType()
     var t9: Value; // IntegerType()
     var t10: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 8), GetLocal(m, old_size + 9)));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9)));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    ret0 := GetLocal(m, old_size + 10);
+    ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestAbortIf_abort8_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestAbortIf_abort8(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort9 (x: Value, y: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((x) == (y)));
-ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean(i#Integer(x) < i#Integer(y))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((x) == (y)));
+ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean(i#Integer(x) < i#Integer(y))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -510,41 +511,40 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
     var t4: Value; // BooleanType()
     var t5: Value; // BooleanType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     goto Label_Abort;
 
@@ -552,12 +552,12 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestAbortIf_abort9_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestAbortIf_abort9(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -7,7 +7,7 @@
 // ** functions of module U64Util
 
 procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -18,7 +18,7 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module AddressUtil
 
 procedure {:inline 1} AddressUtil_address_to_bytes (addr: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -29,7 +29,7 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module BytearrayUtil
 
 procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -40,10 +40,10 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module Hash
 
 procedure {:inline 1} Hash_sha2_256 (data: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} Hash_sha3_256 (data: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -59,7 +59,6 @@ procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -79,7 +78,6 @@ procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_str
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -99,7 +97,6 @@ procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_str
 {
     assume IsValidU128(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -114,61 +111,60 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 // ** functions of module LibraCoin
 
 procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // AddressType()
     var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
 procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -190,57 +186,56 @@ requires ExistsTxnSenderAccount(m, txn);
     var t18: Reference; // ReferenceType(IntegerType())
     var t19: Value; // IntegerType()
     var t20: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 21;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(value);
-    assume is#Vector(Dereference(m, capability));
-    assume IsValidReferenceParameter(m, local_counter, capability);
-
-    old_size := local_counter;
-    local_counter := local_counter + 21;
-    m := UpdateLocal(m, old_size + 0, value);
+    __m := UpdateLocal(__m, __frame + 0, value);
+    assume is#Vector(Dereference(__m, capability));
+    assume IsValidReferenceParameter(__m, __frame, capability);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(1000000000);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1000000000);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(1000000);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(1000000);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Le(GetLocal(m, old_size + 3), GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Le(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    tmp := GetLocal(m, old_size + 8);
-    if (!b#Boolean(tmp)) { goto Label_9; }
+    __tmp := GetLocal(__m, __frame + 8);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     goto Label_Abort;
 
 Label_9:
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := BorrowGlobal(GetLocal(m, old_size + 10), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t12 := BorrowField(t11, LibraCoin_MarketCap_total_value);
 
@@ -248,49 +243,48 @@ Label_9:
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU128(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU128(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CastU128(GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := CastU128(GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
-
-    call tmp := AddU128(GetLocal(m, old_size + 14), GetLocal(m, old_size + 16));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := AddU128(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 16));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     call t18 := CopyOrMoveRef(t2);
 
-    call WriteRef(t18, GetLocal(m, old_size + 17));
+    call WriteRef(t18, GetLocal(__m, __frame + 17));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 19));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    ret0 := GetLocal(m, old_size + 20);
+    ret0 := GetLocal(__m, __frame + 20);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -302,212 +296,206 @@ requires ExistsTxnSenderAccount(m, txn);
     var t6: Value; // LibraCoin_MintCapability_type_value()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 0), GetLocal(__m, __frame + 1)));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := GetLocal(m, old_size + 3);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 3);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_initialize();
 }
 
 procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
     var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU128(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU128(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_market_cap_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_market_cap();
 }
 
 procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // IntegerType()
     var t1: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_zero_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_zero();
 }
 
 procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(coin_ref);
 
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_value(coin_ref);
 }
 
 procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -516,63 +504,62 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, coin);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
-    ret1 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 6);
+    ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := LibraCoin_split(coin, amount);
 }
 
 procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -591,147 +578,144 @@ requires ExistsTxnSenderAccount(m, txn);
     var t15: Reference; // ReferenceType(IntegerType())
     var t16: Value; // IntegerType()
     var t17: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(coin_ref);
 
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
-    call tmp := ReadRef(t4);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t4);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     call t14 := CopyOrMoveRef(coin_ref);
 
     call t15 := BorrowField(t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(m, old_size + 13));
+    call WriteRef(t15, GetLocal(__m, __frame + 13));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(m, old_size + 17);
+    ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
 procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin1);
+    __m := UpdateLocal(__m, __frame + 0, coin1);
     assume is#Vector(coin2);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, coin1);
-    m := UpdateLocal(m, old_size + 1, coin2);
+    __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(old_size+0);
+    call t2 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -746,76 +730,74 @@ requires ExistsTxnSenderAccount(m, txn);
     var t11: Value; // IntegerType()
     var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t13: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 14;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume is#Vector(check);
-
-    old_size := local_counter;
-    local_counter := local_counter + 14;
-    m := UpdateLocal(m, old_size + 1, check);
+    __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(coin_ref);
 
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, t8);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 10, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(coin_ref);
 
     call t13 := BorrowField(t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(m, old_size + 11));
+    call WriteRef(t13, GetLocal(__m, __frame + 11));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_deposit(coin_ref, check);
 }
 
 procedure {:inline 1} LibraCoin_destroy_zero (coin: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -826,48 +808,47 @@ requires ExistsTxnSenderAccount(m, txn);
     var t6: Value; // BooleanType()
     var t7: Value; // BooleanType()
     var t8: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, t3);
+    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5)));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
@@ -875,13 +856,13 @@ Label_10:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_destroy_zero(coin);
 }
 
@@ -918,7 +899,6 @@ procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Va
     assume IsValidU64(sequence_number);
     assume is#Vector(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value)
@@ -952,7 +932,6 @@ procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(account_address: Va
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(_struct: Value) returns (account_address: Value)
@@ -972,7 +951,6 @@ procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(account_address: V
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(_struct: Value) returns (account_address: Value)
@@ -998,7 +976,6 @@ procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: V
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) returns (amount: Value, payee: Value, metadata: Value)
@@ -1028,7 +1005,6 @@ procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, paye
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) returns (amount: Value, payer: Value, metadata: Value)
@@ -1052,7 +1028,6 @@ procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) ret
 {
     assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) returns (counter: Value)
@@ -1075,7 +1050,6 @@ procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Val
     assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (counter: Value, guid: Value)
@@ -1092,112 +1066,110 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 // ** functions of module LibraAccount
 
 procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Vector(to_deposit);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, to_deposit);
+    __m := UpdateLocal(__m, __frame + 1, to_deposit);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(4, ByteArrayPoolIndex(0))
 
-    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_metadata(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit(payee, to_deposit);
 }
 
 procedure {:inline 1} LibraAccount_deposit_with_metadata (payee: Value, to_deposit: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t3: Value; // AddressType()
     var t4: Value; // AddressType()
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Vector(to_deposit);
+    __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, to_deposit);
-    m := UpdateLocal(m, old_size + 2, metadata);
+    __m := UpdateLocal(__m, __frame + 2, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4), GetLocal(m, old_size + 5), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit_with_metadata(payee, to_deposit, metadata);
 }
 
 procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // IntegerType()
@@ -1229,65 +1201,64 @@ requires ExistsTxnSenderAccount(m, txn);
     var t30: Value; // AddressType()
     var t31: Value; // ByteArrayType()
     var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 33;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Address(sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
     assume is#Vector(to_deposit);
+    __m := UpdateLocal(__m, __frame + 2, to_deposit);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 33;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, sender);
-    m := UpdateLocal(m, old_size + 2, to_deposit);
-    m := UpdateLocal(m, old_size + 3, metadata);
+    __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call t7 := BorrowLoc(old_size+2);
+    call t7 := BorrowLoc(__frame + 2);
 
     call t8 := LibraCoin_value(t7);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    tmp := GetLocal(m, old_size + 12);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 12);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(7);
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     goto Label_Abort;
 
 Label_10:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := BorrowGlobal(GetLocal(m, old_size + 14), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t15);
 
@@ -1295,26 +1266,26 @@ Label_10:
 
     call t17 := BorrowField(t16, LibraAccount_T_sent_events);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(m, old_size + 21));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(__m, __frame + 21));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call t23 := BorrowGlobal(GetLocal(m, old_size + 22), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t23);
 
@@ -1322,46 +1293,46 @@ Label_10:
 
     call t25 := BorrowField(t24, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call LibraCoin_deposit(t25, GetLocal(m, old_size + 26));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t25, GetLocal(__m, __frame + 26));
+    if (__abort_flag) { goto Label_Abort; }
 
     call t27 := CopyOrMoveRef(t5);
 
     call t28 := BorrowField(t27, LibraAccount_T_received_events);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 29, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 29, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 30, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 30, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 31, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 31, __tmp);
 
-    call tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(m, old_size + 29), GetLocal(m, old_size + 30), GetLocal(m, old_size + 31));
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(m, old_size + 32));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(__m, __frame + 32));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit_with_sender_and_metadata(payee, sender, to_deposit, metadata);
 }
 
 procedure {:inline 1} LibraAccount_mint_to_address (payee: Value, amount: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -1371,73 +1342,72 @@ requires ExistsTxnSenderAccount(m, txn);
     var t6: Value; // AddressType()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := GetLocal(m, old_size + 4);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := LibraCoin_mint_with_default_capability(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call LibraAccount_deposit(GetLocal(m, old_size + 6), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_mint_to_address(payee, amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -1446,60 +1416,59 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Value; // IntegerType()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(account);
 
     call t4 := BorrowField(t3, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := LibraCoin_withdraw(t4, GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := LibraCoin_withdraw(t4, GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -1512,27 +1481,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Value; // IntegerType()
     var t10: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -1540,48 +1508,47 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
 
-    call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_9; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t10);
 
-    m := UpdateLocal(m, old_size + 10, t10);
+    __m := UpdateLocal(__m, __frame + 10, t10);
 
-    ret0 := GetLocal(m, old_size + 10);
+    ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -1592,66 +1559,64 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t8: Value; // IntegerType()
     var t9: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(cap);
 
     call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
 
-    call tmp := ReadRef(t4);
-    assume is#Address(tmp);
+    call __tmp := ReadRef(t4);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
-
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
     call t7 := CopyOrMoveRef(t2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    ret0 := GetLocal(m, old_size + 9);
+    ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
 procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -1669,31 +1634,30 @@ requires ExistsTxnSenderAccount(m, txn);
     var t12: Reference; // ReferenceType(BooleanType())
     var t13: Value; // AddressType()
     var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 15;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 15;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -1705,50 +1669,49 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t8 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t8);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t8);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_13; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_13; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_13:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(t2);
 
-    call WriteRef(t12, GetLocal(m, old_size + 11));
+    call WriteRef(t12, GetLocal(__m, __frame + 11));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 13));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    ret0 := GetLocal(m, old_size + 14);
+    ret0 := GetLocal(__m, __frame + 14);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (cap: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -1760,63 +1723,62 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // BooleanType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Reference; // ReferenceType(BooleanType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, cap);
+    __m := UpdateLocal(__m, __frame + 0, cap);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
+    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t8 := CopyOrMoveRef(t2);
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
 
-    call WriteRef(t9, GetLocal(m, old_size + 7));
+    call WriteRef(t9, GetLocal(__m, __frame + 7));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_restore_withdrawal_capability(cap);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_capability (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -1831,91 +1793,89 @@ requires ExistsTxnSenderAccount(m, txn);
     var t13: Value; // IntegerType()
     var t14: Value; // LibraCoin_T_type_value()
     var t15: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 16;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    __m := UpdateLocal(__m, __frame + 0, payee);
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume IsValidU64(amount);
+    __m := UpdateLocal(__m, __frame + 2, amount);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 16;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 2, amount);
-    m := UpdateLocal(m, old_size + 3, metadata);
+    __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call t9 := CopyOrMoveRef(cap);
 
     call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
 
-    call tmp := ReadRef(t10);
-    assume is#Address(tmp);
-
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := ReadRef(t10);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(cap);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
+    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t14);
 
-    m := UpdateLocal(m, old_size + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, t14);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 8), GetLocal(m, old_size + 11), GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_capability_verify (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_capability(payee, cap, amount, metadata);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (payee: Value, amount: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t3: Value; // AddressType()
@@ -1926,174 +1886,171 @@ requires ExistsTxnSenderAccount(m, txn);
     var t8: Value; // IntegerType()
     var t9: Value; // LibraCoin_T_type_value()
     var t10: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
-    m := UpdateLocal(m, old_size + 2, metadata);
+    __m := UpdateLocal(__m, __frame + 2, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_sender(GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 7), GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_metadata(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (payee: Value, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_sender_with_metadata(payee, amount, metadata);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_sender (payee: Value, amount: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
     var t3: Value; // IntegerType()
     var t4: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(4, ByteArrayPoolIndex(0))
 
-    call LibraAccount_pay_from_sender_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_pay_from_sender_with_metadata(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_sender(payee, amount);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (account: Reference, new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // ByteArrayType()
     var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t4: Reference; // ReferenceType(ByteArrayType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 1, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     call t3 := CopyOrMoveRef(account);
 
     call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
 
-    call WriteRef(t4, GetLocal(m, old_size + 2));
+    call WriteRef(t4, GetLocal(__m, __frame + 2));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (account: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key_for_account(account, new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key (new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -2105,27 +2062,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // IntegerType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -2133,43 +2089,42 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_9; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_verify (new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key(new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (cap: Reference, new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
@@ -2177,57 +2132,55 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Value; // AddressType()
     var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t6: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 1, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(cap);
 
     call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
 
-    call tmp := ReadRef(t3);
-    assume is#Address(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2243,31 +2196,30 @@ requires ExistsTxnSenderAccount(m, txn);
     var t10: Reference; // ReferenceType(BooleanType())
     var t11: Value; // AddressType()
     var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 13;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 13;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := BorrowGlobal(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
@@ -2275,50 +2227,49 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t6 := CopyOrMoveRef(t1);
 
-    call tmp := ReadRef(t6);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t6);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    m := UpdateLocal(m, old_size + 7, tmp);
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call t10 := CopyOrMoveRef(t1);
 
-    call WriteRef(t10, GetLocal(m, old_size + 9));
+    call WriteRef(t10, GetLocal(__m, __frame + 9));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(m, old_size + 12);
+    ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (cap: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -2330,63 +2281,62 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // BooleanType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Reference; // ReferenceType(BooleanType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, cap);
+    __m := UpdateLocal(__m, __frame + 0, cap);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
+    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t8 := CopyOrMoveRef(t2);
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
 
-    call WriteRef(t9, GetLocal(m, old_size + 7));
+    call WriteRef(t9, GetLocal(__m, __frame + 7));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_restore_key_rotation_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_restore_key_rotation_capability(cap);
 }
 
 procedure {:inline 1} LibraAccount_create_account (fresh_address: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
@@ -2407,104 +2357,103 @@ requires ExistsTxnSenderAccount(m, txn);
     var t16: Value; // IntegerType()
     var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
     var t18: Value; // LibraAccount_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 19;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
-
-    old_size := local_counter;
-    local_counter := local_counter + 19;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
     call t7 := LibraCoin_zero();
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowLoc(old_size+1);
+    call t10 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call t13 := BorrowLoc(old_size+1);
+    call t13 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t15);
 
-    m := UpdateLocal(m, old_size + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, t15);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 12), GetLocal(m, old_size + 15), GetLocal(m, old_size + 16), GetLocal(m, old_size + 17));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call LibraAccount_save_account(GetLocal(m, old_size + 4), GetLocal(m, old_size + 18));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_save_account(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_create_account_verify (fresh_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_create_account(fresh_address);
 }
 
 procedure {:inline 1} LibraAccount_create_new_account (fresh_address: Value, initial_balance: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -2513,70 +2462,69 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Value; // BooleanType()
     var t6: Value; // AddressType()
     var t7: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume IsValidU64(initial_balance);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
-    m := UpdateLocal(m, old_size + 1, initial_balance);
+    __m := UpdateLocal(__m, __frame + 1, initial_balance);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 2));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 2));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_9; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call LibraAccount_pay_from_sender(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_pay_from_sender(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_9:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_balance: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
 procedure {:inline 1} LibraAccount_save_account (addr: Value, account: Value) returns ();
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -2584,20 +2532,19 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(account);
@@ -2605,303 +2552,294 @@ requires ExistsTxnSenderAccount(m, txn);
     call t3 := BorrowField(t2, LibraAccount_T_balance);
 
     call t4 := LibraCoin_value(t3);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(m, old_size + 5);
+    ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_for_account_verify (account: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_balance_for_account(account);
 }
 
 procedure {:inline 1} LibraAccount_balance (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_balance_for_account(t2);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_balance(addr);
 }
 
 procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(account);
 
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
 procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_sequence_number(addr);
 }
 
 procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Reference; // ReferenceType(BooleanType())
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
 
-    call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
-
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
 procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Reference; // ReferenceType(BooleanType())
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
 
-    call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
-
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
 procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (ret0: Reference)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
     var t2: Reference; // ReferenceType(AddressType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(cap);
@@ -2912,37 +2850,36 @@ requires ExistsTxnSenderAccount(m, txn);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultReference;
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
 procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (ret0: Reference)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
     var t2: Reference; // ReferenceType(AddressType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(cap);
@@ -2953,62 +2890,61 @@ requires ExistsTxnSenderAccount(m, txn);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultReference;
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
 procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(check_addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, check_addr);
+    __m := UpdateLocal(__m, __frame + 0, check_addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_exists_verify (check_addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_exists(check_addr);
 }
 
 procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -3057,105 +2993,103 @@ requires ExistsTxnSenderAccount(m, txn);
     var t47: Value; // BooleanType()
     var t48: Value; // BooleanType()
     var t49: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 50;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(txn_sequence_number);
+    __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
     assume is#ByteArray(txn_public_key);
+    __m := UpdateLocal(__m, __frame + 1, txn_public_key);
     assume IsValidU64(txn_gas_price);
+    __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
-
-    old_size := local_counter;
-    local_counter := local_counter + 50;
-    m := UpdateLocal(m, old_size + 0, txn_sequence_number);
-    m := UpdateLocal(m, old_size + 1, txn_public_key);
-    m := UpdateLocal(m, old_size + 2, txn_gas_price);
-    m := UpdateLocal(m, old_size + 3, txn_max_gas_units);
+    __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 11), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 11), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    tmp := GetLocal(m, old_size + 13);
-    if (!b#Boolean(tmp)) { goto Label_8; }
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_8; }
 
-    call tmp := LdConst(5);
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(5);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     goto Label_Abort;
 
 Label_8:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call t16 := BorrowGlobal(GetLocal(m, old_size + 15), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t16);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call t18 := Hash_sha3_256(GetLocal(m, old_size + 17));
-    if (abort_flag) { goto Label_Abort; }
+    call t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t18);
 
-    m := UpdateLocal(m, old_size + 18, t18);
+    __m := UpdateLocal(__m, __frame + 18, t18);
 
     call t19 := CopyOrMoveRef(t5);
 
     call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
 
-    call tmp := ReadRef(t20);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t20);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    m := UpdateLocal(m, old_size + 21, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 21)));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 21)));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 22));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 22));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    __tmp := GetLocal(__m, __frame + 23);
+    if (!b#Boolean(__tmp)) { goto Label_21; }
 
-    tmp := GetLocal(m, old_size + 23);
-    if (!b#Boolean(tmp)) { goto Label_21; }
-
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 24, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 24, __tmp);
 
     goto Label_Abort;
 
 Label_21:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 27, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 25), GetLocal(__m, __frame + 26));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 27));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t28 := CopyOrMoveRef(t5);
 
@@ -3166,31 +3100,31 @@ Label_21:
     call t30 := CopyOrMoveRef(t6);
 
     call t31 := LibraAccount_balance_for_account(t30);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t31);
 
-    m := UpdateLocal(m, old_size + 31, t31);
+    __m := UpdateLocal(__m, __frame + 31, t31);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 31));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 33, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 33, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 32), GetLocal(m, old_size + 33));
-    m := UpdateLocal(m, old_size + 34, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 32), GetLocal(__m, __frame + 33));
+    __m := UpdateLocal(__m, __frame + 34, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 34));
-    m := UpdateLocal(m, old_size + 35, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 34));
+    __m := UpdateLocal(__m, __frame + 35, __tmp);
 
-    tmp := GetLocal(m, old_size + 35);
-    if (!b#Boolean(tmp)) { goto Label_38; }
+    __tmp := GetLocal(__m, __frame + 35);
+    if (!b#Boolean(__tmp)) { goto Label_38; }
 
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 36, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
     goto Label_Abort;
 
@@ -3199,52 +3133,51 @@ Label_38:
 
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
 
-    call tmp := ReadRef(t38);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t38);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 39, __tmp);
 
-    m := UpdateLocal(m, old_size + 39, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 39));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 39));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 40, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 40, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 41, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 41, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 40), GetLocal(__m, __frame + 41));
+    __m := UpdateLocal(__m, __frame + 42, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 40), GetLocal(m, old_size + 41));
-    m := UpdateLocal(m, old_size + 42, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 42));
+    __m := UpdateLocal(__m, __frame + 43, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 42));
-    m := UpdateLocal(m, old_size + 43, tmp);
+    __tmp := GetLocal(__m, __frame + 43);
+    if (!b#Boolean(__tmp)) { goto Label_49; }
 
-    tmp := GetLocal(m, old_size + 43);
-    if (!b#Boolean(tmp)) { goto Label_49; }
-
-    call tmp := LdConst(3);
-    m := UpdateLocal(m, old_size + 44, tmp);
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 44, __tmp);
 
     goto Label_Abort;
 
 Label_49:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 45, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 45, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 46, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 46, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 45), GetLocal(m, old_size + 46)));
-    m := UpdateLocal(m, old_size + 47, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 45), GetLocal(__m, __frame + 46)));
+    __m := UpdateLocal(__m, __frame + 47, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 47));
-    m := UpdateLocal(m, old_size + 48, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 47));
+    __m := UpdateLocal(__m, __frame + 48, __tmp);
 
-    tmp := GetLocal(m, old_size + 48);
-    if (!b#Boolean(tmp)) { goto Label_56; }
+    __tmp := GetLocal(__m, __frame + 48);
+    if (!b#Boolean(__tmp)) { goto Label_56; }
 
-    call tmp := LdConst(4);
-    m := UpdateLocal(m, old_size + 49, tmp);
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 49, __tmp);
 
     goto Label_Abort;
 
@@ -3252,18 +3185,18 @@ Label_56:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units);
 }
 
 procedure {:inline 1} LibraAccount_epilogue (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -3299,55 +3232,54 @@ requires ExistsTxnSenderAccount(m, txn);
     var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t36: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 37;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(txn_sequence_number);
+    __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
     assume IsValidU64(txn_gas_price);
+    __m := UpdateLocal(__m, __frame + 1, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
+    __m := UpdateLocal(__m, __frame + 2, txn_max_gas_units);
     assume IsValidU64(gas_units_remaining);
-
-    old_size := local_counter;
-    local_counter := local_counter + 37;
-    m := UpdateLocal(m, old_size + 0, txn_sequence_number);
-    m := UpdateLocal(m, old_size + 1, txn_gas_price);
-    m := UpdateLocal(m, old_size + 2, txn_max_gas_units);
-    m := UpdateLocal(m, old_size + 3, gas_units_remaining);
+    __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowGlobal(GetLocal(m, old_size + 9), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t10);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 12), GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t16 := CopyOrMoveRef(t4);
 
@@ -3358,64 +3290,64 @@ requires ExistsTxnSenderAccount(m, txn);
     call t18 := CopyOrMoveRef(t6);
 
     call t19 := LibraAccount_balance_for_account(t18);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t19);
 
-    m := UpdateLocal(m, old_size + 19, t19);
+    __m := UpdateLocal(__m, __frame + 19, t19);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 21));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 21));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    tmp := GetLocal(m, old_size + 22);
-    if (!b#Boolean(tmp)) { goto Label_20; }
+    __tmp := GetLocal(__m, __frame + 22);
+    if (!b#Boolean(__tmp)) { goto Label_20; }
 
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     goto Label_Abort;
 
 Label_20:
     call t24 := CopyOrMoveRef(t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(m, old_size + 25));
-    if (abort_flag) { goto Label_Abort; }
+    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(__m, __frame + 25));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t26);
 
-    m := UpdateLocal(m, old_size + 26, t26);
+    __m := UpdateLocal(__m, __frame + 26, t26);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 26));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 27, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 28, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 28, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 29, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 27), GetLocal(__m, __frame + 28));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 29, __tmp);
 
     call t30 := CopyOrMoveRef(t4);
 
     call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
 
-    call WriteRef(t31, GetLocal(m, old_size + 29));
+    call WriteRef(t31, GetLocal(__m, __frame + 29));
 
-    call tmp := LdAddr(4078);
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := LdAddr(4078);
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call t33 := BorrowGlobal(GetLocal(m, old_size + 32), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t33);
 
@@ -3423,27 +3355,27 @@ Label_20:
 
     call t35 := BorrowField(t34, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 36, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call LibraCoin_deposit(t35, GetLocal(m, old_size + 36));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t35, GetLocal(__m, __frame + 36));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
 procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -3466,22 +3398,21 @@ requires ExistsTxnSenderAccount(m, txn);
     var t19: Value; // ByteArrayType()
     var t20: Value; // ByteArrayType()
     var t21: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 22;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, counter));
-    assume IsValidReferenceParameter(m, local_counter, counter);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, counter));
+    assume IsValidReferenceParameter(__m, __frame, counter);
     assume is#Address(sender);
-
-    old_size := local_counter;
-    local_counter := local_counter + 22;
-    m := UpdateLocal(m, old_size + 1, sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
     call t6 := CopyOrMoveRef(counter);
@@ -3490,87 +3421,85 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t2 := CopyOrMoveRef(t7);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     call t10 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t10);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    m := UpdateLocal(m, old_size + 11, tmp);
-
-    call t12 := U64Util_u64_to_bytes(GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 15, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
     call t17 := CopyOrMoveRef(t2);
 
-    call WriteRef(t17, GetLocal(m, old_size + 16));
+    call WriteRef(t17, GetLocal(__m, __frame + 16));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19));
-    if (abort_flag) { goto Label_Abort; }
+    call t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t20);
 
-    m := UpdateLocal(m, old_size + 20, t20);
+    __m := UpdateLocal(__m, __frame + 20, t20);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    ret0 := GetLocal(m, old_size + 21);
+    ret0 := GetLocal(__m, __frame + 21);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
 procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -3578,58 +3507,57 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Value; // AddressType()
     var t5: Value; // ByteArrayType()
     var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, counter));
-    assume IsValidReferenceParameter(m, local_counter, counter);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, counter));
+    assume IsValidReferenceParameter(__m, __frame, counter);
     assume is#Address(sender);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 1, sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     call t3 := CopyOrMoveRef(counter);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraAccount_fresh_guid(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraAccount_fresh_guid(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(m, old_size + 2), GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
 procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -3640,25 +3568,24 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
     var t6: Value; // AddressType()
     var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -3666,32 +3593,32 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, LibraAccount_T_event_generator);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_new_event_handle(tv0);
 }
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -3710,34 +3637,32 @@ requires ExistsTxnSenderAccount(m, txn);
     var t15: Value; // IntegerType()
     var t16: Value; // IntegerType()
     var t17: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, handle_ref));
-    assume IsValidReferenceParameter(m, local_counter, handle_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, msg);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, handle_ref));
+    assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    __m := UpdateLocal(__m, __frame + 1, msg);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(handle_ref);
 
     call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
 
-    call tmp := ReadRef(t5);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call t7 := CopyOrMoveRef(handle_ref);
 
@@ -3745,58 +3670,56 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t2 := CopyOrMoveRef(t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call t10 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t10);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
-
-    call LibraAccount_write_to_event_store(tv0, GetLocal(m, old_size + 9), GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_write_to_event_store(tv0, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 15, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
     call t17 := CopyOrMoveRef(t2);
 
-    call WriteRef(t17, GetLocal(m, old_size + 16));
+    call WriteRef(t17, GetLocal(__m, __frame + 16));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_emit_event(tv0, handle_ref, msg);
 }
 
 procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, guid: Value, count: Value, msg: Value) returns ();
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, handle: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // ByteArrayType()
@@ -3804,45 +3727,44 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
     var t4: Value; // IntegerType()
     var t5: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(handle);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
-    m := UpdateLocal(m, old_size + 0, handle);
+    __m := UpdateLocal(__m, __frame + 0, handle);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
-    m := UpdateLocal(m, old_size + 5, t5);
+    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_destroy_handle(tv0, handle);
 }
 
@@ -3863,7 +3785,6 @@ procedure {:inline 1} Pack_AccessPathTest_ProverGhostTypes(a: Value, b: Value) r
     assume is#Vector(a);
     assume is#Vector(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, a), b));
-
 }
 
 procedure {:inline 1} Unpack_AccessPathTest_ProverGhostTypes(_struct: Value) returns (a: Value, b: Value)
@@ -3880,9 +3801,10 @@ procedure {:inline 1} Unpack_AccessPathTest_ProverGhostTypes(_struct: Value) ret
 // ** functions of module AccessPathTest
 
 procedure {:inline 1} AccessPathTest_fail_if_empty_balance (a: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(a)))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(a))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_value(), a#Address(a)))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(m, GetResourceReference(LibraAccount_T_type_value(), a#Address(a))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(a)))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(a))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(a)))))) || b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(a))), LibraAccount_T_balance), LibraCoin_T_value)) == (Integer(0))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -3890,42 +3812,41 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(m, LibraAccount_T_type_
     var t3: Value; // IntegerType()
     var t4: Value; // BooleanType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(a);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
-    m := UpdateLocal(m, old_size + 0, a);
+    __m := UpdateLocal(__m, __frame + 0, a);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := LibraAccount_balance(GetLocal(m, old_size + 1));
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := LibraAccount_balance(GetLocal(__m, __frame + 1));
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t2);
 
-    m := UpdateLocal(m, old_size + 2, t2);
+    __m := UpdateLocal(__m, __frame + 2, t2);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3)));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3)));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := GetLocal(m, old_size + 4);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(77);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(77);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     goto Label_Abort;
 
@@ -3933,12 +3854,12 @@ Label_7:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure AccessPathTest_fail_if_empty_balance_verify (a: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call AccessPathTest_fail_if_empty_balance(a);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -7,7 +7,7 @@
 // ** functions of module TestArithmetic
 
 procedure {:inline 1} TestArithmetic_add_two_number (x: Value, y: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -18,68 +18,67 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // IntegerType()
     var t8: Value; // IntegerType()
     var t9: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := LdConst(3);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    ret0 := GetLocal(m, old_size + 8);
-    ret1 := GetLocal(m, old_size + 9);
+    ret0 := GetLocal(__m, __frame + 8);
+    ret1 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure TestArithmetic_add_two_number_verify (x: Value, y: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := TestArithmetic_add_two_number(x, y);
 }
 
 procedure {:inline 1} TestArithmetic_multiple_ops (x: Value, y: Value, z: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t3: Value; // IntegerType()
@@ -89,66 +88,65 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // IntegerType()
     var t8: Value; // IntegerType()
     var t9: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
+    __m := UpdateLocal(__m, __frame + 1, y);
     assume IsValidU64(z);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
-    m := UpdateLocal(m, old_size + 2, z);
+    __m := UpdateLocal(__m, __frame + 2, z);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    ret0 := GetLocal(m, old_size + 9);
+    ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestArithmetic_multiple_ops_verify (x: Value, y: Value, z: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestArithmetic_multiple_ops(x, y, z);
 }
 
 procedure {:inline 1} TestArithmetic_bool_ops (a: Value, b: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // BooleanType()
@@ -172,89 +170,88 @@ requires ExistsTxnSenderAccount(m, txn);
     var t20: Value; // BooleanType()
     var t21: Value; // BooleanType()
     var t22: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 23;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(a);
+    __m := UpdateLocal(__m, __frame + 0, a);
     assume IsValidU64(b);
-
-    old_size := local_counter;
-    local_counter := local_counter + 23;
-    m := UpdateLocal(m, old_size + 0, a);
-    m := UpdateLocal(m, old_size + 1, b);
+    __m := UpdateLocal(__m, __frame + 1, b);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := And(GetLocal(m, old_size + 6), GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := And(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Lt(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Lt(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := Le(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := Le(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := Or(GetLocal(m, old_size + 13), GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := Or(GetLocal(__m, __frame + 13), GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 17));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    tmp := Boolean(!IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19)));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    __tmp := Boolean(!IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19)));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    tmp := GetLocal(m, old_size + 21);
-    if (!b#Boolean(tmp)) { goto Label_23; }
+    __tmp := GetLocal(__m, __frame + 21);
+    if (!b#Boolean(__tmp)) { goto Label_23; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
     goto Label_Abort;
 
@@ -262,18 +259,18 @@ Label_23:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestArithmetic_bool_ops_verify (a: Value, b: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestArithmetic_bool_ops(a, b);
 }
 
 procedure {:inline 1} TestArithmetic_arithmetic_ops (a: Value, b: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -295,111 +292,110 @@ requires ExistsTxnSenderAccount(m, txn);
     var t18: Value; // IntegerType()
     var t19: Value; // IntegerType()
     var t20: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 21;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(a);
+    __m := UpdateLocal(__m, __frame + 0, a);
     assume IsValidU64(b);
-
-    old_size := local_counter;
-    local_counter := local_counter + 21;
-    m := UpdateLocal(m, old_size + 0, a);
-    m := UpdateLocal(m, old_size + 1, b);
+    __m := UpdateLocal(__m, __frame + 1, b);
 
     // bytecode translation starts here
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(4);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 5), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := LdConst(3);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Div(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := Div(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := LdConst(4);
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Mod(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Mod(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 13));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15)));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15)));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    tmp := GetLocal(m, old_size + 17);
-    if (!b#Boolean(tmp)) { goto Label_19; }
+    __tmp := GetLocal(__m, __frame + 17);
+    if (!b#Boolean(__tmp)) { goto Label_19; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
     goto Label_Abort;
 
 Label_19:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    ret0 := GetLocal(m, old_size + 19);
-    ret1 := GetLocal(m, old_size + 20);
+    ret0 := GetLocal(__m, __frame + 19);
+    ret1 := GetLocal(__m, __frame + 20);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure TestArithmetic_arithmetic_ops_verify (a: Value, b: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := TestArithmetic_arithmetic_ops(a, b);
 }
 
 procedure {:inline 1} TestArithmetic_overflow () returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // IntegerType()
@@ -408,54 +404,53 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(9223372036854775807);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(9223372036854775807);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestArithmetic_overflow_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestArithmetic_overflow();
 }
 
 procedure {:inline 1} TestArithmetic_underflow () returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // IntegerType()
@@ -464,54 +459,53 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestArithmetic_underflow_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestArithmetic_underflow();
 }
 
 procedure {:inline 1} TestArithmetic_div_by_zero () returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // IntegerType()
@@ -520,48 +514,47 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Div(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestArithmetic_div_by_zero_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestArithmetic_div_by_zero();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -7,7 +7,7 @@
 // ** functions of module TestControlFlow
 
 procedure {:inline 1} TestControlFlow_branch_once (cond: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // BooleanType()
@@ -15,56 +15,55 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Boolean(cond);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
-    m := UpdateLocal(m, old_size + 0, cond);
+    __m := UpdateLocal(__m, __frame + 0, cond);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := GetLocal(m, old_size + 1);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 1);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_6:
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(m, old_size + 5);
+    ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestControlFlow_branch_once_verify (cond: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestControlFlow_branch_once(cond);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -7,105 +7,104 @@
 // ** functions of module TestFuncCall
 
 procedure {:inline 1} TestFuncCall_f (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestFuncCall_f_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestFuncCall_f(x);
 }
 
 procedure {:inline 1} TestFuncCall_g (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestFuncCall_g_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestFuncCall_g(x);
 }
 
 procedure {:inline 1} TestFuncCall_h (b: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -131,124 +130,123 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     var t21: Value; // BooleanType()
     var t22: Value; // IntegerType()
     var t23: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 24;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Boolean(b);
-
-    old_size := local_counter;
-    local_counter := local_counter + 24;
-    m := UpdateLocal(m, old_size + 0, b);
+    __m := UpdateLocal(__m, __frame + 0, b);
 
     // bytecode translation starts here
-    call tmp := LdConst(3);
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := GetLocal(m, old_size + 4);
-    if (!b#Boolean(tmp)) { goto Label_8; }
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_8; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := TestFuncCall_f(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := TestFuncCall_f(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     goto Label_11;
 
 Label_8:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := TestFuncCall_g(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call t8 := TestFuncCall_g(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
 Label_11:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := LdConst(4);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 10), GetLocal(m, old_size + 11)));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11)));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := And(GetLocal(m, old_size + 9), GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := And(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 14));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 14));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := LdConst(5);
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := LdConst(5);
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 16), GetLocal(m, old_size + 17)));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17)));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := And(GetLocal(m, old_size + 15), GetLocal(m, old_size + 18));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := And(GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 18));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := Or(GetLocal(m, old_size + 13), GetLocal(m, old_size + 19));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := Or(GetLocal(__m, __frame + 13), GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    tmp := GetLocal(m, old_size + 21);
-    if (!b#Boolean(tmp)) { goto Label_27; }
+    __tmp := GetLocal(__m, __frame + 21);
+    if (!b#Boolean(__tmp)) { goto Label_27; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
     goto Label_Abort;
 
 Label_27:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(m, old_size + 23);
+    ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestFuncCall_h_verify (b: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestFuncCall_h(b);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -12,7 +12,6 @@ procedure {:inline 1} Pack_TestGenerics_R(v: Value) returns (_struct: Value)
 {
     assume is#Vector(v);
     _struct := Vector(ExtendValueArray(EmptyValueArray, v));
-
 }
 
 procedure {:inline 1} Unpack_TestGenerics_R(_struct: Value) returns (v: Value)
@@ -32,7 +31,6 @@ procedure {:inline 1} Pack_TestGenerics_T(tv0: TypeValue, v: Value) returns (_st
 {
     assume is#Vector(v);
     _struct := Vector(ExtendValueArray(EmptyValueArray, v));
-
 }
 
 procedure {:inline 1} Unpack_TestGenerics_T(_struct: Value) returns (v: Value)
@@ -47,7 +45,7 @@ procedure {:inline 1} Unpack_TestGenerics_T(_struct: Value) returns (v: Value)
 // ** functions of module TestGenerics
 
 procedure {:inline 1} TestGenerics_move2 (x1: Value, x2: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // Vector_T_type_value(IntegerType())
@@ -60,79 +58,78 @@ requires ExistsTxnSenderAccount(m, txn);
     var t9: Value; // Vector_T_type_value(IntegerType())
     var t10: Value; // TestGenerics_R_type_value()
     var t11: Value; // TestGenerics_R_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x1);
+    __m := UpdateLocal(__m, __frame + 0, x1);
     assume IsValidU64(x2);
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
-    m := UpdateLocal(m, old_size + 0, x1);
-    m := UpdateLocal(m, old_size + 1, x2);
+    __m := UpdateLocal(__m, __frame + 1, x2);
 
     // bytecode translation starts here
     call t4 := Vector_empty(IntegerType());
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t5 := BorrowLoc(old_size+2);
+    call t5 := BorrowLoc(__frame + 2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call Vector_push_back(IntegerType(), t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call Vector_push_back(IntegerType(), t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t7 := BorrowLoc(old_size+2);
+    call t7 := BorrowLoc(__frame + 2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call Vector_push_back(IntegerType(), t7, GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call Vector_push_back(IntegerType(), t7, GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Pack_TestGenerics_R(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := Pack_TestGenerics_R(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call MoveToSender(TestGenerics_R_type_value(), GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(TestGenerics_R_type_value(), GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestGenerics_move2_verify (x1: Value, x2: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestGenerics_move2(x1, x2);
 }
 
 procedure {:inline 1} TestGenerics_create (tv0: TypeValue, x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // Vector_T_type_value(tv0)
@@ -141,61 +138,60 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Value; // tv0
     var t5: Value; // Vector_T_type_value(tv0)
     var t6: Value; // TestGenerics_T_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
+    // process and type check arguments
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
     call t2 := Vector_empty(tv0);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t2);
 
-    m := UpdateLocal(m, old_size + 2, t2);
+    __m := UpdateLocal(__m, __frame + 2, t2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t3 := BorrowLoc(old_size+1);
+    call t3 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call Vector_push_back(tv0, t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call Vector_push_back(tv0, t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Pack_TestGenerics_T(tv0, GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_TestGenerics_T(tv0, GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestGenerics_create_verify (tv0: TypeValue, x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestGenerics_create(tv0, x);
 }
 
 procedure {:inline 1} TestGenerics_overcomplicated_equals (tv0: TypeValue, x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // BooleanType()
@@ -209,78 +205,77 @@ requires ExistsTxnSenderAccount(m, txn);
     var t10: Value; // TestGenerics_T_type_value(tv0)
     var t11: Value; // BooleanType()
     var t12: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 13;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 13;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    // process and type check arguments
+    __m := UpdateLocal(__m, __frame + 0, x);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := TestGenerics_create(tv0, GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := TestGenerics_create(tv0, GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := TestGenerics_create(tv0, GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call t8 := TestGenerics_create(tv0, GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10)));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10)));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(m, old_size + 12);
+    ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestGenerics_overcomplicated_equals_verify (tv0: TypeValue, x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestGenerics_overcomplicated_equals(tv0, x, y);
 }
 
 procedure {:inline 1} TestGenerics_test () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // BooleanType()
@@ -288,49 +283,48 @@ requires ExistsTxnSenderAccount(m, txn);
     var t2: Value; // IntegerType()
     var t3: Value; // BooleanType()
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := TestGenerics_overcomplicated_equals(IntegerType(), GetLocal(m, old_size + 1), GetLocal(m, old_size + 2));
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := TestGenerics_overcomplicated_equals(IntegerType(), GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Boolean(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestGenerics_test_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestGenerics_test();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -7,7 +7,7 @@
 // ** functions of module U64Util
 
 procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -18,7 +18,7 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module AddressUtil
 
 procedure {:inline 1} AddressUtil_address_to_bytes (addr: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -29,7 +29,7 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module BytearrayUtil
 
 procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -40,10 +40,10 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module Hash
 
 procedure {:inline 1} Hash_sha2_256 (data: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} Hash_sha3_256 (data: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -54,10 +54,10 @@ requires ExistsTxnSenderAccount(m, txn);
 // ** functions of module Signature
 
 procedure {:inline 1} Signature_ed25519_verify (signature: Value, public_key: Value, message: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} Signature_ed25519_threshold_verify (bitmap: Value, signature: Value, public_key: Value, message: Value) returns (ret0: Value);
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
@@ -76,7 +76,6 @@ procedure {:inline 1} Pack_GasSchedule_Cost(cpu: Value, storage: Value) returns 
     assume IsValidU64(cpu);
     assume IsValidU64(storage);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, cpu), storage));
-
 }
 
 procedure {:inline 1} Unpack_GasSchedule_Cost(_struct: Value) returns (cpu: Value, storage: Value)
@@ -101,7 +100,6 @@ procedure {:inline 1} Pack_GasSchedule_T(instruction_schedule: Value, native_sch
     assume is#Vector(instruction_schedule);
     assume is#Vector(native_schedule);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, instruction_schedule), native_schedule));
-
 }
 
 procedure {:inline 1} Unpack_GasSchedule_T(_struct: Value) returns (instruction_schedule: Value, native_schedule: Value)
@@ -118,7 +116,7 @@ procedure {:inline 1} Unpack_GasSchedule_T(_struct: Value) returns (instruction_
 // ** functions of module GasSchedule
 
 procedure {:inline 1} GasSchedule_initialize (gas_schedule: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -127,64 +125,63 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Value; // BooleanType()
     var t5: Value; // IntegerType()
     var t6: Value; // GasSchedule_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(gas_schedule);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, gas_schedule);
+    __m := UpdateLocal(__m, __frame + 0, gas_schedule);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 1), GetLocal(m, old_size + 2)));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2)));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := GetLocal(m, old_size + 4);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call MoveToSender(GasSchedule_T_type_value(), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(GasSchedule_T_type_value(), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure GasSchedule_initialize_verify (gas_schedule: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call GasSchedule_initialize(gas_schedule);
 }
 
 procedure {:inline 1} GasSchedule_instruction_table_size () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Reference; // ReferenceType(GasSchedule_T_type_value())
@@ -195,25 +192,24 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
     var t6: Value; // IntegerType()
     var t7: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), GasSchedule_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), GasSchedule_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -222,34 +218,34 @@ requires ExistsTxnSenderAccount(m, txn);
     call t5 := BorrowField(t4, GasSchedule_T_instruction_schedule);
 
     call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure GasSchedule_instruction_table_size_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := GasSchedule_instruction_table_size();
 }
 
 procedure {:inline 1} GasSchedule_native_table_size () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Reference; // ReferenceType(GasSchedule_T_type_value())
@@ -260,25 +256,24 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
     var t6: Value; // IntegerType()
     var t7: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), GasSchedule_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), GasSchedule_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -287,29 +282,29 @@ requires ExistsTxnSenderAccount(m, txn);
     call t5 := BorrowField(t4, GasSchedule_T_native_schedule);
 
     call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure GasSchedule_native_table_size_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := GasSchedule_native_table_size();
 }
 
@@ -342,7 +337,6 @@ procedure {:inline 1} Pack_ValidatorConfig_Config(consensus_pubkey: Value, valid
     assume is#ByteArray(fullnodes_network_identity_pubkey);
     assume is#ByteArray(fullnodes_network_address);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, consensus_pubkey), validator_network_signing_pubkey), validator_network_identity_pubkey), validator_network_address), fullnodes_network_identity_pubkey), fullnodes_network_address));
-
 }
 
 procedure {:inline 1} Unpack_ValidatorConfig_Config(_struct: Value) returns (consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value)
@@ -372,7 +366,6 @@ procedure {:inline 1} Pack_ValidatorConfig_T(config: Value) returns (_struct: Va
 {
     assume is#Vector(config);
     _struct := Vector(ExtendValueArray(EmptyValueArray, config));
-
 }
 
 procedure {:inline 1} Unpack_ValidatorConfig_T(_struct: Value) returns (config: Value)
@@ -387,50 +380,49 @@ procedure {:inline 1} Unpack_ValidatorConfig_T(_struct: Value) returns (config: 
 // ** functions of module ValidatorConfig
 
 procedure {:inline 1} ValidatorConfig_has (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 1), ValidatorConfig_T_type_value());
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 1), ValidatorConfig_T_type_value());
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_has_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_has(addr);
 }
 
 procedure {:inline 1} ValidatorConfig_config (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
@@ -439,27 +431,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Reference; // ReferenceType(ValidatorConfig_T_type_value())
     var t5: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t6: Value; // ValidatorConfig_Config_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), ValidatorConfig_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), ValidatorConfig_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -467,310 +458,297 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, ValidatorConfig_T_config);
 
-    call tmp := ReadRef(t5);
-    assume is#Vector(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Vector(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_config_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_config(addr);
 }
 
 procedure {:inline 1} ValidatorConfig_consensus_pubkey (config_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t2: Reference; // ReferenceType(ByteArrayType())
     var t3: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, config_ref));
-    assume IsValidReferenceParameter(m, local_counter, config_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, config_ref));
+    assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(config_ref);
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_consensus_pubkey);
 
-    call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t2);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_consensus_pubkey_verify (config_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_consensus_pubkey(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_validator_network_signing_pubkey (config_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t2: Reference; // ReferenceType(ByteArrayType())
     var t3: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, config_ref));
-    assume IsValidReferenceParameter(m, local_counter, config_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, config_ref));
+    assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(config_ref);
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_signing_pubkey);
 
-    call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t2);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_validator_network_signing_pubkey_verify (config_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_validator_network_signing_pubkey(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_validator_network_identity_pubkey (config_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t2: Reference; // ReferenceType(ByteArrayType())
     var t3: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, config_ref));
-    assume IsValidReferenceParameter(m, local_counter, config_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, config_ref));
+    assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(config_ref);
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_identity_pubkey);
 
-    call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t2);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_validator_network_identity_pubkey_verify (config_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_validator_network_identity_pubkey(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_validator_network_address (config_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t2: Reference; // ReferenceType(ByteArrayType())
     var t3: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, config_ref));
-    assume IsValidReferenceParameter(m, local_counter, config_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, config_ref));
+    assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(config_ref);
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_address);
 
-    call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t2);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_validator_network_address_verify (config_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_validator_network_address(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_fullnodes_network_identity_pubkey (config_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t2: Reference; // ReferenceType(ByteArrayType())
     var t3: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, config_ref));
-    assume IsValidReferenceParameter(m, local_counter, config_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, config_ref));
+    assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(config_ref);
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_fullnodes_network_identity_pubkey);
 
-    call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t2);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_fullnodes_network_identity_pubkey_verify (config_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_fullnodes_network_identity_pubkey(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_fullnodes_network_address (config_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
     var t2: Reference; // ReferenceType(ByteArrayType())
     var t3: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, config_ref));
-    assume IsValidReferenceParameter(m, local_counter, config_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, config_ref));
+    assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(config_ref);
 
     call t2 := BorrowField(t1, ValidatorConfig_Config_fullnodes_network_address);
 
-    call tmp := ReadRef(t2);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t2);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure ValidatorConfig_fullnodes_network_address_verify (config_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := ValidatorConfig_fullnodes_network_address(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_register_candidate_validator (consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t6: Value; // ByteArrayType()
@@ -781,74 +759,73 @@ requires ExistsTxnSenderAccount(m, txn);
     var t11: Value; // ByteArrayType()
     var t12: Value; // ValidatorConfig_Config_type_value()
     var t13: Value; // ValidatorConfig_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 14;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(consensus_pubkey);
+    __m := UpdateLocal(__m, __frame + 0, consensus_pubkey);
     assume is#ByteArray(validator_network_signing_pubkey);
+    __m := UpdateLocal(__m, __frame + 1, validator_network_signing_pubkey);
     assume is#ByteArray(validator_network_identity_pubkey);
+    __m := UpdateLocal(__m, __frame + 2, validator_network_identity_pubkey);
     assume is#ByteArray(validator_network_address);
+    __m := UpdateLocal(__m, __frame + 3, validator_network_address);
     assume is#ByteArray(fullnodes_network_identity_pubkey);
+    __m := UpdateLocal(__m, __frame + 4, fullnodes_network_identity_pubkey);
     assume is#ByteArray(fullnodes_network_address);
-
-    old_size := local_counter;
-    local_counter := local_counter + 14;
-    m := UpdateLocal(m, old_size + 0, consensus_pubkey);
-    m := UpdateLocal(m, old_size + 1, validator_network_signing_pubkey);
-    m := UpdateLocal(m, old_size + 2, validator_network_identity_pubkey);
-    m := UpdateLocal(m, old_size + 3, validator_network_address);
-    m := UpdateLocal(m, old_size + 4, fullnodes_network_identity_pubkey);
-    m := UpdateLocal(m, old_size + 5, fullnodes_network_address);
+    __m := UpdateLocal(__m, __frame + 5, fullnodes_network_address);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Pack_ValidatorConfig_Config(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 10), GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Pack_ValidatorConfig_Config(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Pack_ValidatorConfig_T(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Pack_ValidatorConfig_T(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call MoveToSender(ValidatorConfig_T_type_value(), GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(ValidatorConfig_T_type_value(), GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure ValidatorConfig_register_candidate_validator_verify (consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ValidatorConfig_register_candidate_validator(consensus_pubkey, validator_network_signing_pubkey, validator_network_identity_pubkey, validator_network_address, fullnodes_network_identity_pubkey, fullnodes_network_address);
 }
 
 procedure {:inline 1} ValidatorConfig_rotate_consensus_pubkey (consensus_pubkey: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
@@ -862,27 +839,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t9: Reference; // ReferenceType(ByteArrayType())
     var t10: Value; // ByteArrayType()
     var t11: Reference; // ReferenceType(ByteArrayType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(consensus_pubkey);
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
-    m := UpdateLocal(m, old_size + 0, consensus_pubkey);
+    __m := UpdateLocal(__m, __frame + 0, consensus_pubkey);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), ValidatorConfig_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -898,28 +874,28 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := CopyOrMoveRef(t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     call t11 := CopyOrMoveRef(t3);
 
-    call WriteRef(t11, GetLocal(m, old_size + 10));
+    call WriteRef(t11, GetLocal(__m, __frame + 10));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure ValidatorConfig_rotate_consensus_pubkey_verify (consensus_pubkey: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ValidatorConfig_rotate_consensus_pubkey(consensus_pubkey);
 }
 
 procedure {:inline 1} ValidatorConfig_rotate_validator_network_identity_pubkey (validator_network_identity_pubkey: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
@@ -933,27 +909,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t9: Reference; // ReferenceType(ByteArrayType())
     var t10: Value; // ByteArrayType()
     var t11: Reference; // ReferenceType(ByteArrayType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(validator_network_identity_pubkey);
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
-    m := UpdateLocal(m, old_size + 0, validator_network_identity_pubkey);
+    __m := UpdateLocal(__m, __frame + 0, validator_network_identity_pubkey);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), ValidatorConfig_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -969,28 +944,28 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := CopyOrMoveRef(t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     call t11 := CopyOrMoveRef(t3);
 
-    call WriteRef(t11, GetLocal(m, old_size + 10));
+    call WriteRef(t11, GetLocal(__m, __frame + 10));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure ValidatorConfig_rotate_validator_network_identity_pubkey_verify (validator_network_identity_pubkey: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ValidatorConfig_rotate_validator_network_identity_pubkey(validator_network_identity_pubkey);
 }
 
 procedure {:inline 1} ValidatorConfig_rotate_validator_network_address (validator_network_address: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
@@ -1004,27 +979,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t9: Reference; // ReferenceType(ByteArrayType())
     var t10: Value; // ByteArrayType()
     var t11: Reference; // ReferenceType(ByteArrayType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(validator_network_address);
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
-    m := UpdateLocal(m, old_size + 0, validator_network_address);
+    __m := UpdateLocal(__m, __frame + 0, validator_network_address);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), ValidatorConfig_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -1040,23 +1014,23 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t3 := CopyOrMoveRef(t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     call t11 := CopyOrMoveRef(t3);
 
-    call WriteRef(t11, GetLocal(m, old_size + 10));
+    call WriteRef(t11, GetLocal(__m, __frame + 10));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure ValidatorConfig_rotate_validator_network_address_verify (validator_network_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ValidatorConfig_rotate_validator_network_address(validator_network_address);
 }
 
@@ -1074,7 +1048,6 @@ procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -1094,7 +1067,6 @@ procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_str
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -1114,7 +1086,6 @@ procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_str
 {
     assume IsValidU128(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
-
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -1129,61 +1100,60 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 // ** functions of module LibraCoin
 
 procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // AddressType()
     var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraCoin_MintCapability_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(m, old_size + 1), t3);
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
 procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -1205,57 +1175,56 @@ requires ExistsTxnSenderAccount(m, txn);
     var t18: Reference; // ReferenceType(IntegerType())
     var t19: Value; // IntegerType()
     var t20: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 21;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(value);
-    assume is#Vector(Dereference(m, capability));
-    assume IsValidReferenceParameter(m, local_counter, capability);
-
-    old_size := local_counter;
-    local_counter := local_counter + 21;
-    m := UpdateLocal(m, old_size + 0, value);
+    __m := UpdateLocal(__m, __frame + 0, value);
+    assume is#Vector(Dereference(__m, capability));
+    assume IsValidReferenceParameter(__m, __frame, capability);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(1000000000);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1000000000);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(1000000);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(1000000);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Le(GetLocal(m, old_size + 3), GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Le(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    tmp := GetLocal(m, old_size + 8);
-    if (!b#Boolean(tmp)) { goto Label_9; }
+    __tmp := GetLocal(__m, __frame + 8);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     goto Label_Abort;
 
 Label_9:
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := BorrowGlobal(GetLocal(m, old_size + 10), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t12 := BorrowField(t11, LibraCoin_MarketCap_total_value);
 
@@ -1263,49 +1232,48 @@ Label_9:
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU128(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU128(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CastU128(GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := CastU128(GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
-
-    call tmp := AddU128(GetLocal(m, old_size + 14), GetLocal(m, old_size + 16));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := AddU128(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 16));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     call t18 := CopyOrMoveRef(t2);
 
-    call WriteRef(t18, GetLocal(m, old_size + 17));
+    call WriteRef(t18, GetLocal(__m, __frame + 17));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 19));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    ret0 := GetLocal(m, old_size + 20);
+    ret0 := GetLocal(__m, __frame + 20);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -1317,212 +1285,206 @@ requires ExistsTxnSenderAccount(m, txn);
     var t6: Value; // LibraCoin_MintCapability_type_value()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 0), GetLocal(m, old_size + 1)));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 0), GetLocal(__m, __frame + 1)));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    tmp := GetLocal(m, old_size + 3);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 3);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     goto Label_Abort;
 
 Label_7:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Pack_LibraCoin_MintCapability(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Pack_LibraCoin_MarketCap(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_initialize();
 }
 
 procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
     var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdAddr(173345816);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(m, old_size + 0), LibraCoin_MarketCap_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU128(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU128(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_market_cap_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_market_cap();
 }
 
 procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // IntegerType()
     var t1: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_zero_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_zero();
 }
 
 procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(coin_ref);
 
     call t2 := BorrowField(t1, LibraCoin_T_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_value(coin_ref);
 }
 
 procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -1531,63 +1493,62 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, coin);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
-    ret1 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 6);
+    ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := LibraCoin_split(coin, amount);
 }
 
 procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -1606,147 +1567,144 @@ requires ExistsTxnSenderAccount(m, txn);
     var t15: Reference; // ReferenceType(IntegerType())
     var t16: Value; // IntegerType()
     var t17: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(coin_ref);
 
     call t4 := BorrowField(t3, LibraCoin_T_value);
 
-    call tmp := ReadRef(t4);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t4);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     call t14 := CopyOrMoveRef(coin_ref);
 
     call t15 := BorrowField(t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(m, old_size + 13));
+    call WriteRef(t15, GetLocal(__m, __frame + 13));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := Pack_LibraCoin_T(GetLocal(m, old_size + 16));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(m, old_size + 17);
+    ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
 procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin1);
+    __m := UpdateLocal(__m, __frame + 0, coin1);
     assume is#Vector(coin2);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, coin1);
-    m := UpdateLocal(m, old_size + 1, coin2);
+    __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(old_size+0);
+    call t2 := BorrowLoc(__frame + 0);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -1761,76 +1719,74 @@ requires ExistsTxnSenderAccount(m, txn);
     var t11: Value; // IntegerType()
     var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t13: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 14;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, coin_ref));
-    assume IsValidReferenceParameter(m, local_counter, coin_ref);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, coin_ref));
+    assume IsValidReferenceParameter(__m, __frame, coin_ref);
     assume is#Vector(check);
-
-    old_size := local_counter;
-    local_counter := local_counter + 14;
-    m := UpdateLocal(m, old_size + 1, check);
+    __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(coin_ref);
 
     call t5 := BorrowField(t4, LibraCoin_T_value);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, t8);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 10, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(coin_ref);
 
     call t13 := BorrowField(t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(m, old_size + 11));
+    call WriteRef(t13, GetLocal(__m, __frame + 11));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_deposit(coin_ref, check);
 }
 
 procedure {:inline 1} LibraCoin_destroy_zero (coin: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -1841,48 +1797,47 @@ requires ExistsTxnSenderAccount(m, txn);
     var t6: Value; // BooleanType()
     var t7: Value; // BooleanType()
     var t8: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(coin);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, coin);
+    __m := UpdateLocal(__m, __frame + 0, coin);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, t3);
+    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5)));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5)));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
@@ -1890,13 +1845,13 @@ Label_10:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_destroy_zero(coin);
 }
 
@@ -1933,7 +1888,6 @@ procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Va
     assume IsValidU64(sequence_number);
     assume is#Vector(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value)
@@ -1967,7 +1921,6 @@ procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(account_address: Va
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(_struct: Value) returns (account_address: Value)
@@ -1987,7 +1940,6 @@ procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(account_address: V
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(_struct: Value) returns (account_address: Value)
@@ -2013,7 +1965,6 @@ procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: V
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) returns (amount: Value, payee: Value, metadata: Value)
@@ -2043,7 +1994,6 @@ procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, paye
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) returns (amount: Value, payer: Value, metadata: Value)
@@ -2067,7 +2017,6 @@ procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) ret
 {
     assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) returns (counter: Value)
@@ -2090,7 +2039,6 @@ procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Val
     assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
-
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (counter: Value, guid: Value)
@@ -2107,112 +2055,110 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 // ** functions of module LibraAccount
 
 procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
     var t3: Value; // LibraCoin_T_type_value()
     var t4: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Vector(to_deposit);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, to_deposit);
+    __m := UpdateLocal(__m, __frame + 1, to_deposit);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(4, ByteArrayPoolIndex(0))
 
-    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_metadata(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit(payee, to_deposit);
 }
 
 procedure {:inline 1} LibraAccount_deposit_with_metadata (payee: Value, to_deposit: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t3: Value; // AddressType()
     var t4: Value; // AddressType()
     var t5: Value; // LibraCoin_T_type_value()
     var t6: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Vector(to_deposit);
+    __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, to_deposit);
-    m := UpdateLocal(m, old_size + 2, metadata);
+    __m := UpdateLocal(__m, __frame + 2, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4), GetLocal(m, old_size + 5), GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit_with_metadata(payee, to_deposit, metadata);
 }
 
 procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // IntegerType()
@@ -2244,65 +2190,64 @@ requires ExistsTxnSenderAccount(m, txn);
     var t30: Value; // AddressType()
     var t31: Value; // ByteArrayType()
     var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 33;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume is#Address(sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
     assume is#Vector(to_deposit);
+    __m := UpdateLocal(__m, __frame + 2, to_deposit);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 33;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, sender);
-    m := UpdateLocal(m, old_size + 2, to_deposit);
-    m := UpdateLocal(m, old_size + 3, metadata);
+    __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call t7 := BorrowLoc(old_size+2);
+    call t7 := BorrowLoc(__frame + 2);
 
     call t8 := LibraCoin_value(t7);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    tmp := GetLocal(m, old_size + 12);
-    if (!b#Boolean(tmp)) { goto Label_10; }
+    __tmp := GetLocal(__m, __frame + 12);
+    if (!b#Boolean(__tmp)) { goto Label_10; }
 
-    call tmp := LdConst(7);
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     goto Label_Abort;
 
 Label_10:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := BorrowGlobal(GetLocal(m, old_size + 14), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t6 := CopyOrMoveRef(t15);
 
@@ -2310,26 +2255,26 @@ Label_10:
 
     call t17 := BorrowField(t16, LibraAccount_T_sent_events);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(m, old_size + 21));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(__m, __frame + 21));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call t23 := BorrowGlobal(GetLocal(m, old_size + 22), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t23);
 
@@ -2337,46 +2282,46 @@ Label_10:
 
     call t25 := BorrowField(t24, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call LibraCoin_deposit(t25, GetLocal(m, old_size + 26));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t25, GetLocal(__m, __frame + 26));
+    if (__abort_flag) { goto Label_Abort; }
 
     call t27 := CopyOrMoveRef(t5);
 
     call t28 := BorrowField(t27, LibraAccount_T_received_events);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 29, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 29, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 30, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 30, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 31, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 31, __tmp);
 
-    call tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(m, old_size + 29), GetLocal(m, old_size + 30), GetLocal(m, old_size + 31));
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(m, old_size + 32));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(__m, __frame + 32));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_deposit_with_sender_and_metadata(payee, sender, to_deposit, metadata);
 }
 
 procedure {:inline 1} LibraAccount_mint_to_address (payee: Value, amount: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -2386,73 +2331,72 @@ requires ExistsTxnSenderAccount(m, txn);
     var t6: Value; // AddressType()
     var t7: Value; // IntegerType()
     var t8: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 9;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    tmp := GetLocal(m, old_size + 4);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := LibraCoin_mint_with_default_capability(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call LibraAccount_deposit(GetLocal(m, old_size + 6), GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_mint_to_address(payee, amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // LibraCoin_T_type_value()
@@ -2461,60 +2405,59 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Value; // IntegerType()
     var t6: Value; // LibraCoin_T_type_value()
     var t7: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(account);
 
     call t4 := BorrowField(t3, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := LibraCoin_withdraw(t4, GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := LibraCoin_withdraw(t4, GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -2527,27 +2470,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Value; // IntegerType()
     var t10: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
-    m := UpdateLocal(m, old_size + 0, amount);
+    __m := UpdateLocal(__m, __frame + 0, amount);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -2555,48 +2497,47 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
 
-    call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_9; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t10);
 
-    m := UpdateLocal(m, old_size + 10, t10);
+    __m := UpdateLocal(__m, __frame + 10, t10);
 
-    ret0 := GetLocal(m, old_size + 10);
+    ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
 procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -2607,66 +2548,64 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t8: Value; // IntegerType()
     var t9: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
     call t3 := CopyOrMoveRef(cap);
 
     call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
 
-    call tmp := ReadRef(t4);
-    assume is#Address(tmp);
+    call __tmp := ReadRef(t4);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    m := UpdateLocal(m, old_size + 5, tmp);
-
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
     call t7 := CopyOrMoveRef(t2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    ret0 := GetLocal(m, old_size + 9);
+    ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
 procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -2684,31 +2623,30 @@ requires ExistsTxnSenderAccount(m, txn);
     var t12: Reference; // ReferenceType(BooleanType())
     var t13: Value; // AddressType()
     var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 15;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 15;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t5);
 
@@ -2720,50 +2658,49 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t8 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t8);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t8);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    m := UpdateLocal(m, old_size + 9, tmp);
+    __tmp := GetLocal(__m, __frame + 9);
+    if (!b#Boolean(__tmp)) { goto Label_13; }
 
-    tmp := GetLocal(m, old_size + 9);
-    if (!b#Boolean(tmp)) { goto Label_13; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     goto Label_Abort;
 
 Label_13:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(t2);
 
-    call WriteRef(t12, GetLocal(m, old_size + 11));
+    call WriteRef(t12, GetLocal(__m, __frame + 11));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 13));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    ret0 := GetLocal(m, old_size + 14);
+    ret0 := GetLocal(__m, __frame + 14);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (cap: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -2775,63 +2712,62 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // BooleanType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Reference; // ReferenceType(BooleanType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, cap);
+    __m := UpdateLocal(__m, __frame + 0, cap);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
+    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t8 := CopyOrMoveRef(t2);
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
 
-    call WriteRef(t9, GetLocal(m, old_size + 7));
+    call WriteRef(t9, GetLocal(__m, __frame + 7));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_restore_withdrawal_capability(cap);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_capability (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -2846,91 +2782,89 @@ requires ExistsTxnSenderAccount(m, txn);
     var t13: Value; // IntegerType()
     var t14: Value; // LibraCoin_T_type_value()
     var t15: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 16;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    __m := UpdateLocal(__m, __frame + 0, payee);
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume IsValidU64(amount);
+    __m := UpdateLocal(__m, __frame + 2, amount);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 16;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 2, amount);
-    m := UpdateLocal(m, old_size + 3, metadata);
+    __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call t9 := CopyOrMoveRef(cap);
 
     call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
 
-    call tmp := ReadRef(t10);
-    assume is#Address(tmp);
-
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := ReadRef(t10);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call t12 := CopyOrMoveRef(cap);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
+    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t14);
 
-    m := UpdateLocal(m, old_size + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, t14);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(m, old_size + 8), GetLocal(m, old_size + 11), GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_sender_and_metadata(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_capability_verify (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_capability(payee, cap, amount, metadata);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (payee: Value, amount: Value, metadata: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t3: Value; // AddressType()
@@ -2941,174 +2875,171 @@ requires ExistsTxnSenderAccount(m, txn);
     var t8: Value; // IntegerType()
     var t9: Value; // LibraCoin_T_type_value()
     var t10: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
     assume is#ByteArray(metadata);
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
-    m := UpdateLocal(m, old_size + 2, metadata);
+    __m := UpdateLocal(__m, __frame + 2, metadata);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_6; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_6:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_sender(GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call LibraAccount_deposit_with_metadata(GetLocal(m, old_size + 7), GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_deposit_with_metadata(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (payee: Value, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_sender_with_metadata(payee, amount, metadata);
 }
 
 procedure {:inline 1} LibraAccount_pay_from_sender (payee: Value, amount: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
     var t3: Value; // IntegerType()
     var t4: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(payee);
+    __m := UpdateLocal(__m, __frame + 0, payee);
     assume IsValidU64(amount);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, payee);
-    m := UpdateLocal(m, old_size + 1, amount);
+    __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    // unimplemented instruction
+    // unimplemented instruction: LdByteArray(4, ByteArrayPoolIndex(0))
 
-    call LibraAccount_pay_from_sender_with_metadata(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_pay_from_sender_with_metadata(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_pay_from_sender_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_pay_from_sender(payee, amount);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (account: Reference, new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // ByteArrayType()
     var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t4: Reference; // ReferenceType(ByteArrayType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 1, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     call t3 := CopyOrMoveRef(account);
 
     call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
 
-    call WriteRef(t4, GetLocal(m, old_size + 2));
+    call WriteRef(t4, GetLocal(__m, __frame + 2));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (account: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key_for_account(account, new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key (new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -3120,27 +3051,26 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // IntegerType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t1 := CopyOrMoveRef(t3);
 
@@ -3148,43 +3078,42 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call tmp := ReadRef(t5);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_9; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     goto Label_Abort;
 
 Label_9:
     call t8 := CopyOrMoveRef(t1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(m, old_size + 9));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(__m, __frame + 9));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_verify (new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key(new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (cap: Reference, new_authentication_key: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
@@ -3192,57 +3121,55 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Value; // AddressType()
     var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t6: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
     assume is#ByteArray(new_authentication_key);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 1, new_authentication_key);
+    __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(cap);
 
     call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
 
-    call tmp := ReadRef(t3);
-    assume is#Address(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Address(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := BorrowGlobal(GetLocal(m, old_size + 4), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
 procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -3258,31 +3185,30 @@ requires ExistsTxnSenderAccount(m, txn);
     var t10: Reference; // ReferenceType(BooleanType())
     var t11: Value; // AddressType()
     var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 13;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 13;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := BorrowGlobal(GetLocal(m, old_size + 3), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
 
@@ -3290,50 +3216,49 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t6 := CopyOrMoveRef(t1);
 
-    call tmp := ReadRef(t6);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t6);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    m := UpdateLocal(m, old_size + 7, tmp);
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_11; }
 
-    tmp := GetLocal(m, old_size + 7);
-    if (!b#Boolean(tmp)) { goto Label_11; }
-
-    call tmp := LdConst(11);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(11);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     goto Label_Abort;
 
 Label_11:
-    call tmp := LdTrue();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdTrue();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call t10 := CopyOrMoveRef(t1);
 
-    call WriteRef(t10, GetLocal(m, old_size + 9));
+    call WriteRef(t10, GetLocal(__m, __frame + 9));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(m, old_size + 12);
+    ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (cap: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
@@ -3345,63 +3270,62 @@ requires ExistsTxnSenderAccount(m, txn);
     var t7: Value; // BooleanType()
     var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t9: Reference; // ReferenceType(BooleanType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 10;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 10;
-    m := UpdateLocal(m, old_size + 0, cap);
+    __m := UpdateLocal(__m, __frame + 0, cap);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
+    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(m, old_size + 5), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t6);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t8 := CopyOrMoveRef(t2);
 
     call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
 
-    call WriteRef(t9, GetLocal(m, old_size + 7));
+    call WriteRef(t9, GetLocal(__m, __frame + 7));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_restore_key_rotation_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_restore_key_rotation_capability(cap);
 }
 
 procedure {:inline 1} LibraAccount_create_account (fresh_address: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
@@ -3422,104 +3346,103 @@ requires ExistsTxnSenderAccount(m, txn);
     var t16: Value; // IntegerType()
     var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
     var t18: Value; // LibraAccount_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 19;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
-
-    old_size := local_counter;
-    local_counter := local_counter + 19;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 5));
-    if (abort_flag) { goto Label_Abort; }
+    call t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t6);
 
-    m := UpdateLocal(m, old_size + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, t6);
 
     call t7 := LibraCoin_zero();
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowLoc(old_size+1);
+    call t10 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call t13 := BorrowLoc(old_size+1);
+    call t13 := BorrowLoc(__frame + 1);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
+    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t15);
 
-    m := UpdateLocal(m, old_size + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, t15);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call tmp := Pack_LibraAccount_T(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7), GetLocal(m, old_size + 8), GetLocal(m, old_size + 9), GetLocal(m, old_size + 12), GetLocal(m, old_size + 15), GetLocal(m, old_size + 16), GetLocal(m, old_size + 17));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call LibraAccount_save_account(GetLocal(m, old_size + 4), GetLocal(m, old_size + 18));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_save_account(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_create_account_verify (fresh_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_create_account(fresh_address);
 }
 
 procedure {:inline 1} LibraAccount_create_new_account (fresh_address: Value, initial_balance: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // AddressType()
@@ -3528,70 +3451,69 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Value; // BooleanType()
     var t6: Value; // AddressType()
     var t7: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(fresh_address);
+    __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume IsValidU64(initial_balance);
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
-    m := UpdateLocal(m, old_size + 0, fresh_address);
-    m := UpdateLocal(m, old_size + 1, initial_balance);
+    __m := UpdateLocal(__m, __frame + 1, initial_balance);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call LibraAccount_create_account(GetLocal(m, old_size + 2));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_create_account(GetLocal(__m, __frame + 2));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Gt(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Gt(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    tmp := GetLocal(m, old_size + 5);
-    if (!b#Boolean(tmp)) { goto Label_9; }
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_9; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call LibraAccount_pay_from_sender(GetLocal(m, old_size + 6), GetLocal(m, old_size + 7));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_pay_from_sender(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7));
+    if (__abort_flag) { goto Label_Abort; }
 
 Label_9:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_balance: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
 procedure {:inline 1} LibraAccount_save_account (addr: Value, account: Value) returns ();
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -3599,20 +3521,19 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
     call t2 := CopyOrMoveRef(account);
@@ -3620,303 +3541,294 @@ requires ExistsTxnSenderAccount(m, txn);
     call t3 := BorrowField(t2, LibraAccount_T_balance);
 
     call t4 := LibraCoin_value(t3);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(m, old_size + 5);
+    ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_for_account_verify (account: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_balance_for_account(account);
 }
 
 procedure {:inline 1} LibraAccount_balance (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_balance_for_account(t2);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_balance_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_balance(addr);
 }
 
 procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, account));
-    assume IsValidReferenceParameter(m, local_counter, account);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, account));
+    assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(account);
 
     call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
 procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := LibraAccount_sequence_number_for_account(t2);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_sequence_number_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_sequence_number(addr);
 }
 
 procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Reference; // ReferenceType(BooleanType())
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
 
-    call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
-
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
 procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t3: Reference; // ReferenceType(BooleanType())
     var t4: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, addr);
+    __m := UpdateLocal(__m, __frame + 0, addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
 
-    call tmp := ReadRef(t3);
-    assume is#Boolean(tmp);
+    call __tmp := ReadRef(t3);
+    assume is#Boolean(__tmp);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    m := UpdateLocal(m, old_size + 4, tmp);
-
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
 procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (ret0: Reference)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
     var t2: Reference; // ReferenceType(AddressType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(cap);
@@ -3927,37 +3839,36 @@ requires ExistsTxnSenderAccount(m, txn);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultReference;
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
 procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (ret0: Reference)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
     var t2: Reference; // ReferenceType(AddressType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, cap));
-    assume IsValidReferenceParameter(m, local_counter, cap);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, cap));
+    assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(cap);
@@ -3968,62 +3879,61 @@ requires ExistsTxnSenderAccount(m, txn);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultReference;
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
 procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // AddressType()
     var t2: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(check_addr);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, check_addr);
+    __m := UpdateLocal(__m, __frame + 0, check_addr);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 1), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_exists_verify (check_addr: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_exists(check_addr);
 }
 
 procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Value; // AddressType()
@@ -4072,105 +3982,103 @@ requires ExistsTxnSenderAccount(m, txn);
     var t47: Value; // BooleanType()
     var t48: Value; // BooleanType()
     var t49: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 50;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(txn_sequence_number);
+    __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
     assume is#ByteArray(txn_public_key);
+    __m := UpdateLocal(__m, __frame + 1, txn_public_key);
     assume IsValidU64(txn_gas_price);
+    __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
-
-    old_size := local_counter;
-    local_counter := local_counter + 50;
-    m := UpdateLocal(m, old_size + 0, txn_sequence_number);
-    m := UpdateLocal(m, old_size + 1, txn_public_key);
-    m := UpdateLocal(m, old_size + 2, txn_gas_price);
-    m := UpdateLocal(m, old_size + 3, txn_max_gas_units);
+    __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 11), LibraAccount_T_type_value());
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 11), LibraAccount_T_type_value());
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    tmp := GetLocal(m, old_size + 13);
-    if (!b#Boolean(tmp)) { goto Label_8; }
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_8; }
 
-    call tmp := LdConst(5);
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(5);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     goto Label_Abort;
 
 Label_8:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call t16 := BorrowGlobal(GetLocal(m, old_size + 15), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t16);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call t18 := Hash_sha3_256(GetLocal(m, old_size + 17));
-    if (abort_flag) { goto Label_Abort; }
+    call t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t18);
 
-    m := UpdateLocal(m, old_size + 18, t18);
+    __m := UpdateLocal(__m, __frame + 18, t18);
 
     call t19 := CopyOrMoveRef(t5);
 
     call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
 
-    call tmp := ReadRef(t20);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t20);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    m := UpdateLocal(m, old_size + 21, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 21)));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 21)));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 22));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 22));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    __tmp := GetLocal(__m, __frame + 23);
+    if (!b#Boolean(__tmp)) { goto Label_21; }
 
-    tmp := GetLocal(m, old_size + 23);
-    if (!b#Boolean(tmp)) { goto Label_21; }
-
-    call tmp := LdConst(2);
-    m := UpdateLocal(m, old_size + 24, tmp);
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 24, __tmp);
 
     goto Label_Abort;
 
 Label_21:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 25), GetLocal(m, old_size + 26));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 27, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 25), GetLocal(__m, __frame + 26));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 27));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t28 := CopyOrMoveRef(t5);
 
@@ -4181,31 +4089,31 @@ Label_21:
     call t30 := CopyOrMoveRef(t6);
 
     call t31 := LibraAccount_balance_for_account(t30);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t31);
 
-    m := UpdateLocal(m, old_size + 31, t31);
+    __m := UpdateLocal(__m, __frame + 31, t31);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 31));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 33, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 33, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 32), GetLocal(m, old_size + 33));
-    m := UpdateLocal(m, old_size + 34, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 32), GetLocal(__m, __frame + 33));
+    __m := UpdateLocal(__m, __frame + 34, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 34));
-    m := UpdateLocal(m, old_size + 35, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 34));
+    __m := UpdateLocal(__m, __frame + 35, __tmp);
 
-    tmp := GetLocal(m, old_size + 35);
-    if (!b#Boolean(tmp)) { goto Label_38; }
+    __tmp := GetLocal(__m, __frame + 35);
+    if (!b#Boolean(__tmp)) { goto Label_38; }
 
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 36, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
     goto Label_Abort;
 
@@ -4214,52 +4122,51 @@ Label_38:
 
     call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
 
-    call tmp := ReadRef(t38);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t38);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 39, __tmp);
 
-    m := UpdateLocal(m, old_size + 39, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 39));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 39));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 40, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 40, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 41, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 41, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 40), GetLocal(__m, __frame + 41));
+    __m := UpdateLocal(__m, __frame + 42, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 40), GetLocal(m, old_size + 41));
-    m := UpdateLocal(m, old_size + 42, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 42));
+    __m := UpdateLocal(__m, __frame + 43, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 42));
-    m := UpdateLocal(m, old_size + 43, tmp);
+    __tmp := GetLocal(__m, __frame + 43);
+    if (!b#Boolean(__tmp)) { goto Label_49; }
 
-    tmp := GetLocal(m, old_size + 43);
-    if (!b#Boolean(tmp)) { goto Label_49; }
-
-    call tmp := LdConst(3);
-    m := UpdateLocal(m, old_size + 44, tmp);
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 44, __tmp);
 
     goto Label_Abort;
 
 Label_49:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 45, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 45, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 46, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 46, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 45), GetLocal(m, old_size + 46)));
-    m := UpdateLocal(m, old_size + 47, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 45), GetLocal(__m, __frame + 46)));
+    __m := UpdateLocal(__m, __frame + 47, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 47));
-    m := UpdateLocal(m, old_size + 48, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 47));
+    __m := UpdateLocal(__m, __frame + 48, __tmp);
 
-    tmp := GetLocal(m, old_size + 48);
-    if (!b#Boolean(tmp)) { goto Label_56; }
+    __tmp := GetLocal(__m, __frame + 48);
+    if (!b#Boolean(__tmp)) { goto Label_56; }
 
-    call tmp := LdConst(4);
-    m := UpdateLocal(m, old_size + 49, tmp);
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 49, __tmp);
 
     goto Label_Abort;
 
@@ -4267,18 +4174,18 @@ Label_56:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units);
 }
 
 procedure {:inline 1} LibraAccount_epilogue (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -4314,55 +4221,54 @@ requires ExistsTxnSenderAccount(m, txn);
     var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
     var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
     var t36: Value; // LibraCoin_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 37;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(txn_sequence_number);
+    __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
     assume IsValidU64(txn_gas_price);
+    __m := UpdateLocal(__m, __frame + 1, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
+    __m := UpdateLocal(__m, __frame + 2, txn_max_gas_units);
     assume IsValidU64(gas_units_remaining);
-
-    old_size := local_counter;
-    local_counter := local_counter + 37;
-    m := UpdateLocal(m, old_size + 0, txn_sequence_number);
-    m := UpdateLocal(m, old_size + 1, txn_gas_price);
-    m := UpdateLocal(m, old_size + 2, txn_max_gas_units);
-    m := UpdateLocal(m, old_size + 3, gas_units_remaining);
+    __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowGlobal(GetLocal(m, old_size + 9), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t4 := CopyOrMoveRef(t10);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call tmp := Sub(GetLocal(m, old_size + 12), GetLocal(m, old_size + 13));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := Sub(GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 13));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 11), GetLocal(m, old_size + 14));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 14));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 15));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t16 := CopyOrMoveRef(t4);
 
@@ -4373,64 +4279,64 @@ requires ExistsTxnSenderAccount(m, txn);
     call t18 := CopyOrMoveRef(t6);
 
     call t19 := LibraAccount_balance_for_account(t18);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t19);
 
-    m := UpdateLocal(m, old_size + 19, t19);
+    __m := UpdateLocal(__m, __frame + 19, t19);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Ge(GetLocal(m, old_size + 19), GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Ge(GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 21));
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 21));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    tmp := GetLocal(m, old_size + 22);
-    if (!b#Boolean(tmp)) { goto Label_20; }
+    __tmp := GetLocal(__m, __frame + 22);
+    if (!b#Boolean(__tmp)) { goto Label_20; }
 
-    call tmp := LdConst(6);
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := LdConst(6);
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     goto Label_Abort;
 
 Label_20:
     call t24 := CopyOrMoveRef(t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 25, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(m, old_size + 25));
-    if (abort_flag) { goto Label_Abort; }
+    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(__m, __frame + 25));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t26);
 
-    m := UpdateLocal(m, old_size + 26, t26);
+    __m := UpdateLocal(__m, __frame + 26, t26);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 26));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 27, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 28, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 28, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 27), GetLocal(m, old_size + 28));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 29, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 27), GetLocal(__m, __frame + 28));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 29, __tmp);
 
     call t30 := CopyOrMoveRef(t4);
 
     call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
 
-    call WriteRef(t31, GetLocal(m, old_size + 29));
+    call WriteRef(t31, GetLocal(__m, __frame + 29));
 
-    call tmp := LdAddr(4078);
-    m := UpdateLocal(m, old_size + 32, tmp);
+    call __tmp := LdAddr(4078);
+    __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call t33 := BorrowGlobal(GetLocal(m, old_size + 32), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t33);
 
@@ -4438,27 +4344,27 @@ Label_20:
 
     call t35 := BorrowField(t34, LibraAccount_T_balance);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 36, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call LibraCoin_deposit(t35, GetLocal(m, old_size + 36));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraCoin_deposit(t35, GetLocal(__m, __frame + 36));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
 procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -4481,22 +4387,21 @@ requires ExistsTxnSenderAccount(m, txn);
     var t19: Value; // ByteArrayType()
     var t20: Value; // ByteArrayType()
     var t21: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 22;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, counter));
-    assume IsValidReferenceParameter(m, local_counter, counter);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, counter));
+    assume IsValidReferenceParameter(__m, __frame, counter);
     assume is#Address(sender);
-
-    old_size := local_counter;
-    local_counter := local_counter + 22;
-    m := UpdateLocal(m, old_size + 1, sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
     call t6 := CopyOrMoveRef(counter);
@@ -4505,87 +4410,85 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t2 := CopyOrMoveRef(t7);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := AddressUtil_address_to_bytes(GetLocal(m, old_size + 8));
-    if (abort_flag) { goto Label_Abort; }
+    call t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t9);
 
-    m := UpdateLocal(m, old_size + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     call t10 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t10);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    m := UpdateLocal(m, old_size + 11, tmp);
-
-    call t12 := U64Util_u64_to_bytes(GetLocal(m, old_size + 11));
-    if (abort_flag) { goto Label_Abort; }
+    call t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t12);
 
-    m := UpdateLocal(m, old_size + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, t12);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 15, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
     call t17 := CopyOrMoveRef(t2);
 
-    call WriteRef(t17, GetLocal(m, old_size + 16));
+    call WriteRef(t17, GetLocal(__m, __frame + 16));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 19, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := BytearrayUtil_bytearray_concat(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19));
-    if (abort_flag) { goto Label_Abort; }
+    call t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t20);
 
-    m := UpdateLocal(m, old_size + 20, t20);
+    __m := UpdateLocal(__m, __frame + 20, t20);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    ret0 := GetLocal(m, old_size + 21);
+    ret0 := GetLocal(__m, __frame + 21);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
 procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -4593,58 +4496,57 @@ requires ExistsTxnSenderAccount(m, txn);
     var t4: Value; // AddressType()
     var t5: Value; // ByteArrayType()
     var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, counter));
-    assume IsValidReferenceParameter(m, local_counter, counter);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, counter));
+    assume IsValidReferenceParameter(__m, __frame, counter);
     assume is#Address(sender);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 1, sender);
+    __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     call t3 := CopyOrMoveRef(counter);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraAccount_fresh_guid(t3, GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call t5 := LibraAccount_fresh_guid(t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#ByteArray(t5);
 
-    m := UpdateLocal(m, old_size + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(m, old_size + 2), GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
 procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
@@ -4655,25 +4557,24 @@ requires ExistsTxnSenderAccount(m, txn);
     var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
     var t6: Value; // AddressType()
     var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 8;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 8;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(m, old_size + 2), LibraAccount_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t0 := CopyOrMoveRef(t3);
 
@@ -4681,32 +4582,32 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t5 := BorrowField(t4, LibraAccount_T_event_generator);
 
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t7);
 
-    m := UpdateLocal(m, old_size + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, t7);
 
-    ret0 := GetLocal(m, old_size + 7);
+    ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := LibraAccount_new_event_handle(tv0);
 }
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Reference; // ReferenceType(IntegerType())
@@ -4725,34 +4626,32 @@ requires ExistsTxnSenderAccount(m, txn);
     var t15: Value; // IntegerType()
     var t16: Value; // IntegerType()
     var t17: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 18;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, handle_ref));
-    assume IsValidReferenceParameter(m, local_counter, handle_ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 18;
-    m := UpdateLocal(m, old_size + 1, msg);
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, handle_ref));
+    assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    __m := UpdateLocal(__m, __frame + 1, msg);
 
     // bytecode translation starts here
     call t4 := CopyOrMoveRef(handle_ref);
 
     call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
 
-    call tmp := ReadRef(t5);
-    assume is#ByteArray(tmp);
+    call __tmp := ReadRef(t5);
+    assume is#ByteArray(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
-
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call t7 := CopyOrMoveRef(handle_ref);
 
@@ -4760,58 +4659,56 @@ requires ExistsTxnSenderAccount(m, txn);
 
     call t2 := CopyOrMoveRef(t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call t10 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t10);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 12, tmp);
-
-    call LibraAccount_write_to_event_store(tv0, GetLocal(m, old_size + 9), GetLocal(m, old_size + 11), GetLocal(m, old_size + 12));
-    if (abort_flag) { goto Label_Abort; }
+    call LibraAccount_write_to_event_store(tv0, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
+    if (__abort_flag) { goto Label_Abort; }
 
     call t13 := CopyOrMoveRef(t2);
 
-    call tmp := ReadRef(t13);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t13);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 15, tmp);
-
-    call tmp := AddU64(GetLocal(m, old_size + 14), GetLocal(m, old_size + 15));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
     call t17 := CopyOrMoveRef(t2);
 
-    call WriteRef(t17, GetLocal(m, old_size + 16));
+    call WriteRef(t17, GetLocal(__m, __frame + 16));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_emit_event(tv0, handle_ref, msg);
 }
 
 procedure {:inline 1} LibraAccount_write_to_event_store (tv0: TypeValue, guid: Value, count: Value, msg: Value) returns ();
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, handle: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // ByteArrayType()
@@ -4819,45 +4716,44 @@ requires ExistsTxnSenderAccount(m, txn);
     var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
     var t4: Value; // IntegerType()
     var t5: Value; // ByteArrayType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(handle);
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
-    m := UpdateLocal(m, old_size + 0, handle);
+    __m := UpdateLocal(__m, __frame + 0, handle);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, t4);
-    m := UpdateLocal(m, old_size + 5, t5);
+    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 5, t5);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_destroy_handle(tv0, handle);
 }
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -12,7 +12,6 @@ procedure {:inline 1} Pack_TestReference_T(value: Value) returns (_struct: Value
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
-
 }
 
 procedure {:inline 1} Unpack_TestReference_T(_struct: Value) returns (value: Value)
@@ -27,51 +26,51 @@ procedure {:inline 1} Unpack_TestReference_T(_struct: Value) returns (value: Val
 // ** functions of module TestReference
 
 procedure {:inline 1} TestReference_mut_b (b: Reference) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume IsValidU64(Dereference(m, b));
-    assume IsValidReferenceParameter(m, local_counter, b);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume IsValidU64(Dereference(__m, b));
+    assume IsValidReferenceParameter(__m, __frame, b);
 
     // bytecode translation starts here
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     call t2 := CopyOrMoveRef(b);
 
-    call WriteRef(t2, GetLocal(m, old_size + 1));
+    call WriteRef(t2, GetLocal(__m, __frame + 1));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestReference_mut_b_verify (b: Reference) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestReference_mut_b(b);
 }
 
 procedure {:inline 1} TestReference_mut_ref () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // IntegerType()
@@ -86,62 +85,60 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     var t9: Value; // BooleanType()
     var t10: Value; // BooleanType()
     var t11: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(20);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(20);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
     call t1 := CopyOrMoveRef(t3);
 
     call t4 := CopyOrMoveRef(t1);
 
     call TestReference_mut_b(t4);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t1);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8)));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8)));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    __tmp := GetLocal(__m, __frame + 10);
+    if (!b#Boolean(__tmp)) { goto Label_16; }
 
-    tmp := GetLocal(m, old_size + 10);
-    if (!b#Boolean(tmp)) { goto Label_16; }
-
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     goto Label_Abort;
 
@@ -149,12 +146,12 @@ Label_16:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestReference_mut_ref_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestReference_mut_ref();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -1,12 +1,9 @@
 
-// ** helpers from test_mvir/test-specs-translate.prover.bpl// Boogie helper functions for test-specs-translate.mvir
+// ** helpers from test_mvir/test-specs-translate.prover.bpl
+// Boogie helper functions for test-specs-translate.mvir
 
 function {:inline} number_in_range(x: Value): Value {
   Boolean(i#Integer(x) >= 0 && i#Integer(x) < 128)
-}
-
-function {:inline} max_u64(): Value {
-  Integer(MAX_U64)
 }
 
 
@@ -22,7 +19,6 @@ procedure {:inline 1} Pack_TestSpecs_S(a: Value) returns (_struct: Value)
 {
     assume is#Address(a);
     _struct := Vector(ExtendValueArray(EmptyValueArray, a));
-
 }
 
 procedure {:inline 1} Unpack_TestSpecs_S(_struct: Value) returns (a: Value)
@@ -45,7 +41,6 @@ procedure {:inline 1} Pack_TestSpecs_R(x: Value, s: Value) returns (_struct: Val
     assume IsValidU64(x);
     assume is#Vector(s);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, x), s));
-
 }
 
 procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value, s: Value)
@@ -63,10 +58,11 @@ procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value, s: V
 
 procedure {:inline 1} TestSpecs_div (x1: Value, x2: Value) returns (ret0: Value)
 requires b#Boolean(Boolean(i#Integer(x2) > i#Integer(Integer(0))));
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(Boolean((ret0) == (Integer(i#Integer(x1) * i#Integer(x2)))));
-ensures old(!(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) && (b#Boolean(Boolean(i#Integer(x1) > i#Integer(Integer(1)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean((ret0) == (Integer(i#Integer(x1) * i#Integer(x2)))));
+ensures old(!(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) && (b#Boolean(Boolean(i#Integer(x1) > i#Integer(Integer(1)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -74,278 +70,272 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> abor
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x1);
+    __m := UpdateLocal(__m, __frame + 0, x1);
     assume IsValidU64(x2);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x1);
-    m := UpdateLocal(m, old_size + 1, x2);
+    __m := UpdateLocal(__m, __frame + 1, x2);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Div(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_div_verify (x1: Value, x2: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_div(x1, x2);
 }
 
 procedure {:inline 1} TestSpecs_create_resource () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(1))));
-ensures old(!(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(1)))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(1))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(1))));
+ensures old(!(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(1)))))) ==> !__abort_flag;
+ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(1))))) ==> __abort_flag;
+
 {
     // declare local variables
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 0;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 0;
+    // process and type check arguments
 
     // bytecode translation starts here
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_create_resource_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_create_resource();
 }
 
 procedure {:inline 1} TestSpecs_select_from_global_resource () returns ()
-requires b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, GetResourceReference(TestSpecs_R_type_value(), a#Address(Address(1)))), TestSpecs_R_x)) > i#Integer(Integer(0))));
-requires ExistsTxnSenderAccount(m, txn);
+requires b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, GetResourceReference(TestSpecs_R_type_value(), a#Address(Address(1)))), TestSpecs_R_x)) > i#Integer(Integer(0))));
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 0;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 0;
+    // process and type check arguments
 
     // bytecode translation starts here
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_select_from_global_resource_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_select_from_global_resource();
 }
 
 procedure {:inline 1} TestSpecs_select_from_resource (r: Value) returns (ret0: Value)
 requires b#Boolean(Boolean(i#Integer(SelectField(r, TestSpecs_R_x)) > i#Integer(Integer(0))));
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // TestSpecs_R_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(r);
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
-    m := UpdateLocal(m, old_size + 0, r);
+    __m := UpdateLocal(__m, __frame + 0, r);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_select_from_resource_verify (r: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_select_from_resource(r);
 }
 
 procedure {:inline 1} TestSpecs_select_from_resource_nested (r: Value) returns (ret0: Value)
 requires b#Boolean(Boolean((SelectField(SelectField(r, TestSpecs_R_s), TestSpecs_S_a)) == (Address(1))));
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // TestSpecs_R_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(r);
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
-    m := UpdateLocal(m, old_size + 0, r);
+    __m := UpdateLocal(__m, __frame + 0, r);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_select_from_resource_nested_verify (r: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_select_from_resource_nested(r);
 }
 
 procedure {:inline 1} TestSpecs_select_from_global_resource_dynamic_address (r: Value) returns (ret0: Value)
-requires b#Boolean(Boolean(i#Integer(SelectField(Dereference(m, GetResourceReference(TestSpecs_R_type_value(), a#Address(SelectField(SelectField(r, TestSpecs_R_s), TestSpecs_S_a)))), TestSpecs_R_x)) > i#Integer(Integer(0))));
-requires ExistsTxnSenderAccount(m, txn);
+requires b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, GetResourceReference(TestSpecs_R_type_value(), a#Address(SelectField(SelectField(r, TestSpecs_R_s), TestSpecs_S_a)))), TestSpecs_R_x)) > i#Integer(Integer(0))));
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // TestSpecs_R_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(r);
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
-    m := UpdateLocal(m, old_size + 0, r);
+    __m := UpdateLocal(__m, __frame + 0, r);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_select_from_global_resource_dynamic_address_verify (r: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_select_from_global_resource_dynamic_address(r);
 }
 
 procedure {:inline 1} TestSpecs_select_from_reference (r: Reference) returns ()
-requires b#Boolean(Boolean((SelectField(SelectField(Dereference(m, r), TestSpecs_R_s), TestSpecs_S_a)) == (Address(1))));
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((SelectField(SelectField(Dereference(m, r), TestSpecs_R_s), TestSpecs_S_a)) == (old(SelectField(SelectField(Dereference(m, r), TestSpecs_R_s), TestSpecs_S_a)))));
+requires b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, r), TestSpecs_R_s), TestSpecs_S_a)) == (Address(1))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((SelectField(SelectField(Dereference(__m, r), TestSpecs_R_s), TestSpecs_S_a)) == (old(SelectField(SelectField(Dereference(__m, r), TestSpecs_R_s), TestSpecs_S_a)))));
 {
     // declare local variables
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 1;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, r));
-    assume IsValidReferenceParameter(m, local_counter, r);
-
-    old_size := local_counter;
-    local_counter := local_counter + 1;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, r));
+    assume IsValidReferenceParameter(__m, __frame, r);
 
     // bytecode translation starts here
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_select_from_reference_verify (r: Reference) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_select_from_reference(r);
 }
 
 procedure {:inline 1} TestSpecs_ret_values () returns (ret0: Value, ret1: Value, ret2: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean((ret0) == (Integer(7))));
 ensures b#Boolean(Boolean((ret1) == (Boolean(false))));
 ensures b#Boolean(Boolean((ret2) == (Integer(10))));
@@ -354,37 +344,36 @@ ensures b#Boolean(Boolean((ret2) == (Integer(10))));
     var t0: Value; // IntegerType()
     var t1: Value; // BooleanType()
     var t2: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(7);
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 0);
-    ret1 := GetLocal(m, old_size + 1);
-    ret2 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 0);
+    ret1 := GetLocal(__m, __frame + 1);
+    ret2 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
     ret2 := DefaultValue;
@@ -392,46 +381,45 @@ Label_Abort:
 
 procedure TestSpecs_ret_values_verify () returns (ret0: Value, ret1: Value, ret2: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1, ret2 := TestSpecs_ret_values();
 }
 
 procedure {:inline 1} TestSpecs_helper_function (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean(b#Boolean(number_in_range(x)) && b#Boolean(Boolean(i#Integer(x) < i#Integer(max_u64())))));
 {
     // declare local variables
     var t1: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 2;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 2;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(m, old_size + 1);
+    ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_helper_function_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_helper_function(x);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -15,7 +15,6 @@ procedure {:inline 1} Pack_TestStruct_B(addr: Value, val: Value) returns (_struc
     assume is#Address(addr);
     assume IsValidU64(val);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, addr), val));
-
 }
 
 procedure {:inline 1} Unpack_TestStruct_B(_struct: Value) returns (addr: Value, val: Value)
@@ -40,7 +39,6 @@ procedure {:inline 1} Pack_TestStruct_A(val: Value, b: Value) returns (_struct: 
     assume IsValidU64(val);
     assume is#Vector(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, val), b));
-
 }
 
 procedure {:inline 1} Unpack_TestStruct_A(_struct: Value) returns (val: Value, b: Value)
@@ -65,7 +63,6 @@ procedure {:inline 1} Pack_TestStruct_C(val: Value, b: Value) returns (_struct: 
     assume IsValidU64(val);
     assume is#Vector(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, val), b));
-
 }
 
 procedure {:inline 1} Unpack_TestStruct_C(_struct: Value) returns (val: Value, b: Value)
@@ -87,7 +84,6 @@ procedure {:inline 1} Pack_TestStruct_T(x: Value) returns (_struct: Value)
 {
     assume IsValidU64(x);
     _struct := Vector(ExtendValueArray(EmptyValueArray, x));
-
 }
 
 procedure {:inline 1} Unpack_TestStruct_T(_struct: Value) returns (x: Value)
@@ -102,54 +98,53 @@ procedure {:inline 1} Unpack_TestStruct_T(_struct: Value) returns (x: Value)
 // ** functions of module TestStruct
 
 procedure {:inline 1} TestStruct_identity (a: Value, c: Value) returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t2: Value; // TestStruct_A_type_value()
     var t3: Value; // TestStruct_C_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Vector(a);
+    __m := UpdateLocal(__m, __frame + 0, a);
     assume is#Vector(c);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
-    m := UpdateLocal(m, old_size + 0, a);
-    m := UpdateLocal(m, old_size + 1, c);
+    __m := UpdateLocal(__m, __frame + 1, c);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
-    ret1 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 2);
+    ret1 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure TestStruct_identity_verify (a: Value, c: Value) returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := TestStruct_identity(a, c);
 }
 
 procedure {:inline 1} TestStruct_module_builtins (a: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // TestStruct_T_type_value()
@@ -171,110 +166,109 @@ requires ExistsTxnSenderAccount(m, txn);
     var t17: Value; // TestStruct_T_type_value()
     var t18: Value; // TestStruct_T_type_value()
     var t19: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 20;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(a);
-
-    old_size := local_counter;
-    local_counter := local_counter + 20;
-    m := UpdateLocal(m, old_size + 0, a);
+    __m := UpdateLocal(__m, __frame + 0, a);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 5), TestStruct_T_type_value());
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 5), TestStruct_T_type_value());
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    tmp := GetLocal(m, old_size + 8);
-    if (!b#Boolean(tmp)) { goto Label_8; }
+    __tmp := GetLocal(__m, __frame + 8);
+    if (!b#Boolean(__tmp)) { goto Label_8; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     goto Label_Abort;
 
 Label_8:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := BorrowGlobal(GetLocal(m, old_size + 10), TestStruct_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t11 := BorrowGlobal(GetLocal(__m, __frame + 10), TestStruct_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t2 := CopyOrMoveRef(t11);
 
     call t12 := CopyOrMoveRef(t2);
 
-    // unimplemented instruction
+    // unimplemented instruction: NoOp
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := BorrowGlobal(GetLocal(m, old_size + 13), TestStruct_T_type_value());
-    if (abort_flag) { goto Label_Abort; }
+    call t14 := BorrowGlobal(GetLocal(__m, __frame + 13), TestStruct_T_type_value());
+    if (__abort_flag) { goto Label_Abort; }
 
     call t3 := CopyOrMoveRef(t14);
 
     call t15 := CopyOrMoveRef(t3);
 
-    // unimplemented instruction
+    // unimplemented instruction: NoOp
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 16, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call tmp := MoveFrom(GetLocal(m, old_size + 16), TestStruct_T_type_value());
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := MoveFrom(GetLocal(__m, __frame + 16), TestStruct_T_type_value());
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
     assume is#Vector(t17);
+    if (__abort_flag) { goto Label_Abort; }
 
-    if (abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 17));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call MoveToSender(TestStruct_T_type_value(), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call MoveToSender(TestStruct_T_type_value(), GetLocal(m, old_size + 18));
-    if (abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 19, tmp);
-
-    ret0 := GetLocal(m, old_size + 19);
+    ret0 := GetLocal(__m, __frame + 19);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestStruct_module_builtins_verify (a: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestStruct_module_builtins(a);
 }
 
 procedure {:inline 1} TestStruct_nested_struct (a: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // TestStruct_A_type_value()
@@ -300,57 +294,56 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     var t21: Value; // BooleanType()
     var t22: Value; // IntegerType()
     var t23: Value; // TestStruct_B_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 24;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(a);
-
-    old_size := local_counter;
-    local_counter := local_counter + 24;
-    m := UpdateLocal(m, old_size + 0, a);
+    __m := UpdateLocal(__m, __frame + 0, a);
 
     // bytecode translation starts here
-    call tmp := LdFalse();
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    tmp := GetLocal(m, old_size + 6);
-    if (!b#Boolean(tmp)) { goto Label_7; }
+    __tmp := GetLocal(__m, __frame + 6);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := Pack_TestStruct_B(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Pack_TestStruct_B(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     goto Label_11;
 
 Label_7:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := Pack_TestStruct_B(GetLocal(m, old_size + 10), GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    call __tmp := Pack_TestStruct_B(GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
 Label_11:
-    call t13 := BorrowLoc(old_size+2);
+    call t13 := BorrowLoc(__frame + 2);
 
     call t3 := CopyOrMoveRef(t13);
 
@@ -362,57 +355,57 @@ Label_11:
 
     call t16 := CopyOrMoveRef(t4);
 
-    call tmp := ReadRef(t16);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t16);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    m := UpdateLocal(m, old_size + 17, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 17));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 19, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19)));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 18), GetLocal(m, old_size + 19)));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    __tmp := GetLocal(__m, __frame + 21);
+    if (!b#Boolean(__tmp)) { goto Label_26; }
 
-    tmp := GetLocal(m, old_size + 21);
-    if (!b#Boolean(tmp)) { goto Label_26; }
-
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 22, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
 
     goto Label_Abort;
 
 Label_26:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 23, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(m, old_size + 23);
+    ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestStruct_nested_struct_verify (a: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestStruct_nested_struct(a);
 }
 
 procedure {:inline 1} TestStruct_try_unpack (a: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
@@ -430,82 +423,81 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     var t13: Value; // BooleanType()
     var t14: Value; // IntegerType()
     var t15: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 16;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Address(a);
-
-    old_size := local_counter;
-    local_counter := local_counter + 16;
-    m := UpdateLocal(m, old_size + 0, a);
+    __m := UpdateLocal(__m, __frame + 0, a);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := Pack_TestStruct_B(GetLocal(m, old_size + 4), GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := Pack_TestStruct_B(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8, t9 := Unpack_TestStruct_B(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 8, t8);
-    m := UpdateLocal(m, old_size + 9, t9);
+    call t8, t9 := Unpack_TestStruct_B(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 9, t9);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 10), GetLocal(m, old_size + 11)));
-    m := UpdateLocal(m, old_size + 12, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11)));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 12));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    tmp := GetLocal(m, old_size + 13);
-    if (!b#Boolean(tmp)) { goto Label_15; }
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_15; }
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 14, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     goto Label_Abort;
 
 Label_15:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 15, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    ret0 := GetLocal(m, old_size + 15);
+    ret0 := GetLocal(__m, __frame + 15);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestStruct_try_unpack_verify (a: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestStruct_try_unpack(a);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -15,7 +15,6 @@ procedure {:inline 1} Pack_Test3_T(f: Value, g: Value) returns (_struct: Value)
     assume IsValidU64(f);
     assume IsValidU64(g);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, f), g));
-
 }
 
 procedure {:inline 1} Unpack_Test3_T(_struct: Value) returns (f: Value, g: Value)
@@ -32,9 +31,10 @@ procedure {:inline 1} Unpack_Test3_T(_struct: Value) returns (f: Value, g: Value
 // ** functions of module Test3
 
 procedure {:inline 1} Test3_test3 (flag: Value) returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // Test3_T_type_value()
@@ -93,43 +93,42 @@ ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
     var t54: Value; // BooleanType()
     var t55: Value; // BooleanType()
     var t56: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 57;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume is#Boolean(flag);
-
-    old_size := local_counter;
-    local_counter := local_counter + 57;
-    m := UpdateLocal(m, old_size + 0, flag);
+    __m := UpdateLocal(__m, __frame + 0, flag);
 
     // bytecode translation starts here
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := LdConst(0);
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Pack_Test3_T(GetLocal(m, old_size + 9), GetLocal(m, old_size + 10));
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := Pack_Test3_T(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 11));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t12 := BorrowLoc(old_size+1);
+    call t12 := BorrowLoc(__frame + 1);
 
     call t2 := CopyOrMoveRef(t12);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 13, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    tmp := GetLocal(m, old_size + 13);
-    if (!b#Boolean(tmp)) { goto Label_12; }
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_12; }
 
     call t14 := CopyOrMoveRef(t2);
 
@@ -147,21 +146,21 @@ Label_12:
     call t3 := CopyOrMoveRef(t17);
 
 Label_15:
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 18, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
     call t19 := CopyOrMoveRef(t3);
 
-    call WriteRef(t19, GetLocal(m, old_size + 18));
+    call WriteRef(t19, GetLocal(__m, __frame + 18));
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 20, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 20));
-    m := UpdateLocal(m, old_size + 21, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 20));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    tmp := GetLocal(m, old_size + 21);
-    if (!b#Boolean(tmp)) { goto Label_25; }
+    __tmp := GetLocal(__m, __frame + 21);
+    if (!b#Boolean(__tmp)) { goto Label_25; }
 
     call t22 := CopyOrMoveRef(t2);
 
@@ -179,12 +178,12 @@ Label_25:
     call t4 := CopyOrMoveRef(t25);
 
 Label_28:
-    call tmp := LdConst(20);
-    m := UpdateLocal(m, old_size + 26, tmp);
+    call __tmp := LdConst(20);
+    __m := UpdateLocal(__m, __frame + 26, __tmp);
 
     call t27 := CopyOrMoveRef(t4);
 
-    call WriteRef(t27, GetLocal(m, old_size + 26));
+    call WriteRef(t27, GetLocal(__m, __frame + 26));
 
     call t28 := CopyOrMoveRef(t2);
 
@@ -200,68 +199,66 @@ Label_28:
 
     call t32 := CopyOrMoveRef(t5);
 
-    call tmp := ReadRef(t32);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t32);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 33, __tmp);
 
-    m := UpdateLocal(m, old_size + 33, tmp);
-
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 33));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 33));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call t34 := CopyOrMoveRef(t6);
 
-    call tmp := ReadRef(t34);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t34);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 35, __tmp);
 
-    m := UpdateLocal(m, old_size + 35, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 35));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 35));
-    m := UpdateLocal(m, old_size + 8, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 36, tmp);
+    __tmp := GetLocal(__m, __frame + 36);
+    if (!b#Boolean(__tmp)) { goto Label_60; }
 
-    tmp := GetLocal(m, old_size + 36);
-    if (!b#Boolean(tmp)) { goto Label_60; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 37, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 37, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 38, __tmp);
 
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 38, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 37), GetLocal(__m, __frame + 38)));
+    __m := UpdateLocal(__m, __frame + 39, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 37), GetLocal(m, old_size + 38)));
-    m := UpdateLocal(m, old_size + 39, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 39));
+    __m := UpdateLocal(__m, __frame + 40, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 39));
-    m := UpdateLocal(m, old_size + 40, tmp);
+    __tmp := GetLocal(__m, __frame + 40);
+    if (!b#Boolean(__tmp)) { goto Label_52; }
 
-    tmp := GetLocal(m, old_size + 40);
-    if (!b#Boolean(tmp)) { goto Label_52; }
-
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 41, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 41, __tmp);
 
     goto Label_Abort;
 
 Label_52:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 42, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 42, __tmp);
 
-    call tmp := LdConst(20);
-    m := UpdateLocal(m, old_size + 43, tmp);
+    call __tmp := LdConst(20);
+    __m := UpdateLocal(__m, __frame + 43, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 42), GetLocal(m, old_size + 43)));
-    m := UpdateLocal(m, old_size + 44, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 42), GetLocal(__m, __frame + 43)));
+    __m := UpdateLocal(__m, __frame + 44, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 44));
-    m := UpdateLocal(m, old_size + 45, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 44));
+    __m := UpdateLocal(__m, __frame + 45, __tmp);
 
-    tmp := GetLocal(m, old_size + 45);
-    if (!b#Boolean(tmp)) { goto Label_59; }
+    __tmp := GetLocal(__m, __frame + 45);
+    if (!b#Boolean(__tmp)) { goto Label_59; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 46, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 46, __tmp);
 
     goto Label_Abort;
 
@@ -269,44 +266,44 @@ Label_59:
     goto Label_74;
 
 Label_60:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 7));
-    m := UpdateLocal(m, old_size + 47, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 47, __tmp);
 
-    call tmp := LdConst(20);
-    m := UpdateLocal(m, old_size + 48, tmp);
+    call __tmp := LdConst(20);
+    __m := UpdateLocal(__m, __frame + 48, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 47), GetLocal(m, old_size + 48)));
-    m := UpdateLocal(m, old_size + 49, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 47), GetLocal(__m, __frame + 48)));
+    __m := UpdateLocal(__m, __frame + 49, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 49));
-    m := UpdateLocal(m, old_size + 50, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 49));
+    __m := UpdateLocal(__m, __frame + 50, __tmp);
 
-    tmp := GetLocal(m, old_size + 50);
-    if (!b#Boolean(tmp)) { goto Label_67; }
+    __tmp := GetLocal(__m, __frame + 50);
+    if (!b#Boolean(__tmp)) { goto Label_67; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 51, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 51, __tmp);
 
     goto Label_Abort;
 
 Label_67:
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 52, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 52, __tmp);
 
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 53, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 53, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 52), GetLocal(m, old_size + 53)));
-    m := UpdateLocal(m, old_size + 54, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 52), GetLocal(__m, __frame + 53)));
+    __m := UpdateLocal(__m, __frame + 54, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 54));
-    m := UpdateLocal(m, old_size + 55, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 54));
+    __m := UpdateLocal(__m, __frame + 55, __tmp);
 
-    tmp := GetLocal(m, old_size + 55);
-    if (!b#Boolean(tmp)) { goto Label_74; }
+    __tmp := GetLocal(__m, __frame + 55);
+    if (!b#Boolean(__tmp)) { goto Label_74; }
 
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 56, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 56, __tmp);
 
     goto Label_Abort;
 
@@ -314,12 +311,12 @@ Label_74:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure Test3_test3_verify (flag: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call Test3_test3(flag);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
@@ -7,261 +7,261 @@
 // ** functions of module TestAddition
 
 procedure {:inline 1} TestAddition_overflow_u8_add_bad (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU8(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU8(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := AddU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := AddU8(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestAddition_overflow_u8_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestAddition_overflow_u8_add_bad(x, y);
 }
 
 procedure {:inline 1} TestAddition_overflow_u8_add_ok (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU8(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU8(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := AddU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := AddU8(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestAddition_overflow_u8_add_ok_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestAddition_overflow_u8_add_ok(x, y);
 }
 
 procedure {:inline 1} TestAddition_overflow_u64_add_bad (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestAddition_overflow_u64_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestAddition_overflow_u64_add_bad(x, y);
 }
 
 procedure {:inline 1} TestAddition_overflow_u64_add_ok (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := AddU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := AddU64(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestAddition_overflow_u64_add_ok_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestAddition_overflow_u64_add_ok(x, y);
 }
 
 procedure {:inline 1} TestAddition_overflow_u128_add_bad (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU128(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU128(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := AddU128(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := AddU128(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestAddition_overflow_u128_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestAddition_overflow_u128_add_bad(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
@@ -7,185 +7,185 @@
 // ** functions of module CastBad
 
 procedure {:inline 1} CastBad_aborting_u8_cast_bad (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CastU8(GetLocal(m, old_size + 1));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CastU8(GetLocal(__m, __frame + 1));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure CastBad_aborting_u8_cast_bad_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := CastBad_aborting_u8_cast_bad(x);
 }
 
 procedure {:inline 1} CastBad_aborting_u8_cast_ok (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CastU8(GetLocal(m, old_size + 1));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CastU8(GetLocal(__m, __frame + 1));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure CastBad_aborting_u8_cast_ok_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := CastBad_aborting_u8_cast_ok(x);
 }
 
 procedure {:inline 1} CastBad_aborting_u64_cast_bad (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU128(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CastU64(GetLocal(m, old_size + 1));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CastU64(GetLocal(__m, __frame + 1));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure CastBad_aborting_u64_cast_bad_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := CastBad_aborting_u64_cast_bad(x);
 }
 
 procedure {:inline 1} CastBad_aborting_u64_cast_ok (x: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU128(x);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
-    m := UpdateLocal(m, old_size + 0, x);
+    __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CastU64(GetLocal(m, old_size + 1));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CastU64(GetLocal(__m, __frame + 1));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(m, old_size + 2);
+    ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure CastBad_aborting_u64_cast_ok_verify (x: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := CastBad_aborting_u64_cast_ok(x);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -12,7 +12,6 @@ procedure {:inline 1} Pack_TestSpecs_R(x: Value) returns (_struct: Value)
 {
     assume IsValidU64(x);
     _struct := Vector(ExtendValueArray(EmptyValueArray, x));
-
 }
 
 procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value)
@@ -27,10 +26,11 @@ procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value)
 // ** functions of module TestSpecs
 
 procedure {:inline 1} TestSpecs_create_resource () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
-ensures old(!(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn))))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(__txn)))));
+ensures old(!(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(__txn))))))) ==> !__abort_flag;
+ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
@@ -38,92 +38,91 @@ ensures old(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Addr
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // TestSpecs_R_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 0), TestSpecs_R_type_value());
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 0), TestSpecs_R_type_value());
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := GetLocal(m, old_size + 1);
-    if (!b#Boolean(tmp)) { goto Label_5; }
+    __tmp := GetLocal(__m, __frame + 1);
+    if (!b#Boolean(__tmp)) { goto Label_5; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     goto Label_Abort;
 
 Label_5:
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := Pack_TestSpecs_R(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := Pack_TestSpecs_R(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call MoveToSender(TestSpecs_R_type_value(), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
+    call MoveToSender(TestSpecs_R_type_value(), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_create_resource_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_create_resource();
 }
 
 procedure {:inline 1} TestSpecs_create_resource_error () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures !abort_flag ==> b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))));
-ensures old(!(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn))))))) ==> !abort_flag;
-ensures old(b#Boolean(ExistsResource(m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(txn)))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(__txn)))));
+ensures old(!(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(__txn))))))) ==> !__abort_flag;
+ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t0: Value; // AddressType()
     var t1: Value; // BooleanType()
     var t2: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := GetTxnSenderAddress();
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := Exists(GetLocal(m, old_size + 0), TestSpecs_R_type_value());
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := Exists(GetLocal(__m, __frame + 0), TestSpecs_R_type_value());
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    tmp := GetLocal(m, old_size + 1);
-    if (!b#Boolean(tmp)) { goto Label_5; }
+    __tmp := GetLocal(__m, __frame + 1);
+    if (!b#Boolean(__tmp)) { goto Label_5; }
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     goto Label_Abort;
 
@@ -131,12 +130,12 @@ Label_5:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_create_resource_error_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_create_resource_error();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
@@ -7,8 +7,8 @@
 // ** functions of module TestSpecs
 
 procedure {:inline 1} TestSpecs_div (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abort_flag;
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -16,58 +16,57 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !abort
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Div(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_div_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_div(x, y);
 }
 
 procedure {:inline 1} TestSpecs_div_by_zero_detected (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 {
     // declare local variables
     var t2: Value; // IntegerType()
@@ -75,51 +74,50 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     var t4: Value; // IntegerType()
     var t5: Value; // IntegerType()
     var t6: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 7;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 7;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := Div(GetLocal(m, old_size + 3), GetLocal(m, old_size + 4));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := Div(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 5));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(m, old_size + 6);
+    ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_div_by_zero_detected_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_div_by_zero_detected(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -7,50 +7,49 @@
 // ** functions of module TestSpecs
 
 procedure {:inline 1} TestSpecs_mut_b (b: Reference) returns ()
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
     var t1: Value; // IntegerType()
     var t2: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 3;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume IsValidU64(Dereference(m, b));
-    assume IsValidReferenceParameter(m, local_counter, b);
-
-    old_size := local_counter;
-    local_counter := local_counter + 3;
+    // process and type check arguments
+    assume IsValidU64(Dereference(__m, b));
+    assume IsValidReferenceParameter(__m, __frame, b);
 
     // bytecode translation starts here
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     call t2 := CopyOrMoveRef(b);
 
-    call WriteRef(t2, GetLocal(m, old_size + 1));
+    call WriteRef(t2, GetLocal(__m, __frame + 1));
 
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_mut_b_verify (b: Reference) returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_mut_b(b);
 }
 
 procedure {:inline 1} TestSpecs_mut_ref () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 {
     // declare local variables
     var t0: Value; // IntegerType()
@@ -65,62 +64,60 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     var t9: Value; // BooleanType()
     var t10: Value; // BooleanType()
     var t11: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(20);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(20);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
     call t1 := CopyOrMoveRef(t3);
 
     call t4 := CopyOrMoveRef(t1);
 
     call TestSpecs_mut_b(t4);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t1);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := LdConst(10);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8)));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8)));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    __tmp := GetLocal(__m, __frame + 10);
+    if (!b#Boolean(__tmp)) { goto Label_16; }
 
-    tmp := GetLocal(m, old_size + 10);
-    if (!b#Boolean(tmp)) { goto Label_16; }
-
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     goto Label_Abort;
 
@@ -128,19 +125,19 @@ Label_16:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_mut_ref_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_mut_ref();
 }
 
 procedure {:inline 1} TestSpecs_mut_ref_failure () returns ()
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 {
     // declare local variables
     var t0: Value; // IntegerType()
@@ -155,62 +152,60 @@ ensures old(b#Boolean(Boolean(true))) ==> !abort_flag;
     var t9: Value; // BooleanType()
     var t10: Value; // BooleanType()
     var t11: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 12;
+    // process and type check arguments
 
     // bytecode translation starts here
-    call tmp := LdConst(20);
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := LdConst(20);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := BorrowLoc(old_size+0);
+    call t3 := BorrowLoc(__frame + 0);
 
     call t1 := CopyOrMoveRef(t3);
 
     call t4 := CopyOrMoveRef(t1);
 
     call TestSpecs_mut_b(t4);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
 
     call t5 := CopyOrMoveRef(t1);
 
-    call tmp := ReadRef(t5);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t5);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 6));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 7, tmp);
+    call __tmp := LdConst(9);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call tmp := LdConst(9);
-    m := UpdateLocal(m, old_size + 8, tmp);
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8)));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    tmp := Boolean(IsEqual(GetLocal(m, old_size + 7), GetLocal(m, old_size + 8)));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := Not(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call tmp := Not(GetLocal(m, old_size + 9));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    __tmp := GetLocal(__m, __frame + 10);
+    if (!b#Boolean(__tmp)) { goto Label_16; }
 
-    tmp := GetLocal(m, old_size + 10);
-    if (!b#Boolean(tmp)) { goto Label_16; }
-
-    call tmp := LdConst(42);
-    m := UpdateLocal(m, old_size + 11, tmp);
+    call __tmp := LdConst(42);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     goto Label_Abort;
 
@@ -218,12 +213,12 @@ Label_16:
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
 }
 
 procedure TestSpecs_mut_ref_failure_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call TestSpecs_mut_ref_failure();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
@@ -7,209 +7,209 @@
 // ** functions of module TestMultiplication
 
 procedure {:inline 1} TestMultiplication_overflow_u8_mul_bad (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU8(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU8(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := MulU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := MulU8(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestMultiplication_overflow_u8_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestMultiplication_overflow_u8_mul_bad(x, y);
 }
 
 procedure {:inline 1} TestMultiplication_overflow_u8_mul_ok (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255)))))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255))))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255)))))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255))))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU8(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU8(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := MulU8(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := MulU8(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestMultiplication_overflow_u8_mul_ok_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestMultiplication_overflow_u8_mul_ok(x, y);
 }
 
 procedure {:inline 1} TestMultiplication_overflow_u64_mul_bad (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU64(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU64(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := MulU64(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := MulU64(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestMultiplication_overflow_u64_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestMultiplication_overflow_u64_mul_bad(x, y);
 }
 
 procedure {:inline 1} TestMultiplication_overflow_u128_mul_bad (x: Value, y: Value) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures old(!(b#Boolean(Boolean(false)))) ==> !abort_flag;
-ensures old(b#Boolean(Boolean(false))) ==> abort_flag;
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
+
 {
     // declare local variables
     var t2: Value; // IntegerType()
     var t3: Value; // IntegerType()
     var t4: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 5;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
+    // process and type check arguments
     assume IsValidU128(x);
+    __m := UpdateLocal(__m, __frame + 0, x);
     assume IsValidU128(y);
-
-    old_size := local_counter;
-    local_counter := local_counter + 5;
-    m := UpdateLocal(m, old_size + 0, x);
-    m := UpdateLocal(m, old_size + 1, y);
+    __m := UpdateLocal(__m, __frame + 1, y);
 
     // bytecode translation starts here
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 3, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call tmp := MulU128(GetLocal(m, old_size + 2), GetLocal(m, old_size + 3));
-    if (abort_flag) { goto Label_Abort; }
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := MulU128(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
+    ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestMultiplication_overflow_u128_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestMultiplication_overflow_u128_mul_bad(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -12,7 +12,6 @@ procedure {:inline 1} Pack_TestSpecs_T(value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
-
 }
 
 procedure {:inline 1} Unpack_TestSpecs_T(_struct: Value) returns (value: Value)
@@ -27,49 +26,47 @@ procedure {:inline 1} Unpack_TestSpecs_T(_struct: Value) returns (value: Value)
 // ** functions of module TestSpecs
 
 procedure {:inline 1} TestSpecs_value (ref: Reference) returns (ret0: Value)
-requires ExistsTxnSenderAccount(m, txn);
-ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(m, ref), TestSpecs_T_value))));
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean((ret0) == (SelectField(Dereference(__m, ref), TestSpecs_T_value))));
 {
     // declare local variables
     var t1: Reference; // ReferenceType(TestSpecs_T_type_value())
     var t2: Reference; // ReferenceType(IntegerType())
     var t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-    assume is#Vector(Dereference(m, ref));
-    assume IsValidReferenceParameter(m, local_counter, ref);
-
-    old_size := local_counter;
-    local_counter := local_counter + 4;
+    // process and type check arguments
+    assume is#Vector(Dereference(__m, ref));
+    assume IsValidReferenceParameter(__m, __frame, ref);
 
     // bytecode translation starts here
     call t1 := CopyOrMoveRef(ref);
 
     call t2 := BorrowField(t1, TestSpecs_T_value);
 
-    call tmp := ReadRef(t2);
-    assume IsValidU64(tmp);
+    call __tmp := ReadRef(t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    m := UpdateLocal(m, old_size + 3, tmp);
-
-    ret0 := GetLocal(m, old_size + 3);
+    ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
 }
 
 procedure TestSpecs_value_verify (ref: Reference) returns (ret0: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0 := TestSpecs_value(ref);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -7,7 +7,7 @@
 // ** functions of module VerifyVector
 
 procedure {:inline 1} VerifyVector_test_empty1 () returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean((ret0) == (ret1)));
 {
     // declare local variables
@@ -17,63 +17,62 @@ ensures b#Boolean(Boolean((ret0) == (ret1)));
     var t3: Value; // Vector_T_type_value(IntegerType())
     var t4: Value; // Vector_T_type_value(IntegerType())
     var t5: Value; // Vector_T_type_value(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 6;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 6;
+    // process and type check arguments
 
     // bytecode translation starts here
     call t2 := Vector_empty(IntegerType());
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t2);
 
-    m := UpdateLocal(m, old_size + 2, t2);
+    __m := UpdateLocal(__m, __frame + 2, t2);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 2));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
     call t3 := Vector_empty(IntegerType());
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 4, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 5, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(m, old_size + 4);
-    ret1 := GetLocal(m, old_size + 5);
+    ret0 := GetLocal(__m, __frame + 4);
+    ret1 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure VerifyVector_test_empty1_verify () returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := VerifyVector_test_empty1();
 }
 
 procedure {:inline 1} VerifyVector_test_empty2 () returns (ret0: Value, ret1: Value)
-requires ExistsTxnSenderAccount(m, txn);
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean((ret0) == (ret1)));
 {
     // declare local variables
@@ -88,76 +87,75 @@ ensures b#Boolean(Boolean((ret0) == (ret1)));
     var t8: Value; // IntegerType()
     var t9: Value; // Vector_T_type_value(IntegerType())
     var t10: Value; // Vector_T_type_value(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
 
-    var tmp: Value;
-    var old_size: int;
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 11;
 
-    var saved_m: Memory;
-    assume !abort_flag;
-    saved_m := m;
-
-    // assume arguments are of correct types
-
-    old_size := local_counter;
-    local_counter := local_counter + 11;
+    // process and type check arguments
 
     // bytecode translation starts here
     call t3 := Vector_empty(IntegerType());
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t3);
 
-    m := UpdateLocal(m, old_size + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, t3);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 3));
-    m := UpdateLocal(m, old_size + 0, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
 
     call t4 := Vector_empty(IntegerType());
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume is#Vector(t4);
 
-    m := UpdateLocal(m, old_size + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, t4);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 4));
-    m := UpdateLocal(m, old_size + 1, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t5 := BorrowLoc(old_size+0);
+    call t5 := BorrowLoc(__frame + 0);
 
-    call tmp := LdConst(1);
-    m := UpdateLocal(m, old_size + 6, tmp);
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call Vector_push_back(IntegerType(), t5, GetLocal(m, old_size + 6));
-    if (abort_flag) { goto Label_Abort; }
+    call Vector_push_back(IntegerType(), t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) { goto Label_Abort; }
 
-    call t7 := BorrowLoc(old_size+0);
+    call t7 := BorrowLoc(__frame + 0);
 
     call t8 := Vector_pop_back(IntegerType(), t7);
-    if (abort_flag) { goto Label_Abort; }
+    if (__abort_flag) { goto Label_Abort; }
     assume IsValidU64(t8);
 
-    m := UpdateLocal(m, old_size + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, t8);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 8));
-    m := UpdateLocal(m, old_size + 2, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 0));
-    m := UpdateLocal(m, old_size + 9, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call tmp := CopyOrMoveValue(GetLocal(m, old_size + 1));
-    m := UpdateLocal(m, old_size + 10, tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    ret0 := GetLocal(m, old_size + 9);
-    ret1 := GetLocal(m, old_size + 10);
+    ret0 := GetLocal(__m, __frame + 9);
+    ret1 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
-    abort_flag := true;
-    m := saved_m;
+    __abort_flag := true;
+    __m := __saved_m;
     ret0 := DefaultValue;
     ret1 := DefaultValue;
 }
 
 procedure VerifyVector_test_empty2_verify () returns (ret0: Value, ret1: Value)
 {
-    assume ExistsTxnSenderAccount(m, txn);
+    assume ExistsTxnSenderAccount(__m, __txn);
     call ret0, ret1 := VerifyVector_test_empty2();
 }


### PR DESCRIPTION
This implements source level error reporting, both for type checking errors, as well as Boogie errors.

Example of a verification checking error:

```
error:  A postcondition might not hold on this return path.
- libra_account.mvir:339:8
339 |         ensures global<Self.T>(txn_sender).balance.value == old(global<Self.T>(txn_sender).balance.value) - amount
help: Execution trace for previous error:
    at libra_account.mvir:352:8
    at libra_account.mvir:324:4
    at libra_account.mvir:342:15
    ...
```

As a side-effect, boogie output is not longer dumped to terminal. Instead it is written to a file `<out>.bpl.log`.

Details:

- All code generation is now directed via a new helper `CodeWriter` which tracks location information.
- The existing `SourceMap` functionality is used to populate the `CodeWriter` with source location info.
  It is also used to give locations to functions and other items in the environment for type check
  error reporting.
- A new helper `BoogieWrapper` is introduced to abstract Boogie execution, parsing of its output,
  and converting locations.
- Error reporting is handled via the well-known `codespan_reporting` crate.

The introduction of the `CodeWriter` caused a number of changes in the bytecode_translator, because
the design requires sequential writing of code instead of composing it via code snippet strings. This
lead to slight differences in code layout and many changes in golden files.

## Motivation

Improve DevX.

## Test Plan

Existing tests, golden file updates.

## Related PRs

NA
