### PR TITLE
[docker] build safety-rules in all images

### DIFF
--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -16,7 +16,7 @@ FROM toolchain AS builder
 
 COPY . /libra
 
-RUN cargo build --release -p libra-node -p cli -p config-builder && cd target/release && rm -r build deps incremental
+RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
 
 ### Production Image ###
 FROM debian:buster AS prod

--- a/docker/validator-dynamic/validator-dynamic.Dockerfile
+++ b/docker/validator-dynamic/validator-dynamic.Dockerfile
@@ -16,7 +16,7 @@ FROM toolchain AS config_builder
 
 COPY . /libra
 
-RUN cargo build --release -p libra-node -p cli -p config-builder && cd target/release && rm -r build deps incremental
+RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
 
 ### Production Image ###
 FROM libra_e2e:latest as validator_with_config


### PR DESCRIPTION
## Motivation
We added safety-rules to some images but not all. It causes DLC miss in our CP pipeline doubling the total build time. Build safety-rules package in all docker images to avoid DLC miss.

## Test Plan
Canary in Circle https://circleci.com/gh/libra/libra/30189
