### PR TITLE
[mempool] redo commit notification flow across consensus, state sync, mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,6 +4414,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "network 0.1.0",

--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -6,7 +6,7 @@ use admission_control_proto::proto::admission_control::{
     admission_control_server::AdmissionControl, SubmitTransactionRequest,
 };
 use futures::executor::block_on;
-use libra_mempool::mocks::mock_shared_mempool;
+use libra_mempool::mocks::MockSharedMempool;
 use libra_proptest_helpers::ValueGenerator;
 use libra_prost_ext::MessageExt;
 use libra_types::transaction::SignedTransaction;
@@ -38,7 +38,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
 /// service
 pub fn fuzzer(data: &[u8]) {
     // set up AC backed by SMP
-    let smp = mock_shared_mempool(None);
+    let smp = MockSharedMempool::new(None);
     let ac_service = AdmissionControlService::new(smp.ac_client, Arc::new(MockStorageReadClient));
 
     // parse SubmitTransactionRequest

--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -38,8 +38,8 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
 /// service
 pub fn fuzzer(data: &[u8]) {
     // set up AC backed by SMP
-    let (_runtime, ac_sender) = mock_shared_mempool();
-    let ac_service = AdmissionControlService::new(ac_sender, Arc::new(MockStorageReadClient));
+    let smp = mock_shared_mempool(None);
+    let ac_service = AdmissionControlService::new(smp.ac_client, Arc::new(MockStorageReadClient));
 
     // parse SubmitTransactionRequest
     let req = match SubmitTransactionRequest::decode(data) {

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -65,4 +65,4 @@ vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = ["proptest", "consensus-types/fuzzing", "libra-config/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]
+fuzzing = ["proptest", "consensus-types/fuzzing", "libra-config/fuzzing", "libra-crypto/fuzzing", "libra-mempool/fuzzing", "libra-types/fuzzing"]

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -14,11 +14,16 @@ use crate::{
     consensus_provider::ConsensusProvider,
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
-use consensus_types::vote_msg::VoteMsg;
 use futures::{channel::mpsc, executor::block_on, prelude::*};
+use consensus_types::{
+    proposal_msg::{ProposalMsg, ProposalUncheckedSignatures},
+    vote_msg::VoteMsg,
+};
+use futures::{channel::mpsc, executor::block_on, prelude::*, stream::StreamExt};
 use libra_config::config::ConsensusConfig;
 use libra_config::{
     config::{
+        ConsensusConfig,
         ConsensusProposerType::{self, FixedProposer, MultipleOrderedProposers, RotatingProposer},
         NodeConfig, SafetyRulesConfig,
     },
@@ -36,9 +41,8 @@ struct SMRNode {
     smr_id: usize,
     smr: ChainedBftSMR<TestPayload>,
     commit_cb_receiver: mpsc::UnboundedReceiver<LedgerInfoWithSignatures>,
-    mempool: MockTransactionManager,
-    mempool_notif_receiver: mpsc::Receiver<usize>,
     storage: Arc<MockStorage<TestPayload>>,
+    state_sync: mpsc::UnboundedReceiver<Vec<usize>>,
 }
 
 impl SMRNode {
@@ -59,22 +63,22 @@ impl SMRNode {
         let (_, conn_status_rx) = conn_status_channel::new();
         let network_sender = ConsensusNetworkSender::new(network_reqs_tx, conn_mgr_reqs_tx);
         let network_events = ConsensusNetworkEvents::new(consensus_rx, conn_status_rx);
-
         playground.add_node(author, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);
+        let (state_sync_client, state_sync) = mpsc::unbounded();
         let (commit_cb_sender, commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
-        let (mempool, commit_receiver) = MockTransactionManager::new();
 
         let mut smr = ChainedBftSMR::new(
             network_sender,
             network_events,
             &mut config.clone(),
             Arc::new(MockStateComputer::new(
+                state_sync_client,
                 commit_cb_sender,
                 Arc::clone(&storage),
                 executor_with_reconfig,
             )),
             storage.clone(),
-            Box::new(mempool.clone()),
+            Box::new(MockTransactionManager::new()),
         );
 
         smr.start().expect("Failed to start SMR!");
@@ -83,9 +87,8 @@ impl SMRNode {
             smr_id,
             smr,
             commit_cb_receiver,
-            mempool,
-            mempool_notif_receiver: commit_receiver,
             storage,
+            state_sync,
         }
     }
 
@@ -550,14 +553,16 @@ fn basic_state_sync() {
         playground
             .wait_for_messages(3, NetworkPlayground::proposals_only)
             .await;
-        // Verify that node 3 has notified its mempool about the committed txn of next block.
-        nodes[3]
-            .mempool_notif_receiver
+
+        // TODO check ACK from state sync
+        let committed_txns = nodes[3]
+            .state_sync
             .next()
             .await
-            .expect("Fail to be notified by a mempool committed txns");
+            .expect("MockStateSync failed to be notified by a mempool committed txns");
         let max_block_size = ConsensusConfig::default().max_block_size as usize;
-        assert_eq!(nodes[3].mempool.get_committed_txns().len(), max_block_size);
+        //        assert_eq!(nodes[3].mempool.get_committed_txns().len(), max_block_size);
+        assert_eq!(committed_txns.len(), max_block_size);
     });
 }
 

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -282,6 +282,7 @@ impl<T: Payload> EpochManager<T> {
             proposal_generator,
             safety_rules,
             network_sender,
+            self.txn_manager.clone(),
             self.storage.clone(),
             self.time_service.clone(),
             validators,

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -281,7 +281,6 @@ impl<T: Payload> EpochManager<T> {
             proposer_election,
             proposal_generator,
             safety_rules,
-            self.txn_manager.clone(),
             network_sender,
             self.storage.clone(),
             self.time_service.clone(),

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -17,7 +17,6 @@ use crate::{
         },
     },
     counters,
-    state_replication::TxnManager,
     util::time_service::{
         duration_since_epoch, wait_if_possible, TimeService, WaitingError, WaitingSuccess,
     },
@@ -38,13 +37,15 @@ use consensus_types::{
 use libra_crypto::hash::TransactionAccumulatorHasher;
 use libra_logger::prelude::*;
 use libra_prost_ext::MessageExt;
-use libra_types::crypto_proxies::{
-    LedgerInfoWithSignatures, ValidatorChangeProof, ValidatorVerifier,
+use libra_types::{
+    crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof, ValidatorVerifier},
+    transaction::TransactionStatus,
 };
 use network::proto::ConsensusMsg;
 
 use crate::chained_bft::network::IncomingBlockRetrievalRequest;
 use consensus_types::block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus};
+use consensus_types::executed_block::ExecutedBlock;
 #[cfg(test)]
 use safety_rules::ConsensusState;
 use safety_rules::TSafetyRules;
@@ -148,7 +149,6 @@ pub struct EventProcessor<T> {
     proposer_election: Box<dyn ProposerElection<T> + Send + Sync>,
     proposal_generator: ProposalGenerator<T>,
     safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
-    txn_manager: Box<dyn TxnManager<Payload = T>>,
     network: NetworkSender<T>,
     storage: Arc<dyn PersistentLivenessStorage<T>>,
     time_service: Arc<dyn TimeService>,
@@ -165,7 +165,6 @@ impl<T: Payload> EventProcessor<T> {
         proposer_election: Box<dyn ProposerElection<T> + Send + Sync>,
         proposal_generator: ProposalGenerator<T>,
         safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
-        txn_manager: Box<dyn TxnManager<Payload = T>>,
         network: NetworkSender<T>,
         storage: Arc<dyn PersistentLivenessStorage<T>>,
         time_service: Arc<dyn TimeService>,
@@ -186,7 +185,6 @@ impl<T: Payload> EventProcessor<T> {
             proposer_election,
             proposal_generator,
             safety_rules,
-            txn_manager,
             network,
             storage,
             time_service,
@@ -833,10 +831,7 @@ impl<T: Payload> EventProcessor<T> {
         .await
     }
 
-    /// Upon (potentially) new commit:
-    /// 1. Commit the blocks via block store.
-    /// 2. After the state is finalized, update the txn manager with the status of the committed
-    /// transactions.
+    /// Upon (potentially) new commit, commit the blocks via block store.
     async fn process_commit(&mut self, finality_proof: LedgerInfoWithSignatures) {
         let blocks_to_commit = match self.block_store.commit(finality_proof.clone()).await {
             Ok(blocks) => blocks,
@@ -845,26 +840,9 @@ impl<T: Payload> EventProcessor<T> {
                 return;
             }
         };
-        // At this moment the new state is persisted and we can notify the clients.
-        // Multiple blocks might be committed at once: notify about all the transactions in the
-        // path from the old root to the new root.
-        for committed in blocks_to_commit {
-            if let Some(time_to_commit) = duration_since_epoch()
-                .checked_sub(Duration::from_micros(committed.timestamp_usecs()))
-            {
-                counters::CREATION_TO_COMMIT_S.observe_duration(time_to_commit);
-            }
-            if let Some(payload) = committed.payload() {
-                let compute_result = committed.compute_result();
-                if let Err(e) = self
-                    .txn_manager
-                    .commit_txns(payload, &compute_result, committed.timestamp_usecs())
-                    .await
-                {
-                    error!("Failed to notify mempool: {:?}", e);
-                }
-            }
-        }
+        Self::update_counters_for_committed_blocks(blocks_to_commit);
+        // TODO notify mempool of rejected txns via txn_manager
+
         if finality_proof.ledger_info().next_validator_set().is_some() {
             self.network
                 .broadcast_epoch_change(ValidatorChangeProof::new(
@@ -872,6 +850,48 @@ impl<T: Payload> EventProcessor<T> {
                     /* more = */ false,
                 ))
                 .await
+        }
+    }
+
+    fn update_counters_for_committed_blocks(blocks_to_commit: Vec<Arc<ExecutedBlock<T>>>) {
+        for block in blocks_to_commit {
+            if let Some(time_to_commit) =
+                duration_since_epoch().checked_sub(Duration::from_micros(block.timestamp_usecs()))
+            {
+                counters::CREATION_TO_COMMIT_S.observe_duration(time_to_commit);
+            }
+            counters::COMMITTED_BLOCKS_COUNT.inc();
+            let block_txns = block.output().transaction_data();
+            counters::NUM_TXNS_PER_BLOCK.observe(block_txns.len() as f64);
+
+            for txn in block_txns.iter() {
+                match txn.txn_info_hash() {
+                    Some(_) => {
+                        counters::COMMITTED_TXNS_COUNT
+                            .with_label_values(&["success"])
+                            .inc();
+                    }
+                    None => {
+                        counters::COMMITTED_TXNS_COUNT
+                            .with_label_values(&["failed"])
+                            .inc();
+                    }
+                }
+            }
+            for status in block.compute_result().compute_status.iter() {
+                match status {
+                    TransactionStatus::Keep(_) => {
+                        counters::COMMITTED_TXNS_COUNT
+                            .with_label_values(&["success"])
+                            .inc();
+                    }
+                    TransactionStatus::Discard(_) => {
+                        counters::COMMITTED_TXNS_COUNT
+                            .with_label_values(&["failed"])
+                            .inc();
+                    }
+                }
+            }
         }
     }
 

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -17,6 +17,7 @@ use crate::{
         },
     },
     counters,
+    state_replication::TxnManager,
     util::time_service::{
         duration_since_epoch, wait_if_possible, TimeService, WaitingError, WaitingSuccess,
     },
@@ -44,8 +45,10 @@ use libra_types::{
 use network::proto::ConsensusMsg;
 
 use crate::chained_bft::network::IncomingBlockRetrievalRequest;
-use consensus_types::block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus};
-use consensus_types::executed_block::ExecutedBlock;
+use consensus_types::{
+    block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus},
+    executed_block::ExecutedBlock,
+};
 #[cfg(test)]
 use safety_rules::ConsensusState;
 use safety_rules::TSafetyRules;
@@ -150,6 +153,7 @@ pub struct EventProcessor<T> {
     proposal_generator: ProposalGenerator<T>,
     safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
     network: NetworkSender<T>,
+    txn_manager: Box<dyn TxnManager<Payload = T>>,
     storage: Arc<dyn PersistentLivenessStorage<T>>,
     time_service: Arc<dyn TimeService>,
     // Cache of the last sent vote message.
@@ -166,6 +170,7 @@ impl<T: Payload> EventProcessor<T> {
         proposal_generator: ProposalGenerator<T>,
         safety_rules: Box<dyn TSafetyRules<T> + Send + Sync>,
         network: NetworkSender<T>,
+        txn_manager: Box<dyn TxnManager<Payload = T>>,
         storage: Arc<dyn PersistentLivenessStorage<T>>,
         time_service: Arc<dyn TimeService>,
         validators: Arc<ValidatorVerifier>,
@@ -185,6 +190,7 @@ impl<T: Payload> EventProcessor<T> {
             proposer_election,
             proposal_generator,
             safety_rules,
+            txn_manager,
             network,
             storage,
             time_service,
@@ -840,8 +846,17 @@ impl<T: Payload> EventProcessor<T> {
                 return;
             }
         };
-        Self::update_counters_for_committed_blocks(blocks_to_commit);
-        // TODO notify mempool of rejected txns via txn_manager
+        Self::update_counters_for_committed_blocks(blocks_to_commit.clone());
+
+        // notify mempool of rejected txns via txn_manager
+        for committed in blocks_to_commit {
+            if let Some(payload) = committed.payload() {
+                let compute_result = committed.compute_result();
+                if let Err(e) = self.txn_manager.commit_txns(payload, &compute_result).await {
+                    error!("Failed to notify mempool of rejected txns: {:?}", e);
+                }
+            }
+        }
 
         if finality_proof.ledger_info().next_validator_set().is_some() {
             self.network

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -23,8 +23,7 @@ use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, Val
 use network::validator_network::ConsensusNetworkSender;
 use once_cell::sync::Lazy;
 use safety_rules::{PersistentSafetyStorage, SafetyRules};
-use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 use tokio::runtime::Runtime;
 
 // This generates a proposal for round 1
@@ -114,7 +113,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     let proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new()),
+        Box::new(MockTransactionManager::new(None)),
         time_service.clone(),
         1,
     );
@@ -134,6 +133,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         proposal_generator,
         Box::new(safety_rules),
         network,
+        Box::new(MockTransactionManager::new(None)),
         storage,
         time_service,
         validators,

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -114,7 +114,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     let proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new().0),
+        Box::new(MockTransactionManager::new()),
         time_service.clone(),
         1,
     );
@@ -133,7 +133,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         proposer_election,
         proposal_generator,
         Box::new(safety_rules),
-        Box::new(MockTransactionManager::new().0),
         network,
         storage,
         time_service,

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -157,7 +157,9 @@ impl NodeSetup {
         executor.spawn(task.start());
         let last_vote_sent = initial_data.last_vote();
         let (commit_cb_sender, _commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
+        let (state_sync_client, _state_sync) = mpsc::unbounded();
         let state_computer = Arc::new(MockStateComputer::new(
+            state_sync_client,
             commit_cb_sender,
             Arc::clone(&storage),
             None,
@@ -175,7 +177,7 @@ impl NodeSetup {
         let proposal_generator = ProposalGenerator::new(
             author,
             block_store.clone(),
-            Box::new(MockTransactionManager::new().0),
+            Box::new(MockTransactionManager::new()),
             time_service.clone(),
             1,
         );
@@ -191,7 +193,6 @@ impl NodeSetup {
             proposer_election,
             proposal_generator,
             safety_rules_manager.client(),
-            Box::new(MockTransactionManager::new().0),
             network,
             storage.clone(),
             time_service,

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -177,7 +177,7 @@ impl NodeSetup {
         let proposal_generator = ProposalGenerator::new(
             author,
             block_store.clone(),
-            Box::new(MockTransactionManager::new()),
+            Box::new(MockTransactionManager::new(None)),
             time_service.clone(),
             1,
         );
@@ -194,6 +194,7 @@ impl NodeSetup {
             proposal_generator,
             safety_rules_manager.client(),
             network,
+            Box::new(MockTransactionManager::new(None)),
             storage.clone(),
             time_service,
             validators.clone(),

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -9,8 +9,10 @@ use crate::{
     },
     util::mock_time_service::SimulatedTimeService,
 };
-use consensus_types::block::block_test_utils::{certificate_for_genesis, gen_test_certificate};
-use consensus_types::block::Block;
+use consensus_types::block::{
+    block_test_utils::{certificate_for_genesis, gen_test_certificate},
+    Block,
+};
 use futures::executor::block_on;
 use libra_types::crypto_proxies::ValidatorSigner;
 use std::{
@@ -29,7 +31,7 @@ fn test_proposal_generation_empty_tree() {
     let mut proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new()),
+        Box::new(MockTransactionManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -55,7 +57,7 @@ fn test_proposal_generation_parent() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new()),
+        Box::new(MockTransactionManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -96,7 +98,7 @@ fn test_old_proposal_generation() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new()),
+        Box::new(MockTransactionManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -115,7 +117,7 @@ fn test_empty_proposal_after_reconfiguration() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new()),
+        Box::new(MockTransactionManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
     );

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -29,7 +29,7 @@ fn test_proposal_generation_empty_tree() {
     let mut proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new().0),
+        Box::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -55,7 +55,7 @@ fn test_proposal_generation_parent() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new().0),
+        Box::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -96,7 +96,7 @@ fn test_old_proposal_generation() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new().0),
+        Box::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
     );
@@ -115,7 +115,7 @@ fn test_empty_proposal_after_reconfiguration() {
     let mut proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
-        Box::new(MockTransactionManager::new().0),
+        Box::new(MockTransactionManager::new()),
         Arc::new(SimulatedTimeService::new()),
         1,
     );

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -1,9 +1,16 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_replication::TxnManager;
+use crate::{state_replication::TxnManager, txn_manager::MempoolProxy};
 use anyhow::Result;
 use executor::StateComputeResult;
+use futures::channel::mpsc;
+use libra_mempool::ConsensusRequest;
+use libra_types::{
+    transaction::TransactionStatus,
+    vm_error::{StatusCode, VMStatus},
+};
+use rand::Rng;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -15,14 +22,37 @@ pub type MockTransaction = usize;
 #[derive(Clone)]
 pub struct MockTransactionManager {
     next_val: Arc<AtomicUsize>,
+    rejected_txns: Vec<usize>,
+    // used non-mocked TxnManager to test interaction with shared mempool
+    mempool_proxy: Option<MempoolProxy>,
 }
 
 impl MockTransactionManager {
-    pub fn new() -> Self {
+    pub fn new(consensus_to_mempool_sender: Option<mpsc::Sender<ConsensusRequest>>) -> Self {
+        let mempool_proxy = match consensus_to_mempool_sender {
+            Some(sender) => Some(MempoolProxy::new(sender)),
+            None => None,
+        };
         Self {
             next_val: Arc::new(AtomicUsize::new(0)),
+            rejected_txns: vec![],
+            mempool_proxy,
         }
     }
+}
+
+// mock transaction status on the fly
+fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
+    let mut statuses = vec![];
+    for _ in 0..count {
+        let random_status = match rand::thread_rng().gen_range(0, 2) {
+            0 => TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED)),
+            1 => TransactionStatus::Discard(VMStatus::new(StatusCode::UNKNOWN_VALIDATION_STATUS)),
+            _ => unreachable!(),
+        };
+        statuses.push(random_status);
+    }
+    statuses
 }
 
 #[async_trait::async_trait]
@@ -44,12 +74,21 @@ impl TxnManager for MockTransactionManager {
 
     async fn commit_txns(
         &mut self,
-        _txns: &Self::Payload,
-        _compute_results: &StateComputeResult,
-        // Monotonic timestamp_usecs of committed blocks is used to GC expired transactions.
-        _timestamp_usecs: u64,
+        txns: &Self::Payload,
+        compute_results: &StateComputeResult,
     ) -> Result<()> {
-        unimplemented!()
+        if self.mempool_proxy.is_some() {
+            let mut compute_results_clone = compute_results.clone();
+            compute_results_clone.compute_status = mock_transaction_status(txns.len());
+            assert!(self
+                .mempool_proxy
+                .as_mut()
+                .unwrap()
+                .commit_txns(&vec![], &compute_results_clone)
+                .await
+                .is_ok());
+        }
+        Ok(())
     }
 
     fn _clone_box(&self) -> Box<dyn TxnManager<Payload = Self::Payload>> {

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -18,6 +18,7 @@ use tokio::runtime;
 
 mod mock_state_computer;
 mod mock_storage;
+#[cfg(any(test, feature = "fuzzing"))]
 mod mock_txn_manager;
 
 use consensus_types::block::block_test_utils::gen_test_certificate;

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -114,10 +114,11 @@ impl StateComputer for ExecutionProxy {
             })
             .collect();
 
-        self.executor
-            .commit_blocks(committable_blocks, finality_proof, committed_trees)?;
+        let committed_txns =
+            self.executor
+                .commit_blocks(committable_blocks, finality_proof, committed_trees)?;
         counters::BLOCK_COMMIT_DURATION_S.observe_duration(pre_commit_instant.elapsed());
-        if let Err(e) = self.synchronizer.commit().await {
+        if let Err(e) = self.synchronizer.commit(committed_txns).await {
             error!("failed to notify state synchronizer: {:?}", e);
         }
         Ok(())

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -27,8 +27,6 @@ pub trait TxnManager: Send + Sync {
         &mut self,
         txns: &Self::Payload,
         compute_result: &StateComputeResult,
-        // Monotonic timestamp_usecs of committed blocks is used to GC expired transactions.
-        timestamp_usecs: u64,
     ) -> Result<()>;
 
     /// Bypass the trait object non-clonable limit.

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -117,6 +117,18 @@ pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransact
     }
 }
 
+pub(crate) fn batch_add_signed_txn(
+    pool: &mut CoreMempool,
+    transactions: Vec<SignedTransaction>,
+) -> Result<()> {
+    for txn in transactions.into_iter() {
+        if let Err(e) = add_signed_txn(pool, txn) {
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+
 // helper struct that keeps state between `.get_block` calls. Imitates work of Consensus
 pub struct ConsensusMock(HashSet<TxnPointer>);
 

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -6,7 +6,7 @@ use crate::{
         unit_tests::common::{batch_add_signed_txn, TestTransaction},
         CoreMempool, TimelineState,
     },
-    mocks::mock_shared_mempool,
+    mocks::MockSharedMempool,
     shared_mempool::{
         start_shared_mempool, ConsensusRequest, SharedMempoolNotification, SyncEvent,
     },
@@ -436,7 +436,7 @@ fn test_broadcast_updated_transaction() {
 
 #[test]
 fn test_consensus_events_rejected_txns() {
-    let smp = mock_shared_mempool(None);
+    let smp = MockSharedMempool::new(None);
 
     // add txns 1, 2, 3, 4
     // txn 1: committed successfully
@@ -486,7 +486,7 @@ fn test_consensus_events_rejected_txns() {
 #[test]
 fn test_state_sync_events_committed_txns() {
     let (mut state_sync_sender, state_sync_events) = mpsc::channel(1_024);
-    let smp = mock_shared_mempool(Some(state_sync_events));
+    let smp = MockSharedMempool::new(Some(state_sync_events));
 
     // add txns 1, 2, 3, 4
     // txn 1: committed successfully

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -63,7 +63,8 @@ extern crate prometheus;
 #[cfg(feature = "fuzzing")]
 pub mod mocks;
 pub use shared_mempool::{
-    bootstrap, CommittedTransaction, MempoolRequest, MempoolResponse, TransactionExclusion,
+    bootstrap, CommitNotification, CommitResponse, CommittedTransaction, ConsensusRequest,
+    ConsensusResponse, TransactionExclusion,
 };
 
 mod core_mempool;

--- a/mempool/src/mocks/mock_shared_mempool.rs
+++ b/mempool/src/mocks/mock_shared_mempool.rs
@@ -1,18 +1,22 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use crate::{core_mempool::CoreMempool, shared_mempool::start_shared_mempool};
+use crate::core_mempool::TimelineState;
+use crate::{
+    core_mempool::CoreMempool, shared_mempool::start_shared_mempool, CommitNotification,
+    ConsensusRequest,
+};
 use admission_control_proto::proto::admission_control::{
     SubmitTransactionRequest, SubmitTransactionResponse,
 };
-use anyhow::Result;
-use channel::libra_channel;
-use channel::message_queues::QueueStyle;
+use anyhow::{format_err, Result};
+use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::channel::{
     mpsc::{self, unbounded},
     oneshot,
 };
 use libra_config::config::{NetworkConfig, NodeConfig};
-use libra_types::PeerId;
+use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
+use libra_types::{transaction::SignedTransaction, PeerId};
 use network::peer_manager::conn_status_channel;
 use network::validator_network::{MempoolNetworkEvents, MempoolNetworkSender};
 use std::num::NonZeroUsize;
@@ -21,22 +25,63 @@ use storage_service::mocks::mock_storage_client::MockStorageReadClient;
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
-/// Creates a mock of a running instance of shared mempool
-/// Returns the runtime on which the shared mempool is running
-/// and the channel through which shared mempool receives client events
-pub fn mock_shared_mempool() -> (
-    Runtime,
-    mpsc::Sender<(
+/// Mock of a running instance of shared mempool
+pub struct MockSharedMempool {
+    _runtime: Runtime,
+    /// sender from admission control to shared mempool
+    pub ac_client: mpsc::Sender<(
         SubmitTransactionRequest,
         oneshot::Sender<Result<SubmitTransactionResponse>>,
     )>,
-) {
+    /// mempool
+    pub mempool: Arc<Mutex<CoreMempool>>,
+    /// sender from consensus to shared mempool
+    pub consensus_sender: mpsc::Sender<ConsensusRequest>,
+    /// sender from state sync to shared mempool
+    pub state_sync_sender: Option<mpsc::Sender<CommitNotification>>,
+}
+
+impl MockSharedMempool {
+    /// add txns to mempool
+    pub fn add_txns(&self, txns: Vec<SignedTransaction>) -> Result<()> {
+        {
+            let mut pool = self
+                .mempool
+                .lock()
+                .expect("[mock shared mempool] failed to acquire mempool lock");
+            for txn in txns {
+                if pool.add_txn(txn, 0, 0, 1000, TimelineState::NotReady).code
+                    != MempoolAddTransactionStatusCode::Valid
+                {
+                    return Err(format_err!("failed to insert into mock mempool"));
+                };
+            }
+        }
+        Ok(())
+    }
+
+    /// true if all given txns are in mempool, else false
+    pub fn read_timeline(&self, timeline_id: u64, count: usize) -> Vec<SignedTransaction> {
+        let mut pool = self
+            .mempool
+            .lock()
+            .expect("[mock shared mempool] failed to acquire mempool lock");
+        pool.read_timeline(timeline_id, count).0
+    }
+}
+
+/// Creates a mock of a running instance of shared mempool
+/// Returns the runtime on which the shared mempool is running
+/// and the channel through which shared mempool receives client events
+pub fn mock_shared_mempool(
+    state_sync: Option<mpsc::Receiver<CommitNotification>>,
+) -> MockSharedMempool {
     let runtime = Builder::new()
-        .thread_name("shared-mem-")
+        .thread_name("mock-shared-mem-")
         .threaded_scheduler()
         .enable_all()
         .build()
-        .expect("[shared mempool] failed to create runtime");
+        .expect("[mock shared mempool] failed to create runtime");
 
     let peer_id = PeerId::random();
     let mut validator_network_config = NetworkConfig::default();
@@ -53,22 +98,36 @@ pub fn mock_shared_mempool() -> (
     let network_sender = MempoolNetworkSender::new(network_reqs_tx);
     let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_notifs_rx);
     let (sender, _subscriber) = unbounded();
-    let (ac_sender, client_events) = mpsc::channel(1_024);
-    let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
+    let (ac_client, client_events) = mpsc::channel(1_024);
+    let (consensus_sender, consensus_events) = mpsc::channel(1_024);
+    let (state_sync_sender, state_sync_events) = match state_sync {
+        None => {
+            let (sender, events) = mpsc::channel(1_024);
+            (Some(sender), events)
+        }
+        Some(state_sync) => (None, state_sync),
+    };
     let network_handles = vec![(peer_id, network_sender, network_events)];
 
     start_shared_mempool(
         runtime.handle(),
         &config,
-        mempool,
+        mempool.clone(),
         network_handles,
         client_events,
         consensus_events,
+        state_sync_events,
         Arc::new(MockStorageReadClient),
         Arc::new(MockVMValidator),
         vec![sender],
         None,
     );
 
-    (runtime, ac_sender)
+    MockSharedMempool {
+        _runtime: runtime,
+        ac_client,
+        mempool,
+        consensus_sender,
+        state_sync_sender,
+    }
 }

--- a/mempool/src/mocks/mock_shared_mempool.rs
+++ b/mempool/src/mocks/mock_shared_mempool.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use crate::core_mempool::TimelineState;
 use crate::{
-    core_mempool::CoreMempool, shared_mempool::start_shared_mempool, CommitNotification,
-    ConsensusRequest,
+    core_mempool::{CoreMempool, TimelineState},
+    shared_mempool::start_shared_mempool,
+    CommitNotification, ConsensusRequest,
 };
 use admission_control_proto::proto::admission_control::{
     SubmitTransactionRequest, SubmitTransactionResponse,
@@ -17,10 +17,14 @@ use futures::channel::{
 use libra_config::config::{NetworkConfig, NodeConfig};
 use libra_mempool_shared_proto::proto::mempool_status::MempoolAddTransactionStatusCode;
 use libra_types::{transaction::SignedTransaction, PeerId};
-use network::peer_manager::conn_status_channel;
-use network::validator_network::{MempoolNetworkEvents, MempoolNetworkSender};
-use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
+use network::{
+    peer_manager::conn_status_channel,
+    validator_network::{MempoolNetworkEvents, MempoolNetworkSender},
+};
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+};
 use storage_service::mocks::mock_storage_client::MockStorageReadClient;
 use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
@@ -42,6 +46,66 @@ pub struct MockSharedMempool {
 }
 
 impl MockSharedMempool {
+    /// Creates a mock of a running instance of shared mempool
+    /// Returns the runtime on which the shared mempool is running
+    /// and the channel through which shared mempool receives client events
+    pub fn new(state_sync: Option<mpsc::Receiver<CommitNotification>>) -> Self {
+        let runtime = Builder::new()
+            .thread_name("mock-shared-mem-")
+            .threaded_scheduler()
+            .enable_all()
+            .build()
+            .expect("[mock shared mempool] failed to create runtime");
+
+        let peer_id = PeerId::random();
+        let mut validator_network_config = NetworkConfig::default();
+        validator_network_config.peer_id = peer_id;
+        let mut config = NodeConfig::random();
+        config.validator_network = Some(validator_network_config);
+
+        let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
+        let (network_reqs_tx, _network_reqs_rx) =
+            libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+        let (_network_notifs_tx, network_notifs_rx) =
+            libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+        let (_, conn_notifs_rx) = conn_status_channel::new();
+        let network_sender = MempoolNetworkSender::new(network_reqs_tx);
+        let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_notifs_rx);
+        let (sender, _subscriber) = unbounded();
+        let (ac_client, client_events) = mpsc::channel(1_024);
+        let (consensus_sender, consensus_events) = mpsc::channel(1_024);
+        let (state_sync_sender, state_sync_events) = match state_sync {
+            None => {
+                let (sender, events) = mpsc::channel(1_024);
+                (Some(sender), events)
+            }
+            Some(state_sync) => (None, state_sync),
+        };
+        let network_handles = vec![(peer_id, network_sender, network_events)];
+
+        start_shared_mempool(
+            runtime.handle(),
+            &config,
+            mempool.clone(),
+            network_handles,
+            client_events,
+            consensus_events,
+            state_sync_events,
+            Arc::new(MockStorageReadClient),
+            Arc::new(MockVMValidator),
+            vec![sender],
+            None,
+        );
+
+        Self {
+            _runtime: runtime,
+            ac_client,
+            mempool,
+            consensus_sender,
+            state_sync_sender,
+        }
+    }
+
     /// add txns to mempool
     pub fn add_txns(&self, txns: Vec<SignedTransaction>) -> Result<()> {
         {
@@ -67,67 +131,5 @@ impl MockSharedMempool {
             .lock()
             .expect("[mock shared mempool] failed to acquire mempool lock");
         pool.read_timeline(timeline_id, count).0
-    }
-}
-
-/// Creates a mock of a running instance of shared mempool
-/// Returns the runtime on which the shared mempool is running
-/// and the channel through which shared mempool receives client events
-pub fn mock_shared_mempool(
-    state_sync: Option<mpsc::Receiver<CommitNotification>>,
-) -> MockSharedMempool {
-    let runtime = Builder::new()
-        .thread_name("mock-shared-mem-")
-        .threaded_scheduler()
-        .enable_all()
-        .build()
-        .expect("[mock shared mempool] failed to create runtime");
-
-    let peer_id = PeerId::random();
-    let mut validator_network_config = NetworkConfig::default();
-    validator_network_config.peer_id = peer_id;
-    let mut config = NodeConfig::random();
-    config.validator_network = Some(validator_network_config);
-
-    let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
-    let (network_reqs_tx, _network_reqs_rx) =
-        libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (_network_notifs_tx, network_notifs_rx) =
-        libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (_, conn_notifs_rx) = conn_status_channel::new();
-    let network_sender = MempoolNetworkSender::new(network_reqs_tx);
-    let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_notifs_rx);
-    let (sender, _subscriber) = unbounded();
-    let (ac_client, client_events) = mpsc::channel(1_024);
-    let (consensus_sender, consensus_events) = mpsc::channel(1_024);
-    let (state_sync_sender, state_sync_events) = match state_sync {
-        None => {
-            let (sender, events) = mpsc::channel(1_024);
-            (Some(sender), events)
-        }
-        Some(state_sync) => (None, state_sync),
-    };
-    let network_handles = vec![(peer_id, network_sender, network_events)];
-
-    start_shared_mempool(
-        runtime.handle(),
-        &config,
-        mempool.clone(),
-        network_handles,
-        client_events,
-        consensus_events,
-        state_sync_events,
-        Arc::new(MockStorageReadClient),
-        Arc::new(MockVMValidator),
-        vec![sender],
-        None,
-    );
-
-    MockSharedMempool {
-        _runtime: runtime,
-        ac_client,
-        mempool,
-        consensus_sender,
-        state_sync_sender,
     }
 }

--- a/mempool/src/mocks/mod.rs
+++ b/mempool/src/mocks/mod.rs
@@ -3,4 +3,4 @@
 
 mod mock_shared_mempool;
 
-pub use mock_shared_mempool::{mock_shared_mempool, MockSharedMempool};
+pub use mock_shared_mempool::MockSharedMempool;

--- a/mempool/src/mocks/mod.rs
+++ b/mempool/src/mocks/mod.rs
@@ -3,4 +3,4 @@
 
 mod mock_shared_mempool;
 
-pub use mock_shared_mempool::mock_shared_mempool;
+pub use mock_shared_mempool::{mock_shared_mempool, MockSharedMempool};

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -30,6 +30,7 @@ use libra_mempool_shared_proto::proto::mempool_status::{
     MempoolAddTransactionStatusCode,
 };
 use libra_types::{
+    account_address::AccountAddress,
     proto::types::{SignedTransaction as SignedTransactionProto, VmStatus as VmStatusProto},
     transaction::SignedTransaction,
     vm_error::{StatusCode::RESOURCE_DOES_NOT_EXIST, VMStatus},
@@ -96,51 +97,69 @@ where
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
 }
 
-/// Message sent from Consensus to Mempool
-pub enum MempoolRequest {
-    /// get block req
-    GetBlockRequest {
-        /// max block size
-        max_block_size: u64,
-        /// txns in the block
-        transactions: Vec<TransactionExclusion>,
-    },
-    /// commit txns req
-    CommitTransactionsRequest {
-        /// txns to commit
-        transactions: Vec<CommittedTransaction>,
-        /// timestamp of block
-        block_timestamp_usecs: u64,
-    },
+/// Message sent from consensus to mempool
+pub enum ConsensusRequest {
+    /// request to pull block to submit to consensus
+    GetBlockRequest(
+        // max block size
+        u64,
+        // transactions to exclude from requested block
+        Vec<TransactionExclusion>,
+        // callback to send response back to sender
+        oneshot::Sender<Result<ConsensusResponse>>,
+    ),
+    /// notifications about *rejected* committed txns
+    RejectNotification(
+        // committed transactions
+        Vec<CommittedTransaction>,
+        // callback to send response back to sender
+        oneshot::Sender<Result<ConsensusResponse>>,
+    ),
 }
 
-/// Message sent from Mempool to Consensus
-pub enum MempoolResponse {
-    /// response to get block req
-    GetBlockResponse {
-        /// txns in block
-        transactions: Vec<SignedTransaction>,
-    },
-    /// response to commit txns req
-    CommitTransactionsResponse {},
+/// Response setn from mempool to consensus
+pub enum ConsensusResponse {
+    /// block to submit to consensus
+    GetBlockResponse(
+        // transactions in block
+        Vec<SignedTransaction>,
+    ),
+    /// ACK for commit notification
+    CommitResponse(),
+}
+
+/// notification from state sync to mempool of commit event
+/// This notifies mempool to remove committed txns
+pub struct CommitNotification {
+    /// committed transactions
+    pub transactions: Vec<CommittedTransaction>,
+    /// timestamp of committed block
+    pub block_timestamp_usecs: u64,
+    /// callback to send back response from mempool to State Sync
+    pub callback: oneshot::Sender<Result<CommitResponse>>,
+}
+
+/// ACK response to commit notification
+#[derive(Debug)]
+pub struct CommitResponse {
+    /// error msg if applicable - empty string if commit was processed successfully by mempool
+    pub msg: String,
+}
+
+/// successfully executed and committed txn
+pub struct CommittedTransaction {
+    /// sender
+    pub sender: AccountAddress,
+    /// sequence number
+    pub sequence_number: u64,
 }
 
 /// excluded txn
 pub struct TransactionExclusion {
     /// sender
-    pub sender: PeerId,
+    pub sender: AccountAddress,
     /// sequence number
     pub sequence_number: u64,
-}
-
-/// committed txn
-pub struct CommittedTransaction {
-    /// sender
-    pub sender: PeerId,
-    /// sequence number
-    pub sequence_number: u64,
-    /// is rejected
-    pub is_rejected: bool,
 }
 
 fn notify_subscribers(
@@ -448,18 +467,60 @@ where
     crit!("SharedMempool outbound_sync_task terminated");
 }
 
-async fn process_consensus_request<V>(
+async fn commit_txns<V>(
     smp: SharedMempool<V>,
-    msg: MempoolRequest,
-    callback: oneshot::Sender<Result<MempoolResponse>>,
+    transactions: Vec<CommittedTransaction>,
+    block_timestamp_usecs: u64,
+    is_rejected: bool,
 ) where
     V: TransactionValidation,
 {
-    let resp = match msg {
-        MempoolRequest::GetBlockRequest {
-            max_block_size,
-            transactions,
-        } => {
+    let mut pool = smp
+        .mempool
+        .lock()
+        .expect("[shared mempool] failed to get mempool lock");
+
+    for transaction in transactions {
+        pool.remove_transaction(
+            &transaction.sender,
+            transaction.sequence_number,
+            is_rejected,
+        );
+    }
+
+    if block_timestamp_usecs > 0 {
+        pool.gc_by_expiration_time(Duration::from_micros(block_timestamp_usecs));
+    }
+}
+
+async fn process_state_sync_request<V>(smp: SharedMempool<V>, req: CommitNotification)
+where
+    V: TransactionValidation,
+{
+    commit_txns(smp, req.transactions, req.block_timestamp_usecs, false).await;
+    // send back to callback
+    if let Err(e) = req
+        .callback
+        .send(Ok(CommitResponse {
+            msg: "".to_string(),
+        }))
+        .map_err(|_| {
+            format_err!("[shared mempool] timeout on callback sending response to Mempool request")
+        })
+    {
+        error!(
+            "[shared mempool] failed to send back CommitResponse with error: {:?}",
+            e
+        );
+    }
+}
+
+async fn process_consensus_request<V>(smp: SharedMempool<V>, req: ConsensusRequest)
+where
+    V: TransactionValidation,
+{
+    let (resp, callback) = match req {
+        ConsensusRequest::GetBlockRequest(max_block_size, transactions, callback) => {
             let block_size = cmp::max(max_block_size, 1);
             counters::MEMPOOL_SERVICE
                 .with_label_values(&["get_block", "requested"])
@@ -469,44 +530,27 @@ async fn process_consensus_request<V>(
                 .iter()
                 .map(|txn| (txn.sender, txn.sequence_number))
                 .collect();
-
             let mut txns = smp
                 .mempool
                 .lock()
                 .expect("[get_block] acquire mempool lock")
                 .get_block(block_size, exclude_transactions);
-
             let transactions = txns.drain(..).map(SignedTransaction::into).collect();
 
-            MempoolResponse::GetBlockResponse { transactions }
+            (ConsensusResponse::GetBlockResponse(transactions), callback)
         }
-        MempoolRequest::CommitTransactionsRequest {
-            transactions,
-            block_timestamp_usecs,
-        } => {
-            let mut pool = smp.mempool.lock().unwrap();
-            for transaction in transactions.iter() {
-                pool.remove_transaction(
-                    &transaction.sender,
-                    transaction.sequence_number,
-                    transaction.is_rejected,
-                );
-            }
-
-            if block_timestamp_usecs > 0 {
-                pool.gc_by_expiration_time(Duration::from_micros(block_timestamp_usecs));
-            }
-
-            MempoolResponse::CommitTransactionsResponse {}
+        ConsensusRequest::RejectNotification(transactions, callback) => {
+            // handle rejected txns
+            commit_txns(smp, transactions, 0, true).await;
+            (ConsensusResponse::CommitResponse(), callback)
         }
     };
-
-    if let Err(e) = callback
-        .send(Ok(resp))
-        .map_err(|_| format_err!("[shared mempool] timeout on callback send to consensus"))
-    {
+    // send back to callback
+    if let Err(e) = callback.send(Ok(resp)).map_err(|_| {
+        format_err!("[shared mempool] timeout on callback sending response to Mempool request")
+    }) {
         error!(
-            "[shared mempool] failed to send back mempool response to consensus with error: {:?}",
+            "[shared mempool] failed to send back mempool response with error: {:?}",
             e
         );
     }
@@ -521,10 +565,8 @@ async fn inbound_network_task<V>(
         SubmitTransactionRequest,
         oneshot::Sender<Result<SubmitTransactionResponse>>,
     )>,
-    mut consensus_events: mpsc::Receiver<(
-        MempoolRequest,
-        oneshot::Sender<Result<MempoolResponse>>,
-    )>,
+    mut consensus_requests: mpsc::Receiver<ConsensusRequest>,
+    mut state_sync_requests: mpsc::Receiver<CommitNotification>,
     node_config: NodeConfig,
 ) where
     V: TransactionValidation,
@@ -553,14 +595,11 @@ async fn inbound_network_task<V>(
                 ))
                 .await;
             },
-            (mut msg, callback) = consensus_events.select_next_some() => {
-                bounded_executor
-                .spawn(process_consensus_request(
-                    smp.clone(),
-                    msg,
-                    callback,
-                ))
-                .await;
+            msg = consensus_requests.select_next_some() => {
+                process_consensus_request(smp.clone(), msg).await;
+            }
+            msg = state_sync_requests.select_next_some() => {
+                tokio::spawn(process_state_sync_request(smp.clone(), msg));
             },
             (network_id, event) = events.select_next_some() => {
                 match event {
@@ -662,7 +701,8 @@ pub(crate) fn start_shared_mempool<V>(
         SubmitTransactionRequest,
         oneshot::Sender<Result<SubmitTransactionResponse>>,
     )>,
-    consensus_events: mpsc::Receiver<(MempoolRequest, oneshot::Sender<Result<MempoolResponse>>)>,
+    consensus_requests: mpsc::Receiver<ConsensusRequest>,
+    state_sync_requests: mpsc::Receiver<CommitNotification>,
     storage_read_client: Arc<dyn StorageRead>,
     validator: Arc<V>,
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
@@ -704,7 +744,8 @@ pub(crate) fn start_shared_mempool<V>(
         executor.clone(),
         all_network_events,
         client_events,
-        consensus_events,
+        consensus_requests,
+        state_sync_requests,
         config_clone,
     ));
 
@@ -724,7 +765,8 @@ pub fn bootstrap(
         SubmitTransactionRequest,
         oneshot::Sender<Result<SubmitTransactionResponse>>,
     )>,
-    consensus_events: Receiver<(MempoolRequest, oneshot::Sender<Result<MempoolResponse>>)>,
+    consensus_requests: Receiver<ConsensusRequest>,
+    state_sync_requests: Receiver<CommitNotification>,
 ) -> Runtime {
     let runtime = Builder::new()
         .thread_name("shared-mem-")
@@ -747,7 +789,8 @@ pub fn bootstrap(
         mempool,
         mempool_network_handles,
         client_events,
-        consensus_events,
+        consensus_requests,
+        state_sync_requests,
         storage_client,
         vm_validator,
         vec![],

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -24,6 +24,7 @@ libra-config = { path = "../config", version = "0.1.0" }
 executor = { path = "../executor", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-mempool = { path = "../mempool", version = "0.1.0"}
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
@@ -42,4 +43,4 @@ channel = { path = "../common/channel", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing"]
+fuzzing = ["libra-mempool/fuzzing", "libra-types/fuzzing"]

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -18,7 +18,7 @@ use libra_crypto::{
     HashValue,
 };
 use libra_logger::set_simple_logger;
-use libra_mempool::mocks::{mock_shared_mempool, MockSharedMempool};
+use libra_mempool::mocks::MockSharedMempool;
 use libra_types::{
     block_info::BlockInfo,
     crypto_proxies::{
@@ -324,7 +324,7 @@ impl SynchronizerEnv {
             MockExecutorProxy::new(handler, storage_proxy.clone()),
         );
         self.mempools
-            .push(mock_shared_mempool(Some(mempool_requests)));
+            .push(MockSharedMempool::new(Some(mempool_requests)));
         let client = synchronizer.create_client();
         self.synchronizers.push(synchronizer);
         self.clients.push(client);


### PR DESCRIPTION
## Summary

Originally, the notification flow of committed txns was s.t. consensus notified mempool of committed txns (both successful and failed), which causes problems described in #1874 

This PR implements a solution for notifying successfully committed txns by changing notification flow to:
- consensus notifies state sync of successful commits (first commit)
- state sync notifies successfully committed txns on both validator and full nodes (first commit)
- consensus notifies mempool of rejected commits (second commit)

## Test Plan

Added unit tests for mempool handling commit notifications from consensus and state sync
Added integration tests for testing consensus- and state-sync-triggered commit notifications being processed by shared mempool
Added integration testing for consensus-mempool interaction (notifying rejected txns)
