### PR TITLE
[move source language] Added Variable Elimination

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -244,6 +244,16 @@ impl Command_ {
         }
     }
 
+    pub fn is_unit(&self) -> bool {
+        use Command_ as C;
+        match self {
+            C::Assign(ls, e) => ls.is_empty() && e.is_unit(),
+            C::IgnoreAndPop { exp: e, .. } => e.is_unit(),
+
+            C::Mutate(_, _) | C::Return(_) | C::Abort(_) | C::JumpIf { .. } | C::Jump(_) => false,
+        }
+    }
+
     pub fn successors(&self) -> BTreeSet<Label> {
         use Command_::*;
 
@@ -264,6 +274,21 @@ impl Command_ {
             }
         }
         successors
+    }
+}
+
+impl Exp {
+    pub fn is_unit(&self) -> bool {
+        self.exp.value.is_unit()
+    }
+}
+
+impl UnannotatedExp_ {
+    pub fn is_unit(&self) -> bool {
+        match self {
+            UnannotatedExp_::Unit => true,
+            _ => false,
+        }
     }
 }
 

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -1,0 +1,445 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::cfg::BlockCFG;
+use crate::parser::ast::Var;
+use std::collections::BTreeSet;
+
+pub fn optimize(cfg: &mut BlockCFG) {
+    super::remove_no_ops::optimize(cfg);
+    loop {
+        let ssa_temps = {
+            let s = count(cfg);
+            if s.is_empty() {
+                return;
+            }
+            s
+        };
+        eliminate(cfg, ssa_temps);
+        super::remove_no_ops::optimize(cfg);
+    }
+}
+
+//**************************************************************************************************
+// Count assignment and usage
+//**************************************************************************************************
+
+fn count(cfg: &BlockCFG) -> BTreeSet<Var> {
+    let mut context = count::Context::new();
+    for block in cfg.blocks().values() {
+        for cmd in block {
+            count::command(&mut context, cmd)
+        }
+    }
+    context.finish()
+}
+
+mod count {
+    use crate::{
+        cfgir::ast::*,
+        parser::ast::{BinOp, UnaryOp, Var},
+        shared::*,
+    };
+    use std::collections::{BTreeMap, BTreeSet};
+
+    pub struct Context {
+        assigned: BTreeMap<Var, Option<usize>>,
+        used: BTreeMap<Var, Option<usize>>,
+    }
+
+    impl Context {
+        pub fn new() -> Self {
+            Context {
+                assigned: BTreeMap::new(),
+                used: BTreeMap::new(),
+            }
+        }
+
+        fn assign(&mut self, var: &Var, substitutable: bool) {
+            if !substitutable {
+                self.assigned.insert(var.clone(), None);
+                return;
+            }
+
+            if let Some(count) = self.assigned.entry(var.clone()).or_insert_with(|| Some(0)) {
+                *count += 1
+            }
+        }
+
+        fn used(&mut self, var: &Var, is_borrow_local: bool) {
+            if is_borrow_local {
+                self.used.insert(var.clone(), None);
+                return;
+            }
+
+            if let Some(count) = self.used.entry(var.clone()).or_insert_with(|| Some(0)) {
+                *count += 1
+            }
+        }
+
+        pub fn finish(self) -> BTreeSet<Var> {
+            let Context { assigned, used } = self;
+            assigned
+                .into_iter()
+                .filter(|(_v, count)| count.map(|c| c == 1).unwrap_or(false))
+                .map(|(v, _count)| v)
+                .filter(|v| {
+                    used.get(v)
+                        .unwrap_or(&None)
+                        .map(|c| c == 1)
+                        .unwrap_or(false)
+                })
+                .collect()
+        }
+    }
+
+    pub fn command(context: &mut Context, sp!(_, cmd_): &Command) {
+        use Command_ as C;
+        match cmd_ {
+            C::Assign(ls, e) => {
+                exp(context, e);
+                let substitutable_rvalues = can_subst_exp(ls.len(), e);
+                lvalues(context, ls, substitutable_rvalues);
+            }
+            C::Mutate(el, er) => {
+                exp(context, er);
+                exp(context, el)
+            }
+            C::Return(e)
+            | C::Abort(e)
+            | C::IgnoreAndPop { exp: e, .. }
+            | C::JumpIf { cond: e, .. } => exp(context, e),
+
+            C::Jump(_) => (),
+        }
+    }
+
+    fn lvalues(context: &mut Context, ls: &[LValue], substitutable_rvalues: Vec<bool>) {
+        assert!(ls.len() == substitutable_rvalues.len());
+        ls.iter()
+            .zip(substitutable_rvalues)
+            .for_each(|(l, substitutable)| lvalue(context, l, substitutable))
+    }
+
+    fn lvalue(context: &mut Context, sp!(_, l_): &LValue, substitutable: bool) {
+        use LValue_ as L;
+        match l_ {
+            L::Ignore | L::Unpack(_, _, _) => (),
+            L::Var(v, _) => context.assign(v, substitutable),
+        }
+    }
+
+    fn exp(context: &mut Context, parent_e: &Exp) {
+        use UnannotatedExp_ as E;
+        match &parent_e.exp.value {
+            E::Unit | E::Value(_) | E::UnresolvedError => (),
+
+            E::BorrowLocal(_, var) => context.used(var, true),
+
+            E::Copy { var, .. } | E::Move { var, .. } => context.used(var, false),
+
+            E::ModuleCall(mcall) => exp(context, &mcall.arguments),
+            E::Builtin(_, e)
+            | E::Freeze(e)
+            | E::Dereference(e)
+            | E::UnaryExp(_, e)
+            | E::Borrow(_, e, _) => exp(context, e),
+
+            E::BinopExp(e1, _, e2) => {
+                exp(context, e1);
+                exp(context, e2)
+            }
+
+            E::Pack(_, _, fields) => fields.iter().for_each(|(_, _, e)| exp(context, e)),
+
+            E::ExpList(es) => es.iter().for_each(|item| exp_list_item(context, item)),
+        }
+    }
+
+    fn exp_list_item(context: &mut Context, item: &ExpListItem) {
+        match item {
+            ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => exp(context, e),
+        }
+    }
+
+    fn can_subst_exp(lvalue_len: usize, exp: &Exp) -> Vec<bool> {
+        use ExpListItem as I;
+        use UnannotatedExp_ as E;
+        match (lvalue_len, &exp.exp.value) {
+            (0, _) => vec![],
+            (1, _) => vec![can_subst_exp_single(exp)],
+            (_, E::ExpList(es))
+                if es.iter().all(|item| match item {
+                    I::Splat(_, _, _) => false,
+                    I::Single(_, _) => true,
+                }) =>
+            {
+                es.iter()
+                    .map(|item| match item {
+                        I::Single(e, _) => can_subst_exp_single(e),
+                        I::Splat(_, _, _) => unreachable!(),
+                    })
+                    .collect()
+            }
+            (_, _) => (0..lvalue_len).map(|_| false).collect(),
+        }
+    }
+
+    fn can_subst_exp_single(parent_e: &Exp) -> bool {
+        use UnannotatedExp_ as E;
+        match &parent_e.exp.value {
+            E::UnresolvedError
+            | E::BorrowLocal(_, _)
+            | E::Copy { .. }
+            | E::Builtin(_, _)
+            | E::Freeze(_)
+            | E::Dereference(_)
+            | E::Move { .. }
+            | E::Borrow(_, _, _) => false,
+
+            E::Unit | E::Value(_) => true,
+
+            E::UnaryExp(op, e) => can_subst_exp_unary(op) && can_subst_exp_single(e),
+            E::BinopExp(e1, op, e2) => {
+                can_subst_exp_binary(op) && can_subst_exp_single(e1) && can_subst_exp_single(e2)
+            }
+            E::ModuleCall(mcall) => can_subst_exp_module_call(mcall),
+            E::ExpList(es) => es.iter().all(|i| can_subst_exp_item(i)),
+            E::Pack(_, _, fields) => fields.iter().all(|(_, _, e)| can_subst_exp_single(e)),
+        }
+    }
+
+    fn can_subst_exp_unary(sp!(_, op_): &UnaryOp) -> bool {
+        op_.is_pure()
+    }
+
+    fn can_subst_exp_binary(sp!(_, op_): &BinOp) -> bool {
+        op_.is_pure()
+    }
+
+    fn can_subst_exp_module_call(mcall: &ModuleCall) -> bool {
+        use crate::shared::fake_natives::transaction as TXN;
+        let ModuleCall {
+            module,
+            name,
+            arguments,
+            ..
+        } = mcall;
+        let a_m_f = (
+            &module.0.value.address,
+            module.0.value.name.value(),
+            name.value(),
+        );
+        let call_is_pure = match a_m_f {
+            (&Address::LIBRA_CORE, TXN::MOD, TXN::ASSERT) => panic!("ICE should have been inlined"),
+            (&Address::LIBRA_CORE, TXN::MOD, TXN::MAX_GAS)
+            | (&Address::LIBRA_CORE, TXN::MOD, TXN::SENDER)
+            | (&Address::LIBRA_CORE, TXN::MOD, TXN::SEQUENCE_NUM)
+            | (&Address::LIBRA_CORE, TXN::MOD, TXN::PUBLIC_KEY)
+            | (&Address::LIBRA_CORE, TXN::MOD, TXN::GAS_PRICE) => true,
+            _ => false,
+        };
+        call_is_pure && can_subst_exp_single(arguments)
+    }
+
+    fn can_subst_exp_item(item: &ExpListItem) -> bool {
+        use ExpListItem as I;
+        match item {
+            I::Single(e, _) => can_subst_exp_single(e),
+            I::Splat(_, es, _) => can_subst_exp_single(es),
+        }
+    }
+}
+
+//**************************************************************************************************
+// Eliminate
+//**************************************************************************************************
+
+fn eliminate(cfg: &mut BlockCFG, ssa_temps: BTreeSet<Var>) {
+    let context = &mut eliminate::Context::new(ssa_temps);
+    loop {
+        for block in cfg.blocks_mut().values_mut() {
+            for cmd in block {
+                eliminate::command(context, cmd)
+            }
+        }
+        if context.finished() {
+            return;
+        }
+    }
+}
+
+mod eliminate {
+    use crate::{cfgir::ast, cfgir::ast::*, parser::ast::Var, shared::*};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    pub struct Context {
+        eliminated: BTreeMap<Var, Exp>,
+        ssa_temps: BTreeSet<Var>,
+    }
+
+    impl Context {
+        pub fn new(ssa_temps: BTreeSet<Var>) -> Self {
+            Context {
+                ssa_temps,
+                eliminated: BTreeMap::new(),
+            }
+        }
+
+        pub fn finished(&self) -> bool {
+            self.eliminated.is_empty() && self.ssa_temps.is_empty()
+        }
+    }
+
+    pub fn command(context: &mut Context, sp!(_, cmd_): &mut Command) {
+        use Command_ as C;
+        match cmd_ {
+            C::Assign(ls, e) => {
+                exp(context, e);
+                let eliminated = lvalues(context, ls);
+                remove_eliminated(context, eliminated, e)
+            }
+            C::Mutate(el, er) => {
+                exp(context, er);
+                exp(context, el)
+            }
+            C::Return(e)
+            | C::Abort(e)
+            | C::IgnoreAndPop { exp: e, .. }
+            | C::JumpIf { cond: e, .. } => exp(context, e),
+
+            C::Jump(_) => (),
+        }
+    }
+
+    enum LRes {
+        Same(LValue),
+        Elim(Var),
+    }
+
+    fn lvalues(context: &mut Context, ls: &mut Vec<LValue>) -> Vec<Option<Var>> {
+        let old = std::mem::replace(ls, vec![]);
+        old.into_iter()
+            .map(|l| match lvalue(context, l) {
+                LRes::Same(lvalue) => {
+                    ls.push(lvalue);
+                    None
+                }
+                LRes::Elim(v) => Some(v),
+            })
+            .collect()
+    }
+
+    fn lvalue(context: &mut Context, sp!(loc, l_): LValue) -> LRes {
+        use LValue_ as L;
+        match l_ {
+            l_ @ L::Ignore | l_ @ L::Unpack(_, _, _) => LRes::Same(sp(loc, l_)),
+            L::Var(v, t) => {
+                let contained = context.ssa_temps.remove(&v);
+                if contained {
+                    LRes::Elim(v)
+                } else {
+                    LRes::Same(sp(loc, L::Var(v, t)))
+                }
+            }
+        }
+    }
+
+    fn exp(context: &mut Context, parent_e: &mut Exp) {
+        use UnannotatedExp_ as E;
+        match &mut parent_e.exp.value {
+            E::Copy { var, .. } | E::Move { var, .. } => {
+                if let Some(replacement) = context.eliminated.remove(var) {
+                    *parent_e = replacement
+                }
+            }
+
+            E::Unit | E::Value(_) | E::UnresolvedError | E::BorrowLocal(_, _) => (),
+
+            E::ModuleCall(mcall) => exp(context, &mut mcall.arguments),
+            E::Builtin(_, e)
+            | E::Freeze(e)
+            | E::Dereference(e)
+            | E::UnaryExp(_, e)
+            | E::Borrow(_, e, _) => exp(context, e),
+
+            E::BinopExp(e1, _, e2) => {
+                exp(context, e1);
+                exp(context, e2)
+            }
+
+            E::Pack(_, _, fields) => fields.iter_mut().for_each(|(_, _, e)| exp(context, e)),
+
+            E::ExpList(es) => es.iter_mut().for_each(|item| exp_list_item(context, item)),
+        }
+    }
+
+    fn exp_list_item(context: &mut Context, item: &mut ExpListItem) {
+        match item {
+            ExpListItem::Single(e, _) | ExpListItem::Splat(_, e, _) => exp(context, e),
+        }
+    }
+
+    fn remove_eliminated(context: &mut Context, mut eliminated: Vec<Option<Var>>, e: &mut Exp) {
+        if eliminated.iter().all(|opt| opt.is_none()) {
+            return;
+        }
+
+        match eliminated.len() {
+            0 => (),
+            1 => remove_eliminated_single(context, eliminated.pop().unwrap().unwrap(), e),
+
+            _ => {
+                let tys = match &mut e.ty.value {
+                    Type_::Multiple(tys) => tys,
+                    _ => panic!("ICE local elimination type mismatch"),
+                };
+                let es = match &mut e.exp.value {
+                    UnannotatedExp_::ExpList(es) => es,
+                    _ => panic!("ICE local elimination type mismatch"),
+                };
+                let old_tys = std::mem::replace(tys, vec![]);
+                let old_es = std::mem::replace(es, vec![]);
+                for ((mut item, ty), elim_opt) in old_es.into_iter().zip(old_tys).zip(eliminated) {
+                    let e = match &mut item {
+                        ExpListItem::Single(e, _) => e,
+                        ExpListItem::Splat(_, _, _) => {
+                            panic!("ICE local elimination filtering failed")
+                        }
+                    };
+                    match elim_opt {
+                        None => {
+                            tys.push(ty);
+                            es.push(item)
+                        }
+                        Some(v) => {
+                            remove_eliminated_single(context, v, e);
+                            match &e.ty.value {
+                                Type_::Unit => (),
+                                Type_::Single(_) => {
+                                    tys.push(ty);
+                                    es.push(item)
+                                }
+                                Type_::Multiple(_) => {
+                                    panic!("ICE local elimination replacement type mismatch")
+                                }
+                            }
+                        }
+                    }
+                }
+                if es.is_empty() {
+                    *e = unit(e.exp.loc)
+                }
+            }
+        }
+    }
+
+    fn remove_eliminated_single(context: &mut Context, v: Var, e: &mut Exp) {
+        let old = std::mem::replace(e, unit(e.exp.loc));
+        context.eliminated.insert(v, old);
+    }
+
+    fn unit(loc: Loc) -> Exp {
+        ast::exp(sp(loc, Type_::Unit), sp(loc, UnannotatedExp_::Unit))
+    }
+}

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -242,7 +242,7 @@ fn use_local(context: &mut Context, loc: &Loc, local: &Var) {
             };
             let unavailable = *unavailable;
             let vstr = match display_var(local.value()) {
-                DisplayVar::Tmp => panic!("ICE invalid use tmp local"),
+                DisplayVar::Tmp => panic!("ICE invalid use tmp local {}", local.value()),
                 DisplayVar::Orig(s) => s,
             };
             context.error(vec![

--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -5,8 +5,10 @@ mod absint;
 pub mod ast;
 mod borrows;
 pub mod cfg;
+mod eliminate_locals;
 mod liveness;
 mod locals;
+mod remove_no_ops;
 pub mod translate;
 
 use crate::shared::unique_map::UniqueMap;
@@ -15,20 +17,15 @@ use ast::*;
 use cfg::*;
 use std::collections::BTreeSet;
 
-/// This is a placeholder for "optimization passes" that "fix" operations so the behave as expected
-/// The two major passes here are:
-/// - Last inferred copy becomes an inferred move
-/// - References are "released"/popped after their last usage
-///   - Might prove be a bit tricky to get exactly right as it might happen only at the statement
-///     level instead of the expression level
-pub fn refine_and_verify(
+pub fn refine_inference_and_verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
     locals: &UniqueMap<Var, SingleType>,
     cfg: &mut BlockCFG,
     infinite_loop_starts: &BTreeSet<Label>,
 ) {
-    liveness::refine_and_verify(errors, signature, locals, cfg, infinite_loop_starts);
+    remove_no_ops::optimize(cfg);
+    liveness::refine_inference_and_verify(errors, signature, locals, cfg, infinite_loop_starts);
 }
 
 pub fn verify(
@@ -39,4 +36,12 @@ pub fn verify(
 ) {
     locals::verify(errors, signature, locals, cfg);
     borrows::verify(errors, signature, locals, cfg)
+}
+
+pub fn optimize(
+    _signature: &FunctionSignature,
+    _locals: &UniqueMap<Var, SingleType>,
+    cfg: &mut BlockCFG,
+) {
+    eliminate_locals::optimize(cfg);
 }

--- a/language/move-lang/src/cfgir/remove_no_ops.rs
+++ b/language/move-lang/src/cfgir/remove_no_ops.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ast::*, cfg::BlockCFG};
+
+pub fn optimize(cfg: &mut BlockCFG) {
+    for block in cfg.blocks_mut().values_mut() {
+        let old_block = std::mem::replace(block, BasicBlock::new());
+        *block = old_block
+            .into_iter()
+            .filter(|c| !c.value.is_unit())
+            .collect()
+    }
+}

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -128,7 +128,7 @@ pub enum Statement_ {
         else_block: Block,
     },
     While {
-        cond: Box<Exp>,
+        cond: (Block, Box<Exp>),
         block: Block,
     },
     Loop {
@@ -530,9 +530,20 @@ impl AstDebug for Statement_ {
                 w.write(" else ");
                 w.block(|w| else_block.ast_debug(w));
             }
-            S::While { cond, block } => {
+            S::While {
+                cond: (cond_block, cond_exp),
+                block,
+            } => {
                 w.write("while (");
-                cond.ast_debug(w);
+                if cond_block.is_empty() {
+                    cond_exp.ast_debug(w);
+                } else {
+                    w.block(|w| {
+                        cond_block.ast_debug(w);
+                        w.writeln(";");
+                        cond_exp.ast_debug(w);
+                    })
+                }
                 w.write(")");
                 w.block(|w| block.ast_debug(w))
             }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -441,6 +441,35 @@ impl Type_ {
     }
 }
 
+impl BinOp_ {
+    pub fn is_pure(&self) -> bool {
+        use BinOp_ as B;
+        match self {
+            B::Add | B::Sub | B::Mul | B::Mod | B::Div => false,
+            B::BitOr
+            | B::BitAnd
+            | B::Xor
+            | B::And
+            | B::Or
+            | B::Eq
+            | B::Neq
+            | B::Lt
+            | B::Gt
+            | B::Le
+            | B::Ge => true,
+        }
+    }
+}
+
+impl UnaryOp_ {
+    pub fn is_pure(&self) -> bool {
+        use UnaryOp_ as U;
+        match self {
+            U::Not | U::Neg => true,
+        }
+    }
+}
+
 //**************************************************************************************************
 // Display
 //**************************************************************************************************

--- a/language/move-lang/tests/functional/evaluation_order/struct_arguments.move
+++ b/language/move-lang/tests/functional/evaluation_order/struct_arguments.move
@@ -1,0 +1,101 @@
+//! new-transaction
+
+module M {
+    struct S {
+        a: u64,
+        b: u64,
+    }
+
+    resource struct R {}
+    resource struct Cup {
+        a: u64,
+        b: R,
+    }
+
+    public t0() {
+        S { b: 1 / 0, a: fail(0) };
+    }
+
+    public t1() {
+        S { b: 18446744073709551615 + 18446744073709551615, a: fail(0) };
+    }
+
+    public t2() {
+        S { b: 0 - 1, a: fail(0) };
+    }
+
+    public t3() {
+        S { b: 1 % 0, a: fail(0) };
+    }
+
+    public t4() {
+        S { b: 18446744073709551615 * 18446744073709551615, a: fail(0) };
+    }
+
+    public t5() acquires R {
+        move_to_sender(Cup { b: move_from(0x0), a: fail(0) });
+    }
+
+    public t6() {
+        move_to_sender(Cup { b: R{}, a: 0 });
+        S { b: mts(), a: fail(0) };
+    }
+
+    fail(code: u64): u64 {
+        abort code
+    }
+
+    mts(): u64 {
+        move_to_sender(Cup { b: R{}, a: 0 });
+        0
+    }
+}
+
+//! new-transaction
+// check: ARITHMETIC_ERROR
+use {{default}}::M;
+main() {
+  M::t0()
+}
+
+//! new-transaction
+// check: ARITHMETIC_ERROR
+use {{default}}::M;
+main() {
+  M::t1()
+}
+
+//! new-transaction
+// check: ARITHMETIC_ERROR
+use {{default}}::M;
+main() {
+  M::t2()
+}
+
+//! new-transaction
+// check: ARITHMETIC_ERROR
+use {{default}}::M;
+main() {
+  M::t3()
+}
+
+//! new-transaction
+// check: ARITHMETIC_ERROR
+use {{default}}::M;
+main() {
+  M::t4()
+}
+
+//! new-transaction
+// check: MISSING_DATA
+use {{default}}::M;
+main() {
+  M::t5()
+}
+
+//! new-transaction
+// check: CANNOT_WRITE_EXISTING_RESOURCE
+use {{default}}::M;
+main() {
+  M::t6()
+}

--- a/language/move-lang/tests/functional_testsuite.rs
+++ b/language/move-lang/tests/functional_testsuite.rs
@@ -66,9 +66,9 @@ impl Compiler for MoveSourceCompiler {
     }
 }
 
-fn run_test(path: &Path) -> datatest_stable::Result<()> {
+fn functional_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let compiler = MoveSourceCompiler::new(stdlib_files());
     testsuite::functional_tests(compiler, path)
 }
 
-datatest_stable::harness!(run_test, "tests/functional", r".*\.move");
+datatest_stable::harness!(functional_testsuite, "tests/functional", r".*\.move");

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch.move
@@ -42,4 +42,13 @@ module M {
         _ = move x;
     }
 
+    t4(cond: bool) {
+        let x = cond;
+        let x_ref = &x;
+        if (*x_ref) {
+        } else {
+        };
+        _ = x;
+        _ = move x;
+    }
 }

--- a/language/move-lang/tests/move_check/liveness/dead_refs_loop.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_loop.move
@@ -30,4 +30,14 @@ module M {
         _ = move x;
     }
 
+    t4(cond: bool) {
+        let x = cond;
+        let x_ref = &x;
+        while (*x_ref) {
+
+        };
+        _ = x;
+        _ = move x;
+    }
+
 }

--- a/language/move-lang/tests/move_check/locals/eliminate_temps.exp
+++ b/language/move-lang/tests/move_check/locals/eliminate_temps.exp
@@ -1,0 +1,44 @@
+error: 
+
+   ┌── tests/move_check/locals/eliminate_temps.move:7:39 ───
+   │
+ 7 │         let (boom, u): (&u64, u64) = (&mut x, x);
+   │                                               ^ Invalid copy of local 'x'
+   ·
+ 7 │         let (boom, u): (&u64, u64) = (&mut x, x);
+   │                                       ------ It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/locals/eliminate_temps.move:14:36 ───
+    │
+ 14 │         let (f, u): (&u64, u64) = (r, *r);
+    │                                       ^^ Invalid dereference.
+    ·
+ 14 │         let (f, u): (&u64, u64) = (r, *r);
+    │                                    - It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/eliminate_temps.move:20:36 ───
+    │
+ 20 │         let (f, u): (&u64, u64) = (&mut s.f, s.f);
+    │                                              ^^^ Invalid immutable borrow at field 'f'.
+    ·
+ 20 │         let (f, u): (&u64, u64) = (&mut s.f, s.f);
+    │                                    -------- Field 'f' is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/eliminate_temps.move:27:33 ───
+    │
+ 27 │         let (f, u): (&R, &R) = (borrow_global_mut<R>(a), borrow_global<R>(a));
+    │                                                          ^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
+    ·
+ 27 │         let (f, u): (&R, &R) = (borrow_global_mut<R>(a), borrow_global<R>(a));
+    │                                 ----------------------- It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/locals/eliminate_temps.move
+++ b/language/move-lang/tests/move_check/locals/eliminate_temps.move
@@ -1,0 +1,31 @@
+module M {
+    struct S {f: u64}
+    resource struct R {}
+
+    public borrow_local(x: u64): u64 {
+        // implicit freeze creates a temp local. If the temp is inlined, the copy won't fail
+        let (boom, u): (&u64, u64) = (&mut x, x);
+        *boom + u + x
+    }
+
+    public deref(x: u64): u64 {
+        let r = &mut x;
+        // implicit freeze creates a temp local. If the temp is inlined, the deref won't fail
+        let (f, u): (&u64, u64) = (r, *r);
+        *f + u + x
+    }
+
+    public borrow_field(s: &mut S): u64 {
+        // implicit freeze creates a temp local. If the temp is inlined, the borrow field won't fail
+        let (f, u): (&u64, u64) = (&mut s.f, s.f);
+        *f + u
+    }
+
+    public bg(a: address) acquires R {
+        // implicit freeze creates a temp local.
+        // If the temp is inlined, the borrow global won't fail
+        let (f, u): (&R, &R) = (borrow_global_mut<R>(a), borrow_global<R>(a));
+        f;
+        u;
+    }
+}

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -130,7 +130,7 @@ error:
     │ ╰─────^ Invalid return
     ·
  28 │         let _ = &R{};
-    │                 ---- The resource is created but not used. The resource must be consumed before the function returns
+    │                  --- The resource is created but not used. The resource must be consumed before the function returns
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
@@ -79,13 +79,13 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:33:17 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:33:18 ───
     │
  34 │         return ()
     │         ^^^^^^^^^ Invalid return
     ·
  33 │         let x = &R{};
-    │                 ---- The resource is created but not used. The resource must be consumed before the function returns
+    │                  --- The resource is created but not used. The resource must be consumed before the function returns
     │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/borrow_local_temp_resource.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_temp_resource.exp
@@ -10,7 +10,7 @@ error:
    │ ╰─────^ Invalid return
    ·
  6 │         &R{};
-   │         ---- The resource is created but not used. The resource must be consumed before the function returns
+   │          --- The resource is created but not used. The resource must be consumed before the function returns
    │
 
 error: 
@@ -25,6 +25,6 @@ error:
    │ ╰─────^ Invalid return
    ·
  7 │         &mut R{};
-   │         -------- The resource is created but not used. The resource must be consumed before the function returns
+   │              --- The resource is created but not used. The resource must be consumed before the function returns
    │
 

--- a/language/move-lang/tests/move_check/typing/while_condition.move
+++ b/language/move-lang/tests/move_check/typing/while_condition.move
@@ -5,8 +5,8 @@ module M {
     }
 
     t1() {
-        while ({ let x = true; x }) ();
-        while ({ let x = false; x }) ()
+        while ({ let foo = true; foo }) ();
+        while ({ let bar = false; bar }) ()
     }
 
 }


### PR DESCRIPTION
## Motivation

- Temps are introduced to help reorder the evaluation of the fields for pack and for freezing exp-list/tuples
- Often, these temps are not needed and can be removed
- Added a pass to eliminate locals (user defined or compiler generated) that:
  - Are used once (all of them should be)
  - Are assigned once (if statement results are not)
  - And have a "pure" expression for their binding

As a follow up, I'll probably add a StLoc/MoveLoc elimination at the bytecode level

## Test Plan

- New functional tests for runtime results 
- New test to make sure an incorrect program is not made correct