### PR TITLE
[docker] Add config-builder to validator image

### DIFF
--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -17,6 +17,7 @@ FROM toolchain AS builder
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder && cd target/release && rm -r build deps incremental
+RUN strip /libra/target/release/config-builder
 
 ### Production Image ###
 FROM debian:buster AS prod
@@ -26,6 +27,7 @@ RUN addgroup --system --gid 6180 libra && adduser --system --ingroup libra --no-
 RUN mkdir -p /opt/libra/bin /opt/libra/etc
 COPY docker/install-tools.sh /root
 COPY --from=builder /libra/target/release/libra-node /opt/libra/bin
+COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
 
 # Admission control
 EXPOSE 8000


### PR DESCRIPTION
## Motivation

Some pre-mainnet partners want to run their validator without an
initContainer to do the configuration. Include the (stripped)
config-builder to support this use case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Built the image.