### PR TITLE
[Executor/Storage] Add a simple benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "storage-client 0.1.0",
  "storage-proto 0.1.0",
  "storage-service 0.1.0",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,14 +170,6 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "backoff"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,7 +1257,6 @@ name = "executor"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5856,7 +5847,6 @@ dependencies = [
 "checksum async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
-"checksum backoff 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "afe2eef13bc0f5a77e7c2fec6d863fa59eea6901e4949830b67f0c348d720100"
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-backoff = { version = "0.1.5", default-features = false }
 futures = "0.3.0"
 itertools = { version = "0.8.0", default-features = false }
 once_cell = "1.2.0"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -15,32 +15,31 @@ backoff = { version = "0.1.5", default-features = false }
 futures = "0.3.0"
 itertools = { version = "0.8.0", default-features = false }
 once_cell = "1.2.0"
+rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }
 tokio = { version = "0.2.8", features = ["full"] }
 
+config-builder = { path = "../config/config-builder", version = "0.1.0" }
+lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-prost-ext = { path = "../common/prost-ext", version = "0.1.0" }
-lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
-scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 storage-proto = { path = "../storage/storage-proto", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0" }
+storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.2"
-rand = "0.6.5"
 rusty-fork = "0.2.1"
 
-lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
-storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
-transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
-config-builder = { path = "../config/config-builder", version = "0.1.0" }
 
 [features]
 default = []

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -16,6 +16,7 @@ itertools = { version = "0.8.0", default-features = false }
 once_cell = "1.2.0"
 rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }
+structopt = "0.3"
 tokio = { version = "0.2.8", features = ["full"] }
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.0"
 itertools = { version = "0.8.0", default-features = false }
 once_cell = "1.2.0"
 rand = "0.6.5"
+rayon = "1"
 serde = { version = "1.0.99", default-features = false }
 structopt = "0.3"
 tokio = { version = "0.2.8", features = ["full"] }

--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -1,0 +1,309 @@
+use crate::{utils::create_storage_service_and_executor, ExecutedTrees, Executor};
+use libra_crypto::{
+    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
+    hash::{CryptoHash, HashValue},
+    traits::{PrivateKey, SigningKey},
+};
+use libra_types::{
+    account_address::AccountAddress,
+    account_config::{association_address, AccountResource},
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    transaction::{RawTransaction, Script, SignedTransaction, Transaction},
+};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    sync::{mpsc, Arc},
+};
+use storage_client::{StorageRead, StorageReadServiceClient};
+use transaction_builder::{encode_create_account_script, encode_transfer_script};
+use vm_runtime::LibraVM;
+
+struct AccountData {
+    private_key: Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
+    address: AccountAddress,
+    sequence_number: u64,
+}
+
+struct TransactionGenerator {
+    /// The current state of the accounts. The main purpose is to keep track of the sequence number
+    /// so generated transactions are guaranteed to be successfully executed.
+    accounts: Vec<AccountData>,
+
+    /// Used to mint accounts.
+    genesis_key: Ed25519PrivateKey,
+
+    /// For deterministic transaction generation.
+    rng: StdRng,
+
+    /// Each generated block of transactions are sent to this channel. Using `SyncSender` to make
+    /// sure if execution is slow to consume the transactions, we do not run out of memory.
+    block_sender: Option<mpsc::SyncSender<Vec<Transaction>>>,
+
+    /// Used to verify account sequence numbers after all transactions are committed.
+    storage_client: StorageReadServiceClient,
+}
+
+impl TransactionGenerator {
+    fn new(
+        genesis_key: Ed25519PrivateKey,
+        num_accounts: usize,
+        block_sender: mpsc::SyncSender<Vec<Transaction>>,
+        storage_client: StorageReadServiceClient,
+    ) -> Self {
+        let seed = [1u8; 32];
+        let mut rng = StdRng::from_seed(seed);
+
+        let mut accounts = Vec::with_capacity(num_accounts);
+        for _i in 0..num_accounts {
+            let (private_key, public_key) = ed25519::compat::generate_keypair(&mut rng);
+            let address = AccountAddress::from_public_key(&public_key);
+            let account = AccountData {
+                private_key,
+                public_key,
+                address,
+                sequence_number: 0,
+            };
+            accounts.push(account);
+        }
+
+        Self {
+            accounts,
+            genesis_key,
+            rng,
+            block_sender: Some(block_sender),
+            storage_client,
+        }
+    }
+
+    fn run(&mut self, init_account_balance: u64, block_size: usize, num_transfer_blocks: usize) {
+        self.gen_mint_transactions(init_account_balance, block_size);
+        self.gen_transfer_transactions(block_size, num_transfer_blocks);
+    }
+
+    /// Generates transactions that allocate `init_account_balance` to every account.
+    fn gen_mint_transactions(&self, init_account_balance: u64, block_size: usize) {
+        let genesis_account = association_address();
+
+        for (i, block) in self.accounts.chunks(block_size).enumerate() {
+            let mut transactions = Vec::with_capacity(block_size);
+            for (j, account) in block.iter().enumerate() {
+                let txn = create_transaction(
+                    genesis_account,
+                    (i * block_size + j + 1) as u64,
+                    &self.genesis_key,
+                    self.genesis_key.public_key(),
+                    encode_create_account_script(&account.address, init_account_balance),
+                );
+                transactions.push(txn);
+            }
+
+            self.block_sender
+                .as_ref()
+                .unwrap()
+                .send(transactions)
+                .unwrap();
+        }
+    }
+
+    /// Generates transactions for random pairs of accounts.
+    fn gen_transfer_transactions(&mut self, block_size: usize, num_blocks: usize) {
+        for _i in 0..num_blocks {
+            let mut transactions = Vec::with_capacity(block_size);
+            for _j in 0..block_size {
+                let indices = rand::seq::index::sample(&mut self.rng, self.accounts.len(), 2);
+                let sender_idx = indices.index(0);
+                let receiver_idx = indices.index(1);
+
+                let sender = &self.accounts[sender_idx];
+                let receiver = &self.accounts[receiver_idx];
+                let txn = create_transaction(
+                    sender.address,
+                    sender.sequence_number,
+                    &sender.private_key,
+                    sender.public_key.clone(),
+                    encode_transfer_script(&receiver.address, 1 /* amount */),
+                );
+                transactions.push(txn);
+
+                self.accounts[sender_idx].sequence_number += 1;
+            }
+
+            self.block_sender
+                .as_ref()
+                .unwrap()
+                .send(transactions)
+                .unwrap();
+        }
+    }
+
+    /// Verifies the sequence numbers in storage match what we have locally.
+    fn verify_sequence_number(&self) {
+        let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+        for account in &self.accounts {
+            let address = account.address;
+            let blob = rt
+                .block_on(self.storage_client.get_latest_account_state(address))
+                .expect("Failed to query storage.")
+                .expect("Account must exist.");
+            let account_resource = AccountResource::try_from(&blob).unwrap();
+            assert_eq!(account_resource.sequence_number(), account.sequence_number);
+        }
+    }
+
+    /// Drops the sender to notify the receiving end of the channel.
+    fn drop_sender(&mut self) {
+        self.block_sender.take().unwrap();
+    }
+}
+
+struct TransactionExecutor {
+    executor: Executor<LibraVM>,
+    committed_trees: ExecutedTrees,
+    block_receiver: mpsc::Receiver<Vec<Transaction>>,
+}
+
+impl TransactionExecutor {
+    fn new(
+        executor: Executor<LibraVM>,
+        committed_trees: ExecutedTrees,
+        block_receiver: mpsc::Receiver<Vec<Transaction>>,
+    ) -> Self {
+        Self {
+            executor,
+            committed_trees,
+            block_receiver,
+        }
+    }
+
+    fn run(&mut self) {
+        let mut version = 0;
+
+        while let Ok(transactions) = self.block_receiver.recv() {
+            version += transactions.len() as u64;
+
+            let output = self
+                .executor
+                .execute_block(
+                    transactions.clone(),
+                    &self.committed_trees,
+                    &self.committed_trees,
+                )
+                .unwrap();
+            let new_committed_trees = output.executed_trees().clone();
+            let block_to_commit = (transactions, Arc::new(output));
+
+            let block_info = BlockInfo::new(
+                1,                 /* epoch */
+                0,                 /* round, doesn't matter */
+                HashValue::zero(), /* id, doesn't matter */
+                new_committed_trees.state_id(),
+                version,
+                0,    /* timestamp_usecs, doesn't matter */
+                None, /* next_validator_set */
+            );
+            let ledger_info = LedgerInfo::new(
+                block_info,
+                HashValue::zero(), /* consensus_data_hash, doesn't matter */
+            );
+            let ledger_info_with_sigs =
+                LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new() /* signatures */);
+
+            self.executor
+                .commit_blocks(
+                    vec![block_to_commit],
+                    ledger_info_with_sigs,
+                    &self.committed_trees,
+                )
+                .unwrap();
+
+            self.committed_trees = new_committed_trees;
+        }
+    }
+}
+
+/// Runs the benchmark with given parameters.
+pub fn run_benchmark(
+    num_accounts: usize,
+    init_account_balance: u64,
+    block_size: usize,
+    num_transfer_blocks: usize,
+) {
+    let (config, genesis_key) = config_builder::test_config();
+    let (_storage_server_handle, executor, committed_trees) =
+        create_storage_service_and_executor(&config);
+    let storage_client = StorageReadServiceClient::new(&config.storage.address);
+
+    let (block_sender, block_receiver) = mpsc::sync_channel(50 /* bound */);
+
+    // Spawn two threads to run transaction generator and executor separately.
+    let gen_thread = std::thread::Builder::new()
+        .name("txn_generator".to_string())
+        .spawn(move || {
+            let mut generator =
+                TransactionGenerator::new(genesis_key, num_accounts, block_sender, storage_client);
+            generator.run(init_account_balance, block_size, num_transfer_blocks);
+            generator
+        })
+        .expect("Failed to spawn transaction generator thread.");
+    let exe_thread = std::thread::Builder::new()
+        .name("txn_executor".to_string())
+        .spawn(move || {
+            let mut exe = TransactionExecutor::new(executor, committed_trees, block_receiver);
+            exe.run();
+        })
+        .expect("Failed to spawn transaction executor thread.");
+
+    // Wait for generator to finish and get back the generator.
+    let mut generator = gen_thread.join().unwrap();
+    // Drop the sender so the executor thread can eventually exit.
+    generator.drop_sender();
+    // Wait until all transactions are committed.
+    exe_thread.join().unwrap();
+
+    // Do a sanity check on the sequence number to make sure all transactions are committed.
+    generator.verify_sequence_number();
+}
+
+fn create_transaction(
+    sender: AccountAddress,
+    sequence_number: u64,
+    private_key: &Ed25519PrivateKey,
+    public_key: Ed25519PublicKey,
+    program: Script,
+) -> Transaction {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let expiration_time = std::time::Duration::from_secs(now.as_secs() + 3600);
+
+    let raw_txn = RawTransaction::new_script(
+        sender,
+        sequence_number,
+        program,
+        200_000,
+        1,
+        expiration_time,
+    );
+
+    let signature = private_key.sign_message(&raw_txn.hash());
+    let signed_txn = SignedTransaction::new(raw_txn, public_key, signature);
+    Transaction::UserTransaction(signed_txn)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_benchmark() {
+        super::run_benchmark(
+            25,        /* num_accounts */
+            1_000_000, /* init_account_balance */
+            5,         /* block_size */
+            5,         /* num_transfer_blocks */
+        );
+    }
+}

--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -313,6 +313,7 @@ mod tests {
             1_000_000, /* init_account_balance */
             5,         /* block_size */
             5,         /* num_transfer_blocks */
+            None,      /* db_dir */
         );
     }
 }

--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -294,8 +294,8 @@ fn create_transaction(
         sender,
         sequence_number,
         program,
-        200_000,
-        1,
+        200_000, /* max_gas_amount */
+        1,       /* gas_unit_price */
         expiration_time,
     );
 

--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -18,6 +18,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use std::{
     collections::BTreeMap,
     convert::TryFrom,
+    path::PathBuf,
     sync::{mpsc, Arc},
 };
 use storage_client::{StorageRead, StorageReadServiceClient};
@@ -235,8 +236,13 @@ pub fn run_benchmark(
     init_account_balance: u64,
     block_size: usize,
     num_transfer_blocks: usize,
+    db_dir: Option<PathBuf>,
 ) {
-    let (config, genesis_key) = config_builder::test_config();
+    let (mut config, genesis_key) = config_builder::test_config();
+    if let Some(path) = db_dir {
+        config.storage.dir = path;
+    }
+
     let (_storage_server_handle, executor, committed_trees) =
         create_storage_service_and_executor(&config);
     let storage_client = StorageReadServiceClient::new(&config.storage.address);

--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{utils::create_storage_service_and_executor, ExecutedTrees, Executor};
 use libra_crypto::{
     ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},

--- a/executor/src/bin/bench.rs
+++ b/executor/src/bin/bench.rs
@@ -25,6 +25,11 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
 
+    rayon::ThreadPoolBuilder::new()
+        .thread_name(|index| format!("rayon-global-{}", index))
+        .build_global()
+        .expect("Failed to build rayon global thread pool.");
+
     executor::benchmark::run_benchmark(
         opt.num_accounts,
         opt.init_account_balance,

--- a/executor/src/bin/bench.rs
+++ b/executor/src/bin/bench.rs
@@ -1,16 +1,35 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-const NUM_ACCOUNTS: usize = 1_000_000;
-const INIT_ACCOUNT_BALANCE: u64 = 1_000_000;
-const BLOCK_SIZE: usize = 1000;
-const NUM_TRANSFER_BLOCKS: usize = 1000;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(long, default_value = "1000000")]
+    num_accounts: usize,
+
+    #[structopt(long, default_value = "1000000")]
+    init_account_balance: u64,
+
+    #[structopt(long, default_value = "500")]
+    block_size: usize,
+
+    #[structopt(long, default_value = "1000")]
+    num_transfer_blocks: usize,
+
+    #[structopt(long, parse(from_os_str))]
+    db_dir: Option<PathBuf>,
+}
 
 fn main() {
+    let opt = Opt::from_args();
+
     executor::benchmark::run_benchmark(
-        NUM_ACCOUNTS,
-        INIT_ACCOUNT_BALANCE,
-        BLOCK_SIZE,
-        NUM_TRANSFER_BLOCKS,
+        opt.num_accounts,
+        opt.init_account_balance,
+        opt.block_size,
+        opt.num_transfer_blocks,
+        opt.db_dir,
     );
 }

--- a/executor/src/bin/bench.rs
+++ b/executor/src/bin/bench.rs
@@ -1,0 +1,13 @@
+const NUM_ACCOUNTS: usize = 1_000_000;
+const INIT_ACCOUNT_BALANCE: u64 = 1_000_000;
+const BLOCK_SIZE: usize = 1000;
+const NUM_TRANSFER_BLOCKS: usize = 1000;
+
+fn main() {
+    executor::benchmark::run_benchmark(
+        NUM_ACCOUNTS,
+        INIT_ACCOUNT_BALANCE,
+        BLOCK_SIZE,
+        NUM_TRANSFER_BLOCKS,
+    );
+}

--- a/executor/src/bin/bench.rs
+++ b/executor/src/bin/bench.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 const NUM_ACCOUNTS: usize = 1_000_000;
 const INIT_ACCOUNT_BALANCE: u64 = 1_000_000;
 const BLOCK_SIZE: usize = 1000;

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -312,7 +312,12 @@ where
         storage_write_client: Arc<dyn StorageWrite>,
         config: &NodeConfig,
     ) -> Self {
-        let rt = Runtime::new().unwrap();
+        let rt = tokio::runtime::Builder::new()
+            .threaded_scheduler()
+            .enable_all()
+            .thread_name("tokio-executor")
+            .build()
+            .unwrap();
 
         let mut executor = Executor {
             rt,

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -4,10 +4,12 @@
 #![forbid(unsafe_code)]
 #![allow(dead_code)]
 
+pub mod benchmark;
 #[cfg(test)]
 mod executor_test;
 #[cfg(test)]
 mod mock_vm;
+pub mod utils;
 
 use anyhow::{bail, ensure, format_err, Result};
 use futures::executor::block_on;

--- a/executor/src/utils.rs
+++ b/executor/src/utils.rs
@@ -1,0 +1,27 @@
+use crate::{ExecutedTrees, Executor};
+use libra_config::config::NodeConfig;
+use std::sync::Arc;
+use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
+use storage_service::start_storage_service;
+use tokio::runtime::Runtime;
+use vm_runtime::LibraVM;
+
+pub fn create_storage_service_and_executor(
+    config: &NodeConfig,
+) -> (Runtime, Executor<LibraVM>, ExecutedTrees) {
+    let mut rt = start_storage_service(config);
+
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
+
+    let executor = Executor::new(storage_read_client, storage_write_client, config);
+
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+
+    let startup_info = rt
+        .block_on(storage_read_client.get_startup_info())
+        .expect("unable to read ledger info from storage")
+        .expect("startup info is None");
+    let committed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
+    (rt, executor, committed_trees)
+}

--- a/executor/src/utils.rs
+++ b/executor/src/utils.rs
@@ -1,3 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{ExecutedTrees, Executor};
 use libra_config::config::NodeConfig;
 use std::sync::Arc;

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -36,7 +36,12 @@ use tokio::runtime::Runtime;
 
 /// Starts storage service according to config.
 pub fn start_storage_service(config: &NodeConfig) -> Runtime {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .thread_name("tokio-storage")
+        .build()
+        .unwrap();
 
     let storage_service = StorageService::new(&config.storage.dir());
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This change implements a simple benchmark that allows us to measure the performance of the execution/storage components of the system.

The benchmark has two components:
  - A transaction generator that is responsible for generating load.
  - A transaction executor that pulls blocks and executes them.

The logic is relatively simple: we just execute a block and then immediately commit it. We could consider generating something like a 3-chain and buffer some blocks to simulate real-world scenarios, but current implementation is probably close enough.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Maybe.

## Test Plan

Added a test that runs the benchmark for a small input.