### PR TITLE
Remove unused mempool config address and port

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::utils;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -16,8 +15,6 @@ pub struct MempoolConfig {
     pub capacity_per_user: usize,
     pub system_transaction_timeout_secs: u64,
     pub system_transaction_gc_interval_ms: u64,
-    pub mempool_service_port: u16,
-    pub address: String,
 }
 
 impl Default for MempoolConfig {
@@ -30,15 +27,7 @@ impl Default for MempoolConfig {
             capacity: 1_000_000,
             capacity_per_user: 100,
             system_transaction_timeout_secs: 86400,
-            address: "localhost".to_string(),
-            mempool_service_port: 6182,
             system_transaction_gc_interval_ms: 180_000,
         }
-    }
-}
-
-impl MempoolConfig {
-    pub fn randomize_ports(&mut self) {
-        self.mempool_service_port = utils::get_available_port();
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -256,7 +256,6 @@ impl NodeConfig {
     pub fn randomize_ports(&mut self) {
         self.admission_control.randomize_ports();
         self.debug_interface.randomize_ports();
-        self.mempool.randomize_ports();
         self.storage.randomize_ports();
     }
 

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -50,8 +50,6 @@ capacity = 1000000
 capacity_per_user = 100
 system_transaction_timeout_secs = 86400
 system_transaction_gc_interval_ms = 180000
-mempool_service_port = 6182
-address = "localhost"
 
 [state_sync]
 chunk_limit = 250

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -68,8 +68,6 @@ capacity = 1000000
 capacity_per_user = 100
 system_transaction_timeout_secs = 86400
 system_transaction_gc_interval_ms = 180000
-mempool_service_port = 6182
-address = "localhost"
 
 [state_sync]
 chunk_limit = 250


### PR DESCRIPTION
## Motivation

The address and port in MempoolConfig are not being used. This PR removes them as an effort to clean up the config code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A local run of 'cargo xtest' doesn't produce any issues!

## Related PRs

None.
