### PR TITLE
[cluster-test] Collect suite stats into report

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -7,9 +7,14 @@ TAG=""
 PR=""
 WORKSPACE="cluster-test-ci"
 ENV="env"
+REPORT=""
 
 while (( "$#" )); do
   case "$1" in
+    -R|--report)
+      REPORT=$2
+      shift 2
+      ;;
     -p|--pr)
       PR=$2
       shift 2
@@ -51,6 +56,7 @@ then
       echo "-T|--tag <TAG>: Use image with tag TAG"
       echo "-W|--workspace <WORKSPACE>: Use custom workplace <WORKSPACE>"
       echo "-E|--env <ENV>: Set environment variable, ex. -E RUST_LOG=debug. Can be repeated, e.g. -E A=B -E C=D"
+      echo "-R|--report file.json: Generate json report into file.json"
       echo
       echo "To see cluster test runner arguments run cti --master"
       echo
@@ -71,7 +77,10 @@ if [ -z "$TAG" ]; then
     echo "**TIP Use cti -T $TAG <...> to restart this run with same tag without rebuilding it"
 fi
 
+OUTPUT_TEE=$(mktemp)
+
 echo "**********"
+echo "Copy of this output: $OUTPUT_TEE"
 echo "Dashboard: http://prometheus.${WORKSPACE}.aws.hlw3truzy4ls.com:9091/"
 echo "Logs:"
 echo " * ssh ssh.${WORKSPACE}.aws.hlw3truzy4ls.com"
@@ -79,4 +88,9 @@ echo " * ssh-peer"
 echo " * tail -f /data/libra/libra.log"
 echo "**********"
 
-ssh -t $JUMPHOST ssh -i /libra_rsa ec2-user@ct.priv.${WORKSPACE}.aws.hlw3truzy4ls.com $ENV REMOTE_USER=$USER ct -c cluster-test-ci --image "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:$TAG" --deploy $TAG $*
+
+ssh -t $JUMPHOST ssh -i /libra_rsa ec2-user@ct.priv.${WORKSPACE}.aws.hlw3truzy4ls.com $ENV REMOTE_USER=$USER ct -c cluster-test-ci --image "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:$TAG" --deploy $TAG $* | tee $OUTPUT_TEE
+
+if [ ! -z "$REPORT" ]; then
+    cat $OUTPUT_TEE | awk '/====json-report-begin===/{f=1;next} /====json-report-end===/{f=0} f' > $REPORT
+fi

--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -9,7 +9,7 @@ use crate::effects::Effect;
 use crate::instance::Instance;
 use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt};
-use slog_scope::info;
+use slog_scope::debug;
 use std::fmt;
 use std::time::Duration;
 
@@ -31,7 +31,7 @@ impl NetworkDelay {
 
 impl Effect for NetworkDelay {
     fn activate(&self) -> BoxFuture<Result<()>> {
-        info!("Injecting NetworkDelays for {}", self.instance);
+        debug!("Injecting NetworkDelays for {}", self.instance);
         let mut command = "".to_string();
         command += "sudo tc qdisc delete dev eth0 root; ";
         // Create a HTB https://linux.die.net/man/8/tc-htb

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -66,11 +66,11 @@ impl ExperimentParam for MultiRegionSimulationParams {
 }
 
 impl MultiRegionSimulation {
-    async fn single_run(
-        &self,
+    async fn single_run<'a>(
+        &'a self,
         count: usize,
         cross_region_delay: Duration,
-        context: &mut Context,
+        context: &'a mut Context<'_>,
     ) -> Result<Metrics> {
         let (cluster1, cluster2) = context.cluster.split_n_validators_random(count);
         let (region1, region2) = (
@@ -197,7 +197,7 @@ fn print_results(metrics: Vec<Metrics>) {
 }
 
 impl Experiment for MultiRegionSimulation {
-    fn run<'a>(&'a mut self, context: &'a mut Context) -> BoxFuture<'a, Result<Option<String>>> {
+    fn run<'a>(&'a mut self, context: &'a mut Context) -> BoxFuture<'a, Result<()>> {
         async move {
             let mut emitter = TxEmitter::new(&context.cluster);
             let mut results = vec![];
@@ -235,7 +235,7 @@ impl Experiment for MultiRegionSimulation {
                 }
             }
             print_results(results);
-            Ok(None)
+            Ok(())
         }
         .boxed()
     }

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -65,7 +65,7 @@ impl ExperimentParam for PacketLossRandomValidatorsParams {
 }
 
 impl Experiment for PacketLossRandomValidators {
-    fn run(&mut self, _context: &mut Context) -> BoxFuture<Result<Option<String>>> {
+    fn run(&mut self, _context: &mut Context) -> BoxFuture<Result<()>> {
         async move {
             let mut instances = vec![];
             for instance in self.instances.iter() {
@@ -78,7 +78,7 @@ impl Experiment for PacketLossRandomValidators {
                 let remove_network_effects = RemoveNetworkEffects::new(instance.clone());
                 remove_network_effects.apply().await?;
             }
-            Ok(None)
+            Ok(())
         }
         .boxed()
     }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -70,10 +70,7 @@ impl Experiment for PerformanceBenchmarkNodesDown {
         instance::instancelist_to_set(&self.down_instances)
     }
 
-    fn run<'a>(
-        &'a mut self,
-        context: &'a mut Context,
-    ) -> BoxFuture<'a, anyhow::Result<Option<String>>> {
+    fn run<'a>(&'a mut self, context: &'a mut Context) -> BoxFuture<'a, anyhow::Result<()>> {
         async move {
             let stop_effects: Vec<_> = self
                 .down_instances
@@ -98,10 +95,15 @@ impl Experiment for PerformanceBenchmarkNodesDown {
             );
             let futures = stop_effects.iter().map(|e| e.deactivate());
             join_all(futures).await;
-            Ok(Some(format!(
+            context.report.report_metric(&self, "avg_tps", avg_tps);
+            context
+                .report
+                .report_metric(&self, "avg_latency", avg_latency);
+            context.report.report_text(format!(
                 "{} : {:.0} TPS, {:.1} ms latency",
                 self, avg_tps, avg_latency
-            )))
+            ));
+            Ok(())
         }
         .boxed()
     }

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -57,7 +57,7 @@ impl Experiment for RebootRandomValidators {
         instance::instancelist_to_set(&self.instances)
     }
 
-    fn run(&mut self, _context: &mut Context) -> BoxFuture<Result<Option<String>>> {
+    fn run(&mut self, _context: &mut Context) -> BoxFuture<Result<()>> {
         async move {
             let futures = self.instances.iter().map(|instance| {
                 async move {
@@ -72,7 +72,7 @@ impl Experiment for RebootRandomValidators {
             if results.iter().any(Result::is_err) {
                 bail!("Failed to reboot one of nodes");
             }
-            Ok(None)
+            Ok(())
         }
         .boxed()
     }

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -10,6 +10,7 @@ pub mod github;
 pub mod health;
 pub mod instance;
 pub mod prometheus;
+pub mod report;
 pub mod slack;
 pub mod stats;
 pub mod suite;

--- a/testsuite/cluster-test/src/report.rs
+++ b/testsuite/cluster-test/src/report.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Serialize;
+use std::fmt;
+
+#[derive(Serialize)]
+pub struct SuiteReport {
+    metrics: Vec<ReportedMetric>,
+    text: String,
+}
+
+#[derive(Serialize)]
+pub struct ReportedMetric {
+    pub experiment: String,
+    pub metric: String,
+    pub value: f64,
+}
+
+impl SuiteReport {
+    pub fn new() -> Self {
+        SuiteReport {
+            metrics: vec![],
+            text: String::new(),
+        }
+    }
+
+    pub fn report_metric<E: ToString, M: ToString>(
+        &mut self,
+        experiment: E,
+        metric: M,
+        value: f64,
+    ) {
+        self.metrics.push(ReportedMetric {
+            experiment: experiment.to_string(),
+            metric: metric.to_string(),
+            value,
+        });
+    }
+
+    pub fn report_text(&mut self, text: String) {
+        if !self.text.is_empty() {
+            self.text.push_str("\n");
+        }
+        self.text.push_str(&text);
+    }
+}
+
+impl fmt::Display for SuiteReport {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.text)
+    }
+}

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -52,7 +52,6 @@ use util::retry;
 
 const MAX_TXN_BATCH_SIZE: usize = 100; // Max transactions per account in mempool
 
-#[derive(Clone)]
 pub struct TxEmitter {
     accounts: Vec<AccountData>,
     mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,


### PR DESCRIPTION
Main change in this PR is that `Context` now has `report: SuiteReport` field. Instead of returning `Option<String>`, experiments now can submit data into suite report:

```
    context.report.report_text("Arbitrary text");
    context.report.report_metric(self, "tps", tps_value);
```

Metrics are currently ignored, but later will be populated into suite report JSON, as well as Prometheus.

This diff also reworks how experiment loop works. This rework was techdebt anyway, and its needed to solve now in order to be able to pass mutable reference to SuiteReport inside.

Previously experiment loop was some mix of async and sync code, and required usage of Noop context
This PR rewrites this loop into `select!` of various conditions.
