### PR TITLE
[RFC][Consensus] Add prelude stage to event processor

### DIFF
--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -140,25 +140,8 @@ impl<T: Payload> BlockStore<T> {
         if !self.need_sync_for_quorum_cert(&highest_commit_cert) {
             return Ok(());
         }
-        debug!(
-            "Start state sync with peer: {}, to block: {} from {}",
-            retriever.preferred_peer.short_str(),
-            highest_commit_cert.commit_info(),
-            self.root()
-        );
-        let blocks = retriever
-            .retrieve_block_for_qc(&highest_commit_cert, 3)
-            .await?;
-        assert_eq!(
-            blocks.last().expect("should have 3-chain").id(),
-            highest_commit_cert.commit_info().id(),
-        );
-        let mut quorum_certs = vec![];
-        quorum_certs.push(highest_commit_cert.clone());
-        quorum_certs.push(blocks[0].quorum_cert().clone());
-        quorum_certs.push(blocks[1].quorum_cert().clone());
-        // If a node restarts in the middle of state synchronization, it is going to try to catch up
-        // to the stored quorum certs as the new root.
+        let (blocks, quorum_certs) =
+            Self::fast_forward_sync(&highest_commit_cert, retriever).await?;
         self.storage
             .save_tree(blocks.clone(), quorum_certs.clone())?;
         let pre_sync_instance = Instant::now();
@@ -166,7 +149,8 @@ impl<T: Payload> BlockStore<T> {
             .sync_to(highest_commit_cert.ledger_info().clone())
             .await?;
         counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());
-        let (root, root_executed_trees, blocks, quorum_certs) = self.storage.start().await.take();
+        let (root, root_executed_trees, blocks, quorum_certs) =
+            self.storage.start().await.unwrap().take();
         debug!("{}Sync to{} {}", Fg(Blue), Fg(Reset), root.0);
         self.rebuild(root, root_executed_trees, blocks, quorum_certs)
             .await;
@@ -181,6 +165,31 @@ impl<T: Payload> BlockStore<T> {
                 .await;
         }
         Ok(())
+    }
+
+    pub async fn fast_forward_sync(
+        highest_commit_cert: &QuorumCert,
+        retriever: &mut BlockRetriever,
+    ) -> anyhow::Result<(Vec<Block<T>>, Vec<QuorumCert>)> {
+        debug!(
+            "Start state sync with peer: {}, to block: {}",
+            retriever.preferred_peer.short_str(),
+            highest_commit_cert.commit_info(),
+        );
+        let blocks = retriever
+            .retrieve_block_for_qc(&highest_commit_cert, 3)
+            .await?;
+        assert_eq!(
+            blocks.last().expect("should have 3-chain").id(),
+            highest_commit_cert.commit_info().id(),
+        );
+        let mut quorum_certs = vec![];
+        quorum_certs.push(highest_commit_cert.clone());
+        quorum_certs.push(blocks[0].quorum_cert().clone());
+        quorum_certs.push(blocks[1].quorum_cert().clone());
+        // If a node restarts in the middle of state synchronization, it is going to try to catch up
+        // to the stored quorum certs as the new root.
+        Ok((blocks, quorum_certs))
     }
 }
 


### PR DESCRIPTION
## Motivation

#2188 
The things this PR did:
1. Added a new struct `RemoteRecoveryData` which is used to capture data that we can get directly from remote ledger
2. Added `EventProcessorPrelude` which is responsible for:
   1. assembling `initial_data` and use it to bootstrap `event_processor`
   2. In case `initial_data` can't be assembled, wait for `sync_info` from peers and reconstruct `BlockStore` using the data get from peers
   3. Pass through all other events to the actual `EventProcessor` when it's created
3. Use `EventProcessorPrelude` in `EpochManager`

TODO:
- [ ] Figure out a good way to pass safety rules through prelude and make this thing compile
- [ ] Break up PR into three pieces:
        1. Introduction of `RemoteRecoveryData`
        2. Implementation of `EventProcessorPrelude`
        3. Use `EventProcessorPrelude` in `EpochManager`
- [ ] Add unit tests and smoke tests

## Test Plan