### PR TITLE
Remove unused address and port in ExecutionConfig

### DIFF
--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::RootPath, utils};
+use crate::config::RootPath;
 use anyhow::Result;
 use libra_types::transaction::Transaction;
 use serde::{Deserialize, Serialize};
@@ -16,8 +16,6 @@ const GENESIS_DEFAULT: &str = "genesis.blob";
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ExecutionConfig {
-    pub address: String,
-    pub port: u16,
     #[serde(skip)]
     pub genesis: Option<Transaction>,
     pub genesis_file_location: PathBuf,
@@ -26,8 +24,6 @@ pub struct ExecutionConfig {
 impl Default for ExecutionConfig {
     fn default() -> ExecutionConfig {
         ExecutionConfig {
-            address: "localhost".to_string(),
-            port: 6183,
             genesis: None,
             genesis_file_location: PathBuf::new(),
         }
@@ -58,10 +54,6 @@ impl ExecutionConfig {
             file.write_all(&lcs::to_bytes(&genesis)?)?;
         }
         Ok(())
-    }
-
-    pub fn randomize_ports(&mut self) {
-        self.port = utils::get_available_port();
     }
 }
 

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -256,7 +256,6 @@ impl NodeConfig {
     pub fn randomize_ports(&mut self) {
         self.admission_control.randomize_ports();
         self.debug_interface.randomize_ports();
-        self.execution.randomize_ports();
         self.mempool.randomize_ports();
         self.storage.randomize_ports();
     }

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -30,8 +30,6 @@ public_metrics_server_port = 9102
 address = "0.0.0.0"
 
 [execution]
-address = "localhost"
-port = 6183
 genesis_file_location = ""
 
 [logger]

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -8,8 +8,6 @@ dir = "metrics"
 enabled = false
 
 [execution]
-address = "localhost"
-port = 6183
 genesis_file_location = ""
 
 [admission_control]


### PR DESCRIPTION
## Motivation

The address and port in ExecutionConfig are not being used at all. This PR removes them as an effort to clean up the config code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A local run of 'cargo xtest' doesn't produce any issues!

## Related PRs

None.
