### PR TITLE
[move-prover] Use local names provided by the bytecode-source-map crate.

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/env.rs
+++ b/language/move-prover/bytecode-to-boogie/src/env.rs
@@ -785,7 +785,18 @@ impl<'env> FunctionEnv<'env> {
         if (idx as usize) < self.data.arg_names.len() {
             return self.data.arg_names[idx as usize].to_string();
         }
-        format!("t{}", idx)
+        // Try to obtain name from source map.
+        if let Ok(fmap) = self
+            .module_env
+            .data
+            .source_map
+            .get_function_source_map(self.data.def_idx)
+        {
+            if let Some((ident, _)) = fmap.get_local_name(idx as u64) {
+                return ident.to_string();
+            }
+        }
+        format!("__t{}", idx)
     }
 
     /// Returns specification conditions associated with this function.

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -545,7 +545,7 @@ impl<'env> SpecTranslator<'env> {
                 BoogieExpr("<ret>".to_string(), GlobalType::U64),
             )
         } else {
-            BoogieExpr(format!("ret{}", index), return_types[index].clone())
+            BoogieExpr(format!("__ret{}", index), return_types[index].clone())
         }
     }
 

--- a/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
@@ -132,10 +132,10 @@ fn verify_boogie_output(sources: &[&str], boogie_str: &str, mut out: BoogieOutpu
         path = Path::new(path.file_name().unwrap());
         let basename = path.file_stem().unwrap().to_str().unwrap();
         info!("Test failure for {}!!!", basename);
-        info!("Writing boogie output to `{}.bpl`", basename);
-        fs::write(&format!("{}.bpl", basename), &boogie_str).unwrap_or(());
-        info!("Writing boogie log to `{}.bpl.log`", basename);
-        fs::write(&format!("{}.bpl.log", basename), &out.all_output).unwrap_or(());
+        info!("Writing boogie output to `failed_{}.bpl`", basename);
+        fs::write(&format!("failed_{}.bpl", basename), &boogie_str).unwrap_or(());
+        info!("Writing boogie log to `failed_{}.bpl.log`", basename);
+        fs::write(&format!("failed_{}.bpl.log", basename), &out.all_output).unwrap_or(());
         panic!(msg.join("\n"));
     }
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -119,19 +119,19 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 
 // ** functions of module LibraCoin
 
-procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value), Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -153,61 +153,61 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    call __t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), __t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t4);
+    assume is#Vector(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
+procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint_with_default_capability(amount);
+    call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
-procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value), Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(value)))));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), value)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), value)));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t3: Value; // IntegerType()
-    var t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // AddressType()
-    var t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // IntegerType()
-    var t17: Value; // IntegerType()
-    var t18: Value; // IntegerType()
-    var t19: Value; // IntegerType()
-    var t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t21: Reference; // ReferenceType(IntegerType())
-    var t22: Value; // IntegerType()
-    var t23: Value; // LibraCoin_T_type_value()
+    var market_cap_ref: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var market_cap_total_value: Value; // IntegerType()
+    var __t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // AddressType()
+    var __t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // IntegerType()
+    var __t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t21: Reference; // ReferenceType(IntegerType())
+    var __t22: Value; // IntegerType()
+    var __t23: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -225,7 +225,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume IsValidReferenceParameter(__m, __frame, capability);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(capability);
+    call __t4 := CopyOrMoveRef(capability);
 
     // unimplemented instruction: NoOp
 
@@ -260,16 +260,16 @@ Label_11:
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call t13 := BorrowGlobal(GetLocal(__m, __frame + 12), LibraCoin_MarketCap_type_value());
+    call __t13 := BorrowGlobal(GetLocal(__m, __frame + 12), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t13);
+    call market_cap_ref := CopyOrMoveRef(__t13);
 
-    call t14 := CopyOrMoveRef(t2);
+    call __t14 := CopyOrMoveRef(market_cap_ref);
 
-    call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
+    call __t15 := BorrowField(__t14, LibraCoin_MarketCap_total_value);
 
-    call __tmp := ReadRef(t15);
+    call __tmp := ReadRef(__t15);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
@@ -286,11 +286,11 @@ Label_11:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := CopyOrMoveRef(t2);
+    call __t20 := CopyOrMoveRef(market_cap_ref);
 
-    call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
+    call __t21 := BorrowField(__t20, LibraCoin_MarketCap_total_value);
 
-    call WriteRef(t21, GetLocal(__m, __frame + 19));
+    call WriteRef(__t21, GetLocal(__m, __frame + 19));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
@@ -298,19 +298,19 @@ Label_11:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 22));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 23);
+    __ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
+procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint(value, capability);
+    call __ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
@@ -323,15 +323,15 @@ ensures old(b#Boolean(Boolean(!IsEqual(Address(TxnSenderAddress(__txn)), Address
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // LibraCoin_MintCapability_type_value()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __t0: Value; // AddressType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // LibraCoin_MintCapability_type_value()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_MarketCap_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -397,18 +397,18 @@ procedure LibraCoin_initialize_verify () returns ()
     call LibraCoin_initialize();
 }
 
-procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_market_cap () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t0: Value; // AddressType()
+    var __t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -425,37 +425,37 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    call __t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+    call __t2 := BorrowField(__t1, LibraCoin_MarketCap_total_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_market_cap_verify () returns (ret0: Value)
+procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_market_cap();
+    call __ret0 := LibraCoin_market_cap();
 }
 
-procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_zero () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(0))));
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Integer(0))));
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // LibraCoin_T_type_value()
+    var __t0: Value; // IntegerType()
+    var __t1: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -475,29 +475,29 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_zero_verify () returns (ret0: Value)
+procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_zero();
+    call __ret0 := LibraCoin_zero();
 }
 
-procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))));
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -513,43 +513,43 @@ ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, coin_ref), 
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(coin_ref);
+    call __t1 := CopyOrMoveRef(coin_ref);
 
-    call t2 := BorrowField(t1, LibraCoin_T_value);
+    call __t2 := BorrowField(__t1, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
+procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_value(coin_ref);
+    call __ret0 := LibraCoin_value(coin_ref);
 }
 
-procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(ret1, LibraCoin_T_value), amount))) && b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(__ret1, LibraCoin_T_value), amount))) && b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
 ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var other: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -567,16 +567,16 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraCoin_withdraw(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t5);
+    assume is#Vector(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -587,48 +587,48 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
-    ret1 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 6);
+    __ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := LibraCoin_split(coin, amount);
+    call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
-procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value), Integer(i#Integer(old(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraCoin_T_type_value()
+    var value: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -646,11 +646,11 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(coin_ref);
+    call __t3 := CopyOrMoveRef(coin_ref);
 
-    call t4 := BorrowField(t3, LibraCoin_T_value);
+    call __t4 := BorrowField(__t3, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
@@ -688,11 +688,11 @@ Label_11:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := CopyOrMoveRef(coin_ref);
+    call __t14 := CopyOrMoveRef(coin_ref);
 
-    call t15 := BorrowField(t14, LibraCoin_T_value);
+    call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(__m, __frame + 13));
+    call WriteRef(__t15, GetLocal(__m, __frame + 13));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -700,32 +700,32 @@ Label_11:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 17);
+    __ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_withdraw(coin_ref, amount);
+    call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
-procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -743,30 +743,30 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_join(coin1, coin2);
+    call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
@@ -777,18 +777,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t13: Reference; // ReferenceType(IntegerType())
+    var value: Value; // IntegerType()
+    var check_value: Value; // IntegerType()
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t13: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -806,11 +806,11 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(coin_ref);
+    call __t4 := CopyOrMoveRef(coin_ref);
 
-    call t5 := BorrowField(t4, LibraCoin_T_value);
+    call __t5 := BorrowField(__t4, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -820,8 +820,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    call __t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -836,11 +836,11 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(coin_ref);
+    call __t12 := CopyOrMoveRef(coin_ref);
 
-    call t13 := BorrowField(t12, LibraCoin_T_value);
+    call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(__m, __frame + 11));
+    call WriteRef(__t13, GetLocal(__m, __frame + 11));
 
     return;
 
@@ -862,14 +862,14 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
+    var value: Value; // IntegerType()
+    var __t2: Value; // LibraCoin_T_type_value()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -888,8 +888,8 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    call __t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -1159,38 +1159,38 @@ procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (c
 
 // ** functions of module LibraAccount
 
-procedure {:inline 1} LibraAccount_make (fresh_address: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_make (fresh_address: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(SelectField(SelectField(ret0, LibraAccount_T_balance), LibraCoin_T_value), Integer(0))));
-ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(SelectField(ret0, LibraAccount_T_delegated_key_rotation_capability))))) && b#Boolean(Boolean(!(b#Boolean(SelectField(ret0, LibraAccount_T_delegated_withdrawal_capability)))))));
-ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(ret0, LibraAccount_T_received_events), LibraAccount_EventHandle_counter), Integer(0)))) && b#Boolean(Boolean(IsEqual(SelectField(SelectField(ret0, LibraAccount_T_sent_events), LibraAccount_EventHandle_counter), Integer(0))))));
+ensures b#Boolean(Boolean(IsEqual(SelectField(SelectField(__ret0, LibraAccount_T_balance), LibraCoin_T_value), Integer(0))));
+ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(SelectField(__ret0, LibraAccount_T_delegated_key_rotation_capability))))) && b#Boolean(Boolean(!(b#Boolean(SelectField(__ret0, LibraAccount_T_delegated_withdrawal_capability)))))));
+ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__ret0, LibraAccount_T_received_events), LibraAccount_EventHandle_counter), Integer(0)))) && b#Boolean(Boolean(IsEqual(SelectField(SelectField(__ret0, LibraAccount_T_sent_events), LibraAccount_EventHandle_counter), Integer(0))))));
 {
     // declare local variables
-    var t1: Value; // LibraCoin_T_type_value()
-    var t2: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t3: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
-    var t4: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
-    var t5: Value; // ByteArrayType()
-    var t6: Value; // AddressType()
-    var t7: Value; // ByteArrayType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
-    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t14: Value; // AddressType()
-    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
-    var t16: Value; // LibraCoin_T_type_value()
-    var t17: Value; // ByteArrayType()
-    var t18: Value; // LibraCoin_T_type_value()
-    var t19: Value; // BooleanType()
-    var t20: Value; // BooleanType()
-    var t21: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
-    var t22: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
-    var t23: Value; // IntegerType()
-    var t24: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t25: Value; // LibraAccount_T_type_value()
+    var zero_balance: Value; // LibraCoin_T_type_value()
+    var generator: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var sent_handle: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var received_handle: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var auth_key: Value; // ByteArrayType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // ByteArrayType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var __t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t14: Value; // AddressType()
+    var __t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var __t16: Value; // LibraCoin_T_type_value()
+    var __t17: Value; // ByteArrayType()
+    var __t18: Value; // LibraCoin_T_type_value()
+    var __t19: Value; // BooleanType()
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var __t22: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var __t23: Value; // IntegerType()
+    var __t24: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t25: Value; // LibraAccount_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1209,11 +1209,11 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(ret0
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 6));
+    call __t7 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t7);
+    assume is#ByteArray(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -1227,39 +1227,39 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(ret0
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t10 := BorrowLoc(__frame + 2);
+    call __t10 := BorrowLoc(__frame + 2);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    call __t12 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), __t10, GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t12);
+    assume is#Vector(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t13 := BorrowLoc(__frame + 2);
+    call __t13 := BorrowLoc(__frame + 2);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    call __t15 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), __t13, GetLocal(__m, __frame + 14));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t15);
+    assume is#Vector(__t15);
 
-    __m := UpdateLocal(__m, __frame + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, __t15);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t16 := LibraCoin_zero();
+    call __t16 := LibraCoin_zero();
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t16);
+    assume is#Vector(__t16);
 
-    __m := UpdateLocal(__m, __frame + 16, t16);
+    __m := UpdateLocal(__m, __frame + 16, __t16);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -1291,19 +1291,19 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(ret0
     call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20), GetLocal(__m, __frame + 21), GetLocal(__m, __frame + 22), GetLocal(__m, __frame + 23), GetLocal(__m, __frame + 24));
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 25);
+    __ret0 := GetLocal(__m, __frame + 25);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_make_verify (fresh_address: Value) returns (ret0: Value)
+procedure LibraAccount_make_verify (fresh_address: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_make(fresh_address);
+    call __ret0 := LibraAccount_make(fresh_address);
 }
 
 procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) returns ()
@@ -1314,9 +1314,9 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1366,10 +1366,10 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // ByteArrayType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1425,35 +1425,35 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t4: Value; // IntegerType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // BooleanType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // AddressType()
-    var t15: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
-    var t18: Value; // IntegerType()
-    var t19: Value; // AddressType()
-    var t20: Value; // ByteArrayType()
-    var t21: Value; // LibraAccount_SentPaymentEvent_type_value()
-    var t22: Value; // AddressType()
-    var t23: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t25: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t26: Value; // LibraCoin_T_type_value()
-    var t27: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
-    var t29: Value; // IntegerType()
-    var t30: Value; // AddressType()
-    var t31: Value; // ByteArrayType()
-    var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+    var deposit_value: Value; // IntegerType()
+    var payee_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var sender_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // BooleanType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // AddressType()
+    var __t15: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // AddressType()
+    var __t20: Value; // ByteArrayType()
+    var __t21: Value; // LibraAccount_SentPaymentEvent_type_value()
+    var __t22: Value; // AddressType()
+    var __t23: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t25: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t26: Value; // LibraCoin_T_type_value()
+    var __t27: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
+    var __t29: Value; // IntegerType()
+    var __t30: Value; // AddressType()
+    var __t31: Value; // ByteArrayType()
+    var __t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1475,13 +1475,13 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2);
 
-    call t8 := LibraCoin_value(t7);
+    call __t8 := LibraCoin_value(__t7);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t8);
+    assume IsValidU64(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -1510,14 +1510,14 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
+    call __t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t6 := CopyOrMoveRef(t15);
+    call sender_account_ref := CopyOrMoveRef(__t15);
 
-    call t16 := CopyOrMoveRef(t6);
+    call __t16 := CopyOrMoveRef(sender_account_ref);
 
-    call t17 := BorrowField(t16, LibraAccount_T_sent_events);
+    call __t17 := BorrowField(__t16, LibraAccount_T_sent_events);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -1531,30 +1531,30 @@ Label_10:
     call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(__m, __frame + 21));
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), __t17, GetLocal(__m, __frame + 21));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
+    call __t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t23);
+    call payee_account_ref := CopyOrMoveRef(__t23);
 
-    call t24 := CopyOrMoveRef(t5);
+    call __t24 := CopyOrMoveRef(payee_account_ref);
 
-    call t25 := BorrowField(t24, LibraAccount_T_balance);
+    call __t25 := BorrowField(__t24, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call LibraCoin_deposit(t25, GetLocal(__m, __frame + 26));
+    call LibraCoin_deposit(__t25, GetLocal(__m, __frame + 26));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t27 := CopyOrMoveRef(t5);
+    call __t27 := CopyOrMoveRef(payee_account_ref);
 
-    call t28 := BorrowField(t27, LibraAccount_T_received_events);
+    call __t28 := BorrowField(__t27, LibraAccount_T_received_events);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 29, __tmp);
@@ -1568,7 +1568,7 @@ Label_10:
     call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(__m, __frame + 32));
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), __t28, GetLocal(__m, __frame + 32));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -1595,13 +1595,13 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
 
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // AddressType()
-    var t6: Value; // AddressType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_T_type_value()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1644,11 +1644,11 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
+    call __t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t8);
+    assume is#Vector(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call LibraAccount_deposit(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
@@ -1666,21 +1666,21 @@ procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) retu
     call LibraAccount_mint_to_address(payee, amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value), Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
 ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Value; // IntegerType()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var to_withdraw: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1698,18 +1698,18 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(account);
+    call __t3 := CopyOrMoveRef(account);
 
-    call t4 := BorrowField(t3, LibraAccount_T_balance);
+    call __t4 := BorrowField(__t3, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := LibraCoin_withdraw(t4, GetLocal(__m, __frame + 5));
+    call __t6 := LibraCoin_withdraw(__t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t6);
+    assume is#Vector(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -1717,40 +1717,40 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_from_account(account, amount);
+    call __ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value), Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
 ensures old(!(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Value; // IntegerType()
-    var t10: Value; // LibraCoin_T_type_value()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1769,16 +1769,16 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call sender_account := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(sender_account);
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_withdrawal_capability);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -1791,49 +1791,49 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     goto Label_Abort;
 
 Label_9:
-    call t8 := CopyOrMoveRef(t1);
+    call __t8 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(__m, __frame + 9));
+    call __t10 := LibraAccount_withdraw_from_account(__t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t10);
+    assume is#Vector(__t10);
 
-    __m := UpdateLocal(__m, __frame + 10, t10);
+    __m := UpdateLocal(__m, __frame + 10, __t10);
 
-    ret0 := GetLocal(__m, __frame + 10);
+    __ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_from_sender(amount);
+    call __ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value), Integer(i#Integer(old(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value))) - i#Integer(amount)))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address))))))) || b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(SelectField(Dereference(__m, cap), LibraAccount_WithdrawalCapability_account_address)))), LibraAccount_T_balance), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t4: Reference; // ReferenceType(AddressType())
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t8: Value; // IntegerType()
-    var t9: Value; // LibraCoin_T_type_value()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t4: Reference; // ReferenceType(AddressType())
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1851,69 +1851,69 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(cap);
+    call __t3 := CopyOrMoveRef(cap);
 
-    call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
+    call __t4 := BorrowField(__t3, LibraAccount_WithdrawalCapability_account_address);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
-    call t7 := CopyOrMoveRef(t2);
+    call __t7 := CopyOrMoveRef(account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(__m, __frame + 8));
+    call __t9 := LibraAccount_withdraw_from_account(__t7, GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t9);
+    assume is#Vector(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
-    ret0 := GetLocal(__m, __frame + 9);
+    __ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_with_capability(cap, amount);
+    call __ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
-procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraAccount_WithdrawalCapability_account_address), Address(TxnSenderAddress(__txn)))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraAccount_WithdrawalCapability_account_address), Address(TxnSenderAddress(__txn)))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_withdrawal_capability))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Reference; // ReferenceType(BooleanType())
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(BooleanType())
-    var t8: Reference; // ReferenceType(BooleanType())
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // BooleanType()
-    var t12: Reference; // ReferenceType(BooleanType())
-    var t13: Value; // AddressType()
-    var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var sender: Value; // AddressType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var delegated_ref: Reference; // ReferenceType(BooleanType())
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(BooleanType())
+    var __t8: Reference; // ReferenceType(BooleanType())
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // BooleanType()
+    var __t12: Reference; // ReferenceType(BooleanType())
+    var __t13: Value; // AddressType()
+    var __t14: Value; // LibraAccount_WithdrawalCapability_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1936,20 +1936,20 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t5);
+    call sender_account := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(sender_account);
 
-    call t7 := BorrowField(t6, LibraAccount_T_delegated_withdrawal_capability);
+    call __t7 := BorrowField(__t6, LibraAccount_T_delegated_withdrawal_capability);
 
-    call t2 := CopyOrMoveRef(t7);
+    call delegated_ref := CopyOrMoveRef(__t7);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(delegated_ref);
 
-    call __tmp := ReadRef(t8);
+    call __tmp := ReadRef(__t8);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
@@ -1965,9 +1965,9 @@ Label_13:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(t2);
+    call __t12 := CopyOrMoveRef(delegated_ref);
 
-    call WriteRef(t12, GetLocal(__m, __frame + 11));
+    call WriteRef(__t12, GetLocal(__m, __frame + 11));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
@@ -1975,19 +1975,19 @@ Label_13:
     call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 14);
+    __ret0 := GetLocal(__m, __frame + 14);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
+procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_extract_sender_withdrawal_capability();
+    call __ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (cap: Value) returns ()
@@ -1998,15 +1998,15 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // LibraAccount_WithdrawalCapability_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // BooleanType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Reference; // ReferenceType(BooleanType())
+    var account_address: Value; // AddressType()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Value; // BooleanType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Reference; // ReferenceType(BooleanType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2025,8 +2025,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    call __t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -2034,19 +2034,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(account);
 
-    call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
+    call __t9 := BorrowField(__t8, LibraAccount_T_delegated_withdrawal_capability);
 
-    call WriteRef(t9, GetLocal(__m, __frame + 7));
+    call WriteRef(__t9, GetLocal(__m, __frame + 7));
 
     return;
 
@@ -2067,18 +2067,18 @@ ensures b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(pay
 ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(payee)))))))))) || b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(payee))), LibraAccount_T_balance), LibraCoin_T_value), amount)))));
 {
     // declare local variables
-    var t4: Value; // AddressType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // AddressType()
-    var t8: Value; // AddressType()
-    var t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t10: Reference; // ReferenceType(AddressType())
-    var t11: Value; // AddressType()
-    var t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t13: Value; // IntegerType()
-    var t14: Value; // LibraCoin_T_type_value()
-    var t15: Value; // ByteArrayType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // AddressType()
+    var __t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t10: Reference; // ReferenceType(AddressType())
+    var __t11: Value; // AddressType()
+    var __t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // LibraCoin_T_type_value()
+    var __t15: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2122,24 +2122,24 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := CopyOrMoveRef(cap);
+    call __t9 := CopyOrMoveRef(cap);
 
-    call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
+    call __t10 := BorrowField(__t9, LibraAccount_WithdrawalCapability_account_address);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(cap);
+    call __t12 := CopyOrMoveRef(cap);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(__m, __frame + 13));
+    call __t14 := LibraAccount_withdraw_with_capability(__t12, GetLocal(__m, __frame + 13));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t14);
+    assume is#Vector(__t14);
 
-    __m := UpdateLocal(__m, __frame + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, __t14);
 
     // unimplemented instruction: LdByteArray(15, ByteArrayPoolIndex(0))
 
@@ -2170,19 +2170,19 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
 
 {
     // declare local variables
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // AddressType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // AddressType()
-    var t12: Value; // AddressType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // LibraCoin_T_type_value()
-    var t15: Value; // ByteArrayType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // AddressType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // AddressType()
+    var __t12: Value; // AddressType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // LibraCoin_T_type_value()
+    var __t15: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2248,11 +2248,11 @@ Label_13:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 13));
+    call __t14 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 13));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t14);
+    assume is#Vector(__t14);
 
-    __m := UpdateLocal(__m, __frame + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, __t14);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 15, __tmp);
@@ -2284,14 +2284,14 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
 
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // AddressType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // AddressType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2359,9 +2359,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, account), LibraAccount_T_authentication_key), new_authentication_key)));
 {
     // declare local variables
-    var t2: Value; // ByteArrayType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(ByteArrayType())
+    var __t2: Value; // ByteArrayType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(ByteArrayType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2382,11 +2382,11 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, account), LibraAc
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := CopyOrMoveRef(account);
+    call __t3 := CopyOrMoveRef(account);
 
-    call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
+    call __t4 := BorrowField(__t3, LibraAccount_T_authentication_key);
 
-    call WriteRef(t4, GetLocal(__m, __frame + 2));
+    call WriteRef(__t4, GetLocal(__m, __frame + 2));
 
     return;
 
@@ -2409,15 +2409,15 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Value; // ByteArrayType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2436,16 +2436,16 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call sender_account := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(sender_account);
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -2458,12 +2458,12 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     goto Label_Abort;
 
 Label_9:
-    call t8 := CopyOrMoveRef(t1);
+    call __t8 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(__m, __frame + 9));
+    call LibraAccount_rotate_authentication_key_for_account(__t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -2486,11 +2486,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
-    var t3: Reference; // ReferenceType(AddressType())
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Value; // ByteArrayType()
+    var __t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var __t3: Reference; // ReferenceType(AddressType())
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t6: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2508,21 +2508,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
-    call t2 := CopyOrMoveRef(cap);
+    call __t2 := CopyOrMoveRef(cap);
 
-    call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
+    call __t3 := BorrowField(__t2, LibraAccount_KeyRotationCapability_account_address);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(__m, __frame + 6));
+    call LibraAccount_rotate_authentication_key_for_account(__t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -2538,27 +2538,27 @@ procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Re
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
-procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraAccount_KeyRotationCapability_account_address), Address(TxnSenderAddress(__txn)))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraAccount_KeyRotationCapability_account_address), Address(TxnSenderAddress(__txn)))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_key_rotation_capability)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_delegated_key_rotation_capability))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(BooleanType())
-    var t2: Value; // AddressType()
-    var t3: Value; // AddressType()
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Reference; // ReferenceType(BooleanType())
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Reference; // ReferenceType(BooleanType())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var sender: Value; // AddressType()
+    var delegated_ref: Reference; // ReferenceType(BooleanType())
+    var __t2: Value; // AddressType()
+    var __t3: Value; // AddressType()
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Reference; // ReferenceType(BooleanType())
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Reference; // ReferenceType(BooleanType())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_KeyRotationCapability_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2581,16 +2581,16 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    call __t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call t1 := CopyOrMoveRef(t5);
+    call delegated_ref := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(delegated_ref);
 
-    call __tmp := ReadRef(t6);
+    call __tmp := ReadRef(__t6);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
@@ -2606,9 +2606,9 @@ Label_11:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := CopyOrMoveRef(t1);
+    call __t10 := CopyOrMoveRef(delegated_ref);
 
-    call WriteRef(t10, GetLocal(__m, __frame + 9));
+    call WriteRef(__t10, GetLocal(__m, __frame + 9));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -2616,19 +2616,19 @@ Label_11:
     call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 12);
+    __ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
+procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_extract_sender_key_rotation_capability();
+    call __ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (cap: Value) returns ()
@@ -2639,15 +2639,15 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // LibraAccount_KeyRotationCapability_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // BooleanType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Reference; // ReferenceType(BooleanType())
+    var account_address: Value; // AddressType()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Value; // BooleanType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Reference; // ReferenceType(BooleanType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2666,8 +2666,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    call __t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -2675,19 +2675,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(account);
 
-    call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
+    call __t9 := BorrowField(__t8, LibraAccount_T_delegated_key_rotation_capability);
 
-    call WriteRef(t9, GetLocal(__m, __frame + 7));
+    call WriteRef(__t9, GetLocal(__m, __frame + 7));
 
     return;
 
@@ -2712,24 +2712,24 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
 
 {
     // declare local variables
-    var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t2: Value; // IntegerType()
-    var t3: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Value; // ByteArrayType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
-    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t14: Value; // AddressType()
-    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t18: Value; // LibraAccount_T_type_value()
+    var generator: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // ByteArrayType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var __t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t14: Value; // AddressType()
+    var __t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t18: Value; // LibraAccount_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2760,17 +2760,17 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
+    call __t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t6);
+    assume is#ByteArray(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
-    call t7 := LibraCoin_zero();
+    call __t7 := LibraCoin_zero();
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t7);
+    assume is#Vector(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -2778,27 +2778,27 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    call __t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), __t10, GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t12);
+    assume is#Vector(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
-    call t13 := BorrowLoc(__frame + 1);
+    call __t13 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    call __t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), __t13, GetLocal(__m, __frame + 14));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t15);
+    assume is#Vector(__t15);
 
-    __m := UpdateLocal(__m, __frame + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, __t15);
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -2836,12 +2836,12 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
 
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // AddressType()
-    var t7: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2900,16 +2900,16 @@ procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
-procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(SelectField(Dereference(__m, account), LibraAccount_T_balance), LibraCoin_T_value))));
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var balance_value: Value; // IntegerType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2925,15 +2925,15 @@ ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(SelectField(Dereference(__m,
     assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
-    call t2 := CopyOrMoveRef(account);
+    call __t2 := CopyOrMoveRef(account);
 
-    call t3 := BorrowField(t2, LibraAccount_T_balance);
+    call __t3 := BorrowField(__t2, LibraAccount_T_balance);
 
-    call t4 := LibraCoin_value(t3);
+    call __t4 := LibraCoin_value(__t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t4);
+    assume IsValidU64(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -2941,32 +2941,32 @@ ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(SelectField(Dereference(__m,
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 5);
+    __ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_balance_for_account_verify (account: Reference) returns (ret0: Value)
+procedure LibraAccount_balance_for_account_verify (account: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_balance_for_account(account);
+    call __ret0 := LibraAccount_balance_for_account(account);
 }
 
-procedure {:inline 1} LibraAccount_balance (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_balance (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_balance), LibraCoin_T_value))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_balance), LibraCoin_T_value))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2985,38 +2985,38 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := LibraAccount_balance_for_account(t2);
+    call __t3 := LibraAccount_balance_for_account(__t2);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t3);
+    assume IsValidU64(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_balance_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_balance_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_balance(addr);
+    call __ret0 := LibraAccount_balance(addr);
 }
 
-procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, account), LibraAccount_T_sequence_number))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, account), LibraAccount_T_sequence_number))));
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3032,40 +3032,40 @@ ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, account), L
     assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(account);
+    call __t1 := CopyOrMoveRef(account);
 
-    call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
+    call __t2 := BorrowField(__t1, LibraAccount_T_sequence_number);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (ret0: Value)
+procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_sequence_number_for_account(account);
+    call __ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
-procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_sequence_number))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_sequence_number))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3084,42 +3084,42 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := LibraAccount_sequence_number_for_account(t2);
+    call __t3 := LibraAccount_sequence_number_for_account(__t2);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t3);
+    assume IsValidU64(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_sequence_number_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_sequence_number_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_sequence_number(addr);
+    call __ret0 := LibraAccount_sequence_number(addr);
 }
 
-procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_key_rotation_capability))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_key_rotation_capability))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(BooleanType())
-    var t4: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(BooleanType())
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3138,42 +3138,42 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
+    call __t3 := BorrowField(__t2, LibraAccount_T_delegated_key_rotation_capability);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_delegated_key_rotation_capability(addr);
+    call __ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
-procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_withdrawal_capability))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(addr))), LibraAccount_T_delegated_withdrawal_capability))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr)))))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address(addr))))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(BooleanType())
-    var t4: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(BooleanType())
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3192,37 +3192,37 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
+    call __t3 := BorrowField(__t2, LibraAccount_T_delegated_withdrawal_capability);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_delegated_withdrawal_capability(addr);
+    call __ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
-procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (ret0: Reference)
+procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (__ret0: Reference)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean((ret0) == (SelectFieldFromRef(cap, LibraAccount_WithdrawalCapability_account_address))));
+ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_WithdrawalCapability_account_address))));
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t2: Reference; // ReferenceType(AddressType())
+    var __t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t2: Reference; // ReferenceType(AddressType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3238,32 +3238,32 @@ ensures b#Boolean(Boolean((ret0) == (SelectFieldFromRef(cap, LibraAccount_Withdr
     assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(cap);
+    call __t1 := CopyOrMoveRef(cap);
 
-    call t2 := BorrowField(t1, LibraAccount_WithdrawalCapability_account_address);
+    call __t2 := BorrowField(__t1, LibraAccount_WithdrawalCapability_account_address);
 
-    ret0 := t2;
+    __ret0 := __t2;
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultReference;
+    __ret0 := DefaultReference;
 }
 
-procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (ret0: Reference)
+procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdrawal_capability_address(cap);
+    call __ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
-procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (ret0: Reference)
+procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (__ret0: Reference)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean((ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyRotationCapability_account_address))));
+ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyRotationCapability_account_address))));
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
-    var t2: Reference; // ReferenceType(AddressType())
+    var __t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var __t2: Reference; // ReferenceType(AddressType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3279,32 +3279,32 @@ ensures b#Boolean(Boolean((ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyRot
     assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(cap);
+    call __t1 := CopyOrMoveRef(cap);
 
-    call t2 := BorrowField(t1, LibraAccount_KeyRotationCapability_account_address);
+    call __t2 := BorrowField(__t1, LibraAccount_KeyRotationCapability_account_address);
 
-    ret0 := t2;
+    __ret0 := __t2;
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultReference;
+    __ret0 := DefaultReference;
 }
 
-procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (ret0: Reference)
+procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_key_rotation_capability_address(cap);
+    call __ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
-procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, ExistsResource(__m, LibraAccount_T_type_value(), a#Address(check_addr)))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, ExistsResource(__m, LibraAccount_T_type_value(), a#Address(check_addr)))));
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3326,71 +3326,71 @@ ensures b#Boolean(Boolean(IsEqual(ret0, ExistsResource(__m, LibraAccount_T_type_
     call __tmp := Exists(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_exists_verify (check_addr: Value) returns (ret0: Value)
+procedure LibraAccount_exists_verify (check_addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_exists(check_addr);
+    call __ret0 := LibraAccount_exists(check_addr);
 }
 
 procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Value; // AddressType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // BooleanType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // AddressType()
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Value; // ByteArrayType()
-    var t18: Value; // ByteArrayType()
-    var t19: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t20: Reference; // ReferenceType(ByteArrayType())
-    var t21: Value; // ByteArrayType()
-    var t22: Value; // BooleanType()
-    var t23: Value; // BooleanType()
-    var t24: Value; // IntegerType()
-    var t25: Value; // IntegerType()
-    var t26: Value; // IntegerType()
-    var t27: Value; // IntegerType()
-    var t28: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t29: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t31: Value; // IntegerType()
-    var t32: Value; // IntegerType()
-    var t33: Value; // IntegerType()
-    var t34: Value; // BooleanType()
-    var t35: Value; // BooleanType()
-    var t36: Value; // IntegerType()
-    var t37: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t38: Reference; // ReferenceType(IntegerType())
-    var t39: Value; // IntegerType()
-    var t40: Value; // IntegerType()
-    var t41: Value; // IntegerType()
-    var t42: Value; // BooleanType()
-    var t43: Value; // BooleanType()
-    var t44: Value; // IntegerType()
-    var t45: Value; // IntegerType()
-    var t46: Value; // IntegerType()
-    var t47: Value; // BooleanType()
-    var t48: Value; // BooleanType()
-    var t49: Value; // IntegerType()
+    var transaction_sender: Value; // AddressType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var imm_sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var max_transaction_fee: Value; // IntegerType()
+    var balance_amount: Value; // IntegerType()
+    var sequence_number_value: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Value; // AddressType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // AddressType()
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Value; // ByteArrayType()
+    var __t18: Value; // ByteArrayType()
+    var __t19: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t20: Reference; // ReferenceType(ByteArrayType())
+    var __t21: Value; // ByteArrayType()
+    var __t22: Value; // BooleanType()
+    var __t23: Value; // BooleanType()
+    var __t24: Value; // IntegerType()
+    var __t25: Value; // IntegerType()
+    var __t26: Value; // IntegerType()
+    var __t27: Value; // IntegerType()
+    var __t28: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t29: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t31: Value; // IntegerType()
+    var __t32: Value; // IntegerType()
+    var __t33: Value; // IntegerType()
+    var __t34: Value; // BooleanType()
+    var __t35: Value; // BooleanType()
+    var __t36: Value; // IntegerType()
+    var __t37: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t38: Reference; // ReferenceType(IntegerType())
+    var __t39: Value; // IntegerType()
+    var __t40: Value; // IntegerType()
+    var __t41: Value; // IntegerType()
+    var __t42: Value; // BooleanType()
+    var __t43: Value; // BooleanType()
+    var __t44: Value; // IntegerType()
+    var __t45: Value; // IntegerType()
+    var __t46: Value; // IntegerType()
+    var __t47: Value; // BooleanType()
+    var __t48: Value; // BooleanType()
+    var __t49: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3439,25 +3439,25 @@ Label_8:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    call t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
+    call __t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t16);
+    call sender_account := CopyOrMoveRef(__t16);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
+    call __t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t18);
+    assume is#ByteArray(__t18);
 
-    __m := UpdateLocal(__m, __frame + 18, t18);
+    __m := UpdateLocal(__m, __frame + 18, __t18);
 
-    call t19 := CopyOrMoveRef(t5);
+    call __t19 := CopyOrMoveRef(sender_account);
 
-    call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
+    call __t20 := BorrowField(__t19, LibraAccount_T_authentication_key);
 
-    call __tmp := ReadRef(t20);
+    call __tmp := ReadRef(__t20);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
@@ -3489,19 +3489,19 @@ Label_21:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t28 := CopyOrMoveRef(t5);
+    call __t28 := CopyOrMoveRef(sender_account);
 
-    call t29 := FreezeRef(t28);
+    call __t29 := FreezeRef(__t28);
 
-    call t6 := CopyOrMoveRef(t29);
+    call imm_sender_account := CopyOrMoveRef(__t29);
 
-    call t30 := CopyOrMoveRef(t6);
+    call __t30 := CopyOrMoveRef(imm_sender_account);
 
-    call t31 := LibraAccount_balance_for_account(t30);
+    call __t31 := LibraAccount_balance_for_account(__t30);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t31);
+    assume IsValidU64(__t31);
 
-    __m := UpdateLocal(__m, __frame + 31, t31);
+    __m := UpdateLocal(__m, __frame + 31, __t31);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -3527,11 +3527,11 @@ Label_21:
     goto Label_Abort;
 
 Label_38:
-    call t37 := CopyOrMoveRef(t5);
+    call __t37 := CopyOrMoveRef(sender_account);
 
-    call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
+    call __t38 := BorrowField(__t37, LibraAccount_T_sequence_number);
 
-    call __tmp := ReadRef(t38);
+    call __tmp := ReadRef(__t38);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 39, __tmp);
 
@@ -3597,39 +3597,39 @@ procedure {:inline 1} LibraAccount_epilogue (txn_sequence_number: Value, txn_gas
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_T_type_value()
-    var t9: Value; // AddressType()
-    var t10: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t18: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t19: Value; // IntegerType()
-    var t20: Value; // IntegerType()
-    var t21: Value; // BooleanType()
-    var t22: Value; // BooleanType()
-    var t23: Value; // IntegerType()
-    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t25: Value; // IntegerType()
-    var t26: Value; // LibraCoin_T_type_value()
-    var t27: Value; // IntegerType()
-    var t28: Value; // IntegerType()
-    var t29: Value; // IntegerType()
-    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t31: Reference; // ReferenceType(IntegerType())
-    var t32: Value; // AddressType()
-    var t33: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t36: Value; // LibraCoin_T_type_value()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var transaction_fee_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var imm_sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var transaction_fee_amount: Value; // IntegerType()
+    var transaction_fee: Value; // LibraCoin_T_type_value()
+    var __t9: Value; // AddressType()
+    var __t10: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t18: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // IntegerType()
+    var __t21: Value; // BooleanType()
+    var __t22: Value; // BooleanType()
+    var __t23: Value; // IntegerType()
+    var __t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t25: Value; // IntegerType()
+    var __t26: Value; // LibraCoin_T_type_value()
+    var __t27: Value; // IntegerType()
+    var __t28: Value; // IntegerType()
+    var __t29: Value; // IntegerType()
+    var __t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t31: Reference; // ReferenceType(IntegerType())
+    var __t32: Value; // AddressType()
+    var __t33: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t34: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t35: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t36: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3654,10 +3654,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
+    call __t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := CopyOrMoveRef(t10);
+    call sender_account := CopyOrMoveRef(__t10);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -3679,19 +3679,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t16 := CopyOrMoveRef(t4);
+    call __t16 := CopyOrMoveRef(sender_account);
 
-    call t17 := FreezeRef(t16);
+    call __t17 := FreezeRef(__t16);
 
-    call t6 := CopyOrMoveRef(t17);
+    call imm_sender_account := CopyOrMoveRef(__t17);
 
-    call t18 := CopyOrMoveRef(t6);
+    call __t18 := CopyOrMoveRef(imm_sender_account);
 
-    call t19 := LibraAccount_balance_for_account(t18);
+    call __t19 := LibraAccount_balance_for_account(__t18);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t19);
+    assume IsValidU64(__t19);
 
-    __m := UpdateLocal(__m, __frame + 19, t19);
+    __m := UpdateLocal(__m, __frame + 19, __t19);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -3711,16 +3711,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_20:
-    call t24 := CopyOrMoveRef(t4);
+    call __t24 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(__m, __frame + 25));
+    call __t26 := LibraAccount_withdraw_from_account(__t24, GetLocal(__m, __frame + 25));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t26);
+    assume is#Vector(__t26);
 
-    __m := UpdateLocal(__m, __frame + 26, t26);
+    __m := UpdateLocal(__m, __frame + 26, __t26);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -3735,28 +3735,28 @@ Label_20:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 29, __tmp);
 
-    call t30 := CopyOrMoveRef(t4);
+    call __t30 := CopyOrMoveRef(sender_account);
 
-    call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
+    call __t31 := BorrowField(__t30, LibraAccount_T_sequence_number);
 
-    call WriteRef(t31, GetLocal(__m, __frame + 29));
+    call WriteRef(__t31, GetLocal(__m, __frame + 29));
 
     call __tmp := LdAddr(4078);
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
+    call __t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t33);
+    call transaction_fee_account := CopyOrMoveRef(__t33);
 
-    call t34 := CopyOrMoveRef(t5);
+    call __t34 := CopyOrMoveRef(transaction_fee_account);
 
-    call t35 := BorrowField(t34, LibraAccount_T_balance);
+    call __t35 := BorrowField(__t34, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call LibraCoin_deposit(t35, GetLocal(__m, __frame + 36));
+    call LibraCoin_deposit(__t35, GetLocal(__m, __frame + 36));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -3772,33 +3772,33 @@ procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_pric
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
-procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // ByteArrayType()
-    var t4: Value; // ByteArrayType()
-    var t5: Value; // ByteArrayType()
-    var t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t7: Reference; // ReferenceType(IntegerType())
-    var t8: Value; // AddressType()
-    var t9: Value; // ByteArrayType()
-    var t10: Reference; // ReferenceType(IntegerType())
-    var t11: Value; // IntegerType()
-    var t12: Value; // ByteArrayType()
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Reference; // ReferenceType(IntegerType())
-    var t18: Value; // ByteArrayType()
-    var t19: Value; // ByteArrayType()
-    var t20: Value; // ByteArrayType()
-    var t21: Value; // ByteArrayType()
+    var count: Reference; // ReferenceType(IntegerType())
+    var count_bytes: Value; // ByteArrayType()
+    var preimage: Value; // ByteArrayType()
+    var sender_bytes: Value; // ByteArrayType()
+    var __t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t7: Reference; // ReferenceType(IntegerType())
+    var __t8: Value; // AddressType()
+    var __t9: Value; // ByteArrayType()
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // ByteArrayType()
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Reference; // ReferenceType(IntegerType())
+    var __t18: Value; // ByteArrayType()
+    var __t19: Value; // ByteArrayType()
+    var __t20: Value; // ByteArrayType()
+    var __t21: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3816,42 +3816,42 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
-    call t6 := CopyOrMoveRef(counter);
+    call __t6 := CopyOrMoveRef(counter);
 
-    call t7 := BorrowField(t6, LibraAccount_EventHandleGenerator_counter);
+    call __t7 := BorrowField(__t6, LibraAccount_EventHandleGenerator_counter);
 
-    call t2 := CopyOrMoveRef(t7);
+    call count := CopyOrMoveRef(__t7);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
+    call __t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t9);
+    assume is#ByteArray(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t10 := CopyOrMoveRef(t2);
+    call __t10 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
+    call __t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t12);
+    assume is#ByteArray(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -3862,9 +3862,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t17 := CopyOrMoveRef(t2);
+    call __t17 := CopyOrMoveRef(count);
 
-    call WriteRef(t17, GetLocal(__m, __frame + 16));
+    call WriteRef(__t17, GetLocal(__m, __frame + 16));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -3872,11 +3872,11 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
+    call __t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t20);
+    assume is#ByteArray(__t20);
 
-    __m := UpdateLocal(__m, __frame + 20, t20);
+    __m := UpdateLocal(__m, __frame + 20, __t20);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -3884,33 +3884,33 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 21);
+    __ret0 := GetLocal(__m, __frame + 21);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (ret0: Value)
+procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_fresh_guid(counter, sender);
+    call __ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereference(__m, counter), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t4: Value; // AddressType()
-    var t5: Value; // ByteArrayType()
-    var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __t2: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t4: Value; // AddressType()
+    var __t5: Value; // ByteArrayType()
+    var __t6: Value; // LibraAccount_EventHandle_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3931,50 +3931,50 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := CopyOrMoveRef(counter);
+    call __t3 := CopyOrMoveRef(counter);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraAccount_fresh_guid(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraAccount_fresh_guid(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t5);
+    assume is#ByteArray(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
+    call __ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64()))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectField(Dereference(__m, GetResourceReference(LibraAccount_T_type_value(), a#Address(Address(TxnSenderAddress(__txn))))), LibraAccount_T_event_generator), LibraAccount_EventHandleGenerator_counter)) + i#Integer(Integer(1)))) > i#Integer(max_u64())))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t1: Value; // ByteArrayType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t6: Value; // AddressType()
-    var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var sender_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var sender_bytes: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t6: Value; // AddressType()
+    var __t7: Value; // LibraAccount_EventHandle_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3991,37 +3991,37 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t0 := CopyOrMoveRef(t3);
+    call sender_account_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t0);
+    call __t4 := CopyOrMoveRef(sender_account_ref);
 
-    call t5 := BorrowField(t4, LibraAccount_T_event_generator);
+    call __t5 := BorrowField(__t4, LibraAccount_T_event_generator);
 
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(__m, __frame + 6));
+    call __t7 := LibraAccount_new_event_handle_impl(tv0, __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t7);
+    assume is#Vector(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_new_event_handle(tv0);
+    call __ret0 := LibraAccount_new_event_handle(tv0);
 }
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
@@ -4031,22 +4031,22 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // ByteArrayType()
-    var t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
-    var t5: Reference; // ReferenceType(ByteArrayType())
-    var t6: Value; // ByteArrayType()
-    var t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
-    var t8: Reference; // ReferenceType(IntegerType())
-    var t9: Value; // ByteArrayType()
-    var t10: Reference; // ReferenceType(IntegerType())
-    var t11: Value; // IntegerType()
-    var t12: Value; // tv0
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Reference; // ReferenceType(IntegerType())
+    var count: Reference; // ReferenceType(IntegerType())
+    var guid: Value; // ByteArrayType()
+    var __t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var __t5: Reference; // ReferenceType(ByteArrayType())
+    var __t6: Value; // ByteArrayType()
+    var __t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var __t8: Reference; // ReferenceType(IntegerType())
+    var __t9: Value; // ByteArrayType()
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // tv0
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4063,29 +4063,29 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __m := UpdateLocal(__m, __frame + 1, msg);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(handle_ref);
+    call __t4 := CopyOrMoveRef(handle_ref);
 
-    call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
+    call __t5 := BorrowField(__t4, LibraAccount_EventHandle_guid);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t7 := CopyOrMoveRef(handle_ref);
+    call __t7 := CopyOrMoveRef(handle_ref);
 
-    call t8 := BorrowField(t7, LibraAccount_EventHandle_counter);
+    call __t8 := BorrowField(__t7, LibraAccount_EventHandle_counter);
 
-    call t2 := CopyOrMoveRef(t8);
+    call count := CopyOrMoveRef(__t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := CopyOrMoveRef(t2);
+    call __t10 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
@@ -4095,9 +4095,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call LibraAccount_write_to_event_store(tv0, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -4108,9 +4108,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t17 := CopyOrMoveRef(t2);
+    call __t17 := CopyOrMoveRef(count);
 
-    call WriteRef(t17, GetLocal(__m, __frame + 16));
+    call WriteRef(__t17, GetLocal(__m, __frame + 16));
 
     return;
 
@@ -4132,11 +4132,11 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // ByteArrayType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
-    var t4: Value; // IntegerType()
-    var t5: Value; // ByteArrayType()
+    var guid: Value; // ByteArrayType()
+    var count: Value; // IntegerType()
+    var __t3: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4155,9 +4155,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    call __t4, __t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -63,19 +63,19 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 
 // ** functions of module LibraCoin
 
-procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value), Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(amount)))));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapability_type_value(), a#Address(Address(TxnSenderAddress(__txn)))))))) || b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(amount) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(amount) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -97,61 +97,61 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    call __t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), __t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t4);
+    assume is#Vector(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
+procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint_with_default_capability(amount);
+    call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
-procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value), Integer(i#Integer(old(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))) + i#Integer(value)))));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), value)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), value)));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))) || b#Boolean(Boolean(i#Integer(value) > i#Integer(Integer(1000000000000000)))) || b#Boolean(Boolean(i#Integer(Integer(i#Integer(value) + i#Integer(SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t3: Value; // IntegerType()
-    var t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // AddressType()
-    var t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // IntegerType()
-    var t17: Value; // IntegerType()
-    var t18: Value; // IntegerType()
-    var t19: Value; // IntegerType()
-    var t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t21: Reference; // ReferenceType(IntegerType())
-    var t22: Value; // IntegerType()
-    var t23: Value; // LibraCoin_T_type_value()
+    var market_cap_ref: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var market_cap_total_value: Value; // IntegerType()
+    var __t4: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // AddressType()
+    var __t13: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t14: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // IntegerType()
+    var __t20: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t21: Reference; // ReferenceType(IntegerType())
+    var __t22: Value; // IntegerType()
+    var __t23: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -169,7 +169,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume IsValidReferenceParameter(__m, __frame, capability);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(capability);
+    call __t4 := CopyOrMoveRef(capability);
 
     // unimplemented instruction: NoOp
 
@@ -204,16 +204,16 @@ Label_11:
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call t13 := BorrowGlobal(GetLocal(__m, __frame + 12), LibraCoin_MarketCap_type_value());
+    call __t13 := BorrowGlobal(GetLocal(__m, __frame + 12), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t13);
+    call market_cap_ref := CopyOrMoveRef(__t13);
 
-    call t14 := CopyOrMoveRef(t2);
+    call __t14 := CopyOrMoveRef(market_cap_ref);
 
-    call t15 := BorrowField(t14, LibraCoin_MarketCap_total_value);
+    call __t15 := BorrowField(__t14, LibraCoin_MarketCap_total_value);
 
-    call __tmp := ReadRef(t15);
+    call __tmp := ReadRef(__t15);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
@@ -230,11 +230,11 @@ Label_11:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := CopyOrMoveRef(t2);
+    call __t20 := CopyOrMoveRef(market_cap_ref);
 
-    call t21 := BorrowField(t20, LibraCoin_MarketCap_total_value);
+    call __t21 := BorrowField(__t20, LibraCoin_MarketCap_total_value);
 
-    call WriteRef(t21, GetLocal(__m, __frame + 19));
+    call WriteRef(__t21, GetLocal(__m, __frame + 19));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
@@ -242,19 +242,19 @@ Label_11:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 22));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 23);
+    __ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
+procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint(value, capability);
+    call __ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
@@ -267,15 +267,15 @@ ensures old(b#Boolean(Boolean(!IsEqual(Address(TxnSenderAddress(__txn)), Address
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // LibraCoin_MintCapability_type_value()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __t0: Value; // AddressType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // LibraCoin_MintCapability_type_value()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_MarketCap_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -341,18 +341,18 @@ procedure LibraCoin_initialize_verify () returns ()
     call LibraCoin_initialize();
 }
 
-procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_market_cap () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, GetResourceReference(LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))), LibraCoin_MarketCap_total_value))));
 ensures old(!(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816))))))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCap_type_value(), a#Address(Address(173345816)))))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t0: Value; // AddressType()
+    var __t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -369,37 +369,37 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    call __t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+    call __t2 := BorrowField(__t1, LibraCoin_MarketCap_total_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_market_cap_verify () returns (ret0: Value)
+procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_market_cap();
+    call __ret0 := LibraCoin_market_cap();
 }
 
-procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_zero () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(0))));
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Integer(0))));
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // LibraCoin_T_type_value()
+    var __t0: Value; // IntegerType()
+    var __t1: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -419,29 +419,29 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_zero_verify () returns (ret0: Value)
+procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_zero();
+    call __ret0 := LibraCoin_zero();
 }
 
-procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))));
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -457,43 +457,43 @@ ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, coin_ref), 
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(coin_ref);
+    call __t1 := CopyOrMoveRef(coin_ref);
 
-    call t2 := BorrowField(t1, LibraCoin_T_value);
+    call __t2 := BorrowField(__t1, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
+procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_value(coin_ref);
+    call __ret0 := LibraCoin_value(coin_ref);
 }
 
-procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(ret1, LibraCoin_T_value), amount))) && b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(__ret1, LibraCoin_T_value), amount))) && b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin, LibraCoin_T_value))) - i#Integer(amount)))))));
 ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var other: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -511,16 +511,16 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraCoin_withdraw(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t5);
+    assume is#Vector(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -531,48 +531,48 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
-    ret1 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 6);
+    __ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := LibraCoin_split(coin, amount);
+    call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
-procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value), Integer(i#Integer(old(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value))) - i#Integer(amount)))));
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), amount)));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), amount)));
 ensures old(!(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), LibraCoin_T_value)) < i#Integer(amount)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraCoin_T_type_value()
+    var value: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -590,11 +590,11 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(coin_ref);
+    call __t3 := CopyOrMoveRef(coin_ref);
 
-    call t4 := BorrowField(t3, LibraCoin_T_value);
+    call __t4 := BorrowField(__t3, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
@@ -632,11 +632,11 @@ Label_11:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := CopyOrMoveRef(coin_ref);
+    call __t14 := CopyOrMoveRef(coin_ref);
 
-    call t15 := BorrowField(t14, LibraCoin_T_value);
+    call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(__m, __frame + 13));
+    call WriteRef(__t15, GetLocal(__m, __frame + 13));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -644,32 +644,32 @@ Label_11:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 17);
+    __ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_withdraw(coin_ref, amount);
+    call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
-procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Integer(i#Integer(old(SelectField(coin1, LibraCoin_T_value))) + i#Integer(old(SelectField(coin2, LibraCoin_T_value)))))));
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, LibraCoin_T_value)) + i#Integer(SelectField(coin2, LibraCoin_T_value)))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -687,30 +687,30 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_join(coin1, coin2);
+    call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
@@ -721,18 +721,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t13: Reference; // ReferenceType(IntegerType())
+    var value: Value; // IntegerType()
+    var check_value: Value; // IntegerType()
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t13: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -750,11 +750,11 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(coin_ref);
+    call __t4 := CopyOrMoveRef(coin_ref);
 
-    call t5 := BorrowField(t4, LibraCoin_T_value);
+    call __t5 := BorrowField(__t4, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -764,8 +764,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    call __t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -780,11 +780,11 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(coin_ref);
+    call __t12 := CopyOrMoveRef(coin_ref);
 
-    call t13 := BorrowField(t12, LibraCoin_T_value);
+    call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(__m, __frame + 11));
+    call WriteRef(__t13, GetLocal(__m, __frame + 11));
 
     return;
 
@@ -806,14 +806,14 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
+    var value: Value; // IntegerType()
+    var __t2: Value; // LibraCoin_T_type_value()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -832,8 +832,8 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    call __t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -13,11 +13,11 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -113,9 +113,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // BooleanType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // BooleanType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -168,11 +168,11 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -231,11 +231,11 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -294,11 +294,11 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -357,11 +357,11 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -413,23 +413,23 @@ procedure TestAbortIf_abort7_verify (x: Value, y: Value) returns ()
     call TestAbortIf_abort7(x, y);
 }
 
-procedure {:inline 1} TestAbortIf_abort8 (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestAbortIf_abort8 (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, Boolean(true))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, Boolean(true))));
 ensures old(!(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) && (b#Boolean(Boolean(i#Integer(x) > i#Integer(y))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // BooleanType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -483,19 +483,19 @@ Label_7:
     __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9)));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 10);
+    __ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestAbortIf_abort8_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestAbortIf_abort8_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestAbortIf_abort8(x, y);
+    call __ret0 := TestAbortIf_abort8(x, y);
 }
 
 procedure {:inline 1} TestAbortIf_abort9 (x: Value, y: Value) returns ()
@@ -506,11 +506,11 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -6,7 +6,7 @@
 
 // ** functions of module U64Util
 
-procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (ret0: Value);
+procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -17,7 +17,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module AddressUtil
 
-procedure {:inline 1} AddressUtil_address_to_bytes (addr: Value) returns (ret0: Value);
+procedure {:inline 1} AddressUtil_address_to_bytes (addr: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -28,7 +28,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module BytearrayUtil
 
-procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (ret0: Value);
+procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -39,10 +39,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module Hash
 
-procedure {:inline 1} Hash_sha2_256 (data: Value) returns (ret0: Value);
+procedure {:inline 1} Hash_sha2_256 (data: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
-procedure {:inline 1} Hash_sha3_256 (data: Value) returns (ret0: Value);
+procedure {:inline 1} Hash_sha3_256 (data: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -110,14 +110,14 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 
 // ** functions of module LibraCoin
 
-procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -139,53 +139,53 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    call __t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), __t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t4);
+    assume is#Vector(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
+procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint_with_default_capability(amount);
+    call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
-procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t12: Reference; // ReferenceType(IntegerType())
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Value; // IntegerType()
-    var t18: Reference; // ReferenceType(IntegerType())
-    var t19: Value; // IntegerType()
-    var t20: Value; // LibraCoin_T_type_value()
+    var total_value_ref: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t12: Reference; // ReferenceType(IntegerType())
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Reference; // ReferenceType(IntegerType())
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -234,16 +234,16 @@ Label_9:
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraCoin_MarketCap_type_value());
+    call __t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t12 := BorrowField(t11, LibraCoin_MarketCap_total_value);
+    call __t12 := BorrowField(__t11, LibraCoin_MarketCap_total_value);
 
-    call t2 := CopyOrMoveRef(t12);
+    call total_value_ref := CopyOrMoveRef(__t12);
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(total_value_ref);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU128(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -258,9 +258,9 @@ Label_9:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call t18 := CopyOrMoveRef(t2);
+    call __t18 := CopyOrMoveRef(total_value_ref);
 
-    call WriteRef(t18, GetLocal(__m, __frame + 17));
+    call WriteRef(__t18, GetLocal(__m, __frame + 17));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
@@ -268,34 +268,34 @@ Label_9:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 19));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 20);
+    __ret0 := GetLocal(__m, __frame + 20);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
+procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint(value, capability);
+    call __ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // LibraCoin_MintCapability_type_value()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __t0: Value; // AddressType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // LibraCoin_MintCapability_type_value()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_MarketCap_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -361,14 +361,14 @@ procedure LibraCoin_initialize_verify () returns ()
     call LibraCoin_initialize();
 }
 
-procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_market_cap () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t0: Value; // AddressType()
+    var __t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -385,36 +385,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    call __t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+    call __t2 := BorrowField(__t1, LibraCoin_MarketCap_total_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU128(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_market_cap_verify () returns (ret0: Value)
+procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_market_cap();
+    call __ret0 := LibraCoin_market_cap();
 }
 
-procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_zero () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // LibraCoin_T_type_value()
+    var __t0: Value; // IntegerType()
+    var __t1: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -434,28 +434,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_zero_verify () returns (ret0: Value)
+procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_zero();
+    call __ret0 := LibraCoin_zero();
 }
 
-procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -471,39 +471,39 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(coin_ref);
+    call __t1 := CopyOrMoveRef(coin_ref);
 
-    call t2 := BorrowField(t1, LibraCoin_T_value);
+    call __t2 := BorrowField(__t1, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
+procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_value(coin_ref);
+    call __ret0 := LibraCoin_value(coin_ref);
 }
 
-procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var other: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -521,16 +521,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraCoin_withdraw(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t5);
+    assume is#Vector(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -541,43 +541,43 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
-    ret1 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 6);
+    __ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := LibraCoin_split(coin, amount);
+    call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
-procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraCoin_T_type_value()
+    var value: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -595,11 +595,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(coin_ref);
+    call __t3 := CopyOrMoveRef(coin_ref);
 
-    call t4 := BorrowField(t3, LibraCoin_T_value);
+    call __t4 := BorrowField(__t3, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
@@ -637,11 +637,11 @@ Label_11:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := CopyOrMoveRef(coin_ref);
+    call __t14 := CopyOrMoveRef(coin_ref);
 
-    call t15 := BorrowField(t14, LibraCoin_T_value);
+    call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(__m, __frame + 13));
+    call WriteRef(__t15, GetLocal(__m, __frame + 13));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -649,28 +649,28 @@ Label_11:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 17);
+    __ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_withdraw(coin_ref, amount);
+    call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
-procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -688,48 +688,48 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_join(coin1, coin2);
+    call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t13: Reference; // ReferenceType(IntegerType())
+    var value: Value; // IntegerType()
+    var check_value: Value; // IntegerType()
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t13: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -747,11 +747,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(coin_ref);
+    call __t4 := CopyOrMoveRef(coin_ref);
 
-    call t5 := BorrowField(t4, LibraCoin_T_value);
+    call __t5 := BorrowField(__t4, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -761,8 +761,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    call __t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -777,11 +777,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(coin_ref);
+    call __t12 := CopyOrMoveRef(coin_ref);
 
-    call t13 := BorrowField(t12, LibraCoin_T_value);
+    call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(__m, __frame + 11));
+    call WriteRef(__t13, GetLocal(__m, __frame + 11));
 
     return;
 
@@ -800,14 +800,14 @@ procedure {:inline 1} LibraCoin_destroy_zero (coin: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
+    var value: Value; // IntegerType()
+    var __t2: Value; // LibraCoin_T_type_value()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -826,8 +826,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    call __t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -864,6 +864,614 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
     assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_destroy_zero(coin);
+}
+
+
+
+// ** structs of module LibraTimestamp
+
+const unique LibraTimestamp_CurrentTimeMicroseconds: TypeName;
+const LibraTimestamp_CurrentTimeMicroseconds_microseconds: FieldName;
+axiom LibraTimestamp_CurrentTimeMicroseconds_microseconds == 0;
+function LibraTimestamp_CurrentTimeMicroseconds_type_value(): TypeValue {
+    StructType(LibraTimestamp_CurrentTimeMicroseconds, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+procedure {:inline 1} Pack_LibraTimestamp_CurrentTimeMicroseconds(microseconds: Value) returns (_struct: Value)
+{
+    assume IsValidU64(microseconds);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, microseconds));
+}
+
+procedure {:inline 1} Unpack_LibraTimestamp_CurrentTimeMicroseconds(_struct: Value) returns (microseconds: Value)
+{
+    assume is#Vector(_struct);
+    microseconds := SelectField(_struct, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+    assume IsValidU64(microseconds);
+}
+
+
+
+// ** functions of module LibraTimestamp
+
+procedure {:inline 1} LibraTimestamp_initialize_timer () returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var timer: Value; // LibraTimestamp_CurrentTimeMicroseconds_type_value()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraTimestamp_CurrentTimeMicroseconds_type_value()
+    var __t8: Value; // LibraTimestamp_CurrentTimeMicroseconds_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
+
+    // process and type check arguments
+
+    // bytecode translation starts here
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2)));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_LibraTimestamp_CurrentTimeMicroseconds(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call MoveToSender(LibraTimestamp_CurrentTimeMicroseconds_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTimestamp_initialize_timer_verify () returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTimestamp_initialize_timer();
+}
+
+procedure {:inline 1} LibraTimestamp_update_global_time (proposer: Value, timestamp: Value) returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var global_timer: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t3: Value; // AddressType()
+    var __t4: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t5: Value; // AddressType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
+    var __t9: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // IntegerType()
+    var __t15: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t16: Reference; // ReferenceType(IntegerType())
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // BooleanType()
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // IntegerType()
+    var __t22: Value; // IntegerType()
+    var __t23: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t24: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 25;
+
+    // process and type check arguments
+    assume is#Address(proposer);
+    __m := UpdateLocal(__m, __frame + 0, proposer);
+    assume IsValidU64(timestamp);
+    __m := UpdateLocal(__m, __frame + 1, timestamp);
+
+    // bytecode translation starts here
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraTimestamp_CurrentTimeMicroseconds_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call global_timer := CopyOrMoveRef(__t4);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := LdAddr(0);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6)));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_17; }
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call __t9 := CopyOrMoveRef(global_timer);
+
+    call __t10 := BorrowField(__t9, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call __tmp := ReadRef(__t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 11)));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_16; }
+
+    call __tmp := LdConst(5001);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
+
+    goto Label_Abort;
+
+Label_16:
+    goto Label_26;
+
+Label_17:
+    call __t15 := CopyOrMoveRef(global_timer);
+
+    call __t16 := BorrowField(__t15, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call __tmp := ReadRef(__t16);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
+
+    call __tmp := Lt(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 20);
+    if (!b#Boolean(__tmp)) { goto Label_26; }
+
+    call __tmp := LdConst(5001);
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
+
+    goto Label_Abort;
+
+Label_26:
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
+
+    call __t23 := CopyOrMoveRef(global_timer);
+
+    call __t24 := BorrowField(__t23, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call WriteRef(__t24, GetLocal(__m, __frame + 22));
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTimestamp_update_global_time_verify (proposer: Value, timestamp: Value) returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTimestamp_update_global_time(proposer, timestamp);
+}
+
+procedure {:inline 1} LibraTimestamp_now_microseconds () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var __t0: Value; // AddressType()
+    var __t1: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
+
+    // process and type check arguments
+
+    // bytecode translation starts here
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+
+    call __t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraTimestamp_CurrentTimeMicroseconds_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call __t2 := BorrowField(__t1, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call __tmp := ReadRef(__t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 3);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure LibraTimestamp_now_microseconds_verify () returns (__ret0: Value)
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call __ret0 := LibraTimestamp_now_microseconds();
+}
+
+
+
+// ** structs of module LibraTransactionTimeout
+
+const unique LibraTransactionTimeout_TTL: TypeName;
+const LibraTransactionTimeout_TTL_duration_microseconds: FieldName;
+axiom LibraTransactionTimeout_TTL_duration_microseconds == 0;
+function LibraTransactionTimeout_TTL_type_value(): TypeValue {
+    StructType(LibraTransactionTimeout_TTL, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+procedure {:inline 1} Pack_LibraTransactionTimeout_TTL(duration_microseconds: Value) returns (_struct: Value)
+{
+    assume IsValidU64(duration_microseconds);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, duration_microseconds));
+}
+
+procedure {:inline 1} Unpack_LibraTransactionTimeout_TTL(_struct: Value) returns (duration_microseconds: Value)
+{
+    assume is#Vector(_struct);
+    duration_microseconds := SelectField(_struct, LibraTransactionTimeout_TTL_duration_microseconds);
+    assume IsValidU64(duration_microseconds);
+}
+
+
+
+// ** functions of module LibraTransactionTimeout
+
+procedure {:inline 1} LibraTransactionTimeout_initialize () returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var timeout: Value; // LibraTransactionTimeout_TTL_type_value()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraTransactionTimeout_TTL_type_value()
+    var __t8: Value; // LibraTransactionTimeout_TTL_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
+
+    // process and type check arguments
+
+    // bytecode translation starts here
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2)));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call __tmp := LdConst(86400000000);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_LibraTransactionTimeout_TTL(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call MoveToSender(LibraTransactionTimeout_TTL_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTransactionTimeout_initialize_verify () returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTransactionTimeout_initialize();
+}
+
+procedure {:inline 1} LibraTransactionTimeout_set_timeout (new_duration: Value) returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var timeout: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // AddressType()
+    var __t8: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t11: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
+
+    // process and type check arguments
+    assume IsValidU64(new_duration);
+    __m := UpdateLocal(__m, __frame + 0, new_duration);
+
+    // bytecode translation starts here
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3)));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __t8 := BorrowGlobal(GetLocal(__m, __frame + 7), LibraTransactionTimeout_TTL_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call timeout := CopyOrMoveRef(__t8);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __t10 := CopyOrMoveRef(timeout);
+
+    call __t11 := BorrowField(__t10, LibraTransactionTimeout_TTL_duration_microseconds);
+
+    call WriteRef(__t11, GetLocal(__m, __frame + 9));
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTransactionTimeout_set_timeout_verify (new_duration: Value) returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTransactionTimeout_set_timeout(new_duration);
+}
+
+procedure {:inline 1} LibraTransactionTimeout_is_valid_transaction_timestamp (timestamp: Value) returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var current_block_time: Value; // IntegerType()
+    var max_txn_time: Value; // IntegerType()
+    var timeout: Value; // IntegerType()
+    var txn_time_microseconds: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t12: Reference; // ReferenceType(IntegerType())
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // IntegerType()
+    var __t21: Value; // IntegerType()
+    var __t22: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 23;
+
+    // process and type check arguments
+    assume IsValidU64(timestamp);
+    __m := UpdateLocal(__m, __frame + 0, timestamp);
+
+    // bytecode translation starts here
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := LdConst(9223372036854);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Gt(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
+
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 8);
+    return;
+
+Label_6:
+    call __t9 := LibraTimestamp_now_microseconds();
+    if (__abort_flag) { goto Label_Abort; }
+    assume IsValidU64(__t9);
+
+    __m := UpdateLocal(__m, __frame + 9, __t9);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
+
+    call __t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraTransactionTimeout_TTL_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call __t12 := BorrowField(__t11, LibraTransactionTimeout_TTL_duration_microseconds);
+
+    call __tmp := ReadRef(__t12);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
+
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
+
+    call __tmp := LdConst(1000000);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
+
+    call __tmp := MulU64(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
+
+    call __tmp := Lt(GetLocal(__m, __frame + 20), GetLocal(__m, __frame + 21));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 22);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure LibraTransactionTimeout_is_valid_transaction_timestamp_verify (timestamp: Value) returns (__ret0: Value)
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call __ret0 := LibraTransactionTimeout_is_valid_transaction_timestamp(timestamp);
 }
 
 
@@ -1069,9 +1677,9 @@ procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) ret
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1117,10 +1725,10 @@ procedure {:inline 1} LibraAccount_deposit_with_metadata (payee: Value, to_depos
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // ByteArrayType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1172,35 +1780,35 @@ procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (payee: Valu
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // IntegerType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // BooleanType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // AddressType()
-    var t15: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
-    var t18: Value; // IntegerType()
-    var t19: Value; // AddressType()
-    var t20: Value; // ByteArrayType()
-    var t21: Value; // LibraAccount_SentPaymentEvent_type_value()
-    var t22: Value; // AddressType()
-    var t23: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t25: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t26: Value; // LibraCoin_T_type_value()
-    var t27: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
-    var t29: Value; // IntegerType()
-    var t30: Value; // AddressType()
-    var t31: Value; // ByteArrayType()
-    var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+    var deposit_value: Value; // IntegerType()
+    var payee_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var sender_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // BooleanType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // AddressType()
+    var __t15: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // AddressType()
+    var __t20: Value; // ByteArrayType()
+    var __t21: Value; // LibraAccount_SentPaymentEvent_type_value()
+    var __t22: Value; // AddressType()
+    var __t23: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t25: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t26: Value; // LibraCoin_T_type_value()
+    var __t27: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
+    var __t29: Value; // IntegerType()
+    var __t30: Value; // AddressType()
+    var __t31: Value; // ByteArrayType()
+    var __t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1222,13 +1830,13 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2);
 
-    call t8 := LibraCoin_value(t7);
+    call __t8 := LibraCoin_value(__t7);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t8);
+    assume IsValidU64(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -1257,14 +1865,14 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
+    call __t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t6 := CopyOrMoveRef(t15);
+    call sender_account_ref := CopyOrMoveRef(__t15);
 
-    call t16 := CopyOrMoveRef(t6);
+    call __t16 := CopyOrMoveRef(sender_account_ref);
 
-    call t17 := BorrowField(t16, LibraAccount_T_sent_events);
+    call __t17 := BorrowField(__t16, LibraAccount_T_sent_events);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -1278,30 +1886,30 @@ Label_10:
     call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(__m, __frame + 21));
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), __t17, GetLocal(__m, __frame + 21));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
+    call __t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t23);
+    call payee_account_ref := CopyOrMoveRef(__t23);
 
-    call t24 := CopyOrMoveRef(t5);
+    call __t24 := CopyOrMoveRef(payee_account_ref);
 
-    call t25 := BorrowField(t24, LibraAccount_T_balance);
+    call __t25 := BorrowField(__t24, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call LibraCoin_deposit(t25, GetLocal(__m, __frame + 26));
+    call LibraCoin_deposit(__t25, GetLocal(__m, __frame + 26));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t27 := CopyOrMoveRef(t5);
+    call __t27 := CopyOrMoveRef(payee_account_ref);
 
-    call t28 := BorrowField(t27, LibraAccount_T_received_events);
+    call __t28 := BorrowField(__t27, LibraAccount_T_received_events);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 29, __tmp);
@@ -1315,7 +1923,7 @@ Label_10:
     call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(__m, __frame + 32));
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), __t28, GetLocal(__m, __frame + 32));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -1335,13 +1943,13 @@ procedure {:inline 1} LibraAccount_mint_to_address (payee: Value, amount: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // AddressType()
-    var t6: Value; // AddressType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_T_type_value()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1384,11 +1992,11 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
+    call __t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t8);
+    assume is#Vector(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call LibraAccount_deposit(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
@@ -1406,16 +2014,16 @@ procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) retu
     call LibraAccount_mint_to_address(payee, amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Value; // IntegerType()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var to_withdraw: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1433,18 +2041,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(account);
+    call __t3 := CopyOrMoveRef(account);
 
-    call t4 := BorrowField(t3, LibraAccount_T_balance);
+    call __t4 := BorrowField(__t3, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := LibraCoin_withdraw(t4, GetLocal(__m, __frame + 5));
+    call __t6 := LibraCoin_withdraw(__t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t6);
+    assume is#Vector(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -1452,35 +2060,35 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_from_account(account, amount);
+    call __ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Value; // IntegerType()
-    var t10: Value; // LibraCoin_T_type_value()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1499,16 +2107,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call sender_account := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(sender_account);
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_withdrawal_capability);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -1521,44 +2129,44 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_9:
-    call t8 := CopyOrMoveRef(t1);
+    call __t8 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(__m, __frame + 9));
+    call __t10 := LibraAccount_withdraw_from_account(__t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t10);
+    assume is#Vector(__t10);
 
-    __m := UpdateLocal(__m, __frame + 10, t10);
+    __m := UpdateLocal(__m, __frame + 10, __t10);
 
-    ret0 := GetLocal(__m, __frame + 10);
+    __ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_from_sender(amount);
+    call __ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t4: Reference; // ReferenceType(AddressType())
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t8: Value; // IntegerType()
-    var t9: Value; // LibraCoin_T_type_value()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t4: Reference; // ReferenceType(AddressType())
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1576,64 +2184,64 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(cap);
+    call __t3 := CopyOrMoveRef(cap);
 
-    call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
+    call __t4 := BorrowField(__t3, LibraAccount_WithdrawalCapability_account_address);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
-    call t7 := CopyOrMoveRef(t2);
+    call __t7 := CopyOrMoveRef(account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(__m, __frame + 8));
+    call __t9 := LibraAccount_withdraw_from_account(__t7, GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t9);
+    assume is#Vector(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
-    ret0 := GetLocal(__m, __frame + 9);
+    __ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_with_capability(cap, amount);
+    call __ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
-procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Reference; // ReferenceType(BooleanType())
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(BooleanType())
-    var t8: Reference; // ReferenceType(BooleanType())
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // BooleanType()
-    var t12: Reference; // ReferenceType(BooleanType())
-    var t13: Value; // AddressType()
-    var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var sender: Value; // AddressType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var delegated_ref: Reference; // ReferenceType(BooleanType())
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(BooleanType())
+    var __t8: Reference; // ReferenceType(BooleanType())
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // BooleanType()
+    var __t12: Reference; // ReferenceType(BooleanType())
+    var __t13: Value; // AddressType()
+    var __t14: Value; // LibraAccount_WithdrawalCapability_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1656,20 +2264,20 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t5);
+    call sender_account := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(sender_account);
 
-    call t7 := BorrowField(t6, LibraAccount_T_delegated_withdrawal_capability);
+    call __t7 := BorrowField(__t6, LibraAccount_T_delegated_withdrawal_capability);
 
-    call t2 := CopyOrMoveRef(t7);
+    call delegated_ref := CopyOrMoveRef(__t7);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(delegated_ref);
 
-    call __tmp := ReadRef(t8);
+    call __tmp := ReadRef(__t8);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
@@ -1685,9 +2293,9 @@ Label_13:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(t2);
+    call __t12 := CopyOrMoveRef(delegated_ref);
 
-    call WriteRef(t12, GetLocal(__m, __frame + 11));
+    call WriteRef(__t12, GetLocal(__m, __frame + 11));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
@@ -1695,34 +2303,34 @@ Label_13:
     call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 14);
+    __ret0 := GetLocal(__m, __frame + 14);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
+procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_extract_sender_withdrawal_capability();
+    call __ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (cap: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // LibraAccount_WithdrawalCapability_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // BooleanType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Reference; // ReferenceType(BooleanType())
+    var account_address: Value; // AddressType()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Value; // BooleanType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Reference; // ReferenceType(BooleanType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1741,8 +2349,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    call __t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -1750,19 +2358,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(account);
 
-    call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
+    call __t9 := BorrowField(__t8, LibraAccount_T_delegated_withdrawal_capability);
 
-    call WriteRef(t9, GetLocal(__m, __frame + 7));
+    call WriteRef(__t9, GetLocal(__m, __frame + 7));
 
     return;
 
@@ -1781,18 +2389,18 @@ procedure {:inline 1} LibraAccount_pay_from_capability (payee: Value, cap: Refer
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // AddressType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // AddressType()
-    var t8: Value; // AddressType()
-    var t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t10: Reference; // ReferenceType(AddressType())
-    var t11: Value; // AddressType()
-    var t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t13: Value; // IntegerType()
-    var t14: Value; // LibraCoin_T_type_value()
-    var t15: Value; // ByteArrayType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // AddressType()
+    var __t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t10: Reference; // ReferenceType(AddressType())
+    var __t11: Value; // AddressType()
+    var __t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // LibraCoin_T_type_value()
+    var __t15: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1836,24 +2444,24 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := CopyOrMoveRef(cap);
+    call __t9 := CopyOrMoveRef(cap);
 
-    call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
+    call __t10 := BorrowField(__t9, LibraAccount_WithdrawalCapability_account_address);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(cap);
+    call __t12 := CopyOrMoveRef(cap);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(__m, __frame + 13));
+    call __t14 := LibraAccount_withdraw_with_capability(__t12, GetLocal(__m, __frame + 13));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t14);
+    assume is#Vector(__t14);
 
-    __m := UpdateLocal(__m, __frame + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, __t14);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 15, __tmp);
@@ -1878,14 +2486,14 @@ procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (payee: Value, 
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t3: Value; // AddressType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // AddressType()
-    var t7: Value; // AddressType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // LibraCoin_T_type_value()
-    var t10: Value; // ByteArrayType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // LibraCoin_T_type_value()
+    var __t10: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1930,11 +2538,11 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 8));
+    call __t9 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t9);
+    assume is#Vector(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -1959,9 +2567,9 @@ procedure {:inline 1} LibraAccount_pay_from_sender (payee: Value, amount: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2007,9 +2615,9 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (accoun
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // ByteArrayType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(ByteArrayType())
+    var __t2: Value; // ByteArrayType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(ByteArrayType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2030,11 +2638,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := CopyOrMoveRef(account);
+    call __t3 := CopyOrMoveRef(account);
 
-    call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
+    call __t4 := BorrowField(__t3, LibraAccount_T_authentication_key);
 
-    call WriteRef(t4, GetLocal(__m, __frame + 2));
+    call WriteRef(__t4, GetLocal(__m, __frame + 2));
 
     return;
 
@@ -2053,15 +2661,15 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key (new_authentication
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Value; // ByteArrayType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2080,16 +2688,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call sender_account := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(sender_account);
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -2102,12 +2710,12 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_9:
-    call t8 := CopyOrMoveRef(t1);
+    call __t8 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(__m, __frame + 9));
+    call LibraAccount_rotate_authentication_key_for_account(__t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -2127,11 +2735,11 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (ca
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
-    var t3: Reference; // ReferenceType(AddressType())
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Value; // ByteArrayType()
+    var __t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var __t3: Reference; // ReferenceType(AddressType())
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t6: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2149,21 +2757,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
-    call t2 := CopyOrMoveRef(cap);
+    call __t2 := CopyOrMoveRef(cap);
 
-    call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
+    call __t3 := BorrowField(__t2, LibraAccount_KeyRotationCapability_account_address);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(__m, __frame + 6));
+    call LibraAccount_rotate_authentication_key_for_account(__t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -2179,23 +2787,23 @@ procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Re
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
-procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(BooleanType())
-    var t2: Value; // AddressType()
-    var t3: Value; // AddressType()
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Reference; // ReferenceType(BooleanType())
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Reference; // ReferenceType(BooleanType())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var sender: Value; // AddressType()
+    var delegated_ref: Reference; // ReferenceType(BooleanType())
+    var __t2: Value; // AddressType()
+    var __t3: Value; // AddressType()
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Reference; // ReferenceType(BooleanType())
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Reference; // ReferenceType(BooleanType())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_KeyRotationCapability_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2218,16 +2826,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    call __t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call t1 := CopyOrMoveRef(t5);
+    call delegated_ref := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(delegated_ref);
 
-    call __tmp := ReadRef(t6);
+    call __tmp := ReadRef(__t6);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
@@ -2243,9 +2851,9 @@ Label_11:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := CopyOrMoveRef(t1);
+    call __t10 := CopyOrMoveRef(delegated_ref);
 
-    call WriteRef(t10, GetLocal(__m, __frame + 9));
+    call WriteRef(__t10, GetLocal(__m, __frame + 9));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -2253,34 +2861,34 @@ Label_11:
     call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 12);
+    __ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
+procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_extract_sender_key_rotation_capability();
+    call __ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (cap: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // LibraAccount_KeyRotationCapability_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // BooleanType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Reference; // ReferenceType(BooleanType())
+    var account_address: Value; // AddressType()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Value; // BooleanType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Reference; // ReferenceType(BooleanType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2299,8 +2907,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    call __t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -2308,19 +2916,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(account);
 
-    call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
+    call __t9 := BorrowField(__t8, LibraAccount_T_delegated_key_rotation_capability);
 
-    call WriteRef(t9, GetLocal(__m, __frame + 7));
+    call WriteRef(__t9, GetLocal(__m, __frame + 7));
 
     return;
 
@@ -2339,24 +2947,24 @@ procedure {:inline 1} LibraAccount_create_account (fresh_address: Value) returns
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t2: Value; // IntegerType()
-    var t3: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Value; // ByteArrayType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
-    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t14: Value; // AddressType()
-    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t18: Value; // LibraAccount_T_type_value()
+    var generator: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // ByteArrayType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var __t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t14: Value; // AddressType()
+    var __t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t18: Value; // LibraAccount_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2387,17 +2995,17 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
+    call __t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t6);
+    assume is#ByteArray(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
-    call t7 := LibraCoin_zero();
+    call __t7 := LibraCoin_zero();
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t7);
+    assume is#Vector(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -2405,27 +3013,27 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    call __t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), __t10, GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t12);
+    assume is#Vector(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
-    call t13 := BorrowLoc(__frame + 1);
+    call __t13 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    call __t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), __t13, GetLocal(__m, __frame + 14));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t15);
+    assume is#Vector(__t15);
 
-    __m := UpdateLocal(__m, __frame + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, __t15);
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -2456,12 +3064,12 @@ procedure {:inline 1} LibraAccount_create_new_account (fresh_address: Value, ini
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // AddressType()
-    var t7: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2523,15 +3131,15 @@ procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_
 procedure {:inline 1} LibraAccount_save_account (addr: Value, account: Value) returns ();
 requires ExistsTxnSenderAccount(__m, __txn);
 
-procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var balance_value: Value; // IntegerType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2547,15 +3155,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
-    call t2 := CopyOrMoveRef(account);
+    call __t2 := CopyOrMoveRef(account);
 
-    call t3 := BorrowField(t2, LibraAccount_T_balance);
+    call __t3 := BorrowField(__t2, LibraAccount_T_balance);
 
-    call t4 := LibraCoin_value(t3);
+    call __t4 := LibraCoin_value(__t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t4);
+    assume IsValidU64(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -2563,28 +3171,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 5);
+    __ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_balance_for_account_verify (account: Reference) returns (ret0: Value)
+procedure LibraAccount_balance_for_account_verify (account: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_balance_for_account(account);
+    call __ret0 := LibraAccount_balance_for_account(account);
 }
 
-procedure {:inline 1} LibraAccount_balance (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_balance (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2603,37 +3211,37 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := LibraAccount_balance_for_account(t2);
+    call __t3 := LibraAccount_balance_for_account(__t2);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t3);
+    assume IsValidU64(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_balance_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_balance_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_balance(addr);
+    call __ret0 := LibraAccount_balance(addr);
 }
 
-procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2649,36 +3257,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(account);
+    call __t1 := CopyOrMoveRef(account);
 
-    call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
+    call __t2 := BorrowField(__t1, LibraAccount_T_sequence_number);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (ret0: Value)
+procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_sequence_number_for_account(account);
+    call __ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
-procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2697,38 +3305,38 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := LibraAccount_sequence_number_for_account(t2);
+    call __t3 := LibraAccount_sequence_number_for_account(__t2);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t3);
+    assume IsValidU64(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_sequence_number_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_sequence_number_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_sequence_number(addr);
+    call __ret0 := LibraAccount_sequence_number(addr);
 }
 
-procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(BooleanType())
-    var t4: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(BooleanType())
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2747,38 +3355,38 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
+    call __t3 := BorrowField(__t2, LibraAccount_T_delegated_key_rotation_capability);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_delegated_key_rotation_capability(addr);
+    call __ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
-procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(BooleanType())
-    var t4: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(BooleanType())
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2797,36 +3405,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
+    call __t3 := BorrowField(__t2, LibraAccount_T_delegated_withdrawal_capability);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_delegated_withdrawal_capability(addr);
+    call __ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
-procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (ret0: Reference)
+procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (__ret0: Reference)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t2: Reference; // ReferenceType(AddressType())
+    var __t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t2: Reference; // ReferenceType(AddressType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2842,31 +3450,31 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(cap);
+    call __t1 := CopyOrMoveRef(cap);
 
-    call t2 := BorrowField(t1, LibraAccount_WithdrawalCapability_account_address);
+    call __t2 := BorrowField(__t1, LibraAccount_WithdrawalCapability_account_address);
 
-    ret0 := t2;
+    __ret0 := __t2;
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultReference;
+    __ret0 := DefaultReference;
 }
 
-procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (ret0: Reference)
+procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdrawal_capability_address(cap);
+    call __ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
-procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (ret0: Reference)
+procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (__ret0: Reference)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
-    var t2: Reference; // ReferenceType(AddressType())
+    var __t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var __t2: Reference; // ReferenceType(AddressType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2882,31 +3490,31 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(cap);
+    call __t1 := CopyOrMoveRef(cap);
 
-    call t2 := BorrowField(t1, LibraAccount_KeyRotationCapability_account_address);
+    call __t2 := BorrowField(__t1, LibraAccount_KeyRotationCapability_account_address);
 
-    ret0 := t2;
+    __ret0 := __t2;
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultReference;
+    __ret0 := DefaultReference;
 }
 
-procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (ret0: Reference)
+procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_key_rotation_capability_address(cap);
+    call __ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
-procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2928,71 +3536,75 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := Exists(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_exists_verify (check_addr: Value) returns (ret0: Value)
+procedure LibraAccount_exists_verify (check_addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_exists(check_addr);
+    call __ret0 := LibraAccount_exists(check_addr);
 }
 
-procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
+procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value, txn_expiration_time: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Value; // AddressType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // BooleanType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // AddressType()
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Value; // ByteArrayType()
-    var t18: Value; // ByteArrayType()
-    var t19: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t20: Reference; // ReferenceType(ByteArrayType())
-    var t21: Value; // ByteArrayType()
-    var t22: Value; // BooleanType()
-    var t23: Value; // BooleanType()
-    var t24: Value; // IntegerType()
-    var t25: Value; // IntegerType()
-    var t26: Value; // IntegerType()
-    var t27: Value; // IntegerType()
-    var t28: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t29: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t31: Value; // IntegerType()
-    var t32: Value; // IntegerType()
-    var t33: Value; // IntegerType()
-    var t34: Value; // BooleanType()
-    var t35: Value; // BooleanType()
-    var t36: Value; // IntegerType()
-    var t37: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t38: Reference; // ReferenceType(IntegerType())
-    var t39: Value; // IntegerType()
-    var t40: Value; // IntegerType()
-    var t41: Value; // IntegerType()
-    var t42: Value; // BooleanType()
-    var t43: Value; // BooleanType()
-    var t44: Value; // IntegerType()
-    var t45: Value; // IntegerType()
-    var t46: Value; // IntegerType()
-    var t47: Value; // BooleanType()
-    var t48: Value; // BooleanType()
-    var t49: Value; // IntegerType()
+    var transaction_sender: Value; // AddressType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var imm_sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var max_transaction_fee: Value; // IntegerType()
+    var balance_amount: Value; // IntegerType()
+    var sequence_number_value: Value; // IntegerType()
+    var __t11: Value; // AddressType()
+    var __t12: Value; // AddressType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // BooleanType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // AddressType()
+    var __t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t18: Value; // ByteArrayType()
+    var __t19: Value; // ByteArrayType()
+    var __t20: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t21: Reference; // ReferenceType(ByteArrayType())
+    var __t22: Value; // ByteArrayType()
+    var __t23: Value; // BooleanType()
+    var __t24: Value; // BooleanType()
+    var __t25: Value; // IntegerType()
+    var __t26: Value; // IntegerType()
+    var __t27: Value; // IntegerType()
+    var __t28: Value; // IntegerType()
+    var __t29: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t31: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t32: Value; // IntegerType()
+    var __t33: Value; // IntegerType()
+    var __t34: Value; // IntegerType()
+    var __t35: Value; // BooleanType()
+    var __t36: Value; // BooleanType()
+    var __t37: Value; // IntegerType()
+    var __t38: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t39: Reference; // ReferenceType(IntegerType())
+    var __t40: Value; // IntegerType()
+    var __t41: Value; // IntegerType()
+    var __t42: Value; // IntegerType()
+    var __t43: Value; // BooleanType()
+    var __t44: Value; // BooleanType()
+    var __t45: Value; // IntegerType()
+    var __t46: Value; // IntegerType()
+    var __t47: Value; // IntegerType()
+    var __t48: Value; // BooleanType()
+    var __t49: Value; // BooleanType()
+    var __t50: Value; // IntegerType()
+    var __t51: Value; // IntegerType()
+    var __t52: Value; // BooleanType()
+    var __t53: Value; // BooleanType()
+    var __t54: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3001,7 +3613,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 50;
+    __local_counter := __local_counter + 55;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -3012,176 +3624,199 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
+    assume IsValidU64(txn_expiration_time);
+    __m := UpdateLocal(__m, __frame + 4, txn_expiration_time);
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
-    __m := UpdateLocal(__m, __frame + 10, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
-    __m := UpdateLocal(__m, __frame + 4, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Exists(GetLocal(__m, __frame + 11), LibraAccount_T_type_value());
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 12));
+    call __tmp := Exists(GetLocal(__m, __frame + 12), LibraAccount_T_type_value());
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 13);
+    call __tmp := Not(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 14);
     if (!b#Boolean(__tmp)) { goto Label_8; }
 
     call __tmp := LdConst(5);
-    __m := UpdateLocal(__m, __frame + 14, __tmp);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
     goto Label_Abort;
 
 Label_8:
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
-    __m := UpdateLocal(__m, __frame + 15, __tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
+    call __t17 := BorrowGlobal(GetLocal(__m, __frame + 16), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t16);
+    call sender_account := CopyOrMoveRef(__t17);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
-    __m := UpdateLocal(__m, __frame + 17, __tmp);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
+    call __t19 := Hash_sha3_256(GetLocal(__m, __frame + 18));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t18);
+    assume is#ByteArray(__t19);
 
-    __m := UpdateLocal(__m, __frame + 18, t18);
+    __m := UpdateLocal(__m, __frame + 19, __t19);
 
-    call t19 := CopyOrMoveRef(t5);
+    call __t20 := CopyOrMoveRef(sender_account);
 
-    call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
+    call __t21 := BorrowField(__t20, LibraAccount_T_authentication_key);
 
-    call __tmp := ReadRef(t20);
+    call __tmp := ReadRef(__t21);
     assume is#ByteArray(__tmp);
-    __m := UpdateLocal(__m, __frame + 21, __tmp);
-
-    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 21)));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 22));
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 22)));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 23);
+    call __tmp := Not(GetLocal(__m, __frame + 23));
+    __m := UpdateLocal(__m, __frame + 24, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 24);
     if (!b#Boolean(__tmp)) { goto Label_21; }
 
     call __tmp := LdConst(2);
-    __m := UpdateLocal(__m, __frame + 24, __tmp);
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
     goto Label_Abort;
 
 Label_21:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
-    __m := UpdateLocal(__m, __frame + 25, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call __tmp := MulU64(GetLocal(__m, __frame + 25), GetLocal(__m, __frame + 26));
-    if (__abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
-    __m := UpdateLocal(__m, __frame + 7, __tmp);
-
-    call t28 := CopyOrMoveRef(t5);
-
-    call t29 := FreezeRef(t28);
-
-    call t6 := CopyOrMoveRef(t29);
-
-    call t30 := CopyOrMoveRef(t6);
-
-    call t31 := LibraAccount_balance_for_account(t30);
+    call __tmp := MulU64(GetLocal(__m, __frame + 26), GetLocal(__m, __frame + 27));
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t31);
+    __m := UpdateLocal(__m, __frame + 28, __tmp);
 
-    __m := UpdateLocal(__m, __frame + 31, t31);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 28));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
-    __m := UpdateLocal(__m, __frame + 32, __tmp);
+    call __t29 := CopyOrMoveRef(sender_account);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    call __t30 := FreezeRef(__t29);
+
+    call imm_sender_account := CopyOrMoveRef(__t30);
+
+    call __t31 := CopyOrMoveRef(imm_sender_account);
+
+    call __t32 := LibraAccount_balance_for_account(__t31);
+    if (__abort_flag) { goto Label_Abort; }
+    assume IsValidU64(__t32);
+
+    __m := UpdateLocal(__m, __frame + 32, __t32);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 32));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 33, __tmp);
 
-    call __tmp := Ge(GetLocal(__m, __frame + 32), GetLocal(__m, __frame + 33));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 34, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 34));
+    call __tmp := Ge(GetLocal(__m, __frame + 33), GetLocal(__m, __frame + 34));
     __m := UpdateLocal(__m, __frame + 35, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 35);
+    call __tmp := Not(GetLocal(__m, __frame + 35));
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 36);
     if (!b#Boolean(__tmp)) { goto Label_38; }
 
     call __tmp := LdConst(6);
-    __m := UpdateLocal(__m, __frame + 36, __tmp);
+    __m := UpdateLocal(__m, __frame + 37, __tmp);
 
     goto Label_Abort;
 
 Label_38:
-    call t37 := CopyOrMoveRef(t5);
+    call __t38 := CopyOrMoveRef(sender_account);
 
-    call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
+    call __t39 := BorrowField(__t38, LibraAccount_T_sequence_number);
 
-    call __tmp := ReadRef(t38);
+    call __tmp := ReadRef(__t39);
     assume IsValidU64(__tmp);
-    __m := UpdateLocal(__m, __frame + 39, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 39));
-    __m := UpdateLocal(__m, __frame + 9, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 40, __tmp);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 40));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 41, __tmp);
 
-    call __tmp := Ge(GetLocal(__m, __frame + 40), GetLocal(__m, __frame + 41));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 42, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 42));
+    call __tmp := Ge(GetLocal(__m, __frame + 41), GetLocal(__m, __frame + 42));
     __m := UpdateLocal(__m, __frame + 43, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 43);
+    call __tmp := Not(GetLocal(__m, __frame + 43));
+    __m := UpdateLocal(__m, __frame + 44, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 44);
     if (!b#Boolean(__tmp)) { goto Label_49; }
 
     call __tmp := LdConst(3);
-    __m := UpdateLocal(__m, __frame + 44, __tmp);
+    __m := UpdateLocal(__m, __frame + 45, __tmp);
 
     goto Label_Abort;
 
 Label_49:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
-    __m := UpdateLocal(__m, __frame + 45, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 46, __tmp);
 
-    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 45), GetLocal(__m, __frame + 46)));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 47, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 47));
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 46), GetLocal(__m, __frame + 47)));
     __m := UpdateLocal(__m, __frame + 48, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 48);
+    call __tmp := Not(GetLocal(__m, __frame + 48));
+    __m := UpdateLocal(__m, __frame + 49, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 49);
     if (!b#Boolean(__tmp)) { goto Label_56; }
 
     call __tmp := LdConst(4);
-    __m := UpdateLocal(__m, __frame + 49, __tmp);
+    __m := UpdateLocal(__m, __frame + 50, __tmp);
 
     goto Label_Abort;
 
 Label_56:
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 51, __tmp);
+
+    call __t52 := LibraTransactionTimeout_is_valid_transaction_timestamp(GetLocal(__m, __frame + 51));
+    if (__abort_flag) { goto Label_Abort; }
+    assume is#Boolean(__t52);
+
+    __m := UpdateLocal(__m, __frame + 52, __t52);
+
+    call __tmp := Not(GetLocal(__m, __frame + 52));
+    __m := UpdateLocal(__m, __frame + 53, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 53);
+    if (!b#Boolean(__tmp)) { goto Label_62; }
+
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 54, __tmp);
+
+    goto Label_Abort;
+
+Label_62:
     return;
 
 Label_Abort:
@@ -3189,49 +3824,49 @@ Label_Abort:
     __m := __saved_m;
 }
 
-procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
+procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value, txn_expiration_time: Value) returns ()
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units);
+    call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units, txn_expiration_time);
 }
 
 procedure {:inline 1} LibraAccount_epilogue (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_T_type_value()
-    var t9: Value; // AddressType()
-    var t10: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t18: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t19: Value; // IntegerType()
-    var t20: Value; // IntegerType()
-    var t21: Value; // BooleanType()
-    var t22: Value; // BooleanType()
-    var t23: Value; // IntegerType()
-    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t25: Value; // IntegerType()
-    var t26: Value; // LibraCoin_T_type_value()
-    var t27: Value; // IntegerType()
-    var t28: Value; // IntegerType()
-    var t29: Value; // IntegerType()
-    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t31: Reference; // ReferenceType(IntegerType())
-    var t32: Value; // AddressType()
-    var t33: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t36: Value; // LibraCoin_T_type_value()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var transaction_fee_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var imm_sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var transaction_fee_amount: Value; // IntegerType()
+    var transaction_fee: Value; // LibraCoin_T_type_value()
+    var __t9: Value; // AddressType()
+    var __t10: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t18: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // IntegerType()
+    var __t21: Value; // BooleanType()
+    var __t22: Value; // BooleanType()
+    var __t23: Value; // IntegerType()
+    var __t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t25: Value; // IntegerType()
+    var __t26: Value; // LibraCoin_T_type_value()
+    var __t27: Value; // IntegerType()
+    var __t28: Value; // IntegerType()
+    var __t29: Value; // IntegerType()
+    var __t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t31: Reference; // ReferenceType(IntegerType())
+    var __t32: Value; // AddressType()
+    var __t33: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t34: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t35: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t36: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3256,10 +3891,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
+    call __t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := CopyOrMoveRef(t10);
+    call sender_account := CopyOrMoveRef(__t10);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -3281,19 +3916,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t16 := CopyOrMoveRef(t4);
+    call __t16 := CopyOrMoveRef(sender_account);
 
-    call t17 := FreezeRef(t16);
+    call __t17 := FreezeRef(__t16);
 
-    call t6 := CopyOrMoveRef(t17);
+    call imm_sender_account := CopyOrMoveRef(__t17);
 
-    call t18 := CopyOrMoveRef(t6);
+    call __t18 := CopyOrMoveRef(imm_sender_account);
 
-    call t19 := LibraAccount_balance_for_account(t18);
+    call __t19 := LibraAccount_balance_for_account(__t18);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t19);
+    assume IsValidU64(__t19);
 
-    __m := UpdateLocal(__m, __frame + 19, t19);
+    __m := UpdateLocal(__m, __frame + 19, __t19);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -3313,16 +3948,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_20:
-    call t24 := CopyOrMoveRef(t4);
+    call __t24 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(__m, __frame + 25));
+    call __t26 := LibraAccount_withdraw_from_account(__t24, GetLocal(__m, __frame + 25));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t26);
+    assume is#Vector(__t26);
 
-    __m := UpdateLocal(__m, __frame + 26, t26);
+    __m := UpdateLocal(__m, __frame + 26, __t26);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -3337,28 +3972,28 @@ Label_20:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 29, __tmp);
 
-    call t30 := CopyOrMoveRef(t4);
+    call __t30 := CopyOrMoveRef(sender_account);
 
-    call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
+    call __t31 := BorrowField(__t30, LibraAccount_T_sequence_number);
 
-    call WriteRef(t31, GetLocal(__m, __frame + 29));
+    call WriteRef(__t31, GetLocal(__m, __frame + 29));
 
     call __tmp := LdAddr(4078);
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
+    call __t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t33);
+    call transaction_fee_account := CopyOrMoveRef(__t33);
 
-    call t34 := CopyOrMoveRef(t5);
+    call __t34 := CopyOrMoveRef(transaction_fee_account);
 
-    call t35 := BorrowField(t34, LibraAccount_T_balance);
+    call __t35 := BorrowField(__t34, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call LibraCoin_deposit(t35, GetLocal(__m, __frame + 36));
+    call LibraCoin_deposit(__t35, GetLocal(__m, __frame + 36));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -3374,30 +4009,30 @@ procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_pric
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
-procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // ByteArrayType()
-    var t4: Value; // ByteArrayType()
-    var t5: Value; // ByteArrayType()
-    var t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t7: Reference; // ReferenceType(IntegerType())
-    var t8: Value; // AddressType()
-    var t9: Value; // ByteArrayType()
-    var t10: Reference; // ReferenceType(IntegerType())
-    var t11: Value; // IntegerType()
-    var t12: Value; // ByteArrayType()
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Reference; // ReferenceType(IntegerType())
-    var t18: Value; // ByteArrayType()
-    var t19: Value; // ByteArrayType()
-    var t20: Value; // ByteArrayType()
-    var t21: Value; // ByteArrayType()
+    var count: Reference; // ReferenceType(IntegerType())
+    var count_bytes: Value; // ByteArrayType()
+    var preimage: Value; // ByteArrayType()
+    var sender_bytes: Value; // ByteArrayType()
+    var __t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t7: Reference; // ReferenceType(IntegerType())
+    var __t8: Value; // AddressType()
+    var __t9: Value; // ByteArrayType()
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // ByteArrayType()
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Reference; // ReferenceType(IntegerType())
+    var __t18: Value; // ByteArrayType()
+    var __t19: Value; // ByteArrayType()
+    var __t20: Value; // ByteArrayType()
+    var __t21: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3415,42 +4050,42 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
-    call t6 := CopyOrMoveRef(counter);
+    call __t6 := CopyOrMoveRef(counter);
 
-    call t7 := BorrowField(t6, LibraAccount_EventHandleGenerator_counter);
+    call __t7 := BorrowField(__t6, LibraAccount_EventHandleGenerator_counter);
 
-    call t2 := CopyOrMoveRef(t7);
+    call count := CopyOrMoveRef(__t7);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
+    call __t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t9);
+    assume is#ByteArray(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t10 := CopyOrMoveRef(t2);
+    call __t10 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
+    call __t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t12);
+    assume is#ByteArray(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -3461,9 +4096,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t17 := CopyOrMoveRef(t2);
+    call __t17 := CopyOrMoveRef(count);
 
-    call WriteRef(t17, GetLocal(__m, __frame + 16));
+    call WriteRef(__t17, GetLocal(__m, __frame + 16));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -3471,11 +4106,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
+    call __t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t20);
+    assume is#ByteArray(__t20);
 
-    __m := UpdateLocal(__m, __frame + 20, t20);
+    __m := UpdateLocal(__m, __frame + 20, __t20);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -3483,30 +4118,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 21);
+    __ret0 := GetLocal(__m, __frame + 21);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (ret0: Value)
+procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_fresh_guid(counter, sender);
+    call __ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t4: Value; // AddressType()
-    var t5: Value; // ByteArrayType()
-    var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __t2: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t4: Value; // AddressType()
+    var __t5: Value; // ByteArrayType()
+    var __t6: Value; // LibraAccount_EventHandle_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3527,47 +4162,47 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := CopyOrMoveRef(counter);
+    call __t3 := CopyOrMoveRef(counter);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraAccount_fresh_guid(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraAccount_fresh_guid(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t5);
+    assume is#ByteArray(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
+    call __ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t1: Value; // ByteArrayType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t6: Value; // AddressType()
-    var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var sender_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var sender_bytes: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t6: Value; // AddressType()
+    var __t7: Value; // LibraAccount_EventHandle_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3584,59 +4219,59 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t0 := CopyOrMoveRef(t3);
+    call sender_account_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t0);
+    call __t4 := CopyOrMoveRef(sender_account_ref);
 
-    call t5 := BorrowField(t4, LibraAccount_T_event_generator);
+    call __t5 := BorrowField(__t4, LibraAccount_T_event_generator);
 
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(__m, __frame + 6));
+    call __t7 := LibraAccount_new_event_handle_impl(tv0, __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t7);
+    assume is#Vector(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_new_event_handle(tv0);
+    call __ret0 := LibraAccount_new_event_handle(tv0);
 }
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // ByteArrayType()
-    var t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
-    var t5: Reference; // ReferenceType(ByteArrayType())
-    var t6: Value; // ByteArrayType()
-    var t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
-    var t8: Reference; // ReferenceType(IntegerType())
-    var t9: Value; // ByteArrayType()
-    var t10: Reference; // ReferenceType(IntegerType())
-    var t11: Value; // IntegerType()
-    var t12: Value; // tv0
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Reference; // ReferenceType(IntegerType())
+    var count: Reference; // ReferenceType(IntegerType())
+    var guid: Value; // ByteArrayType()
+    var __t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var __t5: Reference; // ReferenceType(ByteArrayType())
+    var __t6: Value; // ByteArrayType()
+    var __t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var __t8: Reference; // ReferenceType(IntegerType())
+    var __t9: Value; // ByteArrayType()
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // tv0
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3653,29 +4288,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, msg);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(handle_ref);
+    call __t4 := CopyOrMoveRef(handle_ref);
 
-    call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
+    call __t5 := BorrowField(__t4, LibraAccount_EventHandle_guid);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t7 := CopyOrMoveRef(handle_ref);
+    call __t7 := CopyOrMoveRef(handle_ref);
 
-    call t8 := BorrowField(t7, LibraAccount_EventHandle_counter);
+    call __t8 := BorrowField(__t7, LibraAccount_EventHandle_counter);
 
-    call t2 := CopyOrMoveRef(t8);
+    call count := CopyOrMoveRef(__t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := CopyOrMoveRef(t2);
+    call __t10 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
@@ -3685,9 +4320,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_write_to_event_store(tv0, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -3698,9 +4333,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t17 := CopyOrMoveRef(t2);
+    call __t17 := CopyOrMoveRef(count);
 
-    call WriteRef(t17, GetLocal(__m, __frame + 16));
+    call WriteRef(__t17, GetLocal(__m, __frame + 16));
 
     return;
 
@@ -3722,11 +4357,11 @@ procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, handle: Value
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // ByteArrayType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
-    var t4: Value; // IntegerType()
-    var t5: Value; // ByteArrayType()
+    var guid: Value; // ByteArrayType()
+    var count: Value; // IntegerType()
+    var __t3: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3745,9 +4380,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    call __t4, __t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -3807,11 +4442,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3830,11 +4465,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := LibraAccount_balance(GetLocal(__m, __frame + 1));
+    call __t2 := LibraAccount_balance(GetLocal(__m, __frame + 1));
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t2);
+    assume IsValidU64(__t2);
 
-    __m := UpdateLocal(__m, __frame + 2, t2);
+    __m := UpdateLocal(__m, __frame + 2, __t2);
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 3, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -6,18 +6,18 @@
 
 // ** functions of module TestArithmetic
 
-procedure {:inline 1} TestArithmetic_add_two_number (x: Value, y: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} TestArithmetic_add_two_number (x: Value, y: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
+    var res: Value; // IntegerType()
+    var z: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -60,34 +60,34 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 8);
-    ret1 := GetLocal(__m, __frame + 9);
+    __ret0 := GetLocal(__m, __frame + 8);
+    __ret1 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure TestArithmetic_add_two_number_verify (x: Value, y: Value) returns (ret0: Value, ret1: Value)
+procedure TestArithmetic_add_two_number_verify (x: Value, y: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := TestArithmetic_add_two_number(x, y);
+    call __ret0, __ret1 := TestArithmetic_add_two_number(x, y);
 }
 
-procedure {:inline 1} TestArithmetic_multiple_ops (x: Value, y: Value, z: Value) returns (ret0: Value)
+procedure {:inline 1} TestArithmetic_multiple_ops (x: Value, y: Value, z: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
+    var res: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -130,46 +130,46 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 9);
+    __ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestArithmetic_multiple_ops_verify (x: Value, y: Value, z: Value) returns (ret0: Value)
+procedure TestArithmetic_multiple_ops_verify (x: Value, y: Value, z: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestArithmetic_multiple_ops(x, y, z);
+    call __ret0 := TestArithmetic_multiple_ops(x, y, z);
 }
 
 procedure {:inline 1} TestArithmetic_bool_ops (a: Value, b: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // BooleanType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // BooleanType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // BooleanType()
-    var t17: Value; // BooleanType()
-    var t18: Value; // BooleanType()
-    var t19: Value; // BooleanType()
-    var t20: Value; // BooleanType()
-    var t21: Value; // BooleanType()
-    var t22: Value; // IntegerType()
+    var c: Value; // BooleanType()
+    var d: Value; // BooleanType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // BooleanType()
+    var __t17: Value; // BooleanType()
+    var __t18: Value; // BooleanType()
+    var __t19: Value; // BooleanType()
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // BooleanType()
+    var __t22: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -269,29 +269,29 @@ procedure TestArithmetic_bool_ops_verify (a: Value, b: Value) returns ()
     call TestArithmetic_bool_ops(a, b);
 }
 
-procedure {:inline 1} TestArithmetic_arithmetic_ops (a: Value, b: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} TestArithmetic_arithmetic_ops (a: Value, b: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // BooleanType()
-    var t17: Value; // BooleanType()
-    var t18: Value; // IntegerType()
-    var t19: Value; // IntegerType()
-    var t20: Value; // IntegerType()
+    var c: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // BooleanType()
+    var __t17: Value; // BooleanType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -377,33 +377,33 @@ Label_19:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 19);
-    ret1 := GetLocal(__m, __frame + 20);
+    __ret0 := GetLocal(__m, __frame + 19);
+    __ret1 := GetLocal(__m, __frame + 20);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure TestArithmetic_arithmetic_ops_verify (a: Value, b: Value) returns (ret0: Value, ret1: Value)
+procedure TestArithmetic_arithmetic_ops_verify (a: Value, b: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := TestArithmetic_arithmetic_ops(a, b);
+    call __ret0, __ret1 := TestArithmetic_arithmetic_ops(a, b);
 }
 
 procedure {:inline 1} TestArithmetic_overflow () returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var x: Value; // IntegerType()
+    var y: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -453,12 +453,12 @@ procedure {:inline 1} TestArithmetic_underflow () returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var x: Value; // IntegerType()
+    var y: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -508,12 +508,12 @@ procedure {:inline 1} TestArithmetic_div_by_zero () returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var x: Value; // IntegerType()
+    var y: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -6,15 +6,15 @@
 
 // ** functions of module TestControlFlow
 
-procedure {:inline 1} TestControlFlow_branch_once (cond: Value) returns (ret0: Value)
+procedure {:inline 1} TestControlFlow_branch_once (cond: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // BooleanType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var __t1: Value; // BooleanType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -46,24 +46,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_6:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 5);
+    __ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestControlFlow_branch_once_verify (cond: Value) returns (ret0: Value)
+procedure TestControlFlow_branch_once_verify (cond: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestControlFlow_branch_once(cond);
+    call __ret0 := TestControlFlow_branch_once(cond);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -6,13 +6,13 @@
 
 // ** functions of module TestFuncCall
 
-procedure {:inline 1} TestFuncCall_f (x: Value) returns (ret0: Value)
+procedure {:inline 1} TestFuncCall_f (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -38,28 +38,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestFuncCall_f_verify (x: Value) returns (ret0: Value)
+procedure TestFuncCall_f_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestFuncCall_f(x);
+    call __ret0 := TestFuncCall_f(x);
 }
 
-procedure {:inline 1} TestFuncCall_g (x: Value) returns (ret0: Value)
+procedure {:inline 1} TestFuncCall_g (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -85,51 +85,51 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestFuncCall_g_verify (x: Value) returns (ret0: Value)
+procedure TestFuncCall_g_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestFuncCall_g(x);
+    call __ret0 := TestFuncCall_g(x);
 }
 
-procedure {:inline 1} TestFuncCall_h (b: Value) returns (ret0: Value)
+procedure {:inline 1} TestFuncCall_h (b: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // BooleanType()
-    var t14: Value; // BooleanType()
-    var t15: Value; // BooleanType()
-    var t16: Value; // IntegerType()
-    var t17: Value; // IntegerType()
-    var t18: Value; // BooleanType()
-    var t19: Value; // BooleanType()
-    var t20: Value; // BooleanType()
-    var t21: Value; // BooleanType()
-    var t22: Value; // IntegerType()
-    var t23: Value; // IntegerType()
+    var x: Value; // IntegerType()
+    var y: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // BooleanType()
+    var __t15: Value; // BooleanType()
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // BooleanType()
+    var __t19: Value; // BooleanType()
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // BooleanType()
+    var __t22: Value; // IntegerType()
+    var __t23: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -160,11 +160,11 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := TestFuncCall_f(GetLocal(__m, __frame + 5));
+    call __t6 := TestFuncCall_f(GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t6);
+    assume IsValidU64(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -175,11 +175,11 @@ Label_8:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := TestFuncCall_g(GetLocal(__m, __frame + 7));
+    call __t8 := TestFuncCall_g(GetLocal(__m, __frame + 7));
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t8);
+    assume IsValidU64(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -236,17 +236,17 @@ Label_27:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 23);
+    __ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestFuncCall_h_verify (b: Value) returns (ret0: Value)
+procedure TestFuncCall_h_verify (b: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestFuncCall_h(b);
+    call __ret0 := TestFuncCall_h(b);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -48,16 +48,16 @@ procedure {:inline 1} TestGenerics_move2 (x1: Value, x2: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // Vector_T_type_value(IntegerType())
-    var t3: Value; // TestGenerics_R_type_value()
-    var t4: Value; // Vector_T_type_value(IntegerType())
-    var t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
-    var t6: Value; // IntegerType()
-    var t7: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
-    var t8: Value; // IntegerType()
-    var t9: Value; // Vector_T_type_value(IntegerType())
-    var t10: Value; // TestGenerics_R_type_value()
-    var t11: Value; // TestGenerics_R_type_value()
+    var v: Value; // Vector_T_type_value(IntegerType())
+    var r: Value; // TestGenerics_R_type_value()
+    var __t4: Value; // Vector_T_type_value(IntegerType())
+    var __t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var __t6: Value; // IntegerType()
+    var __t7: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // Vector_T_type_value(IntegerType())
+    var __t10: Value; // TestGenerics_R_type_value()
+    var __t11: Value; // TestGenerics_R_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -75,29 +75,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, x2);
 
     // bytecode translation starts here
-    call t4 := Vector_empty(IntegerType());
+    call __t4 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t4);
+    assume is#Vector(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t5 := BorrowLoc(__frame + 2);
+    call __t5 := BorrowLoc(__frame + 2);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call Vector_push_back(IntegerType(), t5, GetLocal(__m, __frame + 6));
+    call Vector_push_back(IntegerType(), __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call Vector_push_back(IntegerType(), t7, GetLocal(__m, __frame + 8));
+    call Vector_push_back(IntegerType(), __t7, GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
@@ -128,16 +128,16 @@ procedure TestGenerics_move2_verify (x1: Value, x2: Value) returns ()
     call TestGenerics_move2(x1, x2);
 }
 
-procedure {:inline 1} TestGenerics_create (tv0: TypeValue, x: Value) returns (ret0: Value)
+procedure {:inline 1} TestGenerics_create (tv0: TypeValue, x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // Vector_T_type_value(tv0)
-    var t2: Value; // Vector_T_type_value(tv0)
-    var t3: Reference; // ReferenceType(Vector_T_type_value(tv0))
-    var t4: Value; // tv0
-    var t5: Value; // Vector_T_type_value(tv0)
-    var t6: Value; // TestGenerics_T_type_value(tv0)
+    var v: Value; // Vector_T_type_value(tv0)
+    var __t2: Value; // Vector_T_type_value(tv0)
+    var __t3: Reference; // ReferenceType(Vector_T_type_value(tv0))
+    var __t4: Value; // tv0
+    var __t5: Value; // Vector_T_type_value(tv0)
+    var __t6: Value; // TestGenerics_T_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -152,21 +152,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 0, x);
 
     // bytecode translation starts here
-    call t2 := Vector_empty(tv0);
+    call __t2 := Vector_empty(tv0);
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t2);
+    assume is#Vector(__t2);
 
-    __m := UpdateLocal(__m, __frame + 2, t2);
+    __m := UpdateLocal(__m, __frame + 2, __t2);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t3 := BorrowLoc(__frame + 1);
+    call __t3 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call Vector_push_back(tv0, t3, GetLocal(__m, __frame + 4));
+    call Vector_push_back(tv0, __t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -175,36 +175,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := Pack_TestGenerics_T(tv0, GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestGenerics_create_verify (tv0: TypeValue, x: Value) returns (ret0: Value)
+procedure TestGenerics_create_verify (tv0: TypeValue, x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestGenerics_create(tv0, x);
+    call __ret0 := TestGenerics_create(tv0, x);
 }
 
-procedure {:inline 1} TestGenerics_overcomplicated_equals (tv0: TypeValue, x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestGenerics_overcomplicated_equals (tv0: TypeValue, x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // BooleanType()
-    var t3: Value; // TestGenerics_T_type_value(tv0)
-    var t4: Value; // TestGenerics_T_type_value(tv0)
-    var t5: Value; // tv0
-    var t6: Value; // TestGenerics_T_type_value(tv0)
-    var t7: Value; // tv0
-    var t8: Value; // TestGenerics_T_type_value(tv0)
-    var t9: Value; // TestGenerics_T_type_value(tv0)
-    var t10: Value; // TestGenerics_T_type_value(tv0)
-    var t11: Value; // BooleanType()
-    var t12: Value; // BooleanType()
+    var r: Value; // BooleanType()
+    var x1: Value; // TestGenerics_T_type_value(tv0)
+    var y1: Value; // TestGenerics_T_type_value(tv0)
+    var __t5: Value; // tv0
+    var __t6: Value; // TestGenerics_T_type_value(tv0)
+    var __t7: Value; // tv0
+    var __t8: Value; // TestGenerics_T_type_value(tv0)
+    var __t9: Value; // TestGenerics_T_type_value(tv0)
+    var __t10: Value; // TestGenerics_T_type_value(tv0)
+    var __t11: Value; // BooleanType()
+    var __t12: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -223,11 +223,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := TestGenerics_create(tv0, GetLocal(__m, __frame + 5));
+    call __t6 := TestGenerics_create(tv0, GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t6);
+    assume is#Vector(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -235,11 +235,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := TestGenerics_create(tv0, GetLocal(__m, __frame + 7));
+    call __t8 := TestGenerics_create(tv0, GetLocal(__m, __frame + 7));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t8);
+    assume is#Vector(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -259,30 +259,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 12);
+    __ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestGenerics_overcomplicated_equals_verify (tv0: TypeValue, x: Value, y: Value) returns (ret0: Value)
+procedure TestGenerics_overcomplicated_equals_verify (tv0: TypeValue, x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestGenerics_overcomplicated_equals(tv0, x, y);
+    call __ret0 := TestGenerics_overcomplicated_equals(tv0, x, y);
 }
 
-procedure {:inline 1} TestGenerics_test () returns (ret0: Value)
+procedure {:inline 1} TestGenerics_test () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // BooleanType()
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // BooleanType()
+    var r: Value; // BooleanType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -302,11 +302,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := TestGenerics_overcomplicated_equals(IntegerType(), GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2));
+    call __t3 := TestGenerics_overcomplicated_equals(IntegerType(), GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Boolean(t3);
+    assume is#Boolean(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
@@ -314,17 +314,17 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestGenerics_test_verify () returns (ret0: Value)
+procedure TestGenerics_test_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestGenerics_test();
+    call __ret0 := TestGenerics_test();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -6,7 +6,7 @@
 
 // ** functions of module U64Util
 
-procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (ret0: Value);
+procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -17,7 +17,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module AddressUtil
 
-procedure {:inline 1} AddressUtil_address_to_bytes (addr: Value) returns (ret0: Value);
+procedure {:inline 1} AddressUtil_address_to_bytes (addr: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -28,7 +28,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module BytearrayUtil
 
-procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (ret0: Value);
+procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -39,10 +39,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module Hash
 
-procedure {:inline 1} Hash_sha2_256 (data: Value) returns (ret0: Value);
+procedure {:inline 1} Hash_sha2_256 (data: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
-procedure {:inline 1} Hash_sha3_256 (data: Value) returns (ret0: Value);
+procedure {:inline 1} Hash_sha3_256 (data: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -53,10 +53,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 // ** functions of module Signature
 
-procedure {:inline 1} Signature_ed25519_verify (signature: Value, public_key: Value, message: Value) returns (ret0: Value);
+procedure {:inline 1} Signature_ed25519_verify (signature: Value, public_key: Value, message: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
-procedure {:inline 1} Signature_ed25519_threshold_verify (bitmap: Value, signature: Value, public_key: Value, message: Value) returns (ret0: Value);
+procedure {:inline 1} Signature_ed25519_threshold_verify (bitmap: Value, signature: Value, public_key: Value, message: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
 
 
@@ -119,12 +119,12 @@ procedure {:inline 1} GasSchedule_initialize (gas_schedule: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Value; // AddressType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // GasSchedule_T_type_value()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // GasSchedule_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -180,18 +180,18 @@ procedure GasSchedule_initialize_verify (gas_schedule: Value) returns ()
     call GasSchedule_initialize(gas_schedule);
 }
 
-procedure {:inline 1} GasSchedule_instruction_table_size () returns (ret0: Value)
+procedure {:inline 1} GasSchedule_instruction_table_size () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Reference; // ReferenceType(GasSchedule_T_type_value())
-    var t1: Value; // IntegerType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(GasSchedule_T_type_value())
-    var t4: Reference; // ReferenceType(GasSchedule_T_type_value())
-    var t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
+    var table: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var instruction_table_len: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var __t4: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var __t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -208,20 +208,20 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), GasSchedule_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), GasSchedule_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t0 := CopyOrMoveRef(t3);
+    call table := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t0);
+    call __t4 := CopyOrMoveRef(table);
 
-    call t5 := BorrowField(t4, GasSchedule_T_instruction_schedule);
+    call __t5 := BorrowField(__t4, GasSchedule_T_instruction_schedule);
 
-    call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
+    call __t6 := Vector_length(GasSchedule_Cost_type_value(), __t5);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t6);
+    assume IsValidU64(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -229,33 +229,33 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure GasSchedule_instruction_table_size_verify () returns (ret0: Value)
+procedure GasSchedule_instruction_table_size_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := GasSchedule_instruction_table_size();
+    call __ret0 := GasSchedule_instruction_table_size();
 }
 
-procedure {:inline 1} GasSchedule_native_table_size () returns (ret0: Value)
+procedure {:inline 1} GasSchedule_native_table_size () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Reference; // ReferenceType(GasSchedule_T_type_value())
-    var t1: Value; // IntegerType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(GasSchedule_T_type_value())
-    var t4: Reference; // ReferenceType(GasSchedule_T_type_value())
-    var t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
+    var table: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var native_table_len: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var __t4: Reference; // ReferenceType(GasSchedule_T_type_value())
+    var __t5: Reference; // ReferenceType(Vector_T_type_value(GasSchedule_Cost_type_value()))
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -272,20 +272,20 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), GasSchedule_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), GasSchedule_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t0 := CopyOrMoveRef(t3);
+    call table := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t0);
+    call __t4 := CopyOrMoveRef(table);
 
-    call t5 := BorrowField(t4, GasSchedule_T_native_schedule);
+    call __t5 := BorrowField(__t4, GasSchedule_T_native_schedule);
 
-    call t6 := Vector_length(GasSchedule_Cost_type_value(), t5);
+    call __t6 := Vector_length(GasSchedule_Cost_type_value(), __t5);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t6);
+    assume IsValidU64(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -293,19 +293,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure GasSchedule_native_table_size_verify () returns (ret0: Value)
+procedure GasSchedule_native_table_size_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := GasSchedule_native_table_size();
+    call __ret0 := GasSchedule_native_table_size();
 }
 
 
@@ -379,12 +379,12 @@ procedure {:inline 1} Unpack_ValidatorConfig_T(_struct: Value) returns (config: 
 
 // ** functions of module ValidatorConfig
 
-procedure {:inline 1} ValidatorConfig_has (addr: Value) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_has (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -406,31 +406,31 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := Exists(GetLocal(__m, __frame + 1), ValidatorConfig_T_type_value());
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_has_verify (addr: Value) returns (ret0: Value)
+procedure ValidatorConfig_has_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_has(addr);
+    call __ret0 := ValidatorConfig_has(addr);
 }
 
-procedure {:inline 1} ValidatorConfig_config (addr: Value) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_config (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t4: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t5: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t6: Value; // ValidatorConfig_Config_type_value()
+    var t_ref: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t4: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t5: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t6: Value; // ValidatorConfig_Config_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -449,41 +449,41 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), ValidatorConfig_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), ValidatorConfig_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call t_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(t_ref);
 
-    call t5 := BorrowField(t4, ValidatorConfig_T_config);
+    call __t5 := BorrowField(__t4, ValidatorConfig_T_config);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Vector(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_config_verify (addr: Value) returns (ret0: Value)
+procedure ValidatorConfig_config_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_config(addr);
+    call __ret0 := ValidatorConfig_config(addr);
 }
 
-procedure {:inline 1} ValidatorConfig_consensus_pubkey (config_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_consensus_pubkey (config_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t2: Reference; // ReferenceType(ByteArrayType())
-    var t3: Value; // ByteArrayType()
+    var __t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t2: Reference; // ReferenceType(ByteArrayType())
+    var __t3: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -499,36 +499,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(config_ref);
+    call __t1 := CopyOrMoveRef(config_ref);
 
-    call t2 := BorrowField(t1, ValidatorConfig_Config_consensus_pubkey);
+    call __t2 := BorrowField(__t1, ValidatorConfig_Config_consensus_pubkey);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_consensus_pubkey_verify (config_ref: Reference) returns (ret0: Value)
+procedure ValidatorConfig_consensus_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_consensus_pubkey(config_ref);
+    call __ret0 := ValidatorConfig_consensus_pubkey(config_ref);
 }
 
-procedure {:inline 1} ValidatorConfig_validator_network_signing_pubkey (config_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_validator_network_signing_pubkey (config_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t2: Reference; // ReferenceType(ByteArrayType())
-    var t3: Value; // ByteArrayType()
+    var __t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t2: Reference; // ReferenceType(ByteArrayType())
+    var __t3: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -544,36 +544,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(config_ref);
+    call __t1 := CopyOrMoveRef(config_ref);
 
-    call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_signing_pubkey);
+    call __t2 := BorrowField(__t1, ValidatorConfig_Config_validator_network_signing_pubkey);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_validator_network_signing_pubkey_verify (config_ref: Reference) returns (ret0: Value)
+procedure ValidatorConfig_validator_network_signing_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_validator_network_signing_pubkey(config_ref);
+    call __ret0 := ValidatorConfig_validator_network_signing_pubkey(config_ref);
 }
 
-procedure {:inline 1} ValidatorConfig_validator_network_identity_pubkey (config_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_validator_network_identity_pubkey (config_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t2: Reference; // ReferenceType(ByteArrayType())
-    var t3: Value; // ByteArrayType()
+    var __t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t2: Reference; // ReferenceType(ByteArrayType())
+    var __t3: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -589,36 +589,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(config_ref);
+    call __t1 := CopyOrMoveRef(config_ref);
 
-    call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_identity_pubkey);
+    call __t2 := BorrowField(__t1, ValidatorConfig_Config_validator_network_identity_pubkey);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_validator_network_identity_pubkey_verify (config_ref: Reference) returns (ret0: Value)
+procedure ValidatorConfig_validator_network_identity_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_validator_network_identity_pubkey(config_ref);
+    call __ret0 := ValidatorConfig_validator_network_identity_pubkey(config_ref);
 }
 
-procedure {:inline 1} ValidatorConfig_validator_network_address (config_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_validator_network_address (config_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t2: Reference; // ReferenceType(ByteArrayType())
-    var t3: Value; // ByteArrayType()
+    var __t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t2: Reference; // ReferenceType(ByteArrayType())
+    var __t3: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -634,36 +634,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(config_ref);
+    call __t1 := CopyOrMoveRef(config_ref);
 
-    call t2 := BorrowField(t1, ValidatorConfig_Config_validator_network_address);
+    call __t2 := BorrowField(__t1, ValidatorConfig_Config_validator_network_address);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_validator_network_address_verify (config_ref: Reference) returns (ret0: Value)
+procedure ValidatorConfig_validator_network_address_verify (config_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_validator_network_address(config_ref);
+    call __ret0 := ValidatorConfig_validator_network_address(config_ref);
 }
 
-procedure {:inline 1} ValidatorConfig_fullnodes_network_identity_pubkey (config_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_fullnodes_network_identity_pubkey (config_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t2: Reference; // ReferenceType(ByteArrayType())
-    var t3: Value; // ByteArrayType()
+    var __t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t2: Reference; // ReferenceType(ByteArrayType())
+    var __t3: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -679,36 +679,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(config_ref);
+    call __t1 := CopyOrMoveRef(config_ref);
 
-    call t2 := BorrowField(t1, ValidatorConfig_Config_fullnodes_network_identity_pubkey);
+    call __t2 := BorrowField(__t1, ValidatorConfig_Config_fullnodes_network_identity_pubkey);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_fullnodes_network_identity_pubkey_verify (config_ref: Reference) returns (ret0: Value)
+procedure ValidatorConfig_fullnodes_network_identity_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_fullnodes_network_identity_pubkey(config_ref);
+    call __ret0 := ValidatorConfig_fullnodes_network_identity_pubkey(config_ref);
 }
 
-procedure {:inline 1} ValidatorConfig_fullnodes_network_address (config_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} ValidatorConfig_fullnodes_network_address (config_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t2: Reference; // ReferenceType(ByteArrayType())
-    var t3: Value; // ByteArrayType()
+    var __t1: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t2: Reference; // ReferenceType(ByteArrayType())
+    var __t3: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -724,41 +724,41 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, config_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(config_ref);
+    call __t1 := CopyOrMoveRef(config_ref);
 
-    call t2 := BorrowField(t1, ValidatorConfig_Config_fullnodes_network_address);
+    call __t2 := BorrowField(__t1, ValidatorConfig_Config_fullnodes_network_address);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure ValidatorConfig_fullnodes_network_address_verify (config_ref: Reference) returns (ret0: Value)
+procedure ValidatorConfig_fullnodes_network_address_verify (config_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := ValidatorConfig_fullnodes_network_address(config_ref);
+    call __ret0 := ValidatorConfig_fullnodes_network_address(config_ref);
 }
 
 procedure {:inline 1} ValidatorConfig_register_candidate_validator (consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t6: Value; // ByteArrayType()
-    var t7: Value; // ByteArrayType()
-    var t8: Value; // ByteArrayType()
-    var t9: Value; // ByteArrayType()
-    var t10: Value; // ByteArrayType()
-    var t11: Value; // ByteArrayType()
-    var t12: Value; // ValidatorConfig_Config_type_value()
-    var t13: Value; // ValidatorConfig_T_type_value()
+    var __t6: Value; // ByteArrayType()
+    var __t7: Value; // ByteArrayType()
+    var __t8: Value; // ByteArrayType()
+    var __t9: Value; // ByteArrayType()
+    var __t10: Value; // ByteArrayType()
+    var __t11: Value; // ByteArrayType()
+    var __t12: Value; // ValidatorConfig_Config_type_value()
+    var __t13: Value; // ValidatorConfig_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -828,17 +828,17 @@ procedure {:inline 1} ValidatorConfig_rotate_consensus_pubkey (consensus_pubkey:
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t2: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t3: Reference; // ReferenceType(ByteArrayType())
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t9: Reference; // ReferenceType(ByteArrayType())
-    var t10: Value; // ByteArrayType()
-    var t11: Reference; // ReferenceType(ByteArrayType())
+    var t_ref: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var config_ref: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var key_ref: Reference; // ReferenceType(ByteArrayType())
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t9: Reference; // ReferenceType(ByteArrayType())
+    var __t10: Value; // ByteArrayType()
+    var __t11: Reference; // ReferenceType(ByteArrayType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -857,29 +857,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t5);
+    call t_ref := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(t_ref);
 
-    call t7 := BorrowField(t6, ValidatorConfig_T_config);
+    call __t7 := BorrowField(__t6, ValidatorConfig_T_config);
 
-    call t2 := CopyOrMoveRef(t7);
+    call config_ref := CopyOrMoveRef(__t7);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(config_ref);
 
-    call t9 := BorrowField(t8, ValidatorConfig_Config_consensus_pubkey);
+    call __t9 := BorrowField(__t8, ValidatorConfig_Config_consensus_pubkey);
 
-    call t3 := CopyOrMoveRef(t9);
+    call key_ref := CopyOrMoveRef(__t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := CopyOrMoveRef(t3);
+    call __t11 := CopyOrMoveRef(key_ref);
 
-    call WriteRef(t11, GetLocal(__m, __frame + 10));
+    call WriteRef(__t11, GetLocal(__m, __frame + 10));
 
     return;
 
@@ -898,17 +898,17 @@ procedure {:inline 1} ValidatorConfig_rotate_validator_network_identity_pubkey (
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t2: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t3: Reference; // ReferenceType(ByteArrayType())
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t9: Reference; // ReferenceType(ByteArrayType())
-    var t10: Value; // ByteArrayType()
-    var t11: Reference; // ReferenceType(ByteArrayType())
+    var t_ref: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var config_ref: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var key_ref: Reference; // ReferenceType(ByteArrayType())
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t9: Reference; // ReferenceType(ByteArrayType())
+    var __t10: Value; // ByteArrayType()
+    var __t11: Reference; // ReferenceType(ByteArrayType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -927,29 +927,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t5);
+    call t_ref := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(t_ref);
 
-    call t7 := BorrowField(t6, ValidatorConfig_T_config);
+    call __t7 := BorrowField(__t6, ValidatorConfig_T_config);
 
-    call t2 := CopyOrMoveRef(t7);
+    call config_ref := CopyOrMoveRef(__t7);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(config_ref);
 
-    call t9 := BorrowField(t8, ValidatorConfig_Config_validator_network_identity_pubkey);
+    call __t9 := BorrowField(__t8, ValidatorConfig_Config_validator_network_identity_pubkey);
 
-    call t3 := CopyOrMoveRef(t9);
+    call key_ref := CopyOrMoveRef(__t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := CopyOrMoveRef(t3);
+    call __t11 := CopyOrMoveRef(key_ref);
 
-    call WriteRef(t11, GetLocal(__m, __frame + 10));
+    call WriteRef(__t11, GetLocal(__m, __frame + 10));
 
     return;
 
@@ -968,17 +968,17 @@ procedure {:inline 1} ValidatorConfig_rotate_validator_network_address (validato
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t2: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t3: Reference; // ReferenceType(ByteArrayType())
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
-    var t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
-    var t9: Reference; // ReferenceType(ByteArrayType())
-    var t10: Value; // ByteArrayType()
-    var t11: Reference; // ReferenceType(ByteArrayType())
+    var t_ref: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var config_ref: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var key_ref: Reference; // ReferenceType(ByteArrayType())
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t6: Reference; // ReferenceType(ValidatorConfig_T_type_value())
+    var __t7: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t8: Reference; // ReferenceType(ValidatorConfig_Config_type_value())
+    var __t9: Reference; // ReferenceType(ByteArrayType())
+    var __t10: Value; // ByteArrayType()
+    var __t11: Reference; // ReferenceType(ByteArrayType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -997,29 +997,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), ValidatorConfig_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t5);
+    call t_ref := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(t_ref);
 
-    call t7 := BorrowField(t6, ValidatorConfig_T_config);
+    call __t7 := BorrowField(__t6, ValidatorConfig_T_config);
 
-    call t2 := CopyOrMoveRef(t7);
+    call config_ref := CopyOrMoveRef(__t7);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(config_ref);
 
-    call t9 := BorrowField(t8, ValidatorConfig_Config_validator_network_address);
+    call __t9 := BorrowField(__t8, ValidatorConfig_Config_validator_network_address);
 
-    call t3 := CopyOrMoveRef(t9);
+    call key_ref := CopyOrMoveRef(__t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := CopyOrMoveRef(t3);
+    call __t11 := CopyOrMoveRef(key_ref);
 
-    call WriteRef(t11, GetLocal(__m, __frame + 10));
+    call WriteRef(__t11, GetLocal(__m, __frame + 10));
 
     return;
 
@@ -1099,14 +1099,14 @@ procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_
 
 // ** functions of module LibraCoin
 
-procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint_with_default_capability (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraCoin_MintCapability_type_value())
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1128,53 +1128,53 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraCoin_MintCapability_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), t3);
+    call __t4 := LibraCoin_mint(GetLocal(__m, __frame + 1), __t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t4);
+    assume is#Vector(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (ret0: Value)
+procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint_with_default_capability(amount);
+    call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
-procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_mint (value: Value, capability: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t12: Reference; // ReferenceType(IntegerType())
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Value; // IntegerType()
-    var t18: Reference; // ReferenceType(IntegerType())
-    var t19: Value; // IntegerType()
-    var t20: Value; // LibraCoin_T_type_value()
+    var total_value_ref: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t12: Reference; // ReferenceType(IntegerType())
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Reference; // ReferenceType(IntegerType())
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1223,16 +1223,16 @@ Label_9:
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraCoin_MarketCap_type_value());
+    call __t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t12 := BorrowField(t11, LibraCoin_MarketCap_total_value);
+    call __t12 := BorrowField(__t11, LibraCoin_MarketCap_total_value);
 
-    call t2 := CopyOrMoveRef(t12);
+    call total_value_ref := CopyOrMoveRef(__t12);
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(total_value_ref);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU128(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -1247,9 +1247,9 @@ Label_9:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call t18 := CopyOrMoveRef(t2);
+    call __t18 := CopyOrMoveRef(total_value_ref);
 
-    call WriteRef(t18, GetLocal(__m, __frame + 17));
+    call WriteRef(__t18, GetLocal(__m, __frame + 17));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
@@ -1257,34 +1257,34 @@ Label_9:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 19));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 20);
+    __ret0 := GetLocal(__m, __frame + 20);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (ret0: Value)
+procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_mint(value, capability);
+    call __ret0 := LibraCoin_mint(value, capability);
 }
 
 procedure {:inline 1} LibraCoin_initialize () returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // LibraCoin_MintCapability_type_value()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_MarketCap_type_value()
+    var __t0: Value; // AddressType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // LibraCoin_MintCapability_type_value()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_MarketCap_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1350,14 +1350,14 @@ procedure LibraCoin_initialize_verify () returns ()
     call LibraCoin_initialize();
 }
 
-procedure {:inline 1} LibraCoin_market_cap () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_market_cap () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t0: Value; // AddressType()
+    var __t1: Reference; // ReferenceType(LibraCoin_MarketCap_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1374,36 +1374,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
+    call __t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraCoin_MarketCap_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := BorrowField(t1, LibraCoin_MarketCap_total_value);
+    call __t2 := BorrowField(__t1, LibraCoin_MarketCap_total_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU128(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_market_cap_verify () returns (ret0: Value)
+procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_market_cap();
+    call __ret0 := LibraCoin_market_cap();
 }
 
-procedure {:inline 1} LibraCoin_zero () returns (ret0: Value)
+procedure {:inline 1} LibraCoin_zero () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // LibraCoin_T_type_value()
+    var __t0: Value; // IntegerType()
+    var __t1: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1423,28 +1423,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_zero_verify () returns (ret0: Value)
+procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_zero();
+    call __ret0 := LibraCoin_zero();
 }
 
-procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_value (coin_ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1460,39 +1460,39 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(coin_ref);
+    call __t1 := CopyOrMoveRef(coin_ref);
 
-    call t2 := BorrowField(t1, LibraCoin_T_value);
+    call __t2 := BorrowField(__t1, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_value_verify (coin_ref: Reference) returns (ret0: Value)
+procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_value(coin_ref);
+    call __ret0 := LibraCoin_value(coin_ref);
 }
 
-procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} LibraCoin_split (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var other: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1510,16 +1510,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraCoin_withdraw(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraCoin_withdraw(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t5);
+    assume is#Vector(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -1530,43 +1530,43 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
-    ret1 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 6);
+    __ret1 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (ret0: Value, ret1: Value)
+procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := LibraCoin_split(coin, amount);
+    call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
-procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_withdraw (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraCoin_T_type_value()
+    var value: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1584,11 +1584,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(coin_ref);
+    call __t3 := CopyOrMoveRef(coin_ref);
 
-    call t4 := BorrowField(t3, LibraCoin_T_value);
+    call __t4 := BorrowField(__t3, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
@@ -1626,11 +1626,11 @@ Label_11:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := CopyOrMoveRef(coin_ref);
+    call __t14 := CopyOrMoveRef(coin_ref);
 
-    call t15 := BorrowField(t14, LibraCoin_T_value);
+    call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
-    call WriteRef(t15, GetLocal(__m, __frame + 13));
+    call WriteRef(__t15, GetLocal(__m, __frame + 13));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -1638,28 +1638,28 @@ Label_11:
     call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 17);
+    __ret0 := GetLocal(__m, __frame + 17);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (ret0: Value)
+procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_withdraw(coin_ref, amount);
+    call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
-procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure {:inline 1} LibraCoin_join (coin1: Value, coin2: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // LibraCoin_T_type_value()
+    var __t2: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1677,48 +1677,48 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, coin2);
 
     // bytecode translation starts here
-    call t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call LibraCoin_deposit(t2, GetLocal(__m, __frame + 3));
+    call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (ret0: Value)
+procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraCoin_join(coin1, coin2);
+    call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
 procedure {:inline 1} LibraCoin_deposit (coin_ref: Reference, check: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // IntegerType()
-    var t12: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t13: Reference; // ReferenceType(IntegerType())
+    var value: Value; // IntegerType()
+    var check_value: Value; // IntegerType()
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // IntegerType()
+    var __t12: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t13: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1736,11 +1736,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, check);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(coin_ref);
+    call __t4 := CopyOrMoveRef(coin_ref);
 
-    call t5 := BorrowField(t4, LibraCoin_T_value);
+    call __t5 := BorrowField(__t4, LibraCoin_T_value);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -1750,8 +1750,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    call __t8 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -1766,11 +1766,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(coin_ref);
+    call __t12 := CopyOrMoveRef(coin_ref);
 
-    call t13 := BorrowField(t12, LibraCoin_T_value);
+    call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
-    call WriteRef(t13, GetLocal(__m, __frame + 11));
+    call WriteRef(__t13, GetLocal(__m, __frame + 11));
 
     return;
 
@@ -1789,14 +1789,14 @@ procedure {:inline 1} LibraCoin_destroy_zero (coin: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
+    var value: Value; // IntegerType()
+    var __t2: Value; // LibraCoin_T_type_value()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -1815,8 +1815,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    call __t3 := Unpack_LibraCoin_T(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -1853,6 +1853,614 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
     assume ExistsTxnSenderAccount(__m, __txn);
     call LibraCoin_destroy_zero(coin);
+}
+
+
+
+// ** structs of module LibraTimestamp
+
+const unique LibraTimestamp_CurrentTimeMicroseconds: TypeName;
+const LibraTimestamp_CurrentTimeMicroseconds_microseconds: FieldName;
+axiom LibraTimestamp_CurrentTimeMicroseconds_microseconds == 0;
+function LibraTimestamp_CurrentTimeMicroseconds_type_value(): TypeValue {
+    StructType(LibraTimestamp_CurrentTimeMicroseconds, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+procedure {:inline 1} Pack_LibraTimestamp_CurrentTimeMicroseconds(microseconds: Value) returns (_struct: Value)
+{
+    assume IsValidU64(microseconds);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, microseconds));
+}
+
+procedure {:inline 1} Unpack_LibraTimestamp_CurrentTimeMicroseconds(_struct: Value) returns (microseconds: Value)
+{
+    assume is#Vector(_struct);
+    microseconds := SelectField(_struct, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+    assume IsValidU64(microseconds);
+}
+
+
+
+// ** functions of module LibraTimestamp
+
+procedure {:inline 1} LibraTimestamp_initialize_timer () returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var timer: Value; // LibraTimestamp_CurrentTimeMicroseconds_type_value()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraTimestamp_CurrentTimeMicroseconds_type_value()
+    var __t8: Value; // LibraTimestamp_CurrentTimeMicroseconds_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
+
+    // process and type check arguments
+
+    // bytecode translation starts here
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2)));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_LibraTimestamp_CurrentTimeMicroseconds(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call MoveToSender(LibraTimestamp_CurrentTimeMicroseconds_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTimestamp_initialize_timer_verify () returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTimestamp_initialize_timer();
+}
+
+procedure {:inline 1} LibraTimestamp_update_global_time (proposer: Value, timestamp: Value) returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var global_timer: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t3: Value; // AddressType()
+    var __t4: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t5: Value; // AddressType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
+    var __t9: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // IntegerType()
+    var __t15: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t16: Reference; // ReferenceType(IntegerType())
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // BooleanType()
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // IntegerType()
+    var __t22: Value; // IntegerType()
+    var __t23: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t24: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 25;
+
+    // process and type check arguments
+    assume is#Address(proposer);
+    __m := UpdateLocal(__m, __frame + 0, proposer);
+    assume IsValidU64(timestamp);
+    __m := UpdateLocal(__m, __frame + 1, timestamp);
+
+    // bytecode translation starts here
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraTimestamp_CurrentTimeMicroseconds_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call global_timer := CopyOrMoveRef(__t4);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := LdAddr(0);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6)));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_17; }
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call __t9 := CopyOrMoveRef(global_timer);
+
+    call __t10 := BorrowField(__t9, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call __tmp := ReadRef(__t10);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 11, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 11)));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 13);
+    if (!b#Boolean(__tmp)) { goto Label_16; }
+
+    call __tmp := LdConst(5001);
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
+
+    goto Label_Abort;
+
+Label_16:
+    goto Label_26;
+
+Label_17:
+    call __t15 := CopyOrMoveRef(global_timer);
+
+    call __t16 := BorrowField(__t15, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call __tmp := ReadRef(__t16);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
+
+    call __tmp := Lt(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18));
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 20);
+    if (!b#Boolean(__tmp)) { goto Label_26; }
+
+    call __tmp := LdConst(5001);
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
+
+    goto Label_Abort;
+
+Label_26:
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
+
+    call __t23 := CopyOrMoveRef(global_timer);
+
+    call __t24 := BorrowField(__t23, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call WriteRef(__t24, GetLocal(__m, __frame + 22));
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTimestamp_update_global_time_verify (proposer: Value, timestamp: Value) returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTimestamp_update_global_time(proposer, timestamp);
+}
+
+procedure {:inline 1} LibraTimestamp_now_microseconds () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var __t0: Value; // AddressType()
+    var __t1: Reference; // ReferenceType(LibraTimestamp_CurrentTimeMicroseconds_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 4;
+
+    // process and type check arguments
+
+    // bytecode translation starts here
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+
+    call __t1 := BorrowGlobal(GetLocal(__m, __frame + 0), LibraTimestamp_CurrentTimeMicroseconds_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call __t2 := BorrowField(__t1, LibraTimestamp_CurrentTimeMicroseconds_microseconds);
+
+    call __tmp := ReadRef(__t2);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 3);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure LibraTimestamp_now_microseconds_verify () returns (__ret0: Value)
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call __ret0 := LibraTimestamp_now_microseconds();
+}
+
+
+
+// ** structs of module LibraTransactionTimeout
+
+const unique LibraTransactionTimeout_TTL: TypeName;
+const LibraTransactionTimeout_TTL_duration_microseconds: FieldName;
+axiom LibraTransactionTimeout_TTL_duration_microseconds == 0;
+function LibraTransactionTimeout_TTL_type_value(): TypeValue {
+    StructType(LibraTransactionTimeout_TTL, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+procedure {:inline 1} Pack_LibraTransactionTimeout_TTL(duration_microseconds: Value) returns (_struct: Value)
+{
+    assume IsValidU64(duration_microseconds);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, duration_microseconds));
+}
+
+procedure {:inline 1} Unpack_LibraTransactionTimeout_TTL(_struct: Value) returns (duration_microseconds: Value)
+{
+    assume is#Vector(_struct);
+    duration_microseconds := SelectField(_struct, LibraTransactionTimeout_TTL_duration_microseconds);
+    assume IsValidU64(duration_microseconds);
+}
+
+
+
+// ** functions of module LibraTransactionTimeout
+
+procedure {:inline 1} LibraTransactionTimeout_initialize () returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var timeout: Value; // LibraTransactionTimeout_TTL_type_value()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // LibraTransactionTimeout_TTL_type_value()
+    var __t8: Value; // LibraTransactionTimeout_TTL_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 9;
+
+    // process and type check arguments
+
+    // bytecode translation starts here
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 1), GetLocal(__m, __frame + 2)));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 4);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call __tmp := LdConst(86400000000);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_LibraTransactionTimeout_TTL(GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call MoveToSender(LibraTransactionTimeout_TTL_type_value(), GetLocal(__m, __frame + 8));
+    if (__abort_flag) { goto Label_Abort; }
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTransactionTimeout_initialize_verify () returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTransactionTimeout_initialize();
+}
+
+procedure {:inline 1} LibraTransactionTimeout_set_timeout (new_duration: Value) returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var timeout: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // AddressType()
+    var __t8: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t11: Reference; // ReferenceType(IntegerType())
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 12;
+
+    // process and type check arguments
+    assume IsValidU64(new_duration);
+    __m := UpdateLocal(__m, __frame + 0, new_duration);
+
+    // bytecode translation starts here
+    call __tmp := GetTxnSenderAddress();
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 3)));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := Not(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 5);
+    if (!b#Boolean(__tmp)) { goto Label_7; }
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    goto Label_Abort;
+
+Label_7:
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __t8 := BorrowGlobal(GetLocal(__m, __frame + 7), LibraTransactionTimeout_TTL_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call timeout := CopyOrMoveRef(__t8);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __t10 := CopyOrMoveRef(timeout);
+
+    call __t11 := BorrowField(__t10, LibraTransactionTimeout_TTL_duration_microseconds);
+
+    call WriteRef(__t11, GetLocal(__m, __frame + 9));
+
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure LibraTransactionTimeout_set_timeout_verify (new_duration: Value) returns ()
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call LibraTransactionTimeout_set_timeout(new_duration);
+}
+
+procedure {:inline 1} LibraTransactionTimeout_is_valid_transaction_timestamp (timestamp: Value) returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var current_block_time: Value; // IntegerType()
+    var max_txn_time: Value; // IntegerType()
+    var timeout: Value; // IntegerType()
+    var txn_time_microseconds: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Reference; // ReferenceType(LibraTransactionTimeout_TTL_type_value())
+    var __t12: Reference; // ReferenceType(IntegerType())
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // IntegerType()
+    var __t21: Value; // IntegerType()
+    var __t22: Value; // BooleanType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+    __local_counter := __local_counter + 23;
+
+    // process and type check arguments
+    assume IsValidU64(timestamp);
+    __m := UpdateLocal(__m, __frame + 0, timestamp);
+
+    // bytecode translation starts here
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := LdConst(9223372036854);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Gt(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 7);
+    if (!b#Boolean(__tmp)) { goto Label_6; }
+
+    call __tmp := LdFalse();
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 8);
+    return;
+
+Label_6:
+    call __t9 := LibraTimestamp_now_microseconds();
+    if (__abort_flag) { goto Label_Abort; }
+    assume IsValidU64(__t9);
+
+    __m := UpdateLocal(__m, __frame + 9, __t9);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := LdAddr(173345816);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
+
+    call __t11 := BorrowGlobal(GetLocal(__m, __frame + 10), LibraTransactionTimeout_TTL_type_value());
+    if (__abort_flag) { goto Label_Abort; }
+
+    call __t12 := BorrowField(__t11, LibraTransactionTimeout_TTL_duration_microseconds);
+
+    call __tmp := ReadRef(__t12);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
+
+    call __tmp := AddU64(GetLocal(__m, __frame + 14), GetLocal(__m, __frame + 15));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
+
+    call __tmp := LdConst(1000000);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
+
+    call __tmp := MulU64(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18));
+    if (__abort_flag) { goto Label_Abort; }
+    __m := UpdateLocal(__m, __frame + 19, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 19));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 21, __tmp);
+
+    call __tmp := Lt(GetLocal(__m, __frame + 20), GetLocal(__m, __frame + 21));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 22);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure LibraTransactionTimeout_is_valid_transaction_timestamp_verify (timestamp: Value) returns (__ret0: Value)
+{
+    assume ExistsTxnSenderAccount(__m, __txn);
+    call __ret0 := LibraTransactionTimeout_is_valid_transaction_timestamp(timestamp);
 }
 
 
@@ -2058,9 +2666,9 @@ procedure {:inline 1} LibraAccount_deposit (payee: Value, to_deposit: Value) ret
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // LibraCoin_T_type_value()
-    var t4: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // LibraCoin_T_type_value()
+    var __t4: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2106,10 +2714,10 @@ procedure {:inline 1} LibraAccount_deposit_with_metadata (payee: Value, to_depos
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Value; // LibraCoin_T_type_value()
-    var t6: Value; // ByteArrayType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // LibraCoin_T_type_value()
+    var __t6: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2161,35 +2769,35 @@ procedure {:inline 1} LibraAccount_deposit_with_sender_and_metadata (payee: Valu
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // IntegerType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // BooleanType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // AddressType()
-    var t15: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
-    var t18: Value; // IntegerType()
-    var t19: Value; // AddressType()
-    var t20: Value; // ByteArrayType()
-    var t21: Value; // LibraAccount_SentPaymentEvent_type_value()
-    var t22: Value; // AddressType()
-    var t23: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t25: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t26: Value; // LibraCoin_T_type_value()
-    var t27: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
-    var t29: Value; // IntegerType()
-    var t30: Value; // AddressType()
-    var t31: Value; // ByteArrayType()
-    var t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
+    var deposit_value: Value; // IntegerType()
+    var payee_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var sender_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // BooleanType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // AddressType()
+    var __t15: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value()))
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // AddressType()
+    var __t20: Value; // ByteArrayType()
+    var __t21: Value; // LibraAccount_SentPaymentEvent_type_value()
+    var __t22: Value; // AddressType()
+    var __t23: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t25: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t26: Value; // LibraCoin_T_type_value()
+    var __t27: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t28: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value()))
+    var __t29: Value; // IntegerType()
+    var __t30: Value; // AddressType()
+    var __t31: Value; // ByteArrayType()
+    var __t32: Value; // LibraAccount_ReceivedPaymentEvent_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2211,13 +2819,13 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, metadata);
 
     // bytecode translation starts here
-    call t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2);
 
-    call t8 := LibraCoin_value(t7);
+    call __t8 := LibraCoin_value(__t7);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t8);
+    assume IsValidU64(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2246,14 +2854,14 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
+    call __t15 := BorrowGlobal(GetLocal(__m, __frame + 14), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t6 := CopyOrMoveRef(t15);
+    call sender_account_ref := CopyOrMoveRef(__t15);
 
-    call t16 := CopyOrMoveRef(t6);
+    call __t16 := CopyOrMoveRef(sender_account_ref);
 
-    call t17 := BorrowField(t16, LibraAccount_T_sent_events);
+    call __t17 := BorrowField(__t16, LibraAccount_T_sent_events);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -2267,30 +2875,30 @@ Label_10:
     call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), t17, GetLocal(__m, __frame + 21));
+    call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), __t17, GetLocal(__m, __frame + 21));
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
+    call __t23 := BorrowGlobal(GetLocal(__m, __frame + 22), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t23);
+    call payee_account_ref := CopyOrMoveRef(__t23);
 
-    call t24 := CopyOrMoveRef(t5);
+    call __t24 := CopyOrMoveRef(payee_account_ref);
 
-    call t25 := BorrowField(t24, LibraAccount_T_balance);
+    call __t25 := BorrowField(__t24, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call LibraCoin_deposit(t25, GetLocal(__m, __frame + 26));
+    call LibraCoin_deposit(__t25, GetLocal(__m, __frame + 26));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t27 := CopyOrMoveRef(t5);
+    call __t27 := CopyOrMoveRef(payee_account_ref);
 
-    call t28 := BorrowField(t27, LibraAccount_T_received_events);
+    call __t28 := BorrowField(__t27, LibraAccount_T_received_events);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 29, __tmp);
@@ -2304,7 +2912,7 @@ Label_10:
     call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), t28, GetLocal(__m, __frame + 32));
+    call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), __t28, GetLocal(__m, __frame + 32));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -2324,13 +2932,13 @@ procedure {:inline 1} LibraAccount_mint_to_address (payee: Value, amount: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // BooleanType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // AddressType()
-    var t6: Value; // AddressType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_T_type_value()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // BooleanType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2373,11 +2981,11 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
+    call __t8 := LibraCoin_mint_with_default_capability(GetLocal(__m, __frame + 7));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t8);
+    assume is#Vector(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call LibraAccount_deposit(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
@@ -2395,16 +3003,16 @@ procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) retu
     call LibraAccount_mint_to_address(payee, amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_from_account (account: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // LibraCoin_T_type_value()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t5: Value; // IntegerType()
-    var t6: Value; // LibraCoin_T_type_value()
-    var t7: Value; // LibraCoin_T_type_value()
+    var to_withdraw: Value; // LibraCoin_T_type_value()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // LibraCoin_T_type_value()
+    var __t7: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2422,18 +3030,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(account);
+    call __t3 := CopyOrMoveRef(account);
 
-    call t4 := BorrowField(t3, LibraAccount_T_balance);
+    call __t4 := BorrowField(__t3, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := LibraCoin_withdraw(t4, GetLocal(__m, __frame + 5));
+    call __t6 := LibraCoin_withdraw(__t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t6);
+    assume is#Vector(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -2441,35 +3049,35 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_from_account(account, amount);
+    call __ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_from_sender (amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Value; // IntegerType()
-    var t10: Value; // LibraCoin_T_type_value()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2488,16 +3096,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call sender_account := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(sender_account);
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_withdrawal_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_withdrawal_capability);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -2510,44 +3118,44 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_9:
-    call t8 := CopyOrMoveRef(t1);
+    call __t8 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := LibraAccount_withdraw_from_account(t8, GetLocal(__m, __frame + 9));
+    call __t10 := LibraAccount_withdraw_from_account(__t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t10);
+    assume is#Vector(__t10);
 
-    __m := UpdateLocal(__m, __frame + 10, t10);
+    __m := UpdateLocal(__m, __frame + 10, __t10);
 
-    ret0 := GetLocal(__m, __frame + 10);
+    __ret0 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_from_sender(amount);
+    call __ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
-procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_withdraw_with_capability (cap: Reference, amount: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t4: Reference; // ReferenceType(AddressType())
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t8: Value; // IntegerType()
-    var t9: Value; // LibraCoin_T_type_value()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t4: Reference; // ReferenceType(AddressType())
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2565,64 +3173,64 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, amount);
 
     // bytecode translation starts here
-    call t3 := CopyOrMoveRef(cap);
+    call __t3 := CopyOrMoveRef(cap);
 
-    call t4 := BorrowField(t3, LibraAccount_WithdrawalCapability_account_address);
+    call __t4 := BorrowField(__t3, LibraAccount_WithdrawalCapability_account_address);
 
-    call __tmp := ReadRef(t4);
+    call __tmp := ReadRef(__t4);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
-    call t7 := CopyOrMoveRef(t2);
+    call __t7 := CopyOrMoveRef(account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_account(t7, GetLocal(__m, __frame + 8));
+    call __t9 := LibraAccount_withdraw_from_account(__t7, GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t9);
+    assume is#Vector(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
-    ret0 := GetLocal(__m, __frame + 9);
+    __ret0 := GetLocal(__m, __frame + 9);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (ret0: Value)
+procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdraw_with_capability(cap, amount);
+    call __ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
-procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_extract_sender_withdrawal_capability () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Reference; // ReferenceType(BooleanType())
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Reference; // ReferenceType(BooleanType())
-    var t8: Reference; // ReferenceType(BooleanType())
-    var t9: Value; // BooleanType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // BooleanType()
-    var t12: Reference; // ReferenceType(BooleanType())
-    var t13: Value; // AddressType()
-    var t14: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var sender: Value; // AddressType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var delegated_ref: Reference; // ReferenceType(BooleanType())
+    var __t3: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Reference; // ReferenceType(BooleanType())
+    var __t8: Reference; // ReferenceType(BooleanType())
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // BooleanType()
+    var __t12: Reference; // ReferenceType(BooleanType())
+    var __t13: Value; // AddressType()
+    var __t14: Value; // LibraAccount_WithdrawalCapability_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2645,20 +3253,20 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t5);
+    call sender_account := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(sender_account);
 
-    call t7 := BorrowField(t6, LibraAccount_T_delegated_withdrawal_capability);
+    call __t7 := BorrowField(__t6, LibraAccount_T_delegated_withdrawal_capability);
 
-    call t2 := CopyOrMoveRef(t7);
+    call delegated_ref := CopyOrMoveRef(__t7);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(delegated_ref);
 
-    call __tmp := ReadRef(t8);
+    call __tmp := ReadRef(__t8);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
@@ -2674,9 +3282,9 @@ Label_13:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(t2);
+    call __t12 := CopyOrMoveRef(delegated_ref);
 
-    call WriteRef(t12, GetLocal(__m, __frame + 11));
+    call WriteRef(__t12, GetLocal(__m, __frame + 11));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
@@ -2684,34 +3292,34 @@ Label_13:
     call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 14);
+    __ret0 := GetLocal(__m, __frame + 14);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (ret0: Value)
+procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_extract_sender_withdrawal_capability();
+    call __ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_withdrawal_capability (cap: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // LibraAccount_WithdrawalCapability_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // BooleanType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Reference; // ReferenceType(BooleanType())
+    var account_address: Value; // AddressType()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // LibraAccount_WithdrawalCapability_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Value; // BooleanType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Reference; // ReferenceType(BooleanType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2730,8 +3338,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    call __t4 := Unpack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -2739,19 +3347,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(account);
 
-    call t9 := BorrowField(t8, LibraAccount_T_delegated_withdrawal_capability);
+    call __t9 := BorrowField(__t8, LibraAccount_T_delegated_withdrawal_capability);
 
-    call WriteRef(t9, GetLocal(__m, __frame + 7));
+    call WriteRef(__t9, GetLocal(__m, __frame + 7));
 
     return;
 
@@ -2770,18 +3378,18 @@ procedure {:inline 1} LibraAccount_pay_from_capability (payee: Value, cap: Refer
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // AddressType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // AddressType()
-    var t8: Value; // AddressType()
-    var t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t10: Reference; // ReferenceType(AddressType())
-    var t11: Value; // AddressType()
-    var t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t13: Value; // IntegerType()
-    var t14: Value; // LibraCoin_T_type_value()
-    var t15: Value; // ByteArrayType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // AddressType()
+    var __t9: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t10: Reference; // ReferenceType(AddressType())
+    var __t11: Value; // AddressType()
+    var __t12: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // LibraCoin_T_type_value()
+    var __t15: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2825,24 +3433,24 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := CopyOrMoveRef(cap);
+    call __t9 := CopyOrMoveRef(cap);
 
-    call t10 := BorrowField(t9, LibraAccount_WithdrawalCapability_account_address);
+    call __t10 := BorrowField(__t9, LibraAccount_WithdrawalCapability_account_address);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := CopyOrMoveRef(cap);
+    call __t12 := CopyOrMoveRef(cap);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := LibraAccount_withdraw_with_capability(t12, GetLocal(__m, __frame + 13));
+    call __t14 := LibraAccount_withdraw_with_capability(__t12, GetLocal(__m, __frame + 13));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t14);
+    assume is#Vector(__t14);
 
-    __m := UpdateLocal(__m, __frame + 14, t14);
+    __m := UpdateLocal(__m, __frame + 14, __t14);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 15, __tmp);
@@ -2867,14 +3475,14 @@ procedure {:inline 1} LibraAccount_pay_from_sender_with_metadata (payee: Value, 
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t3: Value; // AddressType()
-    var t4: Value; // BooleanType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // AddressType()
-    var t7: Value; // AddressType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // LibraCoin_T_type_value()
-    var t10: Value; // ByteArrayType()
+    var __t3: Value; // AddressType()
+    var __t4: Value; // BooleanType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // LibraCoin_T_type_value()
+    var __t10: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2919,11 +3527,11 @@ Label_6:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 8));
+    call __t9 := LibraAccount_withdraw_from_sender(GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t9);
+    assume is#Vector(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -2948,9 +3556,9 @@ procedure {:inline 1} LibraAccount_pay_from_sender (payee: Value, amount: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -2996,9 +3604,9 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key_for_account (accoun
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // ByteArrayType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(ByteArrayType())
+    var __t2: Value; // ByteArrayType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(ByteArrayType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3019,11 +3627,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := CopyOrMoveRef(account);
+    call __t3 := CopyOrMoveRef(account);
 
-    call t4 := BorrowField(t3, LibraAccount_T_authentication_key);
+    call __t4 := BorrowField(__t3, LibraAccount_T_authentication_key);
 
-    call WriteRef(t4, GetLocal(__m, __frame + 2));
+    call WriteRef(__t4, GetLocal(__m, __frame + 2));
 
     return;
 
@@ -3042,15 +3650,15 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key (new_authentication
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Value; // BooleanType()
-    var t7: Value; // IntegerType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Value; // ByteArrayType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // IntegerType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3069,16 +3677,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t1 := CopyOrMoveRef(t3);
+    call sender_account := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(sender_account);
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -3091,12 +3699,12 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_9:
-    call t8 := CopyOrMoveRef(t1);
+    call __t8 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t8, GetLocal(__m, __frame + 9));
+    call LibraAccount_rotate_authentication_key_for_account(__t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -3116,11 +3724,11 @@ procedure {:inline 1} LibraAccount_rotate_authentication_key_with_capability (ca
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
-    var t3: Reference; // ReferenceType(AddressType())
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Value; // ByteArrayType()
+    var __t2: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var __t3: Reference; // ReferenceType(AddressType())
+    var __t4: Value; // AddressType()
+    var __t5: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t6: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3138,21 +3746,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
 
     // bytecode translation starts here
-    call t2 := CopyOrMoveRef(cap);
+    call __t2 := CopyOrMoveRef(cap);
 
-    call t3 := BorrowField(t2, LibraAccount_KeyRotationCapability_account_address);
+    call __t3 := BorrowField(__t2, LibraAccount_KeyRotationCapability_account_address);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Address(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
+    call __t5 := BorrowGlobal(GetLocal(__m, __frame + 4), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call LibraAccount_rotate_authentication_key_for_account(t5, GetLocal(__m, __frame + 6));
+    call LibraAccount_rotate_authentication_key_for_account(__t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -3168,23 +3776,23 @@ procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Re
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
-procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (ret0: Value)
+procedure {:inline 1} LibraAccount_extract_sender_key_rotation_capability () returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Reference; // ReferenceType(BooleanType())
-    var t2: Value; // AddressType()
-    var t3: Value; // AddressType()
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(BooleanType())
-    var t6: Reference; // ReferenceType(BooleanType())
-    var t7: Value; // BooleanType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Reference; // ReferenceType(BooleanType())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var sender: Value; // AddressType()
+    var delegated_ref: Reference; // ReferenceType(BooleanType())
+    var __t2: Value; // AddressType()
+    var __t3: Value; // AddressType()
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(BooleanType())
+    var __t6: Reference; // ReferenceType(BooleanType())
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Reference; // ReferenceType(BooleanType())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_KeyRotationCapability_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3207,16 +3815,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
+    call __t4 := BorrowGlobal(GetLocal(__m, __frame + 3), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := BorrowField(t4, LibraAccount_T_delegated_key_rotation_capability);
+    call __t5 := BorrowField(__t4, LibraAccount_T_delegated_key_rotation_capability);
 
-    call t1 := CopyOrMoveRef(t5);
+    call delegated_ref := CopyOrMoveRef(__t5);
 
-    call t6 := CopyOrMoveRef(t1);
+    call __t6 := CopyOrMoveRef(delegated_ref);
 
-    call __tmp := ReadRef(t6);
+    call __tmp := ReadRef(__t6);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
@@ -3232,9 +3840,9 @@ Label_11:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := CopyOrMoveRef(t1);
+    call __t10 := CopyOrMoveRef(delegated_ref);
 
-    call WriteRef(t10, GetLocal(__m, __frame + 9));
+    call WriteRef(__t10, GetLocal(__m, __frame + 9));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -3242,34 +3850,34 @@ Label_11:
     call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 12);
+    __ret0 := GetLocal(__m, __frame + 12);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (ret0: Value)
+procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_extract_sender_key_rotation_capability();
+    call __ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
 procedure {:inline 1} LibraAccount_restore_key_rotation_capability (cap: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // LibraAccount_KeyRotationCapability_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // BooleanType()
-    var t8: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t9: Reference; // ReferenceType(BooleanType())
+    var account_address: Value; // AddressType()
+    var account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // LibraAccount_KeyRotationCapability_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t7: Value; // BooleanType()
+    var __t8: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t9: Reference; // ReferenceType(BooleanType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3288,8 +3896,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    call __t4 := Unpack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -3297,19 +3905,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
+    call __t6 := BorrowGlobal(GetLocal(__m, __frame + 5), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t6);
+    call account := CopyOrMoveRef(__t6);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8 := CopyOrMoveRef(t2);
+    call __t8 := CopyOrMoveRef(account);
 
-    call t9 := BorrowField(t8, LibraAccount_T_delegated_key_rotation_capability);
+    call __t9 := BorrowField(__t8, LibraAccount_T_delegated_key_rotation_capability);
 
-    call WriteRef(t9, GetLocal(__m, __frame + 7));
+    call WriteRef(__t9, GetLocal(__m, __frame + 7));
 
     return;
 
@@ -3328,24 +3936,24 @@ procedure {:inline 1} LibraAccount_create_account (fresh_address: Value) returns
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t2: Value; // IntegerType()
-    var t3: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t4: Value; // AddressType()
-    var t5: Value; // AddressType()
-    var t6: Value; // ByteArrayType()
-    var t7: Value; // LibraCoin_T_type_value()
-    var t8: Value; // BooleanType()
-    var t9: Value; // BooleanType()
-    var t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t11: Value; // AddressType()
-    var t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
-    var t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t14: Value; // AddressType()
-    var t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
-    var t16: Value; // IntegerType()
-    var t17: Value; // LibraAccount_EventHandleGenerator_type_value()
-    var t18: Value; // LibraAccount_T_type_value()
+    var generator: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // ByteArrayType()
+    var __t7: Value; // LibraCoin_T_type_value()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // BooleanType()
+    var __t10: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t11: Value; // AddressType()
+    var __t12: Value; // LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())
+    var __t13: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t14: Value; // AddressType()
+    var __t15: Value; // LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())
+    var __t16: Value; // IntegerType()
+    var __t17: Value; // LibraAccount_EventHandleGenerator_type_value()
+    var __t18: Value; // LibraAccount_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3376,17 +3984,17 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
+    call __t6 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 5));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t6);
+    assume is#ByteArray(__t6);
 
-    __m := UpdateLocal(__m, __frame + 6, t6);
+    __m := UpdateLocal(__m, __frame + 6, __t6);
 
-    call t7 := LibraCoin_zero();
+    call __t7 := LibraCoin_zero();
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t7);
+    assume is#Vector(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -3394,27 +4002,27 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), t10, GetLocal(__m, __frame + 11));
+    call __t12 := LibraAccount_new_event_handle_impl(LibraAccount_ReceivedPaymentEvent_type_value(), __t10, GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t12);
+    assume is#Vector(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
-    call t13 := BorrowLoc(__frame + 1);
+    call __t13 := BorrowLoc(__frame + 1);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
-    call t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), t13, GetLocal(__m, __frame + 14));
+    call __t15 := LibraAccount_new_event_handle_impl(LibraAccount_SentPaymentEvent_type_value(), __t13, GetLocal(__m, __frame + 14));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t15);
+    assume is#Vector(__t15);
 
-    __m := UpdateLocal(__m, __frame + 15, t15);
+    __m := UpdateLocal(__m, __frame + 15, __t15);
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -3445,12 +4053,12 @@ procedure {:inline 1} LibraAccount_create_new_account (fresh_address: Value, ini
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // AddressType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // BooleanType()
-    var t6: Value; // AddressType()
-    var t7: Value; // IntegerType()
+    var __t2: Value; // AddressType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // BooleanType()
+    var __t6: Value; // AddressType()
+    var __t7: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3512,15 +4120,15 @@ procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_
 procedure {:inline 1} LibraAccount_save_account (addr: Value, account: Value) returns ();
 requires ExistsTxnSenderAccount(__m, __txn);
 
-procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_balance_for_account (account: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
+    var balance_value: Value; // IntegerType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3536,15 +4144,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
-    call t2 := CopyOrMoveRef(account);
+    call __t2 := CopyOrMoveRef(account);
 
-    call t3 := BorrowField(t2, LibraAccount_T_balance);
+    call __t3 := BorrowField(__t2, LibraAccount_T_balance);
 
-    call t4 := LibraCoin_value(t3);
+    call __t4 := LibraCoin_value(__t3);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t4);
+    assume IsValidU64(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -3552,28 +4160,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 5);
+    __ret0 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_balance_for_account_verify (account: Reference) returns (ret0: Value)
+procedure LibraAccount_balance_for_account_verify (account: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_balance_for_account(account);
+    call __ret0 := LibraAccount_balance_for_account(account);
 }
 
-procedure {:inline 1} LibraAccount_balance (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_balance (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3592,37 +4200,37 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := LibraAccount_balance_for_account(t2);
+    call __t3 := LibraAccount_balance_for_account(__t2);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t3);
+    assume IsValidU64(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_balance_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_balance_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_balance(addr);
+    call __ret0 := LibraAccount_balance(addr);
 }
 
-procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_sequence_number_for_account (account: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3638,36 +4246,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, account);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(account);
+    call __t1 := CopyOrMoveRef(account);
 
-    call t2 := BorrowField(t1, LibraAccount_T_sequence_number);
+    call __t2 := BorrowField(__t1, LibraAccount_T_sequence_number);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (ret0: Value)
+procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_sequence_number_for_account(account);
+    call __ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
-procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_sequence_number (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Value; // IntegerType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3686,38 +4294,38 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := LibraAccount_sequence_number_for_account(t2);
+    call __t3 := LibraAccount_sequence_number_for_account(__t2);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t3);
+    assume IsValidU64(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_sequence_number_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_sequence_number_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_sequence_number(addr);
+    call __ret0 := LibraAccount_sequence_number(addr);
 }
 
-procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_delegated_key_rotation_capability (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(BooleanType())
-    var t4: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(BooleanType())
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3736,38 +4344,38 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := BorrowField(t2, LibraAccount_T_delegated_key_rotation_capability);
+    call __t3 := BorrowField(__t2, LibraAccount_T_delegated_key_rotation_capability);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_delegated_key_rotation_capability(addr);
+    call __ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
-procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_delegated_withdrawal_capability (addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t3: Reference; // ReferenceType(BooleanType())
-    var t4: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t3: Reference; // ReferenceType(BooleanType())
+    var __t4: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3786,36 +4394,36 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
+    call __t2 := BorrowGlobal(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := BorrowField(t2, LibraAccount_T_delegated_withdrawal_capability);
+    call __t3 := BorrowField(__t2, LibraAccount_T_delegated_withdrawal_capability);
 
-    call __tmp := ReadRef(t3);
+    call __tmp := ReadRef(__t3);
     assume is#Boolean(__tmp);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (ret0: Value)
+procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_delegated_withdrawal_capability(addr);
+    call __ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
-procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (ret0: Reference)
+procedure {:inline 1} LibraAccount_withdrawal_capability_address (cap: Reference) returns (__ret0: Reference)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
-    var t2: Reference; // ReferenceType(AddressType())
+    var __t1: Reference; // ReferenceType(LibraAccount_WithdrawalCapability_type_value())
+    var __t2: Reference; // ReferenceType(AddressType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3831,31 +4439,31 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(cap);
+    call __t1 := CopyOrMoveRef(cap);
 
-    call t2 := BorrowField(t1, LibraAccount_WithdrawalCapability_account_address);
+    call __t2 := BorrowField(__t1, LibraAccount_WithdrawalCapability_account_address);
 
-    ret0 := t2;
+    __ret0 := __t2;
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultReference;
+    __ret0 := DefaultReference;
 }
 
-procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (ret0: Reference)
+procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_withdrawal_capability_address(cap);
+    call __ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
-procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (ret0: Reference)
+procedure {:inline 1} LibraAccount_key_rotation_capability_address (cap: Reference) returns (__ret0: Reference)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
-    var t2: Reference; // ReferenceType(AddressType())
+    var __t1: Reference; // ReferenceType(LibraAccount_KeyRotationCapability_type_value())
+    var __t2: Reference; // ReferenceType(AddressType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3871,31 +4479,31 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidReferenceParameter(__m, __frame, cap);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(cap);
+    call __t1 := CopyOrMoveRef(cap);
 
-    call t2 := BorrowField(t1, LibraAccount_KeyRotationCapability_account_address);
+    call __t2 := BorrowField(__t1, LibraAccount_KeyRotationCapability_account_address);
 
-    ret0 := t2;
+    __ret0 := __t2;
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultReference;
+    __ret0 := DefaultReference;
 }
 
-procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (ret0: Reference)
+procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_key_rotation_capability_address(cap);
+    call __ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
-procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_exists (check_addr: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // AddressType()
-    var t2: Value; // BooleanType()
+    var __t1: Value; // AddressType()
+    var __t2: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3917,71 +4525,75 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := Exists(GetLocal(__m, __frame + 1), LibraAccount_T_type_value());
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_exists_verify (check_addr: Value) returns (ret0: Value)
+procedure LibraAccount_exists_verify (check_addr: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_exists(check_addr);
+    call __ret0 := LibraAccount_exists(check_addr);
 }
 
-procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
+procedure {:inline 1} LibraAccount_prologue (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value, txn_expiration_time: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Value; // AddressType()
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Value; // AddressType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // BooleanType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // AddressType()
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Value; // ByteArrayType()
-    var t18: Value; // ByteArrayType()
-    var t19: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t20: Reference; // ReferenceType(ByteArrayType())
-    var t21: Value; // ByteArrayType()
-    var t22: Value; // BooleanType()
-    var t23: Value; // BooleanType()
-    var t24: Value; // IntegerType()
-    var t25: Value; // IntegerType()
-    var t26: Value; // IntegerType()
-    var t27: Value; // IntegerType()
-    var t28: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t29: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t31: Value; // IntegerType()
-    var t32: Value; // IntegerType()
-    var t33: Value; // IntegerType()
-    var t34: Value; // BooleanType()
-    var t35: Value; // BooleanType()
-    var t36: Value; // IntegerType()
-    var t37: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t38: Reference; // ReferenceType(IntegerType())
-    var t39: Value; // IntegerType()
-    var t40: Value; // IntegerType()
-    var t41: Value; // IntegerType()
-    var t42: Value; // BooleanType()
-    var t43: Value; // BooleanType()
-    var t44: Value; // IntegerType()
-    var t45: Value; // IntegerType()
-    var t46: Value; // IntegerType()
-    var t47: Value; // BooleanType()
-    var t48: Value; // BooleanType()
-    var t49: Value; // IntegerType()
+    var transaction_sender: Value; // AddressType()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var imm_sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var max_transaction_fee: Value; // IntegerType()
+    var balance_amount: Value; // IntegerType()
+    var sequence_number_value: Value; // IntegerType()
+    var __t11: Value; // AddressType()
+    var __t12: Value; // AddressType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // BooleanType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // AddressType()
+    var __t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t18: Value; // ByteArrayType()
+    var __t19: Value; // ByteArrayType()
+    var __t20: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t21: Reference; // ReferenceType(ByteArrayType())
+    var __t22: Value; // ByteArrayType()
+    var __t23: Value; // BooleanType()
+    var __t24: Value; // BooleanType()
+    var __t25: Value; // IntegerType()
+    var __t26: Value; // IntegerType()
+    var __t27: Value; // IntegerType()
+    var __t28: Value; // IntegerType()
+    var __t29: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t31: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t32: Value; // IntegerType()
+    var __t33: Value; // IntegerType()
+    var __t34: Value; // IntegerType()
+    var __t35: Value; // BooleanType()
+    var __t36: Value; // BooleanType()
+    var __t37: Value; // IntegerType()
+    var __t38: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t39: Reference; // ReferenceType(IntegerType())
+    var __t40: Value; // IntegerType()
+    var __t41: Value; // IntegerType()
+    var __t42: Value; // IntegerType()
+    var __t43: Value; // BooleanType()
+    var __t44: Value; // BooleanType()
+    var __t45: Value; // IntegerType()
+    var __t46: Value; // IntegerType()
+    var __t47: Value; // IntegerType()
+    var __t48: Value; // BooleanType()
+    var __t49: Value; // BooleanType()
+    var __t50: Value; // IntegerType()
+    var __t51: Value; // IntegerType()
+    var __t52: Value; // BooleanType()
+    var __t53: Value; // BooleanType()
+    var __t54: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -3990,7 +4602,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 50;
+    __local_counter := __local_counter + 55;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -4001,176 +4613,199 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
+    assume IsValidU64(txn_expiration_time);
+    __m := UpdateLocal(__m, __frame + 4, txn_expiration_time);
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
-    __m := UpdateLocal(__m, __frame + 10, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
-    __m := UpdateLocal(__m, __frame + 4, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Exists(GetLocal(__m, __frame + 11), LibraAccount_T_type_value());
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 12));
+    call __tmp := Exists(GetLocal(__m, __frame + 12), LibraAccount_T_type_value());
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 13);
+    call __tmp := Not(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 14, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 14);
     if (!b#Boolean(__tmp)) { goto Label_8; }
 
     call __tmp := LdConst(5);
-    __m := UpdateLocal(__m, __frame + 14, __tmp);
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
 
     goto Label_Abort;
 
 Label_8:
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
-    __m := UpdateLocal(__m, __frame + 15, __tmp);
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t16 := BorrowGlobal(GetLocal(__m, __frame + 15), LibraAccount_T_type_value());
+    call __t17 := BorrowGlobal(GetLocal(__m, __frame + 16), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t16);
+    call sender_account := CopyOrMoveRef(__t17);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
-    __m := UpdateLocal(__m, __frame + 17, __tmp);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call t18 := Hash_sha3_256(GetLocal(__m, __frame + 17));
+    call __t19 := Hash_sha3_256(GetLocal(__m, __frame + 18));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t18);
+    assume is#ByteArray(__t19);
 
-    __m := UpdateLocal(__m, __frame + 18, t18);
+    __m := UpdateLocal(__m, __frame + 19, __t19);
 
-    call t19 := CopyOrMoveRef(t5);
+    call __t20 := CopyOrMoveRef(sender_account);
 
-    call t20 := BorrowField(t19, LibraAccount_T_authentication_key);
+    call __t21 := BorrowField(__t20, LibraAccount_T_authentication_key);
 
-    call __tmp := ReadRef(t20);
+    call __tmp := ReadRef(__t21);
     assume is#ByteArray(__tmp);
-    __m := UpdateLocal(__m, __frame + 21, __tmp);
-
-    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 21)));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 22));
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 22)));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 23);
+    call __tmp := Not(GetLocal(__m, __frame + 23));
+    __m := UpdateLocal(__m, __frame + 24, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 24);
     if (!b#Boolean(__tmp)) { goto Label_21; }
 
     call __tmp := LdConst(2);
-    __m := UpdateLocal(__m, __frame + 24, __tmp);
+    __m := UpdateLocal(__m, __frame + 25, __tmp);
 
     goto Label_Abort;
 
 Label_21:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
-    __m := UpdateLocal(__m, __frame + 25, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call __tmp := MulU64(GetLocal(__m, __frame + 25), GetLocal(__m, __frame + 26));
-    if (__abort_flag) { goto Label_Abort; }
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 27, __tmp);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
-    __m := UpdateLocal(__m, __frame + 7, __tmp);
-
-    call t28 := CopyOrMoveRef(t5);
-
-    call t29 := FreezeRef(t28);
-
-    call t6 := CopyOrMoveRef(t29);
-
-    call t30 := CopyOrMoveRef(t6);
-
-    call t31 := LibraAccount_balance_for_account(t30);
+    call __tmp := MulU64(GetLocal(__m, __frame + 26), GetLocal(__m, __frame + 27));
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t31);
+    __m := UpdateLocal(__m, __frame + 28, __tmp);
 
-    __m := UpdateLocal(__m, __frame + 31, t31);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 28));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
-    __m := UpdateLocal(__m, __frame + 32, __tmp);
+    call __t29 := CopyOrMoveRef(sender_account);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    call __t30 := FreezeRef(__t29);
+
+    call imm_sender_account := CopyOrMoveRef(__t30);
+
+    call __t31 := CopyOrMoveRef(imm_sender_account);
+
+    call __t32 := LibraAccount_balance_for_account(__t31);
+    if (__abort_flag) { goto Label_Abort; }
+    assume IsValidU64(__t32);
+
+    __m := UpdateLocal(__m, __frame + 32, __t32);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 32));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 33, __tmp);
 
-    call __tmp := Ge(GetLocal(__m, __frame + 32), GetLocal(__m, __frame + 33));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 34, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 34));
+    call __tmp := Ge(GetLocal(__m, __frame + 33), GetLocal(__m, __frame + 34));
     __m := UpdateLocal(__m, __frame + 35, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 35);
+    call __tmp := Not(GetLocal(__m, __frame + 35));
+    __m := UpdateLocal(__m, __frame + 36, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 36);
     if (!b#Boolean(__tmp)) { goto Label_38; }
 
     call __tmp := LdConst(6);
-    __m := UpdateLocal(__m, __frame + 36, __tmp);
+    __m := UpdateLocal(__m, __frame + 37, __tmp);
 
     goto Label_Abort;
 
 Label_38:
-    call t37 := CopyOrMoveRef(t5);
+    call __t38 := CopyOrMoveRef(sender_account);
 
-    call t38 := BorrowField(t37, LibraAccount_T_sequence_number);
+    call __t39 := BorrowField(__t38, LibraAccount_T_sequence_number);
 
-    call __tmp := ReadRef(t38);
+    call __tmp := ReadRef(__t39);
     assume IsValidU64(__tmp);
-    __m := UpdateLocal(__m, __frame + 39, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 39));
-    __m := UpdateLocal(__m, __frame + 9, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 40, __tmp);
 
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 40));
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 41, __tmp);
 
-    call __tmp := Ge(GetLocal(__m, __frame + 40), GetLocal(__m, __frame + 41));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 42, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 42));
+    call __tmp := Ge(GetLocal(__m, __frame + 41), GetLocal(__m, __frame + 42));
     __m := UpdateLocal(__m, __frame + 43, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 43);
+    call __tmp := Not(GetLocal(__m, __frame + 43));
+    __m := UpdateLocal(__m, __frame + 44, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 44);
     if (!b#Boolean(__tmp)) { goto Label_49; }
 
     call __tmp := LdConst(3);
-    __m := UpdateLocal(__m, __frame + 44, __tmp);
+    __m := UpdateLocal(__m, __frame + 45, __tmp);
 
     goto Label_Abort;
 
 Label_49:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
-    __m := UpdateLocal(__m, __frame + 45, __tmp);
-
-    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 46, __tmp);
 
-    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 45), GetLocal(__m, __frame + 46)));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 47, __tmp);
 
-    call __tmp := Not(GetLocal(__m, __frame + 47));
+    __tmp := Boolean(IsEqual(GetLocal(__m, __frame + 46), GetLocal(__m, __frame + 47)));
     __m := UpdateLocal(__m, __frame + 48, __tmp);
 
-    __tmp := GetLocal(__m, __frame + 48);
+    call __tmp := Not(GetLocal(__m, __frame + 48));
+    __m := UpdateLocal(__m, __frame + 49, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 49);
     if (!b#Boolean(__tmp)) { goto Label_56; }
 
     call __tmp := LdConst(4);
-    __m := UpdateLocal(__m, __frame + 49, __tmp);
+    __m := UpdateLocal(__m, __frame + 50, __tmp);
 
     goto Label_Abort;
 
 Label_56:
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 51, __tmp);
+
+    call __t52 := LibraTransactionTimeout_is_valid_transaction_timestamp(GetLocal(__m, __frame + 51));
+    if (__abort_flag) { goto Label_Abort; }
+    assume is#Boolean(__t52);
+
+    __m := UpdateLocal(__m, __frame + 52, __t52);
+
+    call __tmp := Not(GetLocal(__m, __frame + 52));
+    __m := UpdateLocal(__m, __frame + 53, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 53);
+    if (!b#Boolean(__tmp)) { goto Label_62; }
+
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 54, __tmp);
+
+    goto Label_Abort;
+
+Label_62:
     return;
 
 Label_Abort:
@@ -4178,49 +4813,49 @@ Label_Abort:
     __m := __saved_m;
 }
 
-procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
+procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value, txn_expiration_time: Value) returns ()
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units);
+    call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units, txn_expiration_time);
 }
 
 procedure {:inline 1} LibraAccount_epilogue (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t6: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t7: Value; // IntegerType()
-    var t8: Value; // LibraCoin_T_type_value()
-    var t9: Value; // AddressType()
-    var t10: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t11: Value; // IntegerType()
-    var t12: Value; // IntegerType()
-    var t13: Value; // IntegerType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t17: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t18: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t19: Value; // IntegerType()
-    var t20: Value; // IntegerType()
-    var t21: Value; // BooleanType()
-    var t22: Value; // BooleanType()
-    var t23: Value; // IntegerType()
-    var t24: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t25: Value; // IntegerType()
-    var t26: Value; // LibraCoin_T_type_value()
-    var t27: Value; // IntegerType()
-    var t28: Value; // IntegerType()
-    var t29: Value; // IntegerType()
-    var t30: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t31: Reference; // ReferenceType(IntegerType())
-    var t32: Value; // AddressType()
-    var t33: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t34: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t35: Reference; // ReferenceType(LibraCoin_T_type_value())
-    var t36: Value; // LibraCoin_T_type_value()
+    var sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var transaction_fee_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var imm_sender_account: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var transaction_fee_amount: Value; // IntegerType()
+    var transaction_fee: Value; // LibraCoin_T_type_value()
+    var __t9: Value; // AddressType()
+    var __t10: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // IntegerType()
+    var __t13: Value; // IntegerType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t17: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t18: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // IntegerType()
+    var __t21: Value; // BooleanType()
+    var __t22: Value; // BooleanType()
+    var __t23: Value; // IntegerType()
+    var __t24: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t25: Value; // IntegerType()
+    var __t26: Value; // LibraCoin_T_type_value()
+    var __t27: Value; // IntegerType()
+    var __t28: Value; // IntegerType()
+    var __t29: Value; // IntegerType()
+    var __t30: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t31: Reference; // ReferenceType(IntegerType())
+    var __t32: Value; // AddressType()
+    var __t33: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t34: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t35: Reference; // ReferenceType(LibraCoin_T_type_value())
+    var __t36: Value; // LibraCoin_T_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4245,10 +4880,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
+    call __t10 := BorrowGlobal(GetLocal(__m, __frame + 9), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t4 := CopyOrMoveRef(t10);
+    call sender_account := CopyOrMoveRef(__t10);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -4270,19 +4905,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t16 := CopyOrMoveRef(t4);
+    call __t16 := CopyOrMoveRef(sender_account);
 
-    call t17 := FreezeRef(t16);
+    call __t17 := FreezeRef(__t16);
 
-    call t6 := CopyOrMoveRef(t17);
+    call imm_sender_account := CopyOrMoveRef(__t17);
 
-    call t18 := CopyOrMoveRef(t6);
+    call __t18 := CopyOrMoveRef(imm_sender_account);
 
-    call t19 := LibraAccount_balance_for_account(t18);
+    call __t19 := LibraAccount_balance_for_account(__t18);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t19);
+    assume IsValidU64(__t19);
 
-    __m := UpdateLocal(__m, __frame + 19, t19);
+    __m := UpdateLocal(__m, __frame + 19, __t19);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -4302,16 +4937,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     goto Label_Abort;
 
 Label_20:
-    call t24 := CopyOrMoveRef(t4);
+    call __t24 := CopyOrMoveRef(sender_account);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
-    call t26 := LibraAccount_withdraw_from_account(t24, GetLocal(__m, __frame + 25));
+    call __t26 := LibraAccount_withdraw_from_account(__t24, GetLocal(__m, __frame + 25));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t26);
+    assume is#Vector(__t26);
 
-    __m := UpdateLocal(__m, __frame + 26, t26);
+    __m := UpdateLocal(__m, __frame + 26, __t26);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -4326,28 +4961,28 @@ Label_20:
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 29, __tmp);
 
-    call t30 := CopyOrMoveRef(t4);
+    call __t30 := CopyOrMoveRef(sender_account);
 
-    call t31 := BorrowField(t30, LibraAccount_T_sequence_number);
+    call __t31 := BorrowField(__t30, LibraAccount_T_sequence_number);
 
-    call WriteRef(t31, GetLocal(__m, __frame + 29));
+    call WriteRef(__t31, GetLocal(__m, __frame + 29));
 
     call __tmp := LdAddr(4078);
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
-    call t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
+    call __t33 := BorrowGlobal(GetLocal(__m, __frame + 32), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t33);
+    call transaction_fee_account := CopyOrMoveRef(__t33);
 
-    call t34 := CopyOrMoveRef(t5);
+    call __t34 := CopyOrMoveRef(transaction_fee_account);
 
-    call t35 := BorrowField(t34, LibraAccount_T_balance);
+    call __t35 := BorrowField(__t34, LibraAccount_T_balance);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 36, __tmp);
 
-    call LibraCoin_deposit(t35, GetLocal(__m, __frame + 36));
+    call LibraCoin_deposit(__t35, GetLocal(__m, __frame + 36));
     if (__abort_flag) { goto Label_Abort; }
 
     return;
@@ -4363,30 +4998,30 @@ procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_pric
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
-procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_fresh_guid (counter: Reference, sender: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // ByteArrayType()
-    var t4: Value; // ByteArrayType()
-    var t5: Value; // ByteArrayType()
-    var t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t7: Reference; // ReferenceType(IntegerType())
-    var t8: Value; // AddressType()
-    var t9: Value; // ByteArrayType()
-    var t10: Reference; // ReferenceType(IntegerType())
-    var t11: Value; // IntegerType()
-    var t12: Value; // ByteArrayType()
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Reference; // ReferenceType(IntegerType())
-    var t18: Value; // ByteArrayType()
-    var t19: Value; // ByteArrayType()
-    var t20: Value; // ByteArrayType()
-    var t21: Value; // ByteArrayType()
+    var count: Reference; // ReferenceType(IntegerType())
+    var count_bytes: Value; // ByteArrayType()
+    var preimage: Value; // ByteArrayType()
+    var sender_bytes: Value; // ByteArrayType()
+    var __t6: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t7: Reference; // ReferenceType(IntegerType())
+    var __t8: Value; // AddressType()
+    var __t9: Value; // ByteArrayType()
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // ByteArrayType()
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Reference; // ReferenceType(IntegerType())
+    var __t18: Value; // ByteArrayType()
+    var __t19: Value; // ByteArrayType()
+    var __t20: Value; // ByteArrayType()
+    var __t21: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4404,42 +5039,42 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, sender);
 
     // bytecode translation starts here
-    call t6 := CopyOrMoveRef(counter);
+    call __t6 := CopyOrMoveRef(counter);
 
-    call t7 := BorrowField(t6, LibraAccount_EventHandleGenerator_counter);
+    call __t7 := BorrowField(__t6, LibraAccount_EventHandleGenerator_counter);
 
-    call t2 := CopyOrMoveRef(t7);
+    call count := CopyOrMoveRef(__t7);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
+    call __t9 := AddressUtil_address_to_bytes(GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t9);
+    assume is#ByteArray(__t9);
 
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call t10 := CopyOrMoveRef(t2);
+    call __t10 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
+    call __t12 := U64Util_u64_to_bytes(GetLocal(__m, __frame + 11));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t12);
+    assume is#ByteArray(__t12);
 
-    __m := UpdateLocal(__m, __frame + 12, t12);
+    __m := UpdateLocal(__m, __frame + 12, __t12);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -4450,9 +5085,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t17 := CopyOrMoveRef(t2);
+    call __t17 := CopyOrMoveRef(count);
 
-    call WriteRef(t17, GetLocal(__m, __frame + 16));
+    call WriteRef(__t17, GetLocal(__m, __frame + 16));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -4460,11 +5095,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
+    call __t20 := BytearrayUtil_bytearray_concat(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t20);
+    assume is#ByteArray(__t20);
 
-    __m := UpdateLocal(__m, __frame + 20, t20);
+    __m := UpdateLocal(__m, __frame + 20, __t20);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -4472,30 +5107,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 21);
+    __ret0 := GetLocal(__m, __frame + 21);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (ret0: Value)
+procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_fresh_guid(counter, sender);
+    call __ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle_impl (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t4: Value; // AddressType()
-    var t5: Value; // ByteArrayType()
-    var t6: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __t2: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t4: Value; // AddressType()
+    var __t5: Value; // ByteArrayType()
+    var __t6: Value; // LibraAccount_EventHandle_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4516,47 +5151,47 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := CopyOrMoveRef(counter);
+    call __t3 := CopyOrMoveRef(counter);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    call t5 := LibraAccount_fresh_guid(t3, GetLocal(__m, __frame + 4));
+    call __t5 := LibraAccount_fresh_guid(__t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#ByteArray(t5);
+    assume is#ByteArray(__t5);
 
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
+    call __ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
-procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (ret0: Value)
+procedure {:inline 1} LibraAccount_new_event_handle (tv0: TypeValue) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t0: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t1: Value; // ByteArrayType()
-    var t2: Value; // AddressType()
-    var t3: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t4: Reference; // ReferenceType(LibraAccount_T_type_value())
-    var t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
-    var t6: Value; // AddressType()
-    var t7: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var sender_account_ref: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var sender_bytes: Value; // ByteArrayType()
+    var __t2: Value; // AddressType()
+    var __t3: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t4: Reference; // ReferenceType(LibraAccount_T_type_value())
+    var __t5: Reference; // ReferenceType(LibraAccount_EventHandleGenerator_type_value())
+    var __t6: Value; // AddressType()
+    var __t7: Value; // LibraAccount_EventHandle_type_value(tv0)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4573,59 +5208,59 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
+    call __t3 := BorrowGlobal(GetLocal(__m, __frame + 2), LibraAccount_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t0 := CopyOrMoveRef(t3);
+    call sender_account_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t0);
+    call __t4 := CopyOrMoveRef(sender_account_ref);
 
-    call t5 := BorrowField(t4, LibraAccount_T_event_generator);
+    call __t5 := BorrowField(__t4, LibraAccount_T_event_generator);
 
     call __tmp := GetTxnSenderAddress();
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call t7 := LibraAccount_new_event_handle_impl(tv0, t5, GetLocal(__m, __frame + 6));
+    call __t7 := LibraAccount_new_event_handle_impl(tv0, __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t7);
+    assume is#Vector(__t7);
 
-    __m := UpdateLocal(__m, __frame + 7, t7);
+    __m := UpdateLocal(__m, __frame + 7, __t7);
 
-    ret0 := GetLocal(__m, __frame + 7);
+    __ret0 := GetLocal(__m, __frame + 7);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (ret0: Value)
+procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := LibraAccount_new_event_handle(tv0);
+    call __ret0 := LibraAccount_new_event_handle(tv0);
 }
 
 procedure {:inline 1} LibraAccount_emit_event (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // ByteArrayType()
-    var t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
-    var t5: Reference; // ReferenceType(ByteArrayType())
-    var t6: Value; // ByteArrayType()
-    var t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
-    var t8: Reference; // ReferenceType(IntegerType())
-    var t9: Value; // ByteArrayType()
-    var t10: Reference; // ReferenceType(IntegerType())
-    var t11: Value; // IntegerType()
-    var t12: Value; // tv0
-    var t13: Reference; // ReferenceType(IntegerType())
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
-    var t16: Value; // IntegerType()
-    var t17: Reference; // ReferenceType(IntegerType())
+    var count: Reference; // ReferenceType(IntegerType())
+    var guid: Value; // ByteArrayType()
+    var __t4: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var __t5: Reference; // ReferenceType(ByteArrayType())
+    var __t6: Value; // ByteArrayType()
+    var __t7: Reference; // ReferenceType(LibraAccount_EventHandle_type_value(tv0))
+    var __t8: Reference; // ReferenceType(IntegerType())
+    var __t9: Value; // ByteArrayType()
+    var __t10: Reference; // ReferenceType(IntegerType())
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // tv0
+    var __t13: Reference; // ReferenceType(IntegerType())
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
+    var __t16: Value; // IntegerType()
+    var __t17: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4642,29 +5277,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, msg);
 
     // bytecode translation starts here
-    call t4 := CopyOrMoveRef(handle_ref);
+    call __t4 := CopyOrMoveRef(handle_ref);
 
-    call t5 := BorrowField(t4, LibraAccount_EventHandle_guid);
+    call __t5 := BorrowField(__t4, LibraAccount_EventHandle_guid);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume is#ByteArray(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t7 := CopyOrMoveRef(handle_ref);
+    call __t7 := CopyOrMoveRef(handle_ref);
 
-    call t8 := BorrowField(t7, LibraAccount_EventHandle_counter);
+    call __t8 := BorrowField(__t7, LibraAccount_EventHandle_counter);
 
-    call t2 := CopyOrMoveRef(t8);
+    call count := CopyOrMoveRef(__t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call t10 := CopyOrMoveRef(t2);
+    call __t10 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t10);
+    call __tmp := ReadRef(__t10);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
@@ -4674,9 +5309,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call LibraAccount_write_to_event_store(tv0, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 11), GetLocal(__m, __frame + 12));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t13 := CopyOrMoveRef(t2);
+    call __t13 := CopyOrMoveRef(count);
 
-    call __tmp := ReadRef(t13);
+    call __tmp := ReadRef(__t13);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
@@ -4687,9 +5322,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call t17 := CopyOrMoveRef(t2);
+    call __t17 := CopyOrMoveRef(count);
 
-    call WriteRef(t17, GetLocal(__m, __frame + 16));
+    call WriteRef(__t17, GetLocal(__m, __frame + 16));
 
     return;
 
@@ -4711,11 +5346,11 @@ procedure {:inline 1} LibraAccount_destroy_handle (tv0: TypeValue, handle: Value
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // ByteArrayType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // LibraAccount_EventHandle_type_value(tv0)
-    var t4: Value; // IntegerType()
-    var t5: Value; // ByteArrayType()
+    var guid: Value; // ByteArrayType()
+    var count: Value; // IntegerType()
+    var __t3: Value; // LibraAccount_EventHandle_type_value(tv0)
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // ByteArrayType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -4734,9 +5369,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call t4, t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
-    __m := UpdateLocal(__m, __frame + 4, t4);
-    __m := UpdateLocal(__m, __frame + 5, t5);
+    call __t4, __t5 := Unpack_LibraAccount_EventHandle(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __t4);
+    __m := UpdateLocal(__m, __frame + 5, __t5);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -29,8 +29,8 @@ procedure {:inline 1} TestReference_mut_b (b: Reference) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Reference; // ReferenceType(IntegerType())
+    var __t1: Value; // IntegerType()
+    var __t2: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -49,9 +49,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := CopyOrMoveRef(b);
+    call __t2 := CopyOrMoveRef(b);
 
-    call WriteRef(t2, GetLocal(__m, __frame + 1));
+    call WriteRef(__t2, GetLocal(__m, __frame + 1));
 
     return;
 
@@ -73,18 +73,18 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Reference; // ReferenceType(IntegerType())
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(IntegerType())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // IntegerType()
+    var b: Value; // IntegerType()
+    var b_ref: Reference; // ReferenceType(IntegerType())
+    var __t2: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(IntegerType())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -104,18 +104,18 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
-    call t1 := CopyOrMoveRef(t3);
+    call b_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(b_ref);
 
-    call TestReference_mut_b(t4);
+    call TestReference_mut_b(__t4);
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t1);
+    call __t5 := CopyOrMoveRef(b_ref);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -56,20 +56,20 @@ procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value, s: V
 
 // ** functions of module TestSpecs
 
-procedure {:inline 1} TestSpecs_div (x1: Value, x2: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_div (x1: Value, x2: Value) returns (__ret0: Value)
 requires b#Boolean(Boolean(i#Integer(x2) > i#Integer(Integer(0))));
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(ret0, Integer(i#Integer(x1) * i#Integer(x2)))));
+ensures !__abort_flag ==> b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(x1) * i#Integer(x2)))));
 ensures old(!(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) && (b#Boolean(Boolean(i#Integer(x1) > i#Integer(Integer(1)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
+    var r: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -103,19 +103,19 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __ab
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_div_verify (x1: Value, x2: Value) returns (ret0: Value)
+procedure TestSpecs_div_verify (x1: Value, x2: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_div(x1, x2);
+    call __ret0 := TestSpecs_div(x1, x2);
 }
 
 procedure {:inline 1} TestSpecs_create_resource () returns ()
@@ -183,12 +183,12 @@ procedure TestSpecs_select_from_global_resource_verify () returns ()
     call TestSpecs_select_from_global_resource();
 }
 
-procedure {:inline 1} TestSpecs_select_from_resource (r: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_select_from_resource (r: Value) returns (__ret0: Value)
 requires b#Boolean(Boolean(i#Integer(SelectField(r, TestSpecs_R_x)) > i#Integer(Integer(0))));
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // TestSpecs_R_type_value()
+    var __t1: Value; // TestSpecs_R_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -207,27 +207,27 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_select_from_resource_verify (r: Value) returns (ret0: Value)
+procedure TestSpecs_select_from_resource_verify (r: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_select_from_resource(r);
+    call __ret0 := TestSpecs_select_from_resource(r);
 }
 
-procedure {:inline 1} TestSpecs_select_from_resource_nested (r: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_select_from_resource_nested (r: Value) returns (__ret0: Value)
 requires b#Boolean(Boolean(IsEqual(SelectField(SelectField(r, TestSpecs_R_s), TestSpecs_S_a), Address(1))));
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // TestSpecs_R_type_value()
+    var __t1: Value; // TestSpecs_R_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -246,27 +246,27 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_select_from_resource_nested_verify (r: Value) returns (ret0: Value)
+procedure TestSpecs_select_from_resource_nested_verify (r: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_select_from_resource_nested(r);
+    call __ret0 := TestSpecs_select_from_resource_nested(r);
 }
 
-procedure {:inline 1} TestSpecs_select_from_global_resource_dynamic_address (r: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_select_from_global_resource_dynamic_address (r: Value) returns (__ret0: Value)
 requires b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, GetResourceReference(TestSpecs_R_type_value(), a#Address(SelectField(SelectField(r, TestSpecs_R_s), TestSpecs_S_a)))), TestSpecs_R_x)) > i#Integer(Integer(0))));
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // TestSpecs_R_type_value()
+    var __t1: Value; // TestSpecs_R_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -285,19 +285,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_select_from_global_resource_dynamic_address_verify (r: Value) returns (ret0: Value)
+procedure TestSpecs_select_from_global_resource_dynamic_address_verify (r: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_select_from_global_resource_dynamic_address(r);
+    call __ret0 := TestSpecs_select_from_global_resource_dynamic_address(r);
 }
 
 procedure {:inline 1} TestSpecs_select_from_reference (r: Reference) returns ()
@@ -334,16 +334,16 @@ procedure TestSpecs_select_from_reference_verify (r: Reference) returns ()
     call TestSpecs_select_from_reference(r);
 }
 
-procedure {:inline 1} TestSpecs_ret_values () returns (ret0: Value, ret1: Value, ret2: Value)
+procedure {:inline 1} TestSpecs_ret_values () returns (__ret0: Value, __ret1: Value, __ret2: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, Integer(7))));
-ensures b#Boolean(Boolean(IsEqual(ret1, Boolean(false))));
-ensures b#Boolean(Boolean(IsEqual(ret2, Integer(10))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(7))));
+ensures b#Boolean(Boolean(IsEqual(__ret1, Boolean(false))));
+ensures b#Boolean(Boolean(IsEqual(__ret2, Integer(10))));
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Value; // BooleanType()
-    var t2: Value; // IntegerType()
+    var __t0: Value; // IntegerType()
+    var __t1: Value; // BooleanType()
+    var __t2: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -366,31 +366,31 @@ ensures b#Boolean(Boolean(IsEqual(ret2, Integer(10))));
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 0);
-    ret1 := GetLocal(__m, __frame + 1);
-    ret2 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 0);
+    __ret1 := GetLocal(__m, __frame + 1);
+    __ret2 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
-    ret2 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
+    __ret2 := DefaultValue;
 }
 
-procedure TestSpecs_ret_values_verify () returns (ret0: Value, ret1: Value, ret2: Value)
+procedure TestSpecs_ret_values_verify () returns (__ret0: Value, __ret1: Value, __ret2: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1, ret2 := TestSpecs_ret_values();
+    call __ret0, __ret1, __ret2 := TestSpecs_ret_values();
 }
 
-procedure {:inline 1} TestSpecs_helper_function (x: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_helper_function (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean(b#Boolean(number_in_range(x)) && b#Boolean(Boolean(i#Integer(x) < i#Integer(max_u64())))));
 {
     // declare local variables
-    var t1: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -409,17 +409,17 @@ ensures b#Boolean(Boolean(b#Boolean(number_in_range(x)) && b#Boolean(Boolean(i#I
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 1);
+    __ret0 := GetLocal(__m, __frame + 1);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_helper_function_verify (x: Value) returns (ret0: Value)
+procedure TestSpecs_helper_function_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_helper_function(x);
+    call __ret0 := TestSpecs_helper_function(x);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -97,12 +97,12 @@ procedure {:inline 1} Unpack_TestStruct_T(_struct: Value) returns (x: Value)
 
 // ** functions of module TestStruct
 
-procedure {:inline 1} TestStruct_identity (a: Value, c: Value) returns (ret0: Value, ret1: Value)
+procedure {:inline 1} TestStruct_identity (a: Value, c: Value) returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t2: Value; // TestStruct_A_type_value()
-    var t3: Value; // TestStruct_C_type_value()
+    var __t2: Value; // TestStruct_A_type_value()
+    var __t3: Value; // TestStruct_C_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -126,46 +126,46 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
-    ret1 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 2);
+    __ret1 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure TestStruct_identity_verify (a: Value, c: Value) returns (ret0: Value, ret1: Value)
+procedure TestStruct_identity_verify (a: Value, c: Value) returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := TestStruct_identity(a, c);
+    call __ret0, __ret1 := TestStruct_identity(a, c);
 }
 
-procedure {:inline 1} TestStruct_module_builtins (a: Value) returns (ret0: Value)
+procedure {:inline 1} TestStruct_module_builtins (a: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // TestStruct_T_type_value()
-    var t2: Reference; // ReferenceType(TestStruct_T_type_value())
-    var t3: Reference; // ReferenceType(TestStruct_T_type_value())
-    var t4: Value; // BooleanType()
-    var t5: Value; // AddressType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // BooleanType()
-    var t8: Value; // BooleanType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Reference; // ReferenceType(TestStruct_T_type_value())
-    var t12: Reference; // ReferenceType(TestStruct_T_type_value())
-    var t13: Value; // AddressType()
-    var t14: Reference; // ReferenceType(TestStruct_T_type_value())
-    var t15: Reference; // ReferenceType(TestStruct_T_type_value())
-    var t16: Value; // AddressType()
-    var t17: Value; // TestStruct_T_type_value()
-    var t18: Value; // TestStruct_T_type_value()
-    var t19: Value; // BooleanType()
+    var t: Value; // TestStruct_T_type_value()
+    var t_ref1: Reference; // ReferenceType(TestStruct_T_type_value())
+    var t_ref2: Reference; // ReferenceType(TestStruct_T_type_value())
+    var b: Value; // BooleanType()
+    var __t5: Value; // AddressType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // BooleanType()
+    var __t8: Value; // BooleanType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Reference; // ReferenceType(TestStruct_T_type_value())
+    var __t12: Reference; // ReferenceType(TestStruct_T_type_value())
+    var __t13: Value; // AddressType()
+    var __t14: Reference; // ReferenceType(TestStruct_T_type_value())
+    var __t15: Reference; // ReferenceType(TestStruct_T_type_value())
+    var __t16: Value; // AddressType()
+    var __t17: Value; // TestStruct_T_type_value()
+    var __t18: Value; // TestStruct_T_type_value()
+    var __t19: Value; // BooleanType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -208,24 +208,24 @@ Label_8:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call t11 := BorrowGlobal(GetLocal(__m, __frame + 10), TestStruct_T_type_value());
+    call __t11 := BorrowGlobal(GetLocal(__m, __frame + 10), TestStruct_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t2 := CopyOrMoveRef(t11);
+    call t_ref1 := CopyOrMoveRef(__t11);
 
-    call t12 := CopyOrMoveRef(t2);
+    call __t12 := CopyOrMoveRef(t_ref1);
 
     // unimplemented instruction: NoOp
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call t14 := BorrowGlobal(GetLocal(__m, __frame + 13), TestStruct_T_type_value());
+    call __t14 := BorrowGlobal(GetLocal(__m, __frame + 13), TestStruct_T_type_value());
     if (__abort_flag) { goto Label_Abort; }
 
-    call t3 := CopyOrMoveRef(t14);
+    call t_ref2 := CopyOrMoveRef(__t14);
 
-    call t15 := CopyOrMoveRef(t3);
+    call __t15 := CopyOrMoveRef(t_ref2);
 
     // unimplemented instruction: NoOp
 
@@ -234,7 +234,7 @@ Label_8:
 
     call __tmp := MoveFrom(GetLocal(__m, __frame + 16), TestStruct_T_type_value());
     __m := UpdateLocal(__m, __frame + 17, __tmp);
-    assume is#Vector(t17);
+    assume is#Vector(__t17);
     if (__abort_flag) { goto Label_Abort; }
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
@@ -249,51 +249,51 @@ Label_8:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 19);
+    __ret0 := GetLocal(__m, __frame + 19);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestStruct_module_builtins_verify (a: Value) returns (ret0: Value)
+procedure TestStruct_module_builtins_verify (a: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestStruct_module_builtins(a);
+    call __ret0 := TestStruct_module_builtins(a);
 }
 
-procedure {:inline 1} TestStruct_nested_struct (a: Value) returns (ret0: Value)
+procedure {:inline 1} TestStruct_nested_struct (a: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // TestStruct_A_type_value()
-    var t2: Value; // TestStruct_B_type_value()
-    var t3: Reference; // ReferenceType(TestStruct_B_type_value())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Value; // IntegerType()
-    var t6: Value; // BooleanType()
-    var t7: Value; // AddressType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // TestStruct_B_type_value()
-    var t10: Value; // AddressType()
-    var t11: Value; // IntegerType()
-    var t12: Value; // TestStruct_B_type_value()
-    var t13: Reference; // ReferenceType(TestStruct_B_type_value())
-    var t14: Reference; // ReferenceType(TestStruct_B_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Reference; // ReferenceType(IntegerType())
-    var t17: Value; // IntegerType()
-    var t18: Value; // IntegerType()
-    var t19: Value; // IntegerType()
-    var t20: Value; // BooleanType()
-    var t21: Value; // BooleanType()
-    var t22: Value; // IntegerType()
-    var t23: Value; // TestStruct_B_type_value()
+    var var_a: Value; // TestStruct_A_type_value()
+    var var_b: Value; // TestStruct_B_type_value()
+    var var_b_ref: Reference; // ReferenceType(TestStruct_B_type_value())
+    var b_val_ref: Reference; // ReferenceType(IntegerType())
+    var b_val: Value; // IntegerType()
+    var __t6: Value; // BooleanType()
+    var __t7: Value; // AddressType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // TestStruct_B_type_value()
+    var __t10: Value; // AddressType()
+    var __t11: Value; // IntegerType()
+    var __t12: Value; // TestStruct_B_type_value()
+    var __t13: Reference; // ReferenceType(TestStruct_B_type_value())
+    var __t14: Reference; // ReferenceType(TestStruct_B_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Reference; // ReferenceType(IntegerType())
+    var __t17: Value; // IntegerType()
+    var __t18: Value; // IntegerType()
+    var __t19: Value; // IntegerType()
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // BooleanType()
+    var __t22: Value; // IntegerType()
+    var __t23: Value; // TestStruct_B_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -343,19 +343,19 @@ Label_7:
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
 Label_11:
-    call t13 := BorrowLoc(__frame + 2);
+    call __t13 := BorrowLoc(__frame + 2);
 
-    call t3 := CopyOrMoveRef(t13);
+    call var_b_ref := CopyOrMoveRef(__t13);
 
-    call t14 := CopyOrMoveRef(t3);
+    call __t14 := CopyOrMoveRef(var_b_ref);
 
-    call t15 := BorrowField(t14, TestStruct_B_val);
+    call __t15 := BorrowField(__t14, TestStruct_B_val);
 
-    call t4 := CopyOrMoveRef(t15);
+    call b_val_ref := CopyOrMoveRef(__t15);
 
-    call t16 := CopyOrMoveRef(t4);
+    call __t16 := CopyOrMoveRef(b_val_ref);
 
-    call __tmp := ReadRef(t16);
+    call __tmp := ReadRef(__t16);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
@@ -386,43 +386,43 @@ Label_26:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 23);
+    __ret0 := GetLocal(__m, __frame + 23);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestStruct_nested_struct_verify (a: Value) returns (ret0: Value)
+procedure TestStruct_nested_struct_verify (a: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestStruct_nested_struct(a);
+    call __ret0 := TestStruct_nested_struct(a);
 }
 
-procedure {:inline 1} TestStruct_try_unpack (a: Value) returns (ret0: Value)
+procedure {:inline 1} TestStruct_try_unpack (a: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // TestStruct_B_type_value()
-    var t3: Value; // AddressType()
-    var t4: Value; // AddressType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // TestStruct_B_type_value()
-    var t7: Value; // TestStruct_B_type_value()
-    var t8: Value; // AddressType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // AddressType()
-    var t11: Value; // AddressType()
-    var t12: Value; // BooleanType()
-    var t13: Value; // BooleanType()
-    var t14: Value; // IntegerType()
-    var t15: Value; // IntegerType()
+    var v: Value; // IntegerType()
+    var b: Value; // TestStruct_B_type_value()
+    var aa: Value; // AddressType()
+    var __t4: Value; // AddressType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // TestStruct_B_type_value()
+    var __t7: Value; // TestStruct_B_type_value()
+    var __t8: Value; // AddressType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // AddressType()
+    var __t11: Value; // AddressType()
+    var __t12: Value; // BooleanType()
+    var __t13: Value; // BooleanType()
+    var __t14: Value; // IntegerType()
+    var __t15: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -453,9 +453,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t8, t9 := Unpack_TestStruct_B(GetLocal(__m, __frame + 7));
-    __m := UpdateLocal(__m, __frame + 8, t8);
-    __m := UpdateLocal(__m, __frame + 9, t9);
+    call __t8, __t9 := Unpack_TestStruct_B(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 8, __t8);
+    __m := UpdateLocal(__m, __frame + 9, __t9);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -487,17 +487,17 @@ Label_15:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 15, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 15);
+    __ret0 := GetLocal(__m, __frame + 15);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestStruct_try_unpack_verify (a: Value) returns (ret0: Value)
+procedure TestStruct_try_unpack_verify (a: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestStruct_try_unpack(a);
+    call __ret0 := TestStruct_try_unpack(a);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -37,62 +37,62 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // Test3_T_type_value()
-    var t2: Reference; // ReferenceType(Test3_T_type_value())
-    var t3: Reference; // ReferenceType(IntegerType())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Reference; // ReferenceType(IntegerType())
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // IntegerType()
-    var t10: Value; // IntegerType()
-    var t11: Value; // Test3_T_type_value()
-    var t12: Reference; // ReferenceType(Test3_T_type_value())
-    var t13: Value; // BooleanType()
-    var t14: Reference; // ReferenceType(Test3_T_type_value())
-    var t15: Reference; // ReferenceType(IntegerType())
-    var t16: Reference; // ReferenceType(Test3_T_type_value())
-    var t17: Reference; // ReferenceType(IntegerType())
-    var t18: Value; // IntegerType()
-    var t19: Reference; // ReferenceType(IntegerType())
-    var t20: Value; // BooleanType()
-    var t21: Value; // BooleanType()
-    var t22: Reference; // ReferenceType(Test3_T_type_value())
-    var t23: Reference; // ReferenceType(IntegerType())
-    var t24: Reference; // ReferenceType(Test3_T_type_value())
-    var t25: Reference; // ReferenceType(IntegerType())
-    var t26: Value; // IntegerType()
-    var t27: Reference; // ReferenceType(IntegerType())
-    var t28: Reference; // ReferenceType(Test3_T_type_value())
-    var t29: Reference; // ReferenceType(IntegerType())
-    var t30: Reference; // ReferenceType(Test3_T_type_value())
-    var t31: Reference; // ReferenceType(IntegerType())
-    var t32: Reference; // ReferenceType(IntegerType())
-    var t33: Value; // IntegerType()
-    var t34: Reference; // ReferenceType(IntegerType())
-    var t35: Value; // IntegerType()
-    var t36: Value; // BooleanType()
-    var t37: Value; // IntegerType()
-    var t38: Value; // IntegerType()
-    var t39: Value; // BooleanType()
-    var t40: Value; // BooleanType()
-    var t41: Value; // IntegerType()
-    var t42: Value; // IntegerType()
-    var t43: Value; // IntegerType()
-    var t44: Value; // BooleanType()
-    var t45: Value; // BooleanType()
-    var t46: Value; // IntegerType()
-    var t47: Value; // IntegerType()
-    var t48: Value; // IntegerType()
-    var t49: Value; // BooleanType()
-    var t50: Value; // BooleanType()
-    var t51: Value; // IntegerType()
-    var t52: Value; // IntegerType()
-    var t53: Value; // IntegerType()
-    var t54: Value; // BooleanType()
-    var t55: Value; // BooleanType()
-    var t56: Value; // IntegerType()
+    var x: Value; // Test3_T_type_value()
+    var x_ref: Reference; // ReferenceType(Test3_T_type_value())
+    var f_or_g_ref: Reference; // ReferenceType(IntegerType())
+    var f_or_g_ref2: Reference; // ReferenceType(IntegerType())
+    var f_ref: Reference; // ReferenceType(IntegerType())
+    var g_ref: Reference; // ReferenceType(IntegerType())
+    var f: Value; // IntegerType()
+    var g: Value; // IntegerType()
+    var __t9: Value; // IntegerType()
+    var __t10: Value; // IntegerType()
+    var __t11: Value; // Test3_T_type_value()
+    var __t12: Reference; // ReferenceType(Test3_T_type_value())
+    var __t13: Value; // BooleanType()
+    var __t14: Reference; // ReferenceType(Test3_T_type_value())
+    var __t15: Reference; // ReferenceType(IntegerType())
+    var __t16: Reference; // ReferenceType(Test3_T_type_value())
+    var __t17: Reference; // ReferenceType(IntegerType())
+    var __t18: Value; // IntegerType()
+    var __t19: Reference; // ReferenceType(IntegerType())
+    var __t20: Value; // BooleanType()
+    var __t21: Value; // BooleanType()
+    var __t22: Reference; // ReferenceType(Test3_T_type_value())
+    var __t23: Reference; // ReferenceType(IntegerType())
+    var __t24: Reference; // ReferenceType(Test3_T_type_value())
+    var __t25: Reference; // ReferenceType(IntegerType())
+    var __t26: Value; // IntegerType()
+    var __t27: Reference; // ReferenceType(IntegerType())
+    var __t28: Reference; // ReferenceType(Test3_T_type_value())
+    var __t29: Reference; // ReferenceType(IntegerType())
+    var __t30: Reference; // ReferenceType(Test3_T_type_value())
+    var __t31: Reference; // ReferenceType(IntegerType())
+    var __t32: Reference; // ReferenceType(IntegerType())
+    var __t33: Value; // IntegerType()
+    var __t34: Reference; // ReferenceType(IntegerType())
+    var __t35: Value; // IntegerType()
+    var __t36: Value; // BooleanType()
+    var __t37: Value; // IntegerType()
+    var __t38: Value; // IntegerType()
+    var __t39: Value; // BooleanType()
+    var __t40: Value; // BooleanType()
+    var __t41: Value; // IntegerType()
+    var __t42: Value; // IntegerType()
+    var __t43: Value; // IntegerType()
+    var __t44: Value; // BooleanType()
+    var __t45: Value; // BooleanType()
+    var __t46: Value; // IntegerType()
+    var __t47: Value; // IntegerType()
+    var __t48: Value; // IntegerType()
+    var __t49: Value; // BooleanType()
+    var __t50: Value; // BooleanType()
+    var __t51: Value; // IntegerType()
+    var __t52: Value; // IntegerType()
+    var __t53: Value; // IntegerType()
+    var __t54: Value; // BooleanType()
+    var __t55: Value; // BooleanType()
+    var __t56: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -120,9 +120,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t12 := BorrowLoc(__frame + 1);
+    call __t12 := BorrowLoc(__frame + 1);
 
-    call t2 := CopyOrMoveRef(t12);
+    call x_ref := CopyOrMoveRef(__t12);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
@@ -130,28 +130,28 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __tmp := GetLocal(__m, __frame + 13);
     if (!b#Boolean(__tmp)) { goto Label_12; }
 
-    call t14 := CopyOrMoveRef(t2);
+    call __t14 := CopyOrMoveRef(x_ref);
 
-    call t15 := BorrowField(t14, Test3_T_f);
+    call __t15 := BorrowField(__t14, Test3_T_f);
 
-    call t3 := CopyOrMoveRef(t15);
+    call f_or_g_ref := CopyOrMoveRef(__t15);
 
     goto Label_15;
 
 Label_12:
-    call t16 := CopyOrMoveRef(t2);
+    call __t16 := CopyOrMoveRef(x_ref);
 
-    call t17 := BorrowField(t16, Test3_T_g);
+    call __t17 := BorrowField(__t16, Test3_T_g);
 
-    call t3 := CopyOrMoveRef(t17);
+    call f_or_g_ref := CopyOrMoveRef(__t17);
 
 Label_15:
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 18, __tmp);
 
-    call t19 := CopyOrMoveRef(t3);
+    call __t19 := CopyOrMoveRef(f_or_g_ref);
 
-    call WriteRef(t19, GetLocal(__m, __frame + 18));
+    call WriteRef(__t19, GetLocal(__m, __frame + 18));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -162,53 +162,53 @@ Label_15:
     __tmp := GetLocal(__m, __frame + 21);
     if (!b#Boolean(__tmp)) { goto Label_25; }
 
-    call t22 := CopyOrMoveRef(t2);
+    call __t22 := CopyOrMoveRef(x_ref);
 
-    call t23 := BorrowField(t22, Test3_T_f);
+    call __t23 := BorrowField(__t22, Test3_T_f);
 
-    call t4 := CopyOrMoveRef(t23);
+    call f_or_g_ref2 := CopyOrMoveRef(__t23);
 
     goto Label_28;
 
 Label_25:
-    call t24 := CopyOrMoveRef(t2);
+    call __t24 := CopyOrMoveRef(x_ref);
 
-    call t25 := BorrowField(t24, Test3_T_g);
+    call __t25 := BorrowField(__t24, Test3_T_g);
 
-    call t4 := CopyOrMoveRef(t25);
+    call f_or_g_ref2 := CopyOrMoveRef(__t25);
 
 Label_28:
     call __tmp := LdConst(20);
     __m := UpdateLocal(__m, __frame + 26, __tmp);
 
-    call t27 := CopyOrMoveRef(t4);
+    call __t27 := CopyOrMoveRef(f_or_g_ref2);
 
-    call WriteRef(t27, GetLocal(__m, __frame + 26));
+    call WriteRef(__t27, GetLocal(__m, __frame + 26));
 
-    call t28 := CopyOrMoveRef(t2);
+    call __t28 := CopyOrMoveRef(x_ref);
 
-    call t29 := BorrowField(t28, Test3_T_f);
+    call __t29 := BorrowField(__t28, Test3_T_f);
 
-    call t5 := CopyOrMoveRef(t29);
+    call f_ref := CopyOrMoveRef(__t29);
 
-    call t30 := CopyOrMoveRef(t2);
+    call __t30 := CopyOrMoveRef(x_ref);
 
-    call t31 := BorrowField(t30, Test3_T_g);
+    call __t31 := BorrowField(__t30, Test3_T_g);
 
-    call t6 := CopyOrMoveRef(t31);
+    call g_ref := CopyOrMoveRef(__t31);
 
-    call t32 := CopyOrMoveRef(t5);
+    call __t32 := CopyOrMoveRef(f_ref);
 
-    call __tmp := ReadRef(t32);
+    call __tmp := ReadRef(__t32);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 33, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 33));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call t34 := CopyOrMoveRef(t6);
+    call __t34 := CopyOrMoveRef(g_ref);
 
-    call __tmp := ReadRef(t34);
+    call __tmp := ReadRef(__t34);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 35, __tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
@@ -6,16 +6,16 @@
 
 // ** functions of module TestAddition
 
-procedure {:inline 1} TestAddition_overflow_u8_add_bad (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestAddition_overflow_u8_add_bad (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -43,31 +43,31 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestAddition_overflow_u8_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestAddition_overflow_u8_add_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestAddition_overflow_u8_add_bad(x, y);
+    call __ret0 := TestAddition_overflow_u8_add_bad(x, y);
 }
 
-procedure {:inline 1} TestAddition_overflow_u8_add_ok (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestAddition_overflow_u8_add_ok (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(255))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -95,31 +95,31 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestAddition_overflow_u8_add_ok_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestAddition_overflow_u8_add_ok_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestAddition_overflow_u8_add_ok(x, y);
+    call __ret0 := TestAddition_overflow_u8_add_ok(x, y);
 }
 
-procedure {:inline 1} TestAddition_overflow_u64_add_bad (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestAddition_overflow_u64_add_bad (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -147,31 +147,31 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestAddition_overflow_u64_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestAddition_overflow_u64_add_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestAddition_overflow_u64_add_bad(x, y);
+    call __ret0 := TestAddition_overflow_u64_add_bad(x, y);
 }
 
-procedure {:inline 1} TestAddition_overflow_u64_add_ok (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestAddition_overflow_u64_add_ok (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -199,31 +199,31 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestAddition_overflow_u64_add_ok_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestAddition_overflow_u64_add_ok_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestAddition_overflow_u64_add_ok(x, y);
+    call __ret0 := TestAddition_overflow_u64_add_ok(x, y);
 }
 
-procedure {:inline 1} TestAddition_overflow_u128_add_bad (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestAddition_overflow_u128_add_bad (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -251,17 +251,17 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestAddition_overflow_u128_add_bad_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestAddition_overflow_u128_add_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestAddition_overflow_u128_add_bad(x, y);
+    call __ret0 := TestAddition_overflow_u128_add_bad(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
@@ -6,15 +6,15 @@
 
 // ** functions of module CastBad
 
-procedure {:inline 1} CastBad_aborting_u8_cast_bad (x: Value) returns (ret0: Value)
+procedure {:inline 1} CastBad_aborting_u8_cast_bad (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -37,30 +37,30 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure CastBad_aborting_u8_cast_bad_verify (x: Value) returns (ret0: Value)
+procedure CastBad_aborting_u8_cast_bad_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := CastBad_aborting_u8_cast_bad(x);
+    call __ret0 := CastBad_aborting_u8_cast_bad(x);
 }
 
-procedure {:inline 1} CastBad_aborting_u8_cast_ok (x: Value) returns (ret0: Value)
+procedure {:inline 1} CastBad_aborting_u8_cast_ok (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -83,30 +83,30 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> __ab
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure CastBad_aborting_u8_cast_ok_verify (x: Value) returns (ret0: Value)
+procedure CastBad_aborting_u8_cast_ok_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := CastBad_aborting_u8_cast_ok(x);
+    call __ret0 := CastBad_aborting_u8_cast_ok(x);
 }
 
-procedure {:inline 1} CastBad_aborting_u64_cast_bad (x: Value) returns (ret0: Value)
+procedure {:inline 1} CastBad_aborting_u64_cast_bad (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -129,30 +129,30 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure CastBad_aborting_u64_cast_bad_verify (x: Value) returns (ret0: Value)
+procedure CastBad_aborting_u64_cast_bad_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := CastBad_aborting_u64_cast_bad(x);
+    call __ret0 := CastBad_aborting_u64_cast_bad(x);
 }
 
-procedure {:inline 1} CastBad_aborting_u64_cast_ok (x: Value) returns (ret0: Value)
+procedure {:inline 1} CastBad_aborting_u64_cast_ok (x: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(9223372036854775807))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Value; // IntegerType()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -175,17 +175,17 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(92233720368547758
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 2);
+    __ret0 := GetLocal(__m, __frame + 2);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure CastBad_aborting_u64_cast_ok_verify (x: Value) returns (ret0: Value)
+procedure CastBad_aborting_u64_cast_ok_verify (x: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := CastBad_aborting_u64_cast_ok(x);
+    call __ret0 := CastBad_aborting_u64_cast_ok(x);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -33,11 +33,11 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Value; // BooleanType()
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // TestSpecs_R_type_value()
+    var __t0: Value; // AddressType()
+    var __t1: Value; // BooleanType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // TestSpecs_R_type_value()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -96,9 +96,9 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
 
 {
     // declare local variables
-    var t0: Value; // AddressType()
-    var t1: Value; // BooleanType()
-    var t2: Value; // IntegerType()
+    var __t0: Value; // AddressType()
+    var __t1: Value; // BooleanType()
+    var __t2: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
@@ -6,16 +6,16 @@
 
 // ** functions of module TestSpecs
 
-procedure {:inline 1} TestSpecs_div (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_div (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abort_flag;
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
+    var r: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -49,31 +49,31 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abo
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_div_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestSpecs_div_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_div(x, y);
+    call __ret0 := TestSpecs_div(x, y);
 }
 
-procedure {:inline 1} TestSpecs_div_by_zero_detected (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_div_by_zero_detected (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
-    var t5: Value; // IntegerType()
-    var t6: Value; // IntegerType()
+    var r: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -107,17 +107,17 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 6);
+    __ret0 := GetLocal(__m, __frame + 6);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_div_by_zero_detected_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestSpecs_div_by_zero_detected_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_div_by_zero_detected(x, y);
+    call __ret0 := TestSpecs_div_by_zero_detected(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -10,8 +10,8 @@ procedure {:inline 1} TestSpecs_mut_b (b: Reference) returns ()
 requires ExistsTxnSenderAccount(__m, __txn);
 {
     // declare local variables
-    var t1: Value; // IntegerType()
-    var t2: Reference; // ReferenceType(IntegerType())
+    var __t1: Value; // IntegerType()
+    var __t2: Reference; // ReferenceType(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -30,9 +30,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t2 := CopyOrMoveRef(b);
+    call __t2 := CopyOrMoveRef(b);
 
-    call WriteRef(t2, GetLocal(__m, __frame + 1));
+    call WriteRef(__t2, GetLocal(__m, __frame + 1));
 
     return;
 
@@ -52,18 +52,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Reference; // ReferenceType(IntegerType())
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(IntegerType())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // IntegerType()
+    var b: Value; // IntegerType()
+    var b_ref: Reference; // ReferenceType(IntegerType())
+    var __t2: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(IntegerType())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -83,18 +83,18 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
-    call t1 := CopyOrMoveRef(t3);
+    call b_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(b_ref);
 
-    call TestSpecs_mut_b(t4);
+    call TestSpecs_mut_b(__t4);
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t1);
+    call __t5 := CopyOrMoveRef(b_ref);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
@@ -140,18 +140,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 {
     // declare local variables
-    var t0: Value; // IntegerType()
-    var t1: Reference; // ReferenceType(IntegerType())
-    var t2: Value; // IntegerType()
-    var t3: Reference; // ReferenceType(IntegerType())
-    var t4: Reference; // ReferenceType(IntegerType())
-    var t5: Reference; // ReferenceType(IntegerType())
-    var t6: Value; // IntegerType()
-    var t7: Value; // IntegerType()
-    var t8: Value; // IntegerType()
-    var t9: Value; // BooleanType()
-    var t10: Value; // BooleanType()
-    var t11: Value; // IntegerType()
+    var b: Value; // IntegerType()
+    var b_ref: Reference; // ReferenceType(IntegerType())
+    var __t2: Value; // IntegerType()
+    var __t3: Reference; // ReferenceType(IntegerType())
+    var __t4: Reference; // ReferenceType(IntegerType())
+    var __t5: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // IntegerType()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // BooleanType()
+    var __t10: Value; // BooleanType()
+    var __t11: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -171,18 +171,18 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0);
 
-    call t1 := CopyOrMoveRef(t3);
+    call b_ref := CopyOrMoveRef(__t3);
 
-    call t4 := CopyOrMoveRef(t1);
+    call __t4 := CopyOrMoveRef(b_ref);
 
-    call TestSpecs_mut_b(t4);
+    call TestSpecs_mut_b(__t4);
     if (__abort_flag) { goto Label_Abort; }
 
-    call t5 := CopyOrMoveRef(t1);
+    call __t5 := CopyOrMoveRef(b_ref);
 
-    call __tmp := ReadRef(t5);
+    call __tmp := ReadRef(__t5);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
@@ -6,16 +6,16 @@
 
 // ** functions of module TestMultiplication
 
-procedure {:inline 1} TestMultiplication_overflow_u8_mul_bad (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestMultiplication_overflow_u8_mul_bad (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -43,31 +43,31 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestMultiplication_overflow_u8_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestMultiplication_overflow_u8_mul_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestMultiplication_overflow_u8_mul_bad(x, y);
+    call __ret0 := TestMultiplication_overflow_u8_mul_bad(x, y);
 }
 
-procedure {:inline 1} TestMultiplication_overflow_u8_mul_ok (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestMultiplication_overflow_u8_mul_ok (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255)))))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > i#Integer(Integer(255))))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -95,31 +95,31 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > 
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestMultiplication_overflow_u8_mul_ok_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestMultiplication_overflow_u8_mul_ok_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestMultiplication_overflow_u8_mul_ok(x, y);
+    call __ret0 := TestMultiplication_overflow_u8_mul_ok(x, y);
 }
 
-procedure {:inline 1} TestMultiplication_overflow_u64_mul_bad (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestMultiplication_overflow_u64_mul_bad (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -147,31 +147,31 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestMultiplication_overflow_u64_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestMultiplication_overflow_u64_mul_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestMultiplication_overflow_u64_mul_bad(x, y);
+    call __ret0 := TestMultiplication_overflow_u64_mul_bad(x, y);
 }
 
-procedure {:inline 1} TestMultiplication_overflow_u128_mul_bad (x: Value, y: Value) returns (ret0: Value)
+procedure {:inline 1} TestMultiplication_overflow_u128_mul_bad (x: Value, y: Value) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
 ensures old(!(b#Boolean(Boolean(false)))) ==> !__abort_flag;
 ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
 {
     // declare local variables
-    var t2: Value; // IntegerType()
-    var t3: Value; // IntegerType()
-    var t4: Value; // IntegerType()
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -199,17 +199,17 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     if (__abort_flag) { goto Label_Abort; }
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
+    __ret0 := GetLocal(__m, __frame + 4);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestMultiplication_overflow_u128_mul_bad_verify (x: Value, y: Value) returns (ret0: Value)
+procedure TestMultiplication_overflow_u128_mul_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestMultiplication_overflow_u128_mul_bad(x, y);
+    call __ret0 := TestMultiplication_overflow_u128_mul_bad(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -25,14 +25,14 @@ procedure {:inline 1} Unpack_TestSpecs_T(_struct: Value) returns (value: Value)
 
 // ** functions of module TestSpecs
 
-procedure {:inline 1} TestSpecs_value (ref: Reference) returns (ret0: Value)
+procedure {:inline 1} TestSpecs_value (ref: Reference) returns (__ret0: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, ref), TestSpecs_T_value))));
+ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, ref), TestSpecs_T_value))));
 {
     // declare local variables
-    var t1: Reference; // ReferenceType(TestSpecs_T_type_value())
-    var t2: Reference; // ReferenceType(IntegerType())
-    var t3: Value; // IntegerType()
+    var __t1: Reference; // ReferenceType(TestSpecs_T_type_value())
+    var __t2: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -48,25 +48,25 @@ ensures b#Boolean(Boolean(IsEqual(ret0, SelectField(Dereference(__m, ref), TestS
     assume IsValidReferenceParameter(__m, __frame, ref);
 
     // bytecode translation starts here
-    call t1 := CopyOrMoveRef(ref);
+    call __t1 := CopyOrMoveRef(ref);
 
-    call t2 := BorrowField(t1, TestSpecs_T_value);
+    call __t2 := BorrowField(__t1, TestSpecs_T_value);
 
-    call __tmp := ReadRef(t2);
+    call __tmp := ReadRef(__t2);
     assume IsValidU64(__tmp);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 3);
+    __ret0 := GetLocal(__m, __frame + 3);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
+    __ret0 := DefaultValue;
 }
 
-procedure TestSpecs_value_verify (ref: Reference) returns (ret0: Value)
+procedure TestSpecs_value_verify (ref: Reference) returns (__ret0: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0 := TestSpecs_value(ref);
+    call __ret0 := TestSpecs_value(ref);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -6,17 +6,17 @@
 
 // ** functions of module VerifyVector
 
-procedure {:inline 1} VerifyVector_test_empty1 () returns (ret0: Value, ret1: Value)
+procedure {:inline 1} VerifyVector_test_empty1 () returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, ret1)));
+ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 {
     // declare local variables
-    var t0: Value; // Vector_T_type_value(IntegerType())
-    var t1: Value; // Vector_T_type_value(IntegerType())
-    var t2: Value; // Vector_T_type_value(IntegerType())
-    var t3: Value; // Vector_T_type_value(IntegerType())
-    var t4: Value; // Vector_T_type_value(IntegerType())
-    var t5: Value; // Vector_T_type_value(IntegerType())
+    var ev1: Value; // Vector_T_type_value(IntegerType())
+    var ev2: Value; // Vector_T_type_value(IntegerType())
+    var __t2: Value; // Vector_T_type_value(IntegerType())
+    var __t3: Value; // Vector_T_type_value(IntegerType())
+    var __t4: Value; // Vector_T_type_value(IntegerType())
+    var __t5: Value; // Vector_T_type_value(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -30,20 +30,20 @@ ensures b#Boolean(Boolean(IsEqual(ret0, ret1)));
     // process and type check arguments
 
     // bytecode translation starts here
-    call t2 := Vector_empty(IntegerType());
+    call __t2 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t2);
+    assume is#Vector(__t2);
 
-    __m := UpdateLocal(__m, __frame + 2, t2);
+    __m := UpdateLocal(__m, __frame + 2, __t2);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t3 := Vector_empty(IntegerType());
+    call __t3 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t3);
+    assume is#Vector(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
@@ -54,39 +54,39 @@ ensures b#Boolean(Boolean(IsEqual(ret0, ret1)));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 4);
-    ret1 := GetLocal(__m, __frame + 5);
+    __ret0 := GetLocal(__m, __frame + 4);
+    __ret1 := GetLocal(__m, __frame + 5);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure VerifyVector_test_empty1_verify () returns (ret0: Value, ret1: Value)
+procedure VerifyVector_test_empty1_verify () returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := VerifyVector_test_empty1();
+    call __ret0, __ret1 := VerifyVector_test_empty1();
 }
 
-procedure {:inline 1} VerifyVector_test_empty2 () returns (ret0: Value, ret1: Value)
+procedure {:inline 1} VerifyVector_test_empty2 () returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
-ensures b#Boolean(Boolean(IsEqual(ret0, ret1)));
+ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 {
     // declare local variables
-    var t0: Value; // Vector_T_type_value(IntegerType())
-    var t1: Value; // Vector_T_type_value(IntegerType())
-    var t2: Value; // IntegerType()
-    var t3: Value; // Vector_T_type_value(IntegerType())
-    var t4: Value; // Vector_T_type_value(IntegerType())
-    var t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
-    var t6: Value; // IntegerType()
-    var t7: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
-    var t8: Value; // IntegerType()
-    var t9: Value; // Vector_T_type_value(IntegerType())
-    var t10: Value; // Vector_T_type_value(IntegerType())
+    var ev1: Value; // Vector_T_type_value(IntegerType())
+    var ev2: Value; // Vector_T_type_value(IntegerType())
+    var x: Value; // IntegerType()
+    var __t3: Value; // Vector_T_type_value(IntegerType())
+    var __t4: Value; // Vector_T_type_value(IntegerType())
+    var __t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var __t6: Value; // IntegerType()
+    var __t7: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // Vector_T_type_value(IntegerType())
+    var __t10: Value; // Vector_T_type_value(IntegerType())
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
@@ -100,39 +100,39 @@ ensures b#Boolean(Boolean(IsEqual(ret0, ret1)));
     // process and type check arguments
 
     // bytecode translation starts here
-    call t3 := Vector_empty(IntegerType());
+    call __t3 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t3);
+    assume is#Vector(__t3);
 
-    __m := UpdateLocal(__m, __frame + 3, t3);
+    __m := UpdateLocal(__m, __frame + 3, __t3);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call t4 := Vector_empty(IntegerType());
+    call __t4 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
-    assume is#Vector(t4);
+    assume is#Vector(__t4);
 
-    __m := UpdateLocal(__m, __frame + 4, t4);
+    __m := UpdateLocal(__m, __frame + 4, __t4);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
-    call t5 := BorrowLoc(__frame + 0);
+    call __t5 := BorrowLoc(__frame + 0);
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call Vector_push_back(IntegerType(), t5, GetLocal(__m, __frame + 6));
+    call Vector_push_back(IntegerType(), __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
 
-    call t7 := BorrowLoc(__frame + 0);
+    call __t7 := BorrowLoc(__frame + 0);
 
-    call t8 := Vector_pop_back(IntegerType(), t7);
+    call __t8 := Vector_pop_back(IntegerType(), __t7);
     if (__abort_flag) { goto Label_Abort; }
-    assume IsValidU64(t8);
+    assume IsValidU64(__t8);
 
-    __m := UpdateLocal(__m, __frame + 8, t8);
+    __m := UpdateLocal(__m, __frame + 8, __t8);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -143,19 +143,19 @@ ensures b#Boolean(Boolean(IsEqual(ret0, ret1)));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    ret0 := GetLocal(__m, __frame + 9);
-    ret1 := GetLocal(__m, __frame + 10);
+    __ret0 := GetLocal(__m, __frame + 9);
+    __ret1 := GetLocal(__m, __frame + 10);
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
-    ret0 := DefaultValue;
-    ret1 := DefaultValue;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
 }
 
-procedure VerifyVector_test_empty2_verify () returns (ret0: Value, ret1: Value)
+procedure VerifyVector_test_empty2_verify () returns (__ret0: Value, __ret1: Value)
 {
     assume ExistsTxnSenderAccount(__m, __txn);
-    call ret0, ret1 := VerifyVector_test_empty2();
+    call __ret0, __ret1 := VerifyVector_test_empty2();
 }


### PR DESCRIPTION
This uses the actual assigned name (as provided by a let) instead of a name generated from the local index, where available. As we have transformed into a stackless machine, we have some unnamed locals, which will continue to use a generated name.

This is a prerequisite for getting model visualization working.

The implementation is based on the `bytecode-source-map` crate, which seems to do the right thing for our test cases out of the box(!).

This also renames the generated name `tN` to `__tN` to avoid clashes. Also fixing some issue with the new boogie error processing which was helpful to debug this PR. Before, we where associating boogie compilation errors with the source. Instead we are marking them now as bugs on the boogie output.

## Motivation

Better DevX for the prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
