### PR TITLE
[language/ir-to-bytecode] use Foo_ for unspanned, Foo for spanned

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -9,7 +9,7 @@ use crate::{
         FunctionCall, FunctionCall_, FunctionName, FunctionSignature as AstFunctionSignature,
         FunctionVisibility, IfElse, ImportDefinition, LValue, LValue_, Loc, Loop, ModuleDefinition,
         ModuleIdent, ModuleName, Program, QualifiedModuleIdent, QualifiedStructIdent, Script,
-        Statement, StructDefinition as MoveStruct_, StructDefinitionFields, Type, TypeVar,
+        Statement, StructDefinition as AstStructDefinition, StructDefinitionFields, Type, TypeVar,
         TypeVar_, UnaryOp, Var, Var_, While,
     },
 };
@@ -546,7 +546,7 @@ fn function_signature(
 fn compile_structs(
     context: &mut Context,
     self_name: &ModuleName,
-    structs: Vec<MoveStruct_>,
+    structs: Vec<AstStructDefinition>,
 ) -> Result<(Vec<StructDefinition>, Vec<FieldDefinition>)> {
     let mut struct_defs = vec![];
     let mut field_defs = vec![];

--- a/language/compiler/ir-to-bytecode/src/context.rs
+++ b/language/compiler/ir-to-bytecode/src/context.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::parser::ast::{
-    Field, FunctionName, Loc, ModuleName, QualifiedModuleIdent, QualifiedStructIdent, StructName,
-    TypeVar,
+    Field_, FunctionName, Loc, ModuleName, QualifiedModuleIdent, QualifiedStructIdent, StructName,
+    TypeVar_,
 };
 
 use anyhow::{bail, format_err, Result};
@@ -25,7 +25,7 @@ use vm::{
     },
 };
 
-type TypeFormalMap = HashMap<TypeVar, TableIndex>;
+type TypeFormalMap = HashMap<TypeVar_, TableIndex>;
 
 macro_rules! get_or_add_item_macro {
     ($m:ident, $k_get:expr, $k_insert:expr) => {{
@@ -170,7 +170,7 @@ pub struct Context<'a> {
     struct_defs: HashMap<StructName, TableIndex>,
 
     // queryable pools
-    fields: HashMap<(StructHandleIndex, Field), (TableIndex, SignatureToken, usize)>,
+    fields: HashMap<(StructHandleIndex, Field_), (TableIndex, SignatureToken, usize)>,
     function_handles: HashMap<(ModuleName, FunctionName), (FunctionHandle, FunctionHandleIndex)>,
     function_signatures:
         HashMap<(ModuleName, FunctionName), (FunctionSignature, FunctionSignatureIndex)>,
@@ -281,7 +281,7 @@ impl<'a> Context<'a> {
     }
 
     /// Bind the type formals into a "pool" for the current context.
-    pub fn bind_type_formals(&mut self, m: HashMap<TypeVar, usize>) -> Result<()> {
+    pub fn bind_type_formals(&mut self, m: HashMap<TypeVar_, usize>) -> Result<()> {
         self.type_formals = m
             .into_iter()
             .map(|(k, idx)| {
@@ -332,7 +332,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get the type formal index, fails if it is not bound.
-    pub fn type_formal_index(&mut self, t: &TypeVar) -> Result<TableIndex> {
+    pub fn type_formal_index(&mut self, t: &TypeVar_) -> Result<TableIndex> {
         match self.type_formals.get(&t) {
             None => bail!("Unbound type parameter {}", t),
             Some(idx) => Ok(*idx),
@@ -366,7 +366,7 @@ impl<'a> Context<'a> {
     pub fn field(
         &self,
         s: StructHandleIndex,
-        f: Field,
+        f: Field_,
     ) -> Result<(FieldDefinitionIndex, SignatureToken, usize)> {
         match self.fields.get(&(s, f.clone())) {
             None => bail!("Unbound field {}", f),
@@ -521,7 +521,7 @@ impl<'a> Context<'a> {
     pub fn declare_field(
         &mut self,
         s: StructHandleIndex,
-        f: Field,
+        f: Field_,
         token: SignatureToken,
         decl_order: usize,
     ) -> Result<FieldDefinitionIndex> {

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -111,7 +111,7 @@ pub fn parse_module(modules_str: &str) -> Result<ast::ModuleDefinition> {
 
 /// Given the raw input of a file, creates a single `Cmd` struct
 /// Fails with `Err(_)` if the text cannot be parsed
-pub fn parse_cmd(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast::Cmd> {
+pub fn parse_cmd(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast::Cmd_> {
     let stripped_string = &strip_comments_and_verify(cmd_str)?;
     syntax::parse_cmd_string(stripped_string).or_else(|e| handle_error(e, stripped_string))
 }

--- a/language/compiler/ir-to-bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/ast.rs
@@ -65,7 +65,7 @@ pub struct Script {
     /// The dependencies of `main`, i.e. of the transaction script
     pub imports: Vec<ImportDefinition>,
     /// The transaction script's `main` procedure
-    pub main: Function_,
+    pub main: Function,
 }
 
 //**************************************************************************************************
@@ -94,9 +94,9 @@ pub struct ModuleDefinition {
     /// the module's dependencies
     pub imports: Vec<ImportDefinition>,
     /// the structs (including resources) that the module defines
-    pub structs: Vec<StructDefinition_>,
+    pub structs: Vec<StructDefinition>,
     /// the procedure that the module defines
-    pub functions: Vec<(FunctionName, Function_)>,
+    pub functions: Vec<(FunctionName, Function)>,
 }
 
 /// Either a qualified module name like `addr.m` or `Transaction.m`, which refers to a module in
@@ -128,17 +128,17 @@ pub struct ImportDefinition {
 
 /// Newtype for a variable/local
 #[derive(Debug, PartialEq, Hash, Eq, Clone, Ord, PartialOrd)]
-pub struct Var(Identifier);
+pub struct Var_(Identifier);
 
 /// The type of a variable with a location
-pub type Var_ = Spanned<Var>;
+pub type Var = Spanned<Var_>;
 
 /// New type that represents a type variable. Used to declare type formals & reference them.
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub struct TypeVar(Identifier);
+pub struct TypeVar_(Identifier);
 
 /// The type of a type variable with a location.
-pub type TypeVar_ = Spanned<TypeVar>;
+pub type TypeVar = Spanned<TypeVar_>;
 
 //**************************************************************************************************
 // Kinds
@@ -181,7 +181,7 @@ pub enum Type {
     /// A reference type, the bool flag indicates whether the reference is mutable
     Reference(bool, Box<Type>),
     /// A type parameter
-    TypeParameter(TypeVar),
+    TypeParameter(TypeVar_),
 }
 
 //**************************************************************************************************
@@ -200,13 +200,13 @@ pub struct QualifiedStructIdent {
 }
 
 /// The field newtype
-pub type Field = libra_types::access_path::Field;
+pub type Field_ = libra_types::access_path::Field;
 
 /// A field coupled with source location information
-pub type Field_ = Spanned<Field>;
+pub type Field = Spanned<Field_>;
 
 /// A field map
-pub type Fields<T> = Vec<(Field_, T)>;
+pub type Fields<T> = Vec<(Field, T)>;
 
 /// Newtype for the name of a struct
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -214,20 +214,20 @@ pub struct StructName(Identifier);
 
 /// A Move struct
 #[derive(Clone, Debug, PartialEq)]
-pub struct StructDefinition {
+pub struct StructDefinition_ {
     /// The struct will have kind resource if `is_nominal_resource` is true
     /// and will be dependent on it's type arguments otherwise
     pub is_nominal_resource: bool,
     /// Human-readable name for the struct that also serves as a nominal type
     pub name: StructName,
     /// Kind constraints of the type parameters
-    pub type_formals: Vec<(TypeVar_, Kind)>,
+    pub type_formals: Vec<(TypeVar, Kind)>,
     /// the fields each instance has
     pub fields: StructDefinitionFields,
 }
 
 /// The type of a StructDefinition along with its source location information
-pub type StructDefinition_ = Spanned<StructDefinition>;
+pub type StructDefinition = Spanned<StructDefinition_>;
 
 /// The fields of a Move struct definition
 #[derive(Clone, Debug, PartialEq)]
@@ -250,11 +250,11 @@ pub struct FunctionName(Identifier);
 #[derive(PartialEq, Debug, Clone)]
 pub struct FunctionSignature {
     /// Possibly-empty list of (formal name, formal type) pairs. Names are unique.
-    pub formals: Vec<(Var_, Type)>,
+    pub formals: Vec<(Var, Type)>,
     /// Optional return types
     pub return_type: Vec<Type>,
     /// Possibly-empty list of (TypeVar, Kind) pairs.s.
-    pub type_formals: Vec<(TypeVar_, Kind)>,
+    pub type_formals: Vec<(TypeVar, Kind)>,
 }
 
 /// Public or internal modifier for a procedure
@@ -275,8 +275,8 @@ pub enum FunctionBody {
     /// `locals` are all of the declared locals
     /// `code` is the code that defines the procedure
     Move {
-        locals: Vec<(Var_, Type)>,
-        code: Block,
+        locals: Vec<(Var, Type)>,
+        code: Block_,
     },
     /// The body is provided by the runtime
     Native,
@@ -284,7 +284,7 @@ pub enum FunctionBody {
 
 /// A Move function/procedure
 #[derive(PartialEq, Debug, Clone)]
-pub struct Function {
+pub struct Function_ {
     /// The visibility (public or internal)
     pub visibility: FunctionVisibility,
     /// The type signature
@@ -301,7 +301,7 @@ pub struct Function {
 }
 
 /// The type of a Function coupled with its source location information.
-pub type Function_ = Spanned<Function>;
+pub type Function = Spanned<Function_>;
 
 //**************************************************************************************************
 // Statements
@@ -338,7 +338,7 @@ pub enum Builtin {
 
 /// Enum for different function calls
 #[derive(Debug, PartialEq, Clone)]
-pub enum FunctionCall {
+pub enum FunctionCall_ {
     /// functions defined in the host environment
     Builtin(Builtin),
     /// The call of a module defined procedure
@@ -349,73 +349,73 @@ pub enum FunctionCall {
     },
 }
 /// The type for a function call and its location
-pub type FunctionCall_ = Spanned<FunctionCall>;
+pub type FunctionCall = Spanned<FunctionCall_>;
 
 /// Enum for Move lvalues
 #[derive(Debug, Clone, PartialEq)]
-pub enum LValue {
+pub enum LValue_ {
     /// `x`
-    Var(Var_),
+    Var(Var),
     /// `*e`
-    Mutate(Exp_),
+    Mutate(Exp),
     /// `_`
     Pop,
 }
-pub type LValue_ = Spanned<LValue>;
+pub type LValue = Spanned<LValue_>;
 
 /// Enum for Move commands
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq)]
-pub enum Cmd {
+pub enum Cmd_ {
     /// `l_1, ..., l_n = e`
-    Assign(Vec<LValue_>, Exp_),
+    Assign(Vec<LValue>, Exp),
     /// `n { f_1: x_1, ... , f_j: x_j  } = e`
-    Unpack(StructName, Vec<Type>, Fields<Var_>, Box<Exp_>),
+    Unpack(StructName, Vec<Type>, Fields<Var>, Box<Exp>),
     /// `abort e`
-    Abort(Option<Box<Exp_>>),
+    Abort(Option<Box<Exp>>),
     /// `return e_1, ... , e_j`
-    Return(Box<Exp_>),
+    Return(Box<Exp>),
     /// `break`
     Break,
     /// `continue`
     Continue,
-    Exp(Box<Exp_>),
+    Exp(Box<Exp>),
 }
 /// The type of a command with its location
-pub type Cmd_ = Spanned<Cmd>;
+pub type Cmd = Spanned<Cmd_>;
 
 /// Struct defining an if statement
 #[derive(Debug, PartialEq, Clone)]
 pub struct IfElse {
     /// the if's condition
-    pub cond: Exp_,
+    pub cond: Exp,
     /// the block taken if the condition is `true`
-    pub if_block: Block_,
+    pub if_block: Block,
     /// the block taken if the condition is `false`
-    pub else_block: Option<Block_>,
+    pub else_block: Option<Block>,
 }
 
 /// Struct defining a while statement
 #[derive(Debug, PartialEq, Clone)]
 pub struct While {
     /// The condition for a while statement
-    pub cond: Exp_,
+    pub cond: Exp,
     /// The block taken if the condition is `true`
-    pub block: Block_,
+    pub block: Block,
 }
 
 /// Struct defining a loop statement
 #[derive(Debug, PartialEq, Clone)]
 pub struct Loop {
     /// The body of the loop
-    pub block: Block_,
+    pub block: Block,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Statement {
     /// `c;`
-    CommandStatement(Cmd_),
+    CommandStatement(Cmd),
     /// `if (e) { s_1 } else { s_2 }`
     IfElseStatement(IfElse),
     /// `while (e) { s }`
@@ -428,13 +428,13 @@ pub enum Statement {
 
 #[derive(Debug, PartialEq, Clone)]
 /// `{ s }`
-pub struct Block {
+pub struct Block_ {
     /// The statements that make up the block
     pub stmts: VecDeque<Statement>,
 }
 
 /// The type of a Block coupled with source location information.
-pub type Block_ = Spanned<Block>;
+pub type Block = Spanned<Block_>;
 
 //**************************************************************************************************
 // Expressions
@@ -443,7 +443,7 @@ pub type Block_ = Spanned<Block>;
 /// Bottom of the value hierarchy. These values can be trivially copyable and stored in statedb as a
 /// single entry.
 #[derive(Debug, PartialEq, Clone)]
-pub enum CopyableVal {
+pub enum CopyableVal_ {
     /// An address in the global storage
     Address(AccountAddress),
     /// An unsigned 8-bit integer
@@ -459,10 +459,10 @@ pub enum CopyableVal {
 }
 
 /// The type of a value and its location
-pub type CopyableVal_ = Spanned<CopyableVal>;
+pub type CopyableVal = Spanned<CopyableVal_>;
 
 /// The type for fields and their bound expressions
-pub type ExpFields = Fields<Exp_>;
+pub type ExpFields = Fields<Exp>;
 
 /// Enum for unary operators
 #[derive(Debug, Clone, PartialEq)]
@@ -519,16 +519,16 @@ pub enum BinOp {
 
 /// Enum for all expressions
 #[derive(Debug, Clone, PartialEq)]
-pub enum Exp {
+pub enum Exp_ {
     /// `*e`
-    Dereference(Box<Exp_>),
+    Dereference(Box<Exp>),
     /// `op e`
-    UnaryExp(UnaryOp, Box<Exp_>),
+    UnaryExp(UnaryOp, Box<Exp>),
     /// `e_1 op e_2`
-    BinopExp(Box<Exp_>, BinOp, Box<Exp_>),
+    BinopExp(Box<Exp>, BinOp, Box<Exp>),
     /// Wrapper to lift `CopyableVal` into `Exp`
     /// `v`
-    Value(CopyableVal_),
+    Value(CopyableVal),
     /// Takes the given field values and instantiates the struct
     /// Returns a fresh `StructInstance` whose type and kind (resource or otherwise)
     /// as the current struct class (i.e., the class of the method we're currently executing).
@@ -539,24 +539,24 @@ pub enum Exp {
         /// mutable or not
         is_mutable: bool,
         /// the expression containing the reference
-        exp: Box<Exp_>,
+        exp: Box<Exp>,
         /// the field being borrowed
-        field: Field,
+        field: Field_,
     },
     /// `move(x)`
-    Move(Var_),
+    Move(Var),
     /// `copy(x)`
-    Copy(Var_),
+    Copy(Var),
     /// `&x` or `&mut x`
-    BorrowLocal(bool, Var_),
+    BorrowLocal(bool, Var),
     /// `f(e)` or `f(e_1, e_2, ..., e_j)`
-    FunctionCall(FunctionCall_, Box<Exp_>),
+    FunctionCall(FunctionCall, Box<Exp>),
     /// (e_1, e_2, e_3, ..., e_j)
-    ExprList(Vec<Exp_>),
+    ExprList(Vec<Exp>),
 }
 
-/// The type for a `Exp` and its location
-pub type Exp_ = Spanned<Exp>;
+/// The type for a `Exp_` and its location
+pub type Exp = Spanned<Exp_>;
 
 //**************************************************************************************************
 // impls
@@ -581,12 +581,12 @@ impl Program {
 
 impl Script {
     /// Create a new `Script` from the imports and the main function
-    pub fn new(imports: Vec<ImportDefinition>, main: Function_) -> Self {
+    pub fn new(imports: Vec<ImportDefinition>, main: Function) -> Self {
         Script { imports, main }
     }
 
     /// Accessor for the body of the 'main' procedure
-    pub fn body(&self) -> &Block {
+    pub fn body(&self) -> &Block_ {
         match self.main.body {
             FunctionBody::Move { ref code, .. } => &code,
             FunctionBody::Native => panic!("main() can't be native"),
@@ -668,8 +668,8 @@ impl ModuleDefinition {
     pub fn new<L>(
         name: impl Into<Box<str>>,
         imports: Vec<ImportDefinition>,
-        structs: Vec<StructDefinition_>,
-        functions: Vec<(FunctionName, Function_)>,
+        structs: Vec<StructDefinition>,
+        functions: Vec<(FunctionName, Function)>,
     ) -> Result<Self, ParseError<L, anyhow::Error>> {
         Ok(ModuleDefinition {
             name: ModuleName::parse(name.into())?,
@@ -768,7 +768,7 @@ impl StructName {
     }
 }
 
-impl StructDefinition {
+impl StructDefinition_ {
     /// Creates a new StructDefinition from the resource kind (true if resource), the string
     /// representation of the name, and the user specified fields, a map from their names to their
     /// types
@@ -777,10 +777,10 @@ impl StructDefinition {
     pub fn move_declared<L>(
         is_nominal_resource: bool,
         name: impl Into<Box<str>>,
-        type_formals: Vec<(TypeVar_, Kind)>,
+        type_formals: Vec<(TypeVar, Kind)>,
         fields: Fields<Type>,
     ) -> Result<Self, ParseError<L, anyhow::Error>> {
-        Ok(StructDefinition {
+        Ok(StructDefinition_ {
             is_nominal_resource,
             name: StructName::parse(name)?,
             type_formals,
@@ -794,9 +794,9 @@ impl StructDefinition {
     pub fn native<L>(
         is_nominal_resource: bool,
         name: impl Into<Box<str>>,
-        type_formals: Vec<(TypeVar_, Kind)>,
+        type_formals: Vec<(TypeVar, Kind)>,
     ) -> Result<Self, ParseError<L, anyhow::Error>> {
-        Ok(StructDefinition {
+        Ok(StructDefinition_ {
             is_nominal_resource,
             name: StructName::parse(name)?,
             type_formals,
@@ -830,9 +830,9 @@ impl FunctionName {
 impl FunctionSignature {
     /// Creates a new function signature from the parameters and the return types
     pub fn new(
-        formals: Vec<(Var_, Type)>,
+        formals: Vec<(Var, Type)>,
         return_type: Vec<Type>,
-        type_formals: Vec<(TypeVar_, Kind)>,
+        type_formals: Vec<(TypeVar, Kind)>,
     ) -> Self {
         FunctionSignature {
             formals,
@@ -842,20 +842,20 @@ impl FunctionSignature {
     }
 }
 
-impl Function {
+impl Function_ {
     /// Creates a new function declaration from the components of the function
     /// See the declaration of the struct `Function` for more details
     pub fn new(
         visibility: FunctionVisibility,
-        formals: Vec<(Var_, Type)>,
+        formals: Vec<(Var, Type)>,
         return_type: Vec<Type>,
-        type_formals: Vec<(TypeVar_, Kind)>,
+        type_formals: Vec<(TypeVar, Kind)>,
         acquires: Vec<StructName>,
         specifications: Vec<Condition_>,
         body: FunctionBody,
     ) -> Self {
         let signature = FunctionSignature::new(formals, return_type, type_formals);
-        Function {
+        Function_ {
             visibility,
             signature,
             acquires,
@@ -865,20 +865,15 @@ impl Function {
     }
 }
 
-impl Var {
+impl Var_ {
     /// Creates a new `Var` from an identifier.
     pub fn new(s: Identifier) -> Self {
-        Var(s)
-    }
-
-    /// Creates a new `Var_` identifier from an identifier with an empty location.
-    pub fn new_(s: Identifier) -> Var_ {
-        Spanned::no_loc(Var::new(s))
+        Var_(s)
     }
 
     /// Creates a new `Var` from a raw string. Intended for use by the parser.
     pub fn parse<L>(s: impl Into<Box<str>>) -> Result<Self, ParseError<L, anyhow::Error>> {
-        Ok(Var::new(parse_identifier(s.into())?))
+        Ok(Var_::new(parse_identifier(s.into())?))
     }
 
     /// Accessor for the name of the var
@@ -887,15 +882,15 @@ impl Var {
     }
 }
 
-impl TypeVar {
+impl TypeVar_ {
     /// Creates a new `TypeVar` from an identifier.
     pub fn new(s: Identifier) -> Self {
-        TypeVar(s)
+        TypeVar_(s)
     }
 
     /// Creates a new `TypeVar` from a raw string. Intended for use by the parser.
     pub fn parse<L>(s: impl Into<Box<str>>) -> Result<Self, ParseError<L, anyhow::Error>> {
-        Ok(TypeVar::new(parse_identifier(s.into())?))
+        Ok(TypeVar_::new(parse_identifier(s.into())?))
     }
 
     /// Accessor for the name of the var.
@@ -904,10 +899,10 @@ impl TypeVar {
     }
 }
 
-impl FunctionCall {
+impl FunctionCall_ {
     /// Creates a `FunctionCall::ModuleFunctionCall` variant
     pub fn module_call(module: ModuleName, name: FunctionName, type_actuals: Vec<Type>) -> Self {
-        FunctionCall::ModuleFunctionCall {
+        FunctionCall_::ModuleFunctionCall {
             module,
             name,
             type_actuals,
@@ -915,26 +910,26 @@ impl FunctionCall {
     }
 
     /// Creates a `FunctionCall::Builtin` variant with no location information
-    pub fn builtin(bif: Builtin) -> FunctionCall_ {
-        Spanned::no_loc(FunctionCall::Builtin(bif))
+    pub fn builtin(bif: Builtin) -> FunctionCall {
+        Spanned::no_loc(FunctionCall_::Builtin(bif))
     }
 }
 
-impl Cmd {
+impl Cmd_ {
     /// Creates a command that returns no values
     pub fn return_empty() -> Self {
-        Cmd::Return(Box::new(Spanned::no_loc(Exp::ExprList(vec![]))))
+        Cmd_::Return(Box::new(Spanned::no_loc(Exp_::ExprList(vec![]))))
     }
 
     /// Creates a command that returns a single value
-    pub fn return_(op: Exp_) -> Self {
-        Cmd::Return(Box::new(op))
+    pub fn return_(op: Exp) -> Self {
+        Cmd_::Return(Box::new(op))
     }
 }
 
 impl IfElse {
     /// Creates an if-statement with no else branch
-    pub fn if_block(cond: Exp_, if_block: Block_) -> Self {
+    pub fn if_block(cond: Exp, if_block: Block) -> Self {
         IfElse {
             cond,
             if_block,
@@ -943,7 +938,7 @@ impl IfElse {
     }
 
     /// Creates an if-statement with an else branch
-    pub fn if_else(cond: Exp_, if_block: Block_, else_block: Block_) -> Self {
+    pub fn if_else(cond: Exp, if_block: Block, else_block: Block) -> Self {
         IfElse {
             cond,
             if_block,
@@ -954,91 +949,91 @@ impl IfElse {
 
 impl Statement {
     /// Lifts a command into a statement
-    pub fn cmd(c: Cmd_) -> Self {
+    pub fn cmd(c: Cmd) -> Self {
         Statement::CommandStatement(c)
     }
 
     /// Creates an `Statement::IfElseStatement` variant with no else branch
-    pub fn if_block(cond: Exp_, if_block: Block_) -> Self {
+    pub fn if_block(cond: Exp, if_block: Block) -> Self {
         Statement::IfElseStatement(IfElse::if_block(cond, if_block))
     }
 
     /// Creates an `Statement::IfElseStatement` variant with an else branch
-    pub fn if_else(cond: Exp_, if_block: Block_, else_block: Block_) -> Self {
+    pub fn if_else(cond: Exp, if_block: Block, else_block: Block) -> Self {
         Statement::IfElseStatement(IfElse::if_else(cond, if_block, else_block))
     }
 }
 
-impl Block {
+impl Block_ {
     /// Creates a new block from the vector of statements
     pub fn new(stmts: Vec<Statement>) -> Self {
-        Block {
+        Block_ {
             stmts: VecDeque::from(stmts),
         }
     }
 
     /// Creates an empty block
     pub fn empty() -> Self {
-        Block {
+        Block_ {
             stmts: VecDeque::new(),
         }
     }
 }
 
-impl Exp {
+impl Exp_ {
     /// Creates a new address `Exp` with no location information
-    pub fn address(addr: AccountAddress) -> Exp_ {
-        Spanned::no_loc(Exp::Value(Spanned::no_loc(CopyableVal::Address(addr))))
+    pub fn address(addr: AccountAddress) -> Exp {
+        Spanned::no_loc(Exp_::Value(Spanned::no_loc(CopyableVal_::Address(addr))))
     }
 
     /// Creates a new value `Exp` with no location information
-    pub fn value(b: CopyableVal) -> Exp_ {
-        Spanned::no_loc(Exp::Value(Spanned::no_loc(b)))
+    pub fn value(b: CopyableVal_) -> Exp {
+        Spanned::no_loc(Exp_::Value(Spanned::no_loc(b)))
     }
 
     /// Creates a new u64 `Exp` with no location information
-    pub fn u64(i: u64) -> Exp_ {
-        Exp::value(CopyableVal::U64(i))
+    pub fn u64(i: u64) -> Exp {
+        Exp_::value(CopyableVal_::U64(i))
     }
 
     /// Creates a new bool `Exp` with no location information
-    pub fn bool(b: bool) -> Exp_ {
-        Exp::value(CopyableVal::Bool(b))
+    pub fn bool(b: bool) -> Exp {
+        Exp_::value(CopyableVal_::Bool(b))
     }
 
     /// Creates a new bytearray `Exp` with no location information
-    pub fn byte_array(buf: ByteArray) -> Exp_ {
-        Exp::value(CopyableVal::ByteArray(buf))
+    pub fn byte_array(buf: ByteArray) -> Exp {
+        Exp_::value(CopyableVal_::ByteArray(buf))
     }
 
     /// Creates a new pack/struct-instantiation `Exp` with no location information
-    pub fn instantiate(n: StructName, tys: Vec<Type>, s: ExpFields) -> Exp_ {
-        Spanned::no_loc(Exp::Pack(n, tys, s))
+    pub fn instantiate(n: StructName, tys: Vec<Type>, s: ExpFields) -> Exp {
+        Spanned::no_loc(Exp_::Pack(n, tys, s))
     }
 
     /// Creates a new binary operator `Exp` with no location information
-    pub fn binop(lhs: Exp_, op: BinOp, rhs: Exp_) -> Exp_ {
-        Spanned::no_loc(Exp::BinopExp(Box::new(lhs), op, Box::new(rhs)))
+    pub fn binop(lhs: Exp, op: BinOp, rhs: Exp) -> Exp {
+        Spanned::no_loc(Exp_::BinopExp(Box::new(lhs), op, Box::new(rhs)))
     }
 
     /// Creates a new `e+e` `Exp` with no location information
-    pub fn add(lhs: Exp_, rhs: Exp_) -> Exp_ {
-        Exp::binop(lhs, BinOp::Add, rhs)
+    pub fn add(lhs: Exp, rhs: Exp) -> Exp {
+        Exp_::binop(lhs, BinOp::Add, rhs)
     }
 
     /// Creates a new `e-e` `Exp` with no location information
-    pub fn sub(lhs: Exp_, rhs: Exp_) -> Exp_ {
-        Exp::binop(lhs, BinOp::Sub, rhs)
+    pub fn sub(lhs: Exp, rhs: Exp) -> Exp {
+        Exp_::binop(lhs, BinOp::Sub, rhs)
     }
 
     /// Creates a new `*e` `Exp` with no location information
-    pub fn dereference(e: Exp_) -> Exp_ {
-        Spanned::no_loc(Exp::Dereference(Box::new(e)))
+    pub fn dereference(e: Exp) -> Exp {
+        Spanned::no_loc(Exp_::Dereference(Box::new(e)))
     }
 
     /// Creates a new borrow field `Exp` with no location information
-    pub fn borrow(is_mutable: bool, exp: Box<Exp_>, field: Field) -> Exp_ {
-        Spanned::no_loc(Exp::Borrow {
+    pub fn borrow(is_mutable: bool, exp: Box<Exp>, field: Field_) -> Exp {
+        Spanned::no_loc(Exp_::Borrow {
             is_mutable,
             exp,
             field,
@@ -1046,28 +1041,28 @@ impl Exp {
     }
 
     /// Creates a new copy-local `Exp` with no location information
-    pub fn copy(v: Var_) -> Exp_ {
-        Spanned::no_loc(Exp::Copy(v))
+    pub fn copy(v: Var) -> Exp {
+        Spanned::no_loc(Exp_::Copy(v))
     }
 
     /// Creates a new move-local `Exp` with no location information
-    pub fn move_(v: Var_) -> Exp_ {
-        Spanned::no_loc(Exp::Move(v))
+    pub fn move_(v: Var) -> Exp {
+        Spanned::no_loc(Exp_::Move(v))
     }
 
     /// Creates a new function call `Exp` with no location information
-    pub fn function_call(f: FunctionCall_, e: Exp_) -> Exp_ {
-        Spanned::no_loc(Exp::FunctionCall(f, Box::new(e)))
+    pub fn function_call(f: FunctionCall, e: Exp) -> Exp {
+        Spanned::no_loc(Exp_::FunctionCall(f, Box::new(e)))
     }
 
-    pub fn expr_list(exps: Vec<Exp_>) -> Exp_ {
-        Spanned::no_loc(Exp::ExprList(exps))
+    pub fn expr_list(exps: Vec<Exp>) -> Exp {
+        Spanned::no_loc(Exp_::ExprList(exps))
     }
 }
 
 /// Parses a field.
-pub fn parse_field<L>(s: impl Into<Box<str>>) -> Result<Field, ParseError<L, anyhow::Error>> {
-    Ok(Field::new(parse_identifier(s.into())?))
+pub fn parse_field<L>(s: impl Into<Box<str>>) -> Result<Field_, ParseError<L, anyhow::Error>> {
+    Ok(Field_::new(parse_identifier(s.into())?))
 }
 
 fn parse_identifier<L>(s: Box<str>) -> Result<Identifier, ParseError<L, anyhow::Error>> {
@@ -1118,7 +1113,7 @@ impl<T> Spanned<T> {
     }
 }
 
-impl Iterator for Block {
+impl Iterator for Block_ {
     type Item = Statement;
 
     fn next(&mut self) -> Option<Statement> {
@@ -1139,7 +1134,7 @@ where
     }
 }
 
-impl fmt::Display for TypeVar {
+impl fmt::Display for TypeVar_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -1221,7 +1216,7 @@ impl fmt::Display for ModuleDefinition {
     }
 }
 
-impl fmt::Display for StructDefinition {
+impl fmt::Display for StructDefinition_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
@@ -1237,7 +1232,7 @@ impl fmt::Display for StructDefinition {
     }
 }
 
-impl fmt::Display for Function {
+impl fmt::Display for Function_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} ({})", self.signature, self.body)
     }
@@ -1280,7 +1275,7 @@ fn intersperse<T: fmt::Display>(items: &[T], join: &str) -> String {
     })
 }
 
-fn format_fields<T: fmt::Display>(fields: &[(Field_, T)]) -> String {
+fn format_fields<T: fmt::Display>(fields: &[(Field, T)]) -> String {
     fields.iter().fold(String::new(), |acc, (field, val)| {
         format!("{} {}: {},", acc, field.value, val)
     })
@@ -1312,7 +1307,7 @@ fn format_type_actuals(tys: &[Type]) -> String {
     }
 }
 
-fn format_type_formals(formals: &[(TypeVar_, Kind)]) -> String {
+fn format_type_formals(formals: &[(TypeVar, Kind)]) -> String {
     if formals.is_empty() {
         "".to_string()
     } else {
@@ -1342,7 +1337,7 @@ impl fmt::Display for Type {
     }
 }
 
-impl fmt::Display for Var {
+impl fmt::Display for Var_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -1375,11 +1370,11 @@ impl fmt::Display for Builtin {
     }
 }
 
-impl fmt::Display for FunctionCall {
+impl fmt::Display for FunctionCall_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FunctionCall::Builtin(fun) => write!(f, "{}", fun),
-            FunctionCall::ModuleFunctionCall {
+            FunctionCall_::Builtin(fun) => write!(f, "{}", fun),
+            FunctionCall_::ModuleFunctionCall {
                 module,
                 name,
                 type_actuals,
@@ -1394,27 +1389,27 @@ impl fmt::Display for FunctionCall {
     }
 }
 
-impl fmt::Display for LValue {
+impl fmt::Display for LValue_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LValue::Var(x) => write!(f, "{}", x),
-            LValue::Mutate(e) => write!(f, "*{}", e),
-            LValue::Pop => write!(f, "_"),
+            LValue_::Var(x) => write!(f, "{}", x),
+            LValue_::Mutate(e) => write!(f, "*{}", e),
+            LValue_::Pop => write!(f, "_"),
         }
     }
 }
 
-impl fmt::Display for Cmd {
+impl fmt::Display for Cmd_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Cmd::Assign(var_list, e) => {
+            Cmd_::Assign(var_list, e) => {
                 if var_list.is_empty() {
                     write!(f, "{};", e)
                 } else {
                     write!(f, "{} = ({});", intersperse(var_list, ", "), e)
                 }
             }
-            Cmd::Unpack(n, tys, bindings, e) => write!(
+            Cmd_::Unpack(n, tys, bindings, e) => write!(
                 f,
                 "{}{} {{ {} }} = {}",
                 n,
@@ -1427,12 +1422,12 @@ impl fmt::Display for Cmd {
                     )),
                 e
             ),
-            Cmd::Abort(None) => write!(f, "abort;"),
-            Cmd::Abort(Some(err)) => write!(f, "abort {};", err),
-            Cmd::Return(exps) => write!(f, "return {};", exps),
-            Cmd::Break => write!(f, "break;"),
-            Cmd::Continue => write!(f, "continue;"),
-            Cmd::Exp(e) => write!(f, "({});", e),
+            Cmd_::Abort(None) => write!(f, "abort;"),
+            Cmd_::Abort(Some(err)) => write!(f, "abort {};", err),
+            Cmd_::Return(exps) => write!(f, "return {};", exps),
+            Cmd_::Break => write!(f, "break;"),
+            Cmd_::Continue => write!(f, "continue;"),
+            Cmd_::Exp(e) => write!(f, "({});", e),
         }
     }
 }
@@ -1485,7 +1480,7 @@ impl fmt::Display for Statement {
     }
 }
 
-impl fmt::Display for Block {
+impl fmt::Display for Block_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for stmt in self.stmts.iter() {
             writeln!(f, "{}", stmt)?;
@@ -1494,15 +1489,15 @@ impl fmt::Display for Block {
     }
 }
 
-impl fmt::Display for CopyableVal {
+impl fmt::Display for CopyableVal_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CopyableVal::U8(v) => write!(f, "{}u8", v),
-            CopyableVal::U64(v) => write!(f, "{}", v),
-            CopyableVal::U128(v) => write!(f, "{}u128", v),
-            CopyableVal::Bool(v) => write!(f, "{}", v),
-            CopyableVal::ByteArray(v) => write!(f, "{}", v),
-            CopyableVal::Address(v) => write!(f, "0x{}", hex::encode(&v)),
+            CopyableVal_::U8(v) => write!(f, "{}u8", v),
+            CopyableVal_::U64(v) => write!(f, "{}", v),
+            CopyableVal_::U128(v) => write!(f, "{}u128", v),
+            CopyableVal_::Bool(v) => write!(f, "{}", v),
+            CopyableVal_::ByteArray(v) => write!(f, "{}", v),
+            CopyableVal_::Address(v) => write!(f, "0x{}", hex::encode(&v)),
         }
     }
 }
@@ -1552,14 +1547,14 @@ impl fmt::Display for BinOp {
     }
 }
 
-impl fmt::Display for Exp {
+impl fmt::Display for Exp_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Exp::Dereference(e) => write!(f, "*({})", e),
-            Exp::UnaryExp(o, e) => write!(f, "({}{})", o, e),
-            Exp::BinopExp(e1, o, e2) => write!(f, "({} {} {})", o, e1, e2),
-            Exp::Value(v) => write!(f, "{}", v),
-            Exp::Pack(n, tys, s) => write!(
+            Exp_::Dereference(e) => write!(f, "*({})", e),
+            Exp_::UnaryExp(o, e) => write!(f, "({}{})", o, e),
+            Exp_::BinopExp(e1, o, e2) => write!(f, "({} {} {})", o, e1, e2),
+            Exp_::Value(v) => write!(f, "{}", v),
+            Exp_::Pack(n, tys, s) => write!(
                 f,
                 "{}{}{{{}}}",
                 n,
@@ -1569,7 +1564,7 @@ impl fmt::Display for Exp {
                     acc, field, op,
                 ))
             ),
-            Exp::Borrow {
+            Exp_::Borrow {
                 is_mutable,
                 exp,
                 field,
@@ -1580,13 +1575,13 @@ impl fmt::Display for Exp {
                 exp,
                 field
             ),
-            Exp::Move(v) => write!(f, "move({})", v),
-            Exp::Copy(v) => write!(f, "copy({})", v),
-            Exp::BorrowLocal(is_mutable, v) => {
+            Exp_::Move(v) => write!(f, "move({})", v),
+            Exp_::Copy(v) => write!(f, "copy({})", v),
+            Exp_::BorrowLocal(is_mutable, v) => {
                 write!(f, "&{}{}", if *is_mutable { "mut " } else { "" }, v)
             }
-            Exp::FunctionCall(func, e) => write!(f, "{}({})", func, e),
-            Exp::ExprList(exps) => {
+            Exp_::FunctionCall(func, e) => write!(f, "{}({})", func, e),
+            Exp_::ExprList(exps) => {
                 if exps.is_empty() {
                     write!(f, "()")
                 } else {

--- a/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/spec_language_ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ast::{BinOp, CopyableVal, Field, QualifiedStructIdent, Spanned, Type};
+use crate::ast::{BinOp, CopyableVal_, Field_, QualifiedStructIdent, Spanned, Type};
 use libra_types::account_address::AccountAddress;
 
 /// AST for the Move Prover specification language. Just postconditions for now
@@ -20,7 +20,7 @@ pub enum StorageLocation {
     /// An access path rooted at `base` with nonempty offsets in `fields`
     AccessPath {
         base: Box<StorageLocation>,
-        fields: Vec<Field>,
+        fields: Vec<Field_>,
     },
     /// Sender address for the current transaction
     TxnSenderAddress,
@@ -35,7 +35,7 @@ pub enum StorageLocation {
 #[derive(PartialEq, Debug, Clone)]
 pub enum SpecExp {
     /// A Move constant
-    Constant(CopyableVal),
+    Constant(CopyableVal_),
     /// A spec language storage location
     StorageLocation(StorageLocation),
     /// Lifting the Move exists operator to a storage location

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::ast::{
-    parse_field, BinOp, Block, Block_, Builtin, Cmd, CopyableVal, CopyableVal_, Exp, Exp_, Field_,
+    parse_field, BinOp, Block, Block_, Builtin, Cmd_, CopyableVal, CopyableVal_, Exp, Exp_, Field,
     Function, FunctionBody, FunctionCall, FunctionCall_, FunctionName, FunctionVisibility,
     Function_, IfElse, ImportDefinition, Kind, LValue, LValue_, Loop, ModuleDefinition,
     ModuleIdent, ModuleName, Program, QualifiedModuleIdent, QualifiedStructIdent, Script,
@@ -169,13 +169,11 @@ fn parse_account_address<'input>(
 //     <n:Name> =>? Var::parse(n),
 // };
 
-fn parse_var<'input>(tokens: &mut Lexer<'input>) -> Result<Var, ParseError<usize, anyhow::Error>> {
-    Var::parse(parse_name(tokens)?)
+fn parse_var<'input>(tokens: &mut Lexer<'input>) -> Result<Var_, ParseError<usize, anyhow::Error>> {
+    Var_::parse(parse_name(tokens)?)
 }
 
-fn parse_var_<'input>(
-    tokens: &mut Lexer<'input>,
-) -> Result<Var_, ParseError<usize, anyhow::Error>> {
+fn parse_var_<'input>(tokens: &mut Lexer<'input>) -> Result<Var, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let var = parse_var(tokens)?;
     let end_loc = tokens.previous_end_loc();
@@ -188,7 +186,7 @@ fn parse_var_<'input>(
 
 fn parse_field_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Field_, ParseError<usize, anyhow::Error>> {
+) -> Result<Field, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let f = parse_field(parse_name(tokens)?)?;
     let end_loc = tokens.previous_end_loc();
@@ -205,20 +203,20 @@ fn parse_field_<'input>(
 
 fn parse_copyable_val_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<CopyableVal_, ParseError<usize, anyhow::Error>> {
+) -> Result<CopyableVal, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let val = match tokens.peek() {
         Tok::AccountAddressValue => {
             let addr = parse_account_address(tokens)?;
-            CopyableVal::Address(addr)
+            CopyableVal_::Address(addr)
         }
         Tok::True => {
             tokens.advance()?;
-            CopyableVal::Bool(true)
+            CopyableVal_::Bool(true)
         }
         Tok::False => {
             tokens.advance()?;
-            CopyableVal::Bool(false)
+            CopyableVal_::Bool(false)
         }
         Tok::U8Value => {
             let mut s = tokens.content();
@@ -227,7 +225,7 @@ fn parse_copyable_val_<'input>(
             }
             let i = u8::from_str(s).unwrap();
             tokens.advance()?;
-            CopyableVal::U8(i)
+            CopyableVal_::U8(i)
         }
         Tok::U64Value => {
             let mut s = tokens.content();
@@ -236,7 +234,7 @@ fn parse_copyable_val_<'input>(
             }
             let i = u64::from_str(s).unwrap();
             tokens.advance()?;
-            CopyableVal::U64(i)
+            CopyableVal_::U64(i)
         }
         Tok::U128Value => {
             let mut s = tokens.content();
@@ -245,7 +243,7 @@ fn parse_copyable_val_<'input>(
             }
             let i = u128::from_str(s).unwrap();
             tokens.advance()?;
-            CopyableVal::U128(i)
+            CopyableVal_::U128(i)
         }
         Tok::ByteArrayValue => {
             let s = tokens.content();
@@ -254,7 +252,7 @@ fn parse_copyable_val_<'input>(
                 unreachable!("The string {:?} is not a valid hex-encoded byte array", s)
             }));
             tokens.advance()?;
-            CopyableVal::ByteArray(buf)
+            CopyableVal_::ByteArray(buf)
         }
         _ => {
             return Err(ParseError::InvalidToken {
@@ -297,18 +295,16 @@ fn get_precedence(token: &Tok) -> u32 {
     }
 }
 
-fn parse_exp_<'input>(
-    tokens: &mut Lexer<'input>,
-) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
+fn parse_exp_<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError<usize, anyhow::Error>> {
     let lhs = parse_unary_exp_(tokens)?;
     parse_rhs_of_binary_exp(tokens, lhs, /* min_prec */ 1)
 }
 
 fn parse_rhs_of_binary_exp<'input>(
     tokens: &mut Lexer<'input>,
-    lhs: Exp_,
+    lhs: Exp,
     min_prec: u32,
-) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp, ParseError<usize, anyhow::Error>> {
     let mut result = lhs;
     let mut next_tok_prec = get_precedence(&tokens.peek());
 
@@ -352,7 +348,7 @@ fn parse_rhs_of_binary_exp<'input>(
         };
         let start_loc = result.span.start();
         let end_loc = tokens.previous_end_loc();
-        let e = Exp::BinopExp(Box::new(result), op, Box::new(rhs));
+        let e = Exp_::BinopExp(Box::new(result), op, Box::new(rhs));
         result = Spanned {
             span: Span::new(start_loc, ByteIndex(end_loc as u32)),
             value: e,
@@ -369,7 +365,7 @@ fn parse_rhs_of_binary_exp<'input>(
 
 fn parse_qualified_function_name_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<FunctionCall_, ParseError<usize, anyhow::Error>> {
+) -> Result<FunctionCall, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let call = match tokens.peek() {
         Tok::Exists
@@ -383,14 +379,14 @@ fn parse_qualified_function_name_<'input>(
         | Tok::ToU64
         | Tok::ToU128 => {
             let f = parse_builtin(tokens)?;
-            FunctionCall::Builtin(f)
+            FunctionCall_::Builtin(f)
         }
         Tok::DotNameValue => {
             let module_dot_name = parse_dot_name(tokens)?;
             let type_actuals = parse_type_actuals(tokens)?;
             let v: Vec<&str> = module_dot_name.split('.').collect();
             assert!(v.len() == 2);
-            FunctionCall::ModuleFunctionCall {
+            FunctionCall_::ModuleFunctionCall {
                 module: ModuleName::parse(v[0])?,
                 name: FunctionName::parse(v[1])?,
                 type_actuals,
@@ -417,7 +413,7 @@ fn parse_qualified_function_name_<'input>(
 fn parse_borrow_field<'input>(
     tokens: &mut Lexer<'input>,
     mutable: bool,
-) -> Result<Exp, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
     // This could be either a field borrow (from UnaryExp) or
     // a borrow of a local variable (from Term). In the latter case,
     // only a simple name token is allowed, and it must not be
@@ -425,7 +421,7 @@ fn parse_borrow_field<'input>(
     let e = if tokens.peek() == Tok::NameValue {
         if tokens.lookahead()? != Tok::LBrace {
             let var = parse_var_(tokens)?;
-            return Ok(Exp::BorrowLocal(mutable, var));
+            return Ok(Exp_::BorrowLocal(mutable, var));
         }
         let start_loc = tokens.start_loc();
         let name = parse_name(tokens)?;
@@ -437,7 +433,7 @@ fn parse_borrow_field<'input>(
     };
     consume_token(tokens, Tok::Period)?;
     let f = parse_field(parse_name(tokens)?)?;
-    Ok(Exp::Borrow {
+    Ok(Exp_::Borrow {
         is_mutable: mutable,
         exp: Box::new(e),
         field: f,
@@ -446,17 +442,17 @@ fn parse_borrow_field<'input>(
 
 fn parse_unary_exp<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Exp, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
     match tokens.peek() {
         Tok::Exclaim => {
             tokens.advance()?;
             let e = parse_unary_exp_(tokens)?;
-            Ok(Exp::UnaryExp(UnaryOp::Not, Box::new(e)))
+            Ok(Exp_::UnaryExp(UnaryOp::Not, Box::new(e)))
         }
         Tok::Star => {
             tokens.advance()?;
             let e = parse_unary_exp_(tokens)?;
-            Ok(Exp::Dereference(Box::new(e)))
+            Ok(Exp_::Dereference(Box::new(e)))
         }
         Tok::AmpMut => {
             tokens.advance()?;
@@ -472,7 +468,7 @@ fn parse_unary_exp<'input>(
 
 fn parse_unary_exp_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let e = parse_unary_exp(tokens)?;
     let end_loc = tokens.previous_end_loc();
@@ -485,7 +481,7 @@ fn parse_unary_exp_<'input>(
 
 fn parse_call_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let f = parse_qualified_function_name_(tokens)?;
     let exp = parse_call_or_term_(tokens)?;
@@ -493,7 +489,7 @@ fn parse_call_<'input>(
     Ok(spanned(
         start_loc,
         end_loc,
-        Exp::FunctionCall(f, Box::new(exp)),
+        Exp_::FunctionCall(f, Box::new(exp)),
     ))
 }
 
@@ -504,7 +500,7 @@ fn parse_call_<'input>(
 
 fn parse_call_or_term<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Exp, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
     match tokens.peek() {
         Tok::Exists
         | Tok::BorrowGlobal
@@ -519,7 +515,7 @@ fn parse_call_or_term<'input>(
         | Tok::ToU128 => {
             let f = parse_qualified_function_name_(tokens)?;
             let exp = parse_call_or_term_(tokens)?;
-            Ok(Exp::FunctionCall(f, Box::new(exp)))
+            Ok(Exp_::FunctionCall(f, Box::new(exp)))
         }
         _ => parse_term(tokens),
     }
@@ -527,7 +523,7 @@ fn parse_call_or_term<'input>(
 
 fn parse_call_or_term_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let v = parse_call_or_term(tokens)?;
     let end_loc = tokens.previous_end_loc();
@@ -540,7 +536,7 @@ fn parse_call_or_term_<'input>(
 
 fn parse_field_exp<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Field_, Exp_), ParseError<usize, anyhow::Error>> {
+) -> Result<(Field, Exp), ParseError<usize, anyhow::Error>> {
     let f = parse_field_(tokens)?;
     consume_token(tokens, Tok::Colon)?;
     let e = parse_exp_(tokens)?;
@@ -561,40 +557,42 @@ fn parse_pack<'input>(
     tokens: &mut Lexer<'input>,
     name: &str,
     type_actuals: Vec<Type>,
-) -> Result<Exp, ParseError<usize, anyhow::Error>> {
+) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
     consume_token(tokens, Tok::LBrace)?;
     let fs = parse_comma_list(tokens, Tok::RBrace, parse_field_exp, true)?;
     consume_token(tokens, Tok::RBrace)?;
-    Ok(Exp::Pack(
+    Ok(Exp_::Pack(
         StructName::parse(name)?,
         type_actuals,
         fs.into_iter().collect::<Vec<_>>(),
     ))
 }
 
-fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError<usize, anyhow::Error>> {
+fn parse_term<'input>(
+    tokens: &mut Lexer<'input>,
+) -> Result<Exp_, ParseError<usize, anyhow::Error>> {
     match tokens.peek() {
         Tok::Move => {
             tokens.advance()?;
             let v = parse_var_(tokens)?;
             consume_token(tokens, Tok::RParen)?;
-            Ok(Exp::Move(v))
+            Ok(Exp_::Move(v))
         }
         Tok::Copy => {
             tokens.advance()?;
             let v = parse_var_(tokens)?;
             consume_token(tokens, Tok::RParen)?;
-            Ok(Exp::Copy(v))
+            Ok(Exp_::Copy(v))
         }
         Tok::AmpMut => {
             tokens.advance()?;
             let v = parse_var_(tokens)?;
-            Ok(Exp::BorrowLocal(true, v))
+            Ok(Exp_::BorrowLocal(true, v))
         }
         Tok::Amp => {
             tokens.advance()?;
             let v = parse_var_(tokens)?;
-            Ok(Exp::BorrowLocal(false, v))
+            Ok(Exp_::BorrowLocal(false, v))
         }
         Tok::AccountAddressValue
         | Tok::True
@@ -602,7 +600,7 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError<usiz
         | Tok::U8Value
         | Tok::U64Value
         | Tok::U128Value
-        | Tok::ByteArrayValue => Ok(Exp::Value(parse_copyable_val_(tokens)?)),
+        | Tok::ByteArrayValue => Ok(Exp_::Value(parse_copyable_val_(tokens)?)),
         Tok::NameValue | Tok::NameBeginTyValue => {
             let (name, type_actuals) = parse_name_and_type_actuals(tokens)?;
             parse_pack(tokens, &name, type_actuals)
@@ -611,7 +609,7 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, ParseError<usiz
             tokens.advance()?;
             let exps = parse_comma_list(tokens, Tok::RParen, parse_exp_, true)?;
             consume_token(tokens, Tok::RParen)?;
-            Ok(Exp::ExprList(exps))
+            Ok(Exp_::ExprList(exps))
         }
         _ => Err(ParseError::InvalidToken {
             location: tokens.start_loc(),
@@ -759,20 +757,20 @@ fn parse_builtin<'input>(
 
 fn parse_lvalue<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<LValue, ParseError<usize, anyhow::Error>> {
+) -> Result<LValue_, ParseError<usize, anyhow::Error>> {
     match tokens.peek() {
         Tok::NameValue => {
             let l = parse_var_(tokens)?;
-            Ok(LValue::Var(l))
+            Ok(LValue_::Var(l))
         }
         Tok::Star => {
             tokens.advance()?;
             let e = parse_exp_(tokens)?;
-            Ok(LValue::Mutate(e))
+            Ok(LValue_::Mutate(e))
         }
         Tok::Underscore => {
             tokens.advance()?;
-            Ok(LValue::Pop)
+            Ok(LValue_::Pop)
         }
         _ => Err(ParseError::InvalidToken {
             location: tokens.start_loc(),
@@ -782,7 +780,7 @@ fn parse_lvalue<'input>(
 
 fn parse_lvalue_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<LValue_, ParseError<usize, anyhow::Error>> {
+) -> Result<LValue, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     let lv = parse_lvalue(tokens)?;
     let end_loc = tokens.previous_end_loc();
@@ -796,7 +794,7 @@ fn parse_lvalue_<'input>(
 
 fn parse_field_bindings<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Field_, Var_), ParseError<usize, anyhow::Error>> {
+) -> Result<(Field, Var), ParseError<usize, anyhow::Error>> {
     let f = parse_field_(tokens)?;
     if tokens.peek() == Tok::Colon {
         tokens.advance()?; // consume the colon
@@ -807,7 +805,7 @@ fn parse_field_bindings<'input>(
             f.clone(),
             Spanned {
                 span: f.span,
-                value: Var::new(f.value.name().into()),
+                value: Var_::new(f.value.name().into()),
             },
         ))
     }
@@ -826,7 +824,7 @@ fn parse_field_bindings<'input>(
 
 fn parse_assign<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Cmd, ParseError<usize, anyhow::Error>> {
+) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
     let lvalues = parse_comma_list(tokens, Tok::Equal, parse_lvalue_, false)?;
     if lvalues.is_empty() {
         return Err(ParseError::InvalidToken {
@@ -835,20 +833,20 @@ fn parse_assign<'input>(
     }
     consume_token(tokens, Tok::Equal)?;
     let e = parse_exp_(tokens)?;
-    Ok(Cmd::Assign(lvalues, e))
+    Ok(Cmd_::Assign(lvalues, e))
 }
 
 fn parse_unpack<'input>(
     tokens: &mut Lexer<'input>,
     name: &str,
     type_actuals: Vec<Type>,
-) -> Result<Cmd, ParseError<usize, anyhow::Error>> {
+) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
     consume_token(tokens, Tok::LBrace)?;
     let bindings = parse_comma_list(tokens, Tok::RBrace, parse_field_bindings, true)?;
     consume_token(tokens, Tok::RBrace)?;
     consume_token(tokens, Tok::Equal)?;
     let e = parse_exp_(tokens)?;
-    Ok(Cmd::Unpack(
+    Ok(Cmd_::Unpack(
         StructName::parse(name)?,
         type_actuals,
         bindings.into_iter().collect(),
@@ -856,7 +854,7 @@ fn parse_unpack<'input>(
     ))
 }
 
-fn parse_cmd<'input>(tokens: &mut Lexer<'input>) -> Result<Cmd, ParseError<usize, anyhow::Error>> {
+fn parse_cmd<'input>(tokens: &mut Lexer<'input>) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
     match tokens.peek() {
         Tok::NameValue => {
             // This could be either an LValue for an assignment or
@@ -880,20 +878,20 @@ fn parse_cmd<'input>(tokens: &mut Lexer<'input>) -> Result<Cmd, ParseError<usize
             } else {
                 Some(Box::new(parse_exp_(tokens)?))
             };
-            Ok(Cmd::Abort(val))
+            Ok(Cmd_::Abort(val))
         }
         Tok::Return => {
             tokens.advance()?;
             let v = parse_comma_list(tokens, Tok::Semicolon, parse_exp_, true)?;
-            Ok(Cmd::Return(Box::new(Spanned::no_loc(Exp::ExprList(v)))))
+            Ok(Cmd_::Return(Box::new(Spanned::no_loc(Exp_::ExprList(v)))))
         }
         Tok::Continue => {
             tokens.advance()?;
-            Ok(Cmd::Continue)
+            Ok(Cmd_::Continue)
         }
         Tok::Break => {
             tokens.advance()?;
-            Ok(Cmd::Break)
+            Ok(Cmd_::Break)
         }
         Tok::Exists
         | Tok::BorrowGlobal
@@ -905,12 +903,12 @@ fn parse_cmd<'input>(tokens: &mut Lexer<'input>) -> Result<Cmd, ParseError<usize
         | Tok::DotNameValue
         | Tok::ToU8
         | Tok::ToU64
-        | Tok::ToU128 => Ok(Cmd::Exp(Box::new(parse_call_(tokens)?))),
+        | Tok::ToU128 => Ok(Cmd_::Exp(Box::new(parse_call_(tokens)?))),
         Tok::LParen => {
             tokens.advance()?;
             let v = parse_comma_list(tokens, Tok::RParen, parse_exp_, true)?;
             consume_token(tokens, Tok::RParen)?;
-            Ok(Cmd::Exp(Box::new(Spanned::no_loc(Exp::ExprList(v)))))
+            Ok(Cmd_::Exp(Box::new(Spanned::no_loc(Exp_::ExprList(v)))))
         }
         _ => Err(ParseError::InvalidToken {
             location: tokens.start_loc(),
@@ -941,21 +939,21 @@ fn parse_statement<'input>(
                 let span = e.span;
                 Spanned {
                     span,
-                    value: Exp::UnaryExp(UnaryOp::Not, Box::new(e)),
+                    value: Exp_::UnaryExp(UnaryOp::Not, Box::new(e)),
                 }
             };
             let span = err.span;
             let stmt = {
                 Statement::CommandStatement(Spanned {
                     span,
-                    value: Cmd::Abort(Some(Box::new(err))),
+                    value: Cmd_::Abort(Some(Box::new(err))),
                 })
             };
             Ok(Statement::IfElseStatement(IfElse::if_block(
                 cond,
                 Spanned {
                     span,
-                    value: Block::new(vec![stmt]),
+                    value: Block_::new(vec![stmt]),
                 },
             )))
         }
@@ -1051,13 +1049,13 @@ fn parse_statements<'input>(
 
 fn parse_block_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Block_, ParseError<usize, anyhow::Error>> {
+) -> Result<Block, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
     consume_token(tokens, Tok::LBrace)?;
     let stmts = parse_statements(tokens)?;
     consume_token(tokens, Tok::RBrace)?;
     let end_loc = tokens.previous_end_loc();
-    Ok(spanned(start_loc, end_loc, Block::new(stmts)))
+    Ok(spanned(start_loc, end_loc, Block_::new(stmts)))
 }
 
 // Declaration: (Var_, Type) = {
@@ -1066,7 +1064,7 @@ fn parse_block_<'input>(
 
 fn parse_declaration<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Var_, Type), ParseError<usize, anyhow::Error>> {
+) -> Result<(Var, Type), ParseError<usize, anyhow::Error>> {
     consume_token(tokens, Tok::Let)?;
     let v = parse_var_(tokens)?;
     consume_token(tokens, Tok::Colon)?;
@@ -1081,8 +1079,8 @@ fn parse_declaration<'input>(
 
 fn parse_declarations<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<Vec<(Var_, Type)>, ParseError<usize, anyhow::Error>> {
-    let mut decls: Vec<(Var_, Type)> = vec![];
+) -> Result<Vec<(Var, Type)>, ParseError<usize, anyhow::Error>> {
+    let mut decls: Vec<(Var, Type)> = vec![];
     // Declarations always begin with the "let" token so continue parsing
     // them until we hit something else.
     while tokens.peek() == Tok::Let {
@@ -1097,12 +1095,12 @@ fn parse_declarations<'input>(
 
 fn parse_function_block<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Vec<(Var_, Type)>, Block), ParseError<usize, anyhow::Error>> {
+) -> Result<(Vec<(Var, Type)>, Block_), ParseError<usize, anyhow::Error>> {
     consume_token(tokens, Tok::LBrace)?;
     let locals = parse_declarations(tokens)?;
     let stmts = parse_statements(tokens)?;
     consume_token(tokens, Tok::RBrace)?;
-    Ok((locals, Block::new(stmts)))
+    Ok((locals, Block_::new(stmts)))
 }
 
 // Kind: Kind = {
@@ -1178,7 +1176,7 @@ fn parse_type<'input>(
             tokens.advance()?;
             Type::Reference(true, Box::new(parse_type(tokens)?))
         }
-        Tok::NameValue => Type::TypeParameter(TypeVar::parse(parse_name(tokens)?)?),
+        Tok::NameValue => Type::TypeParameter(TypeVar_::parse(parse_name(tokens)?)?),
         _ => {
             return Err(ParseError::InvalidToken {
                 location: tokens.start_loc(),
@@ -1195,9 +1193,9 @@ fn parse_type<'input>(
 
 fn parse_type_var_<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<TypeVar_, ParseError<usize, anyhow::Error>> {
+) -> Result<TypeVar, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
-    let type_var = TypeVar::parse(parse_name(tokens)?)?;
+    let type_var = TypeVar_::parse(parse_name(tokens)?)?;
     let end_loc = tokens.previous_end_loc();
     Ok(spanned(start_loc, end_loc, type_var))
 }
@@ -1208,7 +1206,7 @@ fn parse_type_var_<'input>(
 
 fn parse_type_formal<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(TypeVar_, Kind), ParseError<usize, anyhow::Error>> {
+) -> Result<(TypeVar, Kind), ParseError<usize, anyhow::Error>> {
     let type_var = parse_type_var_(tokens)?;
     if tokens.peek() == Tok::Colon {
         tokens.advance()?; // consume the ":"
@@ -1244,7 +1242,7 @@ fn parse_type_actuals<'input>(
 
 fn parse_name_and_type_formals<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(String, Vec<(TypeVar_, Kind)>), ParseError<usize, anyhow::Error>> {
+) -> Result<(String, Vec<(TypeVar, Kind)>), ParseError<usize, anyhow::Error>> {
     let mut has_types = false;
     let n = if tokens.peek() == Tok::NameBeginTyValue {
         has_types = true;
@@ -1293,7 +1291,7 @@ fn parse_name_and_type_actuals<'input>(
 
 fn parse_arg_decl<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Var_, Type), ParseError<usize, anyhow::Error>> {
+) -> Result<(Var, Type), ParseError<usize, anyhow::Error>> {
     let v = parse_var_(tokens)?;
     consume_token(tokens, Tok::Colon)?;
     let t = parse_type(tokens)?;
@@ -1610,7 +1608,7 @@ fn parse_spec_condition<'input>(
 
 fn parse_function_decl<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(FunctionName, Function_), ParseError<usize, anyhow::Error>> {
+) -> Result<(FunctionName, Function), ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
 
     let is_native = if tokens.peek() == Tok::Native {
@@ -1654,7 +1652,7 @@ fn parse_function_decl<'input>(
     }
 
     let func_name = FunctionName::parse(name)?;
-    let func = Function::new(
+    let func = Function_::new(
         if is_public {
             FunctionVisibility::Public
         } else {
@@ -1684,7 +1682,7 @@ fn parse_function_decl<'input>(
 
 fn parse_field_decl<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<(Field_, Type), ParseError<usize, anyhow::Error>> {
+) -> Result<(Field, Type), ParseError<usize, anyhow::Error>> {
     let f = parse_field_(tokens)?;
     consume_token(tokens, Tok::Colon)?;
     let t = parse_type(tokens)?;
@@ -1719,14 +1717,14 @@ fn parse_program<'input>(
         let m = parse_module(tokens)?;
         let ret = Spanned {
             span: Span::default(),
-            value: Cmd::Return(Box::new(Spanned::no_loc(Exp::ExprList(vec![])))),
+            value: Cmd_::Return(Box::new(Spanned::no_loc(Exp_::ExprList(vec![])))),
         };
         let return_stmt = Statement::CommandStatement(ret);
         let body = FunctionBody::Move {
             locals: vec![],
-            code: Block::new(vec![return_stmt]),
+            code: Block_::new(vec![return_stmt]),
         };
-        let main = Function::new(
+        let main = Function_::new(
             FunctionVisibility::Public,
             vec![],
             vec![],
@@ -1769,7 +1767,7 @@ fn parse_script<'input>(
     consume_token(tokens, Tok::RParen)?;
     let (locals, body) = parse_function_block(tokens)?;
     let end_loc = tokens.previous_end_loc();
-    let main = Function::new(
+    let main = Function_::new(
         FunctionVisibility::Public,
         args,
         vec![],
@@ -1795,7 +1793,7 @@ fn parse_script<'input>(
 
 fn parse_struct_decl<'input>(
     tokens: &mut Lexer<'input>,
-) -> Result<StructDefinition_, ParseError<usize, anyhow::Error>> {
+) -> Result<StructDefinition, ParseError<usize, anyhow::Error>> {
     let start_loc = tokens.start_loc();
 
     let is_native = if tokens.peek() == Tok::Native {
@@ -1824,7 +1822,7 @@ fn parse_struct_decl<'input>(
         return Ok(spanned(
             start_loc,
             end_loc,
-            StructDefinition::native(is_nominal_resource, name, type_formals)?,
+            StructDefinition_::native(is_nominal_resource, name, type_formals)?,
         ));
     }
 
@@ -1835,7 +1833,7 @@ fn parse_struct_decl<'input>(
     Ok(spanned(
         start_loc,
         end_loc,
-        StructDefinition::move_declared(is_nominal_resource, name, type_formals, fields)?,
+        StructDefinition_::move_declared(is_nominal_resource, name, type_formals, fields)?,
     ))
 }
 
@@ -1942,12 +1940,12 @@ fn parse_module<'input>(
         imports.push(parse_import_decl(tokens)?);
     }
 
-    let mut structs: Vec<StructDefinition_> = vec![];
+    let mut structs: Vec<StructDefinition> = vec![];
     while is_struct_decl(tokens)? {
         structs.push(parse_struct_decl(tokens)?);
     }
 
-    let mut functions: Vec<(FunctionName, Function_)> = vec![];
+    let mut functions: Vec<(FunctionName, Function)> = vec![];
     while tokens.peek() != Tok::RBrace {
         functions.push(parse_function_decl(tokens)?);
     }
@@ -1973,7 +1971,7 @@ fn parse_script_or_module<'input>(
 
 pub fn parse_cmd_string<'input>(
     input: &'input str,
-) -> Result<Cmd, ParseError<usize, anyhow::Error>> {
+) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_cmd(&mut tokens)

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -6,7 +6,7 @@
 use itertools::Itertools;
 use num::{BigInt, Num};
 
-use ir_to_bytecode_syntax::ast::{BinOp, CopyableVal, Field, Loc, QualifiedStructIdent, Type};
+use ir_to_bytecode_syntax::ast::{BinOp, CopyableVal_, Field_, Loc, QualifiedStructIdent, Type};
 use ir_to_bytecode_syntax::spec_language_ast::{Condition, SpecExp, StorageLocation};
 use libra_types::account_address::AccountAddress;
 
@@ -352,18 +352,18 @@ impl<'env> SpecTranslator<'env> {
     }
 
     /// Translates a constant.
-    fn translate_constant(&mut self, val: &CopyableVal) -> BoogieExpr {
+    fn translate_constant(&mut self, val: &CopyableVal_) -> BoogieExpr {
         match val {
-            CopyableVal::Address(addr) => BoogieExpr(
+            CopyableVal_::Address(addr) => BoogieExpr(
                 format!("Address({})", self.translate_account_address(addr)),
                 GlobalType::Address,
             ),
-            CopyableVal::U8(val) => BoogieExpr(format!("Integer({})", val), GlobalType::U8),
-            CopyableVal::U64(val) => BoogieExpr(format!("Integer({})", val), GlobalType::U64),
-            CopyableVal::U128(val) => BoogieExpr(format!("Integer({})", val), GlobalType::U128),
-            CopyableVal::Bool(val) => BoogieExpr(format!("Boolean({})", val), GlobalType::Bool),
+            CopyableVal_::U8(val) => BoogieExpr(format!("Integer({})", val), GlobalType::U8),
+            CopyableVal_::U64(val) => BoogieExpr(format!("Integer({})", val), GlobalType::U64),
+            CopyableVal_::U128(val) => BoogieExpr(format!("Integer({})", val), GlobalType::U128),
+            CopyableVal_::Bool(val) => BoogieExpr(format!("Boolean({})", val), GlobalType::Bool),
             // TODO: byte arrays
-            CopyableVal::ByteArray(_arr) => BoogieExpr(
+            CopyableVal_::ByteArray(_arr) => BoogieExpr(
                 self.error("ByteArray not implemented", "<bytearray>".to_string()),
                 GlobalType::ByteArray,
             ),
@@ -551,7 +551,7 @@ impl<'env> SpecTranslator<'env> {
 
     /// Translates a field name, where `sig` is the type from which the field is selected.
     /// Returns boogie field name and type.
-    fn translate_field(&mut self, mut sig: &GlobalType, field: &Field) -> (String, GlobalType) {
+    fn translate_field(&mut self, mut sig: &GlobalType, field: &Field_) -> (String, GlobalType) {
         // If this is a reference, use the underlying type. This function works with both
         // references and non-references.
         let is_ref = if let GlobalType::Reference(s) = sig {


### PR DESCRIPTION
This follows the convention in Ocaml and in the Move language source compiler.

In the previous scheme, there was an (unspanned) `Var::new_` method which would
produce a (spanned) `Var_`. Now that the situation is reversed, the naming scheme
stopped making sense (`Var_::new_` would produce `Var`) -- so the method has
been removed and its code inlined.