### PR TITLE
Unify (IP, port) pairs in config using SocketAddr

### DIFF
--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -65,10 +65,8 @@ impl AdmissionControlService {
             .expect("[admission control] failed to create runtime");
 
         // Create storage read client
-        let storage_client: Arc<dyn StorageRead> = Arc::new(StorageReadServiceClient::new(
-            "localhost",
-            config.storage.port,
-        ));
+        let storage_client: Arc<dyn StorageRead> =
+            Arc::new(StorageReadServiceClient::new(&config.storage.address));
         let admission_control_service = AdmissionControlService::new(ac_sender, storage_client);
 
         runtime.spawn(

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -18,7 +18,7 @@ use futures::{
 use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_types::proto::types::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse};
-use std::{convert::TryFrom, net::ToSocketAddrs, sync::Arc};
+use std::{convert::TryFrom, sync::Arc};
 use storage_client::{StorageRead, StorageReadServiceClient};
 use tokio::runtime::{Builder, Runtime};
 
@@ -71,16 +71,10 @@ impl AdmissionControlService {
         ));
         let admission_control_service = AdmissionControlService::new(ac_sender, storage_client);
 
-        let port = config.admission_control.admission_control_service_port;
-        let addr = format!("{}:{}", config.admission_control.address, port)
-            .to_socket_addrs()
-            .unwrap()
-            .next()
-            .unwrap();
         runtime.spawn(
             tonic::transport::Server::builder()
                 .add_service(AdmissionControlServer::new(admission_control_service))
-                .serve(addr),
+                .serve(config.admission_control.address),
         );
         runtime
     }

--- a/config/src/config/admission_control_config.rs
+++ b/config/src/config/admission_control_config.rs
@@ -3,13 +3,13 @@
 
 use crate::utils;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 use std::time::Duration;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AdmissionControlConfig {
-    pub address: String,
-    pub admission_control_service_port: u16,
+    pub address: SocketAddr,
     pub need_to_check_mempool_before_validation: bool,
     pub max_concurrent_inbound_syncs: usize,
     pub upstream_proxy_timeout: Duration,
@@ -18,8 +18,7 @@ pub struct AdmissionControlConfig {
 impl Default for AdmissionControlConfig {
     fn default() -> AdmissionControlConfig {
         AdmissionControlConfig {
-            address: "0.0.0.0".to_string(),
-            admission_control_service_port: 8000,
+            address: "0.0.0.0:8000".parse().unwrap(),
             need_to_check_mempool_before_validation: false,
             max_concurrent_inbound_syncs: 100,
             upstream_proxy_timeout: Duration::from_secs(1),
@@ -29,6 +28,6 @@ impl Default for AdmissionControlConfig {
 
 impl AdmissionControlConfig {
     pub fn randomize_ports(&mut self) {
-        self.admission_control_service_port = utils::get_available_port();
+        self.address.set_port(utils::get_available_port());
     }
 }

--- a/config/src/config/debug_interface_config.rs
+++ b/config/src/config/debug_interface_config.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 #[serde(default, deny_unknown_fields)]
 pub struct DebugInterfaceConfig {
     pub admission_control_node_debug_port: u16,
-    pub storage_node_debug_port: u16,
     // This has similar use to the core-node-debug-server itself
     pub metrics_server_port: u16,
     pub public_metrics_server_port: u16,
@@ -19,7 +18,6 @@ impl Default for DebugInterfaceConfig {
     fn default() -> DebugInterfaceConfig {
         DebugInterfaceConfig {
             admission_control_node_debug_port: 6191,
-            storage_node_debug_port: 6194,
             metrics_server_port: 9101,
             public_metrics_server_port: 9102,
             address: "0.0.0.0".to_string(),
@@ -30,7 +28,6 @@ impl Default for DebugInterfaceConfig {
 impl DebugInterfaceConfig {
     pub fn randomize_ports(&mut self) {
         self.admission_control_node_debug_port = utils::get_available_port();
-        self.storage_node_debug_port = utils::get_available_port();
         self.metrics_server_port = utils::get_available_port();
         self.public_metrics_server_port = utils::get_available_port();
     }

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -3,13 +3,13 @@
 
 use crate::utils;
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
-    pub address: String,
-    pub port: u16,
+    pub address: SocketAddr,
     pub dir: PathBuf,
     pub grpc_max_receive_len: Option<i32>,
     #[serde(skip)]
@@ -19,8 +19,7 @@ pub struct StorageConfig {
 impl Default for StorageConfig {
     fn default() -> StorageConfig {
         StorageConfig {
-            address: "localhost".to_string(),
-            port: 6184,
+            address: "127.0.0.1:6184".parse().unwrap(),
             dir: PathBuf::from("libradb/db"),
             grpc_max_receive_len: Some(100_000_000),
             data_dir: PathBuf::from("/opt/libra/data/common"),
@@ -42,6 +41,6 @@ impl StorageConfig {
     }
 
     pub fn randomize_ports(&mut self) {
-        self.port = utils::get_available_port();
+        self.address.set_port(utils::get_available_port());
     }
 }

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -23,7 +23,6 @@ type = "in_memory_storage"
 
 [debug_interface]
 admission_control_node_debug_port = 6191
-storage_node_debug_port = 6194
 metrics_server_port = 9101
 public_metrics_server_port = 9102
 address = "0.0.0.0"
@@ -63,8 +62,7 @@ max_timeout_ms = 120000
 upstream_peers = []
 
 [storage]
-address = "localhost"
-port = 6184
+address = "127.0.0.1:6184"
 dir = "libradb/db"
 grpc_max_receive_len = 100000000
 

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -1,6 +1,5 @@
 [admission_control]
-address = "0.0.0.0"
-admission_control_service_port = 8000
+address = "0.0.0.0:8000"
 need_to_check_mempool_before_validation = false
 max_concurrent_inbound_syncs = 100
 

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -23,14 +23,12 @@ nanos = 0
 
 [debug_interface]
 admission_control_node_debug_port = 6191
-storage_node_debug_port = 6194
 metrics_server_port = 9101
 public_metrics_server_port = 9102
 address = "0.0.0.0"
 
 [storage]
-address = "localhost"
-port = 6184
+address = "127.0.0.1:6184"
 dir = "libradb/db"
 grpc_max_receive_len = 100000000
 [test.account_keypair]

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -13,8 +13,7 @@ port = 6183
 genesis_file_location = ""
 
 [admission_control]
-address = "0.0.0.0"
-admission_control_service_port = 8000
+address = "0.0.0.0:8000"
 need_to_check_mempool_before_validation = false
 max_concurrent_inbound_syncs = 100
 

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -55,8 +55,5 @@ pub fn make_consensus_provider(
 
 /// Create a storage read client based on the config
 pub fn create_storage_read_client(config: &NodeConfig) -> Arc<dyn StorageRead> {
-    Arc::new(StorageReadServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ))
+    Arc::new(StorageReadServiceClient::new(&config.storage.address))
 }

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -31,19 +31,10 @@ fn create_storage_server(config: &mut NodeConfig) -> Runtime {
 
 fn create_executor(config: &NodeConfig) -> (Executor<MockVM>, ExecutedTrees) {
     let mut rt = Runtime::new().unwrap();
-    let read_client = Arc::new(StorageReadServiceClient::new(
-        "localhost",
-        config.storage.port,
-    ));
-    let write_client = Arc::new(StorageWriteServiceClient::new(
-        "localhost",
-        config.storage.port,
-    ));
+    let read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
     let executor = Executor::new(read_client, write_client, config);
-    let read_client = Arc::new(StorageReadServiceClient::new(
-        "localhost",
-        config.storage.port,
-    ));
+    let read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let startup_info = rt
         .block_on(read_client.get_startup_info())
         .expect("unable to read ledger info from storage")
@@ -320,7 +311,7 @@ fn create_transaction_chunks(
         )
         .unwrap();
 
-    let storage_client = StorageReadServiceClient::new("localhost", config.storage.port);
+    let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
     let batches: Vec<_> = chunk_ranges
         .into_iter()
@@ -363,7 +354,7 @@ fn test_executor_execute_and_commit_chunk() {
     let (mut config, _) = config_builder::test_config();
     let storage_server = create_storage_server(&mut config);
     let (executor, mut committed_trees) = create_executor(&config);
-    let storage_client = StorageReadServiceClient::new("localhost", config.storage.port);
+    let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
     // Execute the first chunk. After that we should still get the genesis ledger info from DB.
     executor
@@ -464,7 +455,7 @@ fn test_executor_execute_and_commit_chunk_restart() {
     // First we simulate syncing the first chunk of transactions.
     {
         let (executor, mut committed_trees) = create_executor(&config);
-        let storage_client = StorageReadServiceClient::new("localhost", config.storage.port);
+        let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
         executor
             .execute_and_commit_chunk(
@@ -485,7 +476,7 @@ fn test_executor_execute_and_commit_chunk_restart() {
     // Then we restart executor and resume to the next chunk.
     {
         let (executor, _) = create_executor(&config);
-        let storage_client = StorageReadServiceClient::new("localhost", config.storage.port);
+        let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
         executor
             .execute_and_commit_chunk(

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -57,21 +57,12 @@ fn create_storage_service_and_executor(
 ) -> (Runtime, Executor<LibraVM>, ExecutedTrees) {
     let mut rt = start_storage_service(config);
 
-    let storage_read_client = Arc::new(StorageReadServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ));
-    let storage_write_client = Arc::new(StorageWriteServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ));
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
 
     let executor = Executor::new(storage_read_client, storage_write_client, config);
 
-    let storage_read_client = Arc::new(StorageReadServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ));
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
 
     let startup_info = rt
         .block_on(storage_read_client.get_startup_info())
@@ -187,10 +178,7 @@ fn test_execution_with_storage() {
     let (_storage_server_handle, executor, mut committed_trees) =
         create_storage_service_and_executor(&config);
 
-    let storage_read_client = Arc::new(StorageReadServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ));
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
 
     let seed = [1u8; 32];
     // TEST_SEED is also used to generate a random validator set in get_test_config. Each account

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -55,14 +55,8 @@ impl Drop for LibraHandle {
 }
 
 fn setup_executor(config: &NodeConfig) -> Arc<Executor<LibraVM>> {
-    let storage_read_client = Arc::new(StorageReadServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ));
-    let storage_write_client = Arc::new(StorageWriteServiceClient::new(
-        &config.storage.address,
-        config.storage.port,
-    ));
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
 
     Arc::new(Executor::new(
         storage_read_client,

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -83,9 +83,7 @@ fn main() {
     println!("To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:");
     println!(
         "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
-        validator_config
-            .admission_control
-            .admission_control_service_port,
+        validator_config.admission_control.address.port(),
         faucet_key_file_path,
     );
     let node_address_list = validator_swarm
@@ -96,7 +94,8 @@ fn main() {
             let port = NodeConfig::load(config)
                 .unwrap()
                 .admission_control
-                .admission_control_service_port;
+                .address
+                .port();
             format!("localhost:{}", port)
         })
         .collect::<Vec<String>>()
@@ -111,9 +110,7 @@ fn main() {
         println!("To connect to the full nodes you just spawned, use this command:");
         println!(
             "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
-            full_node_config
-                .admission_control
-                .admission_control_service_port,
+            full_node_config.admission_control.address.port(),
             faucet_key_file_path,
         );
     }

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -93,7 +93,7 @@ impl LibraNode {
             validator_peer_id,
             role,
             debug_client,
-            ac_port: config.admission_control.admission_control_service_port,
+            ac_port: config.admission_control.address.port(),
             log: log_path,
         })
     }

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -735,10 +735,8 @@ pub fn bootstrap(
         .expect("[shared mempool] failed to create runtime");
     let executor = runtime.handle();
     let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
-    let storage_client: Arc<dyn StorageRead> = Arc::new(StorageReadServiceClient::new(
-        "localhost",
-        config.storage.port,
-    ));
+    let storage_client: Arc<dyn StorageRead> =
+        Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let vm_validator = Arc::new(VMValidator::new(
         &config,
         Arc::clone(&storage_client),

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -54,10 +54,7 @@ pub(crate) struct ExecutorProxy {
 
 impl ExecutorProxy {
     pub(crate) fn new(executor: Arc<Executor<LibraVM>>, config: &NodeConfig) -> Self {
-        let storage_read_client = Arc::new(StorageReadServiceClient::new(
-            &config.storage.address,
-            config.storage.port,
-        ));
+        let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
         Self {
             storage_read_client,
             executor,

--- a/storage/backup-restore/src/bin/backup.rs
+++ b/storage/backup-restore/src/bin/backup.rs
@@ -25,7 +25,8 @@ struct Opt {
 async fn main() {
     let opt = Opt::from_args();
 
-    let client = StorageReadServiceClient::new("localhost", opt.node_port);
+    let address = format!("127.0.0.1:{}", opt.node_port).parse().unwrap();
+    let client = StorageReadServiceClient::new(&address);
 
     let (version, state_root_hash) = client
         .get_latest_state_root()

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -26,6 +26,7 @@ use libra_types::{
     transaction::{TransactionListWithProof, TransactionToCommit, Version},
 };
 use std::convert::TryFrom;
+use std::net::SocketAddr;
 use std::sync::Mutex;
 use storage_proto::{
     proto::storage::{
@@ -41,24 +42,24 @@ use storage_proto::{
 
 /// This provides storage read interfaces backed by real storage service.
 pub struct StorageReadServiceClient {
-    addr: String,
+    http_addr: String,
     client: Mutex<Option<StorageClient<tonic::transport::Channel>>>,
 }
 
 impl StorageReadServiceClient {
-    /// Constructs a `StorageReadServiceClient` with given host and port.
-    pub fn new(host: &str, port: u16) -> Self {
-        let addr = format!("http://{}:{}", host, port);
+    /// Constructs a `StorageReadServiceClient` with given SocketAddr.
+    pub fn new(address: &SocketAddr) -> Self {
+        let http_addr = format!("http://{}", address.to_string());
 
         Self {
             client: Mutex::new(None),
-            addr,
+            http_addr,
         }
     }
 
     async fn client(&self) -> Result<StorageClient<tonic::transport::Channel>, tonic::Status> {
         if self.client.lock().unwrap().is_none() {
-            let client = StorageClient::connect(self.addr.clone())
+            let client = StorageClient::connect(self.http_addr.clone())
                 .await
                 .map_err(|e| tonic::Status::new(tonic::Code::Unavailable, e.to_string()))?;
             *self.client.lock().unwrap() = Some(client);
@@ -236,24 +237,24 @@ impl StorageRead for StorageReadServiceClient {
 
 /// This provides storage write interfaces backed by real storage service.
 pub struct StorageWriteServiceClient {
-    addr: String,
+    http_addr: String,
     client: Mutex<Option<StorageClient<tonic::transport::Channel>>>,
 }
 
 impl StorageWriteServiceClient {
-    /// Constructs a `StorageWriteServiceClient` with given host and port.
-    pub fn new(host: &str, port: u16) -> Self {
-        let addr = format!("http://{}:{}", host, port);
+    /// Constructs a `StorageWriteServiceClient` with given SocketAddr.
+    pub fn new(address: &SocketAddr) -> Self {
+        let http_addr = format!("http://{}", address.to_string());
 
         Self {
             client: Mutex::new(None),
-            addr,
+            http_addr,
         }
     }
 
     async fn client(&self) -> Result<StorageClient<tonic::transport::Channel>, tonic::Status> {
         if self.client.lock().unwrap().is_none() {
-            let client = StorageClient::connect(self.addr.clone())
+            let client = StorageClient::connect(self.http_addr.clone())
                 .await
                 .map_err(|e| tonic::Status::new(tonic::Code::Unavailable, e.to_string()))?;
             *self.client.lock().unwrap() = Some(client);

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -21,7 +21,7 @@ use libra_types::proto::types::{
     UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse, ValidatorChangeProof,
 };
 use libradb::LibraDB;
-use std::{convert::TryFrom, net::ToSocketAddrs, path::Path, sync::Arc};
+use std::{convert::TryFrom, path::Path, sync::Arc};
 use storage_proto::proto::storage::{
     storage_server::{Storage, StorageServer},
     BackupAccountStateRequest, BackupAccountStateResponse, GetAccountStateRangeProofRequest,
@@ -40,15 +40,10 @@ pub fn start_storage_service(config: &NodeConfig) -> Runtime {
 
     let storage_service = StorageService::new(&config.storage.dir());
 
-    let addr = format!("{}:{}", config.storage.address, config.storage.port)
-        .to_socket_addrs()
-        .unwrap()
-        .next()
-        .unwrap();
     rt.spawn(
         tonic::transport::Server::builder()
             .add_service(StorageServer::new(storage_service))
-            .serve(addr),
+            .serve(config.storage.address),
     );
     rt
 }

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -28,8 +28,8 @@ fn start_test_storage_with_read_write_client() -> (
 
     let storage_server_handle = start_storage_service(&config);
 
-    let read_client = StorageReadServiceClient::new(&config.storage.address, config.storage.port);
-    let write_client = StorageWriteServiceClient::new(&config.storage.address, config.storage.port);
+    let read_client = StorageReadServiceClient::new(&config.storage.address);
+    let write_client = StorageWriteServiceClient::new(&config.storage.address);
     (storage_server_handle, tmp_dir, read_client, write_client)
 }
 

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -90,7 +90,7 @@ impl Cluster {
                 }
                 Ok(r) => r,
             };
-            let ac_port = AdmissionControlConfig::default().admission_control_service_port as u32;
+            let ac_port = AdmissionControlConfig::default().address.port() as u32;
             for reservation in result.reservations.expect("no reservations") {
                 for aws_instance in reservation.instances.expect("no instances") {
                     let ip = aws_instance

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -31,15 +31,11 @@ impl TestValidator {
         let storage = start_storage_service(&config);
 
         // setup execution
-        let storage_read_client: Arc<dyn StorageRead> = Arc::new(StorageReadServiceClient::new(
-            &config.storage.address,
-            config.storage.port,
-        ));
+        let storage_read_client: Arc<dyn StorageRead> =
+            Arc::new(StorageReadServiceClient::new(&config.storage.address));
 
-        let storage_write_client = Arc::new(StorageWriteServiceClient::new(
-            &config.storage.address,
-            config.storage.port,
-        ));
+        let storage_write_client =
+            Arc::new(StorageWriteServiceClient::new(&config.storage.address));
 
         // Create executor to initialize genesis state. Otherwise gprc will report error when
         // fetching data from storage.
@@ -47,10 +43,8 @@ impl TestValidator {
 
         // Create another client for the vm_validator since the one used for the executor will be
         // run on another runtime which will be dropped before this function returns.
-        let read_client: Arc<dyn StorageRead> = Arc::new(StorageReadServiceClient::new(
-            &config.storage.address,
-            config.storage.port,
-        ));
+        let read_client: Arc<dyn StorageRead> =
+            Arc::new(StorageReadServiceClient::new(&config.storage.address));
         let vm_validator = VMValidator::new(config, read_client, rt.handle().clone());
 
         (


### PR DESCRIPTION
## Motivation

Configuration currently contains several instances of (IP address, port) pairs. Rather than representing these pairs manually and individually, we should be using the SocketAddr type to encapsulate each pair into a single entity. This PR does this for AdmissionControlConfig and StorageConfig. It also removes the unused 'storage_node_debug_port'.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A local run of 'cargo xtest' doesn't produce any issues.

## Related PRs

None.
