### PR TITLE
Fix issue with temp path on different file system

### DIFF
--- a/common/temppath/src/lib.rs
+++ b/common/temppath/src/lib.rs
@@ -28,11 +28,14 @@ impl Drop for TempPath {
 }
 
 impl TempPath {
-    /// Create new uninitialized temporary path, i.e. a file or directory isn't created
-    /// automatically
+    /// Create new, uninitialized temporary path in the system temp directory.
     pub fn new() -> Self {
-        // Create a random path in the system temp directory
-        let mut temppath = std::env::temp_dir();
+        Self::new_with_temp_dir(std::env::temp_dir())
+    }
+
+    /// Create new, uninitialized temporary path in the specified directory.
+    pub fn new_with_temp_dir(temp_dir: PathBuf) -> Self {
+        let mut temppath = temp_dir;
         let mut rng = rand::thread_rng();
         let mut bytes = [0_u8; 16];
         rng.fill_bytes(&mut bytes);

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -28,9 +28,15 @@ impl OnDiskStorage {
             File::create(&file_path).expect("Unable to create storage");
         }
 
+        // The parent will be one when only a filename is supplied. Therefore use the current
+        // working directory provided by PathBuf::new().
+        let file_dir = file_path
+            .parent()
+            .map_or(PathBuf::new(), |p| p.to_path_buf());
+
         Self {
             file_path,
-            temp_path: TempPath::new(),
+            temp_path: TempPath::new_with_temp_dir(file_dir),
         }
     }
 


### PR DESCRIPTION
This addresses the case where our temp file system isn't on the same file system as the location where safety rules is. The solution is to generate the temp file in the same path as safety rules.

About to start a cluster test to verify it works. It works.