### PR TITLE
[cluster-test] Add experiment to automatically generate CPU FlameGraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.21"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -200,7 +200,7 @@ name = "backup-restore"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,6 +636,7 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "debug-interface 0.1.0",
@@ -753,7 +754,7 @@ name = "consensus"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4367,7 +4368,7 @@ name = "state-synchronizer"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "config-builder 0.1.0",
@@ -4427,7 +4428,7 @@ name = "storage-client"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-state-view 0.1.0",
@@ -4459,7 +4460,7 @@ name = "storage-service"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
@@ -5083,7 +5084,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5585,7 +5586,7 @@ name = "vm-validator"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "executor 0.1.0",
  "libra-config 0.1.0",
@@ -5927,7 +5928,7 @@ dependencies = [
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58982858be7540a465c790b95aaea6710e5139bf8956b1d1344d014fa40100b0"
 "checksum async-stream-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
-"checksum async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
+"checksum async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -45,3 +45,4 @@ hex = { version = "0.3.2", default-features = false }
 
 futures = "0.3.0"
 tokio = { version = "0.2.8", features = ["full"] }
+async-trait = "0.1.24"

--- a/testsuite/cluster-test/src/effects/generate_cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/effects/generate_cpu_flamegraph.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{effects::Action, instance::Instance};
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt};
+use slog_scope::info;
+use std::fmt;
+
+pub struct GenerateCpuFlamegraph {
+    instance: Instance,
+    duration_secs: usize,
+}
+
+impl GenerateCpuFlamegraph {
+    pub fn new(instance: Instance, duration_secs: usize) -> Self {
+        Self {
+            instance,
+            duration_secs,
+        }
+    }
+}
+
+impl Action for GenerateCpuFlamegraph {
+    fn apply(&self) -> BoxFuture<Result<()>> {
+        async move {
+            info!("GenerateCpuFlamegraph {}", self.instance);
+            let cmd = format!(r#"
+                set -e;
+                rm -rf /tmp/perf-data;
+                mkdir /tmp/perf-data;
+                cd /tmp/perf-data;
+                sudo perf record -F 99 -p $(ps aux | grep libra-node | grep -v grep | awk '{{print $2}}') --output=perf.data --call-graph dwarf -- sleep {};
+                sudo perf script --input=perf.data | sudo /usr/local/etc/FlameGraph/stackcollapse-perf.pl > out.perf-folded;
+                sudo /usr/local/etc/FlameGraph/flamegraph.pl out.perf-folded > perf-kernel.svg;
+                "#, self.duration_secs);
+            self.instance
+                .run_cmd(vec![cmd.as_str()])
+                .await?;
+            self.instance.scp("/tmp/perf-data/perf-kernel.svg", "perf-kernel.svg").await?;
+            Ok(())
+        }
+        .boxed()
+    }
+}
+
+impl fmt::Display for GenerateCpuFlamegraph {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "GenerateCpuFlamegraph {}", self.instance)
+    }
+}

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod delete_libra_data;
+mod generate_cpu_flamegraph;
 mod network_delay;
 mod packet_loss;
 mod reboot;
@@ -13,6 +14,7 @@ mod stop_container;
 use anyhow::Result;
 pub use delete_libra_data::DeleteLibraData;
 use futures::future::BoxFuture;
+pub use generate_cpu_flamegraph::GenerateCpuFlamegraph;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -1,0 +1,78 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::experiments::ExperimentParam;
+use crate::{
+    cluster::Cluster, experiments::Context, experiments::Experiment, instance, instance::Instance,
+};
+use futures::future::{BoxFuture, FutureExt};
+use futures::join;
+use crate::effects::{Action, GenerateCpuFlamegraph};
+use std::{
+    collections::HashSet,
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct CpuFlamegraphParams {
+    #[structopt(
+        long,
+        default_value = "60",
+        help = "Number of seconds for which perf should be run"
+    )]
+    pub duration_secs: usize,
+}
+
+pub struct CpuFlamegraph {
+    duration_secs: usize,
+    perf_instance: Instance,
+}
+
+impl ExperimentParam for CpuFlamegraphParams {
+    type E = CpuFlamegraph;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let perf_instance = cluster.random_validator_instance();
+        Self::E {
+            duration_secs: self.duration_secs,
+            perf_instance,
+        }
+    }
+}
+
+impl Experiment for CpuFlamegraph {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&[self.perf_instance.clone()])
+    }
+
+    fn run<'a>(
+        &'a mut self,
+        context: &'a mut Context,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        async move {
+            let buffer = Duration::from_secs(60);
+            let tx_emitter_duration = 2 * buffer + Duration::from_secs(self.duration_secs as u64);
+
+            let emit_future = context.tx_emitter.emit_txn_for(tx_emitter_duration, context.cluster.validator_instances().clone());
+            let generate_flame_graph = GenerateCpuFlamegraph::new(self.perf_instance.clone(), self.duration_secs);
+            let flame_graph_future = generate_flame_graph.apply();
+            let flame_graph_future = tokio::time::delay_for(buffer).then(|_| flame_graph_future);
+            let (emit_result, flame_graph_result) =  join!(emit_future, flame_graph_future);
+//            emit_result?;
+//            flame_graph_result?;
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(480)
+    }
+}
+
+impl Display for CpuFlamegraph {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "Generating CpuFlamegraph on {}", self.perf_instance)
+    }
+}

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod cpu_flamegraph;
 mod multi_region_network_simulation;
 mod packet_loss_random_validators;
 mod performance_benchmark_nodes_down;
@@ -30,6 +31,7 @@ use crate::cluster::Cluster;
 use crate::prometheus::Prometheus;
 use crate::report::SuiteReport;
 use crate::tx_emitter::TxEmitter;
+pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use structopt::{clap::AppSettings, StructOpt};
@@ -110,6 +112,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
         "reboot_random_validators",
         f::<RebootRandomValidatorsParams>(),
     );
+    known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -35,12 +35,16 @@ pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use structopt::{clap::AppSettings, StructOpt};
+use async_trait::async_trait;
 
+
+#[async_trait]
 pub trait Experiment: Display + Send {
     fn affected_validators(&self) -> HashSet<String> {
         HashSet::new()
     }
     fn run<'a>(&'a mut self, context: &'a mut Context<'a>) -> BoxFuture<'a, anyhow::Result<()>>;
+    async fn run_async(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> { Ok(()) }
     fn deadline(&self) -> Duration;
 }
 

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -21,6 +21,7 @@ use crate::experiments::Experiment;
 use crate::tx_emitter::{EmitJobRequest, EmitThreadParams, TxEmitter};
 use crate::util::unix_timestamp_now;
 use futures::future::{join_all, BoxFuture, FutureExt};
+use async_trait::async_trait;
 
 #[derive(Default, Debug)]
 struct Metrics {
@@ -196,6 +197,7 @@ fn print_results(metrics: Vec<Metrics>) {
     }
 }
 
+#[async_trait]
 impl Experiment for MultiRegionSimulation {
     fn run<'a>(&'a mut self, context: &'a mut Context) -> BoxFuture<'a, Result<()>> {
         async move {

--- a/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
+++ b/testsuite/cluster-test/src/experiments/packet_loss_random_validators.rs
@@ -16,6 +16,7 @@ use anyhow::Result;
 use futures::future::{BoxFuture, FutureExt};
 use std::{fmt, time::Duration};
 use structopt::StructOpt;
+use async_trait::async_trait;
 
 pub struct PacketLossRandomValidators {
     instances: Vec<Instance>,
@@ -64,6 +65,7 @@ impl ExperimentParam for PacketLossRandomValidatorsParams {
     }
 }
 
+#[async_trait]
 impl Experiment for PacketLossRandomValidators {
     fn run(&mut self, _context: &mut Context) -> BoxFuture<Result<()>> {
         async move {

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -21,6 +21,7 @@ use std::{
     time::Duration,
 };
 use structopt::StructOpt;
+use async_trait::async_trait;
 
 #[derive(StructOpt, Debug)]
 pub struct PerformanceBenchmarkNodesDownParams {
@@ -66,6 +67,7 @@ impl ExperimentParam for PerformanceBenchmarkNodesDownParams {
     }
 }
 
+#[async_trait]
 impl Experiment for PerformanceBenchmarkNodesDown {
     fn affected_validators(&self) -> HashSet<String> {
         instance::instancelist_to_set(&self.down_instances)

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -16,6 +16,7 @@ use std::{
     time::Duration,
 };
 use structopt::StructOpt;
+use async_trait::async_trait;
 
 pub struct PerformanceBenchmarkThreeRegionSimulation {
     cluster: Cluster,
@@ -33,6 +34,7 @@ impl ExperimentParam for PerformanceBenchmarkThreeRegionSimulationParams {
     }
 }
 
+#[async_trait]
 impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
     fn run<'a>(&'a mut self, context: &'a mut Context) -> BoxFuture<'a, anyhow::Result<()>> {
         async move {

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -20,6 +20,7 @@ use crate::{
 use futures::future::{join_all, BoxFuture, FutureExt};
 use slog_scope::warn;
 use structopt::StructOpt;
+use async_trait::async_trait;
 
 #[derive(StructOpt, Debug)]
 pub struct RebootRandomValidatorsParams {
@@ -52,6 +53,7 @@ impl ExperimentParam for RebootRandomValidatorsParams {
     }
 }
 
+#[async_trait]
 impl Experiment for RebootRandomValidators {
     fn affected_validators(&self) -> HashSet<String> {
         instance::instancelist_to_set(&self.instances)

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -18,6 +18,7 @@ use crate::tx_emitter::{EmitJobRequest, EmitThreadParams};
 use crate::{effects::Action, experiments::Experiment};
 use slog_scope::info;
 use std::time::Instant;
+use async_trait::async_trait;
 
 #[derive(StructOpt, Debug)]
 pub struct RecoveryTimeParams {
@@ -45,6 +46,7 @@ impl ExperimentParam for RecoveryTimeParams {
     }
 }
 
+#[async_trait]
 impl Experiment for RecoveryTime {
     fn affected_validators(&self) -> HashSet<String> {
         let mut result = HashSet::new();


### PR DESCRIPTION
## Summary

* We generate load on the cluster and pick one validator and run `perf` against it to generate the FlameGraph
* This FlameGraph is then copied locally to cluster-test. 
* The next step would be to upload this local file to S3 

## Test Plan

Tested on my cluster
