### PR TITLE
[cluster-test] use jumphost in env var if defined

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -66,7 +66,7 @@ then
       exit 1
 fi
 
-JUMPHOST=ssh.${WORKSPACE}.aws.hlw3truzy4ls.com
+JUMPHOST=${JUMPHOST:-ssh.${WORKSPACE}.aws.hlw3truzy4ls.com}
 
 ssh $JUMPHOST echo "ssh ok" >/dev/null || (echo "Failed to ssh to jump host $JUMPHOST. Try renew corp canal cert with cc-certs"; exit 1)
 


### PR DESCRIPTION
## Motivation
Added an option in cluster test runner to use jumphost specified in env
var if there is one defined.  Fall back to default if not.

## Test Plan
```
[youngyl@youngyl-mbp:libra cti_jumphost_option]$ JUMPHOST=foo@bar.com scripts/cti --master
Using JUMPHOST defined in env: foo@bar.com
```
