### PR TITLE
[secure] Introduce vault storage and some underlying fun stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,7 @@ dependencies = [
 name = "libra-secure-storage"
 version = "0.1.0"
 dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +824,15 @@ dependencies = [
 name = "constant_time_eq"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cookie"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2275,8 +2289,10 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-vault-client 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2355,6 +2371,16 @@ dependencies = [
 [[package]]
 name = "libra-util"
 version = "0.1.0"
+
+[[package]]
+name = "libra-vault-client"
+version = "0.1.0"
+dependencies = [
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libra-wallet"
@@ -3316,6 +3342,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5368,6 +5402,23 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ureq"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chunked_transfer 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "qstring 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5691,6 +5742,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "weedle"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5894,6 +5953,7 @@ dependencies = [
 "checksum chacha20-poly1305-aead 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
 "checksum chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff41a3c2c1e39921b9003de14bf0439c7b63a9039637c291e1a64925d8ddfa45"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+"checksum chunked_transfer 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f98beb6554de08a14bd7b5c6014963c79d6a25a1c66b1d4ecb9e733ccba51d6c"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -5903,6 +5963,7 @@ dependencies = [
 "checksum codespan-reporting 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab081a14ab8f9598ce826890fe896d0addee68c7a58ab49008369ccbb51510a8"
 "checksum codespan-reporting 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1d915d9e2b2ad696b2cd73215a84823ef3f0e3084d90304204415921b62c6"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -6090,6 +6151,7 @@ dependencies = [
 "checksum prost-build 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33a7fe588ea94b85bc9dc3471652a9ed71727be3460c8238bca3f0e7280cf1a3"
 "checksum prost-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 "checksum prost-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "738dd42f98597e4d9ea547b46df0fd17b9a16d2653c959feb32f918cc1d120b0"
+"checksum qstring 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 "checksum quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb6ccf8db7bbcb9c2eae558db5ab4f3da1c2a87e4e597ed394726bc8ea6ca1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -6271,6 +6333,7 @@ dependencies = [
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2c64cdf40b4a9645534a943668681bcb219faf51874d4b65d2e0abda1b10a2ab"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
+"checksum ureq 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5281c8b41934f65338942a87ef7dc32052f2a2c1b2f5c53c6a96643ba674372"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
@@ -6293,6 +6356,7 @@ dependencies = [
 "checksum web-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "c84440699cd02ca23bed6f045ffb1497bc18a3c2628bd13e2093186faaaacf6b"
 "checksum webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4"
 "checksum webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b"
+"checksum webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/common/lcs/src/de.rs
+++ b/common/lcs/src/de.rs
@@ -387,11 +387,12 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         visitor.visit_enum(self)
     }
 
+    // LCS does not utilize identifiers, so throw them away
     fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::NotSupported("deserialize_identifier"))
+        self.deserialize_bytes(_visitor)
     }
 
     // LCS is not a self-describing format so we can't implement `deserialize_ignored_any`

--- a/docker/vault/run.sh
+++ b/docker/vault/run.sh
@@ -3,4 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 set -ex
 
-docker run --cap-add=IPC_LOCK --publish 8200:8200 --detach vault
+docker run \
+    --cap-add=IPC_LOCK \
+    -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' \
+    -e 'VAULT_DEV_ROOT_TOKEN_ID=root_token' \
+    --publish 8200:8200 \
+    --detach \
+    vault

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -14,7 +14,9 @@ base64 = "0.9.3"
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+libra-vault-client = { path = "vault", version = "0.1.0" }
 serde = { version = "1.0.99", features = ["rc"], default-features = false }
+serde_json = "1.0.40"
 thiserror = "1.0"
 toml = { version = "0.5.3", default-features = false }
 

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+base64 = "0.9.3"
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -20,9 +20,21 @@ pub enum Error {
     UnexpectedValueType,
 }
 
+impl From<base64::DecodeError> for Error {
+    fn from(error: base64::DecodeError) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
         Self::InternalError(format!("{}", error))
+    }
+}
+
+impl From<lcs::Error> for Error {
+    fn from(error: lcs::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
     }
 }
 
@@ -34,12 +46,6 @@ impl From<toml::de::Error> for Error {
 
 impl From<toml::ser::Error> for Error {
     fn from(error: toml::ser::Error) -> Self {
-        Self::SerializationError(format!("{}", error))
-    }
-}
-
-impl From<lcs::Error> for Error {
-    fn from(error: lcs::Error) -> Self {
         Self::SerializationError(format!("{}", error))
     }
 }

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -23,6 +23,10 @@ impl InMemoryStorage {
 }
 
 impl Storage for InMemoryStorage {
+    fn available(&self) -> bool {
+        true
+    }
+
     fn create(&mut self, key: &str, value: Value, _permissions: &Permissions) -> Result<(), Error> {
         if self.data.contains_key(key) {
             return Err(Error::KeyAlreadyExists(key.to_string()));

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -9,6 +9,7 @@ mod on_disk;
 mod permissions;
 mod storage;
 mod value;
+mod vault;
 
 pub use crate::{
     error::Error,
@@ -17,6 +18,7 @@ pub use crate::{
     permissions::{Id, Permission, Permissions},
     storage::Storage,
     value::Value,
+    vault::VaultStorage,
 };
 
 #[cfg(test)]

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -58,6 +58,10 @@ impl OnDiskStorage {
 }
 
 impl Storage for OnDiskStorage {
+    fn available(&self) -> bool {
+        true
+    }
+
     fn create(&mut self, key: &str, value: Value, _permissions: &Permissions) -> Result<(), Error> {
         let mut data = self.read()?;
         if data.contains_key(key) {

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -8,6 +8,8 @@ use crate::{Error, Permissions, Value};
 /// into a unique and private token for another service. Hence get and set internally will pass the
 /// current service private token to the backend to gain its permissions.
 pub trait Storage: Send + Sync {
+    /// Returns true if the backend service is online and available.
+    fn available(&self) -> bool;
     /// Creates a new value if it does not exist fails only if there is some other issue.
     fn create_if_not_exists(
         &mut self,

--- a/secure/storage/src/tests/in_memory.rs
+++ b/secure/storage/src/tests/in_memory.rs
@@ -6,5 +6,5 @@ use crate::{in_memory::InMemoryStorage, tests::suite};
 #[test]
 fn in_memory() {
     let storage = Box::new(InMemoryStorage::new());
-    suite::run_test_suite(storage);
+    suite::run_test_suite(storage, "InMemoryStorage");
 }

--- a/secure/storage/src/tests/mod.rs
+++ b/secure/storage/src/tests/mod.rs
@@ -4,3 +4,4 @@
 mod in_memory;
 mod on_disk;
 mod suite;
+mod vault;

--- a/secure/storage/src/tests/on_disk.rs
+++ b/secure/storage/src/tests/on_disk.rs
@@ -8,5 +8,5 @@ use libra_temppath::TempPath;
 fn on_disk() {
     let temp_path = TempPath::new();
     let storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
-    suite::run_test_suite(storage);
+    suite::run_test_suite(storage, "OnDiskStorage");
 }

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -13,7 +13,12 @@ use rand::{rngs::StdRng, SeedableRng};
 const KEY_KEY: &str = "key";
 const U64_KEY: &str = "u64";
 
-pub fn run_test_suite(mut storage: Box<dyn Storage>) {
+pub fn run_test_suite(mut storage: Box<dyn Storage>, name: &str) {
+    assert!(
+        storage.available(),
+        eprintln!("Backend storage, {}, is not available", name)
+    );
+
     let no_perms = Permissions {
         readers: Permission::Anyone,
         writers: Permission::Anyone,

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{tests::suite, vault::VaultStorage};
+
+#[ignore]
+#[test]
+fn vault() {
+    let host = "http://localhost:8200".to_string();
+    let token = "root_token".to_string();
+    let storage = VaultStorage::new(host, token);
+    storage.reset().unwrap();
+    suite::run_test_suite(Box::new(storage), "VaultStorage");
+}

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
+use base64;
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use serde::{Deserialize, Serialize};
 
@@ -27,5 +28,41 @@ impl Value {
         } else {
             Err(Error::UnexpectedValueType)
         }
+    }
+
+    pub fn from_base64(input: &str) -> Result<Value, Error> {
+        let bytes = base64::decode(input)?;
+        let value = lcs::from_bytes(&bytes)?;
+        Ok(value)
+    }
+
+    pub fn to_base64(&self) -> Result<String, Error> {
+        let bytes = lcs::to_bytes(self)?;
+        Ok(base64::encode(&bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libra_crypto::Uniform;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn u64() {
+        let value = Value::U64(12341);
+        let base64 = value.to_base64().unwrap();
+        let out_value = Value::from_base64(&base64).unwrap();
+        assert_eq!(value, out_value);
+    }
+
+    #[test]
+    fn ed25519_private_key() {
+        let mut rng = StdRng::from_seed([13u8; 32]);
+        let value = Ed25519PrivateKey::generate_for_testing(&mut rng);
+        let value = Value::Ed25519PrivateKey(value);
+        let base64 = value.to_base64().unwrap();
+        let out_value = Value::from_base64(&base64).unwrap();
+        assert_eq!(value, out_value);
     }
 }

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -1,0 +1,81 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Error, Permissions, Storage, Value};
+use libra_vault_client::Client;
+
+/// VaultStorage utilizes Vault for maintaining encrypted, authenticated data for Libra. This
+/// version currently matches the behavior of OnDiskStorage and InMemoryStorage. In the future,
+/// Vault will be able to create keys, sign messages, and handle permissions across different
+/// services. The specific vault service leveraged herein is called KV (Key Value) Secrets Engine -
+/// Version 2 (https://www.vaultproject.io/api/secret/kv/kv-v2.html). So while Libra Secure Storage
+/// calls pointers to data keys, Vault has actually a secret that contains multiple key value
+/// pairs.
+pub struct VaultStorage {
+    pub client: Client,
+}
+
+impl VaultStorage {
+    pub fn new(host: String, token: String) -> Self {
+        Self {
+            client: Client::new(host, token),
+        }
+    }
+
+    /// Erase all secrets and keys from the vault storage. Use with caution.
+    pub fn reset(&self) -> Result<(), Error> {
+        let secrets = self.client.list_secrets("")?;
+        for secret in secrets {
+            self.client.delete_secret(&secret)?;
+        }
+        Ok(())
+    }
+
+    /// Retrieves a key from a given secret. Libra Secure Storage inserts each key into its own
+    /// distinct secret store and thus the secret and key have the same identifier.
+    fn get_secret(&self, key: &str) -> Result<Value, Error> {
+        let value = self.client.read_secret(key, key)?;
+        let v = Value::from_base64(&value).unwrap();
+        Ok(v)
+    }
+
+    /// Inserts a key, value pair into a secret that shares the name of the key.
+    fn set_secret(&self, key: &str, value: Value) -> Result<(), Error> {
+        self.client.write_secret(key, key, &value.to_base64()?)?;
+        Ok(())
+    }
+}
+
+impl Storage for VaultStorage {
+    fn available(&self) -> bool {
+        self.client.unsealed().unwrap_or(false)
+    }
+
+    fn create(&mut self, key: &str, value: Value, _permissions: &Permissions) -> Result<(), Error> {
+        // Vault internally does not distinguish creation versus update except by permissions. So we
+        // simulate that by first getting the key. If it doesn't exist, we're okay and return back a
+        // fake, but ignored value.
+        self.get_secret(&key).or_else(|e| {
+            if let Error::KeyNotSet(_) = e {
+                Ok(Value::U64(0))
+            } else {
+                Err(e)
+            }
+        })?;
+
+        self.set_secret(&key, value)?;
+        Ok(())
+    }
+
+    fn get(&self, key: &str) -> Result<Value, Error> {
+        self.get_secret(&key)
+    }
+
+    fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        // Vault internally does not distinguish create versus udpate except by permissions. So we
+        // simulate that by first getting the key. If it exists, we can update it.
+        self.get_secret(&key)?;
+        self.set_secret(&key, value)?;
+        Ok(())
+    }
+}

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "libra-vault-client"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+repository = "https://github.com/libra/libra"
+description = "Libra's Restful Vault Client"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0.99", features = ["derive"], default-features = false }
+serde_json = "1.0.40"
+thiserror = "1.0"
+ureq = { version = "0.11.3", features = ["json"] }

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -1,0 +1,172 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use thiserror::Error;
+use ureq;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    #[error("Http error: {1}")]
+    HttpError(u16, String),
+    #[error("Internal error: {0}")]
+    InternalError(String),
+    #[error("Missing field {0}")]
+    MissingField(String),
+    #[error("404: Not Found: {0}/{1}")]
+    NotFound(String, String),
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}
+
+impl From<ureq::Response> for Error {
+    fn from(response: ureq::Response) -> Self {
+        Error::HttpError(response.status(), response.status_line().into())
+    }
+}
+
+impl From<serde_json::error::Error> for Error {
+    fn from(error: serde_json::error::Error) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}
+
+/// Client provides a client around the restful interface to a Vault servce. Learn more
+/// here: https://www.vaultproject.io/api-docs/
+pub struct Client {
+    host: String,
+    token: String,
+}
+
+impl Client {
+    pub fn new(host: String, token: String) -> Self {
+        Self { host, token }
+    }
+
+    /// List all stored secrets
+    pub fn list_secrets(&self, secret: &str) -> Result<Vec<String>, Error> {
+        let response = ureq::request(
+            "LIST",
+            &format!("{}/v1/secret/metadata/{}", self.host, secret),
+        )
+        .set("X-Vault-Token", &self.token)
+        .timeout_connect(10_000)
+        .call();
+        match response.status() {
+            200 => {
+                let response: ReadSecretListResponse =
+                    serde_json::from_str(&response.into_string()?)?;
+                Ok(response.data.keys)
+            }
+            // There are no secrets.
+            404 => Ok(vec![]),
+            _ => Err(response.into()),
+        }
+    }
+
+    /// Delete a specific secret store
+    pub fn delete_secret(&self, secret: &str) -> Result<(), Error> {
+        let response = ureq::delete(&format!("{}/v1/secret/metadata/{}", self.host, secret))
+            .set("X-Vault-Token", &self.token)
+            .timeout_connect(10_000)
+            .call();
+        if response.ok() {
+            Ok(())
+        } else {
+            Err(response.into())
+        }
+    }
+
+    /// Read a key/value pair from a given secret store.
+    pub fn read_secret(&self, secret: &str, key: &str) -> Result<String, Error> {
+        let response = ureq::get(&format!("{}/v1/secret/data/{}", self.host, secret))
+            .set("X-Vault-Token", &self.token)
+            .timeout_connect(10_000)
+            .call();
+        match response.status() {
+            200 => {
+                let mut response: ReadSecretResponse =
+                    serde_json::from_str(&response.into_string()?)?;
+                let value = response
+                    .data
+                    .data
+                    .remove(key)
+                    .ok_or_else(|| Error::NotFound(secret.into(), key.into()))?;
+                Ok(value)
+            }
+            404 => Err(Error::NotFound(secret.into(), key.into())),
+            _ => Err(response.into()),
+        }
+    }
+
+    /// Returns whether or not the vault is unsealed (can be read from / written to)
+    pub fn unsealed(&self) -> Result<bool, Error> {
+        let response = ureq::get(&format!("{}/v1/sys/seal-status", self.host))
+            .timeout_connect(10_000)
+            .call();
+        match response.status() {
+            200 => {
+                let response: SealStatusResponse = serde_json::from_str(&response.into_string()?)?;
+                Ok(!response.sealed)
+            }
+            _ => Err(response.into()),
+        }
+    }
+
+    /// Create or update a key/value pair in a given secret store.
+    pub fn write_secret(&self, secret: &str, key: &str, value: &str) -> Result<(), Error> {
+        let response = ureq::put(&format!("{}/v1/secret/data/{}", self.host, secret))
+            .set("X-Vault-Token", &self.token)
+            .timeout_connect(10_000)
+            .send_json(json!({ "data": { key: value } }));
+        match response.status() {
+            200 => Ok(()),
+            _ => Err(response.into()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct CreateTokenResponse {
+    auth: CreateTokenAuth,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct CreateTokenAuth {
+    client_token: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct ReadSecretListResponse {
+    data: ReadSecretListData,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct ReadSecretListData {
+    keys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct ReadSecretResponse {
+    data: ReadSecretData,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct ReadSecretData {
+    data: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct SealStatusResponse {
+    sealed: bool,
+}


### PR DESCRIPTION
The first few PRs set the stage for the real excitement:
1) Fix a bug with LCS deserialization when tags are assigned to enums
2) Add base64 encoding / decoding for storage values
3) Have an availability check and verify it before beginning tests
4) Introduce vault!

This isn't a complete work on Vault, we still need to implement permissions and explicit key management.