### PR TITLE
[terraform][cluster-test] Add Flamegraph repo to validator hosts

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -34,4 +34,8 @@ cat > /etc/profile.d/libra_prompt.sh <<EOF
 export PS1="[\u:validator@\h \w]$ "
 EOF
 
-yum -y install ngrep tcpdump perf gdb nmap-ncat strace htop sysstat tc
+yum -y install ngrep tcpdump perf gdb nmap-ncat strace htop sysstat tc git
+
+if [ ! -d /usr/local/etc/FlameGraph ] ; then
+    git clone --depth 1 https://github.com/brendangregg/FlameGraph /usr/local/etc/FlameGraph
+fi


### PR DESCRIPTION
## Summary

This is so that we can run the Flamegraph script along with `perf` tool on the same host to generate the performance Flamegraph
