### PR TITLE
[language] Verify scripts (transactions) dependencies

### DIFF
--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -33,19 +33,33 @@ pub struct FakeExecutor {
     data_store: FakeDataStore,
 }
 
-pub fn test_all_genesis_impl<T, F>(test_fn: F) -> Result<(), T>
+pub fn test_all_genesis_impl<T, F>(
+    publishing_options: Option<VMPublishingOption>,
+    test_fn: F,
+) -> Result<(), T>
 where
     F: Fn(FakeExecutor) -> Result<(), T>,
 {
     let genesis: Vec<&WriteSet> = vec![&GENESIS_WRITE_SET];
     genesis
         .iter()
-        .map(|ws| test_fn(FakeExecutor::from_genesis(ws, None)))
+        .map(|ws| test_fn(FakeExecutor::from_genesis(ws, publishing_options.clone())))
         .collect()
 }
 
-pub fn test_all_genesis(test_fn: fn(FakeExecutor) -> ()) {
-    let result: Result<(), ()> = test_all_genesis_impl(|executor| {
+pub fn test_all_genesis_default(test_fn: fn(FakeExecutor) -> ()) {
+    let result: Result<(), ()> = test_all_genesis_impl(None, |executor| {
+        test_fn(executor);
+        Ok(())
+    });
+    result.unwrap()
+}
+
+pub fn test_all_genesis(
+    publishing_options: Option<VMPublishingOption>,
+    test_fn: fn(FakeExecutor) -> (),
+) {
+    let result: Result<(), ()> = test_all_genesis_impl(publishing_options, |executor| {
         test_fn(executor);
         Ok(())
     });

--- a/language/e2e-tests/src/tests.rs
+++ b/language/e2e-tests/src/tests.rs
@@ -16,5 +16,6 @@ mod mint;
 mod module_publishing;
 mod peer_to_peer;
 mod rotate_key;
+mod scripts;
 mod validator_set_management;
 mod verify_txn;

--- a/language/e2e-tests/src/tests/account_universe.rs
+++ b/language/e2e-tests/src/tests/account_universe.rs
@@ -102,7 +102,7 @@ pub(crate) fn run_and_assert_gas_cost_stability(
     universe: AccountUniverseGen,
     transaction_gens: Vec<impl AUTransactionGen + Clone>,
 ) -> Result<(), TestCaseError> {
-    test_all_genesis_impl({
+    test_all_genesis_impl(None, {
         |mut executor| {
             let mut universe = universe.clone().setup_gas_cost_stability(&mut executor);
             let (transactions, expected_values): (Vec<_>, Vec<_>) = transaction_gens
@@ -135,7 +135,7 @@ pub(crate) fn run_and_assert_universe(
     universe: AccountUniverseGen,
     transaction_gens: Vec<impl AUTransactionGen + Clone>,
 ) -> Result<(), TestCaseError> {
-    test_all_genesis_impl({
+    test_all_genesis_impl(None, {
         |mut executor| {
             let mut universe = universe.clone().setup(&mut executor);
             let (transactions, expected_values): (Vec<_>, Vec<_>) = transaction_gens

--- a/language/e2e-tests/src/tests/create_account.rs
+++ b/language/e2e-tests/src/tests/create_account.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::create_account_txn,
-    executor::test_all_genesis,
+    executor::test_all_genesis_default,
 };
 use libra_types::{
     transaction::TransactionStatus,
@@ -14,7 +14,7 @@ use libra_types::{
 #[test]
 fn create_account() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish a sender with 1_000_000 coins
         let sender = AccountData::new(1_000_000, 10);
         executor.add_account_data(&sender);
@@ -49,7 +49,7 @@ fn create_account() {
 #[test]
 fn create_account_zero_balance() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish a sender with 1_000_000 coins
         let sender = AccountData::new(1_000_000, 10);
         executor.add_account_data(&sender);

--- a/language/e2e-tests/src/tests/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/peer_to_peer.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::peer_to_peer_txn,
-    executor::{test_all_genesis, FakeExecutor},
+    executor::{test_all_genesis_default, FakeExecutor},
     gas_costs, transaction_status_eq,
 };
 use libra_config::config::VMPublishingOption;
@@ -19,7 +19,7 @@ use std::{convert::TryFrom, time::Instant};
 fn single_peer_to_peer_with_event() {
     ::libra_logger::try_init_for_testing();
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
         let sender = AccountData::new(1_000_000, 10);
         let receiver = AccountData::new(100_000, 10);
@@ -120,7 +120,7 @@ fn single_peer_to_peer_with_padding() {
 #[test]
 fn few_peer_to_peer_with_event() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
         let sender = AccountData::new(1_000_000, 10);
         let receiver = AccountData::new(100_000, 10);
@@ -188,7 +188,7 @@ fn few_peer_to_peer_with_event() {
 /// Test that a zero-amount transaction fails, per policy.
 #[test]
 fn zero_amount_peer_to_peer() {
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         let sequence_number = 10;
         let sender = AccountData::new(1_000_000, sequence_number);
         let receiver = AccountData::new(100_000, sequence_number);
@@ -215,7 +215,7 @@ fn zero_amount_peer_to_peer() {
 #[test]
 fn peer_to_peer_create_account() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish a sender with 1_000_000 coins
         let sender = AccountData::new(1_000_000, 10);
         executor.add_account_data(&sender);
@@ -405,7 +405,7 @@ fn print_accounts(executor: &FakeExecutor, accounts: &[Account]) {
 #[test]
 fn cycle_peer_to_peer() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish accounts with 2_000_000 coins
         let account_size = 100usize;
         let initial_balance = 2_000_000u64;
@@ -438,7 +438,7 @@ fn cycle_peer_to_peer() {
 #[test]
 fn cycle_peer_to_peer_multi_block() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish accounts with 1_000_000 coins
         let account_size = 100usize;
         let initial_balance = 1_000_000u64;
@@ -485,7 +485,7 @@ fn cycle_peer_to_peer_multi_block() {
 #[test]
 fn one_to_many_peer_to_peer() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish accounts with 4_000_000 coins
         let account_size = 100usize;
         let initial_balance = 4_000_000u64;
@@ -532,7 +532,7 @@ fn one_to_many_peer_to_peer() {
 #[test]
 fn many_to_one_peer_to_peer() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish accounts with 1_000_000 coins
         let account_size = 100usize;
         let initial_balance = 1_000_000u64;

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -4,7 +4,7 @@
 use crate::{
     account::{Account, AccountData},
     common_transactions::{create_account_txn, rotate_key_txn},
-    executor::test_all_genesis,
+    executor::test_all_genesis_default,
 };
 use libra_crypto::ed25519::compat;
 use libra_types::{
@@ -15,7 +15,7 @@ use libra_types::{
 
 #[test]
 fn rotate_key() {
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish sender
         let mut sender = AccountData::new(1_000_000, 10);
         executor.add_account_data(&sender);

--- a/language/e2e-tests/src/tests/scripts.rs
+++ b/language/e2e-tests/src/tests/scripts.rs
@@ -1,0 +1,255 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{account::AccountData, executor::test_all_genesis, gas_costs};
+use libra_config::config::VMPublishingOption;
+use libra_types::{
+    account_address::AccountAddress, identifier::Identifier, transaction::TransactionStatus,
+    vm_error::StatusCode,
+};
+use vm::file_format::{
+    empty_script, AddressPoolIndex, Bytecode, FunctionHandle, FunctionHandleIndex,
+    FunctionSignatureIndex, IdentifierIndex, LocalsSignatureIndex, ModuleHandle, ModuleHandleIndex,
+};
+
+#[test]
+fn script_code_unverifiable() {
+    test_all_genesis(Some(VMPublishingOption::Open), |mut executor| {
+        // create and publish sender
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+
+        // create a bogus script
+        let mut script = empty_script();
+        script.main.code.code = vec![Bytecode::LdU8(0), Bytecode::Add, Bytecode::Ret];
+        let mut blob = vec![];
+        script.serialize(&mut blob).expect("script must serialize");
+        let txn = sender.account().create_signed_txn_with_args(
+            blob,
+            vec![],
+            10,
+            gas_costs::TXN_RESERVED,
+            1,
+        );
+
+        // execute transaction
+        let output = &executor.execute_transaction(txn);
+        let status = output.status();
+        match status {
+            TransactionStatus::Keep(_) => (),
+            _ => panic!("TransactionStatus must be Keep"),
+        }
+        assert_eq!(
+            status.vm_status().major_status,
+            StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK,
+        );
+        executor.apply_write_set(output.write_set());
+
+        // Check that numbers in store are correct.
+        let gas = output.gas_used();
+        let balance = 1_000_000 - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        assert_eq!(balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+    });
+}
+
+#[test]
+fn script_non_existing_module_dep() {
+    test_all_genesis(Some(VMPublishingOption::Open), |mut executor| {
+        // create and publish sender
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+
+        // create a bogus script
+        let mut script = empty_script();
+        // make a non existent external module
+        script.address_pool.push(AccountAddress::new([1u8; 32]));
+        script.identifiers.push(Identifier::new("module").unwrap());
+        let module_handle = ModuleHandle {
+            address: AddressPoolIndex((script.address_pool.len() - 1) as u16),
+            name: IdentifierIndex((script.identifiers.len() - 1) as u16),
+        };
+        script.module_handles.push(module_handle);
+        // make a non existent function on the non existent external module
+        script.identifiers.push(Identifier::new("foo").unwrap());
+        let fun_handle = FunctionHandle {
+            module: ModuleHandleIndex((script.module_handles.len() - 1) as u16),
+            name: IdentifierIndex((script.identifiers.len() - 1) as u16),
+            signature: FunctionSignatureIndex(0),
+        };
+        script.function_handles.push(fun_handle);
+
+        script.main.code.code = vec![
+            Bytecode::Call(
+                FunctionHandleIndex((script.function_handles.len() - 1) as u16),
+                LocalsSignatureIndex(0),
+            ),
+            Bytecode::Ret,
+        ];
+        let mut blob = vec![];
+        script.serialize(&mut blob).expect("script must serialize");
+        let txn = sender.account().create_signed_txn_with_args(
+            blob,
+            vec![],
+            10,
+            gas_costs::TXN_RESERVED,
+            1,
+        );
+
+        // execute transaction
+        let output = &executor.execute_transaction(txn);
+        let status = output.status();
+        match status {
+            TransactionStatus::Keep(_) => (),
+            _ => panic!("TransactionStatus must be Keep"),
+        }
+        assert_eq!(status.vm_status().major_status, StatusCode::LINKER_ERROR,);
+        executor.apply_write_set(output.write_set());
+
+        // Check that numbers in store are correct.
+        let gas = output.gas_used();
+        let balance = 1_000_000 - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        assert_eq!(balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+    });
+}
+
+#[test]
+fn script_non_existing_function_dep() {
+    test_all_genesis(Some(VMPublishingOption::Open), |mut executor| {
+        // create and publish sender
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+
+        // create a bogus script
+        let mut script = empty_script();
+        // AddressUtil module
+        script.address_pool.push(AccountAddress::new([0u8; 32]));
+        script
+            .identifiers
+            .push(Identifier::new("AddressUtil").unwrap());
+        let module_handle = ModuleHandle {
+            address: AddressPoolIndex((script.address_pool.len() - 1) as u16),
+            name: IdentifierIndex((script.identifiers.len() - 1) as u16),
+        };
+        script.module_handles.push(module_handle);
+        // make a non existent function on AddressUtil
+        script.identifiers.push(Identifier::new("foo").unwrap());
+        let fun_handle = FunctionHandle {
+            module: ModuleHandleIndex((script.module_handles.len() - 1) as u16),
+            name: IdentifierIndex((script.identifiers.len() - 1) as u16),
+            signature: FunctionSignatureIndex(0),
+        };
+        script.function_handles.push(fun_handle);
+
+        script.main.code.code = vec![
+            Bytecode::Call(
+                FunctionHandleIndex((script.function_handles.len() - 1) as u16),
+                LocalsSignatureIndex(0),
+            ),
+            Bytecode::Ret,
+        ];
+        let mut blob = vec![];
+        script.serialize(&mut blob).expect("script must serialize");
+        let txn = sender.account().create_signed_txn_with_args(
+            blob,
+            vec![],
+            10,
+            gas_costs::TXN_RESERVED,
+            1,
+        );
+
+        // execute transaction
+        let output = &executor.execute_transaction(txn);
+        let status = output.status();
+        match status {
+            TransactionStatus::Keep(_) => (),
+            _ => panic!("TransactionStatus must be Keep"),
+        }
+        assert_eq!(status.vm_status().major_status, StatusCode::LOOKUP_FAILED,);
+        executor.apply_write_set(output.write_set());
+
+        // Check that numbers in store are correct.
+        let gas = output.gas_used();
+        let balance = 1_000_000 - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        assert_eq!(balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+    });
+}
+
+#[test]
+fn script_bad_sig_function_dep() {
+    test_all_genesis(Some(VMPublishingOption::Open), |mut executor| {
+        // create and publish sender
+        let sender = AccountData::new(1_000_000, 10);
+        executor.add_account_data(&sender);
+
+        // create a bogus script
+        let mut script = empty_script();
+        // AddressUtil module
+        script.address_pool.push(AccountAddress::new([0u8; 32]));
+        script
+            .identifiers
+            .push(Identifier::new("AddressUtil").unwrap());
+        let module_handle = ModuleHandle {
+            address: AddressPoolIndex((script.address_pool.len() - 1) as u16),
+            name: IdentifierIndex((script.identifiers.len() - 1) as u16),
+        };
+        script.module_handles.push(module_handle);
+        // AddressUtil::address_to_bytes with bad sig
+        script
+            .identifiers
+            .push(Identifier::new("address_to_bytes").unwrap());
+        let fun_handle = FunctionHandle {
+            module: ModuleHandleIndex((script.module_handles.len() - 1) as u16),
+            name: IdentifierIndex((script.identifiers.len() - 1) as u16),
+            signature: FunctionSignatureIndex(0),
+        };
+        script.function_handles.push(fun_handle);
+
+        script.main.code.code = vec![
+            Bytecode::Call(
+                FunctionHandleIndex((script.function_handles.len() - 1) as u16),
+                LocalsSignatureIndex(0),
+            ),
+            Bytecode::Ret,
+        ];
+        let mut blob = vec![];
+        script.serialize(&mut blob).expect("script must serialize");
+        let txn = sender.account().create_signed_txn_with_args(
+            blob,
+            vec![],
+            10,
+            gas_costs::TXN_RESERVED,
+            1,
+        );
+
+        // execute transaction
+        let output = &executor.execute_transaction(txn);
+        let status = output.status();
+        match status {
+            TransactionStatus::Keep(_) => (),
+            _ => panic!("TransactionStatus must be Keep"),
+        }
+        assert_eq!(status.vm_status().major_status, StatusCode::TYPE_MISMATCH,);
+        executor.apply_write_set(output.write_set());
+
+        // Check that numbers in store are correct.
+        let gas = output.gas_used();
+        let balance = 1_000_000 - gas;
+        let updated_sender = executor
+            .read_account_resource(sender.account())
+            .expect("sender must exist");
+        assert_eq!(balance, updated_sender.balance());
+        assert_eq!(11, updated_sender.sequence_number());
+    });
+}

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -6,7 +6,7 @@ use crate::{
     assert_prologue_disparity, assert_prologue_parity, assert_status_eq,
     common_transactions::*,
     compile::{compile_module_with_address, compile_script},
-    executor::{test_all_genesis, FakeExecutor},
+    executor::{test_all_genesis_default, FakeExecutor},
     transaction_status_eq,
 };
 use bytecode_verifier::VerifiedModule;
@@ -27,7 +27,7 @@ use vm::gas_schedule::{self, GasAlgebra};
 
 #[test]
 fn verify_signature() {
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         let sender = AccountData::new(900_000, 10);
         executor.add_account_data(&sender);
         // Generate a new key pair to try and sign things with.
@@ -51,7 +51,7 @@ fn verify_signature() {
 
 #[test]
 fn verify_reserved_sender() {
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         let sender = AccountData::new(900_000, 10);
         executor.add_account_data(&sender);
         // Generate a new key pair to try and sign things with.
@@ -75,7 +75,7 @@ fn verify_reserved_sender() {
 
 #[test]
 fn verify_rejected_write_set() {
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         let sender = AccountData::new(900_000, 10);
         executor.add_account_data(&sender);
         let signed_txn = transaction_test_helpers::get_write_set_txn(
@@ -117,7 +117,7 @@ fn verify_whitelist() {
 #[test]
 fn verify_simple_payment() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create and publish a sender with 1_000_000 coins and a receiver with 100_000 coins
         let sender = AccountData::new(900_000, 10);
         let receiver = AccountData::new(100_000, 10);
@@ -350,7 +350,7 @@ fn verify_simple_payment() {
 #[test]
 pub fn test_whitelist() {
     // create a FakeExecutor with a genesis from file
-    test_all_genesis(|mut executor| {
+    test_all_genesis_default(|mut executor| {
         // create an empty transaction
         let sender = AccountData::new(1_000_000, 10);
         executor.add_account_data(&sender);

--- a/language/vm/src/access.rs
+++ b/language/vm/src/access.rs
@@ -186,6 +186,13 @@ pub trait ScriptAccess: Sync {
     /// Returns the `CompiledScript` that will be used for accesses.
     fn as_script(&self) -> &CompiledScript;
 
+    /// Returns the `ModuleHandle` for `self`.
+    fn self_handle(&self) -> &ModuleHandle {
+        self.module_handle_at(ModuleHandleIndex::new(
+            CompiledModule::IMPLEMENTED_MODULE_INDEX,
+        ))
+    }
+
     fn module_handle_at(&self, idx: ModuleHandleIndex) -> &ModuleHandle {
         &self.as_script().as_inner().module_handles[idx.into_index()]
     }

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -1832,3 +1832,50 @@ pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
     module.function_defs.push(fun_def);
     module.freeze().unwrap()
 }
+
+/// Return a simple script that contains only a return in the main()
+pub fn empty_script() -> CompiledScriptMut {
+    let default_address = AccountAddress::new([3u8; 32]);
+    let self_module_name = self_module_name().to_owned();
+    let main_name = Identifier::new("main").unwrap();
+    let void_void_sig = FunctionSignature {
+        arg_types: vec![],
+        return_types: vec![],
+        type_formals: vec![],
+    };
+    let no_args_no_locals = LocalsSignature(vec![]);
+    let self_module_handle = ModuleHandle {
+        address: AddressPoolIndex(0),
+        name: IdentifierIndex(0),
+    };
+    let main = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(1),
+        signature: FunctionSignatureIndex(0),
+    };
+    let code = CodeUnit {
+        max_stack_size: 1,
+        locals: LocalsSignatureIndex(0),
+        code: vec![Bytecode::Ret],
+    };
+    let main_def = FunctionDefinition {
+        function: FunctionHandleIndex(0),
+        flags: CodeUnit::PUBLIC,
+        acquires_global_resources: vec![],
+        code,
+    };
+    CompiledScriptMut {
+        module_handles: vec![self_module_handle],
+        struct_handles: vec![],
+        function_handles: vec![main],
+
+        type_signatures: vec![],
+        function_signatures: vec![void_void_sig],
+        locals_signatures: vec![no_args_no_locals],
+
+        identifiers: vec![self_module_name, main_name],
+        byte_array_pool: vec![],
+        address_pool: vec![default_address],
+        main: main_def,
+    }
+}

--- a/language/vm/vm-runtime/src/runtime.rs
+++ b/language/vm/vm-runtime/src/runtime.rs
@@ -152,7 +152,7 @@ impl<'alloc> VMRuntime<'alloc> {
         script: Vec<u8>,
         args: Vec<Value>,
     ) -> VMResult<()> {
-        let main = self.script_cache.cache_script(&script)?;
+        let main = self.script_cache.cache_script(&script, context)?;
 
         if !verify_actuals(main.signature(), &args) {
             return Err(VMStatus::new(StatusCode::TYPE_MISMATCH)

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -387,6 +387,7 @@ pub enum StatusCode {
     UNUSED_TYPE_SIGNATURE = 1079,
     /// Reported when a struct has zero fields
     ZERO_SIZED_STRUCT = 1080,
+    LINKER_ERROR = 1081,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.
@@ -397,7 +398,7 @@ pub enum StatusCode {
     EMPTY_VALUE_STACK = 2003,
     EMPTY_CALL_STACK = 2004,
     PC_OVERFLOW = 2005,
-    LINKER_ERROR = 2006,
+    VERIFICATION_ERROR = 2006,
     LOCAL_REFERENCE_ERROR = 2007,
     STORAGE_ERROR = 2008,
     INTERNAL_TYPE_ERROR = 2009,


### PR DESCRIPTION
this covers cross module dependencies verification when executing scripts.
Given how we changed transaction validation it is now possible to pass a completely 
bogus script and though the script itself was verified, cross dependencies were not.
So it seems important to come up with a story soon and before we rework the loader and
the Libra/Move layers.
This code will go through a significant refactor/rework soon so this is a temporary solution.
In other words the implementation is not what we would like it to be but to make it 
more proper it is too much change that does not seem appropriate given the rework.
We are also allowing e2e tests to be executing with any executor and not just one with white-lists.
Also added few related utilities here and there.
One behavior that is kind of "new" is that during execution we change every verification error
to a generic verification invariant violation. Verification error should never occur so that seems
a correct approach