### PR TITLE
[Executor] execute_block should not take block IDs

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -62,14 +62,18 @@ impl StateComputer for ExecutionProxy {
         committed_trees: &ExecutedTrees,
     ) -> Result<ProcessedVMOutput> {
         let pre_execution_instant = Instant::now();
+        debug!(
+            "Executing block {:x}. Parent: {:x}.",
+            block.id(),
+            block.parent_id(),
+        );
+
         // TODO: figure out error handling for the prologue txn
         self.executor
             .execute_block(
                 Self::transactions_from_block(block),
                 parent_executed_trees,
                 committed_trees,
-                block.parent_id(),
-                block.id(),
             )
             .and_then(|output| {
                 let execution_duration = pre_execution_instant.elapsed();

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -58,20 +58,10 @@ fn execute_and_commit_block(
     txn_index: u64,
 ) {
     let txn = encode_mint_transaction(gen_address(txn_index), 100);
-    let parent_block_id = match txn_index {
-        0 => *PRE_GENESIS_BLOCK_ID,
-        x => gen_block_id(x),
-    };
     let id = gen_block_id(txn_index + 1);
 
     let output = executor
-        .execute_block(
-            vec![txn.clone()],
-            &committed_trees,
-            &committed_trees,
-            parent_block_id,
-            id,
-        )
+        .execute_block(vec![txn.clone()], &committed_trees, &committed_trees)
         .unwrap();
     assert_eq!(output.version().unwrap(), txn_index + 1);
 
@@ -170,17 +160,8 @@ fn test_executor_status() {
     let txn1 = encode_mint_transaction(gen_address(1), 100);
     let txn2 = encode_transfer_transaction(gen_address(0), gen_address(1), 500);
 
-    let parent_block_id = *PRE_GENESIS_BLOCK_ID;
-    let block_id = gen_block_id(1);
-
     let output = executor
-        .execute_block(
-            vec![txn0, txn1, txn2],
-            &committed_trees,
-            &committed_trees,
-            parent_block_id,
-            block_id,
-        )
+        .execute_block(vec![txn0, txn1, txn2], &committed_trees, &committed_trees)
         .unwrap();
 
     assert_eq!(
@@ -197,7 +178,6 @@ fn test_executor_status() {
 fn test_executor_one_block() {
     let (executor, committed_trees) = TestExecutor::new();
 
-    let parent_block_id = *PRE_GENESIS_BLOCK_ID;
     let block_id = gen_block_id(1);
     let version = 100;
 
@@ -205,13 +185,7 @@ fn test_executor_one_block() {
         .map(|i| encode_mint_transaction(gen_address(i), 100))
         .collect::<Vec<_>>();
     let output = executor
-        .execute_block(
-            txns.clone(),
-            &committed_trees,
-            &committed_trees,
-            parent_block_id,
-            block_id,
-        )
+        .execute_block(txns.clone(), &committed_trees, &committed_trees)
         .unwrap();
     assert_eq!(output.version().unwrap(), 100);
 
@@ -238,7 +212,6 @@ fn test_executor_multiple_blocks() {
 fn test_executor_two_blocks_with_failed_txns() {
     let (executor, committed_trees) = TestExecutor::new();
 
-    let block1_id = gen_block_id(1);
     let block2_id = gen_block_id(2);
     let block1_txns = (0..50)
         .map(|i| encode_mint_transaction(gen_address(i), 100))
@@ -253,21 +226,13 @@ fn test_executor_two_blocks_with_failed_txns() {
         })
         .collect::<Vec<_>>();
     let output1 = executor
-        .execute_block(
-            block1_txns.clone(),
-            &committed_trees,
-            &committed_trees,
-            *PRE_GENESIS_BLOCK_ID,
-            block1_id,
-        )
+        .execute_block(block1_txns.clone(), &committed_trees, &committed_trees)
         .unwrap();
     let output2 = executor
         .execute_block(
             block2_txns.clone(),
             output1.executed_trees(),
             &committed_trees,
-            block1_id,
-            block2_id,
         )
         .unwrap();
     let ledger_info = gen_ledger_info(75, output2.accu_root(), block2_id, 1);
@@ -285,8 +250,6 @@ fn test_executor_two_blocks_with_failed_txns() {
 
 #[test]
 fn test_executor_execute_same_block_multiple_times() {
-    let parent_block_id = *PRE_GENESIS_BLOCK_ID;
-    let block_id = gen_block_id(1);
     let version = 100;
 
     let txns: Vec<_> = (0..version)
@@ -297,13 +260,7 @@ fn test_executor_execute_same_block_multiple_times() {
     let mut responses = vec![];
     for _i in 0..100 {
         let output = executor
-            .execute_block(
-                txns.clone(),
-                &committed_trees,
-                &committed_trees,
-                parent_block_id,
-                block_id,
-            )
+            .execute_block(txns.clone(), &committed_trees, &committed_trees)
             .unwrap();
         responses.push(output.state_compute_result());
     }
@@ -351,13 +308,7 @@ fn create_transaction_chunks(
     let id = gen_block_id(1);
 
     let output = executor
-        .execute_block(
-            txns.clone(),
-            &root_trees,
-            &root_trees,
-            *GENESIS_BLOCK_ID,
-            id,
-        )
+        .execute_block(txns.clone(), &root_trees, &root_trees)
         .unwrap();
     let ledger_version = txns.len() as u64;
     let ledger_info = gen_ledger_info(ledger_version, output.accu_root(), id, 1);
@@ -584,13 +535,7 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
     let first_txn = iter.next().map_or(vec![], |txn| vec![txn]);
     let first_id = gen_block_id(1);
     let mut output = executor
-        .execute_block(
-            first_txn.clone(),
-            &committed_trees,
-            &committed_trees,
-            *GENESIS_BLOCK_ID,
-            gen_block_id(1),
-        )
+        .execute_block(first_txn.clone(), &committed_trees, &committed_trees)
         .unwrap();
     let mut root_hash = output.accu_root();
     let ledger_info = gen_ledger_info(first_txn.len() as u64, root_hash, first_id, 0);
@@ -605,17 +550,10 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
     committed_trees = new_trees;
 
     for (i, txn) in iter.enumerate() {
-        let parent_block_id = gen_block_id(i as u64 + 1);
         // when i = 0, id should be 2.
         let id = gen_block_id(i as u64 + 2);
         output = executor
-            .execute_block(
-                vec![txn.clone()],
-                &committed_trees,
-                &committed_trees,
-                parent_block_id,
-                id,
-            )
+            .execute_block(vec![txn.clone()], &committed_trees, &committed_trees)
             .unwrap();
 
         root_hash = output.accu_root();
@@ -653,15 +591,15 @@ proptest! {
         let (executor, committed_trees) = TestExecutor::new();
 
         let output_a = executor.execute_block(
-            block_a.txns.clone(), &committed_trees, &committed_trees,block_a.parent_id, block_a.id,
+            block_a.txns.clone(), &committed_trees, &committed_trees,
         ).unwrap();
         prop_assert_eq!(output_a.version().unwrap(), a_size);
         let output_b = executor.execute_block(
-            block_b.txns.clone(), output_a.executed_trees(), &committed_trees, block_b.parent_id, block_b.id,
+            block_b.txns.clone(), output_a.executed_trees(), &committed_trees,
         ).unwrap();
         prop_assert_eq!(output_b.version().unwrap(), a_size + b_size);
         let output_c = executor.execute_block(
-            block_c.txns.clone(), output_a.executed_trees(), &committed_trees, block_c.parent_id, block_c.id,
+            block_c.txns.clone(), output_a.executed_trees(), &committed_trees,
         ).unwrap();
         prop_assert_eq!(output_c.version().unwrap(), a_size + c_size);
 
@@ -702,7 +640,7 @@ proptest! {
         {
             let (executor, committed_trees) = create_executor(&config);
             let output_a = executor.execute_block(
-                block_a.txns.clone(), &committed_trees, &committed_trees, block_a.parent_id, block_a.id,
+                block_a.txns.clone(), &committed_trees, &committed_trees,
             ).unwrap();
             let root_hash = output_a.accu_root();
             let ledger_info = gen_ledger_info(block_a.txns.len() as u64, root_hash, block_a.id, 1);
@@ -716,7 +654,7 @@ proptest! {
         let root_hash = {
             let (executor, committed_trees) = create_executor(&config);
             let output_b = executor.execute_block(
-                block_b.txns.clone(), &committed_trees, &committed_trees, block_b.parent_id, block_b.id,
+                block_b.txns.clone(), &committed_trees, &committed_trees,
             ).unwrap();
             let root_hash = output_b.accu_root();
             let ledger_info = gen_ledger_info(
@@ -766,8 +704,6 @@ proptest! {
         executor.execute_and_commit_chunk(txn_list_with_proof_to_commit, ledger_info, None, &mut synced_trees)
             .unwrap();
 
-        let parent_block_id = HashValue::zero();
-        let first_block_id = gen_block_id(1);
         first_block_txns.extend(overlap_txn_list_with_proof.transactions);
         let second_block_txns = ((chunk_size + overlap_size + 1..=chunk_size + overlap_size + num_new_txns)
                              .map(|i| encode_mint_transaction(gen_address(i), 100))).collect::<Vec<_>>();
@@ -776,8 +712,6 @@ proptest! {
             first_block_txns.clone(),
             &committed_trees,
             &committed_trees,
-            parent_block_id,
-            first_block_id,
         ).unwrap();
 
         let second_block_id = gen_block_id(2);
@@ -785,8 +719,6 @@ proptest! {
             second_block_txns.clone(),
             output1.executed_trees(),
             &committed_trees,
-            first_block_id,
-            second_block_id,
         ).unwrap();
 
         let version = chunk_size + overlap_size + num_new_txns;

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -16,8 +16,7 @@ use libra_config::config::VMConfig;
 use libra_crypto::{
     hash::{
         CryptoHash, EventAccumulatorHasher, TransactionAccumulatorHasher,
-        ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID, PRE_GENESIS_BLOCK_ID,
-        SPARSE_MERKLE_PLACEHOLDER_HASH,
+        ACCUMULATOR_PLACEHOLDER_HASH, PRE_GENESIS_BLOCK_ID, SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
     HashValue,
 };
@@ -351,13 +350,7 @@ where
         // We create `PRE_GENESIS_BLOCK_ID` as the parent of the genesis block.
         let pre_genesis_trees = ExecutedTrees::new_empty();
         let output = self
-            .execute_block(
-                genesis_txns.clone(),
-                &pre_genesis_trees,
-                &pre_genesis_trees,
-                *PRE_GENESIS_BLOCK_ID,
-                *GENESIS_BLOCK_ID,
-            )
+            .execute_block(genesis_txns.clone(), &pre_genesis_trees, &pre_genesis_trees)
             .expect("Failed to execute genesis block.");
 
         let root_hash = output.accu_root();
@@ -390,14 +383,7 @@ where
         transactions: Vec<Transaction>,
         parent_trees: &ExecutedTrees,
         committed_trees: &ExecutedTrees,
-        parent_id: HashValue,
-        id: HashValue,
     ) -> Result<ProcessedVMOutput> {
-        debug!(
-            "Received request to execute block. Parent id: {:x}. Id: {:x}.",
-            parent_id, id
-        );
-
         let _timer = OP_COUNTERS.timer("block_execute_time_s");
         // Construct a StateView and pass the transactions to VM.
         let state_view = VerifiedStateView::new(

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -5,9 +5,7 @@ use anyhow::{ensure, format_err, Result};
 use config_builder;
 use executor::{ExecutedTrees, Executor};
 use libra_config::config::{NodeConfig, VMConfig, VMPublishingOption};
-use libra_crypto::{
-    ed25519::*, hash::GENESIS_BLOCK_ID, test_utils::TEST_SEED, HashValue, PrivateKey,
-};
+use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey};
 use libra_types::crypto_proxies::EpochInfo;
 use libra_types::validator_change::VerifierType;
 use libra_types::{
@@ -147,15 +145,8 @@ fn test_reconfiguration() {
     // Create a dummy block prologue transaction that will emit a ValidatorSetChanged event
     let txn3 = encode_block_prologue_script(gen_block_metadata(1, validator_account));
     let txn_block = vec![txn1, txn2, txn3];
-    let block1_id = gen_block_id(1);
     let vm_output = executor
-        .execute_block(
-            txn_block,
-            &committed_trees,
-            &committed_trees,
-            *GENESIS_BLOCK_ID,
-            block1_id,
-        )
+        .execute_block(txn_block, &committed_trees, &committed_trees)
         .unwrap();
 
     // Make sure the execution result sees the reconfiguration
@@ -176,15 +167,8 @@ fn test_reconfiguration() {
     );
     let txn5 = encode_block_prologue_script(gen_block_metadata(2, validator_account));
     let txn_block = vec![txn4, txn5];
-    let block2_id = gen_block_id(2);
     let output = executor
-        .execute_block(
-            txn_block,
-            &committed_trees,
-            &committed_trees,
-            block1_id,
-            block2_id,
-        )
+        .execute_block(txn_block, &committed_trees, &committed_trees)
         .unwrap();
 
     assert!(
@@ -297,13 +281,7 @@ fn test_execution_with_storage() {
     }
 
     let output1 = executor
-        .execute_block(
-            block1.clone(),
-            &committed_trees,
-            &committed_trees,
-            *GENESIS_BLOCK_ID,
-            block1_id,
-        )
+        .execute_block(block1.clone(), &committed_trees, &committed_trees)
         .unwrap();
     let ledger_info_with_sigs = gen_ledger_info_with_sigs(6, output1.accu_root(), block1_id);
     let committed_trees_copy = committed_trees.clone();
@@ -553,13 +531,7 @@ fn test_execution_with_storage() {
 
     // Execution the 2nd block.
     let output2 = executor
-        .execute_block(
-            block2.clone(),
-            &committed_trees,
-            &committed_trees,
-            block1_id,
-            block2_id,
-        )
+        .execute_block(block2.clone(), &committed_trees, &committed_trees)
         .unwrap();
     let ledger_info_with_sigs = gen_ledger_info_with_sigs(20, output2.accu_root(), block2_id);
     executor


### PR DESCRIPTION
Right now the only thing that uses this input is the `debug!` log, so there is no reason to pass the block IDs to the function. Do the logging in the caller instead.