### PR TITLE
[tf] add option to enable logstash in validator instance

### DIFF
--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -1,0 +1,8 @@
+FROM docker.elastic.co/logstash/logstash:7.5.1
+RUN rm -f /usr/share/logstash/pipeline/logstash.conf
+RUN rm -f /usr/share/logstash/config/logstash.yml
+# RUN logstash-plugin install logstash-input-beats
+RUN logstash-plugin install logstash-output-amazon_es
+
+COPY ./logstash.yml /usr/share/logstash/config/
+CMD echo -en "$LOGSTASH_CONFIG" > /usr/share/logstash/pipeline/logstash.conf && /usr/share/logstash/bin/logstash

--- a/docker/logstash/logstash.yml
+++ b/docker/logstash/logstash.yml
@@ -1,0 +1,5 @@
+# use default value for everything
+# pipeline:
+#  batch:
+#    size: 125
+#    delay: 50

--- a/terraform/elasticsearch.tf
+++ b/terraform/elasticsearch.tf
@@ -1,0 +1,50 @@
+resource "aws_elasticsearch_domain" "logging" {
+  domain_name           = "${terraform.workspace}-logging"
+  elasticsearch_version = "7.1"
+  count                 = var.enable_logstash ? 1 : 0
+
+  cluster_config {
+    instance_type = "r5.large.elasticsearch"
+  }
+
+  ebs_options {
+      ebs_enabled = true
+      volume_size = 20
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+}
+
+data "aws_iam_policy_document" "logging" {
+  count     = var.enable_logstash ? 1 : 0
+  statement {
+    actions = [
+      "es:*",
+    ]
+
+    resources = [
+      "${element(aws_elasticsearch_domain.logging.*.arn, count.index)}/*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+
+      values = concat(["199.201.64.0/22",],aws_instance.validator.*.public_ip)
+    }
+  }
+}
+
+resource "aws_elasticsearch_domain_policy" "main" {
+  count       = var.enable_logstash ? 1 : 0
+  domain_name = element(aws_elasticsearch_domain.logging.*.domain_name, count.index)
+
+  access_policies = element(data.aws_iam_policy_document.logging.*.json, count.index)
+}

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -1,4 +1,17 @@
 [
+  %{ if logstash }
+    {
+      "name": "logstash",
+      "image": "${logstash_image}${logstash_version}",
+      "environment": [{"name": "LOGSTASH_CONFIG", "value": "${logstash_config}"}],
+      "cpu": 384,
+      "memory": 1024,
+      "essential": false,
+      "mountPoints": [
+          {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
+      ]
+  },
+  %{ endif }
     {
         "name": "validator",
         "image": "${image}${image_version}",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -157,3 +157,30 @@ variable "monitoring_ebs_volume" {
   default     = 100
   description = "Size of monitoring instance EBS volume in GB"
 }
+
+variable "log_to_file" {
+  type        = bool
+  default     = false
+  description = "Set to true to log to /opt/libra/data/libra.log (in container) and /data/libra/libra.log (on host). This file won't be log rotated, you need to handle log rotation on your own if you choose this option"
+}
+
+variable "log_path" {
+  type        = string
+  default     = "/opt/libra/data/libra.log"
+}
+
+variable "enable_logstash" {
+  type    = bool
+  description = "Enable logstash instance on validator to send logs to elasticservice, this will enable log_to_file"
+  default = false
+}
+
+variable "logstash_image" {
+  type    = string
+  default = ""
+}
+
+variable "logstash_version" {
+  type    = string
+  default = "latest"
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This creates a small container in the validator host to collect data. It's turned off by default, and can be enabled by `-var "enable_logstash=true"`. It will also generate separate elasticsearch domain for each cluster.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan
Deployed on my workspace and tested with cluster test

test result shows no regression.
```
Experiment Result: all up : 669 TPS, 955.9 ms latency
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
