### PR TITLE
[move source language] Added AST debug printers

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -7,6 +7,7 @@ use crate::{
         BinOp, Field, FunctionName, FunctionVisibility, Kind, Kind_, ModuleIdent, ResourceLoc,
         StructName, UnaryOp, Value, Var,
     },
+    shared::ast_debug::*,
     shared::unique_map::UniqueMap,
     shared::*,
 };
@@ -349,6 +350,454 @@ impl Type_ {
             Type_::Multiple(ss) => {
                 assert!(idx < ss.len());
                 ss.get(idx).unwrap()
+            }
+        }
+    }
+}
+
+//**************************************************************************************************
+// Debug
+//**************************************************************************************************
+
+impl AstDebug for Program {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Program { modules, main } = self;
+        for (m, mdef) in modules {
+            w.write(&format!("module {}", m));
+            w.block(|w| mdef.ast_debug(w));
+            w.new_line();
+        }
+
+        if let Some((addr, n, fdef)) = main {
+            w.writeln(&format!("address {}:", addr));
+            (n.clone(), fdef).ast_debug(w);
+        }
+    }
+}
+
+impl AstDebug for ModuleDefinition {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleDefinition {
+            is_source_module,
+            structs,
+            functions,
+        } = self;
+        match is_source_module {
+            None => w.writeln("library module"),
+            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        }
+        for sdef in structs {
+            sdef.ast_debug(w);
+            w.new_line();
+        }
+        for fdef in functions {
+            fdef.ast_debug(w);
+            w.new_line();
+        }
+    }
+}
+
+impl AstDebug for (StructName, &StructDefinition) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (
+            name,
+            StructDefinition {
+                resource_opt,
+                type_parameters,
+                fields,
+            },
+        ) = self;
+        if let StructFields::Native(_) = fields {
+            w.write("native ");
+        }
+        if resource_opt.is_some() {
+            w.write("resource ");
+        }
+        w.write(&format!("struct {}", name));
+        type_parameters.ast_debug(w);
+        if let StructFields::Defined(fields) = fields {
+            w.block(|w| {
+                w.list(fields, ",", |w, (f, bt)| {
+                    w.write(&format!("{}: ", f));
+                    bt.ast_debug(w);
+                    true
+                })
+            })
+        }
+    }
+}
+
+impl AstDebug for (FunctionName, &Function) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (
+            name,
+            Function {
+                visibility,
+                signature,
+                acquires,
+                body,
+            },
+        ) = self;
+        visibility.ast_debug(w);
+        if let FunctionBody_::Native = &body.value {
+            w.write("native ");
+        }
+        w.write(&format!("{}", name));
+        signature.ast_debug(w);
+        if !acquires.is_empty() {
+            w.write(" acquires ");
+            w.comma(acquires, |w, s| w.write(&format!("{}", s)));
+            w.write(" ");
+        }
+        match &body.value {
+            FunctionBody_::Defined {
+                locals,
+                start,
+                blocks,
+            } => w.block(|w| {
+                w.write("locals:");
+                w.indent(4, |w| {
+                    w.list(locals, ",", |w, (v, st)| {
+                        w.write(&format!("{}: ", v));
+                        st.ast_debug(w);
+                        true
+                    })
+                });
+                w.new_line();
+                w.writeln(&format!("start={}", start.0));
+                w.new_line();
+                blocks.ast_debug(w);
+            }),
+            FunctionBody_::Native => w.writeln(";"),
+        }
+    }
+}
+
+impl AstDebug for FunctionSignature {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let FunctionSignature {
+            type_parameters,
+            parameters,
+            return_type,
+        } = self;
+        type_parameters.ast_debug(w);
+        w.write("(");
+        w.comma(parameters, |w, (v, st)| {
+            w.write(&format!("{}: ", v));
+            st.ast_debug(w)
+        });
+        w.write("): ");
+        return_type.ast_debug(w)
+    }
+}
+
+impl AstDebug for BaseType_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            BaseType_::Param(tp) => tp.ast_debug(w),
+            BaseType_::Apply(k, m, ss) => {
+                w.annotate(
+                    |w| {
+                        m.ast_debug(w);
+                        if !ss.is_empty() {
+                            w.write("<");
+                            ss.ast_debug(w);
+                            w.write(">");
+                        }
+                    },
+                    k,
+                );
+            }
+        }
+    }
+}
+
+impl AstDebug for SingleType_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            SingleType_::Base(b) => b.ast_debug(w),
+            SingleType_::Ref(mut_, s) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                s.ast_debug(w)
+            }
+        }
+    }
+}
+
+impl AstDebug for Type_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Type_::Unit => w.write("()"),
+            Type_::Single(s) => s.ast_debug(w),
+            Type_::Multiple(ss) => {
+                w.write("(");
+                ss.ast_debug(w);
+                w.write(")")
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<SingleType> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.comma(self, |w, s| s.ast_debug(w))
+    }
+}
+
+impl AstDebug for Vec<BaseType> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.comma(self, |w, s| s.ast_debug(w))
+    }
+}
+
+impl AstDebug for Blocks {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.list(self, "", |w, lbl_block| {
+            lbl_block.ast_debug(w);
+            w.new_line();
+            true
+        })
+    }
+}
+
+impl AstDebug for (&Label, &BasicBlock) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write(&format!("label {}:", (self.0).0));
+        w.indent(4, |w| w.semicolon(self.1, |w, cmd| cmd.ast_debug(w)))
+    }
+}
+
+impl AstDebug for Command_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Command_ as C;
+        match self {
+            C::Assign(lvalues, rhs) => {
+                lvalues.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
+            }
+            C::Mutate(lhs, rhs) => {
+                w.write("*");
+                lhs.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
+            }
+            C::Abort(e) => {
+                w.write("abort ");
+                e.ast_debug(w);
+            }
+            C::Return(e) => {
+                w.write("return ");
+                e.ast_debug(w);
+            }
+            C::IgnoreAndPop { pop_num, exp } => {
+                w.write("pop ");
+                w.comma(0..*pop_num, |w, _| w.write("_"));
+                w.write(" = ");
+                exp.ast_debug(w);
+            }
+            C::Jump(lbl) => w.write(&format!("jump {}", lbl.0)),
+            C::JumpIf {
+                cond,
+                if_true,
+                if_false,
+            } => {
+                w.write("jump_if(");
+                cond.ast_debug(w);
+                w.write(&format!(") {} else {}", if_true.0, if_false.0));
+            }
+        }
+    }
+}
+
+impl AstDebug for Exp {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Exp { ty, exp } = self;
+        w.annotate(|w| exp.ast_debug(w), ty)
+    }
+}
+
+impl AstDebug for UnannotatedExp_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use UnannotatedExp_ as E;
+        match self {
+            E::Unit => w.write("()"),
+            E::Value(v) => v.ast_debug(w),
+            E::Move {
+                from_user: false,
+                var: v,
+            } => w.write(&format!("move {}", v)),
+            E::Move {
+                from_user: true,
+                var: v,
+            } => w.write(&format!("move@{}", v)),
+            E::Copy {
+                from_user: false,
+                var: v,
+            } => w.write(&format!("copy {}", v)),
+            E::Copy {
+                from_user: true,
+                var: v,
+            } => w.write(&format!("copy@{}", v)),
+            E::ModuleCall(mcall) => {
+                mcall.ast_debug(w);
+            }
+            E::Builtin(bf, rhs) => {
+                bf.ast_debug(w);
+                w.write("(");
+                rhs.ast_debug(w);
+                w.write(")");
+            }
+            E::Freeze(e) => {
+                w.write("freeze(");
+                e.ast_debug(w);
+                w.write(")");
+            }
+            E::Pack(s, tys, fields) => {
+                w.write(&format!("{}", s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, bt, e)| {
+                    w.write(&format!("{}:", f));
+                    bt.ast_debug(w);
+                    w.write(": ");
+                    e.ast_debug(w);
+                });
+                w.write("}");
+            }
+
+            E::ExpList(es) => {
+                w.write("(");
+                w.comma(es, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+
+            E::Dereference(e) => {
+                w.write("*");
+                e.ast_debug(w)
+            }
+            E::UnaryExp(op, e) => {
+                op.ast_debug(w);
+                w.write(" ");
+                e.ast_debug(w);
+            }
+            E::BinopExp(l, op, r) => {
+                l.ast_debug(w);
+                w.write(" ");
+                op.ast_debug(w);
+                w.write(" ");
+                r.ast_debug(w)
+            }
+            E::Borrow(mut_, e, f) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                e.ast_debug(w);
+                w.write(&format!(".{}", f));
+            }
+            E::BorrowLocal(mut_, v) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                w.write(&format!("{}", v));
+            }
+            E::UnresolvedError => w.write("_|_"),
+        }
+    }
+}
+
+impl AstDebug for ModuleCall {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleCall {
+            module,
+            name,
+            type_arguments,
+            acquires,
+            arguments,
+        } = self;
+        w.write(&format!("{}::{}", module, name));
+        if !acquires.is_empty() {
+            w.write("[acquires: [");
+            w.comma(acquires, |w, s| w.write(&format!("{}", s)));
+            w.write("]], ");
+        }
+        w.write("<");
+        type_arguments.ast_debug(w);
+        w.write(">");
+        w.write("(");
+        arguments.ast_debug(w);
+        w.write(")");
+    }
+}
+
+impl AstDebug for BuiltinFunction_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use crate::naming::ast::BuiltinFunction_ as NF;
+        use BuiltinFunction_ as F;
+        let (n, bt) = match self {
+            F::MoveToSender(bt) => (NF::MOVE_TO_SENDER, bt),
+            F::MoveFrom(bt) => (NF::MOVE_FROM, bt),
+            F::BorrowGlobal(true, bt) => (NF::BORROW_GLOBAL_MUT, bt),
+            F::BorrowGlobal(false, bt) => (NF::BORROW_GLOBAL, bt),
+            F::Exists(bt) => (NF::EXISTS, bt),
+        };
+        w.write(n);
+        w.write("<");
+        bt.ast_debug(w);
+        w.write(">");
+    }
+}
+
+impl AstDebug for ExpListItem {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            ExpListItem::Single(e, st) => w.annotate(|w| e.ast_debug(w), st),
+            ExpListItem::Splat(_, e, ss) => {
+                w.write("~");
+                w.annotate(|w| e.ast_debug(w), ss)
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<LValue> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let parens = self.len() != 1;
+        if parens {
+            w.write("(");
+        }
+        w.comma(self, |w, a| a.ast_debug(w));
+        if parens {
+            w.write(")");
+        }
+    }
+}
+
+impl AstDebug for LValue_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use LValue_ as L;
+        match self {
+            L::Ignore => w.write("_"),
+            L::Var(v, st) => w.annotate(|w| w.write(&format!("{}", v)), st),
+
+            L::Unpack(s, tys, fields) => {
+                w.write(&format!("{}", s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, l)| {
+                    w.write(&format!("{}: ", f));
+                    l.ast_debug(w)
+                });
+                w.write("}");
             }
         }
     }

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -1,13 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::unique_map::UniqueMap;
 use crate::{
     naming::ast::{BuiltinTypeName_, TParam, TypeName, TypeName_},
     parser::ast::{
         BinOp, Field, FunctionName, FunctionVisibility, Kind, ModuleIdent, ResourceLoc, StructName,
         UnaryOp, Value, Var,
     },
+    shared::ast_debug::*,
+    shared::unique_map::UniqueMap,
     shared::*,
 };
 use std::collections::{BTreeSet, VecDeque};
@@ -310,5 +311,473 @@ impl Type_ {
             _ => Type_::Multiple(ss),
         };
         sp(loc, t_)
+    }
+}
+
+//**************************************************************************************************
+// Debug
+//**************************************************************************************************
+
+impl AstDebug for Program {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Program { modules, main } = self;
+        for (m, mdef) in modules {
+            w.write(&format!("module {}", m));
+            w.block(|w| mdef.ast_debug(w));
+            w.new_line();
+        }
+
+        if let Some((addr, n, fdef)) = main {
+            w.writeln(&format!("address {}:", addr));
+            (n.clone(), fdef).ast_debug(w);
+        }
+    }
+}
+
+impl AstDebug for ModuleDefinition {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleDefinition {
+            is_source_module,
+            structs,
+            functions,
+        } = self;
+        match is_source_module {
+            None => w.writeln("library module"),
+            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        }
+        for sdef in structs {
+            sdef.ast_debug(w);
+            w.new_line();
+        }
+        for fdef in functions {
+            fdef.ast_debug(w);
+            w.new_line();
+        }
+    }
+}
+
+impl AstDebug for (StructName, &StructDefinition) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (
+            name,
+            StructDefinition {
+                resource_opt,
+                type_parameters,
+                fields,
+            },
+        ) = self;
+        if let StructFields::Native(_) = fields {
+            w.write("native ");
+        }
+        if resource_opt.is_some() {
+            w.write("resource ");
+        }
+        w.write(&format!("struct {}", name));
+        type_parameters.ast_debug(w);
+        if let StructFields::Defined(fields) = fields {
+            w.block(|w| {
+                w.list(fields, ";", |w, (f, bt)| {
+                    w.write(&format!("{}: ", f));
+                    bt.ast_debug(w);
+                    true
+                })
+            })
+        }
+    }
+}
+
+impl AstDebug for (FunctionName, &Function) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (
+            name,
+            Function {
+                visibility,
+                signature,
+                acquires,
+                body,
+            },
+        ) = self;
+        visibility.ast_debug(w);
+        if let FunctionBody_::Native = &body.value {
+            w.write("native ");
+        }
+        w.write(&format!("{}", name));
+        signature.ast_debug(w);
+        if !acquires.is_empty() {
+            w.write(" acquires ");
+            w.comma(acquires, |w, s| w.write(&format!("{}", s)));
+            w.write(" ");
+        }
+        match &body.value {
+            FunctionBody_::Defined { locals, body } => w.block(|w| {
+                w.write("locals:");
+                w.indent(4, |w| {
+                    w.list(locals, ",", |w, (v, st)| {
+                        w.write(&format!("{}: ", v));
+                        st.ast_debug(w);
+                        true
+                    })
+                });
+                w.new_line();
+                body.ast_debug(w);
+            }),
+            FunctionBody_::Native => w.writeln(";"),
+        }
+    }
+}
+
+impl AstDebug for FunctionSignature {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let FunctionSignature {
+            type_parameters,
+            parameters,
+            return_type,
+        } = self;
+        type_parameters.ast_debug(w);
+        w.write("(");
+        w.comma(parameters, |w, (v, st)| {
+            w.write(&format!("{}: ", v));
+            st.ast_debug(w);
+        });
+        w.write("): ");
+        return_type.ast_debug(w)
+    }
+}
+
+impl AstDebug for BaseType_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            BaseType_::Param(tp) => tp.ast_debug(w),
+            BaseType_::Apply(k, m, ss) => {
+                w.annotate(
+                    |w| {
+                        m.ast_debug(w);
+                        if !ss.is_empty() {
+                            w.write("<");
+                            ss.ast_debug(w);
+                            w.write(">");
+                        }
+                    },
+                    k,
+                );
+            }
+            BaseType_::UnresolvedError => w.write("_|_"),
+        }
+    }
+}
+
+impl AstDebug for SingleType_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            SingleType_::Base(b) => b.ast_debug(w),
+            SingleType_::Ref(mut_, s) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                s.ast_debug(w)
+            }
+        }
+    }
+}
+
+impl AstDebug for Type_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Type_::Unit => w.write("()"),
+            Type_::Single(s) => s.ast_debug(w),
+            Type_::Multiple(ss) => {
+                w.write("(");
+                ss.ast_debug(w);
+                w.write(")")
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<SingleType> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.comma(self, |w, s| s.ast_debug(w))
+    }
+}
+
+impl AstDebug for Vec<BaseType> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.comma(self, |w, s| s.ast_debug(w))
+    }
+}
+
+impl AstDebug for VecDeque<Statement> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.semicolon(self, |w, stmt| stmt.ast_debug(w))
+    }
+}
+
+impl AstDebug for Statement_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Statement_ as S;
+        match self {
+            S::Command(cmd) => cmd.ast_debug(w),
+            S::IfElse {
+                cond,
+                if_block,
+                else_block,
+            } => {
+                w.write("if (");
+                cond.ast_debug(w);
+                w.write(") ");
+                w.block(|w| if_block.ast_debug(w));
+                w.write(" else ");
+                w.block(|w| else_block.ast_debug(w));
+            }
+            S::While { cond, block } => {
+                w.write("while (");
+                cond.ast_debug(w);
+                w.write(")");
+                w.block(|w| block.ast_debug(w))
+            }
+            S::Loop {
+                block,
+                has_break,
+                has_return_abort,
+            } => {
+                w.write("loop");
+                if *has_break {
+                    w.write("#has_break");
+                }
+                if *has_return_abort {
+                    w.write("#has_return_abort");
+                }
+                w.write(" ");
+                w.block(|w| block.ast_debug(w))
+            }
+        }
+    }
+}
+
+impl AstDebug for Command_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Command_ as C;
+        match self {
+            C::Assign(lvalues, rhs) => {
+                lvalues.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
+            }
+            C::Mutate(lhs, rhs) => {
+                w.write("*");
+                lhs.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
+            }
+            C::Abort(e) => {
+                w.write("abort ");
+                e.ast_debug(w);
+            }
+            C::Return(e) => {
+                w.write("return ");
+                e.ast_debug(w);
+            }
+            C::Break => w.write("break"),
+            C::Continue => w.write("continue"),
+            C::IgnoreAndPop { pop_num, exp } => {
+                w.write("pop ");
+                w.comma(0..*pop_num, |w, _| w.write("_"));
+                w.write(" = ");
+                exp.ast_debug(w);
+            }
+        }
+    }
+}
+
+impl AstDebug for Exp {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Exp { ty, exp } = self;
+        w.annotate(|w| exp.ast_debug(w), ty)
+    }
+}
+
+impl AstDebug for UnannotatedExp_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use UnannotatedExp_ as E;
+        match self {
+            E::Unit => w.write("()"),
+            E::Value(v) => v.ast_debug(w),
+            E::Move {
+                from_user: false,
+                var: v,
+            } => w.write(&format!("move {}", v)),
+            E::Move {
+                from_user: true,
+                var: v,
+            } => w.write(&format!("move@{}", v)),
+            E::Copy {
+                from_user: false,
+                var: v,
+            } => w.write(&format!("copy {}", v)),
+            E::Copy {
+                from_user: true,
+                var: v,
+            } => w.write(&format!("copy@{}", v)),
+            E::ModuleCall(mcall) => {
+                mcall.ast_debug(w);
+            }
+            E::Builtin(bf, rhs) => {
+                bf.ast_debug(w);
+                w.write("(");
+                rhs.ast_debug(w);
+                w.write(")");
+            }
+            E::Freeze(e) => {
+                w.write("freeze(");
+                e.ast_debug(w);
+                w.write(")");
+            }
+            E::Pack(s, tys, fields) => {
+                w.write(&format!("{}", s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, bt, e)| {
+                    w.annotate(|w| w.write(&format!("{}", f)), bt);
+                    w.write(": ");
+                    e.ast_debug(w);
+                });
+                w.write("}");
+            }
+
+            E::ExpList(es) => {
+                w.write("(");
+                w.comma(es, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+
+            E::Dereference(e) => {
+                w.write("*");
+                e.ast_debug(w)
+            }
+            E::UnaryExp(op, e) => {
+                op.ast_debug(w);
+                w.write(" ");
+                e.ast_debug(w);
+            }
+            E::BinopExp(l, op, r) => {
+                l.ast_debug(w);
+                w.write(" ");
+                op.ast_debug(w);
+                w.write(" ");
+                r.ast_debug(w)
+            }
+            E::Borrow(mut_, e, f) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                e.ast_debug(w);
+                w.write(&format!(".{}", f));
+            }
+            E::BorrowLocal(mut_, v) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                w.write(&format!("{}", v));
+            }
+            E::UnresolvedError => w.write("_|_"),
+        }
+    }
+}
+
+impl AstDebug for ModuleCall {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleCall {
+            module,
+            name,
+            type_arguments,
+            acquires,
+            arguments,
+        } = self;
+        w.write(&format!("{}::{}", module, name));
+        if !acquires.is_empty() {
+            w.write("[acquires: [");
+            w.comma(acquires, |w, s| w.write(&format!("{}", s)));
+            w.write("]], ");
+        }
+        w.write("<");
+        type_arguments.ast_debug(w);
+        w.write(">");
+        w.write("(");
+        arguments.ast_debug(w);
+        w.write(")");
+    }
+}
+
+impl AstDebug for BuiltinFunction_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use crate::naming::ast::BuiltinFunction_ as NF;
+        use BuiltinFunction_ as F;
+        let (n, bt) = match self {
+            F::MoveToSender(bt) => (NF::MOVE_TO_SENDER, bt),
+            F::MoveFrom(bt) => (NF::MOVE_FROM, bt),
+            F::BorrowGlobal(true, bt) => (NF::BORROW_GLOBAL_MUT, bt),
+            F::BorrowGlobal(false, bt) => (NF::BORROW_GLOBAL, bt),
+            F::Exists(bt) => (NF::EXISTS, bt),
+        };
+        w.write(n);
+        w.write("<");
+        bt.ast_debug(w);
+        w.write(">");
+    }
+}
+
+impl AstDebug for ExpListItem {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            ExpListItem::Single(e, st) => w.annotate(|w| e.ast_debug(w), st),
+            ExpListItem::Splat(_, e, ss) => {
+                w.write("~");
+                w.annotate(|w| e.ast_debug(w), ss)
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<LValue> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let parens = self.len() != 1;
+        if parens {
+            w.write("(");
+        }
+        w.comma(self, |w, a| a.ast_debug(w));
+        if parens {
+            w.write(")");
+        }
+    }
+}
+
+impl AstDebug for LValue_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use LValue_ as L;
+        match self {
+            L::Ignore => w.write("_"),
+            L::Var(v, st) => {
+                w.write(&format!("({}: ", v));
+                st.ast_debug(w);
+                w.write(")");
+            }
+            L::Unpack(s, tys, fields) => {
+                w.write(&format!("{}", s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, l)| {
+                    w.write(&format!("{}: ", f));
+                    l.ast_debug(w)
+                });
+                w.write("}");
+            }
+        }
     }
 }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{sp, Address, Identifier, Loc, Name, Spanned, TName};
+use crate::shared::{ast_debug::*, sp, Address, Identifier, Loc, Name, Spanned, TName};
 use std::fmt;
 
 macro_rules! new_name {
@@ -481,6 +481,492 @@ impl fmt::Display for BinOp_ {
             Gt => write!(f, ">"),
             Le => write!(f, "<="),
             Ge => write!(f, ">="),
+        }
+    }
+}
+
+//**************************************************************************************************
+// Debug
+//**************************************************************************************************
+
+impl AstDebug for Program {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write("------ Lib Defs: ------");
+        for src in &self.source_definitions {
+            src.ast_debug(w);
+        }
+        w.new_line();
+        w.write("------ Source Defs: ------");
+        for src in &self.source_definitions {
+            src.ast_debug(w);
+        }
+    }
+}
+
+impl AstDebug for FileDefinition {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            FileDefinition::Main(m) => m.ast_debug(w),
+            FileDefinition::Modules(moras) => {
+                for mora in moras {
+                    mora.ast_debug(w);
+                    w.new_line();
+                    w.new_line();
+                }
+            }
+        }
+    }
+}
+
+impl AstDebug for Main {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Main { uses, function } = self;
+        uses.ast_debug(w);
+        function.ast_debug(w);
+    }
+}
+
+impl AstDebug for ModuleOrAddress {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            ModuleOrAddress::Address(_, addr) => {
+                w.writeln(&format!("address {}:", addr));
+            }
+            ModuleOrAddress::Module(m) => m.ast_debug(w),
+        }
+    }
+}
+
+impl AstDebug for ModuleDefinition {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleDefinition {
+            uses,
+            name,
+            structs,
+            functions,
+        } = self;
+        w.write(&format!("module {}", name));
+        w.block(|w| {
+            uses.ast_debug(w);
+            for sdef in structs {
+                sdef.ast_debug(w);
+                w.new_line();
+            }
+            for fdef in functions {
+                fdef.ast_debug(w);
+                w.new_line();
+            }
+        });
+    }
+}
+
+impl AstDebug for Vec<(ModuleIdent, Option<ModuleName>)> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.semicolon(self, |w, item| item.ast_debug(w));
+        w.writeln(";");
+    }
+}
+
+impl AstDebug for (ModuleIdent, Option<ModuleName>) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (m, alias_opt) = self;
+        w.write(&format!("use {}", m));
+        if let Some(alias) = alias_opt {
+            w.write(&format!(" as {}", alias))
+        }
+        w.writeln(";");
+    }
+}
+
+impl AstDebug for StructDefinition {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let StructDefinition {
+            resource_opt,
+            name,
+            type_parameters,
+            fields,
+        } = self;
+        if let StructFields::Native(_) = fields {
+            w.write("native ");
+        }
+        if resource_opt.is_some() {
+            w.write("resource ");
+        }
+        w.write(&format!("struct {}", name));
+        type_parameters.ast_debug(w);
+        if let StructFields::Defined(fields) = fields {
+            w.block(|w| {
+                w.semicolon(fields, |w, (f, st)| {
+                    w.write(&format!("{}: ", f));
+                    st.ast_debug(w);
+                })
+            })
+        }
+    }
+}
+
+impl AstDebug for Function {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Function {
+            visibility,
+            signature,
+            acquires,
+            name,
+            body,
+        } = self;
+        visibility.ast_debug(w);
+        if let FunctionBody_::Native = &body.value {
+            w.write("native ");
+        }
+        w.write(&format!("{}", name));
+        signature.ast_debug(w);
+        if !acquires.is_empty() {
+            w.write(" acquires ");
+            w.comma(acquires, |w, m| m.ast_debug(w));
+            w.write(" ");
+        }
+        match &body.value {
+            FunctionBody_::Defined(body) => w.block(|w| body.ast_debug(w)),
+            FunctionBody_::Native => w.writeln(";"),
+        }
+    }
+}
+
+impl AstDebug for FunctionVisibility {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            FunctionVisibility::Internal => (),
+            FunctionVisibility::Public(_) => w.write("public "),
+        }
+    }
+}
+
+impl AstDebug for FunctionSignature {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let FunctionSignature {
+            type_parameters,
+            parameters,
+            return_type,
+        } = self;
+        type_parameters.ast_debug(w);
+        w.write("(");
+        w.comma(parameters, |w, (v, st)| {
+            w.write(&format!("{}: ", v));
+            st.ast_debug(w);
+        });
+        w.write(")");
+        w.write(": ");
+        return_type.ast_debug(w)
+    }
+}
+
+impl AstDebug for Vec<(Name, Kind)> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        if !self.is_empty() {
+            w.write("<");
+            w.comma(self, |w, tp| tp.ast_debug(w));
+            w.write(">")
+        }
+    }
+}
+
+impl AstDebug for (Name, Kind) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (n, k) = self;
+        w.write(&n.value);
+        match &k.value {
+            Kind_::Unknown => (),
+            Kind_::Resource | Kind_::Affine => {
+                w.write(": ");
+                k.ast_debug(w)
+            }
+            Kind_::Unrestricted => panic!("ICE 'unrestricted' kind constraint"),
+        }
+    }
+}
+
+impl AstDebug for Kind_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write(match self {
+            Kind_::Unknown => "unknown",
+            Kind_::Resource => "resource",
+            Kind_::Affine => "copyable",
+            Kind_::Unrestricted => "unrestricted",
+        })
+    }
+}
+
+impl AstDebug for Type_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            Type_::Unit => w.write("()"),
+            Type_::Single(s) => s.ast_debug(w),
+            Type_::Multiple(ss) => {
+                w.write("(");
+                ss.ast_debug(w);
+                w.write(")")
+            }
+        }
+    }
+}
+
+impl AstDebug for SingleType_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            SingleType_::Apply(m, ss) => {
+                m.ast_debug(w);
+                if !ss.is_empty() {
+                    w.write("<");
+                    ss.ast_debug(w);
+                    w.write(">");
+                }
+            }
+            SingleType_::Ref(mut_, s) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                s.ast_debug(w)
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<SingleType> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.comma(self, |w, s| s.ast_debug(w))
+    }
+}
+
+impl AstDebug for ModuleAccess_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write(&match self {
+            ModuleAccess_::Name(n) => format!("{}", n),
+            ModuleAccess_::ModuleAccess(m, n) => format!("{}::{}", m, n),
+            ModuleAccess_::QualifiedModuleAccess(m, n) => format!("{}::{}", m, n),
+        })
+    }
+}
+
+impl AstDebug for (Vec<SequenceItem>, Box<Option<Exp>>) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (seq, last_e) = self;
+        w.semicolon(seq, |w, item| item.ast_debug(w));
+        if !seq.is_empty() {
+            w.writeln(";")
+        }
+        if let Some(e) = &**last_e {
+            e.ast_debug(w)
+        }
+    }
+}
+
+impl AstDebug for SequenceItem_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use SequenceItem_ as I;
+        match self {
+            I::Seq(e) => e.ast_debug(w),
+            I::Declare(sp!(_, bs), ty_opt) => {
+                w.write("let ");
+                bs.ast_debug(w);
+                if let Some(ty) = ty_opt {
+                    ty.ast_debug(w)
+                }
+            }
+            I::Bind(sp!(_, bs), ty_opt, e) => {
+                w.write("let ");
+                bs.ast_debug(w);
+                if let Some(ty) = ty_opt {
+                    ty.ast_debug(w)
+                }
+                w.write(" = ");
+                e.ast_debug(w);
+            }
+        }
+    }
+}
+
+impl AstDebug for Exp_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Exp_ as E;
+        match self {
+            E::Unit => w.write("()"),
+            E::Value(v) => v.ast_debug(w),
+            E::Move(v) => w.write(&format!("move {}", v)),
+            E::Copy(v) => w.write(&format!("copy {}", v)),
+            E::Name(n) => w.write(&format!("{}", n)),
+            E::GlobalCall(n, tys_opt, sp!(_, rhs)) => {
+                w.write(&format!("::{}", n));
+                if let Some(ss) = tys_opt {
+                    w.write("<");
+                    ss.ast_debug(w);
+                    w.write(">");
+                }
+                w.write("(");
+                w.comma(rhs, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+            E::Call(ma, tys_opt, sp!(_, rhs)) => {
+                ma.ast_debug(w);
+                if let Some(ss) = tys_opt {
+                    w.write("<");
+                    ss.ast_debug(w);
+                    w.write(">");
+                }
+                w.write("(");
+                w.comma(rhs, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+            E::Pack(ma, tys_opt, fields) => {
+                ma.ast_debug(w);
+                if let Some(ss) = tys_opt {
+                    w.write("<");
+                    ss.ast_debug(w);
+                    w.write(">");
+                }
+                w.write("{");
+                w.comma(fields, |w, (f, e)| {
+                    w.write(&format!("{}: ", f));
+                    e.ast_debug(w);
+                });
+                w.write("}");
+            }
+            E::IfElse(b, t, f_opt) => {
+                w.write("if (");
+                b.ast_debug(w);
+                w.write(") ");
+                t.ast_debug(w);
+                if let Some(f) = f_opt {
+                    w.write(" else ");
+                    f.ast_debug(w);
+                }
+            }
+            E::While(b, e) => {
+                w.write("while (");
+                b.ast_debug(w);
+                w.write(")");
+                e.ast_debug(w);
+            }
+            E::Loop(e) => {
+                w.write("loop ");
+                e.ast_debug(w);
+            }
+            E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::ExpList(es) => {
+                w.write("(");
+                w.comma(es, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+            E::Assign(lvalue, rhs) => {
+                lvalue.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
+            }
+            E::Return(e) => {
+                w.write("return ");
+                e.ast_debug(w);
+            }
+            E::Abort(e) => {
+                w.write("abort ");
+                e.ast_debug(w);
+            }
+            E::Break => w.write("break"),
+            E::Continue => w.write("continue"),
+            E::Dereference(e) => {
+                w.write("*");
+                e.ast_debug(w)
+            }
+            E::UnaryExp(op, e) => {
+                op.ast_debug(w);
+                w.write(" ");
+                e.ast_debug(w);
+            }
+            E::BinopExp(l, op, r) => {
+                l.ast_debug(w);
+                w.write(" ");
+                op.ast_debug(w);
+                w.write(" ");
+                r.ast_debug(w)
+            }
+            E::Borrow(mut_, e) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                e.ast_debug(w);
+            }
+            E::Dot(e, n) => {
+                e.ast_debug(w);
+                w.write(&format!(".{}", n));
+            }
+            E::Annotate(e, ty) => {
+                w.write("(");
+                e.ast_debug(w);
+                w.write(": ");
+                ty.ast_debug(w);
+                w.write(")");
+            }
+            E::UnresolvedError => w.write("_|_"),
+        }
+    }
+}
+
+impl AstDebug for BinOp_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write(&format!("{}", self));
+    }
+}
+
+impl AstDebug for UnaryOp_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write(&format!("{}", self));
+    }
+}
+
+impl AstDebug for Value_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Value_ as V;
+        w.write(&match self {
+            V::Address(addr) => format!("{}", addr),
+            V::U64(u) => format!("{}", u),
+            V::Bool(b) => format!("{}", b),
+            V::Bytearray(v) => format!("{:?}", v),
+        })
+    }
+}
+
+impl AstDebug for Vec<Bind> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let parens = self.len() != 1;
+        if parens {
+            w.write("(");
+        }
+        w.comma(self, |w, b| b.ast_debug(w));
+        if parens {
+            w.write(")");
+        }
+    }
+}
+
+impl AstDebug for Bind_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Bind_ as B;
+        match self {
+            B::Var(v) => w.write(&format!("{}", v)),
+            B::Unpack(ma, tys_opt, fields) => {
+                ma.ast_debug(w);
+                if let Some(ss) = tys_opt {
+                    w.write("<");
+                    ss.ast_debug(w);
+                    w.write(">");
+                }
+                w.write("{");
+                w.comma(fields, |w, (f, b)| {
+                    w.write(&format!("{}: ", f));
+                    b.ast_debug(w);
+                });
+                w.write("}");
+            }
         }
     }
 }

--- a/language/move-lang/src/shared/ast_debug.rs
+++ b/language/move-lang/src/shared/ast_debug.rs
@@ -1,0 +1,178 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Simple trait used for pretty printing the various AST
+///
+/// Unfortunately, the trait implementation cannot be derived. The actual implementation should
+/// closely resemble the source syntax. As suchfield does not get printed in a direct manner, and
+/// most of the logic is ad hoc
+///
+/// To avoid missing fields in the printing, be sure to fully pattern match against the struct
+/// (without the use of `..`) when implementing `AstDebug`. For example,
+///
+/// ```rust,ignore
+/// impl AstDebug for StructDefinition {
+///     fn ast_debug(&self, w: &mut AstWriter) {
+///         let StructDefinition {
+///             resource_opt,
+///             name,
+///             type_parameters,
+///             fields,
+///         } = self;
+///         ...
+///     }
+/// }
+/// ```
+pub trait AstDebug {
+    fn ast_debug(&self, w: &mut AstWriter);
+}
+
+impl<T: AstDebug> AstDebug for Box<T> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        self.as_ref().ast_debug(w)
+    }
+}
+
+pub fn print<T: AstDebug>(t: &T) {
+    let mut writer = AstWriter::normal();
+    t.ast_debug(&mut writer);
+    print!("{}", writer);
+}
+
+pub fn print_verbose<T: AstDebug>(t: &T) {
+    let mut writer = AstWriter::verbose();
+    t.ast_debug(&mut writer);
+    print!("{}", writer);
+}
+
+pub struct AstWriter {
+    verbose: bool,
+    margin: usize,
+    lines: Vec<String>,
+}
+
+impl AstWriter {
+    fn new(verbose: bool) -> Self {
+        Self {
+            verbose,
+            margin: 0,
+            lines: vec![String::new()],
+        }
+    }
+
+    fn normal() -> Self {
+        Self::new(false)
+    }
+
+    fn verbose() -> Self {
+        Self::new(true)
+    }
+
+    fn cur(&mut self) -> &mut String {
+        self.lines.last_mut().unwrap()
+    }
+
+    pub fn new_line(&mut self) {
+        self.lines.push(String::new());
+    }
+
+    pub fn write(&mut self, s: &str) {
+        let margin = self.margin;
+        let cur = self.cur();
+        if cur.is_empty() {
+            (0..margin).for_each(|_| cur.push(' '));
+        }
+        cur.push_str(s);
+    }
+
+    pub fn writeln(&mut self, s: &str) {
+        self.write(s);
+        self.new_line();
+    }
+
+    pub fn indent<F: FnOnce(&mut AstWriter) -> ()>(&mut self, inc: usize, f: F) {
+        self.new_line();
+        self.margin += inc;
+        f(self);
+        self.margin -= inc;
+        self.new_line();
+    }
+
+    pub fn block<F: FnOnce(&mut AstWriter) -> ()>(&mut self, f: F) {
+        self.write(" {");
+        self.indent(4, f);
+        self.write("}");
+    }
+
+    pub fn annotate<F: FnOnce(&mut AstWriter) -> (), Annot: AstDebug>(
+        &mut self,
+        f: F,
+        annot: &Annot,
+    ) {
+        if self.verbose {
+            self.write("(");
+        }
+        f(self);
+        if self.verbose {
+            self.write(": ");
+            annot.ast_debug(self);
+            self.write(")");
+        }
+    }
+
+    pub fn list<T, F: FnMut(&mut AstWriter, T) -> bool>(
+        &mut self,
+        items: impl std::iter::IntoIterator<Item = T>,
+        sep: &str,
+        mut f: F,
+    ) {
+        let iter = items.into_iter();
+        let len = match iter.size_hint() {
+            (lower, None) => {
+                assert!(lower == 0);
+                return;
+            }
+            (_, Some(len)) => len,
+        };
+        for (idx, item) in iter.enumerate() {
+            let needs_newline = f(self, item);
+            if idx + 1 != len {
+                self.write(sep);
+                if needs_newline {
+                    self.new_line()
+                }
+            }
+        }
+    }
+
+    pub fn comma<T, F: FnMut(&mut AstWriter, T) -> ()>(
+        &mut self,
+        items: impl std::iter::IntoIterator<Item = T>,
+        mut f: F,
+    ) {
+        self.list(items, ", ", |w, item| {
+            f(w, item);
+            false
+        })
+    }
+
+    pub fn semicolon<T, F: FnMut(&mut AstWriter, T) -> ()>(
+        &mut self,
+        items: impl std::iter::IntoIterator<Item = T>,
+        mut f: F,
+    ) {
+        self.list(items, ";", |w, item| {
+            f(w, item);
+            true
+        })
+    }
+}
+
+impl std::fmt::Display for AstWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        for line in &self.lines {
+            writeln!(f, "{}", line)?;
+        }
+        Ok(())
+    }
+}

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -11,6 +11,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
 };
 
+pub mod ast_debug;
 pub mod fake_natives;
 pub mod remembering_unique_map;
 pub mod unique_map;
@@ -225,6 +226,12 @@ impl<T: fmt::Display> fmt::Display for Spanned<T> {
 impl<T: fmt::Debug> fmt::Debug for Spanned<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", &self.value)
+    }
+}
+
+impl<T: ast_debug::AstDebug> ast_debug::AstDebug for Spanned<T> {
+    fn ast_debug(&self, w: &mut ast_debug::AstWriter) {
+        self.value.ast_debug(w)
     }
 }
 

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::unique_map::UniqueMap;
 use crate::{
     expansion::ast::Fields,
     naming::ast::{BaseType, FunctionSignature, SingleType, StructDefinition, Type, Type_},
@@ -9,6 +8,8 @@ use crate::{
         BinOp, Field, FunctionName, FunctionVisibility, ModuleIdent, StructName, UnaryOp, Value,
         Var,
     },
+    shared::ast_debug::*,
+    shared::unique_map::UniqueMap,
     shared::*,
 };
 use std::{
@@ -249,5 +250,451 @@ impl fmt::Display for BuiltinFunction_ {
             Freeze(_) => NB::FREEZE,
         };
         write!(f, "{}", s)
+    }
+}
+
+//**************************************************************************************************
+// Debug
+//**************************************************************************************************
+
+impl AstDebug for Program {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Program { modules, main } = self;
+        for (m, mdef) in modules {
+            w.write(&format!("module {}", m));
+            w.block(|w| mdef.ast_debug(w));
+            w.new_line();
+        }
+
+        if let Some((addr, n, fdef)) = main {
+            w.writeln(&format!("address {}:", addr));
+            (n.clone(), fdef).ast_debug(w);
+        }
+    }
+}
+
+impl AstDebug for ModuleDefinition {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleDefinition {
+            is_source_module,
+            structs,
+            functions,
+        } = self;
+        match is_source_module {
+            None => w.writeln("library module"),
+            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        }
+        for sdef in structs {
+            sdef.ast_debug(w);
+            w.new_line();
+        }
+        for fdef in functions {
+            fdef.ast_debug(w);
+            w.new_line();
+        }
+    }
+}
+
+impl AstDebug for (FunctionName, &Function) {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let (
+            name,
+            Function {
+                visibility,
+                signature,
+                acquires,
+                body,
+            },
+        ) = self;
+        visibility.ast_debug(w);
+        if let FunctionBody_::Native = &body.value {
+            w.write("native ");
+        }
+        w.write(&format!("{}", name));
+        signature.ast_debug(w);
+        if !acquires.is_empty() {
+            w.write(" acquires ");
+            w.comma(acquires, |w, s| w.write(&format!("{}", s)));
+            w.write(" ");
+        }
+        match &body.value {
+            FunctionBody_::Defined(body) => w.block(|w| body.ast_debug(w)),
+            FunctionBody_::Native => w.writeln(";"),
+        }
+    }
+}
+
+impl AstDebug for VecDeque<SequenceItem> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.semicolon(self, |w, item| item.ast_debug(w))
+    }
+}
+
+impl AstDebug for SequenceItem_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use SequenceItem_ as I;
+        match self {
+            I::Seq(e) => e.ast_debug(w),
+            I::Declare(sp!(_, bs)) => {
+                w.write("let ");
+                bs.ast_debug(w);
+            }
+            I::Bind(sp!(_, bs), expected_types, e) => {
+                w.write("let ");
+                bs.ast_debug(w);
+                w.write(": (");
+                expected_types.ast_debug(w);
+                w.write(")");
+                w.write(" = ");
+                e.ast_debug(w);
+            }
+        }
+    }
+}
+
+impl AstDebug for UnannotatedExp_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use UnannotatedExp_ as E;
+        match self {
+            E::Unit => w.write("()"),
+            E::Value(v) => v.ast_debug(w),
+            E::Move {
+                from_user: false,
+                var: v,
+            } => w.write(&format!("move {}", v)),
+            E::Move {
+                from_user: true,
+                var: v,
+            } => w.write(&format!("move@{}", v)),
+            E::Copy {
+                from_user: false,
+                var: v,
+            } => w.write(&format!("copy {}", v)),
+            E::Copy {
+                from_user: true,
+                var: v,
+            } => w.write(&format!("copy@{}", v)),
+            E::Use(v) => w.write(&format!("use@{}", v)),
+            E::ModuleCall(mcall) => {
+                mcall.ast_debug(w);
+            }
+            E::Builtin(bf, rhs) => {
+                bf.ast_debug(w);
+                w.write("(");
+                rhs.ast_debug(w);
+                w.write(")");
+            }
+            E::Pack(m, s, tys, fields) => {
+                w.write(&format!("{}::{}", m, s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, idx_bt_e)| {
+                    let (idx, (bt, e)) = idx_bt_e;
+                    w.write(&format!("({}#{}:", idx, f));
+                    bt.ast_debug(w);
+                    w.write("): ");
+                    e.ast_debug(w);
+                });
+                w.write("}");
+            }
+            E::IfElse(b, t, f) => {
+                w.write("if (");
+                b.ast_debug(w);
+                w.write(") ");
+                t.ast_debug(w);
+                w.write(" else ");
+                f.ast_debug(w);
+            }
+            E::While(b, e) => {
+                w.write("while (");
+                b.ast_debug(w);
+                w.write(")");
+                e.ast_debug(w);
+            }
+            E::Loop { has_break, body } => {
+                w.write("loop");
+                if *has_break {
+                    w.write("#with_break");
+                }
+                w.write(" ");
+                body.ast_debug(w);
+            }
+            E::Block(seq) => w.block(|w| seq.ast_debug(w)),
+            E::ExpList(es) => {
+                w.write("(");
+                w.comma(es, |w, e| e.ast_debug(w));
+                w.write(")");
+            }
+
+            E::Assign(sp!(_, lvalues), expected_types, rhs) => {
+                lvalues.ast_debug(w);
+                w.write(": (");
+                expected_types.ast_debug(w);
+                w.write(") = ");
+                rhs.ast_debug(w);
+            }
+
+            E::Mutate(lhs, rhs) => {
+                w.write("*");
+                lhs.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
+            }
+
+            E::Return(e) => {
+                w.write("return ");
+                e.ast_debug(w);
+            }
+            E::Abort(e) => {
+                w.write("abort ");
+                e.ast_debug(w);
+            }
+            E::Break => w.write("break"),
+            E::Continue => w.write("continue"),
+            E::Dereference(e) => {
+                w.write("*");
+                e.ast_debug(w)
+            }
+            E::UnaryExp(op, e) => {
+                op.ast_debug(w);
+                w.write(" ");
+                e.ast_debug(w);
+            }
+            E::BinopExp(l, op, ty, r) => {
+                l.ast_debug(w);
+                w.write(" ");
+                op.ast_debug(w);
+                w.write("@");
+                ty.ast_debug(w);
+                w.write(" ");
+                r.ast_debug(w)
+            }
+            E::Borrow(mut_, e, f) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                e.ast_debug(w);
+                w.write(&format!(".{}", f));
+            }
+            E::TempBorrow(mut_, e) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                e.ast_debug(w);
+            }
+            E::BorrowLocal(mut_, v) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                w.write(&format!("{}", v));
+            }
+            E::Annotate(e, ty) => {
+                w.write("annot(");
+                e.ast_debug(w);
+                w.write(": ");
+                ty.ast_debug(w);
+                w.write(")");
+            }
+            E::UnresolvedError => w.write("_|_"),
+        }
+    }
+}
+
+impl AstDebug for Exp {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let Exp { ty, exp } = self;
+        w.annotate(|w| exp.ast_debug(w), ty)
+    }
+}
+
+impl AstDebug for ModuleCall {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let ModuleCall {
+            module,
+            name,
+            type_arguments,
+            parameter_types,
+            acquires,
+            arguments,
+        } = self;
+        w.write(&format!("{}::{}", module, name));
+        if !acquires.is_empty() || !parameter_types.is_empty() {
+            w.write("[");
+            if !acquires.is_empty() {
+                w.write("acquires: [");
+                w.comma(acquires, |w, s| w.write(&format!("{}", s)));
+                w.write("], ");
+            }
+            if !parameter_types.is_empty() {
+                if !acquires.is_empty() {
+                    w.write(", ");
+                }
+                w.write("parameter_types: [");
+                parameter_types.ast_debug(w);
+                w.write("]");
+            }
+        }
+        w.write("<");
+        type_arguments.ast_debug(w);
+        w.write(">");
+        w.write("(");
+        arguments.ast_debug(w);
+        w.write(")");
+    }
+}
+
+impl AstDebug for BuiltinFunction_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use crate::naming::ast::BuiltinFunction_ as NF;
+        use BuiltinFunction_ as F;
+        let (n, bt) = match self {
+            F::MoveToSender(bt) => (NF::MOVE_TO_SENDER, bt),
+            F::MoveFrom(bt) => (NF::MOVE_FROM, bt),
+            F::BorrowGlobal(true, bt) => (NF::BORROW_GLOBAL_MUT, bt),
+            F::BorrowGlobal(false, bt) => (NF::BORROW_GLOBAL, bt),
+            F::Exists(bt) => (NF::EXISTS, bt),
+            F::Freeze(bt) => (NF::FREEZE, bt),
+        };
+        w.write(n);
+        w.write("<");
+        bt.ast_debug(w);
+        w.write(">");
+    }
+}
+
+impl AstDebug for ExpListItem {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        match self {
+            ExpListItem::Single(e, st) => w.annotate(|w| e.ast_debug(w), st),
+            ExpListItem::Splat(_, e, ss) => {
+                w.write("~");
+                w.annotate(|w| e.ast_debug(w), ss)
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<Bind> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let parens = self.len() != 1;
+        if parens {
+            w.write("(");
+        }
+        w.comma(self, |w, b| b.ast_debug(w));
+        if parens {
+            w.write(")");
+        }
+    }
+}
+
+impl AstDebug for Bind_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Bind_ as B;
+        match self {
+            B::Ignore => w.write("_"),
+            B::Var(v, None) => w.write(&format!("{}", v)),
+            B::Var(v, Some(st)) => w.annotate(|w| w.write(&format!("{}", v)), st),
+            B::Unpack(m, s, tys, fields) => {
+                w.write(&format!("{}::{}", m, s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, idx_bt_b)| {
+                    let (idx, (bt, b)) = idx_bt_b;
+                    w.annotate(|w| w.write(&format!("{}#{}", idx, f)), bt);
+                    w.write(": ");
+                    b.ast_debug(w);
+                });
+                w.write("}");
+            }
+            B::BorrowUnpack(mut_, m, s, tys, fields) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                w.write(&format!("{}::{}", m, s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, idx_bt_b)| {
+                    let (idx, (bt, b)) = idx_bt_b;
+                    w.annotate(|w| w.write(&format!("{}#{}", idx, f)), bt);
+                    w.write(": ");
+                    b.ast_debug(w);
+                });
+                w.write("}");
+            }
+        }
+    }
+}
+
+impl AstDebug for Vec<Option<SingleType>> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.comma(self, |w, s_opt| match s_opt {
+            Some(s) => s.ast_debug(w),
+            None => w.write("%no_exp%"),
+        })
+    }
+}
+
+impl AstDebug for Vec<Assign> {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        let parens = self.len() != 1;
+        if parens {
+            w.write("(");
+        }
+        w.comma(self, |w, a| a.ast_debug(w));
+        if parens {
+            w.write(")");
+        }
+    }
+}
+
+impl AstDebug for Assign_ {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        use Assign_ as A;
+        match self {
+            A::Ignore => w.write("_"),
+            A::Var(v, st) => w.annotate(|w| w.write(&format!("{}", v)), st),
+            A::Unpack(m, s, tys, fields) => {
+                w.write(&format!("{}::{}", m, s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, idx_bt_a)| {
+                    let (idx, (bt, a)) = idx_bt_a;
+                    w.annotate(|w| w.write(&format!("{}#{}", idx, f)), bt);
+                    w.write(": ");
+                    a.ast_debug(w);
+                });
+                w.write("}");
+            }
+            A::BorrowUnpack(mut_, m, s, tys, fields) => {
+                w.write("&");
+                if *mut_ {
+                    w.write("mut ");
+                }
+                w.write(&format!("{}::{}", m, s));
+                w.write("<");
+                tys.ast_debug(w);
+                w.write(">");
+                w.write("{");
+                w.comma(fields, |w, (f, idx_bt_a)| {
+                    let (idx, (bt, a)) = idx_bt_a;
+                    w.annotate(|w| w.write(&format!("{}#{}", idx, f)), bt);
+                    w.write(": ");
+                    a.ast_debug(w);
+                });
+                w.write("}");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Motivation

- Added pretty printer debugging for Move source language asts
- Added basic writer + trait for the printers
  - Display/Debug writers do not have margin settings, thus a custom writer was needed
  - I avoided Display/Debug from the printers accidentally being used in error messages. The printed results are not meant to be read by end users. 

## Test Plan

- eyes
- cargo check
- only for debugging needs

